### PR TITLE
reduce ubsan warnings

### DIFF
--- a/include/fastdds/rtps/common/SerializedPayload.h
+++ b/include/fastdds/rtps/common/SerializedPayload.h
@@ -101,6 +101,9 @@ struct RTPS_DllAPI SerializedPayload_t
             bool with_limit = true)
     {
         length = serData->length;
+        if (length == 0) {
+            return true;
+        }
 
         if (serData->length > max_size)
         {

--- a/test/dds/communication/Publisher.cpp
+++ b/test/dds/communication/Publisher.cpp
@@ -252,7 +252,12 @@ int main(
         return 1;
     }
 
-    types::DynamicType_ptr dyn_type = xmlparser::XMLProfileManager::getDynamicTypeByName("TypeLookup")->build();
+    const xmlparser::p_dynamictypebuilder_t dynamic_type_builder = xmlparser::XMLProfileManager::getDynamicTypeByName("TypeLookup");
+    if (dynamic_type_builder == nullptr) {
+        std::cout << "Please run in the same CWD as the program" << std::endl;
+        return 1;
+    }
+    types::DynamicType_ptr dyn_type = dynamic_type_builder->build();
     TypeSupport type(new types::DynamicPubSubType(dyn_type));
     type.register_type(participant);
 


### PR DESCRIPTION
# Description
I tested DDSSimpleCommunicationPublisher and DDSSimpleCommunicationSubscriber with `-fsanitize=` for address, memory, thread and undefined on gcc 9.2.1. Undefined brought up an issue with calling memcpy with nullptr in include/fastdds/rtps/common/SerializedPayload.h. Next, there was an issue with dereferencing a nullptr, if you run `test/dds/communication/DDSSimpleCommunicationPublisher` from the build directory.

# Lingering issues
There's still some issues I think they are both are related to the new shared memory implementation.

## Running DDSSimpleCommunicationPublisher outside of the working directory
If you run `test/dds/communication/DDSSimpleCommunicationPublisher` with these changes, you still get: https://gist.github.com/geoffviola/dcb8831480478e7187105bd2d9807ea3

## Running with the thread sanitizer
Running `./DDSSimpleCommunicationSubscriber` yields the following error with tsan turned on: https://gist.github.com/geoffviola/4ad64aec7ed2d60b99c6f59ecb3ffb0d