### PR TITLE
Fix for_each_unsent_change and set_change_to_status

### DIFF
--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -82,42 +82,42 @@ StatefulWriter::StatefulWriter(
     const RTPSParticipantAttributes& part_att = pimpl->getRTPSParticipantAttributes();
 
     periodic_hb_event_ = new TimedEvent(pimpl->getEventResource(), [&](TimedEvent::EventCode code) -> bool
+    {
+        if (TimedEvent::EVENT_SUCCESS == code)
+        {
+            if (send_periodic_heartbeat())
             {
-                if(TimedEvent::EVENT_SUCCESS == code)
-                {
-                    if (send_periodic_heartbeat())
-                    {
-                        return true;
-                    }
-                }
+                return true;
+            }
+        }
 
-                return false;
-            },
-            TimeConv::Time_t2MilliSecondsDouble(m_times.heartbeatPeriod));
+        return false;
+    },
+                    TimeConv::Time_t2MilliSecondsDouble(m_times.heartbeatPeriod));
 
     nack_response_event_ = new TimedEvent(pimpl->getEventResource(), [&](TimedEvent::EventCode code) -> bool
-            {
-                if (TimedEvent::EVENT_SUCCESS == code)
-                {
-                    perform_nack_response();
-                }
+    {
+        if (TimedEvent::EVENT_SUCCESS == code)
+        {
+            perform_nack_response();
+        }
 
-                return false;
-            },
-            TimeConv::Time_t2MilliSecondsDouble(m_times.nackResponseDelay));
+        return false;
+    },
+                    TimeConv::Time_t2MilliSecondsDouble(m_times.nackResponseDelay));
 
     if (disable_positive_acks_)
     {
         ack_event_ = new TimedEvent(pimpl->getEventResource(), [&](TimedEvent::EventCode code) -> bool
-                {
-                    if (TimedEvent::EVENT_SUCCESS == code)
-                    {
-                        return ack_timer_expired();
-                    }
+        {
+            if (TimedEvent::EVENT_SUCCESS == code)
+            {
+                return ack_timer_expired();
+            }
 
-                    return false;
-                },
-                    att.keep_duration.to_ns() * 1e-6); // in milliseconds
+            return false;
+        },
+                        att.keep_duration.to_ns() * 1e-6); // in milliseconds
     }
 
     for (size_t n = 0; n < att.matched_readers_allocation.initial; ++n)
@@ -126,10 +126,9 @@ StatefulWriter::StatefulWriter(
     }
 }
 
-
 StatefulWriter::~StatefulWriter()
 {
-    logInfo(RTPS_WRITER,"StatefulWriter destructor");
+    logInfo(RTPS_WRITER, "StatefulWriter destructor");
 
     for (std::unique_ptr<FlowController>& controller : m_controllers)
     {
@@ -195,9 +194,9 @@ void StatefulWriter::unsent_change_added_to_history(
     encrypt_cachechange(change);
 #endif
 
-    if(!matched_readers_.empty())
+    if (!matched_readers_.empty())
     {
-        if(!isAsync())
+        if (!isAsync())
         {
             //TODO(Ricardo) Temporal.
             bool expectsInlineQos = false;
@@ -209,9 +208,9 @@ void StatefulWriter::unsent_change_added_to_history(
             {
                 ChangeForReader_t changeForReader(change);
 
-                if(m_pushMode)
+                if (m_pushMode)
                 {
-                    if(it->is_reliable())
+                    if (it->is_reliable())
                     {
                         changeForReader.setStatus(UNDERWAY);
                     }
@@ -271,18 +270,18 @@ void StatefulWriter::unsent_change_added_to_history(
                     last_sequence_number_ = change->sequenceNumber;
                 }
             }
-            catch(const RTPSMessageGroup::timeout&)
+            catch (const RTPSMessageGroup::timeout&)
             {
                 logError(RTPS_WRITER, "Max blocking time reached");
             }
         }
         else
         {
-            for(ReaderProxy* it : matched_readers_)
+            for (ReaderProxy* it : matched_readers_)
             {
                 ChangeForReader_t changeForReader(change);
 
-                if(m_pushMode)
+                if (m_pushMode)
                 {
                     changeForReader.setStatus(UNSENT);
                 }
@@ -315,14 +314,14 @@ void StatefulWriter::unsent_change_added_to_history(
         if (liveliness_lease_duration_ < c_TimeInfinite)
         {
             mp_RTPSParticipant->wlp()->assert_liveliness(
-                        getGuid(),
-                        liveliness_kind_,
-                        liveliness_lease_duration_);
+                getGuid(),
+                liveliness_kind_,
+                liveliness_lease_duration_);
         }
     }
     else
     {
-        logInfo(RTPS_WRITER,"No reader proxy to add change.");
+        logInfo(RTPS_WRITER, "No reader proxy to add change.");
         if (mp_listener != nullptr)
         {
             mp_listener->onWriterChangeReceivedByAll(this, change);
@@ -330,16 +329,16 @@ void StatefulWriter::unsent_change_added_to_history(
     }
 }
 
-
-bool StatefulWriter::change_removed_by_history(CacheChange_t* a_change)
+bool StatefulWriter::change_removed_by_history(
+        CacheChange_t* a_change)
 {
     SequenceNumber_t sequence_number = a_change->sequenceNumber;
 
     std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
-    logInfo(RTPS_WRITER,"Change "<< sequence_number << " to be removed.");
+    logInfo(RTPS_WRITER, "Change " << sequence_number << " to be removed.");
 
     // Invalidate CacheChange pointer in ReaderProxies.
-    for(ReaderProxy* it : matched_readers_)
+    for (ReaderProxy* it : matched_readers_)
     {
         it->change_has_been_removed(sequence_number);
     }
@@ -360,7 +359,7 @@ void StatefulWriter::send_any_unsent_changes()
     // Separate sending for asynchronous writers
     if (m_pushMode && m_separateSendingEnabled)
     {
-        if(!isAsync())
+        if (!isAsync())
         {
             for (ReaderProxy* remoteReader : matched_readers_)
             {
@@ -374,34 +373,41 @@ void StatefulWriter::send_any_unsent_changes()
 
                     // Loop all changes
                     bool is_reliable = remoteReader->is_reliable();
-                    auto unsent_change_process = [&](const SequenceNumber_t& seqNum, const ChangeForReader_t* unsentChange)
-                    {
-                        if (unsentChange != nullptr && unsentChange->isRelevant() && unsentChange->isValid())
-                        {
-                            // As we checked we are not async, we know we cannot have fragments
-                            if (group.add_data(*(unsentChange->getChange()), remoteReader->expects_inline_qos()))
+                    auto unsent_change_process =
+                            [&](const SequenceNumber_t& seqNum, const ChangeForReader_t* unsentChange) -> bool
                             {
-                                remoteReader->set_change_to_status(seqNum, UNDERWAY, true);
+                                bool need_to_update = false;
 
-                                if (is_reliable)
+                                if (unsentChange != nullptr && unsentChange->isRelevant() && unsentChange->isValid())
                                 {
-                                    activateHeartbeatPeriod = true;
+                                    // As we checked we are not async, we know we cannot have fragments
+                                    if (group.add_data(*(unsentChange->getChange()),
+                                            remoteReader->expects_inline_qos()))
+                                    {
+                                        need_to_update = (1 == remoteReader->set_change_to_status(seqNum, UNDERWAY,
+                                                true));
+
+                                        if (is_reliable)
+                                        {
+                                            activateHeartbeatPeriod = true;
+                                        }
+                                    }
+                                    else
+                                    {
+                                        logError(RTPS_WRITER, "Error sending change " << seqNum);
+                                    }
                                 }
-                            }
-                            else
-                            {
-                                logError(RTPS_WRITER, "Error sending change " << seqNum);
-                            }
-                        }
-                        else
-                        {
-                            if (is_reliable)
-                            {
-                                irrelevant.emplace(seqNum);
-                            }
-                            remoteReader->set_change_to_status(seqNum, UNDERWAY, true);
-                        } // Relevance
-                    };
+                                else
+                                {
+                                    if (is_reliable)
+                                    {
+                                        irrelevant.emplace(seqNum);
+                                    }
+                                    need_to_update = (1 == remoteReader->set_change_to_status(seqNum, UNDERWAY, true));
+                                } // Relevance
+
+                                return need_to_update;
+                            };
                     remoteReader->for_each_unsent_change(max_sequence, unsent_change_process);
 
                     if (!irrelevant.empty())
@@ -409,7 +415,7 @@ void StatefulWriter::send_any_unsent_changes()
                         group.add_gap(irrelevant);
                     }
                 }
-                catch(const RTPSMessageGroup::timeout&)
+                catch (const RTPSMessageGroup::timeout&)
                 {
                     logError(RTPS_WRITER, "Max blocking time reached");
                 }
@@ -433,25 +439,31 @@ void StatefulWriter::send_any_unsent_changes()
 
         for (ReaderProxy* remoteReader : matched_readers_)
         {
-            auto unsent_change_process = [&](const SequenceNumber_t& seq_num, const ChangeForReader_t* unsentChange)
-            {
-                if (unsentChange != nullptr && unsentChange->isRelevant() && unsentChange->isValid())
-                {
-                    if (m_pushMode)
+            auto unsent_change_process =
+                    [&](const SequenceNumber_t& seq_num, const ChangeForReader_t* unsentChange) -> bool
                     {
-                        relevantChanges.add_change(unsentChange->getChange(), remoteReader, unsentChange->getUnsentFragments());
-                    }
-                    else // Change status to UNACKNOWLEDGED
-                    {
-                        remoteReader->set_change_to_status(seq_num, UNACKNOWLEDGED, false);
-                    }
-                }
-                else
-                {
-                    remoteReader->set_change_to_status(seq_num, UNDERWAY, true);
-                    notRelevantChanges.add_sequence_number(seq_num, remoteReader);
-                }
-            };
+                        bool need_to_update = false;
+                        if (unsentChange != nullptr && unsentChange->isRelevant() && unsentChange->isValid())
+                        {
+                            if (m_pushMode)
+                            {
+                                relevantChanges.add_change(
+                                    unsentChange->getChange(), remoteReader, unsentChange->getUnsentFragments());
+                            }
+                            else // Change status to UNACKNOWLEDGED
+                            {
+                                need_to_update = (1 == remoteReader->set_change_to_status(seq_num, UNACKNOWLEDGED,
+                                        false));
+                            }
+                        }
+                        else
+                        {
+                            need_to_update = (1 == remoteReader->set_change_to_status(seq_num, UNDERWAY, true));
+                            notRelevantChanges.add_sequence_number(seq_num, remoteReader);
+                        }
+
+                        return need_to_update;
+                    };
 
             remoteReader->for_each_unsent_change(max_sequence, unsent_change_process);
         }
@@ -500,7 +512,8 @@ void StatefulWriter::send_any_unsent_changes()
 
                     if (changeToSend.fragmentNumber != 0)
                     {
-                        if (group.add_data_frag(*changeToSend.cacheChange, changeToSend.fragmentNumber, expectsInlineQos))
+                        if (group.add_data_frag(*changeToSend.cacheChange, changeToSend.fragmentNumber,
+                                expectsInlineQos))
                         {
                             bool must_wake_up_async_thread = false;
                             for (ReaderProxy* remoteReader : changeToSend.remoteReaders)
@@ -517,14 +530,16 @@ void StatefulWriter::send_any_unsent_changes()
                                         activateHeartbeatPeriod = true;
                                         if (allFragmentsSent)
                                         {
-                                            remoteReader->set_change_to_status(changeToSend.sequenceNumber, UNDERWAY, true);
+                                            remoteReader->set_change_to_status(changeToSend.sequenceNumber, UNDERWAY,
+                                                    true);
                                         }
                                     }
                                     else
                                     {
                                         if (allFragmentsSent)
                                         {
-                                            remoteReader->set_change_to_status(changeToSend.sequenceNumber, ACKNOWLEDGED, false);
+                                            remoteReader->set_change_to_status(changeToSend.sequenceNumber,
+                                                    ACKNOWLEDGED, false);
                                         }
                                     }
                                 }
@@ -543,29 +558,30 @@ void StatefulWriter::send_any_unsent_changes()
                     }
                     else
                     {
-                    if (group.add_data(*changeToSend.cacheChange, expectsInlineQos))
-                    {
-                        for (ReaderProxy* remoteReader : changeToSend.remoteReaders)
+                        if (group.add_data(*changeToSend.cacheChange, expectsInlineQos))
                         {
-                            remoteReader->set_change_to_status(changeToSend.sequenceNumber, UNDERWAY, true);
-
-                            if (remoteReader->is_reliable())
+                            for (ReaderProxy* remoteReader : changeToSend.remoteReaders)
                             {
-                                activateHeartbeatPeriod = true;
+                                remoteReader->set_change_to_status(changeToSend.sequenceNumber, UNDERWAY, true);
+
+                                if (remoteReader->is_reliable())
+                                {
+                                    activateHeartbeatPeriod = true;
+                                }
                             }
                         }
-                    }
-                    else
-                    {
-                        logError(RTPS_WRITER, "Error sending change " << changeToSend.sequenceNumber);
-                    }
+                        else
+                        {
+                            logError(RTPS_WRITER, "Error sending change " << changeToSend.sequenceNumber);
+                        }
                     }
 
                     // Heartbeat piggyback.
                     send_heartbeat_piggyback_nts_(nullptr, group, lastBytesProcessed);
                 }
 
-                for (std::pair<std::vector<ReaderProxy*>, std::set<SequenceNumber_t>> pair : notRelevantChanges.elements())
+                for (std::pair<std::vector<ReaderProxy*>,
+                        std::set<SequenceNumber_t> > pair : notRelevantChanges.elements())
                 {
                     locator_selector_.reset(false);
 
@@ -582,7 +598,7 @@ void StatefulWriter::send_any_unsent_changes()
                     group.add_gap(pair.second);
                 }
             }
-            catch(const RTPSMessageGroup::timeout&)
+            catch (const RTPSMessageGroup::timeout&)
             {
                 logError(RTPS_WRITER, "Max blocking time reached");
             }
@@ -598,7 +614,7 @@ void StatefulWriter::send_any_unsent_changes()
                 RTPSMessageGroup group(mp_RTPSParticipant, this, *this);
                 send_heartbeat_nts_(all_remote_readers_.size(), group, disable_positive_acks_);
             }
-            catch(const RTPSMessageGroup::timeout&)
+            catch (const RTPSMessageGroup::timeout&)
             {
                 logError(RTPS_WRITER, "Max blocking time reached");
             }
@@ -619,7 +635,8 @@ void StatefulWriter::send_any_unsent_changes()
 /*
  * MATCHED_READER-RELATED METHODS
  */
-void StatefulWriter::update_reader_info(bool create_sender_resources)
+void StatefulWriter::update_reader_info(
+        bool create_sender_resources)
 {
     update_cached_info_nts();
     compute_selected_guids();
@@ -634,7 +651,8 @@ void StatefulWriter::update_reader_info(bool create_sender_resources)
     }
 }
 
-bool StatefulWriter::matched_reader_add(const ReaderProxyData& rdata)
+bool StatefulWriter::matched_reader_add(
+        const ReaderProxyData& rdata)
 {
     if (rdata.guid() == c_Guid_Unknown)
     {
@@ -645,9 +663,9 @@ bool StatefulWriter::matched_reader_add(const ReaderProxyData& rdata)
     std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
 
     // Check if it is already matched.
-    for(ReaderProxy* it : matched_readers_)
+    for (ReaderProxy* it : matched_readers_)
     {
-        if(it->guid() == rdata.guid())
+        if (it->guid() == rdata.guid())
         {
             logInfo(RTPS_WRITER, "Attempting to add existing reader, updating information." << endl);
             if (it->update(rdata))
@@ -671,7 +689,7 @@ bool StatefulWriter::matched_reader_add(const ReaderProxyData& rdata)
         else
         {
             logWarning(RTPS_WRITER, "Maximum number of reader proxies (" << max_readers << \
-                ") reached for writer " << m_guid << endl);
+                    ") reached for writer " << m_guid << endl);
             return false;
         }
     }
@@ -691,13 +709,13 @@ bool StatefulWriter::matched_reader_add(const ReaderProxyData& rdata)
     SequenceNumber_t current_seq = get_seq_num_min();
     SequenceNumber_t last_seq = get_seq_num_max();
 
-    if(current_seq != SequenceNumber_t::unknown())
+    if (current_seq != SequenceNumber_t::unknown())
     {
         (void)last_seq;
         assert(last_seq != SequenceNumber_t::unknown());
         assert(current_seq <= last_seq);
 
-        for(std::vector<CacheChange_t*>::iterator cit = mp_history->changesBegin();
+        for (std::vector<CacheChange_t*>::iterator cit = mp_history->changesBegin();
                 cit != mp_history->changesEnd(); ++cit)
         {
             // This is to cover the case when there are holes in the history
@@ -709,10 +727,10 @@ bool StatefulWriter::matched_reader_add(const ReaderProxyData& rdata)
 
             ChangeForReader_t changeForReader(*cit);
 
-            if(rp->durability_kind() >= TRANSIENT_LOCAL && this->getAttributes().durabilityKind >= TRANSIENT_LOCAL)
+            if (rp->durability_kind() >= TRANSIENT_LOCAL && this->getAttributes().durabilityKind >= TRANSIENT_LOCAL)
             {
                 changeForReader.setRelevance(rp->rtps_is_relevant(*cit));
-                if(!rp->rtps_is_relevant(*cit))
+                if (!rp->rtps_is_relevant(*cit))
                 {
                     not_relevant_changes.insert(changeForReader.getSequenceNumber());
                 }
@@ -744,12 +762,12 @@ bool StatefulWriter::matched_reader_add(const ReaderProxyData& rdata)
             send_heartbeat_nts_(1u, group, disable_positive_acks_);
 
             // Send Gap
-            if(!not_relevant_changes.empty())
+            if (!not_relevant_changes.empty())
             {
                 group.add_gap(not_relevant_changes);
             }
         }
-        catch(const RTPSMessageGroup::timeout&)
+        catch (const RTPSMessageGroup::timeout&)
         {
             logError(RTPS_WRITER, "Max blocking time reached");
         }
@@ -765,22 +783,24 @@ bool StatefulWriter::matched_reader_add(const ReaderProxyData& rdata)
 
     matched_readers_.push_back(rp);
 
-    logInfo(RTPS_WRITER, "Reader Proxy "<< rp->guid()<< " added to " << this->m_guid.entityId << " with "
-            << rp->reader_attributes().remote_locators().unicast.size()<<"(u)-"
-            <<rp->reader_attributes().remote_locators().multicast.size()<<"(m) locators");
+    logInfo(RTPS_WRITER, "Reader Proxy " << rp->guid() << " added to " << this->m_guid.entityId << " with "
+                                         << rp->reader_attributes().remote_locators().unicast.size() << "(u)-"
+                                         << rp->reader_attributes().remote_locators().multicast.size() <<
+            "(m) locators");
 
     return true;
 }
 
-bool StatefulWriter::matched_reader_remove(const GUID_t& reader_guid)
+bool StatefulWriter::matched_reader_remove(
+        const GUID_t& reader_guid)
 {
-    ReaderProxy *rproxy = nullptr;
+    ReaderProxy* rproxy = nullptr;
     std::unique_lock<RecursiveTimedMutex> lock(mp_mutex);
 
     ReaderProxyIterator it = matched_readers_.begin();
-    while(it != matched_readers_.end())
+    while (it != matched_readers_.end())
     {
-        if((*it)->guid() == reader_guid)
+        if ((*it)->guid() == reader_guid)
         {
             logInfo(RTPS_WRITER, "Reader Proxy removed: " << reader_guid);
             rproxy = std::move(*it);
@@ -800,7 +820,7 @@ bool StatefulWriter::matched_reader_remove(const GUID_t& reader_guid)
         periodic_hb_event_->cancel_timer();
     }
 
-    if(rproxy != nullptr)
+    if (rproxy != nullptr)
     {
         rproxy->stop();
         matched_readers_pool_.push_back(rproxy);
@@ -811,16 +831,17 @@ bool StatefulWriter::matched_reader_remove(const GUID_t& reader_guid)
         return true;
     }
 
-    logInfo(RTPS_HISTORY,"Reader Proxy doesn't exist in this writer");
+    logInfo(RTPS_HISTORY, "Reader Proxy doesn't exist in this writer");
     return false;
 }
 
-bool StatefulWriter::matched_reader_is_matched(const GUID_t& reader_guid)
+bool StatefulWriter::matched_reader_is_matched(
+        const GUID_t& reader_guid)
 {
     std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
-    for(ReaderProxy* it : matched_readers_)
+    for (ReaderProxy* it : matched_readers_)
     {
-        if(it->guid() == reader_guid)
+        if (it->guid() == reader_guid)
         {
             return true;
         }
@@ -828,12 +849,14 @@ bool StatefulWriter::matched_reader_is_matched(const GUID_t& reader_guid)
     return false;
 }
 
-bool StatefulWriter::matched_reader_lookup(GUID_t& readerGuid,ReaderProxy** RP)
+bool StatefulWriter::matched_reader_lookup(
+        GUID_t& readerGuid,
+        ReaderProxy** RP)
 {
     std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
-    for(ReaderProxy* it : matched_readers_)
+    for (ReaderProxy* it : matched_readers_)
     {
-        if(it->guid() == readerGuid)
+        if (it->guid() == readerGuid)
         {
             *RP = it;
             return true;
@@ -842,22 +865,23 @@ bool StatefulWriter::matched_reader_lookup(GUID_t& readerGuid,ReaderProxy** RP)
     return false;
 }
 
-bool StatefulWriter::is_acked_by_all(const CacheChange_t* change) const
+bool StatefulWriter::is_acked_by_all(
+        const CacheChange_t* change) const
 {
     std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
 
-    if(change->writerGUID != this->getGuid())
+    if (change->writerGUID != this->getGuid())
     {
-        logWarning(RTPS_WRITER,"The given change is not from this Writer");
+        logWarning(RTPS_WRITER, "The given change is not from this Writer");
         return false;
     }
 
     assert(mp_history->next_sequence_number() > change->sequenceNumber);
     return std::all_of(matched_readers_.begin(), matched_readers_.end(),
-        [change](const ReaderProxy* reader)
-        {
-            return reader->change_is_acked(change->sequenceNumber);
-        });
+                   [change](const ReaderProxy* reader)
+    {
+        return reader->change_is_acked(change->sequenceNumber);
+    });
 }
 
 bool StatefulWriter::all_readers_updated()
@@ -875,22 +899,25 @@ bool StatefulWriter::all_readers_updated()
     return true;
 }
 
-bool StatefulWriter::wait_for_all_acked(const Duration_t& max_wait)
+bool StatefulWriter::wait_for_all_acked(
+        const Duration_t& max_wait)
 {
     std::unique_lock<RecursiveTimedMutex> lock(mp_mutex);
     std::unique_lock<std::mutex> all_acked_lock(all_acked_mutex_);
 
     all_acked_ = std::none_of(matched_readers_.begin(), matched_readers_.end(),
-        [](const ReaderProxy* reader)
-        {
-            return reader->has_changes();
-        });
+                    [](const ReaderProxy* reader)
+    {
+        return reader->has_changes();
+    });
     lock.unlock();
 
-    if(!all_acked_)
+    if (!all_acked_)
     {
         std::chrono::microseconds max_w(::TimeConv::Duration_t2MicroSecondsInt64(max_wait));
-        all_acked_cond_.wait_for(all_acked_lock, max_w, [&]() { return all_acked_; });
+        all_acked_cond_.wait_for(all_acked_lock, max_w, [&]() {
+            return all_acked_;
+        });
     }
 
     return all_acked_;
@@ -904,41 +931,41 @@ void StatefulWriter::check_acked_status()
     bool has_min_low_mark = false;
     SequenceNumber_t min_low_mark;
 
-    for(const ReaderProxy* it : matched_readers_)
+    for (const ReaderProxy* it : matched_readers_)
     {
         SequenceNumber_t reader_low_mark = it->changes_low_mark();
-        if(reader_low_mark < min_low_mark || !has_min_low_mark)
+        if (reader_low_mark < min_low_mark || !has_min_low_mark)
         {
             has_min_low_mark = true;
             min_low_mark = reader_low_mark;
         }
 
-        if(it->has_changes())
+        if (it->has_changes())
         {
             all_acked = false;
         }
     }
 
-    if(get_seq_num_min() != SequenceNumber_t::unknown())
+    if (get_seq_num_min() != SequenceNumber_t::unknown())
     {
         // Inform of samples acked.
-        if(mp_listener != nullptr)
+        if (mp_listener != nullptr)
         {
             // In the case where we haven't received an acknack from a recently matched reader,
             // min_low_mark will be zero, and no change will be notified as received by all
             SequenceNumber_t current_seq;
-            for(current_seq = next_all_acked_notify_sequence_; current_seq <= min_low_mark; ++current_seq)
+            for (current_seq = next_all_acked_notify_sequence_; current_seq <= min_low_mark; ++current_seq)
             {
                 std::vector<CacheChange_t*>::iterator history_end = mp_history->changesEnd();
                 std::vector<CacheChange_t*>::iterator cit =
-                    std::lower_bound(mp_history->changesBegin(), history_end, current_seq,
-                        [](
-                                const CacheChange_t* change,
-                                const SequenceNumber_t& seq)
-                        {
-                            return change->sequenceNumber < seq;
-                        });
-                if(cit != history_end && (*cit)->sequenceNumber == current_seq)
+                        std::lower_bound(mp_history->changesBegin(), history_end, current_seq,
+                                [](
+                                    const CacheChange_t* change,
+                                    const SequenceNumber_t& seq)
+                {
+                    return change->sequenceNumber < seq;
+                });
+                if (cit != history_end && (*cit)->sequenceNumber == current_seq)
                 {
                     mp_listener->onWriterChangeReceivedByAll(this, *cit);
                 }
@@ -956,7 +983,7 @@ void StatefulWriter::check_acked_status()
         }
     }
 
-    if(all_acked)
+    if (all_acked)
     {
         std::unique_lock<std::mutex> all_acked_lock(all_acked_mutex_);
         all_acked_ = true;
@@ -985,24 +1012,26 @@ bool StatefulWriter::try_remove_change(
     }
 
     SequenceNumber_t calc = min_low_mark < get_seq_num_min() ? SequenceNumber_t() :
-        (min_low_mark - get_seq_num_min()) + 1;
+            (min_low_mark - get_seq_num_min()) + 1;
     unsigned int may_remove_change = 1;
 
-    if(calc <= SequenceNumber_t())
+    if (calc <= SequenceNumber_t())
     {
         may_remove_change_ = 0;
         may_remove_change_cond_.wait_until(lock, max_blocking_time_point,
-                [&]() { return may_remove_change_ > 0; });
+                [&]() {
+            return may_remove_change_ > 0;
+        });
         may_remove_change = may_remove_change_;
     }
 
     // Some changes acked
-    if(may_remove_change == 1)
+    if (may_remove_change == 1)
     {
         return mp_history->remove_min_change();
     }
     // Waiting a change was removed.
-    else if(may_remove_change == 2)
+    else if (may_remove_change == 2)
     {
         return true;
     }
@@ -1013,26 +1042,28 @@ bool StatefulWriter::try_remove_change(
 /*
  * PARAMETER_RELATED METHODS
  */
-void StatefulWriter::updateAttributes(const WriterAttributes& att)
+void StatefulWriter::updateAttributes(
+        const WriterAttributes& att)
 {
     this->updateTimes(att.times);
 }
 
-void StatefulWriter::updateTimes(const WriterTimes& times)
+void StatefulWriter::updateTimes(
+        const WriterTimes& times)
 {
     std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
-    if(m_times.heartbeatPeriod != times.heartbeatPeriod)
+    if (m_times.heartbeatPeriod != times.heartbeatPeriod)
     {
         periodic_hb_event_->update_interval(times.heartbeatPeriod);
     }
-    if(m_times.nackResponseDelay != times.nackResponseDelay)
+    if (m_times.nackResponseDelay != times.nackResponseDelay)
     {
-        if(nack_response_event_ != nullptr)
+        if (nack_response_event_ != nullptr)
         {
             nack_response_event_->update_interval(times.nackResponseDelay);
         }
     }
-    if(m_times.nackSupressionDuration != times.nackSupressionDuration)
+    if (m_times.nackSupressionDuration != times.nackSupressionDuration)
     {
         for (ReaderProxy* it : matched_readers_)
         {
@@ -1046,7 +1077,8 @@ void StatefulWriter::updateTimes(const WriterTimes& times)
     m_times = times;
 }
 
-void StatefulWriter::add_flow_controller(std::unique_ptr<FlowController> controller)
+void StatefulWriter::add_flow_controller(
+        std::unique_ptr<FlowController> controller)
 {
     m_controllers.push_back(std::move(controller));
 }
@@ -1090,10 +1122,10 @@ bool StatefulWriter::send_periodic_heartbeat(
             assert(firstSeq <= lastSeq);
 
             unacked_changes = std::any_of(matched_readers_.begin(), matched_readers_.end(),
-                [](const ReaderProxy* reader)
-                {
-                    return reader->has_unacknowledged();
-                });
+                            [](const ReaderProxy* reader)
+            {
+                return reader->has_unacknowledged();
+            });
 
             if (unacked_changes)
             {
@@ -1102,7 +1134,7 @@ bool StatefulWriter::send_periodic_heartbeat(
                     RTPSMessageGroup group(mp_RTPSParticipant, this, *this);
                     send_heartbeat_nts_(all_remote_readers_.size(), group, disable_positive_acks_, liveliness);
                 }
-                catch(const RTPSMessageGroup::timeout&)
+                catch (const RTPSMessageGroup::timeout&)
                 {
                     logError(RTPS_WRITER, "Max blocking time reached");
                 }
@@ -1117,7 +1149,7 @@ bool StatefulWriter::send_periodic_heartbeat(
             RTPSMessageGroup group(mp_RTPSParticipant, this, *this);
             send_heartbeat_nts_(all_remote_readers_.size(), group, final, liveliness);
         }
-        catch(const RTPSMessageGroup::timeout&)
+        catch (const RTPSMessageGroup::timeout&)
         {
             logError(RTPS_WRITER, "Max blocking time reached");
         }
@@ -1135,7 +1167,7 @@ void StatefulWriter::send_heartbeat_to_nts(
         RTPSMessageGroup group(mp_RTPSParticipant, this, remoteReaderProxy.message_sender());
         send_heartbeat_nts_(1u, group, disable_positive_acks_, liveliness);
     }
-    catch(const RTPSMessageGroup::timeout&)
+    catch (const RTPSMessageGroup::timeout&)
     {
         logError(RTPS_WRITER, "Max blocking time reached");
     }
@@ -1155,7 +1187,7 @@ void StatefulWriter::send_heartbeat_nts_(
     {
         assert(firstSeq == c_SequenceNumber_Unknown && lastSeq == c_SequenceNumber_Unknown);
 
-        if(number_of_readers == 1 || liveliness)
+        if (number_of_readers == 1 || liveliness)
         {
             firstSeq = next_sequence_number();
             lastSeq = firstSeq - 1;
@@ -1232,7 +1264,8 @@ void StatefulWriter::perform_nack_response()
     }
 }
 
-void StatefulWriter::perform_nack_supression(const GUID_t& reader_guid)
+void StatefulWriter::perform_nack_supression(
+        const GUID_t& reader_guid)
 {
     std::unique_lock<RecursiveTimedMutex> lock(mp_mutex);
 
@@ -1253,7 +1286,7 @@ bool StatefulWriter::process_acknack(
         uint32_t ack_count,
         const SequenceNumberSet_t& sn_set,
         bool final_flag,
-        bool &result)
+        bool& result)
 {
     std::unique_lock<RecursiveTimedMutex> lock(mp_mutex);
     result = (m_guid == writer_guid);
@@ -1341,7 +1374,7 @@ bool StatefulWriter::ack_timer_expired()
 
     while (interval.count() < 0)
     {
-        for(ReaderProxy* remote_reader : matched_readers_)
+        for (ReaderProxy* remote_reader : matched_readers_)
         {
             if (remote_reader->reader_attributes().disable_positive_acks())
             {

--- a/test/blackbox/BlackboxTestsPubSubBasic.cpp
+++ b/test/blackbox/BlackboxTestsPubSubBasic.cpp
@@ -60,8 +60,8 @@ TEST(BlackBox, AsyncPubSubAsNonReliableHelloworld)
     ASSERT_TRUE(reader.isInitialized());
 
     writer.history_depth(100).
-        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-        asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).init();
+    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+    asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -86,7 +86,7 @@ TEST(BlackBox, PubSubAsReliableHelloworld)
     PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
 
     reader.history_depth(100).
-        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
+    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -117,12 +117,12 @@ TEST(BlackBox, AsyncPubSubAsReliableHelloworld)
     PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
 
     reader.history_depth(100).
-        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
+    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
     writer.history_depth(100).
-        asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).init();
+    asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -173,7 +173,7 @@ TEST(BlackBox, PubSubAsReliableData64kb)
     PubSubWriter<Data64kbType> writer(TEST_TOPIC_NAME);
 
     reader.history_depth(10).
-        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
+    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -203,7 +203,7 @@ TEST(BlackBox, PubSubMoreThan256Unacknowledged)
     PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
 
     writer.history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
-        durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS).init();
+    durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -216,8 +216,8 @@ TEST(BlackBox, PubSubMoreThan256Unacknowledged)
     PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
 
     reader.reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-        history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
-        durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS).init();
+    history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
+    durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -231,13 +231,13 @@ TEST(BlackBox, PubSubAsReliableHelloworldMulticastDisabled)
     PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
 
     reader.history_depth(100).
-        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-        disable_multicast(0).init();
+    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+    disable_multicast(0).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
     writer.history_depth(100).
-        disable_multicast(1).init();
+    disable_multicast(1).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -258,3 +258,63 @@ TEST(BlackBox, PubSubAsReliableHelloworldMulticastDisabled)
     reader.block_for_all();
 }
 
+TEST(BlackBox, PubSubAsMixHelloworld)
+{
+    PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+
+    reader.history_depth(100).init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer.history_depth(100).init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Because its volatile the durability
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    auto data = default_helloworld_data_generator();
+
+    reader.startReception(data);
+
+    // Send data
+    writer.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+    // Block reader until reception finished or timeout.
+    reader.block_for_at_least(4);
+}
+
+TEST(BlackBox, AsyncPubSubAsMixHelloworld)
+{
+    PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+
+    reader.history_depth(100).init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer.history_depth(100).
+    asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Because its volatile the durability
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    auto data = default_helloworld_data_generator();
+
+    reader.startReception(data);
+
+    // Send data
+    writer.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+    // Block reader until reception finished or timeout.
+    reader.block_for_at_least(4);
+}


### PR DESCRIPTION
Due to `ReaderProxy::set_change_to_status` can modify `ReaderProxy::changes_for_reader_`, in a future could be a bug using this function inside `ReaderProxy::for_each_unsent_change`. This PR tries to avoid this.