### PR TITLE
Install config files in correct location

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -401,7 +401,7 @@ if((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER)
     endif()
 
     install(FILES ${PROJECT_SOURCE_DIR}/cmake/packaging/windows/${PROJECT_NAME}-config.cmake
-        DESTINATION ${DATA_INSTALL_DIR}/${PROJECT_NAME}/cmake
+        DESTINATION ${LIB_INSTALL_DIR}/${PROJECT_NAME}/cmake${MSVCARCH_DIR_EXTENSION_EXT}
         COMPONENT cmake
         )
 elseif(NOT EPROSIMA_INSTALLER)
@@ -415,7 +415,7 @@ elseif(NOT EPROSIMA_INSTALLER)
 
     export(TARGETS ${PROJECT_NAME} FILE ${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-targets.cmake)
     install(EXPORT ${PROJECT_NAME}-targets
-        DESTINATION ${DATA_INSTALL_DIR}/${PROJECT_NAME}/cmake${MSVCARCH_DIR_EXTENSION_EXT}
+        DESTINATION ${LIB_INSTALL_DIR}/${PROJECT_NAME}/cmake${MSVCARCH_DIR_EXTENSION_EXT}
         COMPONENT cmake
         )
 
@@ -469,7 +469,7 @@ elseif(NOT EPROSIMA_INSTALLER)
 
     configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/packaging/Config.cmake.in
         ${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-config.cmake
-        INSTALL_DESTINATION ${DATA_INSTALL_DIR}$/${PROJECT_NAME}/cmake${MSVCARCH_DIR_EXTENSION_EXT}
+        INSTALL_DESTINATION ${LIB_INSTALL_DIR}$/${PROJECT_NAME}/cmake${MSVCARCH_DIR_EXTENSION_EXT}
         PATH_VARS BIN_INSTALL_DIR INCLUDE_INSTALL_DIR LIB_INSTALL_DIR
         )
     write_basic_package_version_file(${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-config-version.cmake
@@ -478,7 +478,7 @@ elseif(NOT EPROSIMA_INSTALLER)
         )
     install(FILES ${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-config.cmake
         ${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-config-version.cmake
-        DESTINATION ${DATA_INSTALL_DIR}/${PROJECT_NAME}/cmake${MSVCARCH_DIR_EXTENSION_EXT}
+        DESTINATION ${LIB_INSTALL_DIR}/${PROJECT_NAME}/cmake${MSVCARCH_DIR_EXTENSION_EXT}
         COMPONENT cmake
         )
 


### PR DESCRIPTION
According to https://cmake.org/cmake/help/latest/command/find_package.html#search-procedure the config files should be *not* placed under /usr/share (which is what DATA_INSTALL_DIR gives you). Putting it one location under /usr/share makes it impossible to install for multiple libs (or archs).

The provided patch is only tested under Linux and might need extension to work under Windows. See link above for Windows only search path. The Unix search paths should work for Windows too.

PS! This patch uses LIB_INSTALL_DIR/PROJECTNAME/cmake and not LIB_INSTALL_DIR/cmake/PROJECTNAME, which I think is more common on Linux, in the hope that it will work under Windows too.