### PR TITLE
Remove erroneous two-way fnmatch for DDS Security [4963]

### DIFF
--- a/src/cpp/utils/StringMatching.cpp
+++ b/src/cpp/utils/StringMatching.cpp
@@ -97,8 +97,6 @@ bool StringMatching::matchString(const char* str1, const char* str2)
 {
 	if(fnmatch(str1,str2,FNM_NOESCAPE)==0)
 		return true;
-	if(fnmatch(str2,str1,FNM_NOESCAPE)==0)
-		return true;
 	return false;
 }
 


### PR DESCRIPTION
This fixes:  https://github.com/eProsima/Fast-RTPS/issues/441

The query string and the pattern string should never be swapped when evaluating matching criteria, as this unavoidably results in pattern expansion using user input data, weeking the security permissions enforced, and deviates from the standard set by the default DDS Security Access Control plugin. I.e. remote participants can connect to topics that evaluate to matching expressions for string literal topic names that occur in the remote participant's own granted permission set. E.g. participant `A` may publish to topic name `foo*` even though `A` was only ever granted to `foobar`, allowing for side channel communications while retaining the original permission set.


This subtle issue was uncovered during my development of a formal verification framework for the default DDS Security Access Control plugins and procedurally generated permission files.