### PR TITLE
DomainParticipant listener methods

### DIFF
--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -748,7 +748,7 @@ public:                                                                         
          * @param data data to copy in the newly created object \
          */                                                                            \
         RTPS_DllAPI TClassName(                                                            \
-            const TClassName& data) = default;                                         \
+            const TClassName &data) = default;                                         \
                                                                                        \
         /** \
          * Construct from underlying collection type. \
@@ -759,7 +759,7 @@ public:                                                                         
          * @param data data to copy in the newly created object \
          */                                                                            \
         RTPS_DllAPI TClassName(                                                            \
-            const collection_type& data)                                               \
+            const collection_type &data)                                               \
             : GenericDataQosPolicy(TPid, data)                                             \
         {                                                                                  \
         }                                                                                  \
@@ -776,7 +776,7 @@ public:                                                                         
          * @return reference to the current object. \
          */                                                                            \
         TClassName& operator =(                                                            \
-            const TClassName& b) = default;                                            \
+            const TClassName &b) = default;                                            \
                                                                                        \
     };
 

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -105,13 +105,14 @@ public:
      * @return true if the listener was updated.
      */
     RTPS_DllAPI ReturnCode_t set_listener(
-            DomainParticipantListener* listener);
+            DomainParticipantListener* listener,
+            const StatusMask& mask = StatusMask::all());
 
     /**
      * Allows accessing the DomainParticipantListener.
      * @return DomainParticipantListener
      */
-    RTPS_DllAPI const DomainParticipantListener* get_listener() const;
+    RTPS_DllAPI DomainParticipantListener* get_listener() const;
 
     /**
      * Create a Publisher in this Participant.

--- a/include/fastdds/dds/domain/DomainParticipantListener.hpp
+++ b/include/fastdds/dds/domain/DomainParticipantListener.hpp
@@ -42,9 +42,13 @@ class DomainParticipantListener
 {
 public:
 
-    DomainParticipantListener() {}
+    DomainParticipantListener()
+    {
+    }
 
-    virtual ~DomainParticipantListener() {}
+    virtual ~DomainParticipantListener()
+    {
+    }
 
     /*!
      * This method is called when a new Participant is discovered, or a previously discovered participant changes
@@ -60,12 +64,13 @@ public:
     }
 
 #if HAVE_SECURITY
-    virtual void onParticipantAuthentication(
+    virtual void on_participant_authentication(
             DomainParticipant* participant,
             fastrtps::rtps::ParticipantAuthenticationInfo&& info)
     {
         (void)participant, (void)info;
     }
+
 #endif
 
     /*!

--- a/src/cpp/dds/domain/DomainParticipant.cpp
+++ b/src/cpp/dds/domain/DomainParticipant.cpp
@@ -58,17 +58,18 @@ DomainParticipant::~DomainParticipant()
 {
 }
 
-//void DomainParticipant::listener(
-//        Listener* /*listener*/,
-//        const ::dds::core::status::StatusMask& /*event_mask*/)
-//{
-//    this->delegate()->set_listener(listener /*, event_mask*/);
-//}
 
-//typename DomainParticipant::Listener* DomainParticipant::listener() const
-//{
-//    return dynamic_cast<Listener*>(this->delegate()->get_listener());
-//}
+void DomainParticipant::listener(
+        Listener* listener,
+        const ::dds::core::status::StatusMask& event_mask)
+{
+    this->delegate()->set_listener(listener, event_mask);
+}
+
+typename DomainParticipant::Listener* DomainParticipant::listener() const
+{
+    return dynamic_cast<Listener*>(this->delegate()->get_listener());
+}
 
 const dds::domain::qos::DomainParticipantQos& DomainParticipant::qos() const
 {

--- a/src/cpp/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipant.cpp
@@ -63,12 +63,14 @@ const DomainParticipantQos& DomainParticipant::get_qos() const
 }
 
 ReturnCode_t DomainParticipant::set_listener(
-        DomainParticipantListener* listener)
+        DomainParticipantListener* listener,
+        const StatusMask& mask)
 {
+    status_mask_ = mask;
     return impl_->set_listener(listener);
 }
 
-const DomainParticipantListener* DomainParticipant::get_listener() const
+DomainParticipantListener* DomainParticipant::get_listener() const
 {
     return impl_->get_listener();
 }

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -673,7 +673,7 @@ TopicDescription* DomainParticipantImpl::lookup_topicdescription(
         const std::string& topic_name) const
 {
     auto it = topics_.find(topic_name);
-    
+
     if (it != topics_.end())
     {
         return it->second->user_topic_;
@@ -836,7 +836,7 @@ void DomainParticipantImpl::MyRTPSParticipantListener::onParticipantAuthenticati
 {
     if (participant_ != nullptr && participant_->listener_ != nullptr)
     {
-        participant_->listener_->onParticipantAuthentication(participant_->participant_, std::move(info));
+        participant_->listener_->on_participant_authentication(participant_->participant_, std::move(info));
     }
 }
 

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -98,7 +98,7 @@ public:
         return ReturnCode_t::RETCODE_OK;
     }
 
-    const DomainParticipantListener* get_listener() const
+    DomainParticipantListener* get_listener() const
     {
         return listener_;
     }

--- a/test/dds/communication/Publisher.cpp
+++ b/test/dds/communication/Publisher.cpp
@@ -94,7 +94,7 @@ public:
     }
 
 #if HAVE_SECURITY
-    void onParticipantAuthentication(
+    void on_participant_authentication(
             DomainParticipant* participant,
             rtps::ParticipantAuthenticationInfo&& info) override
     {

--- a/test/dds/communication/Subscriber.cpp
+++ b/test/dds/communication/Subscriber.cpp
@@ -150,7 +150,7 @@ public:
     }
 
 #if HAVE_SECURITY
-    void onParticipantAuthentication(
+    void on_participant_authentication(
             DomainParticipant* /*participant*/,
             rtps::ParticipantAuthenticationInfo&& info) override
     {

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -211,6 +211,19 @@ TEST(ParticipantTests, ChangePSMDomainParticipantQos)
 
 }
 
+TEST(ParticipantTests, DomainParticipantListenerMethods)
+{
+    DomainParticipant* participant = DomainParticipantFactory::get_instance()->create_participant(0);
+
+    ASSERT_EQ(participant->get_listener(), nullptr);
+
+    DomainParticipantListener* listener;
+    participant->set_listener(listener);
+
+    ASSERT_EQ(listener, participant->get_listener());
+
+}
+
 TEST(ParticipantTests, CreatePublisher)
 {
     DomainParticipant* participant = DomainParticipantFactory::get_instance()->create_participant(0);

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -220,7 +220,7 @@ TEST(ParticipantTests, DomainParticipantListenerMethods)
 
     ASSERT_EQ(participant->get_listener(), nullptr);
 
-    DomainParticipantListener listener = DomainParticipantListener();
+    DomainParticipantListener listener;
     participant->set_listener(&listener);
 
     ASSERT_EQ(&listener, participant->get_listener());
@@ -233,7 +233,7 @@ TEST(ParticipantTests, DomainParticipantPSMListenerMethods)
 
     ASSERT_EQ(participant.listener(), nullptr);
 
-    ::dds::domain::DomainParticipantListener listener = ::dds::domain::DomainParticipantListener();
+    ::dds::domain::DomainParticipantListener listener;
     participant.listener(&listener, ::dds::core::status::StatusMask::all());
 
     ASSERT_EQ(&listener, participant.listener());

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -220,10 +220,10 @@ TEST(ParticipantTests, DomainParticipantListenerMethods)
 
     ASSERT_EQ(participant->get_listener(), nullptr);
 
-    DomainParticipantListener* listener;
-    participant->set_listener(listener);
+    DomainParticipantListener listener = DomainParticipantListener();
+    participant->set_listener(&listener);
 
-    ASSERT_EQ(listener, participant->get_listener());
+    ASSERT_EQ(&listener, participant->get_listener());
 
 }
 
@@ -233,10 +233,10 @@ TEST(ParticipantTests, DomainParticipantPSMListenerMethods)
 
     ASSERT_EQ(participant.listener(), nullptr);
 
-    ::dds::domain::DomainParticipantListener* listener;
-    participant.listener(listener, ::dds::core::status::StatusMask::all());
+    ::dds::domain::DomainParticipantListener listener = ::dds::domain::DomainParticipantListener();
+    participant.listener(&listener, ::dds::core::status::StatusMask::all());
 
-    ASSERT_EQ(listener, participant.listener());
+    ASSERT_EQ(&listener, participant.listener());
 
 }
 

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -16,6 +16,8 @@
 #include <gtest/gtest.h>
 
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
+#include <fastdds/dds/domain/DomainParticipant.hpp>
+#include <fastdds/dds/domain/DomainParticipantListener.hpp>
 #include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
 #include <fastdds/dds/publisher/Publisher.hpp>
 #include <fastdds/dds/publisher/qos/PublisherQos.hpp>
@@ -23,6 +25,7 @@
 #include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
 #include <fastdds/dds/topic/qos/TopicQos.hpp>
 #include <dds/domain/DomainParticipant.hpp>
+#include <dds/domain/DomainParticipantListener.hpp>
 #include <dds/domain/qos/DomainParticipantQos.hpp>
 #include <dds/pub/qos/PublisherQos.hpp>
 #include <dds/sub/qos/SubscriberQos.hpp>
@@ -221,6 +224,19 @@ TEST(ParticipantTests, DomainParticipantListenerMethods)
     participant->set_listener(listener);
 
     ASSERT_EQ(listener, participant->get_listener());
+
+}
+
+TEST(ParticipantTests, DomainParticipantPSMListenerMethods)
+{
+    ::dds::domain::DomainParticipant participant = ::dds::domain::DomainParticipant(0, PARTICIPANT_QOS_DEFAULT);
+
+    ASSERT_EQ(participant.listener(), nullptr);
+
+    ::dds::domain::DomainParticipantListener* listener;
+    participant.listener(listener, ::dds::core::status::StatusMask::all());
+
+    ASSERT_EQ(listener, participant.listener());
 
 }
 


### PR DESCRIPTION
* set_listener and get_listener adapted to follow the DDS Standard
* New unit test to check PIM functionality
* PSM listener methods implementation
* Add unit test to check PSM functionality

NOTE: This PR ,ust be merged after #1073 
