### PR TITLE
Remove unnecessary copy

### DIFF
--- a/src/cpp/fastrtps_deprecated/types/TypeObjectFactory.cpp
+++ b/src/cpp/fastrtps_deprecated/types/TypeObjectFactory.cpp
@@ -2073,7 +2073,7 @@ void TypeObjectFactory::apply_type_annotations(
         AnnotationDescriptor anno_desc;
         anno_desc.set_type(build_dynamic_type(get_type_name(anno_id), anno_id, get_type_object(anno_id)));
         const AppliedAnnotationParameterSeq& anno_params = annotation.param_seq();
-        for (const AppliedAnnotationParameter a_param : anno_params)
+        for (const AppliedAnnotationParameter& a_param : anno_params)
         {
             std::string param_key = get_key_from_hash(anno_desc.type(), a_param.paramname_hash());
             anno_desc.set_value(param_key, a_param.value().to_string());
@@ -2098,7 +2098,7 @@ void TypeObjectFactory::apply_member_annotations(
         AnnotationDescriptor anno_desc;
         anno_desc.set_type(build_dynamic_type(get_type_name(anno_id), anno_id, get_type_object(anno_id)));
         const AppliedAnnotationParameterSeq& anno_params = annotation.param_seq();
-        for (const AppliedAnnotationParameter a_param : anno_params)
+        for (const AppliedAnnotationParameter& a_param : anno_params)
         {
             std::string param_key = get_key_from_hash(anno_desc.type(), a_param.paramname_hash());
             anno_desc.set_value(param_key, a_param.value().to_string());


### PR DESCRIPTION
Fix warning under Clang:
```
--- stderr: fastrtps                                             
/opt/ros/master/src/eProsima/Fast-RTPS/src/cpp/types/TypeObjectFactory.cpp:1235:47: warning: loop variable 'a_param' of type 'const eprosima::fastrtps::types::AppliedAnnotationParameter' creates a copy from type 'const eprosima::fastrtps::types::AppliedAnnotationParameter' [-Wrange-loop-construct]
        for (const AppliedAnnotationParameter a_param : anno_params)
                                              ^
/opt/ros/master/src/eProsima/Fast-RTPS/src/cpp/types/TypeObjectFactory.cpp:1235:14: note: use reference type 'const eprosima::fastrtps::types::AppliedAnnotationParameter &' to prevent copying
        for (const AppliedAnnotationParameter a_param : anno_params)
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                              &
/opt/ros/master/src/eProsima/Fast-RTPS/src/cpp/types/TypeObjectFactory.cpp:1260:47: warning: loop variable 'a_param' of type 'const eprosima::fastrtps::types::AppliedAnnotationParameter' creates a copy from type 'const eprosima::fastrtps::types::AppliedAnnotationParameter' [-Wrange-loop-construct]
        for (const AppliedAnnotationParameter a_param : anno_params)
                                              ^
/opt/ros/master/src/eProsima/Fast-RTPS/src/cpp/types/TypeObjectFactory.cpp:1260:14: note: use reference type 'const eprosima::fastrtps::types::AppliedAnnotationParameter &' to prevent copying
        for (const AppliedAnnotationParameter a_param : anno_params)
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                              &
2 warnings generated.
---
```