### PR TITLE
OSRF testing patches

### DIFF
--- a/include/fastrtps/qos/ParameterTypes.h
+++ b/include/fastrtps/qos/ParameterTypes.h
@@ -147,11 +147,13 @@ public:
     {
     }
 
+    Parameter_t& operator =(
+            const Parameter_t& p) = default;
+
     bool operator ==(
             const Parameter_t& b) const
     {
-        return (this->Pid == b.Pid) &&
-               (this->length == b.length);
+        return Pid == b.Pid && length == b.length;
     }
 
     /**
@@ -807,6 +809,12 @@ public:
     {
         properties.assign(parameter_properties.properties.begin(), parameter_properties.properties.end());
     }
+
+    ParameterPropertyList_t& operator =(
+            const ParameterPropertyList_t& pl) = default;
+
+    ParameterPropertyList_t& operator =(
+            ParameterPropertyList_t&& pl) = default;
 
     /**
      * Add the parameter to a CDRMessage_t message.

--- a/include/fastrtps/qos/ParameterTypes.h
+++ b/include/fastrtps/qos/ParameterTypes.h
@@ -665,6 +665,65 @@ class ParameterEndpointSecurityInfo_t : public Parameter_t
 
 #endif
 
+template<class T, class PL>
+void set_proxy_property(const T& p, const char* PID, PL& properties)
+{
+    // only valid values
+    if (p == T::unknown())
+    {
+        return;
+    }
+
+    // generate pair
+    std::pair<std::string, std::string> pair;
+    pair.first = PID;
+
+    std::ostringstream data;
+    data << p;
+    pair.second = data.str();
+
+    // if exists replace
+    auto it = std::find_if(
+        properties.begin(),
+        properties.end(),
+        [&pair](const std::pair<std::string, std::string> & p)
+                {
+                    return pair.first == p.first;
+                });
+
+    if (it != properties.end())
+    {
+        *it = std::move(pair);
+    }
+    else
+    {
+        // if not exists add
+        properties.push_back(std::move(pair));
+    }
+}
+
+template<class T, class PL>
+T get_proxy_property(const char* const PID, PL& properties)
+{
+    T property;
+
+    auto it = std::find_if(
+        properties.begin(),
+        properties.end(),
+        [PID](const std::pair<std::string, std::string>& p)
+                {
+                    return PID == p.first;
+                });
+
+    if (it != properties.end())
+    {
+        std::istringstream in(it->second);
+        in >> property;
+    }
+
+    return property;
+}
+
 ///@}
 
 #endif

--- a/include/fastrtps/qos/ParameterTypes.h
+++ b/include/fastrtps/qos/ParameterTypes.h
@@ -14,7 +14,7 @@
 
 /**
  * @file ParameterTypes.h
-*/
+ */
 
 #ifndef PARAMETERTYPES_H_
 #define PARAMETERTYPES_H_
@@ -27,7 +27,7 @@
 #if HAVE_SECURITY
 #include "../rtps/security/accesscontrol/ParticipantSecurityAttributes.h"
 #include "../rtps/security/accesscontrol/EndpointSecurityAttributes.h"
-#endif
+#endif // if HAVE_SECURITY
 
 #include <string>
 #include <vector>
@@ -35,9 +35,9 @@
 namespace eprosima {
 namespace fastrtps {
 
-namespace rtps{
+namespace rtps {
 struct CDRMessage_t;
-}
+} // namespace rtps
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
@@ -46,7 +46,7 @@ struct CDRMessage_t;
  * @{
  */
 
-enum ParameterId_t	: uint16_t
+enum ParameterId_t : uint16_t
 {
     PID_PAD = 0x0000,
     PID_SENTINEL = 0x0001,
@@ -124,18 +124,31 @@ class Parameter_t
 {
 public:
 
-    RTPS_DllAPI Parameter_t() : Pid(PID_PAD), length(0) { }
+    RTPS_DllAPI Parameter_t()
+        : Pid(PID_PAD)
+        , length(0)
+    {
+    }
 
     /**
      * Constructor using a parameter PID and the parameter length
      * @param pid Pid of the parameter
      * @param length Its associated length
      */
-    RTPS_DllAPI Parameter_t(ParameterId_t pid,uint16_t length) : Pid(pid), length(length) {}
+    RTPS_DllAPI Parameter_t(
+            ParameterId_t pid,
+            uint16_t length)
+        : Pid(pid)
+        , length(length)
+    {
+    }
 
-    virtual RTPS_DllAPI ~Parameter_t() { }
+    virtual RTPS_DllAPI ~Parameter_t()
+    {
+    }
 
-    bool operator==(const Parameter_t& b) const
+    bool operator ==(
+            const Parameter_t& b) const
     {
         return (this->Pid == b.Pid) &&
                (this->length == b.length);
@@ -146,9 +159,11 @@ public:
      * @param[in,out] msg Pointer to the message where the parameter should be added.
      * @return True if the parameter was correctly added.
      */
-    RTPS_DllAPI virtual bool addToCDRMessage(rtps::CDRMessage_t* msg) = 0;
+    RTPS_DllAPI virtual bool addToCDRMessage(
+            rtps::CDRMessage_t* msg) = 0;
 
 public:
+
     //!Parameter ID
     ParameterId_t Pid;
     //!Parameter length
@@ -158,64 +173,86 @@ public:
 /**
  *@ingroup PARAMETER_MODULE
  */
-class ParameterKey_t:public Parameter_t{
-    public:
-        rtps::InstanceHandle_t key;
-        ParameterKey_t(){};
-        /**
-         * Constructor using a parameter PID and the parameter length
-         * @param pid Pid of the parameter
-         * @param in_length Its associated length
-         */
-        ParameterKey_t(ParameterId_t pid,uint16_t in_length):Parameter_t(pid,in_length){};
-        ParameterKey_t(ParameterId_t pid,uint16_t in_length,rtps::InstanceHandle_t& ke):Parameter_t(pid,in_length),key(ke){};
-        /**
-         * Add the parameter to a CDRMessage_t message.
-         * @param[in,out] msg Pointer to the message where the parameter should be added.
-         * @return True if the parameter was correctly added.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+class ParameterKey_t : public Parameter_t
+{
+public:
+
+    rtps::InstanceHandle_t key;
+    ParameterKey_t()
+    {
+    }
+
+    /**
+     * Constructor using a parameter PID and the parameter length
+     * @param pid Pid of the parameter
+     * @param in_length Its associated length
+     */
+    ParameterKey_t(
+            ParameterId_t pid,
+            uint16_t in_length)
+        : Parameter_t(pid, in_length)
+    {
+    }
+
+    ParameterKey_t(
+            ParameterId_t pid,
+            uint16_t in_length,
+            rtps::InstanceHandle_t& ke)
+        : Parameter_t(pid, in_length)
+        , key(ke)
+    {
+    }
+
+    /**
+     * Add the parameter to a CDRMessage_t message.
+     * @param[in,out] msg Pointer to the message where the parameter should be added.
+     * @return True if the parameter was correctly added.
+     */
+    bool addToCDRMessage(
+            rtps::CDRMessage_t* msg) override;
 };
 
 /**
  *
  */
-class ParameterLocator_t: public Parameter_t
+class ParameterLocator_t : public Parameter_t
 {
-    public:
-        rtps::Locator_t locator;
+public:
 
-        ParameterLocator_t()
-        {
-        }
+    rtps::Locator_t locator;
 
-        /**
-         * Constructor using a parameter PID and the parameter length
-         * @param pid Pid of the parameter
-         * @param in_length Its associated length
-         */
-        ParameterLocator_t(
-                ParameterId_t pid,
-                uint16_t in_length)
-            : Parameter_t(pid,in_length)
-        {
-        }
+    ParameterLocator_t()
+    {
+    }
 
-        ParameterLocator_t(
-                ParameterId_t pid,
-                uint16_t in_length,
-                const rtps::Locator_t& loc)
-            : Parameter_t(pid,in_length)
-            , locator(loc)
-        {
-        }
+    /**
+     * Constructor using a parameter PID and the parameter length
+     * @param pid Pid of the parameter
+     * @param in_length Its associated length
+     */
+    ParameterLocator_t(
+            ParameterId_t pid,
+            uint16_t in_length)
+        : Parameter_t(pid, in_length)
+    {
+    }
 
-        /**
-         * Add the parameter to a CDRMessage_t message.
-         * @param[in,out] msg Pointer to the message where the parameter should be added.
-         * @return True if the parameter was correctly added.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+    ParameterLocator_t(
+            ParameterId_t pid,
+            uint16_t in_length,
+            const rtps::Locator_t& loc)
+        : Parameter_t(pid, in_length)
+        , locator(loc)
+    {
+    }
+
+    /**
+     * Add the parameter to a CDRMessage_t message.
+     * @param[in,out] msg Pointer to the message where the parameter should be added.
+     * @return True if the parameter was correctly added.
+     */
+    bool addToCDRMessage(
+            rtps::CDRMessage_t* msg) override;
 };
 #define PARAMETER_LOCATOR_LENGTH 24
 
@@ -223,50 +260,100 @@ class ParameterLocator_t: public Parameter_t
 /**
  *
  */
-class ParameterString_t: public Parameter_t
+class ParameterString_t : public Parameter_t
 {
-    public:
-        ParameterString_t(){};
-        /**
-         * Constructor using a parameter PID and the parameter length
-         * @param pid Pid of the parameter
-         * @param in_length Its associated length
-         */
-        ParameterString_t(ParameterId_t pid,uint16_t in_length):Parameter_t(pid,in_length){};
-        ParameterString_t(ParameterId_t pid,uint16_t in_length,const string_255& strin):Parameter_t(pid,in_length),m_string(strin){}
+public:
 
-        /**
-         * Add the parameter to a CDRMessage_t message.
-         * @param[in,out] msg Pointer to the message where the parameter should be added.
-         * @return True if the parameter was correctly added.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
-        inline const char* getName()const { return m_string.c_str(); };
-        inline void setName(const char* name){ m_string = name; };
-    private:
-        string_255 m_string;
+    ParameterString_t()
+    {
+    }
+
+    /**
+     * Constructor using a parameter PID and the parameter length
+     * @param pid Pid of the parameter
+     * @param in_length Its associated length
+     */
+    ParameterString_t(
+            ParameterId_t pid,
+            uint16_t in_length)
+        : Parameter_t(pid, in_length)
+    {
+    }
+
+    ParameterString_t(
+            ParameterId_t pid,
+            uint16_t in_length,
+            const string_255& strin)
+        : Parameter_t(pid, in_length)
+        , m_string(strin)
+    {
+    }
+
+    /**
+     * Add the parameter to a CDRMessage_t message.
+     * @param[in,out] msg Pointer to the message where the parameter should be added.
+     * @return True if the parameter was correctly added.
+     */
+    bool addToCDRMessage(
+            rtps::CDRMessage_t* msg) override;
+    inline const char* getName()const
+    {
+        return m_string.c_str();
+    }
+
+    inline void setName(
+            const char* name)
+    {
+        m_string = name;
+    }
+
+private:
+
+    string_255 m_string;
 };
 
 /**
  *
  */
-class ParameterPort_t: public Parameter_t {
-    public:
-        uint32_t port;
-        ParameterPort_t():port(0){};
-        /**
-         * Constructor using a parameter PID and the parameter length
-         * @param pid Pid of the parameter
-         * @param in_length Its associated length
-         */
-        ParameterPort_t(ParameterId_t pid,uint16_t in_length):Parameter_t(pid,in_length),port(0){};
-        ParameterPort_t(ParameterId_t pid,uint16_t in_length,uint32_t po):Parameter_t(pid,in_length),port(po){};
-        /**
-         * Add the parameter to a CDRMessage_t message.
-         * @param[in,out] msg Pointer to the message where the parameter should be added.
-         * @return True if the parameter was correctly added.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+class ParameterPort_t : public Parameter_t
+{
+public:
+
+    uint32_t port;
+    ParameterPort_t()
+        : port(0)
+    {
+    }
+
+    /**
+     * Constructor using a parameter PID and the parameter length
+     * @param pid Pid of the parameter
+     * @param in_length Its associated length
+     */
+    ParameterPort_t(
+            ParameterId_t pid,
+            uint16_t in_length)
+        : Parameter_t(pid, in_length)
+        , port(0)
+    {
+    }
+
+    ParameterPort_t(
+            ParameterId_t pid,
+            uint16_t in_length,
+            uint32_t po)
+        : Parameter_t(pid, in_length)
+        , port(po)
+    {
+    }
+
+    /**
+     * Add the parameter to a CDRMessage_t message.
+     * @param[in,out] msg Pointer to the message where the parameter should be added.
+     * @return True if the parameter was correctly added.
+     */
+    bool addToCDRMessage(
+            rtps::CDRMessage_t* msg) override;
 };
 
 #define PARAMETER_PORT_LENGTH 4
@@ -274,33 +361,62 @@ class ParameterPort_t: public Parameter_t {
 /**
  *
  */
-class ParameterGuid_t: public Parameter_t {
-    public:
-        rtps::GUID_t guid;
-        ParameterGuid_t(){};
-        /**
-         * Constructor using a parameter PID and the parameter length
-         * @param pid Pid of the parameter
-         * @param in_length Its associated length
-         */
-        ParameterGuid_t(ParameterId_t pid,uint16_t in_length):Parameter_t(pid,in_length){};
-        ParameterGuid_t(ParameterId_t pid,uint16_t in_length,rtps::GUID_t guidin):Parameter_t(pid,in_length),guid(guidin){};
-        ParameterGuid_t(ParameterId_t pid,uint16_t in_length,rtps::InstanceHandle_t& iH):Parameter_t(pid,in_length)
+class ParameterGuid_t : public Parameter_t
+{
+public:
+
+    rtps::GUID_t guid;
+    ParameterGuid_t()
+    {
+    }
+
+    /**
+     * Constructor using a parameter PID and the parameter length
+     * @param pid Pid of the parameter
+     * @param in_length Its associated length
+     */
+    ParameterGuid_t(
+            ParameterId_t pid,
+            uint16_t in_length)
+        : Parameter_t(pid, in_length)
+    {
+    }
+
+    ParameterGuid_t(
+            ParameterId_t pid,
+            uint16_t in_length,
+            rtps::GUID_t guidin)
+        : Parameter_t(pid, in_length)
+        , guid(guidin)
+    {
+    }
+
+    ParameterGuid_t(
+            ParameterId_t pid,
+            uint16_t in_length,
+            rtps::InstanceHandle_t& iH)
+        : Parameter_t(pid, in_length)
+    {
+        for (uint8_t i = 0; i < 16; ++i)
         {
-            for(uint8_t i =0;i<16;++i)
+            if (i < 12)
             {
-                if(i<12)
-                    guid.guidPrefix.value[i] = iH.value[i];
-                else
-                    guid.entityId.value[i-12] = iH.value[i];
+                guid.guidPrefix.value[i] = iH.value[i];
             }
-        };
-        /**
-         * Add the parameter to a CDRMessage_t message.
-         * @param[in,out] msg Pointer to the message where the parameter should be added.
-         * @return True if the parameter was correctly added.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+            else
+            {
+                guid.entityId.value[i - 12] = iH.value[i];
+            }
+        }
+    }
+
+    /**
+     * Add the parameter to a CDRMessage_t message.
+     * @param[in,out] msg Pointer to the message where the parameter should be added.
+     * @return True if the parameter was correctly added.
+     */
+    bool addToCDRMessage(
+            rtps::CDRMessage_t* msg) override;
 };
 
 #define PARAMETER_GUID_LENGTH 16
@@ -308,22 +424,36 @@ class ParameterGuid_t: public Parameter_t {
 /**
  *
  */
-class ParameterProtocolVersion_t: public Parameter_t {
-    public:
-        rtps::ProtocolVersion_t protocolVersion;
-        ParameterProtocolVersion_t(){protocolVersion = rtps::c_ProtocolVersion;};
-        /**
-         * Constructor using a parameter PID and the parameter length
-         * @param pid Pid of the parameter
-         * @param in_length Its associated length
-         */
-        ParameterProtocolVersion_t(ParameterId_t pid,uint16_t in_length):Parameter_t(pid,in_length){protocolVersion = rtps::c_ProtocolVersion;};
-        /**
-         * Add the parameter to a CDRMessage_t message.
-         * @param[in,out] msg Pointer to the message where the parameter should be added.
-         * @return True if the parameter was correctly added.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+class ParameterProtocolVersion_t : public Parameter_t
+{
+public:
+
+    rtps::ProtocolVersion_t protocolVersion;
+    ParameterProtocolVersion_t()
+    {
+        protocolVersion = rtps::c_ProtocolVersion;
+    }
+
+    /**
+     * Constructor using a parameter PID and the parameter length
+     * @param pid Pid of the parameter
+     * @param in_length Its associated length
+     */
+    ParameterProtocolVersion_t(
+            ParameterId_t pid,
+            uint16_t in_length)
+        : Parameter_t(pid, in_length)
+    {
+        protocolVersion = rtps::c_ProtocolVersion;
+    }
+
+    /**
+     * Add the parameter to a CDRMessage_t message.
+     * @param[in,out] msg Pointer to the message where the parameter should be added.
+     * @return True if the parameter was correctly added.
+     */
+    bool addToCDRMessage(
+            rtps::CDRMessage_t* msg) override;
 };
 
 #define PARAMETER_PROTOCOL_LENGTH 4
@@ -331,24 +461,36 @@ class ParameterProtocolVersion_t: public Parameter_t {
 /**
  *
  */
-class ParameterVendorId_t:public Parameter_t{
-    public:
-        rtps::VendorId_t vendorId;
-        ParameterVendorId_t() : vendorId(rtps::c_VendorId_eProsima) {}
-        /**
-         * Constructor using a parameter PID and the parameter length
-         * @param pid Pid of the parameter
-         * @param in_length Its associated length
-         */
-        ParameterVendorId_t(ParameterId_t pid,uint16_t in_length) :
-              Parameter_t(pid,in_length)
-            , vendorId(rtps::c_VendorId_eProsima) {}
-        /**
-         * Add the parameter to a CDRMessage_t message.
-         * @param[in,out] msg Pointer to the message where the parameter should be added.
-         * @return True if the parameter was correctly added.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+class ParameterVendorId_t : public Parameter_t
+{
+public:
+
+    rtps::VendorId_t vendorId;
+    ParameterVendorId_t()
+        : vendorId(rtps::c_VendorId_eProsima)
+    {
+    }
+
+    /**
+     * Constructor using a parameter PID and the parameter length
+     * @param pid Pid of the parameter
+     * @param in_length Its associated length
+     */
+    ParameterVendorId_t(
+            ParameterId_t pid,
+            uint16_t in_length)
+        : Parameter_t(pid, in_length)
+        , vendorId(rtps::c_VendorId_eProsima)
+    {
+    }
+
+    /**
+     * Add the parameter to a CDRMessage_t message.
+     * @param[in,out] msg Pointer to the message where the parameter should be added.
+     * @return True if the parameter was correctly added.
+     */
+    bool addToCDRMessage(
+            rtps::CDRMessage_t* msg) override;
 };
 
 #define PARAMETER_VENDOR_LENGTH 4
@@ -356,23 +498,41 @@ class ParameterVendorId_t:public Parameter_t{
 /**
  *
  */
-class ParameterIP4Address_t :public Parameter_t{
-    public:
-		rtps::octet address[4];
-        ParameterIP4Address_t(){this->setIP4Address(0,0,0,0);};
-        /**
-         * Constructor using a parameter PID and the parameter length
-         * @param pid Pid of the parameter
-         * @param in_length Its associated length
-         */
-        ParameterIP4Address_t(ParameterId_t pid,uint16_t in_length):Parameter_t(pid,in_length){this->setIP4Address(0,0,0,0);};
-        /**
-         * Add the parameter to a CDRMessage_t message.
-         * @param[in,out] msg Pointer to the message where the parameter should be added.
-         * @return True if the parameter was correctly added.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
-        void setIP4Address(rtps::octet o1, rtps::octet o2, rtps::octet o3, rtps::octet o4);
+class ParameterIP4Address_t : public Parameter_t
+{
+public:
+
+    rtps::octet address[4];
+    ParameterIP4Address_t()
+    {
+        this->setIP4Address(0, 0, 0, 0);
+    }
+
+    /**
+     * Constructor using a parameter PID and the parameter length
+     * @param pid Pid of the parameter
+     * @param in_length Its associated length
+     */
+    ParameterIP4Address_t(
+            ParameterId_t pid,
+            uint16_t in_length)
+        : Parameter_t(pid, in_length)
+    {
+        this->setIP4Address(0, 0, 0, 0);
+    }
+
+    /**
+     * Add the parameter to a CDRMessage_t message.
+     * @param[in,out] msg Pointer to the message where the parameter should be added.
+     * @return True if the parameter was correctly added.
+     */
+    bool addToCDRMessage(
+            rtps::CDRMessage_t* msg) override;
+    void setIP4Address(
+            rtps::octet o1,
+            rtps::octet o2,
+            rtps::octet o3,
+            rtps::octet o4);
 };
 
 #define PARAMETER_IP4_LENGTH 4
@@ -380,49 +540,91 @@ class ParameterIP4Address_t :public Parameter_t{
 /**
  *
  */
-class ParameterBool_t:public Parameter_t{
-    public:
-        bool value;
-        ParameterBool_t():value(false){};
-        /**
-         * Constructor using a parameter PID and the parameter length
-         * @param pid Pid of the parameter
-         * @param in_length Its associated length
-         */
-        ParameterBool_t(ParameterId_t pid,uint16_t in_length):Parameter_t(pid,in_length),value(false){};
-        ParameterBool_t(ParameterId_t pid,uint16_t in_length,bool inbool):Parameter_t(pid,in_length),value(inbool){};
-        /**
-         * Add the parameter to a CDRMessage_t message.
-         * @param[in,out] msg Pointer to the message where the parameter should be added.
-         * @return True if the parameter was correctly added.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+class ParameterBool_t : public Parameter_t
+{
+public:
+
+    bool value;
+    ParameterBool_t()
+        : value(false)
+    {
+    }
+
+    /**
+     * Constructor using a parameter PID and the parameter length
+     * @param pid Pid of the parameter
+     * @param in_length Its associated length
+     */
+    ParameterBool_t(
+            ParameterId_t pid,
+            uint16_t in_length)
+        : Parameter_t(pid, in_length)
+        , value(false)
+    {
+    }
+
+    ParameterBool_t(
+            ParameterId_t pid,
+            uint16_t in_length,
+            bool inbool)
+        : Parameter_t(pid, in_length)
+        , value(inbool)
+    {
+    }
+
+    /**
+     * Add the parameter to a CDRMessage_t message.
+     * @param[in,out] msg Pointer to the message where the parameter should be added.
+     * @return True if the parameter was correctly added.
+     */
+    bool addToCDRMessage(
+            rtps::CDRMessage_t* msg) override;
 };
 
 #define PARAMETER_BOOL_LENGTH 4
 
 /**
-*
-*/
-class ParameterStatusInfo_t :public Parameter_t
+ *
+ */
+class ParameterStatusInfo_t : public Parameter_t
 {
 public:
+
     uint8_t status;
-    ParameterStatusInfo_t() :status(0) {}
+    ParameterStatusInfo_t()
+        : status(0)
+    {
+    }
 
     /**
-    * Constructor using a parameter PID and the parameter length
-    * @param pid Pid of the parameter
-    * @param in_length Its associated length
-    */
-    ParameterStatusInfo_t(ParameterId_t pid, uint16_t in_length) :Parameter_t(pid, in_length), status(0) {}
-    ParameterStatusInfo_t(ParameterId_t pid, uint16_t in_length, uint8_t instatus) :Parameter_t(pid, in_length), status(instatus) {}
+     * Constructor using a parameter PID and the parameter length
+     * @param pid Pid of the parameter
+     * @param in_length Its associated length
+     */
+    ParameterStatusInfo_t(
+            ParameterId_t pid,
+            uint16_t in_length)
+        : Parameter_t(pid, in_length)
+        , status(0)
+    {
+    }
+
+    ParameterStatusInfo_t(
+            ParameterId_t pid,
+            uint16_t in_length,
+            uint8_t instatus)
+        : Parameter_t(pid, in_length)
+        , status(instatus)
+    {
+    }
+
     /**
-    * Add the parameter to a CDRMessage_t message.
-    * @param[in,out] msg Pointer to the message where the parameter should be added.
-    * @return True if the parameter was correctly added.
-    */
-    bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+     * Add the parameter to a CDRMessage_t message.
+     * @param[in,out] msg Pointer to the message where the parameter should be added.
+     * @return True if the parameter was correctly added.
+     */
+    bool addToCDRMessage(
+            rtps::CDRMessage_t* msg) override;
 };
 
 #define PARAMETER_STATUS_INFO_LENGTH 4
@@ -430,22 +632,36 @@ public:
 /**
  *
  */
-class ParameterCount_t:public Parameter_t{
-    public:
-		rtps::Count_t count;
-        ParameterCount_t():count(0){};
-        /**
-         * Constructor using a parameter PID and the parameter length
-         * @param pid Pid of the parameter
-         * @param in_length Its associated length
-         */
-        ParameterCount_t(ParameterId_t pid,uint16_t in_length):Parameter_t(pid,in_length),count(0){};
-        /**
-         * Add the parameter to a CDRMessage_t message.
-         * @param[in,out] msg Pointer to the message where the parameter should be added.
-         * @return True if the parameter was correctly added.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+class ParameterCount_t : public Parameter_t
+{
+public:
+
+    rtps::Count_t count;
+    ParameterCount_t()
+        : count(0)
+    {
+    }
+
+    /**
+     * Constructor using a parameter PID and the parameter length
+     * @param pid Pid of the parameter
+     * @param in_length Its associated length
+     */
+    ParameterCount_t(
+            ParameterId_t pid,
+            uint16_t in_length)
+        : Parameter_t(pid, in_length)
+        , count(0)
+    {
+    }
+
+    /**
+     * Add the parameter to a CDRMessage_t message.
+     * @param[in,out] msg Pointer to the message where the parameter should be added.
+     * @return True if the parameter was correctly added.
+     */
+    bool addToCDRMessage(
+            rtps::CDRMessage_t* msg) override;
 };
 
 #define PARAMETER_COUNT_LENGTH 4
@@ -453,22 +669,36 @@ class ParameterCount_t:public Parameter_t{
 /**
  *
  */
-class ParameterEntityId_t:public Parameter_t{
-    public:
-		rtps::EntityId_t entityId;
-        ParameterEntityId_t():entityId(ENTITYID_UNKNOWN){};
-        /**
-         * Constructor using a parameter PID and the parameter length
-         * @param pid Pid of the parameter
-         * @param in_length Its associated length
-         */
-        ParameterEntityId_t(ParameterId_t pid,uint16_t in_length):Parameter_t(pid,in_length),entityId(ENTITYID_UNKNOWN){};
-        /**
-         * Add the parameter to a CDRMessage_t message.
-         * @param[in,out] msg Pointer to the message where the parameter should be added.
-         * @return True if the parameter was correctly added.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+class ParameterEntityId_t : public Parameter_t
+{
+public:
+
+    rtps::EntityId_t entityId;
+    ParameterEntityId_t()
+        : entityId(ENTITYID_UNKNOWN)
+    {
+    }
+
+    /**
+     * Constructor using a parameter PID and the parameter length
+     * @param pid Pid of the parameter
+     * @param in_length Its associated length
+     */
+    ParameterEntityId_t(
+            ParameterId_t pid,
+            uint16_t in_length)
+        : Parameter_t(pid, in_length)
+        , entityId(ENTITYID_UNKNOWN)
+    {
+    }
+
+    /**
+     * Add the parameter to a CDRMessage_t message.
+     * @param[in,out] msg Pointer to the message where the parameter should be added.
+     * @return True if the parameter was correctly added.
+     */
+    bool addToCDRMessage(
+            rtps::CDRMessage_t* msg) override;
 };
 
 #define PARAMETER_ENTITYID_LENGTH 4
@@ -476,22 +706,34 @@ class ParameterEntityId_t:public Parameter_t{
 /**
  *
  */
-class ParameterTime_t:public Parameter_t{
-    public:
-		rtps::Time_t time;
-        ParameterTime_t(){};
-        /**
-         * Constructor using a parameter PID and the parameter length
-         * @param pid Pid of the parameter
-         * @param in_length Its associated length
-         */
-        ParameterTime_t(ParameterId_t pid,uint16_t in_length):Parameter_t(pid,in_length){};
-        /**
-         * Add the parameter to a CDRMessage_t message.
-         * @param[in,out] msg Pointer to the message where the parameter should be added.
-         * @return True if the parameter was correctly added.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+class ParameterTime_t : public Parameter_t
+{
+public:
+
+    rtps::Time_t time;
+    ParameterTime_t()
+    {
+    }
+
+    /**
+     * Constructor using a parameter PID and the parameter length
+     * @param pid Pid of the parameter
+     * @param in_length Its associated length
+     */
+    ParameterTime_t(
+            ParameterId_t pid,
+            uint16_t in_length)
+        : Parameter_t(pid, in_length)
+    {
+    }
+
+    /**
+     * Add the parameter to a CDRMessage_t message.
+     * @param[in,out] msg Pointer to the message where the parameter should be added.
+     * @return True if the parameter was correctly added.
+     */
+    bool addToCDRMessage(
+            rtps::CDRMessage_t* msg) override;
 };
 
 #define PARAMETER_TIME_LENGTH 8
@@ -499,27 +741,36 @@ class ParameterTime_t:public Parameter_t{
 /**
  *
  */
-class ParameterBuiltinEndpointSet_t : public Parameter_t{
-    public:
-		rtps::BuiltinEndpointSet_t endpointSet;
-        ParameterBuiltinEndpointSet_t():endpointSet(0){};
-        /**
-         * Constructor using a parameter PID and the parameter length
-         * @param pid Pid of the parameter
-         * @param in_length Its associated length
-         */
-        ParameterBuiltinEndpointSet_t(
-                ParameterId_t pid,
-                uint16_t in_length)
-            : Parameter_t(pid, in_length)
-            , endpointSet(0)
-        {};
-        /**
-         * Add the parameter to a CDRMessage_t message.
-         * @param[in,out] msg Pointer to the message where the parameter should be added.
-         * @return True if the parameter was correctly added.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+class ParameterBuiltinEndpointSet_t : public Parameter_t
+{
+public:
+
+    rtps::BuiltinEndpointSet_t endpointSet;
+    ParameterBuiltinEndpointSet_t()
+        : endpointSet(0)
+    {
+    }
+
+    /**
+     * Constructor using a parameter PID and the parameter length
+     * @param pid Pid of the parameter
+     * @param in_length Its associated length
+     */
+    ParameterBuiltinEndpointSet_t(
+            ParameterId_t pid,
+            uint16_t in_length)
+        : Parameter_t(pid, in_length)
+        , endpointSet(0)
+    {
+    }
+
+    /**
+     * Add the parameter to a CDRMessage_t message.
+     * @param[in,out] msg Pointer to the message where the parameter should be added.
+     * @return True if the parameter was correctly added.
+     */
+    bool addToCDRMessage(
+            rtps::CDRMessage_t* msg) override;
 };
 
 #define PARAMETER_BUILTINENDPOINTSET_LENGTH 4
@@ -528,29 +779,42 @@ class ParameterBuiltinEndpointSet_t : public Parameter_t{
 /**
  *
  */
-class ParameterPropertyList_t : public Parameter_t {
-    public:
-        std::vector<std::pair<std::string,std::string>> properties;
+class ParameterPropertyList_t : public Parameter_t
+{
+public:
 
-        ParameterPropertyList_t():Parameter_t(PID_PROPERTY_LIST, 0) {}
+    std::vector<std::pair<std::string, std::string> > properties;
 
-        /**
-         * Constructor using a parameter PID and the parameter length
-         * @param in_length Its associated length
-         */
-        ParameterPropertyList_t(ParameterId_t /*pid*/, uint16_t in_length) : Parameter_t(PID_PROPERTY_LIST, in_length) {}
+    ParameterPropertyList_t()
+        : Parameter_t(PID_PROPERTY_LIST, 0)
+    {
+    }
 
-        ParameterPropertyList_t(const ParameterPropertyList_t &parameter_properties) : Parameter_t(PID_PROPERTY_LIST, 0)
-        {
-            properties.assign(parameter_properties.properties.begin(), parameter_properties.properties.end());
-        }
+    /**
+     * Constructor using a parameter PID and the parameter length
+     * @param in_length Its associated length
+     */
+    ParameterPropertyList_t(
+            ParameterId_t /*pid*/,
+            uint16_t in_length)
+        : Parameter_t(PID_PROPERTY_LIST, in_length)
+    {
+    }
 
-        /**
-         * Add the parameter to a CDRMessage_t message.
-         * @param[in,out] msg Pointer to the message where the parameter should be added.
-         * @return True if the parameter was correctly added.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+    ParameterPropertyList_t(
+            const ParameterPropertyList_t& parameter_properties)
+        : Parameter_t(PID_PROPERTY_LIST, 0)
+    {
+        properties.assign(parameter_properties.properties.begin(), parameter_properties.properties.end());
+    }
+
+    /**
+     * Add the parameter to a CDRMessage_t message.
+     * @param[in,out] msg Pointer to the message where the parameter should be added.
+     * @return True if the parameter was correctly added.
+     */
+    bool addToCDRMessage(
+            rtps::CDRMessage_t* msg) override;
 };
 
 /**
@@ -558,24 +822,35 @@ class ParameterPropertyList_t : public Parameter_t {
  */
 class ParameterSampleIdentity_t : public Parameter_t
 {
-    public:
-		rtps::SampleIdentity sample_id;
+public:
 
-        ParameterSampleIdentity_t() : sample_id(rtps::SampleIdentity::unknown()) {}
+    rtps::SampleIdentity sample_id;
 
-        /**
-         * Constructor using a parameter PID and the parameter length
-         * @param pid Pid of the parameter
-         * @param in_length Its associated length
-         */
-        ParameterSampleIdentity_t(ParameterId_t pid, uint16_t in_length) : Parameter_t(pid,in_length), sample_id(rtps::SampleIdentity::unknown()) {}
+    ParameterSampleIdentity_t()
+        : sample_id(rtps::SampleIdentity::unknown())
+    {
+    }
 
-        /**
-         * Add the parameter to a CDRMessage_t message.
-         * @param[in,out] msg Pointer to the message where the parameter should be added.
-         * @return True if the parameter was correctly added.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+    /**
+     * Constructor using a parameter PID and the parameter length
+     * @param pid Pid of the parameter
+     * @param in_length Its associated length
+     */
+    ParameterSampleIdentity_t(
+            ParameterId_t pid,
+            uint16_t in_length)
+        : Parameter_t(pid, in_length)
+        , sample_id(rtps::SampleIdentity::unknown())
+    {
+    }
+
+    /**
+     * Add the parameter to a CDRMessage_t message.
+     * @param[in,out] msg Pointer to the message where the parameter should be added.
+     * @return True if the parameter was correctly added.
+     */
+    bool addToCDRMessage(
+            rtps::CDRMessage_t* msg) override;
 };
 
 #if HAVE_SECURITY
@@ -585,88 +860,112 @@ class ParameterSampleIdentity_t : public Parameter_t
  */
 class ParameterToken_t : public Parameter_t
 {
-    public:
-		rtps::Token token;
+public:
 
-        ParameterToken_t() {}
+    rtps::Token token;
 
-        /**
-         * Constructor using a parameter PID and the parameter length
-         * @param pid Pid of the parameter
-         * @param in_length Its associated length
-         */
-        ParameterToken_t(ParameterId_t pid, uint16_t in_length) : Parameter_t(pid,in_length) {}
+    ParameterToken_t()
+    {
+    }
 
-        /**
-         * Add the parameter to a CDRMessage_t message.
-         * @param[in,out] msg Pointer to the message where the parameter should be added.
-         * @return True if the parameter was correctly added.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+    /**
+     * Constructor using a parameter PID and the parameter length
+     * @param pid Pid of the parameter
+     * @param in_length Its associated length
+     */
+    ParameterToken_t(
+            ParameterId_t pid,
+            uint16_t in_length)
+        : Parameter_t(pid, in_length)
+    {
+    }
+
+    /**
+     * Add the parameter to a CDRMessage_t message.
+     * @param[in,out] msg Pointer to the message where the parameter should be added.
+     * @return True if the parameter was correctly added.
+     */
+    bool addToCDRMessage(
+            rtps::CDRMessage_t* msg) override;
 };
 
 class ParameterParticipantSecurityInfo_t : public Parameter_t
 {
-    public:
-        rtps::security::ParticipantSecurityAttributesMask security_attributes;
-        rtps::security::PluginParticipantSecurityAttributesMask plugin_security_attributes;
+public:
 
-        ParameterParticipantSecurityInfo_t() : Parameter_t(PID_PARTICIPANT_SECURITY_INFO, 0)
-        {
-        }
+    rtps::security::ParticipantSecurityAttributesMask security_attributes;
+    rtps::security::PluginParticipantSecurityAttributesMask plugin_security_attributes;
 
-        /**
-        * Constructor using a parameter PID and the parameter length
-        * @param pid Pid of the parameter
-        * @param in_length Its associated length
-        */
-        ParameterParticipantSecurityInfo_t(ParameterId_t pid, uint16_t in_length) : Parameter_t(pid, in_length)
-        {
-        }
+    ParameterParticipantSecurityInfo_t()
+        : Parameter_t(PID_PARTICIPANT_SECURITY_INFO, 0)
+    {
+    }
 
-        /**
-        * Add the parameter to a CDRMessage_t message.
-        * @param[in,out] msg Pointer to the message where the parameter should be added.
-        * @return True if the parameter was correctly added.
-        */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+    /**
+     * Constructor using a parameter PID and the parameter length
+     * @param pid Pid of the parameter
+     * @param in_length Its associated length
+     */
+    ParameterParticipantSecurityInfo_t(
+            ParameterId_t pid,
+            uint16_t in_length)
+        : Parameter_t(pid, in_length)
+    {
+    }
+
+    /**
+     * Add the parameter to a CDRMessage_t message.
+     * @param[in,out] msg Pointer to the message where the parameter should be added.
+     * @return True if the parameter was correctly added.
+     */
+    bool addToCDRMessage(
+            rtps::CDRMessage_t* msg) override;
 };
 
 #define PARAMETER_PARTICIPANT_SECURITY_INFO_LENGTH 8
 
 class ParameterEndpointSecurityInfo_t : public Parameter_t
 {
-    public:
-        rtps::security::EndpointSecurityAttributesMask security_attributes;
-        rtps::security::PluginEndpointSecurityAttributesMask plugin_security_attributes;
+public:
 
-        ParameterEndpointSecurityInfo_t() : Parameter_t(PID_ENDPOINT_SECURITY_INFO, 0)
-        {
-        }
+    rtps::security::EndpointSecurityAttributesMask security_attributes;
+    rtps::security::PluginEndpointSecurityAttributesMask plugin_security_attributes;
 
-        /**
-        * Constructor using a parameter PID and the parameter length
-        * @param pid Pid of the parameter
-        * @param in_length Its associated length
-        */
-        ParameterEndpointSecurityInfo_t(ParameterId_t pid, uint16_t in_length) : Parameter_t(pid, in_length)
-        {
-        }
+    ParameterEndpointSecurityInfo_t()
+        : Parameter_t(PID_ENDPOINT_SECURITY_INFO, 0)
+    {
+    }
 
-        /**
-        * Add the parameter to a CDRMessage_t message.
-        * @param[in,out] msg Pointer to the message where the parameter should be added.
-        * @return True if the parameter was correctly added.
-        */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+    /**
+     * Constructor using a parameter PID and the parameter length
+     * @param pid Pid of the parameter
+     * @param in_length Its associated length
+     */
+    ParameterEndpointSecurityInfo_t(
+            ParameterId_t pid,
+            uint16_t in_length)
+        : Parameter_t(pid, in_length)
+    {
+    }
+
+    /**
+     * Add the parameter to a CDRMessage_t message.
+     * @param[in,out] msg Pointer to the message where the parameter should be added.
+     * @return True if the parameter was correctly added.
+     */
+    bool addToCDRMessage(
+            rtps::CDRMessage_t* msg) override;
 };
 
 #define PARAMETER_ENDPOINT_SECURITY_INFO_LENGTH 8
 
-#endif
+#endif // if HAVE_SECURITY
 
 template<class T, class PL>
-void set_proxy_property(const T& p, const char* PID, PL& properties)
+void set_proxy_property(
+        const T& p,
+        const char* PID,
+        PL& properties)
 {
     // only valid values
     if (p == T::unknown())
@@ -686,10 +985,10 @@ void set_proxy_property(const T& p, const char* PID, PL& properties)
     auto it = std::find_if(
         properties.begin(),
         properties.end(),
-        [&pair](const std::pair<std::string, std::string> & p)
-                {
-                    return pair.first == p.first;
-                });
+        [&pair](const std::pair<std::string, std::string>& p)
+        {
+            return pair.first == p.first;
+        });
 
     if (it != properties.end())
     {
@@ -703,7 +1002,9 @@ void set_proxy_property(const T& p, const char* PID, PL& properties)
 }
 
 template<class T, class PL>
-T get_proxy_property(const char* const PID, PL& properties)
+T get_proxy_property(
+        const char* const PID,
+        PL& properties)
 {
     T property;
 
@@ -711,13 +1012,13 @@ T get_proxy_property(const char* const PID, PL& properties)
         properties.begin(),
         properties.end(),
         [PID](const std::pair<std::string, std::string>& p)
-                {
-                    return PID == p.first;
-                });
+        {
+            return PID == p.first;
+        });
 
     if (it != properties.end())
     {
-        std::istringstream in(it->second);
+        std::istringstream in (it->second);
         in >> property;
     }
 
@@ -726,10 +1027,10 @@ T get_proxy_property(const char* const PID, PL& properties)
 
 ///@}
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 } //end of namespace
 } //end of namespace eprosima
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif /* PARAMETERTYPES_H_ */

--- a/include/fastrtps/rtps/builtin/data/ParticipantProxyData.h
+++ b/include/fastrtps/rtps/builtin/data/ParticipantProxyData.h
@@ -176,6 +176,32 @@ class ParticipantProxyData
          */
         GUID_t get_persistence_guid() const;
 
+        /**
+         * Set participant client server sample identity
+         * @param sid valid SampleIdentity
+         */
+        void set_sample_identity(
+            const SampleIdentity& sid);
+
+        /**
+         * Retrieve participant SampleIdentity
+         * @return SampleIdentity
+         */
+        SampleIdentity get_sample_identity() const;
+
+        /**
+         * Identifies the participant as client of the given server
+         * @param guid valid backup server GUID
+         */
+        void set_backup_stamp(
+            const GUID_t& guid);
+
+        /**
+         * Retrieves BACKUP server stamp. On deserialization hints if lease duration must be enforced
+         * @return GUID
+         */
+        GUID_t get_backup_stamp() const;
+
         void assert_liveliness();
 
         const std::chrono::steady_clock::time_point& last_received_message_tm() const
@@ -185,11 +211,10 @@ class ParticipantProxyData
 
         const std::chrono::microseconds& lease_duration() const
         {
-            return lease_duration_;
+           return lease_duration_;
         }
 
     private:
-
         //! Store the last timestamp it was received a RTPS message from the remote participant.
         std::chrono::steady_clock::time_point last_received_message_tm_;
 

--- a/include/fastrtps/rtps/builtin/data/ParticipantProxyData.h
+++ b/include/fastrtps/rtps/builtin/data/ParticipantProxyData.h
@@ -31,7 +31,7 @@
 
 #if HAVE_SECURITY
 #include "../../security/accesscontrol/ParticipantSecurityAttributes.h"
-#endif
+#endif // if HAVE_SECURITY
 
 #include <chrono>
 
@@ -63,7 +63,7 @@
 #define DISC_BUILTIN_ENDPOINT_PARTICIPANT_SECURE_DETECTOR        (0x00000001 << 27)
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
 struct CDRMessage_t;
@@ -75,157 +75,165 @@ class WriterProxyData;
 class NetworkFactory;
 
 /**
-* ParticipantProxyData class is used to store and convert the information Participants send to each other during the PDP phase.
-*@ingroup BUILTIN_MODULE
-*/
+ * ParticipantProxyData class is used to store and convert the information Participants send to each other during the PDP phase.
+ *@ingroup BUILTIN_MODULE
+ */
 class ParticipantProxyData
 {
-    public:
+public:
 
-        ParticipantProxyData(const RTPSParticipantAllocationAttributes& allocation);
+    ParticipantProxyData(
+            const RTPSParticipantAllocationAttributes& allocation);
 
-        ParticipantProxyData(const ParticipantProxyData& pdata);
+    ParticipantProxyData(
+            const ParticipantProxyData& pdata);
 
-        virtual ~ParticipantProxyData();
+    virtual ~ParticipantProxyData();
 
-        //!Protocol version
-        ProtocolVersion_t m_protocolVersion;
-        //!GUID
-        GUID_t m_guid;
-        //!Vendor ID
-        VendorId_t m_VendorId;
-        //!Expects Inline QOS.
-        bool m_expectsInlineQos;
-        //!Available builtin endpoints
-        BuiltinEndpointSet_t m_availableBuiltinEndpoints;
-        //!Metatraffic locators
-        RemoteLocatorList metatraffic_locators;
-        //!Default locators
-        RemoteLocatorList default_locators;
-        //!Participant name
-        string_255 m_participantName;
-        //!
-        InstanceHandle_t m_key;
-        //!
-        Duration_t m_leaseDuration;
+    //!Protocol version
+    ProtocolVersion_t m_protocolVersion;
+    //!GUID
+    GUID_t m_guid;
+    //!Vendor ID
+    VendorId_t m_VendorId;
+    //!Expects Inline QOS.
+    bool m_expectsInlineQos;
+    //!Available builtin endpoints
+    BuiltinEndpointSet_t m_availableBuiltinEndpoints;
+    //!Metatraffic locators
+    RemoteLocatorList metatraffic_locators;
+    //!Default locators
+    RemoteLocatorList default_locators;
+    //!Participant name
+    string_255 m_participantName;
+    //!
+    InstanceHandle_t m_key;
+    //!
+    Duration_t m_leaseDuration;
 #if HAVE_SECURITY
-        //!
-        IdentityToken identity_token_;
-        //!
-        PermissionsToken permissions_token_;
-        //!
-        security::ParticipantSecurityAttributesMask security_attributes_;
-        //!
-        security::PluginParticipantSecurityAttributesMask plugin_security_attributes_;
-#endif
-        //!
-        bool isAlive;
-        //!
-        ParameterPropertyList_t m_properties;
-        //!
-        std::vector<octet> m_userData;
-        //!
-        TimedEvent* lease_duration_event;
-        //!
-        bool should_check_lease_duration;
-        //!
-        ResourceLimitedVector<ReaderProxyData*> m_readers;
-        //!
-        ResourceLimitedVector<WriterProxyData*> m_writers;
+    //!
+    IdentityToken identity_token_;
+    //!
+    PermissionsToken permissions_token_;
+    //!
+    security::ParticipantSecurityAttributesMask security_attributes_;
+    //!
+    security::PluginParticipantSecurityAttributesMask plugin_security_attributes_;
+#endif // if HAVE_SECURITY
+    //!
+    bool isAlive;
+    //!
+    ParameterPropertyList_t m_properties;
+    //!
+    std::vector<octet> m_userData;
+    //!
+    TimedEvent* lease_duration_event;
+    //!
+    bool should_check_lease_duration;
+    //!
+    ResourceLimitedVector<ReaderProxyData*> m_readers;
+    //!
+    ResourceLimitedVector<WriterProxyData*> m_writers;
 
-        /**
-         * Update the data.
-         * @param pdata Object to copy the data from
-         * @return True on success
-         */
-        bool updateData(ParticipantProxyData& pdata);
+    /**
+     * Update the data.
+     * @param pdata Object to copy the data from
+     * @return True on success
+     */
+    bool updateData(
+            ParticipantProxyData& pdata);
 
-        /**
-         * Write as a parameter list on a CDRMessage_t
-         * @return True on success
-         */
-        bool writeToCDRMessage(CDRMessage_t* msg, bool write_encapsulation);
+    /**
+     * Write as a parameter list on a CDRMessage_t
+     * @return True on success
+     */
+    bool writeToCDRMessage(
+            CDRMessage_t* msg,
+            bool write_encapsulation);
 
-        /**
-         * Read the parameter list from a recevied CDRMessage_t
-         * @return True on success
-         */
-        bool readFromCDRMessage(
-                CDRMessage_t* msg,
-                bool use_encapsulation,
-                const NetworkFactory& network);
+    /**
+     * Read the parameter list from a recevied CDRMessage_t
+     * @return True on success
+     */
+    bool readFromCDRMessage(
+            CDRMessage_t* msg,
+            bool use_encapsulation,
+            const NetworkFactory& network);
 
-        //! Clear the data (restore to default state).
-        void clear();
+    //! Clear the data (restore to default state).
+    void clear();
 
-        /**
-         * Copy the data from another object.
-         * @param pdata Object to copy the data from
-         */
-        void copy(const ParticipantProxyData& pdata);
+    /**
+     * Copy the data from another object.
+     * @param pdata Object to copy the data from
+     */
+    void copy(
+            const ParticipantProxyData& pdata);
 
-        /**
-         * Set participant persistent GUID_t
-         * @param guid valid GUID_t
-         */
-        void set_persistence_guid(const GUID_t & guid);
-
-        /**
-         * Retrieve participant persistent GUID_t
-         * @return guid persistent GUID_t or c_Guid_Unknown
-         */
-        GUID_t get_persistence_guid() const;
-
-        /**
-         * Set participant client server sample identity
-         * @param sid valid SampleIdentity
-         */
-        void set_sample_identity(
-            const SampleIdentity& sid);
-
-        /**
-         * Retrieve participant SampleIdentity
-         * @return SampleIdentity
-         */
-        SampleIdentity get_sample_identity() const;
-
-        /**
-         * Identifies the participant as client of the given server
-         * @param guid valid backup server GUID
-         */
-        void set_backup_stamp(
+    /**
+     * Set participant persistent GUID_t
+     * @param guid valid GUID_t
+     */
+    void set_persistence_guid(
             const GUID_t& guid);
 
-        /**
-         * Retrieves BACKUP server stamp. On deserialization hints if lease duration must be enforced
-         * @return GUID
-         */
-        GUID_t get_backup_stamp() const;
+    /**
+     * Retrieve participant persistent GUID_t
+     * @return guid persistent GUID_t or c_Guid_Unknown
+     */
+    GUID_t get_persistence_guid() const;
 
-        void assert_liveliness();
+    /**
+     * Set participant client server sample identity
+     * @param sid valid SampleIdentity
+     */
+    void set_sample_identity(
+            const SampleIdentity& sid);
 
-        const std::chrono::steady_clock::time_point& last_received_message_tm() const
-        {
-            return last_received_message_tm_;
-        }
+    /**
+     * Retrieve participant SampleIdentity
+     * @return SampleIdentity
+     */
+    SampleIdentity get_sample_identity() const;
 
-        const std::chrono::microseconds& lease_duration() const
-        {
-           return lease_duration_;
-        }
+    /**
+     * Identifies the participant as client of the given server
+     * @param guid valid backup server GUID
+     */
+    void set_backup_stamp(
+            const GUID_t& guid);
 
-    private:
-        //! Store the last timestamp it was received a RTPS message from the remote participant.
-        std::chrono::steady_clock::time_point last_received_message_tm_;
+    /**
+     * Retrieves BACKUP server stamp. On deserialization hints if lease duration must be enforced
+     * @return GUID
+     */
+    GUID_t get_backup_stamp() const;
 
-        //! Remote participant lease duration in microseconds.
-        std::chrono::microseconds lease_duration_;
+    void assert_liveliness();
+
+    const std::chrono::steady_clock::time_point& last_received_message_tm() const
+    {
+        return last_received_message_tm_;
+    }
+
+    const std::chrono::microseconds& lease_duration() const
+    {
+        return lease_duration_;
+    }
+
+private:
+
+    //! Store the last timestamp it was received a RTPS message from the remote participant.
+    std::chrono::steady_clock::time_point last_received_message_tm_;
+
+    //! Remote participant lease duration in microseconds.
+    std::chrono::microseconds lease_duration_;
 };
 
 } /* namespace rtps */
 } /* namespace fastrtps */
 } /* namespace eprosima */
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 #endif // _RTPS_BUILTIN_DATA_PARTICIPANTPROXYDATA_H_

--- a/include/fastrtps/rtps/builtin/data/ReaderProxyData.h
+++ b/include/fastrtps/rtps/builtin/data/ReaderProxyData.h
@@ -288,6 +288,25 @@ class ReaderProxyData
         }
 
         /**
+         * Set participant client server sample identity
+         * @param sid valid SampleIdentity
+         */
+        void set_sample_identity(
+                const SampleIdentity& sid)
+        {
+            set_proxy_property(sid, "PID_CLIENT_SERVER_KEY", m_properties.properties);
+        }
+
+        /**
+         * Retrieve participant SampleIdentity
+         * @return SampleIdentity
+         */
+        SampleIdentity get_sample_identity() const
+        {
+            return get_proxy_property<SampleIdentity>("PID_CLIENT_SERVER_KEY", m_properties.properties);
+        }
+
+        /**
          * Write as a parameter list on a CDRMessage_t
          * @return True on success
          */
@@ -366,6 +385,9 @@ class ReaderProxyData
         TypeIdV1 m_type_id;
         //!Type Object
         TypeObjectV1 m_type;
+
+        //!
+        ParameterPropertyList_t m_properties;
 };
 
 }

--- a/include/fastrtps/rtps/builtin/data/ReaderProxyData.h
+++ b/include/fastrtps/rtps/builtin/data/ReaderProxyData.h
@@ -29,12 +29,12 @@
 
 #if HAVE_SECURITY
 #include "../../security/accesscontrol/EndpointSecurityAttributes.h"
-#endif
+#endif // if HAVE_SECURITY
 
 #include "../../common/RemoteLocators.hpp"
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
 struct CDRMessage_t;
@@ -47,352 +47,377 @@ class NetworkFactory;
  */
 class ReaderProxyData
 {
-    public:
+public:
 
-        RTPS_DllAPI ReaderProxyData(
-                const size_t max_unicast_locators,
-                const size_t max_multicast_locators);
+    RTPS_DllAPI ReaderProxyData(
+            const size_t max_unicast_locators,
+            const size_t max_multicast_locators);
 
-        RTPS_DllAPI virtual ~ReaderProxyData();
+    RTPS_DllAPI virtual ~ReaderProxyData();
 
-        RTPS_DllAPI ReaderProxyData(const ReaderProxyData& readerInfo);
+    RTPS_DllAPI ReaderProxyData(
+            const ReaderProxyData& readerInfo);
 
-        RTPS_DllAPI ReaderProxyData& operator=(const ReaderProxyData& readerInfo);
+    RTPS_DllAPI ReaderProxyData& operator =(
+            const ReaderProxyData& readerInfo);
 
-        RTPS_DllAPI void guid(const GUID_t& guid)
-        {
-            m_guid = guid;
-        }
+    RTPS_DllAPI void guid(
+            const GUID_t& guid)
+    {
+        m_guid = guid;
+    }
 
-        RTPS_DllAPI void guid(GUID_t&& guid)
-        {
-            m_guid = std::move(guid);
-        }
+    RTPS_DllAPI void guid(
+            GUID_t&& guid)
+    {
+        m_guid = std::move(guid);
+    }
 
-        RTPS_DllAPI const GUID_t& guid() const
-        {
-            return m_guid;
-        }
+    RTPS_DllAPI const GUID_t& guid() const
+    {
+        return m_guid;
+    }
 
-        RTPS_DllAPI GUID_t& guid()
-        {
-            return m_guid;
-        }
+    RTPS_DllAPI GUID_t& guid()
+    {
+        return m_guid;
+    }
 
-        RTPS_DllAPI bool has_locators() const
-        {
-            return !remote_locators_.unicast.empty() || !remote_locators_.multicast.empty();
-        }
+    RTPS_DllAPI bool has_locators() const
+    {
+        return !remote_locators_.unicast.empty() || !remote_locators_.multicast.empty();
+    }
 
-        RTPS_DllAPI const RemoteLocatorList& remote_locators() const
-        { 
-            return remote_locators_;
-        }
+    RTPS_DllAPI const RemoteLocatorList& remote_locators() const
+    {
+        return remote_locators_;
+    }
 
-        RTPS_DllAPI void add_unicast_locator(const Locator_t& locator);
+    RTPS_DllAPI void add_unicast_locator(
+            const Locator_t& locator);
 
-        void set_announced_unicast_locators(
-                const LocatorList_t& locators);
+    void set_announced_unicast_locators(
+            const LocatorList_t& locators);
 
-        void set_remote_unicast_locators(
-                const LocatorList_t& locators,
-                const NetworkFactory& network);
+    void set_remote_unicast_locators(
+            const LocatorList_t& locators,
+            const NetworkFactory& network);
 
-        RTPS_DllAPI void add_multicast_locator(const Locator_t& locator);
+    RTPS_DllAPI void add_multicast_locator(
+            const Locator_t& locator);
 
-        void set_multicast_locators(
-                const LocatorList_t& locators,
-                const NetworkFactory& network);
+    void set_multicast_locators(
+            const LocatorList_t& locators,
+            const NetworkFactory& network);
 
-        void set_locators(
-                const RemoteLocatorList& locators);
+    void set_locators(
+            const RemoteLocatorList& locators);
 
-        void set_remote_locators(
-                const RemoteLocatorList& locators,
-                const NetworkFactory& network,
-                bool use_multicast_locators);
+    void set_remote_locators(
+            const RemoteLocatorList& locators,
+            const NetworkFactory& network,
+            bool use_multicast_locators);
 
-        RTPS_DllAPI void key(const InstanceHandle_t& key)
-        {
-            m_key = key;
-        }
+    RTPS_DllAPI void key(
+            const InstanceHandle_t& key)
+    {
+        m_key = key;
+    }
 
-        RTPS_DllAPI void key(InstanceHandle_t&& key)
-        {
-            m_key = std::move(key);
-        }
+    RTPS_DllAPI void key(
+            InstanceHandle_t&& key)
+    {
+        m_key = std::move(key);
+    }
 
-        RTPS_DllAPI InstanceHandle_t key() const
-        {
-            return m_key;
-        }
+    RTPS_DllAPI InstanceHandle_t key() const
+    {
+        return m_key;
+    }
 
-        RTPS_DllAPI InstanceHandle_t& key()
-        {
-            return m_key;
-        }
+    RTPS_DllAPI InstanceHandle_t& key()
+    {
+        return m_key;
+    }
 
-        RTPS_DllAPI void RTPSParticipantKey(const InstanceHandle_t& RTPSParticipantKey)
-        {
-            m_RTPSParticipantKey = RTPSParticipantKey;
-        }
+    RTPS_DllAPI void RTPSParticipantKey(
+            const InstanceHandle_t& RTPSParticipantKey)
+    {
+        m_RTPSParticipantKey = RTPSParticipantKey;
+    }
 
-        RTPS_DllAPI void RTPSParticipantKey(InstanceHandle_t&& RTPSParticipantKey)
-        {
-            m_RTPSParticipantKey = std::move(RTPSParticipantKey);
-        }
+    RTPS_DllAPI void RTPSParticipantKey(
+            InstanceHandle_t&& RTPSParticipantKey)
+    {
+        m_RTPSParticipantKey = std::move(RTPSParticipantKey);
+    }
 
-        RTPS_DllAPI InstanceHandle_t RTPSParticipantKey() const
-        {
-            return m_RTPSParticipantKey;
-        }
+    RTPS_DllAPI InstanceHandle_t RTPSParticipantKey() const
+    {
+        return m_RTPSParticipantKey;
+    }
 
-        RTPS_DllAPI InstanceHandle_t& RTPSParticipantKey()
-        {
-            return m_RTPSParticipantKey;
-        }
+    RTPS_DllAPI InstanceHandle_t& RTPSParticipantKey()
+    {
+        return m_RTPSParticipantKey;
+    }
 
-        RTPS_DllAPI void typeName(const string_255& typeName)
-        {
-            m_typeName = typeName;
-        }
+    RTPS_DllAPI void typeName(
+            const string_255& typeName)
+    {
+        m_typeName = typeName;
+    }
 
-        RTPS_DllAPI void typeName(string_255&& typeName)
-        {
-            m_typeName = std::move(typeName);
-        }
+    RTPS_DllAPI void typeName(
+            string_255&& typeName)
+    {
+        m_typeName = std::move(typeName);
+    }
 
-        RTPS_DllAPI const string_255& typeName() const
-        {
-            return m_typeName;
-        }
+    RTPS_DllAPI const string_255& typeName() const
+    {
+        return m_typeName;
+    }
 
-        RTPS_DllAPI string_255& typeName()
-        {
-            return m_typeName;
-        }
+    RTPS_DllAPI string_255& typeName()
+    {
+        return m_typeName;
+    }
 
-        RTPS_DllAPI void topicName(const string_255& topicName)
-        {
-            m_topicName = topicName;
-        }
+    RTPS_DllAPI void topicName(
+            const string_255& topicName)
+    {
+        m_topicName = topicName;
+    }
 
-        RTPS_DllAPI void topicName(string_255&& topicName)
-        {
-            m_topicName = std::move(topicName);
-        }
+    RTPS_DllAPI void topicName(
+            string_255&& topicName)
+    {
+        m_topicName = std::move(topicName);
+    }
 
-        RTPS_DllAPI const string_255& topicName() const
-        {
-            return m_topicName;
-        }
+    RTPS_DllAPI const string_255& topicName() const
+    {
+        return m_topicName;
+    }
 
-        RTPS_DllAPI string_255& topicName()
-        {
-            return m_topicName;
-        }
+    RTPS_DllAPI string_255& topicName()
+    {
+        return m_topicName;
+    }
 
-        RTPS_DllAPI void userDefinedId(uint16_t userDefinedId)
-        {
-            m_userDefinedId = userDefinedId;
-        }
+    RTPS_DllAPI void userDefinedId(
+            uint16_t userDefinedId)
+    {
+        m_userDefinedId = userDefinedId;
+    }
 
-        RTPS_DllAPI uint16_t userDefinedId() const
-        {
-            return m_userDefinedId;
-        }
+    RTPS_DllAPI uint16_t userDefinedId() const
+    {
+        return m_userDefinedId;
+    }
 
-        RTPS_DllAPI uint16_t& userDefinedId()
-        {
-            return m_userDefinedId;
-        }
+    RTPS_DllAPI uint16_t& userDefinedId()
+    {
+        return m_userDefinedId;
+    }
 
-        RTPS_DllAPI void isAlive(bool isAlive)
-        {
-            m_isAlive = isAlive;
-        }
+    RTPS_DllAPI void isAlive(
+            bool isAlive)
+    {
+        m_isAlive = isAlive;
+    }
 
-        RTPS_DllAPI bool isAlive() const
-        {
-            return m_isAlive;
-        }
+    RTPS_DllAPI bool isAlive() const
+    {
+        return m_isAlive;
+    }
 
-        RTPS_DllAPI bool& isAlive()
-        {
-            return m_isAlive;
-        }
+    RTPS_DllAPI bool& isAlive()
+    {
+        return m_isAlive;
+    }
 
-        RTPS_DllAPI void topicKind(TopicKind_t topicKind)
-        {
-            m_topicKind = topicKind;
-        }
+    RTPS_DllAPI void topicKind(
+            TopicKind_t topicKind)
+    {
+        m_topicKind = topicKind;
+    }
 
-        RTPS_DllAPI TopicKind_t topicKind() const
-        {
-            return m_topicKind;
-        }
+    RTPS_DllAPI TopicKind_t topicKind() const
+    {
+        return m_topicKind;
+    }
 
-        RTPS_DllAPI TopicKind_t& topicKind()
-        {
-            return m_topicKind;
-        }
+    RTPS_DllAPI TopicKind_t& topicKind()
+    {
+        return m_topicKind;
+    }
 
-        RTPS_DllAPI void type_id(TypeIdV1 type_id)
-        {
-            m_type_id = type_id;
-        }
+    RTPS_DllAPI void type_id(
+            TypeIdV1 type_id)
+    {
+        m_type_id = type_id;
+    }
 
-        RTPS_DllAPI TypeIdV1 type_id() const
-        {
-            return m_type_id;
-        }
+    RTPS_DllAPI TypeIdV1 type_id() const
+    {
+        return m_type_id;
+    }
 
-        RTPS_DllAPI TypeIdV1& type_id()
-        {
-            return m_type_id;
-        }
+    RTPS_DllAPI TypeIdV1& type_id()
+    {
+        return m_type_id;
+    }
 
-        RTPS_DllAPI void type(TypeObjectV1 type)
-        {
-            m_type = type;
-        }
+    RTPS_DllAPI void type(
+            TypeObjectV1 type)
+    {
+        m_type = type;
+    }
 
-        RTPS_DllAPI TypeObjectV1 type() const
-        {
-            return m_type;
-        }
+    RTPS_DllAPI TypeObjectV1 type() const
+    {
+        return m_type;
+    }
 
-        RTPS_DllAPI TypeObjectV1& type()
-        {
-            return m_type;
-        }
+    RTPS_DllAPI TypeObjectV1& type()
+    {
+        return m_type;
+    }
 
-        RTPS_DllAPI void topicDiscoveryKind(TopicDiscoveryKind_t topicDiscoveryKind)
-        {
-            m_topicDiscoveryKind = topicDiscoveryKind;
-        }
+    RTPS_DllAPI void topicDiscoveryKind(
+            TopicDiscoveryKind_t topicDiscoveryKind)
+    {
+        m_topicDiscoveryKind = topicDiscoveryKind;
+    }
 
-        RTPS_DllAPI TopicDiscoveryKind_t topicDiscoveryKind() const
-        {
-            return m_topicDiscoveryKind;
-        }
+    RTPS_DllAPI TopicDiscoveryKind_t topicDiscoveryKind() const
+    {
+        return m_topicDiscoveryKind;
+    }
 
-        RTPS_DllAPI TopicDiscoveryKind_t& topicDiscoveryKind()
-        {
-            return m_topicDiscoveryKind;
-        }
+    RTPS_DllAPI TopicDiscoveryKind_t& topicDiscoveryKind()
+    {
+        return m_topicDiscoveryKind;
+    }
 
-        inline bool disable_positive_acks() const
-        {
-            return m_qos.m_disablePositiveACKs.enabled;
-        }
+    inline bool disable_positive_acks() const
+    {
+        return m_qos.m_disablePositiveACKs.enabled;
+    }
 
-        /**
-         * Set participant client server sample identity
-         * @param sid valid SampleIdentity
-         */
-        void set_sample_identity(
-                const SampleIdentity& sid)
-        {
-            set_proxy_property(sid, "PID_CLIENT_SERVER_KEY", m_properties.properties);
-        }
+    /**
+     * Set participant client server sample identity
+     * @param sid valid SampleIdentity
+     */
+    void set_sample_identity(
+            const SampleIdentity& sid)
+    {
+        set_proxy_property(sid, "PID_CLIENT_SERVER_KEY", m_properties.properties);
+    }
 
-        /**
-         * Retrieve participant SampleIdentity
-         * @return SampleIdentity
-         */
-        SampleIdentity get_sample_identity() const
-        {
-            return get_proxy_property<SampleIdentity>("PID_CLIENT_SERVER_KEY", m_properties.properties);
-        }
+    /**
+     * Retrieve participant SampleIdentity
+     * @return SampleIdentity
+     */
+    SampleIdentity get_sample_identity() const
+    {
+        return get_proxy_property<SampleIdentity>("PID_CLIENT_SERVER_KEY", m_properties.properties);
+    }
 
-        /**
-         * Write as a parameter list on a CDRMessage_t
-         * @return True on success
-         */
-        bool writeToCDRMessage(CDRMessage_t* msg, bool write_encapsulation);
+    /**
+     * Write as a parameter list on a CDRMessage_t
+     * @return True on success
+     */
+    bool writeToCDRMessage(
+            CDRMessage_t* msg,
+            bool write_encapsulation);
 
-        /**
-         *  Read the information from a CDRMessage_t. The position of hte message must be in the beggining on the parameter list.
-         * @param msg Pointer to the message.
-         * @param network Reference to network factory for locator validation and transformation
-         * @return true on success
-         */
-        RTPS_DllAPI bool readFromCDRMessage(
-                CDRMessage_t* msg,
-                const NetworkFactory& network);
+    /**
+     *  Read the information from a CDRMessage_t. The position of hte message must be in the beggining on the parameter list.
+     * @param msg Pointer to the message.
+     * @param network Reference to network factory for locator validation and transformation
+     * @return true on success
+     */
+    RTPS_DllAPI bool readFromCDRMessage(
+            CDRMessage_t* msg,
+            const NetworkFactory& network);
 
-        //!
-        bool m_expectsInlineQos;
-        //!Reader Qos
-        ReaderQos m_qos;
+    //!
+    bool m_expectsInlineQos;
+    //!Reader Qos
+    ReaderQos m_qos;
 
 #if HAVE_SECURITY
-        //!EndpointSecurityInfo.endpoint_security_attributes
-        security::EndpointSecurityAttributesMask security_attributes_;
+    //!EndpointSecurityInfo.endpoint_security_attributes
+    security::EndpointSecurityAttributesMask security_attributes_;
 
-        //!EndpointSecurityInfo.plugin_endpoint_security_attributes
-        security::PluginEndpointSecurityAttributesMask plugin_security_attributes_;
-#endif
+    //!EndpointSecurityInfo.plugin_endpoint_security_attributes
+    security::PluginEndpointSecurityAttributesMask plugin_security_attributes_;
+#endif // if HAVE_SECURITY
 
-        /**
-         * Clear (put to default) the information.
-         */
-        void clear();
+    /**
+     * Clear (put to default) the information.
+     */
+    void clear();
 
-        /**
-         * Check if this object can be updated with the information on another object.
-         * @param rdata ReaderProxyData object to be checked.
-         * @return true if this object can be updated with the information on rdata.
-         */
-        bool is_update_allowed(const ReaderProxyData& rdata) const;
+    /**
+     * Check if this object can be updated with the information on another object.
+     * @param rdata ReaderProxyData object to be checked.
+     * @return true if this object can be updated with the information on rdata.
+     */
+    bool is_update_allowed(
+            const ReaderProxyData& rdata) const;
 
-        /**
-         * Update the information (only certain fields will be updated).
-         * @param rdata Poitner to the object from which we are going to update.
-         */
-        void update(ReaderProxyData* rdata);
+    /**
+     * Update the information (only certain fields will be updated).
+     * @param rdata Poitner to the object from which we are going to update.
+     */
+    void update(
+            ReaderProxyData* rdata);
 
-        /**
-         * Copy ALL the information from another object.
-         * @param rdata Pointer to the object from where the information must be copied.
-         */
-        void copy(ReaderProxyData* rdata);
+    /**
+     * Copy ALL the information from another object.
+     * @param rdata Pointer to the object from where the information must be copied.
+     */
+    void copy(
+            ReaderProxyData* rdata);
 
-    private:
+private:
 
-        //!GUID
-        GUID_t m_guid;
-        //!Holds locator information
-        RemoteLocatorList remote_locators_;
-        //!GUID_t of the Reader converted to InstanceHandle_t
-        InstanceHandle_t m_key;
-        //!GUID_t of the participant converted to InstanceHandle
-        InstanceHandle_t m_RTPSParticipantKey;
-        //!Type name
-        string_255 m_typeName;
-        //!Topic name
-        string_255 m_topicName;
-        //!User defined ID
-        uint16_t m_userDefinedId;
-        //!Field to indicate if the Reader is Alive.
-        bool m_isAlive;
-        //!Topic kind
-        TopicKind_t m_topicKind;
-        //!Topic Discovery Kind
-        TopicDiscoveryKind_t m_topicDiscoveryKind;
-        //!Type Identifier
-        TypeIdV1 m_type_id;
-        //!Type Object
-        TypeObjectV1 m_type;
+    //!GUID
+    GUID_t m_guid;
+    //!Holds locator information
+    RemoteLocatorList remote_locators_;
+    //!GUID_t of the Reader converted to InstanceHandle_t
+    InstanceHandle_t m_key;
+    //!GUID_t of the participant converted to InstanceHandle
+    InstanceHandle_t m_RTPSParticipantKey;
+    //!Type name
+    string_255 m_typeName;
+    //!Topic name
+    string_255 m_topicName;
+    //!User defined ID
+    uint16_t m_userDefinedId;
+    //!Field to indicate if the Reader is Alive.
+    bool m_isAlive;
+    //!Topic kind
+    TopicKind_t m_topicKind;
+    //!Topic Discovery Kind
+    TopicDiscoveryKind_t m_topicDiscoveryKind;
+    //!Type Identifier
+    TypeIdV1 m_type_id;
+    //!Type Object
+    TypeObjectV1 m_type;
 
-        //!
-        ParameterPropertyList_t m_properties;
+    //!
+    ParameterPropertyList_t m_properties;
 };
 
-}
+} // namespace rtps
 } /* namespace rtps */
 } /* namespace eprosima */
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif // _RTPS_BUILTIN_DATA_READERPROXYDATA_H_

--- a/include/fastrtps/rtps/builtin/data/WriterProxyData.h
+++ b/include/fastrtps/rtps/builtin/data/WriterProxyData.h
@@ -309,6 +309,25 @@ class WriterProxyData
         //!WriterQOS
         WriterQos m_qos;
 
+        /**
+         * Set participant client server sample identity
+         * @param sid valid SampleIdentity
+         */
+        void set_sample_identity(
+                const SampleIdentity& sid)
+        {
+            set_proxy_property(sid, "PID_CLIENT_SERVER_KEY", m_properties.properties);
+        }
+
+        /**
+         * Retrieve participant SampleIdentity
+         * @return SampleIdentity
+         */
+        SampleIdentity get_sample_identity() const
+        {
+            return get_proxy_property<SampleIdentity>("PID_CLIENT_SERVER_KEY", m_properties.properties);
+        }
+
 #if HAVE_SECURITY
         //!EndpointSecurityInfo.endpoint_security_attributes
         security::EndpointSecurityAttributesMask security_attributes_;
@@ -386,6 +405,9 @@ class WriterProxyData
 
         //!Type Object
         TypeObjectV1 m_type;
+
+        //!
+        ParameterPropertyList_t m_properties;
 };
 
 } /* namespace rtps */

--- a/include/fastrtps/rtps/builtin/data/WriterProxyData.h
+++ b/include/fastrtps/rtps/builtin/data/WriterProxyData.h
@@ -29,7 +29,7 @@
 
 #if HAVE_SECURITY
 #include "../../security/accesscontrol/EndpointSecurityAttributes.h"
-#endif
+#endif // if HAVE_SECURITY
 
 #include "../../common/RemoteLocators.hpp"
 
@@ -46,373 +46,399 @@ class ParticipantProxyData;
  */
 class WriterProxyData
 {
-    public:
+public:
 
-        RTPS_DllAPI WriterProxyData(
-                const size_t max_unicast_locators,
-                const size_t max_multicast_locators);
+    RTPS_DllAPI WriterProxyData(
+            const size_t max_unicast_locators,
+            const size_t max_multicast_locators);
 
-        virtual RTPS_DllAPI ~WriterProxyData();
+    virtual RTPS_DllAPI ~WriterProxyData();
 
-        RTPS_DllAPI WriterProxyData(const WriterProxyData& writerInfo);
+    RTPS_DllAPI WriterProxyData(
+            const WriterProxyData& writerInfo);
 
-        RTPS_DllAPI WriterProxyData& operator=(const WriterProxyData& writerInfo);
+    RTPS_DllAPI WriterProxyData& operator =(
+            const WriterProxyData& writerInfo);
 
-        RTPS_DllAPI void guid(const GUID_t& guid)
-        {
-            m_guid = guid;
-        }
+    RTPS_DllAPI void guid(
+            const GUID_t& guid)
+    {
+        m_guid = guid;
+    }
 
-        RTPS_DllAPI void guid(GUID_t&& guid)
-        {
-            m_guid = std::move(guid);
-        }
+    RTPS_DllAPI void guid(
+            GUID_t&& guid)
+    {
+        m_guid = std::move(guid);
+    }
 
-        RTPS_DllAPI const GUID_t& guid() const
-        {
-            return m_guid;
-        }
+    RTPS_DllAPI const GUID_t& guid() const
+    {
+        return m_guid;
+    }
 
-        RTPS_DllAPI GUID_t& guid()
-        {
-            return m_guid;
-        }
+    RTPS_DllAPI GUID_t& guid()
+    {
+        return m_guid;
+    }
 
-        RTPS_DllAPI void persistence_guid(const GUID_t& guid)
-        {
-            persistence_guid_ = guid;
-        }
+    RTPS_DllAPI void persistence_guid(
+            const GUID_t& guid)
+    {
+        persistence_guid_ = guid;
+    }
 
-        RTPS_DllAPI void persistence_guid(GUID_t&& guid)
-        {
-            persistence_guid_ = std::move(guid);
-        }
+    RTPS_DllAPI void persistence_guid(
+            GUID_t&& guid)
+    {
+        persistence_guid_ = std::move(guid);
+    }
 
-        RTPS_DllAPI GUID_t persistence_guid() const
-        {
-            return persistence_guid_;
-        }
+    RTPS_DllAPI GUID_t persistence_guid() const
+    {
+        return persistence_guid_;
+    }
 
-        RTPS_DllAPI GUID_t& persistence_guid()
-        {
-            return persistence_guid_;
-        }
+    RTPS_DllAPI GUID_t& persistence_guid()
+    {
+        return persistence_guid_;
+    }
 
-        RTPS_DllAPI void set_persistence_entity_id(const EntityId_t & nid)
-        {
-            persistence_guid_.entityId = persistence_guid_.guidPrefix != c_GuidPrefix_Unknown ? nid : c_EntityId_Unknown;
-        }
+    RTPS_DllAPI void set_persistence_entity_id(
+            const EntityId_t& nid)
+    {
+        persistence_guid_.entityId = persistence_guid_.guidPrefix != c_GuidPrefix_Unknown ? nid : c_EntityId_Unknown;
+    }
 
-        RTPS_DllAPI bool has_locators() const
-        {
-            return !remote_locators_.unicast.empty() || !remote_locators_.multicast.empty();
-        }
+    RTPS_DllAPI bool has_locators() const
+    {
+        return !remote_locators_.unicast.empty() || !remote_locators_.multicast.empty();
+    }
 
-        RTPS_DllAPI const RemoteLocatorList& remote_locators() const
-        {
-            return remote_locators_;
-        }
+    RTPS_DllAPI const RemoteLocatorList& remote_locators() const
+    {
+        return remote_locators_;
+    }
 
-        RTPS_DllAPI void add_unicast_locator(const Locator_t& locator);
+    RTPS_DllAPI void add_unicast_locator(
+            const Locator_t& locator);
 
-        void set_announced_unicast_locators(
-                const LocatorList_t& locators);
+    void set_announced_unicast_locators(
+            const LocatorList_t& locators);
 
-        void set_remote_unicast_locators(
-                const LocatorList_t& locators,
-                const NetworkFactory& network);
+    void set_remote_unicast_locators(
+            const LocatorList_t& locators,
+            const NetworkFactory& network);
 
-        RTPS_DllAPI void add_multicast_locator(const Locator_t& locator);
+    RTPS_DllAPI void add_multicast_locator(
+            const Locator_t& locator);
 
-        void set_multicast_locators(
-                const LocatorList_t& locators,
-                const NetworkFactory& network);
+    void set_multicast_locators(
+            const LocatorList_t& locators,
+            const NetworkFactory& network);
 
-        void set_locators(
-                const RemoteLocatorList& locators);
+    void set_locators(
+            const RemoteLocatorList& locators);
 
-        void set_remote_locators(
-                const RemoteLocatorList& remote_locators,
-                const NetworkFactory& network,
-                bool use_multicast_locators);
+    void set_remote_locators(
+            const RemoteLocatorList& remote_locators,
+            const NetworkFactory& network,
+            bool use_multicast_locators);
 
-        RTPS_DllAPI void key(const InstanceHandle_t& key)
-        {
-            m_key = key;
-        }
+    RTPS_DllAPI void key(
+            const InstanceHandle_t& key)
+    {
+        m_key = key;
+    }
 
-        RTPS_DllAPI void key(InstanceHandle_t&& key)
-        {
-            m_key = std::move(key);
-        }
+    RTPS_DllAPI void key(
+            InstanceHandle_t&& key)
+    {
+        m_key = std::move(key);
+    }
 
-        RTPS_DllAPI InstanceHandle_t key() const
-        {
-            return m_key;
-        }
+    RTPS_DllAPI InstanceHandle_t key() const
+    {
+        return m_key;
+    }
 
-        RTPS_DllAPI InstanceHandle_t& key()
-        {
-            return m_key;
-        }
+    RTPS_DllAPI InstanceHandle_t& key()
+    {
+        return m_key;
+    }
 
-        RTPS_DllAPI void RTPSParticipantKey(const InstanceHandle_t& RTPSParticipantKey)
-        {
-            m_RTPSParticipantKey = RTPSParticipantKey;
-        }
+    RTPS_DllAPI void RTPSParticipantKey(
+            const InstanceHandle_t& RTPSParticipantKey)
+    {
+        m_RTPSParticipantKey = RTPSParticipantKey;
+    }
 
-        RTPS_DllAPI void RTPSParticipantKey(InstanceHandle_t&& RTPSParticipantKey)
-        {
-            m_RTPSParticipantKey = std::move(RTPSParticipantKey);
-        }
+    RTPS_DllAPI void RTPSParticipantKey(
+            InstanceHandle_t&& RTPSParticipantKey)
+    {
+        m_RTPSParticipantKey = std::move(RTPSParticipantKey);
+    }
 
-        RTPS_DllAPI InstanceHandle_t RTPSParticipantKey() const
-        {
-            return m_RTPSParticipantKey;
-        }
+    RTPS_DllAPI InstanceHandle_t RTPSParticipantKey() const
+    {
+        return m_RTPSParticipantKey;
+    }
 
-        RTPS_DllAPI InstanceHandle_t& RTPSParticipantKey()
-        {
-            return m_RTPSParticipantKey;
-        }
+    RTPS_DllAPI InstanceHandle_t& RTPSParticipantKey()
+    {
+        return m_RTPSParticipantKey;
+    }
 
-        RTPS_DllAPI void typeName(const string_255& typeName)
-        {
-            m_typeName = typeName;
-        }
+    RTPS_DllAPI void typeName(
+            const string_255& typeName)
+    {
+        m_typeName = typeName;
+    }
 
-        RTPS_DllAPI void typeName(string_255&& typeName)
-        {
-            m_typeName = std::move(typeName);
-        }
+    RTPS_DllAPI void typeName(
+            string_255&& typeName)
+    {
+        m_typeName = std::move(typeName);
+    }
 
-        RTPS_DllAPI const string_255& typeName() const
-        {
-            return m_typeName;
-        }
+    RTPS_DllAPI const string_255& typeName() const
+    {
+        return m_typeName;
+    }
 
-        RTPS_DllAPI string_255& typeName()
-        {
-            return m_typeName;
-        }
+    RTPS_DllAPI string_255& typeName()
+    {
+        return m_typeName;
+    }
 
-        RTPS_DllAPI void topicName(const string_255& topicName)
-        {
-            m_topicName = topicName;
-        }
+    RTPS_DllAPI void topicName(
+            const string_255& topicName)
+    {
+        m_topicName = topicName;
+    }
 
-        RTPS_DllAPI void topicName(string_255&& topicName)
-        {
-            m_topicName = std::move(topicName);
-        }
+    RTPS_DllAPI void topicName(
+            string_255&& topicName)
+    {
+        m_topicName = std::move(topicName);
+    }
 
-        RTPS_DllAPI const string_255& topicName() const
-        {
-            return m_topicName;
-        }
+    RTPS_DllAPI const string_255& topicName() const
+    {
+        return m_topicName;
+    }
 
-        RTPS_DllAPI string_255& topicName()
-        {
-            return m_topicName;
-        }
+    RTPS_DllAPI string_255& topicName()
+    {
+        return m_topicName;
+    }
 
-        RTPS_DllAPI void userDefinedId(uint16_t userDefinedId)
-        {
-            m_userDefinedId = userDefinedId;
-        }
+    RTPS_DllAPI void userDefinedId(
+            uint16_t userDefinedId)
+    {
+        m_userDefinedId = userDefinedId;
+    }
 
-        RTPS_DllAPI uint16_t userDefinedId() const
-        {
-            return m_userDefinedId;
-        }
+    RTPS_DllAPI uint16_t userDefinedId() const
+    {
+        return m_userDefinedId;
+    }
 
-        RTPS_DllAPI uint16_t& userDefinedId()
-        {
-            return m_userDefinedId;
-        }
+    RTPS_DllAPI uint16_t& userDefinedId()
+    {
+        return m_userDefinedId;
+    }
 
-        RTPS_DllAPI void typeMaxSerialized(uint32_t typeMaxSerialized)
-        {
-            m_typeMaxSerialized = typeMaxSerialized;
-        }
+    RTPS_DllAPI void typeMaxSerialized(
+            uint32_t typeMaxSerialized)
+    {
+        m_typeMaxSerialized = typeMaxSerialized;
+    }
 
-        RTPS_DllAPI uint32_t typeMaxSerialized() const
-        {
-            return m_typeMaxSerialized;
-        }
+    RTPS_DllAPI uint32_t typeMaxSerialized() const
+    {
+        return m_typeMaxSerialized;
+    }
 
-        RTPS_DllAPI uint32_t& typeMaxSerialized()
-        {
-            return m_typeMaxSerialized;
-        }
+    RTPS_DllAPI uint32_t& typeMaxSerialized()
+    {
+        return m_typeMaxSerialized;
+    }
 
-        RTPS_DllAPI void topicKind(TopicKind_t topicKind)
-        {
-            m_topicKind = topicKind;
-        }
+    RTPS_DllAPI void topicKind(
+            TopicKind_t topicKind)
+    {
+        m_topicKind = topicKind;
+    }
 
-        RTPS_DllAPI TopicKind_t topicKind() const
-        {
-            return m_topicKind;
-        }
+    RTPS_DllAPI TopicKind_t topicKind() const
+    {
+        return m_topicKind;
+    }
 
-        RTPS_DllAPI TopicKind_t& topicKind()
-        {
-            return m_topicKind;
-        }
+    RTPS_DllAPI TopicKind_t& topicKind()
+    {
+        return m_topicKind;
+    }
 
-        RTPS_DllAPI void type_id(TypeIdV1 type_id)
-        {
-            m_type_id = type_id;
-        }
+    RTPS_DllAPI void type_id(
+            TypeIdV1 type_id)
+    {
+        m_type_id = type_id;
+    }
 
-        RTPS_DllAPI TypeIdV1 type_id() const
-        {
-            return m_type_id;
-        }
+    RTPS_DllAPI TypeIdV1 type_id() const
+    {
+        return m_type_id;
+    }
 
-        RTPS_DllAPI TypeIdV1& type_id()
-        {
-            return m_type_id;
-        }
+    RTPS_DllAPI TypeIdV1& type_id()
+    {
+        return m_type_id;
+    }
 
-        RTPS_DllAPI void type(TypeObjectV1 type)
-        {
-            m_type = type;
-        }
+    RTPS_DllAPI void type(
+            TypeObjectV1 type)
+    {
+        m_type = type;
+    }
 
-        RTPS_DllAPI TypeObjectV1 type() const
-        {
-            return m_type;
-        }
+    RTPS_DllAPI TypeObjectV1 type() const
+    {
+        return m_type;
+    }
 
-        RTPS_DllAPI TypeObjectV1& type()
-        {
-            return m_type;
-        }
+    RTPS_DllAPI TypeObjectV1& type()
+    {
+        return m_type;
+    }
 
-        RTPS_DllAPI void topicDiscoveryKind(TopicDiscoveryKind_t topicDiscoveryKind)
-        {
-            m_topicDiscoveryKind = topicDiscoveryKind;
-        }
+    RTPS_DllAPI void topicDiscoveryKind(
+            TopicDiscoveryKind_t topicDiscoveryKind)
+    {
+        m_topicDiscoveryKind = topicDiscoveryKind;
+    }
 
-        RTPS_DllAPI TopicDiscoveryKind_t topicDiscoveryKind() const
-        {
-            return m_topicDiscoveryKind;
-        }
+    RTPS_DllAPI TopicDiscoveryKind_t topicDiscoveryKind() const
+    {
+        return m_topicDiscoveryKind;
+    }
 
-        RTPS_DllAPI TopicDiscoveryKind_t& topicDiscoveryKind()
-        {
-            return m_topicDiscoveryKind;
-        }
+    RTPS_DllAPI TopicDiscoveryKind_t& topicDiscoveryKind()
+    {
+        return m_topicDiscoveryKind;
+    }
 
-        //!WriterQOS
-        WriterQos m_qos;
+    //!WriterQOS
+    WriterQos m_qos;
 
-        /**
-         * Set participant client server sample identity
-         * @param sid valid SampleIdentity
-         */
-        void set_sample_identity(
-                const SampleIdentity& sid)
-        {
-            set_proxy_property(sid, "PID_CLIENT_SERVER_KEY", m_properties.properties);
-        }
+    /**
+     * Set participant client server sample identity
+     * @param sid valid SampleIdentity
+     */
+    void set_sample_identity(
+            const SampleIdentity& sid)
+    {
+        set_proxy_property(sid, "PID_CLIENT_SERVER_KEY", m_properties.properties);
+    }
 
-        /**
-         * Retrieve participant SampleIdentity
-         * @return SampleIdentity
-         */
-        SampleIdentity get_sample_identity() const
-        {
-            return get_proxy_property<SampleIdentity>("PID_CLIENT_SERVER_KEY", m_properties.properties);
-        }
+    /**
+     * Retrieve participant SampleIdentity
+     * @return SampleIdentity
+     */
+    SampleIdentity get_sample_identity() const
+    {
+        return get_proxy_property<SampleIdentity>("PID_CLIENT_SERVER_KEY", m_properties.properties);
+    }
 
 #if HAVE_SECURITY
-        //!EndpointSecurityInfo.endpoint_security_attributes
-        security::EndpointSecurityAttributesMask security_attributes_;
+    //!EndpointSecurityInfo.endpoint_security_attributes
+    security::EndpointSecurityAttributesMask security_attributes_;
 
-        //!EndpointSecurityInfo.plugin_endpoint_security_attributes
-        security::PluginEndpointSecurityAttributesMask plugin_security_attributes_;
-#endif
+    //!EndpointSecurityInfo.plugin_endpoint_security_attributes
+    security::PluginEndpointSecurityAttributesMask plugin_security_attributes_;
+#endif // if HAVE_SECURITY
 
-        //!Clear the information and return the object to the default state.
-        void clear();
+    //!Clear the information and return the object to the default state.
+    void clear();
 
-        /**
-         * Check if this object can be updated with the information on another object.
-         * @param wdata WriterProxyData object to be checked.
-         * @return true if this object can be updated with the information on wdata.
-         */
-        bool is_update_allowed(const WriterProxyData& wdata) const;
+    /**
+     * Check if this object can be updated with the information on another object.
+     * @param wdata WriterProxyData object to be checked.
+     * @return true if this object can be updated with the information on wdata.
+     */
+    bool is_update_allowed(
+            const WriterProxyData& wdata) const;
 
-        /**
-         * Update certain parameters from another object.
-         * @param wdata pointer to object with new information.
-         */
-        void update(WriterProxyData* wdata);
+    /**
+     * Update certain parameters from another object.
+     * @param wdata pointer to object with new information.
+     */
+    void update(
+            WriterProxyData* wdata);
 
-        //!Copy all information from another object.
-        void copy(WriterProxyData* wdata);
+    //!Copy all information from another object.
+    void copy(
+            WriterProxyData* wdata);
 
-        //!Write as a parameter list on a CDRMessage_t
-        bool writeToCDRMessage(
-                CDRMessage_t* msg,
-                bool write_encapsulation);
+    //!Write as a parameter list on a CDRMessage_t
+    bool writeToCDRMessage(
+            CDRMessage_t* msg,
+            bool write_encapsulation);
 
-        //!Read a parameter list from a CDRMessage_t.
-        RTPS_DllAPI bool readFromCDRMessage(
-                CDRMessage_t* msg,
-                const NetworkFactory& network);
+    //!Read a parameter list from a CDRMessage_t.
+    RTPS_DllAPI bool readFromCDRMessage(
+            CDRMessage_t* msg,
+            const NetworkFactory& network);
 
-    private:
+private:
 
-        //!GUID
-        GUID_t m_guid;
+    //!GUID
+    GUID_t m_guid;
 
-        //!Holds locator information
-        RemoteLocatorList remote_locators_;
+    //!Holds locator information
+    RemoteLocatorList remote_locators_;
 
-        //!GUID_t of the Writer converted to InstanceHandle_t
-        InstanceHandle_t m_key;
+    //!GUID_t of the Writer converted to InstanceHandle_t
+    InstanceHandle_t m_key;
 
-        //!GUID_t of the participant converted to InstanceHandle
-        InstanceHandle_t m_RTPSParticipantKey;
+    //!GUID_t of the participant converted to InstanceHandle
+    InstanceHandle_t m_RTPSParticipantKey;
 
-        //!Type name
-        string_255 m_typeName;
+    //!Type name
+    string_255 m_typeName;
 
-        //!Topic name
-        string_255 m_topicName;
+    //!Topic name
+    string_255 m_topicName;
 
-        //!User defined ID
-        uint16_t m_userDefinedId;
+    //!User defined ID
+    uint16_t m_userDefinedId;
 
-        //!Maximum size of the type associated with this Wrtiter, serialized.
-        uint32_t m_typeMaxSerialized;
+    //!Maximum size of the type associated with this Wrtiter, serialized.
+    uint32_t m_typeMaxSerialized;
 
-        //!Topic kind
-        TopicKind_t m_topicKind;
+    //!Topic kind
+    TopicKind_t m_topicKind;
 
-        //!Persistence GUID
-        GUID_t persistence_guid_;
+    //!Persistence GUID
+    GUID_t persistence_guid_;
 
-        //!Topic Discovery Kind
-        TopicDiscoveryKind_t m_topicDiscoveryKind;
+    //!Topic Discovery Kind
+    TopicDiscoveryKind_t m_topicDiscoveryKind;
 
-        //!Type Identifier
-        TypeIdV1 m_type_id;
+    //!Type Identifier
+    TypeIdV1 m_type_id;
 
-        //!Type Object
-        TypeObjectV1 m_type;
+    //!Type Object
+    TypeObjectV1 m_type;
 
-        //!
-        ParameterPropertyList_t m_properties;
+    //!
+    ParameterPropertyList_t m_properties;
 };
 
 } /* namespace rtps */
 } /* namespace fastrtps */
 } /* namespace eprosima */
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif // _RTPS_BUILTIN_DATA_WRITERPROXYDATA_H_

--- a/include/fastrtps/rtps/builtin/discovery/endpoint/EDPServer.h
+++ b/include/fastrtps/rtps/builtin/discovery/endpoint/EDPServer.h
@@ -30,7 +30,7 @@
 #include <set>
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
 class EDPServerPUBListener;
@@ -54,7 +54,7 @@ class EDPServer : public EDPSimple
     //! TRANSIENT or TRANSIENT_LOCAL durability;
     DurabilityKind_t _durability;
 
-    public:
+public:
 
     /**
      * Constructor.
@@ -63,25 +63,27 @@ class EDPServer : public EDPSimple
      * @param durability_kind the kind of persistence we want for the discovery data
      */
     EDPServer(
-        PDP* p,
-        RTPSParticipantImpl* part,
-        DurabilityKind_t durability_kind)
+            PDP* p,
+            RTPSParticipantImpl* part,
+            DurabilityKind_t durability_kind)
         : EDPSimple(p, part)
         , _durability(durability_kind)
     {
     }
 
-    ~EDPServer() override {}
+    ~EDPServer() override
+    {
+    }
 
     /**
-      * This method generates the corresponding change in the subscription writer and send it to all known remote endpoints.
-      * @param reader Pointer to the Reader object.
-      * @param rdata Pointer to the ReaderProxyData object.
-      * @return true if correct.
-      */
+     * This method generates the corresponding change in the subscription writer and send it to all known remote endpoints.
+     * @param reader Pointer to the Reader object.
+     * @param rdata Pointer to the ReaderProxyData object.
+     * @return true if correct.
+     */
     bool processLocalReaderProxyData(
-        RTPSReader* reader,
-        ReaderProxyData* rdata) override;
+            RTPSReader* reader,
+            ReaderProxyData* rdata) override;
     /**
      * This method generates the corresponding change in the publciations writer and send it to all known remote endpoints.
      * @param writer Pointer to the Writer object.
@@ -89,26 +91,28 @@ class EDPServer : public EDPSimple
      * @return true if correct.
      */
     bool processLocalWriterProxyData(
-        RTPSWriter* writer,
-        WriterProxyData* wdata) override;
+            RTPSWriter* writer,
+            WriterProxyData* wdata) override;
     /**
      * This methods generates the change disposing of the local Reader and calls the unpairing and removal methods of the base class.
      * @param R Pointer to the RTPSReader object.
      * @return True if correct.
      */
-    bool removeLocalReader(RTPSReader*R) override;
+    bool removeLocalReader(
+            RTPSReader* R) override;
     /**
      * This methods generates the change disposing of the local Writer and calls the unpairing and removal methods of the base class.
      * @param W Pointer to the RTPSWriter object.
      * @return True if correct.
      */
-    bool removeLocalWriter(RTPSWriter*W) override;
+    bool removeLocalWriter(
+            RTPSWriter* W) override;
 
     /**
-    * Some History data is flag for defer removal till every client
-    * acknowledges reception
-    * @return True if trimming must be done
-    */
+     * Some History data is flag for defer removal till every client
+     * acknowledges reception
+     * @return True if trimming must be done
+     */
     inline bool pendingHistoryCleaning()
     {
         return !(_PUBdemises.empty() && _SUBdemises.empty());
@@ -117,14 +121,14 @@ class EDPServer : public EDPSimple
     //! Callback to remove unnecesary WriterHistory info
     bool trimPUBWriterHistory()
     {
-        return trimWriterHistory<ResourceLimitedVector<WriterProxyData*>>(_PUBdemises,
-            *publications_writer_.first, *publications_writer_.second, &ParticipantProxyData::m_writers);
+        return trimWriterHistory<ResourceLimitedVector<WriterProxyData*> >(_PUBdemises,
+                       *publications_writer_.first, *publications_writer_.second, &ParticipantProxyData::m_writers);
     }
 
     bool trimSUBWriterHistory()
     {
-        return trimWriterHistory<ResourceLimitedVector<ReaderProxyData*>>(_SUBdemises,
-            *subscriptions_writer_.first, *subscriptions_writer_.second, &ParticipantProxyData::m_readers);
+        return trimWriterHistory<ResourceLimitedVector<ReaderProxyData*> >(_SUBdemises,
+                       *subscriptions_writer_.first, *subscriptions_writer_.second, &ParticipantProxyData::m_readers);
     }
 
     //! returns true if loading info from persistency database
@@ -145,15 +149,17 @@ class EDPServer : public EDPSimple
 protected:
 
     /**
-        * Add participant CacheChange_ts from reader to writer
-        * @return True if successfully modified WriterHistory
-        */
-    bool addPublisherFromHistory( CacheChange_t& c)
+     * Add participant CacheChange_ts from reader to writer
+     * @return True if successfully modified WriterHistory
+     */
+    bool addPublisherFromHistory(
+            CacheChange_t& c)
     {
         return addEndpointFromHistory(*publications_writer_.first, *publications_writer_.second, c);
     }
 
-    bool addSubscriberFromHistory( CacheChange_t& c)
+    bool addSubscriberFromHistory(
+            CacheChange_t& c)
     {
         return addEndpointFromHistory(*subscriptions_writer_.first, *subscriptions_writer_.second, c);
     }
@@ -161,21 +167,21 @@ protected:
 private:
 
     /**
-    * Callback to remove unnecesary WriterHistory info common implementation
-    * @return True if trim is finished
-    */
+     * Callback to remove unnecesary WriterHistory info common implementation
+     * @return True if trim is finished
+     */
     template<class ProxyCont>
     bool trimWriterHistory(
-        key_list& _demises,
-        StatefulWriter& writer,
-        WriterHistory& history,
-        ProxyCont ParticipantProxyData::* pCont);
+            key_list& _demises,
+            StatefulWriter& writer,
+            WriterHistory& history,
+            ProxyCont ParticipantProxyData::* pCont);
 
     //! addPublisherFromHistory and addSubscriberFromHistory common implementation
     bool addEndpointFromHistory(
-        StatefulWriter& writer,
-        WriterHistory& history,
-        CacheChange_t& c);
+            StatefulWriter& writer,
+            WriterHistory& history,
+            CacheChange_t& c);
 
     /**
      * Create local SEDP Endpoints based on the DiscoveryAttributes.
@@ -189,5 +195,5 @@ private:
 } /* namespace fastrtps */
 } /* namespace eprosima */
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif /* EDPSERVER_H_ */

--- a/include/fastrtps/rtps/builtin/discovery/endpoint/EDPServer.h
+++ b/include/fastrtps/rtps/builtin/discovery/endpoint/EDPServer.h
@@ -107,7 +107,7 @@ public:
             RTPSWriter* W) override;
 
     /**
-     * Some History data is flag for defer removal till every client
+     * Some History data is flagged for deferred removal till every client
      * acknowledges reception
      * @return True if trimming must be done
      */
@@ -117,17 +117,8 @@ public:
     }
 
     //! Callback to remove unnecesary WriterHistory info
-    bool trimPUBWriterHistory()
-    {
-        return trimWriterHistory<ResourceLimitedVector<WriterProxyData*> >(_PUBdemises,
-                       *publications_writer_.first, *publications_writer_.second, &ParticipantProxyData::m_writers);
-    }
-
-    bool trimSUBWriterHistory()
-    {
-        return trimWriterHistory<ResourceLimitedVector<ReaderProxyData*> >(_SUBdemises,
-                       *subscriptions_writer_.first, *subscriptions_writer_.second, &ParticipantProxyData::m_readers);
-    }
+    bool trimPUBWriterHistory();
+    bool trimSUBWriterHistory();
 
     //! returns true if loading info from persistency database
     bool ongoingDeserialization();

--- a/include/fastrtps/rtps/builtin/discovery/endpoint/EDPServer.h
+++ b/include/fastrtps/rtps/builtin/discovery/endpoint/EDPServer.h
@@ -46,8 +46,6 @@ class EDPServer : public EDPSimple
     friend class EDPServerPUBListener;
     friend class EDPServerSUBListener;
 
-    typedef std::set<InstanceHandle_t> key_list;
-
     //! Keys to wipe out from WriterHistory because its related Participants have been removed
     key_list _PUBdemises, _SUBdemises;
 

--- a/include/fastrtps/rtps/builtin/discovery/endpoint/EDPServer.h
+++ b/include/fastrtps/rtps/builtin/discovery/endpoint/EDPServer.h
@@ -107,7 +107,7 @@ public:
             RTPSWriter* W) override;
 
     /**
-     * Some History data is flagged for deferred removal till every client
+     * Some History data is flagged for deferred removal until every client
      * acknowledges reception
      * @return True if trimming must be done
      */
@@ -128,7 +128,6 @@ public:
 
     /**
      * Trigger the participant CacheChange_t removal system
-     * @return True if successfully modified WriterHistory
      */
     void removePublisherFromHistory(
             const InstanceHandle_t&);

--- a/include/fastrtps/rtps/builtin/discovery/endpoint/EDPServer.h
+++ b/include/fastrtps/rtps/builtin/discovery/endpoint/EDPServer.h
@@ -127,6 +127,12 @@ class EDPServer : public EDPSimple
             *subscriptions_writer_.first, *subscriptions_writer_.second, &ParticipantProxyData::m_readers);
     }
 
+    //! returns true if loading info from persistency database
+    bool ongoingDeserialization();
+
+    //! Process the info recorded in the persistence database
+    void processPersistentData();
+
     protected:
 
     /**

--- a/include/fastrtps/rtps/builtin/discovery/endpoint/EDPServer.h
+++ b/include/fastrtps/rtps/builtin/discovery/endpoint/EDPServer.h
@@ -133,7 +133,16 @@ class EDPServer : public EDPSimple
     //! Process the info recorded in the persistence database
     void processPersistentData();
 
-    protected:
+    /**
+     * Trigger the participant CacheChange_t removal system
+     * @return True if successfully modified WriterHistory
+     */
+    void removePublisherFromHistory(
+            const InstanceHandle_t&);
+    void removeSubscriberFromHistory(
+            const InstanceHandle_t&);
+
+protected:
 
     /**
         * Add participant CacheChange_ts from reader to writer
@@ -149,20 +158,13 @@ class EDPServer : public EDPSimple
         return addEndpointFromHistory(*subscriptions_writer_.first, *subscriptions_writer_.second, c);
     }
 
-    /**
-    * Trigger the participant CacheChange_t removal system
-    * @return True if successfully modified WriterHistory
-    */
-    void removePublisherFromHistory(const InstanceHandle_t&);
-    void removeSubscriberFromHistory(const InstanceHandle_t&);
-
-    private:
+private:
 
     /**
     * Callback to remove unnecesary WriterHistory info common implementation
     * @return True if trim is finished
     */
-    template<class ProxyCont> 
+    template<class ProxyCont>
     bool trimWriterHistory(
         key_list& _demises,
         StatefulWriter& writer,

--- a/include/fastrtps/rtps/builtin/discovery/endpoint/EDPServer.h
+++ b/include/fastrtps/rtps/builtin/discovery/endpoint/EDPServer.h
@@ -142,16 +142,10 @@ protected:
      * @return True if successfully modified WriterHistory
      */
     bool addPublisherFromHistory(
-            CacheChange_t& c)
-    {
-        return addEndpointFromHistory(*publications_writer_.first, *publications_writer_.second, c);
-    }
+            CacheChange_t& c);
 
     bool addSubscriberFromHistory(
-            CacheChange_t& c)
-    {
-        return addEndpointFromHistory(*subscriptions_writer_.first, *subscriptions_writer_.second, c);
-    }
+            CacheChange_t& c);
 
 private:
 
@@ -167,6 +161,7 @@ private:
             ProxyCont ParticipantProxyData::* pCont);
 
     //! addPublisherFromHistory and addSubscriberFromHistory common implementation
+    template<class Proxy>
     bool addEndpointFromHistory(
             StatefulWriter& writer,
             WriterHistory& history,

--- a/include/fastrtps/rtps/builtin/discovery/endpoint/EDPSimple.h
+++ b/include/fastrtps/rtps/builtin/discovery/endpoint/EDPSimple.h
@@ -53,6 +53,8 @@ class EDPSimple : public EDP
 
 public:
 
+    typedef std::set<InstanceHandle_t> key_list;
+
     /**
      * Constructor.
      * @param p Pointer to the PDP
@@ -187,9 +189,10 @@ protected:
     virtual bool createSEDPEndpoints();
 
     //! Process the info recorded in the persistence database
-    static void processPersistentData(
+    void processPersistentData(
             t_p_StatefulReader& reader,
-            t_p_StatefulWriter& writer);
+            t_p_StatefulWriter& writer,
+            key_list& demises);
 
 private:
 

--- a/include/fastrtps/rtps/builtin/discovery/endpoint/EDPSimple.h
+++ b/include/fastrtps/rtps/builtin/discovery/endpoint/EDPSimple.h
@@ -46,7 +46,7 @@ class EDPListener;
  * Inherits from EDP class.
  *@ingroup DISCOVERY_MODULE
  */
-class EDPSimple : public EDP  
+class EDPSimple : public EDP
 {
     typedef std::pair<StatefulWriter*,WriterHistory*> t_p_StatefulWriter;
     typedef std::pair<StatefulReader*,ReaderHistory*> t_p_StatefulReader;
@@ -169,6 +169,9 @@ protected:
      * @return True if correct.
      */
     virtual bool createSEDPEndpoints();
+
+    //! Process the info recorded in the persistence database
+    static void processPersistentData(t_p_StatefulReader & reader, t_p_StatefulWriter & writer);
 
 private:
 

--- a/include/fastrtps/rtps/builtin/discovery/endpoint/EDPSimple.h
+++ b/include/fastrtps/rtps/builtin/discovery/endpoint/EDPSimple.h
@@ -27,7 +27,7 @@
 #include <fastrtps/rtps/builtin/data/ReaderProxyData.h>
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
 class StatefulReader;
@@ -48,8 +48,8 @@ class EDPListener;
  */
 class EDPSimple : public EDP
 {
-    typedef std::pair<StatefulWriter*,WriterHistory*> t_p_StatefulWriter;
-    typedef std::pair<StatefulReader*,ReaderHistory*> t_p_StatefulReader;
+    typedef std::pair<StatefulWriter*, WriterHistory*> t_p_StatefulWriter;
+    typedef std::pair<StatefulReader*, ReaderHistory*> t_p_StatefulReader;
 
 public:
 
@@ -58,7 +58,9 @@ public:
      * @param p Pointer to the PDP
      * @param part Pointer to the RTPSParticipantImpl
      */
-    EDPSimple(PDP* p,RTPSParticipantImpl* part);
+    EDPSimple(
+            PDP* p,
+            RTPSParticipantImpl* part);
     virtual ~EDPSimple();
     //!Discovery attributes.
     BuiltinAttributes m_discovery;
@@ -79,7 +81,7 @@ public:
     t_p_StatefulWriter subscriptions_secure_writer_;
 
     t_p_StatefulReader subscriptions_secure_reader_;
-#endif
+#endif // if HAVE_SECURITY
 
     //!Pointer to the listener associated with PubReader and PubWriter.
     EDPListener* publications_listener_;
@@ -92,20 +94,24 @@ public:
      * @param attributes Reference to the DiscoveryAttributes.
      * @return True if correct.
      */
-    bool initEDP(BuiltinAttributes& attributes) override;
+    bool initEDP(
+            BuiltinAttributes& attributes) override;
     /**
      * This method assigns the remote builtin endpoints that the remote RTPSParticipant indicates is using to our local builtin endpoints.
      * @param pdata Pointer to the RTPSParticipantProxyData object.
      */
-    void assignRemoteEndpoints(const ParticipantProxyData& pdata) override;
+    void assignRemoteEndpoints(
+            const ParticipantProxyData& pdata) override;
     /**
      * Remove remote endpoints from the endpoint discovery protocol
      * @param pdata Pointer to the ParticipantProxyData to remove
      */
-    void removeRemoteEndpoints(ParticipantProxyData* pdata) override;
+    void removeRemoteEndpoints(
+            ParticipantProxyData* pdata) override;
 
     //! Verify if the given participant EDP enpoints are matched with us
-    bool areRemoteEndpointsMatched(const ParticipantProxyData* pdata) override;
+    bool areRemoteEndpointsMatched(
+            const ParticipantProxyData* pdata) override;
 
     /**
      * This method generates the corresponding change in the subscription writer and send it to all known remote endpoints.
@@ -113,26 +119,32 @@ public:
      * @param rdata Pointer to the ReaderProxyData object.
      * @return true if correct.
      */
-    bool processLocalReaderProxyData(RTPSReader* reader, ReaderProxyData* rdata) override;
+    bool processLocalReaderProxyData(
+            RTPSReader* reader,
+            ReaderProxyData* rdata) override;
     /**
      * This method generates the corresponding change in the publciations writer and send it to all known remote endpoints.
      * @param writer Pointer to the Writer object.
      * @param wdata Pointer to the WriterProxyData object.
      * @return true if correct.
      */
-    bool processLocalWriterProxyData(RTPSWriter* writer, WriterProxyData* wdata) override;
+    bool processLocalWriterProxyData(
+            RTPSWriter* writer,
+            WriterProxyData* wdata) override;
     /**
      * This methods generates the change disposing of the local Reader and calls the unpairing and removal methods of the base class.
      * @param R Pointer to the RTPSReader object.
      * @return True if correct.
      */
-    bool removeLocalReader(RTPSReader*R) override;
+    bool removeLocalReader(
+            RTPSReader* R) override;
     /**
      * This methods generates the change disposing of the local Writer and calls the unpairing and removal methods of the base class.
      * @param W Pointer to the RTPSWriter object.
      * @return True if correct.
      */
-    bool removeLocalWriter(RTPSWriter*W) override;
+    bool removeLocalWriter(
+            RTPSWriter* W) override;
 
 protected:
 
@@ -141,28 +153,32 @@ protected:
      *
      * @param [out] attributes History attributes to initialize
      */
-    virtual void set_builtin_reader_history_attributes(HistoryAttributes& attributes);
+    virtual void set_builtin_reader_history_attributes(
+            HistoryAttributes& attributes);
 
     /**
      * Initialization of history attributes for EDP built-in writers
      *
      * @param [out] attributes History attributes to initialize
      */
-    virtual void set_builtin_writer_history_attributes(HistoryAttributes& attributes);
+    virtual void set_builtin_writer_history_attributes(
+            HistoryAttributes& attributes);
 
     /**
      * Initialization of reader attributes for EDP built-in readers
      *
      * @param [out] attributes Reader attributes to initialize
      */
-    virtual void set_builtin_reader_attributes(ReaderAttributes& attributes);
+    virtual void set_builtin_reader_attributes(
+            ReaderAttributes& attributes);
 
     /**
      * Initialization of writer attributes for EDP built-in writers
      *
      * @param [out] attributes Writer attributes to initialize
      */
-    virtual void set_builtin_writer_attributes(WriterAttributes& attributes);
+    virtual void set_builtin_writer_attributes(
+            WriterAttributes& attributes);
 
     /**
      * Create local SEDP Endpoints based on the DiscoveryAttributes.
@@ -171,19 +187,23 @@ protected:
     virtual bool createSEDPEndpoints();
 
     //! Process the info recorded in the persistence database
-    static void processPersistentData(t_p_StatefulReader & reader, t_p_StatefulWriter & writer);
+    static void processPersistentData(
+            t_p_StatefulReader& reader,
+            t_p_StatefulWriter& writer);
 
 private:
 
 #if HAVE_SECURITY
     bool create_sedp_secure_endpoints();
 
-    bool pairing_remote_writer_with_local_builtin_reader_after_security(const GUID_t& local_reader,
-                const WriterProxyData& remote_writer_data) override;
+    bool pairing_remote_writer_with_local_builtin_reader_after_security(
+            const GUID_t& local_reader,
+            const WriterProxyData& remote_writer_data) override;
 
-    bool pairing_remote_reader_with_local_builtin_writer_after_security(const GUID_t& local_writer,
-                const ReaderProxyData& remote_reader_data) override;
-#endif
+    bool pairing_remote_reader_with_local_builtin_writer_after_security(
+            const GUID_t& local_writer,
+            const ReaderProxyData& remote_reader_data) override;
+#endif // if HAVE_SECURITY
 
     std::mutex temp_data_lock_;
     ReaderProxyData temp_reader_proxy_data_;
@@ -194,5 +214,5 @@ private:
 } /* namespace fastrtps */
 } /* namespace eprosima */
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif /* EDPSIMPLE_H_ */

--- a/include/fastrtps/rtps/builtin/discovery/endpoint/EDPStatic.h
+++ b/include/fastrtps/rtps/builtin/discovery/endpoint/EDPStatic.h
@@ -25,10 +25,10 @@
 
 
 namespace eprosima {
-namespace fastrtps{
-namespace xmlparser{
-    class XMLEndpointParser;
-}
+namespace fastrtps {
+namespace xmlparser {
+class XMLEndpointParser;
+} // namespace xmlparser
 namespace rtps {
 
 
@@ -39,85 +39,110 @@ namespace rtps {
 class EDPStaticProperty
 {
 public:
-	EDPStaticProperty():m_userId(0){};
-	~EDPStaticProperty(){};
-	//!Endpoint type
-	std::string m_endpointType;
-	//!Status
-	std::string m_status;
-	//!User ID as string
-	std::string m_userIdStr;
-	//!User ID
-	uint16_t m_userId;
-	//!Entity ID
-	EntityId_t m_entityId;
-	/**
-	* Convert information to a property
-	* @param type Type of endpoint
-	* @param status Status of the endpoint
-	* @param id User Id
-	* @param ent EntityId
-	* @return Pair of two strings.
-	*/
-	static std::pair<std::string,std::string> toProperty(std::string type,std::string status,uint16_t id,const EntityId_t& ent);
-	/**
-	* @param in_property Input property-
-	* @return True if correctly read
-	*/
-	bool fromProperty(std::pair<std::string,std::string> in_property);
+
+    EDPStaticProperty()
+        : m_userId(0)
+    {
+    }
+
+    ~EDPStaticProperty()
+    {
+    }
+
+    //!Endpoint type
+    std::string m_endpointType;
+    //!Status
+    std::string m_status;
+    //!User ID as string
+    std::string m_userIdStr;
+    //!User ID
+    uint16_t m_userId;
+    //!Entity ID
+    EntityId_t m_entityId;
+    /**
+     * Convert information to a property
+     * @param type Type of endpoint
+     * @param status Status of the endpoint
+     * @param id User Id
+     * @param ent EntityId
+     * @return Pair of two strings.
+     */
+    static std::pair<std::string, std::string> toProperty(
+            std::string type,
+            std::string status,
+            uint16_t id,
+            const EntityId_t& ent);
+    /**
+     * @param in_property Input property-
+     * @return True if correctly read
+     */
+    bool fromProperty(
+            std::pair<std::string, std::string> in_property);
 };
 
 /**
  * Class EDPStatic, implements a static endpoint discovery module.
  * @ingroup DISCOVERYMODULE
  */
-class EDPStatic : public EDP {
+class EDPStatic : public EDP
+{
 public:
-	/**
-	* Constructor.
-	* @param p Pointer to the PDPSimple.
-	* @param part Pointer to the RTPSParticipantImpl.
-	*/
-	EDPStatic(PDP* p,RTPSParticipantImpl* part);
-	virtual ~EDPStatic();
-	/**
-	 * Abstract method to initialize the EDP.
-	 * @param attributes DiscoveryAttributes structure.
-	 * @return True if correct.
-	 */
-	bool initEDP(BuiltinAttributes& attributes) override;
-	/**
-	 * Abstract method that assigns remote endpoints when a new RTPSParticipantProxyData is discovered.
-	 * @param pdata Pointer to the ParticipantProxyData.
-	 */
-	void assignRemoteEndpoints(const ParticipantProxyData& pdata) override;
-	/**
-	 * Abstract method that removes a local Reader from the discovery method
-	 * @param R Pointer to the Reader to remove.
-	 * @return True if correctly removed.
-	 */
-	bool removeLocalReader(RTPSReader* R) override;
-	/**
-	 * Abstract method that removes a local Writer from the discovery method
-	 * @param W Pointer to the Writer to remove.
-	 * @return True if correctly removed.
-	 */
-	bool removeLocalWriter(RTPSWriter*W) override;
 
-	/**
-	 * After a new local ReaderProxyData has been created some processing is needed (depends on the implementation).
-	 * @param reader Pointer to the RTPSReader object.
-	 * @param rdata Pointer to the ReaderProxyData object.
-	 * @return True if correct.
-	 */
-	bool processLocalReaderProxyData(RTPSReader* reader, ReaderProxyData* rdata) override;
-	/**
-	 * After a new local WriterProxyData has been created some processing is needed (depends on the implementation).
-	 * @param writer Pointer to the RTPSWriter object.
-	 * @param wdata Pointer to the Writer ProxyData object.
-	 * @return True if correct.
-	 */
-	bool processLocalWriterProxyData(RTPSWriter* writer, WriterProxyData* wdata) override;
+    /**
+     * Constructor.
+     * @param p Pointer to the PDPSimple.
+     * @param part Pointer to the RTPSParticipantImpl.
+     */
+    EDPStatic(
+            PDP* p,
+            RTPSParticipantImpl* part);
+    virtual ~EDPStatic();
+    /**
+     * Abstract method to initialize the EDP.
+     * @param attributes DiscoveryAttributes structure.
+     * @return True if correct.
+     */
+    bool initEDP(
+            BuiltinAttributes& attributes) override;
+    /**
+     * Abstract method that assigns remote endpoints when a new RTPSParticipantProxyData is discovered.
+     * @param pdata Pointer to the ParticipantProxyData.
+     */
+    void assignRemoteEndpoints(
+            const ParticipantProxyData& pdata) override;
+    /**
+     * Abstract method that removes a local Reader from the discovery method
+     * @param R Pointer to the Reader to remove.
+     * @return True if correctly removed.
+     */
+    bool removeLocalReader(
+            RTPSReader* R) override;
+    /**
+     * Abstract method that removes a local Writer from the discovery method
+     * @param W Pointer to the Writer to remove.
+     * @return True if correctly removed.
+     */
+    bool removeLocalWriter(
+            RTPSWriter* W) override;
+
+    /**
+     * After a new local ReaderProxyData has been created some processing is needed (depends on the implementation).
+     * @param reader Pointer to the RTPSReader object.
+     * @param rdata Pointer to the ReaderProxyData object.
+     * @return True if correct.
+     */
+    bool processLocalReaderProxyData(
+            RTPSReader* reader,
+            ReaderProxyData* rdata) override;
+    /**
+     * After a new local WriterProxyData has been created some processing is needed (depends on the implementation).
+     * @param writer Pointer to the RTPSWriter object.
+     * @param wdata Pointer to the Writer ProxyData object.
+     * @return True if correct.
+     */
+    bool processLocalWriterProxyData(
+            RTPSWriter* writer,
+            WriterProxyData* wdata) override;
 
     /**
      * New Remote Writer has been found and this method process it and calls the pairing methods.
@@ -132,40 +157,44 @@ public:
             const string_255& participant_name,
             uint16_t user_id,
             EntityId_t ent_id = c_EntityId_Unknown);
-	/**
-	 * New Remote Reader has been found and this method process it and calls the pairing methods.
+    /**
+     * New Remote Reader has been found and this method process it and calls the pairing methods.
      * @param participant_guid  GUID of the participant.
      * @param participant_name  Name of the participant.
      * @param user_id           User Id.
      * @param ent_id            Entity Id.
      * @return true if correct.
-	 */
-	bool newRemoteReader(
+     */
+    bool newRemoteReader(
             const GUID_t& participant_guid,
             const string_255& participant_name,
             uint16_t user_id,
             EntityId_t ent_id = c_EntityId_Unknown);
 
-	/**
-	* This method checks the provided entityId against the topic type to see if it matches
-	* @param rdata Pointer to the readerProxyData
-	* @return True if its correct.
-	**/
-	bool checkEntityId(ReaderProxyData* rdata);
-	/**
-	* This method checks the provided entityId against the topic type to see if it matches
-	* @param wdata Pointer to the writerProxyData
-	* @return True if its correct.
-	**/
-	bool checkEntityId(WriterProxyData* wdata);
+    /**
+     * This method checks the provided entityId against the topic type to see if it matches
+     * @param rdata Pointer to the readerProxyData
+     * @return True if its correct.
+     **/
+    bool checkEntityId(
+            ReaderProxyData* rdata);
+    /**
+     * This method checks the provided entityId against the topic type to see if it matches
+     * @param wdata Pointer to the writerProxyData
+     * @return True if its correct.
+     **/
+    bool checkEntityId(
+            WriterProxyData* wdata);
+
 private:
-	xmlparser::XMLEndpointParser* mp_edpXML;
-	BuiltinAttributes m_attributes;
+
+    xmlparser::XMLEndpointParser* mp_edpXML;
+    BuiltinAttributes m_attributes;
 };
 
-}
+} // namespace rtps
 } /* namespace rtps */
 } /* namespace eprosima */
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif /* EDPSTATIC_H_ */

--- a/include/fastrtps/rtps/builtin/discovery/endpoint/EDPStatic.h
+++ b/include/fastrtps/rtps/builtin/discovery/endpoint/EDPStatic.h
@@ -119,18 +119,18 @@ public:
 	 */
 	bool processLocalWriterProxyData(RTPSWriter* writer, WriterProxyData* wdata) override;
 
-	/**
-	 * New Remote Writer has been found and this method process it and calls the pairing methods.
-	 * @param participant_guid  GUID of the participant.
+    /**
+     * New Remote Writer has been found and this method process it and calls the pairing methods.
+     * @param participant_guid  GUID of the participant.
      * @param participant_name  Name of the participant.
-	 * @param user_id           User Id.
-	 * @param ent_id            Entity Id.
-	 * @return True if correct.
-	 */
-	bool newRemoteWriter(
-            const GUID_t& participant_guid, 
+     * @param user_id           User Id.
+     * @param ent_id            Entity Id.
+     * @return True if correct.
+     */
+    bool newRemoteWriter(
+            const GUID_t& participant_guid,
             const string_255& participant_name,
-            uint16_t user_id, 
+            uint16_t user_id,
             EntityId_t ent_id = c_EntityId_Unknown);
 	/**
 	 * New Remote Reader has been found and this method process it and calls the pairing methods.

--- a/include/fastrtps/rtps/builtin/discovery/participant/PDPServer.h
+++ b/include/fastrtps/rtps/builtin/discovery/participant/PDPServer.h
@@ -26,11 +26,11 @@
 
 #include "timedevent/DServerEvent.h"
 
- // TODO: remove when the Writer API issue is resolved
+// TODO: remove when the Writer API issue is resolved
 #include <fastrtps/rtps/attributes/WriterAttributes.h>
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
 class StatefulWriter;
@@ -78,14 +78,16 @@ public:
             DurabilityKind_t durability_kind = TRANSIENT_LOCAL);
     ~PDPServer();
 
-    void initializeParticipantProxyData(ParticipantProxyData* participant_data) override;
+    void initializeParticipantProxyData(
+            ParticipantProxyData* participant_data) override;
 
     /**
      * Initialize the PDP.
      * @param part Pointer to the RTPSParticipant.
      * @return True on success
      */
-    bool init(RTPSParticipantImpl* part) override;
+    bool init(
+            RTPSParticipantImpl* part) override;
 
     /**
      * Creates an initializes a new participant proxy from a DATA(p) raw info
@@ -94,8 +96,8 @@ public:
      * @return new ParticipantProxyData * or nullptr on failure
      */
     ParticipantProxyData* createParticipantProxyData(
-        const ParticipantProxyData& p,
-        const GUID_t& writer_guid) override;
+            const ParticipantProxyData& p,
+            const GUID_t& writer_guid) override;
 
     /**
      * Create the SPDP Writer and Reader
@@ -135,14 +137,16 @@ public:
      * @param c metatraffic CacheChange_t
      * @return True if successfully modified WriterHistory
      */
-    bool addRelayedChangeToHistory(CacheChange_t& c);
+    bool addRelayedChangeToHistory(
+            CacheChange_t& c);
 
     /**
      * Trigger the participant CacheChange_t removal system
      * @param h instanceHandle associated with participants CacheChange_ts
      * @return True if successfully modified WriterHistory
      */
-    void removeParticipantFromHistory(const InstanceHandle_t& h);
+    void removeParticipantFromHistory(
+            const InstanceHandle_t& h);
 
     /**
      * Methods to synchronize EDP matching
@@ -152,13 +156,15 @@ public:
      * Add a participant to the queue of pending participants to EDP matching
      * @param p ParticipantProxyData associated with the new participant
      */
-    void queueParticipantForEDPMatch(const ParticipantProxyData* p);
+    void queueParticipantForEDPMatch(
+            const ParticipantProxyData* p);
 
     /**
      * Remove a participant from the queue of pending participants to EDP matching
      * @param guid GUID associated with the new participant
      */
-    void removeParticipantForEDPMatch(const GUID_t& guid);
+    void removeParticipantForEDPMatch(
+            const GUID_t& guid);
 
     /**
      * Check if all client have acknowledge the server PDP data
@@ -185,10 +191,10 @@ public:
      */
 
     /**
-    * Check if all servers have acknowledge this server PDP data
-    * This method must be called from a mutex protected context.
-    * @return True if all can reach the client
-    */
+     * Check if all servers have acknowledge this server PDP data
+     * This method must be called from a mutex protected context.
+     * @return True if all can reach the client
+     */
     bool all_servers_acknowledge_PDP();
 
     /**
@@ -211,18 +217,21 @@ public:
      * @param wparams allows to identify the change
      */
     void announceParticipantState(
-        bool new_change,
-        bool dispose = false,
-        WriteParams& wparams = WriteParams::WRITE_PARAM_DEFAULT) override;
+            bool new_change,
+            bool dispose = false,
+            WriteParams& wparams = WriteParams::WRITE_PARAM_DEFAULT) override;
 
     /**
      * These methods wouldn't be needed under perfect server operation (no need of dynamic endpoint allocation)
      * but must be implemented to solve server shutdown situations.
      * @param pdata Pointer to the RTPSParticipantProxyData object.
      */
-    void assignRemoteEndpoints(ParticipantProxyData* pdata) override;
-    void removeRemoteEndpoints(ParticipantProxyData * pdata) override;
-    void notifyAboveRemoteEndpoints(const ParticipantProxyData& pdata) override;
+    void assignRemoteEndpoints(
+            ParticipantProxyData* pdata) override;
+    void removeRemoteEndpoints(
+            ParticipantProxyData* pdata) override;
+    void notifyAboveRemoteEndpoints(
+            const ParticipantProxyData& pdata) override;
 
     //! Get filename for persistence database file
     std::string GetPersistenceFileName();
@@ -234,18 +243,22 @@ public:
     void processPersistentData();
 
     //! Wakes up the DServerEvent for new matching or trimming
-    void awakeServerThread() { mp_sync->restart_timer(); }
+    void awakeServerThread()
+    {
+        mp_sync->restart_timer();
+    }
 
     // The following struct and two methods solve a callback synchronization issue
 
     class InPDPCallback
     {
         friend class PDPServer;
-        PDPServer & server_;
+        PDPServer& server_;
 
     public:
 
-        InPDPCallback(PDPServer & svr);
+        InPDPCallback(
+                PDPServer& svr);
         ~InPDPCallback();
     };
 
@@ -253,21 +266,22 @@ public:
     std::unique_ptr<InPDPCallback> signalCallback();
 
     // ! calls PDP Reader matched_writer_remove preventing deadlocks
-    bool safe_PDP_matched_writer_remove(const GUID_t& wguid);
+    bool safe_PDP_matched_writer_remove(
+            const GUID_t& wguid);
 
-    private:
+private:
 
-     /**
+    /**
      * Callback to remove unnecesary WriterHistory info from PDP alone
      * @return True if trimming is completed
      */
-     bool trimPDPWriterHistory();
+    bool trimPDPWriterHistory();
 
     /**
-    * TimedEvent for server synchronization:
-    *   first stage: periodically resend the local RTPSParticipant information until all servers have acknowledge reception
-    *   second stage: waiting PDP info is up to date before allowing EDP matching
-    */
+     * TimedEvent for server synchronization:
+     *   first stage: periodically resend the local RTPSParticipant information until all servers have acknowledge reception
+     *   second stage: waiting PDP info is up to date before allowing EDP matching
+     */
     DServerEvent* mp_sync;
 
     // ! on PDP DATA(p[UD]) callback. Only modified by transport threads which are
@@ -275,8 +289,8 @@ public:
     volatile bool PDP_callback_;
 };
 
-}
+} // namespace rtps
 } /* namespace rtps */
 } /* namespace eprosima */
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif /* PDPSERVER_H_ */

--- a/include/fastrtps/rtps/builtin/discovery/participant/PDPServer.h
+++ b/include/fastrtps/rtps/builtin/discovery/participant/PDPServer.h
@@ -141,7 +141,6 @@ public:
     /**
      * Trigger the participant CacheChange_t removal system
      * @param h instanceHandle associated with participants CacheChange_ts
-     * @return True if successfully modified WriterHistory
      */
     void removeParticipantFromHistory(
             const InstanceHandle_t& h);

--- a/include/fastrtps/rtps/builtin/discovery/participant/PDPServer.h
+++ b/include/fastrtps/rtps/builtin/discovery/participant/PDPServer.h
@@ -46,8 +46,6 @@ class PDPServer : public PDP
     friend class DServerEvent;
     friend class PDPServerListener;
 
-    friend class InPDPCallback;
-
     typedef std::set<const ParticipantProxyData*> pending_matches_list;
     typedef std::set<InstanceHandle_t> key_list;
 
@@ -242,32 +240,14 @@ public:
     //! Process the info recorded in the persistence database
     void processPersistentData();
 
+    //! adds identity info to DATA(p[UD])s in order to keep it through persistance serialization process
+    static bool set_data_disposal_payload(CDRMessage_t* msg, const SampleIdentity& sid);
+
     //! Wakes up the DServerEvent for new matching or trimming
     void awakeServerThread()
     {
         mp_sync->restart_timer();
     }
-
-    // The following struct and two methods solve a callback synchronization issue
-
-    class InPDPCallback
-    {
-        friend class PDPServer;
-        PDPServer& server_;
-
-    public:
-
-        InPDPCallback(
-                PDPServer& svr);
-        ~InPDPCallback();
-    };
-
-    // ! returns a unique_ptr to an object that handles PDP_callback_ in a RAII fashion
-    std::unique_ptr<InPDPCallback> signalCallback();
-
-    // ! calls PDP Reader matched_writer_remove preventing deadlocks
-    bool safe_PDP_matched_writer_remove(
-            const GUID_t& wguid);
 
 private:
 
@@ -283,10 +263,6 @@ private:
      *   second stage: waiting PDP info is up to date before allowing EDP matching
      */
     DServerEvent* mp_sync;
-
-    // ! on PDP DATA(p[UD]) callback. Only modified by transport threads which are
-    // serialized for PDP reader
-    volatile bool PDP_callback_;
 };
 
 } // namespace rtps

--- a/include/fastrtps/rtps/builtin/discovery/participant/PDPServer.h
+++ b/include/fastrtps/rtps/builtin/discovery/participant/PDPServer.h
@@ -241,7 +241,9 @@ public:
     void processPersistentData();
 
     //! adds identity info to DATA(p[UD])s in order to keep it through persistance serialization process
-    static bool set_data_disposal_payload(CDRMessage_t* msg, const SampleIdentity& sid);
+    static bool set_data_disposal_payload(
+            CDRMessage_t* msg,
+            const SampleIdentity& sid);
 
     //! Wakes up the DServerEvent for new matching or trimming
     void awakeServerThread()

--- a/include/fastrtps/rtps/builtin/discovery/participant/PDPServer.h
+++ b/include/fastrtps/rtps/builtin/discovery/participant/PDPServer.h
@@ -227,6 +227,12 @@ public:
     //! Get filename for persistence database file
     std::string GetPersistenceFileName();
 
+    //! returns true if loading info from persistency database
+    bool ongoingDeserialization();
+
+    //! Process the info recorded in the persistence database
+    void processPersistentData();
+
     //! Wakes up the DServerEvent for new matching or trimming
     void awakeServerThread() { mp_sync->restart_timer(); }
 

--- a/include/fastrtps/rtps/common/Guid.h
+++ b/include/fastrtps/rtps/common/Guid.h
@@ -187,7 +187,7 @@ inline bool operator <(
     return false;
 }
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 const GUID_t c_Guid_Unknown;
 
@@ -254,7 +254,7 @@ inline std::istream& operator >>(
     return input;
 }
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 } // namespace rtps
 } // namespace fastrtps

--- a/include/fastrtps/rtps/common/Guid.h
+++ b/include/fastrtps/rtps/common/Guid.h
@@ -234,8 +234,13 @@ inline std::istream& operator >>(
         {
             input.exceptions(excp_mask | std::ios_base::failbit | std::ios_base::badbit);
 
-            input >> guid.guidPrefix;
-            input >> guid.entityId;
+            char sep;
+            input >> guid.guidPrefix >> sep >> guid.entityId;
+
+            if (sep != '|')
+            {
+                input.setstate(std::ios_base::failbit);
+            }
         }
         catch (std::ios_base::failure&)
         {

--- a/include/fastrtps/rtps/common/SampleIdentity.h
+++ b/include/fastrtps/rtps/common/SampleIdentity.h
@@ -148,7 +148,11 @@ namespace eprosima
                     GUID_t writer_guid_;
 
                     SequenceNumber_t sequence_number_;
-            };
+
+                    friend std::istream& operator >>(std::istream& input, SampleIdentity& sid);
+                    friend std::ostream& operator <<(std::ostream& output, const SampleIdentity& sid);
+           };
+
         } //namespace rtps
     } //namespace fastrtps
 } //namespace eprosima

--- a/include/fastrtps/rtps/common/SampleIdentity.h
+++ b/include/fastrtps/rtps/common/SampleIdentity.h
@@ -153,6 +153,68 @@ namespace eprosima
                     friend std::ostream& operator <<(std::ostream& output, const SampleIdentity& sid);
            };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+
+/**
+ * Stream operator, retrieves a GUID.
+ * @param input Input stream.
+ * @param sid SampleIdentity to read.
+ * @return Stream operator.
+ */
+inline std::istream& operator >>(
+        std::istream& input,
+        SampleIdentity& sid)
+{
+    std::istream::sentry s(input);
+
+    if (s)
+    {
+        std::ios_base::iostate excp_mask = input.exceptions();
+
+        try
+        {
+            input.exceptions(excp_mask | std::ios_base::failbit | std::ios_base::badbit);
+
+            char sep;
+            input >> sid.writer_guid_ >> sep >> sid.sequence_number_;
+
+            if (sep != '|')
+            {
+                input.setstate(std::ios_base::failbit);
+            }
+        }
+        catch (std::ios_base::failure&)
+        {
+            // maybe is unknown or just invalid
+            sid.writer_guid_ = GUID_t::unknown();
+            sid.sequence_number_ = SequenceNumber_t::unknown();
+        }
+
+        input.exceptions(excp_mask);
+    }
+
+    return input;
+}
+
+/**
+ * Stream operator, prints a GUID.
+ * @param output Output stream.
+ * @param sid SampleIdentity to print.
+ * @return Stream operator.
+ */
+inline std::ostream& operator <<(
+        std::ostream& output,
+        const SampleIdentity& sid)
+{
+    output << sid.writer_guid_ << '|' << sid.sequence_number_;
+
+    return output;
+}
+
+#endif DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+
+
+
         } //namespace rtps
     } //namespace fastrtps
 } //namespace eprosima

--- a/include/fastrtps/rtps/common/SampleIdentity.h
+++ b/include/fastrtps/rtps/common/SampleIdentity.h
@@ -21,137 +21,152 @@
 #include "Guid.h"
 #include "SequenceNumber.h"
 
-namespace eprosima
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+/*!
+ * @brief This class is used to specify a sample
+ * @ingroup COMMON_MODULE
+ */
+class RTPS_DllAPI SampleIdentity
 {
-    namespace fastrtps
+public:
+
+    /*!
+     * @brief Default constructor. Constructs an unknown SampleIdentity.
+     */
+    SampleIdentity()
+        : writer_guid_(GUID_t::unknown())
+        , sequence_number_(SequenceNumber_t::unknown())
     {
-        namespace rtps
-        {
-            /*!
-             * @brief This class is used to specify a sample
-             * @ingroup COMMON_MODULE
-             */
-            class RTPS_DllAPI SampleIdentity
-            {
-                public:
+    }
 
-                    /*!
-                     * @brief Default constructor. Constructs an unknown SampleIdentity.
-                     */
-                    SampleIdentity() : writer_guid_(GUID_t::unknown()), sequence_number_(SequenceNumber_t::unknown())
-                    {
-                    }
+    /*!
+     * @brief Copy constructor.
+     */
+    SampleIdentity(
+            const SampleIdentity& sample_id)
+        : writer_guid_(sample_id.writer_guid_)
+        , sequence_number_(sample_id.sequence_number_)
+    {
+    }
 
-                    /*!
-                     * @brief Copy constructor.
-                     */
-                    SampleIdentity(const SampleIdentity &sample_id) : writer_guid_(sample_id.writer_guid_),
-                    sequence_number_(sample_id.sequence_number_)
-                    {
-                    }
+    /*!
+     * @brief Move constructor.
+     */
+    SampleIdentity(
+            SampleIdentity&& sample_id)
+        : writer_guid_(std::move(sample_id.writer_guid_))
+        , sequence_number_(std::move(sample_id.sequence_number_))
+    {
+    }
 
-                    /*!
-                     * @brief Move constructor.
-                     */
-                    SampleIdentity(SampleIdentity &&sample_id) : writer_guid_(std::move(sample_id.writer_guid_)),
-                    sequence_number_(std::move(sample_id.sequence_number_))
-                    {
-                    }
+    /*!
+     * @brief Assignment operator.
+     */
+    SampleIdentity& operator =(
+            const SampleIdentity& sample_id)
+    {
+        writer_guid_ = sample_id.writer_guid_;
+        sequence_number_ = sample_id.sequence_number_;
+        return *this;
+    }
 
-                    /*!
-                     * @brief Assignment operator.
-                     */
-                    SampleIdentity& operator=(const SampleIdentity &sample_id)
-                    {
-                        writer_guid_ = sample_id.writer_guid_;
-                        sequence_number_ = sample_id.sequence_number_;
-                        return *this;
-                    }
+    /*!
+     * @brief Move constructor.
+     */
+    SampleIdentity& operator =(
+            SampleIdentity&& sample_id)
+    {
+        writer_guid_ = std::move(sample_id.writer_guid_);
+        sequence_number_ = std::move(sample_id.sequence_number_);
+        return *this;
+    }
 
-                    /*!
-                     * @brief Move constructor.
-                     */
-                    SampleIdentity& operator=(SampleIdentity &&sample_id)
-                    {
-                        writer_guid_ = std::move(sample_id.writer_guid_);
-                        sequence_number_ = std::move(sample_id.sequence_number_);
-                        return *this;
-                    }
+    /*!
+     * @brief
+     */
+    bool operator ==(
+            const SampleIdentity& sample_id) const
+    {
+        return (writer_guid_ == sample_id.writer_guid_) && (sequence_number_ == sample_id.sequence_number_);
+    }
 
-                    /*!
-                     * @brief
-                     */
-                    bool operator==(const SampleIdentity &sample_id) const
-                    {
-                        return (writer_guid_ == sample_id.writer_guid_) && (sequence_number_ == sample_id.sequence_number_);
-                    }
+    /*!
+     * @brief
+     */
+    bool operator !=(
+            const SampleIdentity& sample_id) const
+    {
+        return !(*this == sample_id);
+    }
 
-                    /*!
-                     * @brief
-                     */
-                    bool operator!=(const SampleIdentity &sample_id) const
-                    {
-                        return !(*this == sample_id);
-                    }
+    SampleIdentity& writer_guid(
+            const GUID_t& guid)
+    {
+        writer_guid_ = guid;
+        return *this;
+    }
 
-                    SampleIdentity& writer_guid(const GUID_t &guid)
-                    {
-                        writer_guid_ = guid;
-                        return *this;
-                    }
+    SampleIdentity& writer_guid(
+            GUID_t&& guid)
+    {
+        writer_guid_ = std::move(guid);
+        return *this;
+    }
 
-                    SampleIdentity& writer_guid(GUID_t &&guid)
-                    {
-                        writer_guid_ = std::move(guid);
-                        return *this;
-                    }
+    const GUID_t& writer_guid() const
+    {
+        return writer_guid_;
+    }
 
-                    const GUID_t& writer_guid() const
-                    {
-                        return writer_guid_;
-                    }
+    GUID_t& writer_guid()
+    {
+        return writer_guid_;
+    }
 
-                    GUID_t& writer_guid()
-                    {
-                        return writer_guid_;
-                    }
+    SampleIdentity& sequence_number(
+            const SequenceNumber_t& seq)
+    {
+        sequence_number_ = seq;
+        return *this;
+    }
 
-                    SampleIdentity& sequence_number(const SequenceNumber_t &seq)
-                    {
-                        sequence_number_ = seq;
-                        return *this;
-                    }
+    SampleIdentity& sequence_number(
+            SequenceNumber_t&& seq)
+    {
+        sequence_number_ = std::move(seq);
+        return *this;
+    }
 
-                    SampleIdentity& sequence_number(SequenceNumber_t &&seq)
-                    {
-                        sequence_number_ = std::move(seq);
-                        return *this;
-                    }
+    const SequenceNumber_t& sequence_number() const
+    {
+        return sequence_number_;
+    }
 
-                    const SequenceNumber_t& sequence_number() const
-                    {
-                        return sequence_number_;
-                    }
+    SequenceNumber_t& sequence_number()
+    {
+        return sequence_number_;
+    }
 
-                    SequenceNumber_t& sequence_number()
-                    {
-                        return sequence_number_;
-                    }
+    static SampleIdentity unknown()
+    {
+        return SampleIdentity();
+    }
 
-                    static SampleIdentity unknown()
-                    {
-                        return SampleIdentity();
-                    }
+private:
 
-                private:
+    GUID_t writer_guid_;
 
-                    GUID_t writer_guid_;
+    SequenceNumber_t sequence_number_;
 
-                    SequenceNumber_t sequence_number_;
-
-                    friend std::istream& operator >>(std::istream& input, SampleIdentity& sid);
-                    friend std::ostream& operator <<(std::ostream& output, const SampleIdentity& sid);
-           };
+    friend std::istream& operator >>(
+            std::istream& input,
+            SampleIdentity& sid);
+    friend std::ostream& operator <<(
+            std::ostream& output,
+            const SampleIdentity& sid);
+};
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
@@ -215,7 +230,7 @@ inline std::ostream& operator <<(
 
 
 
-        } //namespace rtps
-    } //namespace fastrtps
+}         //namespace rtps
+}     //namespace fastrtps
 } //namespace eprosima
 #endif // _FASTRTPS_RTPS_COMMON_SAMPLEIDENTITY_H_

--- a/include/fastrtps/rtps/common/SampleIdentity.h
+++ b/include/fastrtps/rtps/common/SampleIdentity.h
@@ -45,43 +45,25 @@ public:
      * @brief Copy constructor.
      */
     SampleIdentity(
-            const SampleIdentity& sample_id)
-        : writer_guid_(sample_id.writer_guid_)
-        , sequence_number_(sample_id.sequence_number_)
-    {
-    }
+            const SampleIdentity& sample_id) = default;
 
     /*!
      * @brief Move constructor.
      */
     SampleIdentity(
-            SampleIdentity&& sample_id)
-        : writer_guid_(std::move(sample_id.writer_guid_))
-        , sequence_number_(std::move(sample_id.sequence_number_))
-    {
-    }
+            SampleIdentity&& sample_id) = default;
 
     /*!
      * @brief Assignment operator.
      */
     SampleIdentity& operator =(
-            const SampleIdentity& sample_id)
-    {
-        writer_guid_ = sample_id.writer_guid_;
-        sequence_number_ = sample_id.sequence_number_;
-        return *this;
-    }
+            const SampleIdentity& sample_id) = default;
 
     /*!
      * @brief Move constructor.
      */
     SampleIdentity& operator =(
-            SampleIdentity&& sample_id)
-    {
-        writer_guid_ = std::move(sample_id.writer_guid_);
-        sequence_number_ = std::move(sample_id.sequence_number_);
-        return *this;
-    }
+            SampleIdentity&& sample_id) = default;
 
     /*!
      * @brief

--- a/include/fastrtps/rtps/common/SampleIdentity.h
+++ b/include/fastrtps/rtps/common/SampleIdentity.h
@@ -211,7 +211,7 @@ inline std::ostream& operator <<(
     return output;
 }
 
-#endif DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+#endif // DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 
 

--- a/include/fastrtps/rtps/common/SequenceNumber.h
+++ b/include/fastrtps/rtps/common/SequenceNumber.h
@@ -91,7 +91,8 @@ struct RTPS_DllAPI SequenceNumber_t
         return *this;
     }
 
-    SequenceNumber_t operator ++(int) noexcept
+    SequenceNumber_t operator ++(
+            int) noexcept
     {
         SequenceNumber_t result(*this);
         ++(*this);
@@ -287,9 +288,9 @@ inline SequenceNumber_t operator -(
     return res;
 }
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
-const SequenceNumber_t c_SequenceNumber_Unknown(-1,0);
+const SequenceNumber_t c_SequenceNumber_Unknown(-1, 0);
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
@@ -323,7 +324,7 @@ inline std::ostream& operator <<(
         std::ostream& output,
         const std::vector<SequenceNumber_t>& seqNumSet)
 {
-    for(const SequenceNumber_t& sn : seqNumSet)
+    for (const SequenceNumber_t& sn : seqNumSet)
     {
         output << sn << " ";
     }
@@ -341,6 +342,7 @@ struct SequenceNumberHash
     {
         return static_cast<std::size_t>(sequence_number.to64long());
     }
+
 };
 
 struct SequenceNumberDiff
@@ -352,9 +354,10 @@ struct SequenceNumberDiff
         SequenceNumber_t diff = a - b;
         return diff.low;
     }
+
 };
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 //!Structure SequenceNumberSet_t, contains a group of sequencenumbers.
 //!@ingroup COMMON_MODULE
@@ -374,10 +377,10 @@ inline std::ostream& operator <<(
 {
     output << sns.base().to64long() << ":";
     sns.for_each([&output](
-            SequenceNumber_t it)
-    {
-        output << it.to64long() << "-";
-    });
+                SequenceNumber_t it)
+            {
+                output << it.to64long() << "-";
+            });
 
     return output;
 }

--- a/include/fastrtps/rtps/common/SequenceNumber.h
+++ b/include/fastrtps/rtps/common/SequenceNumber.h
@@ -61,7 +61,7 @@ struct RTPS_DllAPI SequenceNumber_t
     }
 
     /*!
-     * @param 64long
+     * @param u
      */
     explicit
     SequenceNumber_t(

--- a/include/fastrtps/rtps/common/SequenceNumber.h
+++ b/include/fastrtps/rtps/common/SequenceNumber.h
@@ -60,6 +60,17 @@ struct RTPS_DllAPI SequenceNumber_t
     {
     }
 
+    /*!
+     * @param 64long
+     */
+    explicit
+    SequenceNumber_t(
+            uint64_t u) noexcept
+        : high( static_cast<int32_t>(u >> 32u) )
+        , low( static_cast<uint32_t>(u) )
+    {
+    }
+
     /*! Convert the number to 64 bit.
      * @return 64 bit representation of the SequenceNumber
      */
@@ -371,7 +382,27 @@ inline std::ostream& operator <<(
     return output;
 }
 
-#endif
+/**
+ *
+ * @param input
+ * @param seqNum
+ * @return
+ */
+inline std::istream& operator >>(
+        std::istream& input,
+        SequenceNumber_t& seqNum)
+{
+    uint64_t aux;
+
+    if (input >> aux)
+    {
+        seqNum = SequenceNumber_t(aux);
+    }
+
+    return input;
+}
+
+#endif DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 } // namespace rtps
 } // namespace fastrtps

--- a/include/fastrtps/rtps/common/SequenceNumber.h
+++ b/include/fastrtps/rtps/common/SequenceNumber.h
@@ -402,7 +402,7 @@ inline std::istream& operator >>(
     return input;
 }
 
-#endif DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+#endif // DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 } // namespace rtps
 } // namespace fastrtps

--- a/include/fastrtps/rtps/resources/AsyncWriterThread.h
+++ b/include/fastrtps/rtps/resources/AsyncWriterThread.h
@@ -27,9 +27,9 @@
 #include <fastrtps/utils/TimedMutex.hpp>
 #include <fastrtps/utils/TimedConditionVariable.hpp>
 
-namespace eprosima{
-namespace fastrtps{
-namespace rtps{
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
 
 class RTPSWriter;
 
@@ -50,7 +50,6 @@ public:
     /*!
      * @brief Unregister a writer if it is waiting to be processed.
      * @param writer Asynchronous writer to be removed.
-     * @return Result of the operation.
      * @note Always call this function from writer's destructor.
      */
     void unregister_writer(
@@ -75,8 +74,10 @@ public:
 
 private:
 
-    AsyncWriterThread(const AsyncWriterThread&) = delete;
-    const AsyncWriterThread& operator=(const AsyncWriterThread&) = delete;
+    AsyncWriterThread(
+            const AsyncWriterThread&) = delete;
+    const AsyncWriterThread& operator =(
+            const AsyncWriterThread&) = delete;
 
     //! @brief runs main method
     void run();

--- a/include/fastrtps/transport/TCPv4TransportDescriptor.h
+++ b/include/fastrtps/transport/TCPv4TransportDescriptor.h
@@ -55,6 +55,11 @@ typedef struct TCPv4TransportDescriptor: public TCPTransportDescriptor {
     RTPS_DllAPI TCPv4TransportDescriptor();
 
     RTPS_DllAPI TCPv4TransportDescriptor(const TCPv4TransportDescriptor& t);
+
+    RTPS_DllAPI TCPv4TransportDescriptor& operator =(const TCPv4TransportDescriptor& ) = default;
+
+    RTPS_DllAPI TCPv4TransportDescriptor& operator =(TCPv4TransportDescriptor&& ) = default;
+
 } TCPv4TransportDescriptor;
 
 } // namespace rtps

--- a/include/fastrtps/transport/TCPv4TransportDescriptor.h
+++ b/include/fastrtps/transport/TCPv4TransportDescriptor.h
@@ -17,33 +17,42 @@
 
 #include <fastrtps/transport/TCPTransportDescriptor.h>
 
-namespace eprosima{
-namespace fastrtps{
-namespace rtps{
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
 
 class TCPTransportInterface;
 /**
  * Transport configuration
  * @ingroup TRANSPORT_MODULE
  */
-typedef struct TCPv4TransportDescriptor: public TCPTransportDescriptor {
-    virtual ~TCPv4TransportDescriptor(){}
+typedef struct TCPv4TransportDescriptor : public TCPTransportDescriptor
+{
+    virtual ~TCPv4TransportDescriptor()
+    {
+    }
 
     virtual TransportInterface* create_transport() const override;
 
     octet wan_addr[4];
 
-    void set_WAN_address(octet o1,octet o2,octet o3,octet o4){
+    void set_WAN_address(
+            octet o1,
+            octet o2,
+            octet o3,
+            octet o4)
+    {
         wan_addr[0] = o1;
         wan_addr[1] = o2;
         wan_addr[2] = o3;
         wan_addr[3] = o4;
     }
 
-    void set_WAN_address(const std::string& in_address)
+    void set_WAN_address(
+            const std::string& in_address)
     {
         std::stringstream ss(in_address);
-        int a,b,c,d; //to store the 4 ints
+        int a, b, c, d; //to store the 4 ints
         char ch; //to temporarily store the '.'
         ss >> a >> ch >> b >> ch >> c >> ch >> d;
         wan_addr[0] = (octet)a;
@@ -54,11 +63,14 @@ typedef struct TCPv4TransportDescriptor: public TCPTransportDescriptor {
 
     RTPS_DllAPI TCPv4TransportDescriptor();
 
-    RTPS_DllAPI TCPv4TransportDescriptor(const TCPv4TransportDescriptor& t);
+    RTPS_DllAPI TCPv4TransportDescriptor(
+            const TCPv4TransportDescriptor& t);
 
-    RTPS_DllAPI TCPv4TransportDescriptor& operator =(const TCPv4TransportDescriptor& ) = default;
+    RTPS_DllAPI TCPv4TransportDescriptor& operator =(
+            const TCPv4TransportDescriptor& ) = default;
 
-    RTPS_DllAPI TCPv4TransportDescriptor& operator =(TCPv4TransportDescriptor&& ) = default;
+    RTPS_DllAPI TCPv4TransportDescriptor& operator =(
+            TCPv4TransportDescriptor&& ) = default;
 
 } TCPv4TransportDescriptor;
 
@@ -66,4 +78,4 @@ typedef struct TCPv4TransportDescriptor: public TCPTransportDescriptor {
 } // namespace fastrtps
 } // namespace eprosima
 
-#endif
+#endif // ifndef TCPV4_TRANSPORT_DESCRIPTOR

--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
@@ -547,188 +547,28 @@ GUID_t ParticipantProxyData::get_persistence_guid() const
 void ParticipantProxyData::set_sample_identity(
         const SampleIdentity& sid)
 {
-    // only valid values
-    if (sid == SampleIdentity::unknown())
-    {
-        return;
-    }
-
-    // generate pair
-    std::pair<std::string, std::string> sample_identity;
-    sample_identity.first = "PID_CLIENT_SERVER_KEY";
-
-    std::ostringstream data;
-    data << sid;
-    sample_identity.second = data.str();
-
-    // if exists replace
-    auto it = std::find_if(
-        m_properties.properties.begin(),
-        m_properties.properties.end(),
-        [&sample_identity](const std::pair<std::string, std::string> & p)
-                {
-                    return sample_identity.first == p.first;
-                });
-
-    if (it != m_properties.properties.end())
-    {
-        *it = sample_identity;
-    }
-    else
-    {
-        // if not exists add
-        m_properties.properties.push_back(sample_identity);
-    }
+    set_proxy_property(sid, "PID_CLIENT_SERVER_KEY", m_properties.properties);
 }
 
 SampleIdentity ParticipantProxyData::get_sample_identity() const
 {
-    SampleIdentity sid;
-
-    auto it = std::find_if(
-        m_properties.properties.begin(),
-        m_properties.properties.end(),
-        [](const std::pair<std::string, std::string>& p)
-                {
-                    return "PID_CLIENT_SERVER_KEY" == p.first;
-                });
-
-    if (it != m_properties.properties.end())
-    {
-        std::istringstream in(it->second);
-        in >> sid;
-    }
-
-    return sid;
+    return get_proxy_property<SampleIdentity>("PID_CLIENT_SERVER_KEY", m_properties.properties);
 }
 
 void ParticipantProxyData::set_backup_stamp(const GUID_t& guid)
 {
-    // only valid values
-    if (guid == c_Guid_Unknown)
-    {
-        return;
-    }
-
-    // generate pair
-    std::pair<std::string, std::string> backup_guid;
-    backup_guid.first = "PID_BACKUP_STAMP";
-
-    std::ostringstream data;
-    data << guid;
-    backup_guid.second = data.str();
-
-    // if exists replace
-    std::vector<std::pair<std::string, std::string>> & props = m_properties.properties;
-
-    std::vector<std::pair<std::string, std::string>>::iterator it =
-        std::find_if(
-            props.begin(),
-            props.end(),
-            [&backup_guid](const std::pair<std::string, std::string> & p)
-            {
-                return backup_guid.first == p.first;
-            });
-
-    if (it != props.end())
-    {
-        *it = std::move(backup_guid);
-    }
-    else
-    {
-        // if not exists add
-        m_properties.properties.push_back(std::move(backup_guid));
-    }
+    set_proxy_property(guid,"PID_BACKUP_STAMP", m_properties.properties);
 }
 
 GUID_t ParticipantProxyData::get_backup_stamp() const
 {
-    GUID_t stamp(c_Guid_Unknown);
-
-    const std::vector<std::pair<std::string, std::string>> & props = m_properties.properties;
-
-    std::vector<std::pair<std::string, std::string>>::const_iterator it =
-        std::find_if(
-            props.cbegin(),
-            props.cend(),
-            [](const std::pair<std::string, std::string> & p)
-            {
-                return "PID_BACKUP_STAMP" == p.first;
-            });
-
-    if (it != props.end())
-    {
-        std::istringstream in(it->second);
-        in >> stamp;
-    }
-
-    return stamp;
+    return get_proxy_property<GUID_t>("PID_BACKUP_STAMP", m_properties.properties);
 }
 
 void ParticipantProxyData::assert_liveliness()
 {
     last_received_message_tm_ = std::chrono::steady_clock::now();
 }
-
-#ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
-
-/**
- * Stream operator, retrieves a GUID.
- * @param input Input stream.
- * @param sid SampleIdentity to read.
- * @return Stream operator.
- */
-std::istream& operator >>(
-        std::istream& input,
-        SampleIdentity& sid)
-{
-    std::istream::sentry s(input);
-
-    if (s)
-    {
-        std::ios_base::iostate excp_mask = input.exceptions();
-
-        try
-        {
-            input.exceptions(excp_mask | std::ios_base::failbit | std::ios_base::badbit);
-
-            char sep;
-            input >> sid.writer_guid_ >> sep >> sid.sequence_number_;
-
-            if (sep != '|')
-            {
-                input.setstate(std::ios_base::failbit);
-            }
-        }
-        catch (std::ios_base::failure&)
-        {
-            // maybe is unknown or just invalid
-            sid.writer_guid_ = GUID_t::unknown();
-            sid.sequence_number_ = SequenceNumber_t::unknown();
-        }
-
-        input.exceptions(excp_mask);
-    }
-
-    return input;
-}
-
-/**
- * Stream operator, prints a GUID.
- * @param output Output stream.
- * @param sid SampleIdentity to print.
- * @return Stream operator.
- */
-inline std::ostream& operator <<(
-        std::ostream& output,
-        const SampleIdentity& sid)
-{
-    output << sid.writer_guid_ << '|' << sid.sequence_number_;
-
-    return output;
-}
-
-#endif DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 } /* namespace rtps */
 } /* namespace fastrtps */

--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
@@ -35,10 +35,11 @@ using namespace eprosima::fastrtps;
 
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
-ParticipantProxyData::ParticipantProxyData(const RTPSParticipantAllocationAttributes& allocation)
+ParticipantProxyData::ParticipantProxyData(
+        const RTPSParticipantAllocationAttributes& allocation)
     : m_protocolVersion(c_ProtocolVersion)
     , m_VendorId(c_VendorId_Unknown)
     , m_expectsInlineQos(false)
@@ -48,16 +49,17 @@ ParticipantProxyData::ParticipantProxyData(const RTPSParticipantAllocationAttrib
 #if HAVE_SECURITY
     , security_attributes_(0UL)
     , plugin_security_attributes_(0UL)
-#endif
+#endif // if HAVE_SECURITY
     , isAlive(false)
     , lease_duration_event(nullptr)
     , should_check_lease_duration(false)
     , m_readers(allocation.readers)
     , m_writers(allocation.writers)
-    {
-    }
+{
+}
 
-ParticipantProxyData::ParticipantProxyData(const ParticipantProxyData& pdata)
+ParticipantProxyData::ParticipantProxyData(
+        const ParticipantProxyData& pdata)
     : m_protocolVersion(pdata.m_protocolVersion)
     , m_guid(pdata.m_guid)
     , m_VendorId(pdata.m_VendorId)
@@ -73,7 +75,7 @@ ParticipantProxyData::ParticipantProxyData(const ParticipantProxyData& pdata)
     , permissions_token_(pdata.permissions_token_)
     , security_attributes_(pdata.security_attributes_)
     , plugin_security_attributes_(pdata.plugin_security_attributes_)
-#endif
+#endif // if HAVE_SECURITY
     , isAlive(pdata.isAlive)
     , m_properties(pdata.m_properties)
     , m_userData(pdata.m_userData)
@@ -84,8 +86,8 @@ ParticipantProxyData::ParticipantProxyData(const ParticipantProxyData& pdata)
     // This method is only called from SecurityManager when a new participant is discovered and the
     // corresponding DiscoveredParticipantInfo struct is created. Only participant info is used,
     // so there is no need to copy m_readers and m_writers
-    {
-    }
+{
+}
 
 ParticipantProxyData::~ParticipantProxyData()
 {
@@ -107,96 +109,146 @@ ParticipantProxyData::~ParticipantProxyData()
     }
 }
 
-bool ParticipantProxyData::writeToCDRMessage(CDRMessage_t* msg, bool write_encapsulation)
+bool ParticipantProxyData::writeToCDRMessage(
+        CDRMessage_t* msg,
+        bool write_encapsulation)
 {
     if (write_encapsulation)
     {
-        if (!ParameterList::writeEncapsulationToCDRMsg(msg)) return false;
+        if (!ParameterList::writeEncapsulationToCDRMsg(msg))
+        {
+            return false;
+        }
     }
 
     {
-        ParameterProtocolVersion_t p(PID_PROTOCOL_VERSION,4);
+        ParameterProtocolVersion_t p(PID_PROTOCOL_VERSION, 4);
         p.protocolVersion = this->m_protocolVersion;
-        if (!p.addToCDRMessage(msg)) return false;
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
     {
-        ParameterVendorId_t p(PID_VENDORID,4);
+        ParameterVendorId_t p(PID_VENDORID, 4);
         p.vendorId[0] = this->m_VendorId[0];
         p.vendorId[1] = this->m_VendorId[1];
-        if (!p.addToCDRMessage(msg)) return false;
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(this->m_expectsInlineQos)
+    if (this->m_expectsInlineQos)
     {
         ParameterBool_t p(PID_EXPECTS_INLINE_QOS, PARAMETER_BOOL_LENGTH, m_expectsInlineQos);
-        if (!p.addToCDRMessage(msg)) return false;
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
     {
         ParameterGuid_t p(PID_PARTICIPANT_GUID, PARAMETER_GUID_LENGTH, m_guid);
-        if (!p.addToCDRMessage(msg)) return false;
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    for(const Locator_t& it : metatraffic_locators.multicast)
+    for (const Locator_t& it : metatraffic_locators.multicast)
     {
         ParameterLocator_t p(PID_METATRAFFIC_MULTICAST_LOCATOR, PARAMETER_LOCATOR_LENGTH, it);
-        if (!p.addToCDRMessage(msg)) return false;
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    for(const Locator_t& it : metatraffic_locators.unicast)
+    for (const Locator_t& it : metatraffic_locators.unicast)
     {
         ParameterLocator_t p(PID_METATRAFFIC_UNICAST_LOCATOR, PARAMETER_LOCATOR_LENGTH, it);
-        if (!p.addToCDRMessage(msg)) return false;
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    for(const Locator_t& it : default_locators.unicast)
+    for (const Locator_t& it : default_locators.unicast)
     {
         ParameterLocator_t p(PID_DEFAULT_UNICAST_LOCATOR, PARAMETER_LOCATOR_LENGTH, it);
-        if (!p.addToCDRMessage(msg)) return false;
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    for(const Locator_t& it : default_locators.multicast)
+    for (const Locator_t& it : default_locators.multicast)
     {
         ParameterLocator_t p(PID_DEFAULT_MULTICAST_LOCATOR, PARAMETER_LOCATOR_LENGTH, it);
-        if (!p.addToCDRMessage(msg)) return false;
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
     {
         ParameterTime_t p(PID_PARTICIPANT_LEASE_DURATION, PARAMETER_TIME_LENGTH);
         p.time = m_leaseDuration;
-        if (!p.addToCDRMessage(msg)) return false;
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
     {
         ParameterBuiltinEndpointSet_t p(PID_BUILTIN_ENDPOINT_SET, PARAMETER_BUILTINENDPOINTSET_LENGTH);
         p.endpointSet = m_availableBuiltinEndpoints;
-        if (!p.addToCDRMessage(msg)) return false;
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
 
-    if(m_participantName.size() > 0)
+    if (m_participantName.size() > 0)
     {
         ParameterString_t p(PID_ENTITY_NAME, 0, m_participantName);
-        if (!p.addToCDRMessage(msg)) return false;
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
 
-    if(this->m_userData.size()>0)
+    if (this->m_userData.size() > 0)
     {
         UserDataQosPolicy p;
         p.setDataVec(m_userData);
-        if (!p.addToCDRMessage(msg)) return false;
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
 
-    if(this->m_properties.properties.size()>0)
+    if (this->m_properties.properties.size() > 0)
     {
         ParameterPropertyList_t p(m_properties);
-        if (!p.addToCDRMessage(msg)) return false;
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
 
 #if HAVE_SECURITY
-    if(!this->identity_token_.class_id().empty())
+    if (!this->identity_token_.class_id().empty())
     {
         ParameterToken_t p(PID_IDENTITY_TOKEN, 0);
         p.token = identity_token_;
-        if (!p.addToCDRMessage(msg)) return false;
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
 
-    if(!this->permissions_token_.class_id().empty())
+    if (!this->permissions_token_.class_id().empty())
     {
         ParameterToken_t p(PID_PERMISSIONS_TOKEN, 0);
         p.token = permissions_token_;
-        if (!p.addToCDRMessage(msg)) return false;
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
 
     if ((this->security_attributes_ != 0UL) || (this->plugin_security_attributes_ != 0UL))
@@ -204,9 +256,12 @@ bool ParticipantProxyData::writeToCDRMessage(CDRMessage_t* msg, bool write_encap
         ParameterParticipantSecurityInfo_t p;
         p.security_attributes = this->security_attributes_;
         p.plugin_security_attributes = this->plugin_security_attributes_;
-        if (!p.addToCDRMessage(msg)) return false;
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-#endif
+#endif // if HAVE_SECURITY
 
     return CDRMessage::addParameterSentinel(msg);
 }
@@ -217,180 +272,181 @@ bool ParticipantProxyData::readFromCDRMessage(
         const NetworkFactory& network)
 {
     auto param_process = [this, &network](const Parameter_t* param)
-    {
-        switch (param->Pid)
-        {
-            case PID_KEY_HASH:
             {
-                const ParameterKey_t* p = dynamic_cast<const ParameterKey_t*>(param);
-                assert(p != nullptr);
-                GUID_t guid;
-                iHandle2GUID(guid, p->key);
-                this->m_guid = guid;
-                this->m_key = p->key;
-                break;
-            }
-            case PID_PROTOCOL_VERSION:
-            {
-                const ParameterProtocolVersion_t* p = dynamic_cast<const ParameterProtocolVersion_t*>(param);
-                assert(p != nullptr);
-                if (p->protocolVersion.m_major < c_ProtocolVersion.m_major)
+                switch (param->Pid)
                 {
-                    return false;
-                }
-                this->m_protocolVersion = p->protocolVersion;
-                break;
-            }
-            case PID_VENDORID:
-            {
-                const ParameterVendorId_t* p = dynamic_cast<const ParameterVendorId_t*>(param);
-                assert(p != nullptr);
-                this->m_VendorId[0] = p->vendorId[0];
-                this->m_VendorId[1] = p->vendorId[1];
-                break;
-            }
-            case PID_EXPECTS_INLINE_QOS:
-            {
-                const ParameterBool_t* p = dynamic_cast<const ParameterBool_t*>(param);
-                assert(p != nullptr);
-                this->m_expectsInlineQos = p->value;
-                break;
-            }
-            case PID_PARTICIPANT_GUID:
-            {
-                const ParameterGuid_t* p = dynamic_cast<const ParameterGuid_t*>(param);
-                assert(p != nullptr);
-                this->m_guid = p->guid;
-                this->m_key = p->guid;
-                break;
-            }
-            case PID_METATRAFFIC_MULTICAST_LOCATOR:
-            {
-                const ParameterLocator_t* p = dynamic_cast<const ParameterLocator_t*>(param);
-                assert(p != nullptr);
-                Locator_t temp_locator;
-                if (network.transform_remote_locator(p->locator, temp_locator))
-                {
-                    metatraffic_locators.add_multicast_locator(temp_locator);
-                }
-                break;
-            }
-            case PID_METATRAFFIC_UNICAST_LOCATOR:
-            {
-                const ParameterLocator_t* p = dynamic_cast<const ParameterLocator_t*>(param);
-                assert(p != nullptr);
-                Locator_t temp_locator;
-                if (network.transform_remote_locator(p->locator, temp_locator))
-                {
-                    metatraffic_locators.add_unicast_locator(temp_locator);
-                }
-                break;
-            }
-            case PID_DEFAULT_UNICAST_LOCATOR:
-            {
-                const ParameterLocator_t* p = dynamic_cast<const ParameterLocator_t*>(param);
-                assert(p != nullptr);
-                Locator_t temp_locator;
-                if (network.transform_remote_locator(p->locator, temp_locator))
-                {
-                    default_locators.add_unicast_locator(temp_locator);
-                }
-                break;
-            }
-            case PID_DEFAULT_MULTICAST_LOCATOR:
-            {
-                const ParameterLocator_t* p = dynamic_cast<const ParameterLocator_t*>(param);
-                assert(p != nullptr);
-                Locator_t temp_locator;
-                if (network.transform_remote_locator(p->locator, temp_locator))
-                {
-                    default_locators.add_multicast_locator(temp_locator);
-                }
-                break;
-            }
-            case PID_PARTICIPANT_LEASE_DURATION:
-            {
-                const ParameterTime_t* p = dynamic_cast<const ParameterTime_t*>(param);
-                assert(p != nullptr);
-                this->m_leaseDuration = p->time.to_duration_t();
-                lease_duration_ = std::chrono::microseconds(TimeConv::Duration_t2MicroSecondsInt64(m_leaseDuration));
-                break;
-            }
-            case PID_BUILTIN_ENDPOINT_SET:
-            {
-                const ParameterBuiltinEndpointSet_t* p = dynamic_cast<const ParameterBuiltinEndpointSet_t*>(param);
-                assert(p != nullptr);
-                this->m_availableBuiltinEndpoints = p->endpointSet;
-                break;
-            }
-            case PID_ENTITY_NAME:
-            {
-                const ParameterString_t* p = dynamic_cast<const ParameterString_t*>(param);
-                assert(p != nullptr);
-                this->m_participantName = p->getName();
-                break;
-            }
-            case PID_PROPERTY_LIST:
-            {
-                const ParameterPropertyList_t* p = dynamic_cast<const ParameterPropertyList_t*>(param);
-                assert(p != nullptr);
-                this->m_properties = *p;
-                break;
-            }
-            case PID_USER_DATA:
-            {
-                const UserDataQosPolicy* p = dynamic_cast<const UserDataQosPolicy*>(param);
-                assert(p != nullptr);
-                this->m_userData = p->getDataVec();
-                break;
-            }
-            case PID_IDENTITY_TOKEN:
-            {
+                    case PID_KEY_HASH:
+                    {
+                        const ParameterKey_t* p = dynamic_cast<const ParameterKey_t*>(param);
+                        assert(p != nullptr);
+                        GUID_t guid;
+                        iHandle2GUID(guid, p->key);
+                        this->m_guid = guid;
+                        this->m_key = p->key;
+                        break;
+                    }
+                    case PID_PROTOCOL_VERSION:
+                    {
+                        const ParameterProtocolVersion_t* p = dynamic_cast<const ParameterProtocolVersion_t*>(param);
+                        assert(p != nullptr);
+                        if (p->protocolVersion.m_major < c_ProtocolVersion.m_major)
+                        {
+                            return false;
+                        }
+                        this->m_protocolVersion = p->protocolVersion;
+                        break;
+                    }
+                    case PID_VENDORID:
+                    {
+                        const ParameterVendorId_t* p = dynamic_cast<const ParameterVendorId_t*>(param);
+                        assert(p != nullptr);
+                        this->m_VendorId[0] = p->vendorId[0];
+                        this->m_VendorId[1] = p->vendorId[1];
+                        break;
+                    }
+                    case PID_EXPECTS_INLINE_QOS:
+                    {
+                        const ParameterBool_t* p = dynamic_cast<const ParameterBool_t*>(param);
+                        assert(p != nullptr);
+                        this->m_expectsInlineQos = p->value;
+                        break;
+                    }
+                    case PID_PARTICIPANT_GUID:
+                    {
+                        const ParameterGuid_t* p = dynamic_cast<const ParameterGuid_t*>(param);
+                        assert(p != nullptr);
+                        this->m_guid = p->guid;
+                        this->m_key = p->guid;
+                        break;
+                    }
+                    case PID_METATRAFFIC_MULTICAST_LOCATOR:
+                    {
+                        const ParameterLocator_t* p = dynamic_cast<const ParameterLocator_t*>(param);
+                        assert(p != nullptr);
+                        Locator_t temp_locator;
+                        if (network.transform_remote_locator(p->locator, temp_locator))
+                        {
+                            metatraffic_locators.add_multicast_locator(temp_locator);
+                        }
+                        break;
+                    }
+                    case PID_METATRAFFIC_UNICAST_LOCATOR:
+                    {
+                        const ParameterLocator_t* p = dynamic_cast<const ParameterLocator_t*>(param);
+                        assert(p != nullptr);
+                        Locator_t temp_locator;
+                        if (network.transform_remote_locator(p->locator, temp_locator))
+                        {
+                            metatraffic_locators.add_unicast_locator(temp_locator);
+                        }
+                        break;
+                    }
+                    case PID_DEFAULT_UNICAST_LOCATOR:
+                    {
+                        const ParameterLocator_t* p = dynamic_cast<const ParameterLocator_t*>(param);
+                        assert(p != nullptr);
+                        Locator_t temp_locator;
+                        if (network.transform_remote_locator(p->locator, temp_locator))
+                        {
+                            default_locators.add_unicast_locator(temp_locator);
+                        }
+                        break;
+                    }
+                    case PID_DEFAULT_MULTICAST_LOCATOR:
+                    {
+                        const ParameterLocator_t* p = dynamic_cast<const ParameterLocator_t*>(param);
+                        assert(p != nullptr);
+                        Locator_t temp_locator;
+                        if (network.transform_remote_locator(p->locator, temp_locator))
+                        {
+                            default_locators.add_multicast_locator(temp_locator);
+                        }
+                        break;
+                    }
+                    case PID_PARTICIPANT_LEASE_DURATION:
+                    {
+                        const ParameterTime_t* p = dynamic_cast<const ParameterTime_t*>(param);
+                        assert(p != nullptr);
+                        this->m_leaseDuration = p->time.to_duration_t();
+                        lease_duration_ =
+                                std::chrono::microseconds(TimeConv::Duration_t2MicroSecondsInt64(m_leaseDuration));
+                        break;
+                    }
+                    case PID_BUILTIN_ENDPOINT_SET:
+                    {
+                        const ParameterBuiltinEndpointSet_t* p =
+                                dynamic_cast<const ParameterBuiltinEndpointSet_t*>(param);
+                        assert(p != nullptr);
+                        this->m_availableBuiltinEndpoints = p->endpointSet;
+                        break;
+                    }
+                    case PID_ENTITY_NAME:
+                    {
+                        const ParameterString_t* p = dynamic_cast<const ParameterString_t*>(param);
+                        assert(p != nullptr);
+                        this->m_participantName = p->getName();
+                        break;
+                    }
+                    case PID_PROPERTY_LIST:
+                    {
+                        const ParameterPropertyList_t* p = dynamic_cast<const ParameterPropertyList_t*>(param);
+                        assert(p != nullptr);
+                        this->m_properties = *p;
+                        break;
+                    }
+                    case PID_USER_DATA:
+                    {
+                        const UserDataQosPolicy* p = dynamic_cast<const UserDataQosPolicy*>(param);
+                        assert(p != nullptr);
+                        this->m_userData = p->getDataVec();
+                        break;
+                    }
+                    case PID_IDENTITY_TOKEN:
+                    {
 #if HAVE_SECURITY
-                const ParameterToken_t* p = dynamic_cast<const ParameterToken_t*>(param);
-                assert(p != nullptr);
-                this->identity_token_ = std::move(p->token);
+                        const ParameterToken_t* p = dynamic_cast<const ParameterToken_t*>(param);
+                        assert(p != nullptr);
+                        this->identity_token_ = std::move(p->token);
 #else
-                logWarning(RTPS_PARTICIPANT, "Received PID_IDENTITY_TOKEN but security is disabled");
-#endif
-                break;
-            }
-            case PID_PERMISSIONS_TOKEN:
-            {
+                        logWarning(RTPS_PARTICIPANT, "Received PID_IDENTITY_TOKEN but security is disabled");
+#endif // if HAVE_SECURITY
+                        break;
+                    }
+                    case PID_PERMISSIONS_TOKEN:
+                    {
 #if HAVE_SECURITY
-                const ParameterToken_t* p = dynamic_cast<const ParameterToken_t*>(param);
-                assert(p != nullptr);
-                this->permissions_token_ = std::move(p->token);
+                        const ParameterToken_t* p = dynamic_cast<const ParameterToken_t*>(param);
+                        assert(p != nullptr);
+                        this->permissions_token_ = std::move(p->token);
 #else
-                logWarning(RTPS_PARTICIPANT, "Received PID_PERMISSIONS_TOKEN but security is disabled");
-#endif
-                break;
-            }
-            case PID_PARTICIPANT_SECURITY_INFO:
-            {
+                        logWarning(RTPS_PARTICIPANT, "Received PID_PERMISSIONS_TOKEN but security is disabled");
+#endif // if HAVE_SECURITY
+                        break;
+                    }
+                    case PID_PARTICIPANT_SECURITY_INFO:
+                    {
 #if HAVE_SECURITY
-                const ParameterParticipantSecurityInfo_t* p =
-                    dynamic_cast<const ParameterParticipantSecurityInfo_t*>(param);
-                assert(p != nullptr);
-                this->security_attributes_ = p->security_attributes;
-                this->plugin_security_attributes_ = p->plugin_security_attributes;
+                        const ParameterParticipantSecurityInfo_t* p =
+                                dynamic_cast<const ParameterParticipantSecurityInfo_t*>(param);
+                        assert(p != nullptr);
+                        this->security_attributes_ = p->security_attributes;
+                        this->plugin_security_attributes_ = p->plugin_security_attributes;
 #else
-                logWarning(RTPS_PARTICIPANT, "Received PID_PARTICIPANT_SECURITY_INFO but security is disabled");
-#endif
-                break;
-            }
+                        logWarning(RTPS_PARTICIPANT, "Received PID_PARTICIPANT_SECURITY_INFO but security is disabled");
+#endif // if HAVE_SECURITY
+                        break;
+                    }
 
-            default: break;
-        }
+                    default: break;
+                }
 
-        return true;
-    };
+                return true;
+            };
 
     uint32_t qos_size;
     clear();
     return ParameterList::readParameterListfromCDRMsg(*msg, param_process, use_encapsulation, qos_size);
 }
-
 
 void ParticipantProxyData::clear()
 {
@@ -414,13 +470,14 @@ void ParticipantProxyData::clear()
     permissions_token_ = PermissionsToken();
     security_attributes_ = 0UL;
     plugin_security_attributes_ = 0UL;
-#endif
+#endif // if HAVE_SECURITY
     m_properties.properties.clear();
     m_properties.length = 0;
     m_userData.clear();
 }
 
-void ParticipantProxyData::copy(const ParticipantProxyData& pdata)
+void ParticipantProxyData::copy(
+        const ParticipantProxyData& pdata)
 {
     m_protocolVersion = pdata.m_protocolVersion;
     m_guid = pdata.m_guid;
@@ -446,10 +503,11 @@ void ParticipantProxyData::copy(const ParticipantProxyData& pdata)
     permissions_token_ = pdata.permissions_token_;
     security_attributes_ = pdata.security_attributes_;
     plugin_security_attributes_ = pdata.plugin_security_attributes_;
-#endif
+#endif // if HAVE_SECURITY
 }
 
-bool ParticipantProxyData::updateData(ParticipantProxyData& pdata)
+bool ParticipantProxyData::updateData(
+        ParticipantProxyData& pdata)
 {
     metatraffic_locators = pdata.metatraffic_locators;
     default_locators = pdata.default_locators;
@@ -462,18 +520,18 @@ bool ParticipantProxyData::updateData(ParticipantProxyData& pdata)
     permissions_token_ = pdata.permissions_token_;
     security_attributes_ = pdata.security_attributes_;
     plugin_security_attributes_ = pdata.plugin_security_attributes_;
-#endif
+#endif // if HAVE_SECURITY
     auto new_lease_duration = std::chrono::microseconds(TimeConv::Duration_t2MicroSecondsInt64(m_leaseDuration));
     if (this->lease_duration_event != nullptr)
     {
-        if(new_lease_duration < lease_duration_)
+        if (new_lease_duration < lease_duration_)
         {
             // Calculate next trigger.
             auto real_lease_tm = last_received_message_tm_ + new_lease_duration;
             auto next_trigger = real_lease_tm - std::chrono::steady_clock::now();
             lease_duration_event->cancel_timer();
             lease_duration_event->update_interval_millisec(
-                    (double)std::chrono::duration_cast<std::chrono::milliseconds>(next_trigger).count());
+                (double)std::chrono::duration_cast<std::chrono::milliseconds>(next_trigger).count());
             lease_duration_event->restart_timer();
         }
     }
@@ -481,7 +539,8 @@ bool ParticipantProxyData::updateData(ParticipantProxyData& pdata)
     return true;
 }
 
-void ParticipantProxyData::set_persistence_guid(const GUID_t& guid)
+void ParticipantProxyData::set_persistence_guid(
+        const GUID_t& guid)
 {
     // only valid values
     if (guid == c_Guid_Unknown)
@@ -498,16 +557,16 @@ void ParticipantProxyData::set_persistence_guid(const GUID_t& guid)
     persistent_guid.second = data.str();
 
     // if exists replace
-    std::vector<std::pair<std::string, std::string>> & props = m_properties.properties;
+    std::vector<std::pair<std::string, std::string> >& props = m_properties.properties;
 
-    std::vector<std::pair<std::string, std::string>>::iterator it =
-        std::find_if(
-            props.begin(),
-            props.end(),
-            [&persistent_guid](const std::pair<std::string, std::string> & p)
-            {
-                return persistent_guid.first == p.first;
-            });
+    std::vector<std::pair<std::string, std::string> >::iterator it =
+            std::find_if(
+        props.begin(),
+        props.end(),
+        [&persistent_guid](const std::pair<std::string, std::string>& p)
+        {
+            return persistent_guid.first == p.first;
+        });
 
     if (it != props.end())
     {
@@ -524,16 +583,16 @@ GUID_t ParticipantProxyData::get_persistence_guid() const
 {
     GUID_t persistent(c_Guid_Unknown);
 
-    const std::vector<std::pair<std::string, std::string>> & props = m_properties.properties;
+    const std::vector<std::pair<std::string, std::string> >& props = m_properties.properties;
 
-    std::vector<std::pair<std::string, std::string>>::const_iterator it =
-        std::find_if(
-            props.cbegin(),
-            props.cend(),
-            [](const std::pair<std::string, std::string> & p)
-            {
-                return "PID_PERSISTENCE_GUID" == p.first;
-            });
+    std::vector<std::pair<std::string, std::string> >::const_iterator it =
+            std::find_if(
+        props.cbegin(),
+        props.cend(),
+        [](const std::pair<std::string, std::string>& p)
+        {
+            return "PID_PERSISTENCE_GUID" == p.first;
+        });
 
     if (it != props.end())
     {
@@ -555,9 +614,10 @@ SampleIdentity ParticipantProxyData::get_sample_identity() const
     return get_proxy_property<SampleIdentity>("PID_CLIENT_SERVER_KEY", m_properties.properties);
 }
 
-void ParticipantProxyData::set_backup_stamp(const GUID_t& guid)
+void ParticipantProxyData::set_backup_stamp(
+        const GUID_t& guid)
 {
-    set_proxy_property(guid,"PID_BACKUP_STAMP", m_properties.properties);
+    set_proxy_property(guid, "PID_BACKUP_STAMP", m_properties.properties);
 }
 
 GUID_t ParticipantProxyData::get_backup_stamp() const

--- a/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
@@ -26,7 +26,7 @@
 #include <fastrtps/rtps/network/NetworkFactory.h>
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
 
@@ -37,27 +37,28 @@ ReaderProxyData::ReaderProxyData (
 #if HAVE_SECURITY
     , security_attributes_(0UL)
     , plugin_security_attributes_(0UL)
-#endif
+#endif // if HAVE_SECURITY
     , remote_locators_(max_unicast_locators, max_multicast_locators)
     , m_userDefinedId(0)
     , m_isAlive(true)
     , m_topicKind(NO_KEY)
     , m_topicDiscoveryKind(NO_CHECK)
-    {
+{
 
-    }
+}
 
 ReaderProxyData::~ReaderProxyData()
 {
-    logInfo(RTPS_PROXY_DATA,"ReaderProxyData destructor: "<< this->m_guid;);
+    logInfo(RTPS_PROXY_DATA, "ReaderProxyData destructor: " << this->m_guid; );
 }
 
-ReaderProxyData::ReaderProxyData(const ReaderProxyData& readerInfo)
+ReaderProxyData::ReaderProxyData(
+        const ReaderProxyData& readerInfo)
     : m_expectsInlineQos(readerInfo.m_expectsInlineQos)
 #if HAVE_SECURITY
     , security_attributes_(readerInfo.security_attributes_)
     , plugin_security_attributes_(readerInfo.plugin_security_attributes_)
-#endif
+#endif // if HAVE_SECURITY
     , m_guid(readerInfo.m_guid)
     , remote_locators_(readerInfo.remote_locators_)
     , m_key(readerInfo.m_key)
@@ -75,13 +76,14 @@ ReaderProxyData::ReaderProxyData(const ReaderProxyData& readerInfo)
     m_qos.setQos(readerInfo.m_qos, true);
 }
 
-ReaderProxyData& ReaderProxyData::operator=(const ReaderProxyData& readerInfo)
+ReaderProxyData& ReaderProxyData::operator =(
+        const ReaderProxyData& readerInfo)
 {
     m_expectsInlineQos = readerInfo.m_expectsInlineQos;
 #if HAVE_SECURITY
     security_attributes_ = readerInfo.security_attributes_;
     plugin_security_attributes_ = readerInfo.plugin_security_attributes_;
-#endif
+#endif // if HAVE_SECURITY
     m_guid = readerInfo.m_guid;
     remote_locators_ = readerInfo.remote_locators_;
     m_key = readerInfo.m_key;
@@ -101,120 +103,203 @@ ReaderProxyData& ReaderProxyData::operator=(const ReaderProxyData& readerInfo)
     return *this;
 }
 
-bool ReaderProxyData::writeToCDRMessage(CDRMessage_t* msg, bool write_encapsulation)
+bool ReaderProxyData::writeToCDRMessage(
+        CDRMessage_t* msg,
+        bool write_encapsulation)
 {
     if (write_encapsulation)
     {
-        if (!ParameterList::writeEncapsulationToCDRMsg(msg)) return false;
+        if (!ParameterList::writeEncapsulationToCDRMsg(msg))
+        {
+            return false;
+        }
     }
 
-    for(const Locator_t& locator : remote_locators_.unicast)
+    for (const Locator_t& locator : remote_locators_.unicast)
     {
-        ParameterLocator_t p(PID_UNICAST_LOCATOR,PARAMETER_LOCATOR_LENGTH,locator);
-        if (!p.addToCDRMessage(msg)) return false;
+        ParameterLocator_t p(PID_UNICAST_LOCATOR, PARAMETER_LOCATOR_LENGTH, locator);
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    for(const Locator_t& locator : remote_locators_.multicast)
+    for (const Locator_t& locator : remote_locators_.multicast)
     {
-        ParameterLocator_t p(PID_MULTICAST_LOCATOR,PARAMETER_LOCATOR_LENGTH,locator);
-        if (!p.addToCDRMessage(msg)) return false;
+        ParameterLocator_t p(PID_MULTICAST_LOCATOR, PARAMETER_LOCATOR_LENGTH, locator);
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
     {
-        ParameterBool_t p(PID_EXPECTS_INLINE_QOS,PARAMETER_BOOL_LENGTH,m_expectsInlineQos);
-        if (!p.addToCDRMessage(msg)) return false;
+        ParameterBool_t p(PID_EXPECTS_INLINE_QOS, PARAMETER_BOOL_LENGTH, m_expectsInlineQos);
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
     {
-        ParameterGuid_t p(PID_PARTICIPANT_GUID,PARAMETER_GUID_LENGTH,m_RTPSParticipantKey);
-        if (!p.addToCDRMessage(msg)) return false;
+        ParameterGuid_t p(PID_PARTICIPANT_GUID, PARAMETER_GUID_LENGTH, m_RTPSParticipantKey);
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
     {
         ParameterString_t p(PID_TOPIC_NAME, 0, m_topicName);
-        if (!p.addToCDRMessage(msg)) return false;
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
     {
-        ParameterString_t p(PID_TYPE_NAME,0,m_typeName);
-        if (!p.addToCDRMessage(msg)) return false;
+        ParameterString_t p(PID_TYPE_NAME, 0, m_typeName);
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
     {
-        ParameterKey_t p(PID_KEY_HASH,16,m_key);
-        if (!p.addToCDRMessage(msg)) return false;
+        ParameterKey_t p(PID_KEY_HASH, 16, m_key);
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
     {
-        ParameterGuid_t p(PID_ENDPOINT_GUID,16,m_guid);
-        if (!p.addToCDRMessage(msg)) return false;
+        ParameterGuid_t p(PID_ENDPOINT_GUID, 16, m_guid);
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
     {
-        ParameterProtocolVersion_t p(PID_PROTOCOL_VERSION,4);
-        if (!p.addToCDRMessage(msg)) return false;
+        ParameterProtocolVersion_t p(PID_PROTOCOL_VERSION, 4);
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
     {
-        ParameterVendorId_t p(PID_VENDORID,4);
-        if (!p.addToCDRMessage(msg)) return false;
+        ParameterVendorId_t p(PID_VENDORID, 4);
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_durability.sendAlways() || m_qos.m_durability.hasChanged)
+    if (m_qos.m_durability.sendAlways() || m_qos.m_durability.hasChanged)
     {
-        if (!m_qos.m_durability.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_durability.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_durabilityService.sendAlways() || m_qos.m_durabilityService.hasChanged)
+    if (m_qos.m_durabilityService.sendAlways() || m_qos.m_durabilityService.hasChanged)
     {
-        if (!m_qos.m_durabilityService.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_durabilityService.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_deadline.sendAlways() || m_qos.m_deadline.hasChanged)
+    if (m_qos.m_deadline.sendAlways() || m_qos.m_deadline.hasChanged)
     {
-        if (!m_qos.m_deadline.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_deadline.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_latencyBudget.sendAlways() || m_qos.m_latencyBudget.hasChanged)
+    if (m_qos.m_latencyBudget.sendAlways() || m_qos.m_latencyBudget.hasChanged)
     {
-        if (!m_qos.m_latencyBudget.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_latencyBudget.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_liveliness.sendAlways() || m_qos.m_liveliness.hasChanged)
+    if (m_qos.m_liveliness.sendAlways() || m_qos.m_liveliness.hasChanged)
     {
-        if (!m_qos.m_liveliness.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_liveliness.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_reliability.sendAlways() || m_qos.m_reliability.hasChanged)
+    if (m_qos.m_reliability.sendAlways() || m_qos.m_reliability.hasChanged)
     {
-        if (!m_qos.m_reliability.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_reliability.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_lifespan.sendAlways() || m_qos.m_lifespan.hasChanged)
+    if (m_qos.m_lifespan.sendAlways() || m_qos.m_lifespan.hasChanged)
     {
-        if (!m_qos.m_lifespan.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_lifespan.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_userData.sendAlways() || m_qos.m_userData.hasChanged)
+    if (m_qos.m_userData.sendAlways() || m_qos.m_userData.hasChanged)
     {
-        if (!m_qos.m_userData.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_userData.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_timeBasedFilter.sendAlways() || m_qos.m_timeBasedFilter.hasChanged)
+    if (m_qos.m_timeBasedFilter.sendAlways() || m_qos.m_timeBasedFilter.hasChanged)
     {
-        if (!m_qos.m_timeBasedFilter.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_timeBasedFilter.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_ownership.sendAlways() || m_qos.m_ownership.hasChanged)
+    if (m_qos.m_ownership.sendAlways() || m_qos.m_ownership.hasChanged)
     {
-        if (!m_qos.m_ownership.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_ownership.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_destinationOrder.sendAlways() || m_qos.m_destinationOrder.hasChanged)
+    if (m_qos.m_destinationOrder.sendAlways() || m_qos.m_destinationOrder.hasChanged)
     {
-        if (!m_qos.m_destinationOrder.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_destinationOrder.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_presentation.sendAlways() || m_qos.m_presentation.hasChanged)
+    if (m_qos.m_presentation.sendAlways() || m_qos.m_presentation.hasChanged)
     {
-        if (!m_qos.m_presentation.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_presentation.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_partition.sendAlways() || m_qos.m_partition.hasChanged)
+    if (m_qos.m_partition.sendAlways() || m_qos.m_partition.hasChanged)
     {
-        if (!m_qos.m_partition.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_partition.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_topicData.sendAlways() || m_qos.m_topicData.hasChanged)
+    if (m_qos.m_topicData.sendAlways() || m_qos.m_topicData.hasChanged)
     {
-        if (!m_qos.m_topicData.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_topicData.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_groupData.sendAlways() || m_qos.m_groupData.hasChanged)
+    if (m_qos.m_groupData.sendAlways() || m_qos.m_groupData.hasChanged)
     {
-        if (!m_qos.m_groupData.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_groupData.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_timeBasedFilter.sendAlways() || m_qos.m_timeBasedFilter.hasChanged)
+    if (m_qos.m_timeBasedFilter.sendAlways() || m_qos.m_timeBasedFilter.hasChanged)
     {
-        if (!m_qos.m_timeBasedFilter.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_timeBasedFilter.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_disablePositiveACKs.sendAlways() || m_qos.m_disablePositiveACKs.hasChanged)
+    if (m_qos.m_disablePositiveACKs.sendAlways() || m_qos.m_disablePositiveACKs.hasChanged)
     {
         if (!m_qos.m_disablePositiveACKs.addToCDRMessage(msg))
         {
@@ -225,19 +310,28 @@ bool ReaderProxyData::writeToCDRMessage(CDRMessage_t* msg, bool write_encapsulat
     {
         if (m_type_id.m_type_identifier._d() != 0)
         {
-            if (!m_type_id.addToCDRMessage(msg)) return false;
+            if (!m_type_id.addToCDRMessage(msg))
+            {
+                return false;
+            }
         }
 
         if (m_type.m_type_object._d() != 0)
         {
-            if (!m_type.addToCDRMessage(msg)) return false;
+            if (!m_type.addToCDRMessage(msg))
+            {
+                return false;
+            }
         }
     }
 
-    if(m_properties.properties.size()>0)
+    if (m_properties.properties.size() > 0)
     {
         ParameterPropertyList_t p(m_properties);
-        if (!p.addToCDRMessage(msg)) return false;
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
 
 #if HAVE_SECURITY
@@ -246,9 +340,12 @@ bool ReaderProxyData::writeToCDRMessage(CDRMessage_t* msg, bool write_encapsulat
         ParameterEndpointSecurityInfo_t p;
         p.security_attributes = security_attributes_;
         p.plugin_security_attributes = plugin_security_attributes_;
-        if (!p.addToCDRMessage(msg)) return false;
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-#endif
+#endif // if HAVE_SECURITY
 
     return CDRMessage::addParameterSentinel(msg);
 }
@@ -257,275 +354,288 @@ bool ReaderProxyData::readFromCDRMessage(
         CDRMessage_t* msg,
         const NetworkFactory& network)
 {
-    auto param_process = [this, & network](const Parameter_t* param)
-    {
-        switch (param->Pid)
-        {
-            case PID_DURABILITY:
+    auto param_process = [this, &network](const Parameter_t* param)
             {
-                const DurabilityQosPolicy* p = dynamic_cast<const DurabilityQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_durability = *p;
-                break;
-            }
-            case PID_DURABILITY_SERVICE:
-            {
-                const DurabilityServiceQosPolicy* p = dynamic_cast<const DurabilityServiceQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_durabilityService = *p;
-                break;
-            }
-            case PID_DEADLINE:
-            {
-                const DeadlineQosPolicy* p = dynamic_cast<const DeadlineQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_deadline = *p;
-                break;
-            }
-            case PID_LATENCY_BUDGET:
-            {
-                const LatencyBudgetQosPolicy* p = dynamic_cast<const LatencyBudgetQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_latencyBudget = *p;
-                break;
-            }
-            case PID_LIVELINESS:
-            {
-                const LivelinessQosPolicy* p = dynamic_cast<const LivelinessQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_liveliness = *p;
-                break;
-            }
-            case PID_RELIABILITY:
-            {
-                const ReliabilityQosPolicy* p = dynamic_cast<const ReliabilityQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_reliability = *p;
-                break;
-            }
-            case PID_LIFESPAN:
-            {
-                const LifespanQosPolicy* p = dynamic_cast<const LifespanQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_lifespan = *p;
-                break;
-            }
-            case PID_USER_DATA:
-            {
-                const UserDataQosPolicy* p = dynamic_cast<const UserDataQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_userData = *p;
-                break;
-            }
-            case PID_TIME_BASED_FILTER:
-            {
-                const TimeBasedFilterQosPolicy* p = dynamic_cast<const TimeBasedFilterQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_timeBasedFilter = *p;
-                break;
-            }
-            case PID_OWNERSHIP:
-            {
-                const OwnershipQosPolicy* p = dynamic_cast<const OwnershipQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_ownership = *p;
-                break;
-            }
-            case PID_DESTINATION_ORDER:
-            {
-                const DestinationOrderQosPolicy* p = dynamic_cast<const DestinationOrderQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_destinationOrder = *p;
-                break;
-            }
+                switch (param->Pid)
+                {
+                    case PID_DURABILITY:
+                    {
+                        const DurabilityQosPolicy* p = dynamic_cast<const DurabilityQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_durability = *p;
+                        break;
+                    }
+                    case PID_DURABILITY_SERVICE:
+                    {
+                        const DurabilityServiceQosPolicy* p = dynamic_cast<const DurabilityServiceQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_durabilityService = *p;
+                        break;
+                    }
+                    case PID_DEADLINE:
+                    {
+                        const DeadlineQosPolicy* p = dynamic_cast<const DeadlineQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_deadline = *p;
+                        break;
+                    }
+                    case PID_LATENCY_BUDGET:
+                    {
+                        const LatencyBudgetQosPolicy* p = dynamic_cast<const LatencyBudgetQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_latencyBudget = *p;
+                        break;
+                    }
+                    case PID_LIVELINESS:
+                    {
+                        const LivelinessQosPolicy* p = dynamic_cast<const LivelinessQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_liveliness = *p;
+                        break;
+                    }
+                    case PID_RELIABILITY:
+                    {
+                        const ReliabilityQosPolicy* p = dynamic_cast<const ReliabilityQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_reliability = *p;
+                        break;
+                    }
+                    case PID_LIFESPAN:
+                    {
+                        const LifespanQosPolicy* p = dynamic_cast<const LifespanQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_lifespan = *p;
+                        break;
+                    }
+                    case PID_USER_DATA:
+                    {
+                        const UserDataQosPolicy* p = dynamic_cast<const UserDataQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_userData = *p;
+                        break;
+                    }
+                    case PID_TIME_BASED_FILTER:
+                    {
+                        const TimeBasedFilterQosPolicy* p = dynamic_cast<const TimeBasedFilterQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_timeBasedFilter = *p;
+                        break;
+                    }
+                    case PID_OWNERSHIP:
+                    {
+                        const OwnershipQosPolicy* p = dynamic_cast<const OwnershipQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_ownership = *p;
+                        break;
+                    }
+                    case PID_DESTINATION_ORDER:
+                    {
+                        const DestinationOrderQosPolicy* p = dynamic_cast<const DestinationOrderQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_destinationOrder = *p;
+                        break;
+                    }
 
-            case PID_PRESENTATION:
-            {
-                const PresentationQosPolicy* p = dynamic_cast<const PresentationQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_presentation = *p;
-                break;
-            }
-            case PID_PARTITION:
-            {
-                const PartitionQosPolicy* p = dynamic_cast<const PartitionQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_partition = *p;
-                break;
-            }
-            case PID_TOPIC_DATA:
-            {
-                const TopicDataQosPolicy* p = dynamic_cast<const TopicDataQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_topicData = *p;
-                break;
-            }
-            case PID_GROUP_DATA:
-            {
-                const GroupDataQosPolicy* p = dynamic_cast<const GroupDataQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_groupData = *p;
-                break;
-            }
-            case PID_TOPIC_NAME:
-            {
-                const ParameterString_t* p = dynamic_cast<const ParameterString_t*>(param);
-                assert(p != nullptr);
-                m_topicName = p->getName();
-                break;
-            }
-            case PID_TYPE_NAME:
-            {
-                const ParameterString_t* p = dynamic_cast<const ParameterString_t*>(param);
-                assert(p != nullptr);
-                m_typeName = p->getName();
-                break;
-            }
-            case PID_PARTICIPANT_GUID:
-            {
-                const ParameterGuid_t* p = dynamic_cast<const ParameterGuid_t*>(param);
-                assert(p != nullptr);
-                for (uint8_t i = 0; i < 16; ++i)
-                {
-                    if (i < 12)
-                        m_RTPSParticipantKey.value[i] = p->guid.guidPrefix.value[i];
-                    else
-                        m_RTPSParticipantKey.value[i] = p->guid.entityId.value[i - 12];
-                }
-                break;
-            }
-            case PID_ENDPOINT_GUID:
-            {
-                const ParameterGuid_t* p = dynamic_cast<const ParameterGuid_t*>(param);
-                assert(p != nullptr);
-                m_guid = p->guid;
-                for (uint8_t i = 0; i<16; ++i)
-                {
-                    if (i<12)
-                        m_key.value[i] = p->guid.guidPrefix.value[i];
-                    else
-                        m_key.value[i] = p->guid.entityId.value[i - 12];
-                }
-                break;
-            }
-            case PID_UNICAST_LOCATOR:
-            {
-                const ParameterLocator_t* p = dynamic_cast<const ParameterLocator_t*>(param);
-                assert(p != nullptr);
-                Locator_t temp_locator;
-                if (network.transform_remote_locator(p->locator, temp_locator))
-                {
-                    remote_locators_.add_unicast_locator(temp_locator);
-                }
-                break;
-            }
-            case PID_MULTICAST_LOCATOR:
-            {
-                const ParameterLocator_t* p = dynamic_cast<const ParameterLocator_t*>(param);
-                assert(p != nullptr);
-                Locator_t temp_locator;
-                if (network.transform_remote_locator(p->locator, temp_locator))
-                {
-                    remote_locators_.add_multicast_locator(temp_locator);
-                }
-                break;
-            }
-            case PID_EXPECTS_INLINE_QOS:
-            {
-                const ParameterBool_t* p = dynamic_cast<const ParameterBool_t*>(param);
-                assert(p != nullptr);
-                m_expectsInlineQos = p->value;
-                break;
-            }
-            case PID_KEY_HASH:
-            {
-                const ParameterKey_t* p = dynamic_cast<const ParameterKey_t*>(param);
-                assert(p != nullptr);
-                m_key = p->key;
-                iHandle2GUID(m_guid, m_key);
-                break;
-            }
-            case PID_DATA_REPRESENTATION:
-            {
-                const DataRepresentationQosPolicy* p = dynamic_cast<const DataRepresentationQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_dataRepresentation = *p;
-                break;
-            }
-            case PID_TYPE_CONSISTENCY_ENFORCEMENT:
-            {
-                const TypeConsistencyEnforcementQosPolicy* p =
-                    dynamic_cast<const TypeConsistencyEnforcementQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_typeConsistency = *p;
-                break;
-            }
-            case PID_TYPE_IDV1:
-            {
-                const TypeIdV1* p = dynamic_cast<const TypeIdV1*>(param);
-                assert(p != nullptr);
-                m_type_id = *p;
-                m_topicDiscoveryKind = MINIMAL;
-                if (m_type_id.m_type_identifier._d() == types::EK_COMPLETE)
-                {
-                    m_topicDiscoveryKind = COMPLETE;
-                }
-                break;
-            }
-            case PID_TYPE_OBJECTV1:
-            {
-                const TypeObjectV1* p = dynamic_cast<const TypeObjectV1*>(param);
-                assert(p != nullptr);
-                m_type = *p;
-                m_topicDiscoveryKind = MINIMAL;
-                if (m_type.m_type_object._d() == types::EK_COMPLETE)
-                {
-                    m_topicDiscoveryKind = COMPLETE;
-                }
-                break;
-            }
-            case PID_DISABLE_POSITIVE_ACKS:
-            {
-                const DisablePositiveACKsQosPolicy* p = dynamic_cast<const DisablePositiveACKsQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_disablePositiveACKs = *p;
-                break;
-            }
+                    case PID_PRESENTATION:
+                    {
+                        const PresentationQosPolicy* p = dynamic_cast<const PresentationQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_presentation = *p;
+                        break;
+                    }
+                    case PID_PARTITION:
+                    {
+                        const PartitionQosPolicy* p = dynamic_cast<const PartitionQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_partition = *p;
+                        break;
+                    }
+                    case PID_TOPIC_DATA:
+                    {
+                        const TopicDataQosPolicy* p = dynamic_cast<const TopicDataQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_topicData = *p;
+                        break;
+                    }
+                    case PID_GROUP_DATA:
+                    {
+                        const GroupDataQosPolicy* p = dynamic_cast<const GroupDataQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_groupData = *p;
+                        break;
+                    }
+                    case PID_TOPIC_NAME:
+                    {
+                        const ParameterString_t* p = dynamic_cast<const ParameterString_t*>(param);
+                        assert(p != nullptr);
+                        m_topicName = p->getName();
+                        break;
+                    }
+                    case PID_TYPE_NAME:
+                    {
+                        const ParameterString_t* p = dynamic_cast<const ParameterString_t*>(param);
+                        assert(p != nullptr);
+                        m_typeName = p->getName();
+                        break;
+                    }
+                    case PID_PARTICIPANT_GUID:
+                    {
+                        const ParameterGuid_t* p = dynamic_cast<const ParameterGuid_t*>(param);
+                        assert(p != nullptr);
+                        for (uint8_t i = 0; i < 16; ++i)
+                        {
+                            if (i < 12)
+                            {
+                                m_RTPSParticipantKey.value[i] = p->guid.guidPrefix.value[i];
+                            }
+                            else
+                            {
+                                m_RTPSParticipantKey.value[i] = p->guid.entityId.value[i - 12];
+                            }
+                        }
+                        break;
+                    }
+                    case PID_ENDPOINT_GUID:
+                    {
+                        const ParameterGuid_t* p = dynamic_cast<const ParameterGuid_t*>(param);
+                        assert(p != nullptr);
+                        m_guid = p->guid;
+                        for (uint8_t i = 0; i < 16; ++i)
+                        {
+                            if (i < 12)
+                            {
+                                m_key.value[i] = p->guid.guidPrefix.value[i];
+                            }
+                            else
+                            {
+                                m_key.value[i] = p->guid.entityId.value[i - 12];
+                            }
+                        }
+                        break;
+                    }
+                    case PID_UNICAST_LOCATOR:
+                    {
+                        const ParameterLocator_t* p = dynamic_cast<const ParameterLocator_t*>(param);
+                        assert(p != nullptr);
+                        Locator_t temp_locator;
+                        if (network.transform_remote_locator(p->locator, temp_locator))
+                        {
+                            remote_locators_.add_unicast_locator(temp_locator);
+                        }
+                        break;
+                    }
+                    case PID_MULTICAST_LOCATOR:
+                    {
+                        const ParameterLocator_t* p = dynamic_cast<const ParameterLocator_t*>(param);
+                        assert(p != nullptr);
+                        Locator_t temp_locator;
+                        if (network.transform_remote_locator(p->locator, temp_locator))
+                        {
+                            remote_locators_.add_multicast_locator(temp_locator);
+                        }
+                        break;
+                    }
+                    case PID_EXPECTS_INLINE_QOS:
+                    {
+                        const ParameterBool_t* p = dynamic_cast<const ParameterBool_t*>(param);
+                        assert(p != nullptr);
+                        m_expectsInlineQos = p->value;
+                        break;
+                    }
+                    case PID_KEY_HASH:
+                    {
+                        const ParameterKey_t* p = dynamic_cast<const ParameterKey_t*>(param);
+                        assert(p != nullptr);
+                        m_key = p->key;
+                        iHandle2GUID(m_guid, m_key);
+                        break;
+                    }
+                    case PID_DATA_REPRESENTATION:
+                    {
+                        const DataRepresentationQosPolicy* p = dynamic_cast<const DataRepresentationQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_dataRepresentation = *p;
+                        break;
+                    }
+                    case PID_TYPE_CONSISTENCY_ENFORCEMENT:
+                    {
+                        const TypeConsistencyEnforcementQosPolicy* p =
+                                dynamic_cast<const TypeConsistencyEnforcementQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_typeConsistency = *p;
+                        break;
+                    }
+                    case PID_TYPE_IDV1:
+                    {
+                        const TypeIdV1* p = dynamic_cast<const TypeIdV1*>(param);
+                        assert(p != nullptr);
+                        m_type_id = *p;
+                        m_topicDiscoveryKind = MINIMAL;
+                        if (m_type_id.m_type_identifier._d() == types::EK_COMPLETE)
+                        {
+                            m_topicDiscoveryKind = COMPLETE;
+                        }
+                        break;
+                    }
+                    case PID_TYPE_OBJECTV1:
+                    {
+                        const TypeObjectV1* p = dynamic_cast<const TypeObjectV1*>(param);
+                        assert(p != nullptr);
+                        m_type = *p;
+                        m_topicDiscoveryKind = MINIMAL;
+                        if (m_type.m_type_object._d() == types::EK_COMPLETE)
+                        {
+                            m_topicDiscoveryKind = COMPLETE;
+                        }
+                        break;
+                    }
+                    case PID_DISABLE_POSITIVE_ACKS:
+                    {
+                        const DisablePositiveACKsQosPolicy* p =
+                                dynamic_cast<const DisablePositiveACKsQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_disablePositiveACKs = *p;
+                        break;
+                    }
 #if HAVE_SECURITY
-            case PID_ENDPOINT_SECURITY_INFO:
-            {
-                const ParameterEndpointSecurityInfo_t* p =
-                    dynamic_cast<const ParameterEndpointSecurityInfo_t*>(param);
-                assert(p != nullptr);
-                security_attributes_ = p->security_attributes;
-                plugin_security_attributes_ = p->plugin_security_attributes;
-            }
-#endif
-            case PID_PROPERTY_LIST:
-            {
-                const ParameterPropertyList_t* p = dynamic_cast<const ParameterPropertyList_t*>(param);
-                assert(p != nullptr);
-                this->m_properties = *p;
-                break;
-            }
+                    case PID_ENDPOINT_SECURITY_INFO:
+                    {
+                        const ParameterEndpointSecurityInfo_t* p =
+                                dynamic_cast<const ParameterEndpointSecurityInfo_t*>(param);
+                        assert(p != nullptr);
+                        security_attributes_ = p->security_attributes;
+                        plugin_security_attributes_ = p->plugin_security_attributes;
+                    }
+#endif // if HAVE_SECURITY
+                    case PID_PROPERTY_LIST:
+                    {
+                        const ParameterPropertyList_t* p = dynamic_cast<const ParameterPropertyList_t*>(param);
+                        assert(p != nullptr);
+                        this->m_properties = *p;
+                        break;
+                    }
 
-            default:
-            {
-                //logInfo(RTPS_PROXY_DATA,"Parameter with ID: "  <<(uint16_t)(param)->Pid << " NOT CONSIDERED");
-                break;
-            }
-        }
-        return true;
-    };
+                    default:
+                    {
+                        //logInfo(RTPS_PROXY_DATA,"Parameter with ID: "  <<(uint16_t)(param)->Pid << " NOT CONSIDERED");
+                        break;
+                    }
+                }
+                return true;
+            };
 
     uint32_t qos_size;
     clear();
     if (ParameterList::readParameterListfromCDRMsg(*msg, param_process, true, qos_size))
     {
         if (m_guid.entityId.value[3] == 0x04)
+        {
             m_topicKind = NO_KEY;
+        }
         else if (m_guid.entityId.value[3] == 0x07)
+        {
             m_topicKind = WITH_KEY;
+        }
 
         return true;
     }
@@ -539,7 +649,7 @@ void ReaderProxyData::clear()
 #if HAVE_SECURITY
     security_attributes_ = 0UL;
     plugin_security_attributes_ = 0UL;
-#endif
+#endif // if HAVE_SECURITY
     m_guid = c_Guid_Unknown;
     remote_locators_.unicast.clear();
     remote_locators_.multicast.clear();
@@ -558,15 +668,16 @@ void ReaderProxyData::clear()
     m_properties.length = 0;
 }
 
-bool ReaderProxyData::is_update_allowed(const ReaderProxyData& rdata) const
+bool ReaderProxyData::is_update_allowed(
+        const ReaderProxyData& rdata) const
 {
-    if( (m_guid != rdata.m_guid) ||
+    if ( (m_guid != rdata.m_guid) ||
 #if HAVE_SECURITY
-        (security_attributes_ != rdata.security_attributes_) ||
-        (plugin_security_attributes_ != rdata.security_attributes_) ||
-#endif
-        (m_typeName != rdata.m_typeName) ||
-        (m_topicName != rdata.m_topicName) )
+            (security_attributes_ != rdata.security_attributes_) ||
+            (plugin_security_attributes_ != rdata.security_attributes_) ||
+#endif // if HAVE_SECURITY
+            (m_typeName != rdata.m_typeName) ||
+            (m_topicName != rdata.m_topicName) )
     {
         return false;
     }
@@ -574,15 +685,17 @@ bool ReaderProxyData::is_update_allowed(const ReaderProxyData& rdata) const
     return m_qos.canQosBeUpdated(rdata.m_qos);
 }
 
-void ReaderProxyData::update(ReaderProxyData* rdata)
+void ReaderProxyData::update(
+        ReaderProxyData* rdata)
 {
     remote_locators_ = rdata->remote_locators_;
-    m_qos.setQos(rdata->m_qos,false);
+    m_qos.setQos(rdata->m_qos, false);
     m_isAlive = rdata->m_isAlive;
     m_expectsInlineQos = rdata->m_expectsInlineQos;
 }
 
-void ReaderProxyData::copy(ReaderProxyData* rdata)
+void ReaderProxyData::copy(
+        ReaderProxyData* rdata)
 {
     m_guid = rdata->m_guid;
     remote_locators_ = rdata->remote_locators_;
@@ -605,7 +718,8 @@ void ReaderProxyData::copy(ReaderProxyData* rdata)
     m_properties = rdata->m_properties;
 }
 
-void ReaderProxyData::add_unicast_locator(const Locator_t& locator)
+void ReaderProxyData::add_unicast_locator(
+        const Locator_t& locator)
 {
     remote_locators_.add_unicast_locator(locator);
 }
@@ -635,7 +749,8 @@ void ReaderProxyData::set_remote_unicast_locators(
     }
 }
 
-void ReaderProxyData::add_multicast_locator(const Locator_t& locator)
+void ReaderProxyData::add_multicast_locator(
+        const Locator_t& locator)
 {
     remote_locators_.add_multicast_locator(locator);
 }

--- a/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
@@ -605,6 +605,7 @@ bool ReaderProxyData::readFromCDRMessage(
                         assert(p != nullptr);
                         security_attributes_ = p->security_attributes;
                         plugin_security_attributes_ = p->plugin_security_attributes;
+                        break;
                     }
 #endif // if HAVE_SECURITY
                     case PID_PROPERTY_LIST:

--- a/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.cpp
@@ -26,7 +26,7 @@
 #include <fastrtps/rtps/network/NetworkFactory.h>
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
 
@@ -39,23 +39,24 @@ WriterProxyData::WriterProxyData(
     , remote_locators_(max_unicast_locators, max_multicast_locators)
 #else
     : remote_locators_(max_unicast_locators, max_multicast_locators)
-#endif
+#endif // if HAVE_SECURITY
     , m_userDefinedId(0)
     , m_typeMaxSerialized(0)
     , m_topicKind(NO_KEY)
     , m_topicDiscoveryKind(NO_CHECK)
-    {
-        // TODO Auto-generated constructor stub
-    }
+{
+    // TODO Auto-generated constructor stub
+}
 
-WriterProxyData::WriterProxyData(const WriterProxyData& writerInfo)
+WriterProxyData::WriterProxyData(
+        const WriterProxyData& writerInfo)
 #if HAVE_SECURITY
     : security_attributes_(writerInfo.security_attributes_)
     , plugin_security_attributes_(writerInfo.plugin_security_attributes_)
     , m_guid(writerInfo.m_guid)
 #else
     : m_guid(writerInfo.m_guid)
-#endif
+#endif // if HAVE_SECURITY
     , remote_locators_(writerInfo.remote_locators_)
     , m_key(writerInfo.m_key)
     , m_RTPSParticipantKey(writerInfo.m_RTPSParticipantKey)
@@ -73,17 +74,19 @@ WriterProxyData::WriterProxyData(const WriterProxyData& writerInfo)
     m_qos.setQos(writerInfo.m_qos, true);
 }
 
-WriterProxyData::~WriterProxyData() {
+WriterProxyData::~WriterProxyData()
+{
     // TODO Auto-generated destructor stub
-    logInfo(RTPS_PROXY_DATA,this->m_guid);
+    logInfo(RTPS_PROXY_DATA, this->m_guid);
 }
 
-WriterProxyData& WriterProxyData::operator=(const WriterProxyData& writerInfo)
+WriterProxyData& WriterProxyData::operator =(
+        const WriterProxyData& writerInfo)
 {
 #if HAVE_SECURITY
     security_attributes_ = writerInfo.security_attributes_;
     plugin_security_attributes_ = writerInfo.plugin_security_attributes_;
-#endif
+#endif // if HAVE_SECURITY
     m_guid = writerInfo.m_guid;
     remote_locators_ = writerInfo.remote_locators_;
     m_key = writerInfo.m_key;
@@ -103,149 +106,244 @@ WriterProxyData& WriterProxyData::operator=(const WriterProxyData& writerInfo)
     return *this;
 }
 
-bool WriterProxyData::writeToCDRMessage(CDRMessage_t* msg, bool write_encapsulation)
+bool WriterProxyData::writeToCDRMessage(
+        CDRMessage_t* msg,
+        bool write_encapsulation)
 {
     if (write_encapsulation)
     {
-        if (!ParameterList::writeEncapsulationToCDRMsg(msg)) return false;
+        if (!ParameterList::writeEncapsulationToCDRMsg(msg))
+        {
+            return false;
+        }
     }
 
-    for(const Locator_t& locator : remote_locators_.unicast)
+    for (const Locator_t& locator : remote_locators_.unicast)
     {
-        ParameterLocator_t p(PID_UNICAST_LOCATOR,PARAMETER_LOCATOR_LENGTH,locator);
-        if (!p.addToCDRMessage(msg)) return false;
+        ParameterLocator_t p(PID_UNICAST_LOCATOR, PARAMETER_LOCATOR_LENGTH, locator);
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    for(const Locator_t& locator : remote_locators_.multicast)
+    for (const Locator_t& locator : remote_locators_.multicast)
     {
-        ParameterLocator_t p(PID_MULTICAST_LOCATOR,PARAMETER_LOCATOR_LENGTH,locator);
-        if (!p.addToCDRMessage(msg)) return false;
+        ParameterLocator_t p(PID_MULTICAST_LOCATOR, PARAMETER_LOCATOR_LENGTH, locator);
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
     {
-        ParameterGuid_t p(PID_PARTICIPANT_GUID,PARAMETER_GUID_LENGTH,m_RTPSParticipantKey);
-        if (!p.addToCDRMessage(msg)) return false;
+        ParameterGuid_t p(PID_PARTICIPANT_GUID, PARAMETER_GUID_LENGTH, m_RTPSParticipantKey);
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
     {
         ParameterString_t p(PID_TOPIC_NAME, 0, m_topicName);
-        if (!p.addToCDRMessage(msg)) return false;
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
     {
-        ParameterString_t p(PID_TYPE_NAME,0,m_typeName);
-        if (!p.addToCDRMessage(msg)) return false;
+        ParameterString_t p(PID_TYPE_NAME, 0, m_typeName);
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
     {
-        ParameterKey_t p(PID_KEY_HASH,16,m_key);
-        if (!p.addToCDRMessage(msg)) return false;
+        ParameterKey_t p(PID_KEY_HASH, 16, m_key);
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
     {
-        ParameterGuid_t p(PID_ENDPOINT_GUID,16,m_guid);
-        if (!p.addToCDRMessage(msg)) return false;
+        ParameterGuid_t p(PID_ENDPOINT_GUID, 16, m_guid);
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
     {
-        ParameterPort_t p(PID_TYPE_MAX_SIZE_SERIALIZED,4,m_typeMaxSerialized);
-        if (!p.addToCDRMessage(msg)) return false;
+        ParameterPort_t p(PID_TYPE_MAX_SIZE_SERIALIZED, 4, m_typeMaxSerialized);
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
     {
-        ParameterProtocolVersion_t p(PID_PROTOCOL_VERSION,4);
-        if (!p.addToCDRMessage(msg)) return false;
+        ParameterProtocolVersion_t p(PID_PROTOCOL_VERSION, 4);
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
     {
-        ParameterVendorId_t p(PID_VENDORID,4);
-        if (!p.addToCDRMessage(msg)) return false;
+        ParameterVendorId_t p(PID_VENDORID, 4);
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(persistence_guid_ != c_Guid_Unknown)
+    if (persistence_guid_ != c_Guid_Unknown)
     {
         ParameterGuid_t p(PID_PERSISTENCE_GUID, 16, persistence_guid_);
-        if (!p.addToCDRMessage(msg)) return false;
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if( m_qos.m_durability.sendAlways() || m_qos.m_durability.hasChanged)
+    if ( m_qos.m_durability.sendAlways() || m_qos.m_durability.hasChanged)
     {
-        if (!m_qos.m_durability.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_durability.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_durabilityService.sendAlways() || m_qos.m_durabilityService.hasChanged)
+    if (m_qos.m_durabilityService.sendAlways() || m_qos.m_durabilityService.hasChanged)
     {
-        if (!m_qos.m_durabilityService.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_durabilityService.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_deadline.sendAlways() ||  m_qos.m_deadline.hasChanged)
+    if (m_qos.m_deadline.sendAlways() ||  m_qos.m_deadline.hasChanged)
     {
-        if (!m_qos.m_deadline.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_deadline.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_latencyBudget.sendAlways() ||  m_qos.m_latencyBudget.hasChanged)
+    if (m_qos.m_latencyBudget.sendAlways() ||  m_qos.m_latencyBudget.hasChanged)
     {
-        if (!m_qos.m_latencyBudget.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_latencyBudget.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_durability.sendAlways() ||  m_qos.m_liveliness.hasChanged)
+    if (m_qos.m_durability.sendAlways() ||  m_qos.m_liveliness.hasChanged)
     {
-        if (!m_qos.m_liveliness.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_liveliness.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_reliability.sendAlways() ||  m_qos.m_reliability.hasChanged)
+    if (m_qos.m_reliability.sendAlways() ||  m_qos.m_reliability.hasChanged)
     {
-        if (!m_qos.m_reliability.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_reliability.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_lifespan.sendAlways() ||  m_qos.m_lifespan.hasChanged)
+    if (m_qos.m_lifespan.sendAlways() ||  m_qos.m_lifespan.hasChanged)
     {
-        if (!m_qos.m_lifespan.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_lifespan.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if( m_qos.m_userData.sendAlways() || m_qos.m_userData.hasChanged)
+    if ( m_qos.m_userData.sendAlways() || m_qos.m_userData.hasChanged)
     {
-        if (!m_qos.m_userData.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_userData.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_timeBasedFilter.sendAlways() ||  m_qos.m_timeBasedFilter.hasChanged)
+    if (m_qos.m_timeBasedFilter.sendAlways() ||  m_qos.m_timeBasedFilter.hasChanged)
     {
-        if (!m_qos.m_timeBasedFilter.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_timeBasedFilter.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_ownership.sendAlways() ||  m_qos.m_ownership.hasChanged)
+    if (m_qos.m_ownership.sendAlways() ||  m_qos.m_ownership.hasChanged)
     {
-        if (!m_qos.m_ownership.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_ownership.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_durability.sendAlways() ||  m_qos.m_ownershipStrength.hasChanged)
+    if (m_qos.m_durability.sendAlways() ||  m_qos.m_ownershipStrength.hasChanged)
     {
-        if (!m_qos.m_ownershipStrength.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_ownershipStrength.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_destinationOrder.sendAlways() ||  m_qos.m_destinationOrder.hasChanged)
+    if (m_qos.m_destinationOrder.sendAlways() ||  m_qos.m_destinationOrder.hasChanged)
     {
-        if (!m_qos.m_destinationOrder.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_destinationOrder.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_presentation.sendAlways() ||  m_qos.m_presentation.hasChanged)
+    if (m_qos.m_presentation.sendAlways() ||  m_qos.m_presentation.hasChanged)
     {
-        if (!m_qos.m_presentation.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_presentation.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_partition.sendAlways() ||  m_qos.m_partition.hasChanged)
+    if (m_qos.m_partition.sendAlways() ||  m_qos.m_partition.hasChanged)
     {
-        if (!m_qos.m_partition.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_partition.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_topicData.sendAlways() || m_qos.m_topicData.hasChanged)
+    if (m_qos.m_topicData.sendAlways() || m_qos.m_topicData.hasChanged)
     {
-        if (!m_qos.m_topicData.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_topicData.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-    if(m_qos.m_disablePositiveACKs.sendAlways() || m_qos.m_topicData.hasChanged)
+    if (m_qos.m_disablePositiveACKs.sendAlways() || m_qos.m_topicData.hasChanged)
     {
         if (!m_qos.m_disablePositiveACKs.addToCDRMessage(msg))
         {
             return false;
         }
     }
-    if(m_qos.m_groupData.sendAlways() ||  m_qos.m_groupData.hasChanged)
+    if (m_qos.m_groupData.sendAlways() ||  m_qos.m_groupData.hasChanged)
     {
-        if (!m_qos.m_groupData.addToCDRMessage(msg)) return false;
+        if (!m_qos.m_groupData.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
 
     if (m_topicDiscoveryKind != NO_CHECK)
     {
         if (m_type_id.m_type_identifier._d() != 0)
         {
-            if (!m_type_id.addToCDRMessage(msg)) return false;
+            if (!m_type_id.addToCDRMessage(msg))
+            {
+                return false;
+            }
         }
 
         if (m_type.m_type_object._d() != 0)
         {
-            if (!m_type.addToCDRMessage(msg)) return false;
+            if (!m_type.addToCDRMessage(msg))
+            {
+                return false;
+            }
         }
     }
 
-    if(m_properties.properties.size()>0)
+    if (m_properties.properties.size() > 0)
     {
         ParameterPropertyList_t p(m_properties);
-        if (!p.addToCDRMessage(msg)) return false;
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
 
 #if HAVE_SECURITY
@@ -254,9 +352,12 @@ bool WriterProxyData::writeToCDRMessage(CDRMessage_t* msg, bool write_encapsulat
         ParameterEndpointSecurityInfo_t p;
         p.security_attributes = security_attributes_;
         p.plugin_security_attributes = plugin_security_attributes_;
-        if (!p.addToCDRMessage(msg)) return false;
+        if (!p.addToCDRMessage(msg))
+        {
+            return false;
+        }
     }
-#endif
+#endif // if HAVE_SECURITY
 
     return CDRMessage::addParameterSentinel(msg);
 }
@@ -265,268 +366,281 @@ bool WriterProxyData::readFromCDRMessage(
         CDRMessage_t* msg,
         const NetworkFactory& network)
 {
-    auto param_process = [this, & network](const Parameter_t* param)
-    {
-        switch (param->Pid)
-        {
-            case PID_DURABILITY:
+    auto param_process = [this, &network](const Parameter_t* param)
             {
-                const DurabilityQosPolicy* p = dynamic_cast<const DurabilityQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_durability = *p;
-                break;
-            }
-            case PID_DURABILITY_SERVICE:
-            {
-                const DurabilityServiceQosPolicy* p = dynamic_cast<const DurabilityServiceQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_durabilityService = *p;
-                break;
-            }
-            case PID_DEADLINE:
-            {
-                const DeadlineQosPolicy* p = dynamic_cast<const DeadlineQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_deadline = *p;
-                break;
-            }
-            case PID_LATENCY_BUDGET:
-            {
-                const LatencyBudgetQosPolicy* p = dynamic_cast<const LatencyBudgetQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_latencyBudget = *p;
-                break;
-            }
-            case PID_LIVELINESS:
-            {
-                const LivelinessQosPolicy* p = dynamic_cast<const LivelinessQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_liveliness = *p;
-                break;
-            }
-            case PID_RELIABILITY:
-            {
-                const ReliabilityQosPolicy* p = dynamic_cast<const ReliabilityQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_reliability = *p;
-                break;
-            }
-            case PID_LIFESPAN:
-            {
-                const LifespanQosPolicy* p = dynamic_cast<const LifespanQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_lifespan = *p;
-                break;
-            }
-            case PID_USER_DATA:
-            {
-                const UserDataQosPolicy* p = dynamic_cast<const UserDataQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_userData = *p;
-                break;
-            }
-            case PID_TIME_BASED_FILTER:
-            {
-                const TimeBasedFilterQosPolicy* p = dynamic_cast<const TimeBasedFilterQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_timeBasedFilter = *p;
-                break;
-            }
-            case PID_OWNERSHIP:
-            {
-                const OwnershipQosPolicy* p = dynamic_cast<const OwnershipQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_ownership = *p;
-                break;
-            }
-            case PID_OWNERSHIP_STRENGTH:
-            {
-                const OwnershipStrengthQosPolicy* p = dynamic_cast<const OwnershipStrengthQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_ownershipStrength = *p;
-                break;
-            }
-            case PID_DESTINATION_ORDER:
-            {
-                const DestinationOrderQosPolicy* p = dynamic_cast<const DestinationOrderQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_destinationOrder = *p;
-                break;
-            }
+                switch (param->Pid)
+                {
+                    case PID_DURABILITY:
+                    {
+                        const DurabilityQosPolicy* p = dynamic_cast<const DurabilityQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_durability = *p;
+                        break;
+                    }
+                    case PID_DURABILITY_SERVICE:
+                    {
+                        const DurabilityServiceQosPolicy* p = dynamic_cast<const DurabilityServiceQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_durabilityService = *p;
+                        break;
+                    }
+                    case PID_DEADLINE:
+                    {
+                        const DeadlineQosPolicy* p = dynamic_cast<const DeadlineQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_deadline = *p;
+                        break;
+                    }
+                    case PID_LATENCY_BUDGET:
+                    {
+                        const LatencyBudgetQosPolicy* p = dynamic_cast<const LatencyBudgetQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_latencyBudget = *p;
+                        break;
+                    }
+                    case PID_LIVELINESS:
+                    {
+                        const LivelinessQosPolicy* p = dynamic_cast<const LivelinessQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_liveliness = *p;
+                        break;
+                    }
+                    case PID_RELIABILITY:
+                    {
+                        const ReliabilityQosPolicy* p = dynamic_cast<const ReliabilityQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_reliability = *p;
+                        break;
+                    }
+                    case PID_LIFESPAN:
+                    {
+                        const LifespanQosPolicy* p = dynamic_cast<const LifespanQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_lifespan = *p;
+                        break;
+                    }
+                    case PID_USER_DATA:
+                    {
+                        const UserDataQosPolicy* p = dynamic_cast<const UserDataQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_userData = *p;
+                        break;
+                    }
+                    case PID_TIME_BASED_FILTER:
+                    {
+                        const TimeBasedFilterQosPolicy* p = dynamic_cast<const TimeBasedFilterQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_timeBasedFilter = *p;
+                        break;
+                    }
+                    case PID_OWNERSHIP:
+                    {
+                        const OwnershipQosPolicy* p = dynamic_cast<const OwnershipQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_ownership = *p;
+                        break;
+                    }
+                    case PID_OWNERSHIP_STRENGTH:
+                    {
+                        const OwnershipStrengthQosPolicy* p = dynamic_cast<const OwnershipStrengthQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_ownershipStrength = *p;
+                        break;
+                    }
+                    case PID_DESTINATION_ORDER:
+                    {
+                        const DestinationOrderQosPolicy* p = dynamic_cast<const DestinationOrderQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_destinationOrder = *p;
+                        break;
+                    }
 
-            case PID_PRESENTATION:
-            {
-                const PresentationQosPolicy* p = dynamic_cast<const PresentationQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_presentation = *p;
-                break;
-            }
-            case PID_PARTITION:
-            {
-                const PartitionQosPolicy* p = dynamic_cast<const PartitionQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_partition = *p;
-                break;
-            }
-            case PID_TOPIC_DATA:
-            {
-                const TopicDataQosPolicy* p = dynamic_cast<const TopicDataQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_topicData = *p;
-                break;
-            }
-            case PID_GROUP_DATA:
-            {
-                const GroupDataQosPolicy* p = dynamic_cast<const GroupDataQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_groupData = *p;
-                break;
-            }
-            case PID_TOPIC_NAME:
-            {
-                const ParameterString_t* p = dynamic_cast<const ParameterString_t*>(param);
-                assert(p != nullptr);
-                m_topicName = p->getName();
-                break;
-            }
-            case PID_TYPE_NAME:
-            {
-                const ParameterString_t* p = dynamic_cast<const ParameterString_t*>(param);
-                assert(p != nullptr);
-                m_typeName = p->getName();
-                break;
-            }
-            case PID_PARTICIPANT_GUID:
-            {
-                const ParameterGuid_t* p = dynamic_cast<const ParameterGuid_t*>(param);
-                assert(p != nullptr);
-                for (uint8_t i = 0; i < 16; ++i)
-                {
-                    if (i < 12)
-                        m_RTPSParticipantKey.value[i] = p->guid.guidPrefix.value[i];
-                    else
-                        m_RTPSParticipantKey.value[i] = p->guid.entityId.value[i - 12];
-                }
-                break;
-            }
-            case PID_ENDPOINT_GUID:
-            {
-                const ParameterGuid_t* p = dynamic_cast<const ParameterGuid_t*>(param);
-                assert(p != nullptr);
-                m_guid = p->guid;
-                for (uint8_t i = 0; i<16; ++i)
-                {
-                    if (i<12)
-                        m_key.value[i] = p->guid.guidPrefix.value[i];
-                    else
-                        m_key.value[i] = p->guid.entityId.value[i - 12];
-                }
-                break;
-            }
-            case PID_PERSISTENCE_GUID:
-            {
-                const ParameterGuid_t* p = dynamic_cast<const ParameterGuid_t*>(param);
-                assert(p != nullptr);
-                persistence_guid_ = p->guid;
-            }
-            break;
-            case PID_UNICAST_LOCATOR:
-            {
-                const ParameterLocator_t* p = dynamic_cast<const ParameterLocator_t*>(param);
-                assert(p != nullptr);
-                Locator_t temp_locator;
-                if (network.transform_remote_locator(p->locator, temp_locator))
-                {
-                    remote_locators_.add_unicast_locator(temp_locator);
-                }
-                break;
-            }
-            case PID_MULTICAST_LOCATOR:
-            {
-                const ParameterLocator_t* p = dynamic_cast<const ParameterLocator_t*>(param);
-                assert(p != nullptr);
-                Locator_t temp_locator;
-                if (network.transform_remote_locator(p->locator, temp_locator))
-                {
-                    remote_locators_.add_multicast_locator(temp_locator);
-                }
-                break;
-            }
-            case PID_KEY_HASH:
-            {
-                const ParameterKey_t* p = dynamic_cast<const ParameterKey_t*>(param);
-                assert(p != nullptr);
-                m_key = p->key;
-                iHandle2GUID(m_guid, m_key);
-                break;
-            }
-            case PID_TYPE_IDV1:
-            {
-                const TypeIdV1* p = dynamic_cast<const TypeIdV1*>(param);
-                assert(p != nullptr);
-                m_type_id = *p;
-                m_topicDiscoveryKind = MINIMAL;
-                if (m_type_id.m_type_identifier._d() == types::EK_COMPLETE)
-                {
-                    m_topicDiscoveryKind = COMPLETE;
-                }
-                break;
-            }
-            case PID_TYPE_OBJECTV1:
-            {
-                const TypeObjectV1* p = dynamic_cast<const TypeObjectV1*>(param);
-                assert(p != nullptr);
-                m_type = *p;
-                m_topicDiscoveryKind = MINIMAL;
-                if (m_type.m_type_object._d() == types::EK_COMPLETE)
-                {
-                    m_topicDiscoveryKind = COMPLETE;
-                }
-                break;
-            }
-            case PID_DISABLE_POSITIVE_ACKS:
-            {
-                const DisablePositiveACKsQosPolicy* p = dynamic_cast<const DisablePositiveACKsQosPolicy*>(param);
-                assert(p != nullptr);
-                m_qos.m_disablePositiveACKs = *p;
-                break;
-            }
+                    case PID_PRESENTATION:
+                    {
+                        const PresentationQosPolicy* p = dynamic_cast<const PresentationQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_presentation = *p;
+                        break;
+                    }
+                    case PID_PARTITION:
+                    {
+                        const PartitionQosPolicy* p = dynamic_cast<const PartitionQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_partition = *p;
+                        break;
+                    }
+                    case PID_TOPIC_DATA:
+                    {
+                        const TopicDataQosPolicy* p = dynamic_cast<const TopicDataQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_topicData = *p;
+                        break;
+                    }
+                    case PID_GROUP_DATA:
+                    {
+                        const GroupDataQosPolicy* p = dynamic_cast<const GroupDataQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_groupData = *p;
+                        break;
+                    }
+                    case PID_TOPIC_NAME:
+                    {
+                        const ParameterString_t* p = dynamic_cast<const ParameterString_t*>(param);
+                        assert(p != nullptr);
+                        m_topicName = p->getName();
+                        break;
+                    }
+                    case PID_TYPE_NAME:
+                    {
+                        const ParameterString_t* p = dynamic_cast<const ParameterString_t*>(param);
+                        assert(p != nullptr);
+                        m_typeName = p->getName();
+                        break;
+                    }
+                    case PID_PARTICIPANT_GUID:
+                    {
+                        const ParameterGuid_t* p = dynamic_cast<const ParameterGuid_t*>(param);
+                        assert(p != nullptr);
+                        for (uint8_t i = 0; i < 16; ++i)
+                        {
+                            if (i < 12)
+                            {
+                                m_RTPSParticipantKey.value[i] = p->guid.guidPrefix.value[i];
+                            }
+                            else
+                            {
+                                m_RTPSParticipantKey.value[i] = p->guid.entityId.value[i - 12];
+                            }
+                        }
+                        break;
+                    }
+                    case PID_ENDPOINT_GUID:
+                    {
+                        const ParameterGuid_t* p = dynamic_cast<const ParameterGuid_t*>(param);
+                        assert(p != nullptr);
+                        m_guid = p->guid;
+                        for (uint8_t i = 0; i < 16; ++i)
+                        {
+                            if (i < 12)
+                            {
+                                m_key.value[i] = p->guid.guidPrefix.value[i];
+                            }
+                            else
+                            {
+                                m_key.value[i] = p->guid.entityId.value[i - 12];
+                            }
+                        }
+                        break;
+                    }
+                    case PID_PERSISTENCE_GUID:
+                    {
+                        const ParameterGuid_t* p = dynamic_cast<const ParameterGuid_t*>(param);
+                        assert(p != nullptr);
+                        persistence_guid_ = p->guid;
+                    }
+                    break;
+                    case PID_UNICAST_LOCATOR:
+                    {
+                        const ParameterLocator_t* p = dynamic_cast<const ParameterLocator_t*>(param);
+                        assert(p != nullptr);
+                        Locator_t temp_locator;
+                        if (network.transform_remote_locator(p->locator, temp_locator))
+                        {
+                            remote_locators_.add_unicast_locator(temp_locator);
+                        }
+                        break;
+                    }
+                    case PID_MULTICAST_LOCATOR:
+                    {
+                        const ParameterLocator_t* p = dynamic_cast<const ParameterLocator_t*>(param);
+                        assert(p != nullptr);
+                        Locator_t temp_locator;
+                        if (network.transform_remote_locator(p->locator, temp_locator))
+                        {
+                            remote_locators_.add_multicast_locator(temp_locator);
+                        }
+                        break;
+                    }
+                    case PID_KEY_HASH:
+                    {
+                        const ParameterKey_t* p = dynamic_cast<const ParameterKey_t*>(param);
+                        assert(p != nullptr);
+                        m_key = p->key;
+                        iHandle2GUID(m_guid, m_key);
+                        break;
+                    }
+                    case PID_TYPE_IDV1:
+                    {
+                        const TypeIdV1* p = dynamic_cast<const TypeIdV1*>(param);
+                        assert(p != nullptr);
+                        m_type_id = *p;
+                        m_topicDiscoveryKind = MINIMAL;
+                        if (m_type_id.m_type_identifier._d() == types::EK_COMPLETE)
+                        {
+                            m_topicDiscoveryKind = COMPLETE;
+                        }
+                        break;
+                    }
+                    case PID_TYPE_OBJECTV1:
+                    {
+                        const TypeObjectV1* p = dynamic_cast<const TypeObjectV1*>(param);
+                        assert(p != nullptr);
+                        m_type = *p;
+                        m_topicDiscoveryKind = MINIMAL;
+                        if (m_type.m_type_object._d() == types::EK_COMPLETE)
+                        {
+                            m_topicDiscoveryKind = COMPLETE;
+                        }
+                        break;
+                    }
+                    case PID_DISABLE_POSITIVE_ACKS:
+                    {
+                        const DisablePositiveACKsQosPolicy* p =
+                                dynamic_cast<const DisablePositiveACKsQosPolicy*>(param);
+                        assert(p != nullptr);
+                        m_qos.m_disablePositiveACKs = *p;
+                        break;
+                    }
 #if HAVE_SECURITY
-            case PID_ENDPOINT_SECURITY_INFO:
-            {
-                const ParameterEndpointSecurityInfo_t* p =
-                    dynamic_cast<const ParameterEndpointSecurityInfo_t*>(param);
-                assert(p != nullptr);
-                security_attributes_ = p->security_attributes;
-                plugin_security_attributes_ = p->plugin_security_attributes;
-                break;
-            }
-#endif
-            case PID_PROPERTY_LIST:
-            {
-                const ParameterPropertyList_t* p = dynamic_cast<const ParameterPropertyList_t*>(param);
-                assert(p != nullptr);
-                this->m_properties = *p;
-                break;
-            }
+                    case PID_ENDPOINT_SECURITY_INFO:
+                    {
+                        const ParameterEndpointSecurityInfo_t* p =
+                                dynamic_cast<const ParameterEndpointSecurityInfo_t*>(param);
+                        assert(p != nullptr);
+                        security_attributes_ = p->security_attributes;
+                        plugin_security_attributes_ = p->plugin_security_attributes;
+                        break;
+                    }
+#endif // if HAVE_SECURITY
+                    case PID_PROPERTY_LIST:
+                    {
+                        const ParameterPropertyList_t* p = dynamic_cast<const ParameterPropertyList_t*>(param);
+                        assert(p != nullptr);
+                        this->m_properties = *p;
+                        break;
+                    }
 
-            default:
-            {
-                //logInfo(RTPS_PROXY_DATA,"Parameter with ID: " << (uint16_t)(param)->Pid <<" NOT CONSIDERED");
-                break;
-            }
-        }
-        return true;
-    };
+                    default:
+                    {
+                        //logInfo(RTPS_PROXY_DATA,"Parameter with ID: " << (uint16_t)(param)->Pid <<" NOT CONSIDERED");
+                        break;
+                    }
+                }
+                return true;
+            };
 
     uint32_t qos_size;
     clear();
     if (ParameterList::readParameterListfromCDRMsg(*msg, param_process, true, qos_size))
     {
         if (m_guid.entityId.value[3] == 0x03)
+        {
             m_topicKind = NO_KEY;
+        }
         else if (m_guid.entityId.value[3] == 0x02)
+        {
             m_topicKind = WITH_KEY;
+        }
 
         return true;
     }
@@ -552,7 +666,8 @@ void WriterProxyData::clear()
     m_properties.length = 0;
 }
 
-void WriterProxyData::copy(WriterProxyData* wdata)
+void WriterProxyData::copy(
+        WriterProxyData* wdata)
 {
     m_guid = wdata->m_guid;
     remote_locators_ = wdata->remote_locators_;
@@ -574,16 +689,17 @@ void WriterProxyData::copy(WriterProxyData* wdata)
     m_properties = wdata->m_properties;
 }
 
-bool WriterProxyData::is_update_allowed(const WriterProxyData& wdata) const
+bool WriterProxyData::is_update_allowed(
+        const WriterProxyData& wdata) const
 {
     if ((m_guid != wdata.m_guid) ||
-        (persistence_guid_ != wdata.persistence_guid_) ||
+            (persistence_guid_ != wdata.persistence_guid_) ||
 #if HAVE_SECURITY
-        (security_attributes_ != wdata.security_attributes_) ||
-        (plugin_security_attributes_ != wdata.security_attributes_) ||
-#endif
-        (m_typeName != wdata.m_typeName) ||
-        (m_topicName != wdata.m_topicName))
+            (security_attributes_ != wdata.security_attributes_) ||
+            (plugin_security_attributes_ != wdata.security_attributes_) ||
+#endif // if HAVE_SECURITY
+            (m_typeName != wdata.m_typeName) ||
+            (m_topicName != wdata.m_topicName))
     {
         return false;
     }
@@ -591,13 +707,15 @@ bool WriterProxyData::is_update_allowed(const WriterProxyData& wdata) const
     return m_qos.canQosBeUpdated(wdata.m_qos);
 }
 
-void WriterProxyData::update(WriterProxyData* wdata)
+void WriterProxyData::update(
+        WriterProxyData* wdata)
 {
     remote_locators_ = wdata->remote_locators_;
-    m_qos.setQos(wdata->m_qos,false);
+    m_qos.setQos(wdata->m_qos, false);
 }
 
-void WriterProxyData::add_unicast_locator(const Locator_t& locator)
+void WriterProxyData::add_unicast_locator(
+        const Locator_t& locator)
 {
     remote_locators_.add_unicast_locator(locator);
 }
@@ -627,7 +745,8 @@ void WriterProxyData::set_remote_unicast_locators(
     }
 }
 
-void WriterProxyData::add_multicast_locator(const Locator_t& locator)
+void WriterProxyData::add_multicast_locator(
+        const Locator_t& locator)
 {
     remote_locators_.add_multicast_locator(locator);
 }

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
@@ -38,7 +38,7 @@
 #include <forward_list>
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
 
@@ -62,22 +62,22 @@ bool EDPServer::createSEDPEndpoints()
 
     watt.endpoint.properties.properties().push_back(Property("dds.persistence.plugin", "builtin.SQLITE3"));
     watt.endpoint.properties.properties().push_back(Property("dds.persistence.sqlite3.filename",
-        pPDP->GetPersistenceFileName()));
+            pPDP->GetPersistenceFileName()));
     watt.endpoint.durabilityKind = _durability;
 
     publications_listener_ = new EDPServerPUBListener(this);
     subscriptions_listener_ = new EDPServerSUBListener(this);
 
-    if(m_discovery.discovery_config.m_simpleEDP.use_PublicationWriterANDSubscriptionReader)
+    if (m_discovery.discovery_config.m_simpleEDP.use_PublicationWriterANDSubscriptionReader)
     {
         publications_writer_.second = new WriterHistory(writer_history_att);
-        created &=this->mp_RTPSParticipant->createWriter(&waux, watt, publications_writer_.second,
-                publications_listener_, c_EntityId_SEDPPubWriter, true);
+        created &= this->mp_RTPSParticipant->createWriter(&waux, watt, publications_writer_.second,
+                        publications_listener_, c_EntityId_SEDPPubWriter, true);
 
-        if(created)
+        if (created)
         {
             publications_writer_.first = dynamic_cast<StatefulWriter*>(waux);
-            logInfo(RTPS_EDP,"SEDP Publication Writer created");
+            logInfo(RTPS_EDP, "SEDP Publication Writer created");
         }
         else
         {
@@ -86,13 +86,13 @@ bool EDPServer::createSEDPEndpoints()
         }
 
         subscriptions_reader_.second = new ReaderHistory(reader_history_att);
-        created &=this->mp_RTPSParticipant->createReader(&raux, ratt, subscriptions_reader_.second,
-                subscriptions_listener_, c_EntityId_SEDPSubReader, true);
+        created &= this->mp_RTPSParticipant->createReader(&raux, ratt, subscriptions_reader_.second,
+                        subscriptions_listener_, c_EntityId_SEDPSubReader, true);
 
-        if(created)
+        if (created)
         {
             subscriptions_reader_.first = dynamic_cast<StatefulReader*>(raux);
-            logInfo(RTPS_EDP,"SEDP Subscription Reader created");
+            logInfo(RTPS_EDP, "SEDP Subscription Reader created");
         }
         else
         {
@@ -100,16 +100,16 @@ bool EDPServer::createSEDPEndpoints()
             subscriptions_reader_.second = nullptr;
         }
     }
-    if(m_discovery.discovery_config.m_simpleEDP.use_PublicationReaderANDSubscriptionWriter)
+    if (m_discovery.discovery_config.m_simpleEDP.use_PublicationReaderANDSubscriptionWriter)
     {
         publications_reader_.second = new ReaderHistory(writer_history_att);
-        created &=this->mp_RTPSParticipant->createReader(&raux, ratt, publications_reader_.second,
-                publications_listener_, c_EntityId_SEDPPubReader, true);
+        created &= this->mp_RTPSParticipant->createReader(&raux, ratt, publications_reader_.second,
+                        publications_listener_, c_EntityId_SEDPPubReader, true);
 
-        if(created)
+        if (created)
         {
             publications_reader_.first = dynamic_cast<StatefulReader*>(raux);
-            logInfo(RTPS_EDP,"SEDP Publication Reader created");
+            logInfo(RTPS_EDP, "SEDP Publication Reader created");
 
         }
         else
@@ -119,13 +119,13 @@ bool EDPServer::createSEDPEndpoints()
         }
 
         subscriptions_writer_.second = new WriterHistory(writer_history_att);
-        created &=this->mp_RTPSParticipant->createWriter(&waux, watt, subscriptions_writer_.second,
-                subscriptions_listener_, c_EntityId_SEDPSubWriter, true);
+        created &= this->mp_RTPSParticipant->createWriter(&waux, watt, subscriptions_writer_.second,
+                        subscriptions_listener_, c_EntityId_SEDPSubWriter, true);
 
-        if(created)
+        if (created)
         {
             subscriptions_writer_.first = dynamic_cast<StatefulWriter*>(waux);
-            logInfo(RTPS_EDP,"SEDP Subscription Writer created");
+            logInfo(RTPS_EDP, "SEDP Subscription Writer created");
 
         }
         else
@@ -134,29 +134,31 @@ bool EDPServer::createSEDPEndpoints()
             subscriptions_writer_.second = nullptr;
         }
     }
-    logInfo(RTPS_EDP,"Creation finished");
+    logInfo(RTPS_EDP, "Creation finished");
     return created;
 }
 
 template<class ProxyCont>
 bool EDPServer::trimWriterHistory(
-    key_list& _demises,
-    StatefulWriter& writer,
-    WriterHistory& history,
-    ProxyCont ParticipantProxyData::* pC)
+        key_list& _demises,
+        StatefulWriter& writer,
+        WriterHistory& history,
+        ProxyCont ParticipantProxyData::* pC)
 {
-    logInfo(RTPS_PDPSERVER_TRIM,"In trimWriteHistory EDP history count: " << history.getHistorySize());
+    logInfo(RTPS_PDPSERVER_TRIM, "In trimWriteHistory EDP history count: " << history.getHistorySize());
 
     // trim demises container
     key_list disposal, aux;
 
     if (_demises.empty())
+    {
         return true;
+    }
 
     // sweep away any resurrected endpoint
     for (auto iD = mp_PDP->ParticipantProxiesBegin(); iD != mp_PDP->ParticipantProxiesEnd(); ++iD)
     {
-        ProxyCont & readers = (*iD)->*pC;
+        ProxyCont& readers = (*iD)->*pC;
 
         for (auto iE : readers)
         {
@@ -164,30 +166,34 @@ bool EDPServer::trimWriterHistory(
         }
     }
     std::set_difference(_demises.cbegin(), _demises.cend(), disposal.cbegin(), disposal.cend(),
-        std::inserter(aux, aux.begin()));
+            std::inserter(aux, aux.begin()));
     _demises.swap(aux);
 
     if (_demises.empty())
+    {
         return true;
+    }
 
     // traverse the WriterHistory searching CacheChanges_t with demised keys
     std::forward_list<CacheChange_t*> removal;
     std::lock_guard<RecursiveTimedMutex> guardW(writer.getMutex());
 
     std::copy_if(history.changesBegin(), history.changesEnd(), std::front_inserter(removal),
-        [_demises](const CacheChange_t* chan)
-        {
-            return _demises.find(chan->instanceHandle) != _demises.cend();
-        });
+            [_demises](const CacheChange_t* chan)
+            {
+                return _demises.find(chan->instanceHandle) != _demises.cend();
+            });
 
-    logInfo(RTPS_PDPSERVER_TRIM,"I've classified the following EDP history data for removal "
-        << std::distance(removal.begin(), removal.end()) );
+    logInfo(RTPS_PDPSERVER_TRIM, "I've classified the following EDP history data for removal "
+            << std::distance(removal.begin(), removal.end()) );
 
     if (removal.empty())
+    {
         return true;
+    }
 
     aux.clear();
-    key_list & pending = aux;
+    key_list& pending = aux;
 
     // remove outdate CacheChange_ts
     for (auto pCh : removal)
@@ -195,16 +201,16 @@ bool EDPServer::trimWriterHistory(
         if (writer.is_acked_by_all(pCh))
         {
             logInfo(RTPS_PDPSERVER_TRIM, "EDPServer is removing DATA("
-                << (pCh->kind == ALIVE ? "w|r" : "w|r[UD]" ) << ") of participant "
-                << pCh->instanceHandle << " from history");
+                    << (pCh->kind == ALIVE ? "w|r" : "w|r[UD]" ) << ") of participant "
+                    << pCh->instanceHandle << " from history");
 
             history.remove_change(pCh);
         }
         else
         {
             logInfo(RTPS_PDPSERVER_TRIM, "EDPServer is procrastinating DATA("
-                << (pCh->kind == ALIVE ? "w|r" : "w|r[UD]" ) << ") of participant "
-                << pCh->instanceHandle << " from history");
+                    << (pCh->kind == ALIVE ? "w|r" : "w|r[UD]" ) << ") of participant "
+                    << pCh->instanceHandle << " from history");
 
             pending.insert(pCh->instanceHandle);
         }
@@ -213,7 +219,7 @@ bool EDPServer::trimWriterHistory(
     // update demises
     _demises.swap(pending);
 
-    logInfo(RTPS_PDPSERVER_TRIM,"After trying to trim EDP we still must remove " << _demises.size() );
+    logInfo(RTPS_PDPSERVER_TRIM, "After trying to trim EDP we still must remove " << _demises.size() );
 
     return _demises.empty(); // is finished?
 
@@ -231,29 +237,29 @@ void EDPServer::processPersistentData()
 }
 
 bool EDPServer::addEndpointFromHistory(
-    StatefulWriter& writer,
-    WriterHistory& history,
-    CacheChange_t& c)
+        StatefulWriter& writer,
+        WriterHistory& history,
+        CacheChange_t& c)
 {
     std::lock_guard<RecursiveTimedMutex> guardW(writer.getMutex());
-    CacheChange_t * pCh = nullptr;
+    CacheChange_t* pCh = nullptr;
 
-    if(ongoingDeserialization())
+    if (ongoingDeserialization())
     {
         return true;
     }
 
     // validate the sample, if no sample data update it
-    WriteParams & wp = c.write_params;
-    SampleIdentity & sid = wp.sample_identity();
+    WriteParams& wp = c.write_params;
+    SampleIdentity& sid = wp.sample_identity();
     if (sid == SampleIdentity::unknown())
     {
         sid.writer_guid(c.writerGUID);
         sid.sequence_number(c.sequenceNumber);
         logError(RTPS_EDP,
                 "A DATA(r|w) received by server " << writer.getGuid()
-                    << " from participant " << c.writerGUID
-                    << " without a valid SampleIdentity");
+                                                  << " from participant " << c.writerGUID
+                                                  << " without a valid SampleIdentity");
         return false;
     }
 
@@ -264,11 +270,12 @@ bool EDPServer::addEndpointFromHistory(
 
     // See if this sample is already in the cache.
     // TODO: Accelerate this search by using a PublisherHistory as mp_PDPWriterHistory
-    auto it = std::find_if(history.changesRbegin(), history.changesRend(), [&sid](CacheChange_t* c) {
-        return sid == c->write_params.sample_identity();
-    });
+    auto it = std::find_if(history.changesRbegin(), history.changesRend(), [&sid](CacheChange_t* c)
+                    {
+                        return sid == c->write_params.sample_identity();
+                    });
 
-    if( it == history.changesRend())
+    if ( it == history.changesRend())
     {
         // history.reserve_Cache(&pCh, DISCOVERY_PUBLICATION_DATA_MAX_SIZE )
         // history.reserve_Cache(&pCh, DISCOVERY_SUBSCRIPTION_DATA_MAX_SIZE )
@@ -282,7 +289,8 @@ bool EDPServer::addEndpointFromHistory(
     return false;
 }
 
-void EDPServer::removePublisherFromHistory(const InstanceHandle_t& key)
+void EDPServer::removePublisherFromHistory(
+        const InstanceHandle_t& key)
 {
     {
         std::lock_guard<std::recursive_mutex> guardP(*mp_PDP->getMutex());
@@ -291,13 +299,14 @@ void EDPServer::removePublisherFromHistory(const InstanceHandle_t& key)
 
     if ( !trimPUBWriterHistory() )
     {
-        PDPServer * pS = dynamic_cast<PDPServer*>(mp_PDP);
+        PDPServer* pS = dynamic_cast<PDPServer*>(mp_PDP);
         assert(pS); // EDPServer should always be associated with a PDPServer
         pS->awakeServerThread();
     }
 }
 
-void EDPServer::removeSubscriberFromHistory(const InstanceHandle_t& key)
+void EDPServer::removeSubscriberFromHistory(
+        const InstanceHandle_t& key)
 {
     {
         std::lock_guard<std::recursive_mutex> guardP(*mp_PDP->getMutex());
@@ -306,13 +315,14 @@ void EDPServer::removeSubscriberFromHistory(const InstanceHandle_t& key)
 
     if (!trimSUBWriterHistory())
     {
-        PDPServer * pS = dynamic_cast<PDPServer*>(mp_PDP);
+        PDPServer* pS = dynamic_cast<PDPServer*>(mp_PDP);
         assert(pS); // EDPServer should always be associated with a PDPServer
         pS->awakeServerThread();
     }
 }
 
-bool EDPServer::removeLocalReader(RTPSReader* R)
+bool EDPServer::removeLocalReader(
+        RTPSReader* R)
 {
     logInfo(RTPS_EDP, R->getGuid().entityId);
 
@@ -350,7 +360,8 @@ bool EDPServer::removeLocalReader(RTPSReader* R)
     return ret;
 }
 
-bool EDPServer::removeLocalWriter(RTPSWriter* W)
+bool EDPServer::removeLocalWriter(
+        RTPSWriter* W)
 {
     logInfo(RTPS_EDP, W->getGuid().entityId);
 
@@ -389,8 +400,8 @@ bool EDPServer::removeLocalWriter(RTPSWriter* W)
 }
 
 bool EDPServer::processLocalWriterProxyData(
-    RTPSWriter* local_writer,
-    WriterProxyData* wdata)
+        RTPSWriter* local_writer,
+        WriterProxyData* wdata)
 {
     logInfo(RTPS_EDP, wdata->guid().entityId);
     (void)local_writer;
@@ -399,11 +410,11 @@ bool EDPServer::processLocalWriterProxyData(
 
     if (writer->first != nullptr)
     {
-        CacheChange_t* change = writer->first->new_change([]() -> uint32_t 
-            {
-                return DISCOVERY_PUBLICATION_DATA_MAX_SIZE;
-            },
-            ALIVE, wdata->key());
+        CacheChange_t* change = writer->first->new_change([]() -> uint32_t
+                        {
+                            return DISCOVERY_PUBLICATION_DATA_MAX_SIZE;
+                        },
+                        ALIVE, wdata->key());
         if (change != nullptr)
         {
             //wdata->toParameterList();
@@ -416,7 +427,7 @@ bool EDPServer::processLocalWriterProxyData(
 #else
             change->serializedPayload.encapsulation = (uint16_t)PL_CDR_LE;
             aux_msg.msg_endian = LITTLEEND;
-#endif
+#endif // if __BIG_ENDIAN__
 
             wdata->writeToCDRMessage(&aux_msg, true);
             change->serializedPayload.length = (uint16_t)aux_msg.length;
@@ -441,8 +452,8 @@ bool EDPServer::processLocalWriterProxyData(
 }
 
 bool EDPServer::processLocalReaderProxyData(
-    RTPSReader* local_reader,
-    ReaderProxyData* rdata)
+        RTPSReader* local_reader,
+        ReaderProxyData* rdata)
 {
     logInfo(RTPS_EDP, rdata->guid().entityId);
     (void)local_reader;
@@ -452,11 +463,11 @@ bool EDPServer::processLocalReaderProxyData(
     if (writer->first != nullptr)
     {
         // TODO(Ricardo) Write a getCdrSerializedPayload for ReaderProxyData.
-        CacheChange_t* change = writer->first->new_change([]() -> uint32_t 
-            {
-                return DISCOVERY_SUBSCRIPTION_DATA_MAX_SIZE;
-            },
-            ALIVE, rdata->key());
+        CacheChange_t* change = writer->first->new_change([]() -> uint32_t
+                        {
+                            return DISCOVERY_SUBSCRIPTION_DATA_MAX_SIZE;
+                        },
+                        ALIVE, rdata->key());
 
         if (change != nullptr)
         {
@@ -468,7 +479,7 @@ bool EDPServer::processLocalReaderProxyData(
 #else
             change->serializedPayload.encapsulation = (uint16_t)PL_CDR_LE;
             aux_msg.msg_endian = LITTLEEND;
-#endif
+#endif // if __BIG_ENDIAN__
 
             rdata->writeToCDRMessage(&aux_msg, true);
             change->serializedPayload.length = (uint16_t)aux_msg.length;

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
@@ -232,8 +232,8 @@ bool EDPServer::ongoingDeserialization()
 
 void EDPServer::processPersistentData()
 {
-    EDPSimple::processPersistentData(publications_reader_, publications_writer_);
-    EDPSimple::processPersistentData(subscriptions_reader_, subscriptions_writer_);
+    EDPSimple::processPersistentData(publications_reader_, publications_writer_, _PUBdemises);
+    EDPSimple::processPersistentData(subscriptions_reader_, subscriptions_writer_, _SUBdemises);
 }
 
 bool EDPServer::addEndpointFromHistory(
@@ -335,7 +335,7 @@ bool EDPServer::removeLocalReader(
         InstanceHandle_t iH;
         iH = guid;
         CacheChange_t* change = writer->first->new_change(
-            [this]() -> uint32_t
+            []() -> uint32_t
             {
                 return DISCOVERY_SUBSCRIPTION_DATA_MAX_SIZE;
             },
@@ -374,7 +374,7 @@ bool EDPServer::removeLocalWriter(
         InstanceHandle_t iH;
         iH = guid;
         CacheChange_t* change = writer->first->new_change(
-            [this]() -> uint32_t
+            []() -> uint32_t
             {
                 return DISCOVERY_PUBLICATION_DATA_MAX_SIZE;
             },

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
@@ -252,6 +252,7 @@ void EDPServer::processPersistentData()
     EDPSimple::processPersistentData(subscriptions_reader_, subscriptions_writer_, _SUBdemises);
 }
 
+template<class Proxy>
 bool EDPServer::addEndpointFromHistory(
         StatefulWriter& writer,
         WriterHistory& history,
@@ -295,14 +296,60 @@ bool EDPServer::addEndpointFromHistory(
     {
         // history.reserve_Cache(&pCh, DISCOVERY_PUBLICATION_DATA_MAX_SIZE )
         // history.reserve_Cache(&pCh, DISCOVERY_SUBSCRIPTION_DATA_MAX_SIZE )
-        if (history.reserve_Cache(&pCh, c.serializedPayload.max_size) && pCh && pCh->copy(&c))
+        if (history.reserve_Cache(&pCh, c.serializedPayload.max_size) && pCh)
         {
-            pCh->writerGUID = writer.getGuid();
-            return history.add_change(pCh, pCh->write_params);
+            if ( writer.getAttributes().durabilityKind == TRANSIENT_LOCAL )
+            {
+                // an ordinary server just copies the payload to history
+                pCh->copy(&c);
+                pCh->writerGUID = writer.getGuid();
+                return history.add_change(pCh, pCh->write_params);
+            }
+            else
+            {
+               pCh->copy_not_memcpy(&c);
+               // a backup server must add extra context properties to replace WriteParams functionality
+               RemoteLocatorsAllocationAttributes& locators_alloc = mp_RTPSParticipant->getAttributes().allocation.locators;
+               Proxy local_data(locators_alloc.max_unicast_locators, locators_alloc.max_multicast_locators);
+               CDRMessage_t deserialization_msg(c.serializedPayload);
+               if (local_data.readFromCDRMessage(&deserialization_msg, mp_RTPSParticipant->network_factory()))
+               {
+                   // insert identity within the payload
+                   // deserialized payload
+                   local_data.set_sample_identity(wp.sample_identity());
+
+                   // Update the payload Add: pCh->serializedPayload.reserve(local_data.get_serialized_size(true)); for
+                   // 2.0.x port.
+                   // Note that DISCOVERY_PUBLICATION_DATA_MAX_SIZE and DISCOVERY_SUBSCRIPTION_DATA_MAX_SIZE share value
+                   pCh->serializedPayload.reserve(DISCOVERY_PUBLICATION_DATA_MAX_SIZE);
+
+                   // serialized payload
+                   CDRMessage_t serialization_msg(pCh->serializedPayload);
+                   if (local_data.writeToCDRMessage(&serialization_msg,true))
+                   {
+                       pCh->writerGUID = writer.getGuid();
+                       pCh->serializedPayload.length = (uint16_t)serialization_msg.length;
+                       // keep the original sample identity by using wp
+                       return history.add_change(pCh, wp);
+                   }
+               }
+            }
         }
     }
 
     return false;
+}
+
+bool EDPServer::addPublisherFromHistory(
+        CacheChange_t& c)
+{
+    return addEndpointFromHistory<WriterProxyData>(*publications_writer_.first, *publications_writer_.second, c);
+}
+
+bool EDPServer::addSubscriberFromHistory(
+        CacheChange_t& c)
+{
+    return addEndpointFromHistory<ReaderProxyData>(*subscriptions_writer_.first, *subscriptions_writer_.second, c);
 }
 
 void EDPServer::removePublisherFromHistory(

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
@@ -312,7 +312,8 @@ bool EDPServer::addEndpointFromHistory(
                 if (c.kind == ALIVE)
                 {
                     // a backup server must add extra context properties to replace WriteParams functionality
-                    RemoteLocatorsAllocationAttributes& locators_alloc = mp_RTPSParticipant->getAttributes().allocation.locators;
+                    RemoteLocatorsAllocationAttributes& locators_alloc =
+                            mp_RTPSParticipant->getAttributes().allocation.locators;
                     Proxy local_data(locators_alloc.max_unicast_locators, locators_alloc.max_multicast_locators);
                     CDRMessage_t deserialization_msg(c.serializedPayload);
                     if (local_data.readFromCDRMessage(&deserialization_msg, mp_RTPSParticipant->network_factory()))
@@ -328,7 +329,7 @@ bool EDPServer::addEndpointFromHistory(
 
                         // serialized payload
                         CDRMessage_t serialization_msg(pCh->serializedPayload);
-                        if (local_data.writeToCDRMessage(&serialization_msg,true))
+                        if (local_data.writeToCDRMessage(&serialization_msg, true))
                         {
                             pCh->writerGUID = writer.getGuid();
                             pCh->serializedPayload.length = (uint16_t)serialization_msg.length;
@@ -342,7 +343,7 @@ bool EDPServer::addEndpointFromHistory(
                     // It's a DATA(w|r[UD]). We need to generate the payload
                     pCh->serializedPayload.reserve(DISCOVERY_PUBLICATION_DATA_MAX_SIZE);
                     CDRMessage_t msg(pCh->serializedPayload);
-                    if (PDPServer::set_data_disposal_payload(&msg,wp.sample_identity()))
+                    if (PDPServer::set_data_disposal_payload(&msg, wp.sample_identity()))
                     {
                         pCh->writerGUID = writer.getGuid();
                         pCh->serializedPayload.length = (uint16_t)msg.length;

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
@@ -174,7 +174,7 @@ bool EDPServer::trimWriterHistory(
     std::forward_list<CacheChange_t*> removal;
     std::lock_guard<RecursiveTimedMutex> guardW(writer.getMutex());
 
-    std::copy_if(history.changesBegin(), history.changesBegin(), std::front_inserter(removal),
+    std::copy_if(history.changesBegin(), history.changesEnd(), std::front_inserter(removal),
         [_demises](const CacheChange_t* chan)
         {
             return _demises.find(chan->instanceHandle) != _demises.cend();
@@ -219,6 +219,17 @@ bool EDPServer::trimWriterHistory(
 
 }
 
+bool EDPServer::ongoingDeserialization()
+{
+    return static_cast<PDPServer*>(mp_PDP)->ongoingDeserialization();
+}
+
+void EDPServer::processPersistentData()
+{
+    EDPSimple::processPersistentData(publications_reader_, publications_writer_);
+    EDPSimple::processPersistentData(subscriptions_reader_, subscriptions_writer_);
+}
+
 bool EDPServer::addEndpointFromHistory(
     StatefulWriter& writer,
     WriterHistory& history,
@@ -227,6 +238,11 @@ bool EDPServer::addEndpointFromHistory(
     std::lock_guard<RecursiveTimedMutex> guardW(writer.getMutex());
     CacheChange_t * pCh = nullptr;
 
+    if(ongoingDeserialization())
+    {
+        return true;
+    }
+
     // validate the sample, if no sample data update it
     WriteParams & wp = c.write_params;
     SampleIdentity & sid = wp.sample_identity();
@@ -234,8 +250,11 @@ bool EDPServer::addEndpointFromHistory(
     {
         sid.writer_guid(c.writerGUID);
         sid.sequence_number(c.sequenceNumber);
-        logError(RTPS_EDP, "A DATA(r|w) received by server " << writer.getGuid()
-            << " from participant " << c.writerGUID << " without a valid SampleIdentity");
+        logError(RTPS_EDP,
+                "A DATA(r|w) received by server " << writer.getGuid()
+                    << " from participant " << c.writerGUID
+                    << " without a valid SampleIdentity");
+        return false;
     }
 
     if (wp.related_sample_identity() == SampleIdentity::unknown())

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners.cpp
@@ -58,7 +58,7 @@ void EDPServerPUBListener::onNewCacheChangeAdded(RTPSReader* reader, const Cache
 
     ReaderHistory* reader_history = sedp_->publications_reader_.second;
 
-    // update the PDP Writer with this reader info
+    // update the EDP Writer with this reader info
     if (!sedp_->addPublisherFromHistory(*change))
     {
         reader_history->remove_change(change);

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners.cpp
@@ -37,23 +37,26 @@
 #include <fastrtps/log/Log.h>
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
-EDPServerPUBListener::EDPServerPUBListener(EDPServer* sedp) 
+EDPServerPUBListener::EDPServerPUBListener(
+        EDPServer* sedp)
     : EDPBasePUBListener(sedp->mp_RTPSParticipant->getAttributes().allocation.locators)
-    , sedp_(sedp) 
+    , sedp_(sedp)
 {
 }
 
-void EDPServerPUBListener::onNewCacheChangeAdded(RTPSReader* reader, const CacheChange_t* const change_in)
+void EDPServerPUBListener::onNewCacheChangeAdded(
+        RTPSReader* reader,
+        const CacheChange_t* const change_in)
 {
     CacheChange_t* change = (CacheChange_t*)change_in;
     //std::lock_guard<std::recursive_mutex> guard(*this->sedp_->publications_reader_.first->getMutex());
-    logInfo(RTPS_EDP,"");
-    if(!computeKey(change))
+    logInfo(RTPS_EDP, "");
+    if (!computeKey(change))
     {
-        logWarning(RTPS_EDP,"Received change with no Key");
+        logWarning(RTPS_EDP, "Received change with no Key");
     }
 
     ReaderHistory* reader_history = sedp_->publications_reader_.second;
@@ -65,14 +68,14 @@ void EDPServerPUBListener::onNewCacheChangeAdded(RTPSReader* reader, const Cache
         return; // already there
     }
 
-    if(change->kind == ALIVE)
+    if (change->kind == ALIVE)
     {
         add_writer_from_change(reader, change, sedp_);
     }
     else
     {
         //REMOVE WRITER FROM OUR READERS:
-        logInfo(RTPS_EDP,"Disposed Remote Writer, removing...");
+        logInfo(RTPS_EDP, "Disposed Remote Writer, removing...");
 
         GUID_t auxGUID = iHandle2GUID(change->instanceHandle);
         this->sedp_->mp_PDP->removeWriterProxyData(auxGUID);
@@ -85,7 +88,9 @@ void EDPServerPUBListener::onNewCacheChangeAdded(RTPSReader* reader, const Cache
     return;
 }
 
-void EDPServerPUBListener::onWriterChangeReceivedByAll(RTPSWriter* writer, CacheChange_t* change)
+void EDPServerPUBListener::onWriterChangeReceivedByAll(
+        RTPSWriter* writer,
+        CacheChange_t* change)
 {
     (void)writer;
 
@@ -93,29 +98,32 @@ void EDPServerPUBListener::onWriterChangeReceivedByAll(RTPSWriter* writer, Cache
     {
         WriterHistory* writer_history =
 #if HAVE_SECURITY
-            writer == sedp_->publications_secure_writer_.first ?
-            sedp_->publications_secure_writer_.second :
-#endif
-            sedp_->publications_writer_.second;
+                writer == sedp_->publications_secure_writer_.first ?
+                sedp_->publications_secure_writer_.second :
+#endif // if HAVE_SECURITY
+                sedp_->publications_writer_.second;
 
         writer_history->remove_change(change);
     }
 }
 
-EDPServerSUBListener::EDPServerSUBListener(EDPServer* sedp)
+EDPServerSUBListener::EDPServerSUBListener(
+        EDPServer* sedp)
     : EDPBaseSUBListener(sedp->mp_RTPSParticipant->getAttributes().allocation.locators)
     , sedp_(sedp)
 {
 }
 
-void EDPServerSUBListener::onNewCacheChangeAdded(RTPSReader* reader, const CacheChange_t* const change_in)
+void EDPServerSUBListener::onNewCacheChangeAdded(
+        RTPSReader* reader,
+        const CacheChange_t* const change_in)
 {
     CacheChange_t* change = (CacheChange_t*)change_in;
     //std::lock_guard<std::recursive_mutex> guard(*this->sedp_->subscriptions_reader_.first->getMutex());
-    logInfo(RTPS_EDP,"");
-    if(!computeKey(change))
+    logInfo(RTPS_EDP, "");
+    if (!computeKey(change))
     {
-        logWarning(RTPS_EDP,"Received change with no Key");
+        logWarning(RTPS_EDP, "Received change with no Key");
     }
 
     ReaderHistory* reader_history = sedp_->subscriptions_reader_.second;
@@ -127,14 +135,14 @@ void EDPServerSUBListener::onNewCacheChangeAdded(RTPSReader* reader, const Cache
         return; // already there
     }
 
-    if(change->kind == ALIVE)
+    if (change->kind == ALIVE)
     {
         add_reader_from_change(reader, change, sedp_);
     }
     else
     {
         //REMOVE WRITER FROM OUR READERS:
-        logInfo(RTPS_EDP,"Disposed Remote Reader, removing...");
+        logInfo(RTPS_EDP, "Disposed Remote Reader, removing...");
 
         GUID_t auxGUID = iHandle2GUID(change->instanceHandle);
         this->sedp_->mp_PDP->removeReaderProxyData(auxGUID);
@@ -147,8 +155,9 @@ void EDPServerSUBListener::onNewCacheChangeAdded(RTPSReader* reader, const Cache
     return;
 }
 
-
-void EDPServerSUBListener::onWriterChangeReceivedByAll(RTPSWriter* writer, CacheChange_t* change)
+void EDPServerSUBListener::onWriterChangeReceivedByAll(
+        RTPSWriter* writer,
+        CacheChange_t* change)
 {
     (void)writer;
 
@@ -156,10 +165,10 @@ void EDPServerSUBListener::onWriterChangeReceivedByAll(RTPSWriter* writer, Cache
     {
         WriterHistory* writer_history =
 #if HAVE_SECURITY
-            writer == sedp_->subscriptions_secure_writer_.first ?
-            sedp_->subscriptions_secure_writer_.second :
-#endif
-            sedp_->subscriptions_writer_.second;
+                writer == sedp_->subscriptions_secure_writer_.first ?
+                sedp_->subscriptions_secure_writer_.second :
+#endif // if HAVE_SECURITY
+                sedp_->subscriptions_writer_.second;
 
         writer_history->remove_change(change);
     }
@@ -167,6 +176,6 @@ void EDPServerSUBListener::onWriterChangeReceivedByAll(RTPSWriter* writer, Cache
 }
 
 } /* namespace rtps */
-}
+} // namespace fastrtps
 } /* namespace eprosima */
 

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -190,7 +190,7 @@ void EDPSimple::processPersistentData(
     auto param_process = [&si, &kind](const Parameter_t* param)
             {
                 // we use the PID_PARTICIPANT_GUID to identify a DATA(r|w)
-                if (param->Pid == PID_PARTICIPANT_GUID )
+                if (param->Pid == PID_PARTICIPANT_GUID)
                 {
                     kind = ALIVE;
                     return true;
@@ -253,7 +253,7 @@ void EDPSimple::processPersistentData(
                 }
 
                 // mark for removal endpoints from unknown participants
-                if ( known_participants.find(handle) == known_participants.end() )
+                if (known_participants.find(handle) == known_participants.end())
                 {
                     demises.insert(change->instanceHandle);
                     return;

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -45,8 +45,8 @@ namespace rtps {
 // Default configuration values for EDP entities.
 static const Duration_t edp_heartbeat_period{1, 0}; // 1 second
 static const Duration_t edp_nack_response_delay{0, 100 * 1000 }; // 100 milliseconds
-static const Duration_t edp_nack_supression_duration{0, 10*1000}; // 10 milliseconds
-static const Duration_t edp_heartbeat_response_delay{0, 10*1000}; // 10 milliseconds
+static const Duration_t edp_nack_supression_duration{0, 10 * 1000}; // 10 milliseconds
+static const Duration_t edp_heartbeat_response_delay{0, 10 * 1000}; // 10 milliseconds
 
 static const int32_t edp_initial_reserved_caches = 20;
 
@@ -54,12 +54,12 @@ static const int32_t edp_initial_reserved_caches = 20;
 EDPSimple::EDPSimple(
         PDP* p,
         RTPSParticipantImpl* part)
-    : EDP(p,part)
+    : EDP(p, part)
     , publications_listener_(nullptr)
     , subscriptions_listener_(nullptr)
     , temp_reader_proxy_data_(
-            part->getRTPSParticipantAttributes().allocation.locators.max_unicast_locators,
-            part->getRTPSParticipantAttributes().allocation.locators.max_multicast_locators)
+        part->getRTPSParticipantAttributes().allocation.locators.max_unicast_locators,
+        part->getRTPSParticipantAttributes().allocation.locators.max_multicast_locators)
     , temp_writer_proxy_data_(
         part->getRTPSParticipantAttributes().allocation.locators.max_unicast_locators,
         part->getRTPSParticipantAttributes().allocation.locators.max_multicast_locators)
@@ -69,123 +69,125 @@ EDPSimple::EDPSimple(
 EDPSimple::~EDPSimple()
 {
 #if HAVE_SECURITY
-    if(this->publications_secure_writer_.first !=nullptr)
+    if (this->publications_secure_writer_.first != nullptr)
     {
         this->mp_RTPSParticipant->deleteUserEndpoint(publications_secure_writer_.first);
         delete(publications_secure_writer_.second);
     }
 
-    if(this->publications_secure_reader_.first !=nullptr)
+    if (this->publications_secure_reader_.first != nullptr)
     {
         this->mp_RTPSParticipant->deleteUserEndpoint(publications_secure_reader_.first);
         delete(publications_secure_reader_.second);
     }
 
-    if(this->subscriptions_secure_writer_.first !=nullptr)
+    if (this->subscriptions_secure_writer_.first != nullptr)
     {
         this->mp_RTPSParticipant->deleteUserEndpoint(subscriptions_secure_writer_.first);
         delete(subscriptions_secure_writer_.second);
     }
 
-    if(this->subscriptions_secure_reader_.first !=nullptr)
+    if (this->subscriptions_secure_reader_.first != nullptr)
     {
         this->mp_RTPSParticipant->deleteUserEndpoint(subscriptions_secure_reader_.first);
         delete(subscriptions_secure_reader_.second);
     }
-#endif
+#endif // if HAVE_SECURITY
 
-    if(this->publications_reader_.first !=nullptr)
+    if (this->publications_reader_.first != nullptr)
     {
         this->mp_RTPSParticipant->deleteUserEndpoint(publications_reader_.first);
         delete(publications_reader_.second);
     }
-    if(this->subscriptions_reader_.first !=nullptr)
+    if (this->subscriptions_reader_.first != nullptr)
     {
         this->mp_RTPSParticipant->deleteUserEndpoint(subscriptions_reader_.first);
         delete(subscriptions_reader_.second);
     }
-    if(this->publications_writer_.first !=nullptr)
+    if (this->publications_writer_.first != nullptr)
     {
         this->mp_RTPSParticipant->deleteUserEndpoint(publications_writer_.first);
         delete(publications_writer_.second);
     }
-    if(this->subscriptions_writer_.first !=nullptr)
+    if (this->subscriptions_writer_.first != nullptr)
     {
         this->mp_RTPSParticipant->deleteUserEndpoint(subscriptions_writer_.first);
         delete(subscriptions_writer_.second);
     }
 
-    if(nullptr != publications_listener_)
+    if (nullptr != publications_listener_)
     {
         delete(publications_listener_);
     }
 
-    if(nullptr != subscriptions_listener_)
+    if (nullptr != subscriptions_listener_)
     {
         delete(subscriptions_listener_);
     }
 }
 
-
-bool EDPSimple::initEDP(BuiltinAttributes& attributes)
+bool EDPSimple::initEDP(
+        BuiltinAttributes& attributes)
 {
-    logInfo(RTPS_EDP,"Beginning Simple Endpoint Discovery Protocol");
+    logInfo(RTPS_EDP, "Beginning Simple Endpoint Discovery Protocol");
     m_discovery = attributes;
 
-    if(!createSEDPEndpoints())
+    if (!createSEDPEndpoints())
     {
-        logError(RTPS_EDP,"Problem creation SimpleEDP endpoints");
+        logError(RTPS_EDP, "Problem creation SimpleEDP endpoints");
         return false;
     }
 
 #if HAVE_SECURITY
-    if(mp_RTPSParticipant->is_secure() && !create_sedp_secure_endpoints())
+    if (mp_RTPSParticipant->is_secure() && !create_sedp_secure_endpoints())
     {
-        logError(RTPS_EDP,"Problem creation SimpleEDP endpoints");
+        logError(RTPS_EDP, "Problem creation SimpleEDP endpoints");
         return false;
     }
-#endif
+#endif // if HAVE_SECURITY
 
     return true;
 }
 
 //! Process the info recorded in the persistence database
-void EDPSimple::processPersistentData(t_p_StatefulReader & reader, t_p_StatefulWriter & writer)
+void EDPSimple::processPersistentData(
+        t_p_StatefulReader& reader,
+        t_p_StatefulWriter& writer)
 {
     std::lock_guard<RecursiveTimedMutex> guardR(reader.first->getMutex());
     std::lock_guard<RecursiveTimedMutex> guardW(writer.first->getMutex());
 
     std::for_each(writer.second->changesBegin(),
-        writer.second->changesEnd(),
-        [&reader](CacheChange_t* change)
-    {
-        CacheChange_t* change_to_add = nullptr;
+            writer.second->changesEnd(),
+            [&reader](CacheChange_t* change)
+            {
+                CacheChange_t* change_to_add = nullptr;
 
-        if (!reader.first->reserveCache(&change_to_add, change->serializedPayload.length)) //Reserve a new cache from the corresponding cache pool
-        {
-            logError(RTPS_EDP, "Problem reserving CacheChange in EDPServer reader");
-            return;
-        }
+                if (!reader.first->reserveCache(&change_to_add, change->serializedPayload.length)) //Reserve a new cache from the corresponding cache pool
+                {
+                    logError(RTPS_EDP, "Problem reserving CacheChange in EDPServer reader");
+                    return;
+                }
 
-        if (!change_to_add->copy(change))
-        {
-            logWarning(RTPS_EDP,"Problem copying CacheChange, received data is: " 
-                << change->serializedPayload.length << " bytes and max size in EDPServer reader"
-                << " is " << change_to_add->serializedPayload.max_size);
+                if (!change_to_add->copy(change))
+                {
+                    logWarning(RTPS_EDP, "Problem copying CacheChange, received data is: "
+                        << change->serializedPayload.length << " bytes and max size in EDPServer reader"
+                        << " is " << change_to_add->serializedPayload.max_size);
 
-            reader.first->releaseCache(change_to_add);
-            return ;
-        }
+                    reader.first->releaseCache(change_to_add);
+                    return;
+                }
 
-        if (!reader.first->change_received(change_to_add, nullptr))
-        {
-            logInfo(RTPS_EDP, "EDPServer couldn't process database data not add change "
-                << change_to_add->sequenceNumber);
-            reader.first->releaseCache(change_to_add);
-        }
+                if (!reader.first->change_received(change_to_add, nullptr))
+                {
+                    logInfo(RTPS_EDP, "EDPServer couldn't process database data not add change "
+                        << change_to_add->sequenceNumber);
+                    reader.first->releaseCache(change_to_add);
+                }
 
-        // change_to_add would be released within change_received
-    });
+                // change_to_add would be released within change_received
+            });
 }
 
 void EDPSimple::set_builtin_reader_history_attributes(
@@ -196,18 +198,20 @@ void EDPSimple::set_builtin_reader_history_attributes(
     attributes.memoryPolicy = mp_PDP->builtin_attributes().readerHistoryMemoryPolicy;
 }
 
-void EDPSimple::set_builtin_writer_history_attributes(HistoryAttributes& attributes)
+void EDPSimple::set_builtin_writer_history_attributes(
+        HistoryAttributes& attributes)
 {
     attributes.initialReservedCaches = edp_initial_reserved_caches;
     attributes.payloadMaxSize = DISCOVERY_PUBLICATION_DATA_MAX_SIZE;
     attributes.memoryPolicy = mp_PDP->builtin_attributes().writerHistoryMemoryPolicy;
 }
 
-void EDPSimple::set_builtin_reader_attributes(ReaderAttributes& attributes)
+void EDPSimple::set_builtin_reader_attributes(
+        ReaderAttributes& attributes)
 {
     // Matched writers will depend on total number of participants
     attributes.matched_writers_allocation =
-        mp_PDP->getRTPSParticipant()->getRTPSParticipantAttributes().allocation.participants;
+            mp_PDP->getRTPSParticipant()->getRTPSParticipantAttributes().allocation.participants;
 
     // As participants allocation policy includes the local participant, one has to be substracted
     if (attributes.matched_writers_allocation.initial > 1)
@@ -215,7 +219,7 @@ void EDPSimple::set_builtin_reader_attributes(ReaderAttributes& attributes)
         attributes.matched_writers_allocation.initial--;
     }
     if ((attributes.matched_writers_allocation.maximum > 1) &&
-        (attributes.matched_writers_allocation.maximum < std::numeric_limits<size_t>::max()))
+            (attributes.matched_writers_allocation.maximum < std::numeric_limits<size_t>::max()))
     {
         attributes.matched_writers_allocation.maximum--;
     }
@@ -244,11 +248,12 @@ void EDPSimple::set_builtin_reader_attributes(ReaderAttributes& attributes)
     attributes.expectsInlineQos = false;
 }
 
-void EDPSimple::set_builtin_writer_attributes(WriterAttributes& attributes)
+void EDPSimple::set_builtin_writer_attributes(
+        WriterAttributes& attributes)
 {
     // Matched readers will depend on total number of participants
     attributes.matched_readers_allocation =
-        mp_PDP->getRTPSParticipant()->getRTPSParticipantAttributes().allocation.participants;
+            mp_PDP->getRTPSParticipant()->getRTPSParticipantAttributes().allocation.participants;
 
     // As participants allocation policy includes the local participant, one has to be substracted
     if (attributes.matched_readers_allocation.initial > 1)
@@ -256,7 +261,7 @@ void EDPSimple::set_builtin_writer_attributes(WriterAttributes& attributes)
         attributes.matched_readers_allocation.initial--;
     }
     if ((attributes.matched_readers_allocation.maximum > 1) &&
-        (attributes.matched_readers_allocation.maximum < std::numeric_limits<size_t>::max()))
+            (attributes.matched_readers_allocation.maximum < std::numeric_limits<size_t>::max()))
     {
         attributes.matched_readers_allocation.maximum--;
     }
@@ -285,7 +290,7 @@ void EDPSimple::set_builtin_writer_attributes(WriterAttributes& attributes)
 
     // Set as asynchronous if there is a throughput controller installed
     if (mp_RTPSParticipant->getRTPSParticipantAttributes().throughputController.bytesPerPeriod != UINT32_MAX &&
-        mp_RTPSParticipant->getRTPSParticipantAttributes().throughputController.periodMillisecs != 0)
+            mp_RTPSParticipant->getRTPSParticipantAttributes().throughputController.periodMillisecs != 0)
     {
         attributes.mode = ASYNCHRONOUS_WRITER;
     }
@@ -309,16 +314,16 @@ bool EDPSimple::createSEDPEndpoints()
     publications_listener_ = new EDPSimplePUBListener(this);
     subscriptions_listener_ = new EDPSimpleSUBListener(this);
 
-    if(m_discovery.discovery_config.m_simpleEDP.use_PublicationWriterANDSubscriptionReader)
+    if (m_discovery.discovery_config.m_simpleEDP.use_PublicationWriterANDSubscriptionReader)
     {
         publications_writer_.second = new WriterHistory(writer_history_att);
-        created &=this->mp_RTPSParticipant->createWriter(&waux, watt, publications_writer_.second,
-                publications_listener_, c_EntityId_SEDPPubWriter, true);
+        created &= this->mp_RTPSParticipant->createWriter(&waux, watt, publications_writer_.second,
+                        publications_listener_, c_EntityId_SEDPPubWriter, true);
 
-        if(created)
+        if (created)
         {
             publications_writer_.first = dynamic_cast<StatefulWriter*>(waux);
-            logInfo(RTPS_EDP,"SEDP Publication Writer created");
+            logInfo(RTPS_EDP, "SEDP Publication Writer created");
         }
         else
         {
@@ -327,13 +332,13 @@ bool EDPSimple::createSEDPEndpoints()
         }
 
         subscriptions_reader_.second = new ReaderHistory(reader_history_att);
-        created &=this->mp_RTPSParticipant->createReader(&raux, ratt, subscriptions_reader_.second,
-                subscriptions_listener_, c_EntityId_SEDPSubReader, true);
+        created &= this->mp_RTPSParticipant->createReader(&raux, ratt, subscriptions_reader_.second,
+                        subscriptions_listener_, c_EntityId_SEDPSubReader, true);
 
-        if(created)
+        if (created)
         {
             subscriptions_reader_.first = dynamic_cast<StatefulReader*>(raux);
-            logInfo(RTPS_EDP,"SEDP Subscription Reader created");
+            logInfo(RTPS_EDP, "SEDP Subscription Reader created");
         }
         else
         {
@@ -341,16 +346,16 @@ bool EDPSimple::createSEDPEndpoints()
             subscriptions_reader_.second = nullptr;
         }
     }
-    if(m_discovery.discovery_config.m_simpleEDP.use_PublicationReaderANDSubscriptionWriter)
+    if (m_discovery.discovery_config.m_simpleEDP.use_PublicationReaderANDSubscriptionWriter)
     {
         publications_reader_.second = new ReaderHistory(reader_history_att);
-        created &=this->mp_RTPSParticipant->createReader(&raux, ratt, publications_reader_.second,
-                publications_listener_, c_EntityId_SEDPPubReader, true);
+        created &= this->mp_RTPSParticipant->createReader(&raux, ratt, publications_reader_.second,
+                        publications_listener_, c_EntityId_SEDPPubReader, true);
 
-        if(created)
+        if (created)
         {
             publications_reader_.first = dynamic_cast<StatefulReader*>(raux);
-            logInfo(RTPS_EDP,"SEDP Publication Reader created");
+            logInfo(RTPS_EDP, "SEDP Publication Reader created");
 
         }
         else
@@ -360,13 +365,13 @@ bool EDPSimple::createSEDPEndpoints()
         }
 
         subscriptions_writer_.second = new WriterHistory(writer_history_att);
-        created &=this->mp_RTPSParticipant->createWriter(&waux, watt, subscriptions_writer_.second,
-                subscriptions_listener_, c_EntityId_SEDPSubWriter, true);
+        created &= this->mp_RTPSParticipant->createWriter(&waux, watt, subscriptions_writer_.second,
+                        subscriptions_listener_, c_EntityId_SEDPSubWriter, true);
 
-        if(created)
+        if (created)
         {
             subscriptions_writer_.first = dynamic_cast<StatefulWriter*>(waux);
-            logInfo(RTPS_EDP,"SEDP Subscription Writer created");
+            logInfo(RTPS_EDP, "SEDP Subscription Writer created");
 
         }
         else
@@ -375,7 +380,7 @@ bool EDPSimple::createSEDPEndpoints()
             subscriptions_writer_.second = nullptr;
         }
     }
-    logInfo(RTPS_EDP,"Creation finished");
+    logInfo(RTPS_EDP, "Creation finished");
     return created;
 }
 
@@ -410,29 +415,29 @@ bool EDPSimple::create_sedp_secure_endpoints()
         if (plugin_part_attr.is_discovery_encrypted)
         {
             ratt.endpoint.security_attributes().plugin_endpoint_attributes |=
-                PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ENCRYPTED;
+                    PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ENCRYPTED;
             watt.endpoint.security_attributes().plugin_endpoint_attributes |=
-                PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ENCRYPTED;
+                    PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ENCRYPTED;
         }
         if (plugin_part_attr.is_discovery_origin_authenticated)
         {
             ratt.endpoint.security_attributes().plugin_endpoint_attributes |=
-                PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ORIGIN_AUTHENTICATED;
+                    PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ORIGIN_AUTHENTICATED;
             watt.endpoint.security_attributes().plugin_endpoint_attributes |=
-                PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ORIGIN_AUTHENTICATED;
+                    PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ORIGIN_AUTHENTICATED;
         }
     }
 
-    if(m_discovery.discovery_config.m_simpleEDP.enable_builtin_secure_publications_writer_and_subscriptions_reader)
+    if (m_discovery.discovery_config.m_simpleEDP.enable_builtin_secure_publications_writer_and_subscriptions_reader)
     {
         publications_secure_writer_.second = new WriterHistory(writer_history_att);
-        created &=this->mp_RTPSParticipant->createWriter(&waux, watt, publications_secure_writer_.second,
-                publications_listener_, sedp_builtin_publications_secure_writer, true);
+        created &= this->mp_RTPSParticipant->createWriter(&waux, watt, publications_secure_writer_.second,
+                        publications_listener_, sedp_builtin_publications_secure_writer, true);
 
-        if(created)
+        if (created)
         {
             publications_secure_writer_.first = dynamic_cast<StatefulWriter*>(waux);
-            logInfo(RTPS_EDP,"SEDP Publication Writer created");
+            logInfo(RTPS_EDP, "SEDP Publication Writer created");
         }
         else
         {
@@ -440,13 +445,13 @@ bool EDPSimple::create_sedp_secure_endpoints()
             publications_secure_writer_.second = nullptr;
         }
         subscriptions_secure_reader_.second = new ReaderHistory(reader_history_att);
-        created &=this->mp_RTPSParticipant->createReader(&raux, ratt, subscriptions_secure_reader_.second,
-                subscriptions_listener_, sedp_builtin_subscriptions_secure_reader, true);
+        created &= this->mp_RTPSParticipant->createReader(&raux, ratt, subscriptions_secure_reader_.second,
+                        subscriptions_listener_, sedp_builtin_subscriptions_secure_reader, true);
 
-        if(created)
+        if (created)
         {
             subscriptions_secure_reader_.first = dynamic_cast<StatefulReader*>(raux);
-            logInfo(RTPS_EDP,"SEDP Subscription Reader created");
+            logInfo(RTPS_EDP, "SEDP Subscription Reader created");
         }
         else
         {
@@ -455,16 +460,16 @@ bool EDPSimple::create_sedp_secure_endpoints()
         }
     }
 
-    if(m_discovery.discovery_config.m_simpleEDP.enable_builtin_secure_subscriptions_writer_and_publications_reader)
+    if (m_discovery.discovery_config.m_simpleEDP.enable_builtin_secure_subscriptions_writer_and_publications_reader)
     {
         publications_secure_reader_.second = new ReaderHistory(reader_history_att);
-        created &=this->mp_RTPSParticipant->createReader(&raux, ratt, publications_secure_reader_.second,
-                publications_listener_, sedp_builtin_publications_secure_reader, true);
+        created &= this->mp_RTPSParticipant->createReader(&raux, ratt, publications_secure_reader_.second,
+                        publications_listener_, sedp_builtin_publications_secure_reader, true);
 
-        if(created)
+        if (created)
         {
             publications_secure_reader_.first = dynamic_cast<StatefulReader*>(raux);
-            logInfo(RTPS_EDP,"SEDP Publication Reader created");
+            logInfo(RTPS_EDP, "SEDP Publication Reader created");
 
         }
         else
@@ -474,13 +479,13 @@ bool EDPSimple::create_sedp_secure_endpoints()
         }
 
         subscriptions_secure_writer_.second = new WriterHistory(writer_history_att);
-        created &=this->mp_RTPSParticipant->createWriter(&waux, watt, subscriptions_secure_writer_.second,
-            subscriptions_listener_, sedp_builtin_subscriptions_secure_writer, true);
+        created &= this->mp_RTPSParticipant->createWriter(&waux, watt, subscriptions_secure_writer_.second,
+                        subscriptions_listener_, sedp_builtin_subscriptions_secure_writer, true);
 
-        if(created)
+        if (created)
         {
             subscriptions_secure_writer_.first = dynamic_cast<StatefulWriter*>(waux);
-            logInfo(RTPS_EDP,"SEDP Subscription Writer created");
+            logInfo(RTPS_EDP, "SEDP Subscription Writer created");
 
         }
         else
@@ -489,32 +494,38 @@ bool EDPSimple::create_sedp_secure_endpoints()
             subscriptions_secure_writer_.second = nullptr;
         }
     }
-    logInfo(RTPS_EDP,"Creation finished");
+    logInfo(RTPS_EDP, "Creation finished");
     return created;
 }
-#endif
 
-bool EDPSimple::processLocalReaderProxyData(RTPSReader* local_reader, ReaderProxyData* rdata)
+#endif // if HAVE_SECURITY
+
+bool EDPSimple::processLocalReaderProxyData(
+        RTPSReader* local_reader,
+        ReaderProxyData* rdata)
 {
-    logInfo(RTPS_EDP,rdata->guid().entityId);
+    logInfo(RTPS_EDP, rdata->guid().entityId);
     (void)local_reader;
 
     auto* writer = &subscriptions_writer_;
 
 #if HAVE_SECURITY
-    if(local_reader->getAttributes().security_attributes().is_discovery_protected)
+    if (local_reader->getAttributes().security_attributes().is_discovery_protected)
     {
         writer = &subscriptions_secure_writer_;
     }
-#endif
+#endif // if HAVE_SECURITY
 
-    if(writer->first != nullptr)
+    if (writer->first != nullptr)
     {
         // TODO(Ricardo) Write a getCdrSerializedPayload for ReaderProxyData.
-        CacheChange_t* change = writer->first->new_change([]() -> uint32_t {return DISCOVERY_SUBSCRIPTION_DATA_MAX_SIZE;},
-                ALIVE,rdata->key());
+        CacheChange_t* change = writer->first->new_change([]() -> uint32_t
+                        {
+                            return DISCOVERY_SUBSCRIPTION_DATA_MAX_SIZE;
+                        },
+                        ALIVE, rdata->key());
 
-        if(change !=nullptr)
+        if (change != nullptr)
         {
             CDRMessage_t aux_msg(change->serializedPayload);
 
@@ -524,16 +535,16 @@ bool EDPSimple::processLocalReaderProxyData(RTPSReader* local_reader, ReaderProx
 #else
             change->serializedPayload.encapsulation = (uint16_t)PL_CDR_LE;
             aux_msg.msg_endian =  LITTLEEND;
-#endif
+#endif // if __BIG_ENDIAN__
 
             rdata->writeToCDRMessage(&aux_msg, true);
             change->serializedPayload.length = (uint16_t)aux_msg.length;
 
             {
                 std::unique_lock<RecursiveTimedMutex> lock(*writer->second->getMutex());
-                for(auto ch = writer->second->changesBegin(); ch != writer->second->changesEnd(); ++ch)
+                for (auto ch = writer->second->changesBegin(); ch != writer->second->changesEnd(); ++ch)
                 {
-                    if((*ch)->instanceHandle == change->instanceHandle)
+                    if ((*ch)->instanceHandle == change->instanceHandle)
                     {
                         writer->second->remove_change(*ch);
                         break;
@@ -552,7 +563,9 @@ bool EDPSimple::processLocalReaderProxyData(RTPSReader* local_reader, ReaderProx
     return true;
 }
 
-bool EDPSimple::processLocalWriterProxyData(RTPSWriter* local_writer, WriterProxyData* wdata)
+bool EDPSimple::processLocalWriterProxyData(
+        RTPSWriter* local_writer,
+        WriterProxyData* wdata)
 {
     logInfo(RTPS_EDP, wdata->guid().entityId);
     (void)local_writer;
@@ -560,17 +573,20 @@ bool EDPSimple::processLocalWriterProxyData(RTPSWriter* local_writer, WriterProx
     auto* writer = &publications_writer_;
 
 #if HAVE_SECURITY
-    if(local_writer->getAttributes().security_attributes().is_discovery_protected)
+    if (local_writer->getAttributes().security_attributes().is_discovery_protected)
     {
         writer = &publications_secure_writer_;
     }
-#endif
+#endif // if HAVE_SECURITY
 
-    if(writer->first !=nullptr)
+    if (writer->first != nullptr)
     {
-        CacheChange_t* change = writer->first->new_change([]() -> uint32_t {return DISCOVERY_PUBLICATION_DATA_MAX_SIZE;},
-                ALIVE, wdata->key());
-        if(change != nullptr)
+        CacheChange_t* change = writer->first->new_change([]() -> uint32_t
+                        {
+                            return DISCOVERY_PUBLICATION_DATA_MAX_SIZE;
+                        },
+                        ALIVE, wdata->key());
+        if (change != nullptr)
         {
             CDRMessage_t aux_msg(change->serializedPayload);
 
@@ -580,16 +596,16 @@ bool EDPSimple::processLocalWriterProxyData(RTPSWriter* local_writer, WriterProx
 #else
             change->serializedPayload.encapsulation = (uint16_t)PL_CDR_LE;
             aux_msg.msg_endian =  LITTLEEND;
-#endif
+#endif // if __BIG_ENDIAN__
 
             wdata->writeToCDRMessage(&aux_msg, true);
             change->serializedPayload.length = (uint16_t)aux_msg.length;
 
             {
                 std::unique_lock<RecursiveTimedMutex> lock(*writer->second->getMutex());
-                for(auto ch = writer->second->changesBegin(); ch != writer->second->changesEnd(); ++ch)
+                for (auto ch = writer->second->changesBegin(); ch != writer->second->changesEnd(); ++ch)
                 {
-                    if((*ch)->instanceHandle == change->instanceHandle)
+                    if ((*ch)->instanceHandle == change->instanceHandle)
                     {
                         writer->second->remove_change(*ch);
                         break;
@@ -606,32 +622,36 @@ bool EDPSimple::processLocalWriterProxyData(RTPSWriter* local_writer, WriterProx
     return true;
 }
 
-bool EDPSimple::removeLocalWriter(RTPSWriter* W)
+bool EDPSimple::removeLocalWriter(
+        RTPSWriter* W)
 {
-    logInfo(RTPS_EDP,W->getGuid().entityId);
+    logInfo(RTPS_EDP, W->getGuid().entityId);
 
     auto* writer = &publications_writer_;
 
 #if HAVE_SECURITY
-    if(W->getAttributes().security_attributes().is_discovery_protected)
+    if (W->getAttributes().security_attributes().is_discovery_protected)
     {
         writer = &publications_secure_writer_;
     }
-#endif
+#endif // if HAVE_SECURITY
 
-    if(writer->first!=nullptr)
+    if (writer->first != nullptr)
     {
         InstanceHandle_t iH;
         iH = W->getGuid();
-        CacheChange_t* change = writer->first->new_change([]() -> uint32_t {return DISCOVERY_PUBLICATION_DATA_MAX_SIZE;},
-                NOT_ALIVE_DISPOSED_UNREGISTERED,iH);
-        if(change != nullptr)
+        CacheChange_t* change = writer->first->new_change([]() -> uint32_t
+                        {
+                            return DISCOVERY_PUBLICATION_DATA_MAX_SIZE;
+                        },
+                        NOT_ALIVE_DISPOSED_UNREGISTERED, iH);
+        if (change != nullptr)
         {
             {
                 std::lock_guard<RecursiveTimedMutex> guard(*writer->second->getMutex());
-                for(auto ch = writer->second->changesBegin(); ch != writer->second->changesEnd(); ++ch)
+                for (auto ch = writer->second->changesBegin(); ch != writer->second->changesEnd(); ++ch)
                 {
-                    if((*ch)->instanceHandle == change->instanceHandle)
+                    if ((*ch)->instanceHandle == change->instanceHandle)
                     {
                         writer->second->remove_change(*ch);
                         break;
@@ -646,32 +666,36 @@ bool EDPSimple::removeLocalWriter(RTPSWriter* W)
     return mp_PDP->removeWriterProxyData(W->getGuid());
 }
 
-bool EDPSimple::removeLocalReader(RTPSReader* R)
+bool EDPSimple::removeLocalReader(
+        RTPSReader* R)
 {
-    logInfo(RTPS_EDP,R->getGuid().entityId);
+    logInfo(RTPS_EDP, R->getGuid().entityId);
 
     auto* writer = &subscriptions_writer_;
 
 #if HAVE_SECURITY
-    if(R->getAttributes().security_attributes().is_discovery_protected)
+    if (R->getAttributes().security_attributes().is_discovery_protected)
     {
         writer = &subscriptions_secure_writer_;
     }
-#endif
+#endif // if HAVE_SECURITY
 
-    if(writer->first!=nullptr)
+    if (writer->first != nullptr)
     {
         InstanceHandle_t iH;
         iH = (R->getGuid());
-        CacheChange_t* change = writer->first->new_change([]() -> uint32_t {return DISCOVERY_SUBSCRIPTION_DATA_MAX_SIZE;},
-                NOT_ALIVE_DISPOSED_UNREGISTERED,iH);
-        if(change != nullptr)
+        CacheChange_t* change = writer->first->new_change([]() -> uint32_t
+                        {
+                            return DISCOVERY_SUBSCRIPTION_DATA_MAX_SIZE;
+                        },
+                        NOT_ALIVE_DISPOSED_UNREGISTERED, iH);
+        if (change != nullptr)
         {
             {
                 std::lock_guard<RecursiveTimedMutex> guard(*writer->second->getMutex());
-                for(auto ch = writer->second->changesBegin(); ch != writer->second->changesEnd(); ++ch)
+                for (auto ch = writer->second->changesBegin(); ch != writer->second->changesEnd(); ++ch)
                 {
-                    if((*ch)->instanceHandle == change->instanceHandle)
+                    if ((*ch)->instanceHandle == change->instanceHandle)
                     {
                         writer->second->remove_change(*ch);
                         break;
@@ -685,15 +709,16 @@ bool EDPSimple::removeLocalReader(RTPSReader* R)
     return mp_PDP->removeReaderProxyData(R->getGuid());
 }
 
-void EDPSimple::assignRemoteEndpoints(const ParticipantProxyData& pdata)
+void EDPSimple::assignRemoteEndpoints(
+        const ParticipantProxyData& pdata)
 {
-    logInfo(RTPS_EDP,"New DPD received, adding remote endpoints to our SimpleEDP endpoints");
+    logInfo(RTPS_EDP, "New DPD received, adding remote endpoints to our SimpleEDP endpoints");
     const NetworkFactory& network = mp_RTPSParticipant->network_factory();
     uint32_t endp = pdata.m_availableBuiltinEndpoints;
     uint32_t auxendp = endp;
     bool use_multicast_locators = !mp_PDP->getRTPSParticipant()->getAttributes().builtin.avoid_builtin_multicast ||
-                                  pdata.metatraffic_locators.unicast.empty();
-    auxendp &=DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER;
+            pdata.metatraffic_locators.unicast.empty();
+    auxendp &= DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER;
 
     std::lock_guard<std::mutex> data_guard(temp_data_lock_);
 
@@ -713,20 +738,20 @@ void EDPSimple::assignRemoteEndpoints(const ParticipantProxyData& pdata)
 
     //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
     //auxendp = 1;
-    if(auxendp!=0 && publications_reader_.first!=nullptr) //Exist Pub Writer and i have pub reader
+    if (auxendp != 0 && publications_reader_.first != nullptr) //Exist Pub Writer and i have pub reader
     {
-        logInfo(RTPS_EDP,"Adding SEDP Pub Writer to my Pub Reader");
+        logInfo(RTPS_EDP, "Adding SEDP Pub Writer to my Pub Reader");
         temp_writer_proxy_data_.guid().entityId = c_EntityId_SEDPPubWriter;
         temp_writer_proxy_data_.set_persistence_entity_id(c_EntityId_SEDPPubWriter);
         publications_reader_.first->matched_writer_add(temp_writer_proxy_data_);
     }
     auxendp = endp;
-    auxendp &=DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR;
+    auxendp &= DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR;
     //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
     //auxendp = 1;
-    if(auxendp!=0 && publications_writer_.first!=nullptr) //Exist Pub Detector
+    if (auxendp != 0 && publications_writer_.first != nullptr) //Exist Pub Detector
     {
-        logInfo(RTPS_EDP,"Adding SEDP Pub Reader to my Pub Writer");
+        logInfo(RTPS_EDP, "Adding SEDP Pub Reader to my Pub Writer");
         temp_reader_proxy_data_.guid().entityId = c_EntityId_SEDPPubReader;
         publications_writer_.first->matched_reader_add(temp_reader_proxy_data_);
     }
@@ -734,9 +759,9 @@ void EDPSimple::assignRemoteEndpoints(const ParticipantProxyData& pdata)
     auxendp &= DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER;
     //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
     //auxendp = 1;
-    if(auxendp!=0 && subscriptions_reader_.first!=nullptr) //Exist Pub Announcer
+    if (auxendp != 0 && subscriptions_reader_.first != nullptr) //Exist Pub Announcer
     {
-        logInfo(RTPS_EDP,"Adding SEDP Sub Writer to my Sub Reader");
+        logInfo(RTPS_EDP, "Adding SEDP Sub Writer to my Sub Reader");
         temp_writer_proxy_data_.guid().entityId = c_EntityId_SEDPSubWriter;
         temp_writer_proxy_data_.set_persistence_entity_id(c_EntityId_SEDPSubWriter);
         subscriptions_reader_.first->matched_writer_add(temp_writer_proxy_data_);
@@ -745,9 +770,9 @@ void EDPSimple::assignRemoteEndpoints(const ParticipantProxyData& pdata)
     auxendp &= DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_DETECTOR;
     //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
     //auxendp = 1;
-    if(auxendp!=0 && subscriptions_writer_.first!=nullptr) //Exist Pub Announcer
+    if (auxendp != 0 && subscriptions_writer_.first != nullptr) //Exist Pub Announcer
     {
-        logInfo(RTPS_EDP,"Adding SEDP Sub Reader to my Sub Writer");
+        logInfo(RTPS_EDP, "Adding SEDP Sub Reader to my Sub Writer");
         temp_reader_proxy_data_.guid().entityId = c_EntityId_SEDPSubReader;
         subscriptions_writer_.first->matched_reader_add(temp_reader_proxy_data_);
     }
@@ -757,12 +782,12 @@ void EDPSimple::assignRemoteEndpoints(const ParticipantProxyData& pdata)
     auxendp &= DISC_BUILTIN_ENDPOINT_PUBLICATION_SECURE_ANNOUNCER;
     //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
     //auxendp = 1;
-    if(auxendp != 0 && publications_secure_reader_.first != nullptr)
+    if (auxendp != 0 && publications_secure_reader_.first != nullptr)
     {
         temp_writer_proxy_data_.guid().entityId = sedp_builtin_publications_secure_writer;
         temp_writer_proxy_data_.set_persistence_entity_id(sedp_builtin_publications_secure_writer);
 
-        if(!mp_RTPSParticipant->security_manager().discovered_builtin_writer(
+        if (!mp_RTPSParticipant->security_manager().discovered_builtin_writer(
                     publications_secure_reader_.first->getGuid(), pdata.m_guid, temp_writer_proxy_data_,
                     publications_secure_reader_.first->getAttributes().security_attributes()))
         {
@@ -775,10 +800,10 @@ void EDPSimple::assignRemoteEndpoints(const ParticipantProxyData& pdata)
     auxendp &= DISC_BUILTIN_ENDPOINT_PUBLICATION_SECURE_DETECTOR;
     //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
     //auxendp = 1;
-    if(auxendp != 0 && publications_secure_writer_.first!=nullptr)
+    if (auxendp != 0 && publications_secure_writer_.first != nullptr)
     {
         temp_reader_proxy_data_.guid().entityId = sedp_builtin_publications_secure_reader;
-        if(!mp_RTPSParticipant->security_manager().discovered_builtin_reader(
+        if (!mp_RTPSParticipant->security_manager().discovered_builtin_reader(
                     publications_secure_writer_.first->getGuid(), pdata.m_guid, temp_reader_proxy_data_,
                     publications_secure_writer_.first->getAttributes().security_attributes()))
         {
@@ -791,12 +816,12 @@ void EDPSimple::assignRemoteEndpoints(const ParticipantProxyData& pdata)
     auxendp &= DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_SECURE_ANNOUNCER;
     //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
     //auxendp = 1;
-    if(auxendp != 0 && subscriptions_secure_reader_.first != nullptr)
+    if (auxendp != 0 && subscriptions_secure_reader_.first != nullptr)
     {
         temp_writer_proxy_data_.guid().entityId = sedp_builtin_subscriptions_secure_writer;
         temp_writer_proxy_data_.set_persistence_entity_id(sedp_builtin_subscriptions_secure_writer);
 
-        if(!mp_RTPSParticipant->security_manager().discovered_builtin_writer(
+        if (!mp_RTPSParticipant->security_manager().discovered_builtin_writer(
                     subscriptions_secure_reader_.first->getGuid(), pdata.m_guid, temp_writer_proxy_data_,
                     subscriptions_secure_reader_.first->getAttributes().security_attributes()))
         {
@@ -809,11 +834,11 @@ void EDPSimple::assignRemoteEndpoints(const ParticipantProxyData& pdata)
     auxendp &= DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_SECURE_DETECTOR;
     //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
     //auxendp = 1;
-    if(auxendp != 0 && subscriptions_secure_writer_.first!=nullptr)
+    if (auxendp != 0 && subscriptions_secure_writer_.first != nullptr)
     {
-        logInfo(RTPS_EDP,"Adding SEDP Sub Reader to my Sub Writer");
+        logInfo(RTPS_EDP, "Adding SEDP Sub Reader to my Sub Writer");
         temp_reader_proxy_data_.guid().entityId = sedp_builtin_subscriptions_secure_reader;
-        if(!mp_RTPSParticipant->security_manager().discovered_builtin_reader(
+        if (!mp_RTPSParticipant->security_manager().discovered_builtin_reader(
                     subscriptions_secure_writer_.first->getGuid(), pdata.m_guid, temp_reader_proxy_data_,
                     subscriptions_secure_writer_.first->getAttributes().security_attributes()))
         {
@@ -821,31 +846,32 @@ void EDPSimple::assignRemoteEndpoints(const ParticipantProxyData& pdata)
                     subscriptions_secure_writer_.first->getGuid());
         }
     }
-#endif
+#endif // if HAVE_SECURITY
 }
 
-void EDPSimple::removeRemoteEndpoints(ParticipantProxyData* pdata)
+void EDPSimple::removeRemoteEndpoints(
+        ParticipantProxyData* pdata)
 {
-    logInfo(RTPS_EDP,"For RTPSParticipant: "<<pdata->m_guid);
+    logInfo(RTPS_EDP, "For RTPSParticipant: " << pdata->m_guid);
 
     GUID_t tmp_guid;
     tmp_guid.guidPrefix = pdata->m_guid.guidPrefix;
 
     uint32_t endp = pdata->m_availableBuiltinEndpoints;
     uint32_t auxendp = endp;
-    auxendp &=DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER;
+    auxendp &= DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER;
     //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
     //auxendp = 1;
-    if(auxendp!=0 && publications_reader_.first!=nullptr) //Exist Pub Writer and i have pub reader
+    if (auxendp != 0 && publications_reader_.first != nullptr) //Exist Pub Writer and i have pub reader
     {
         tmp_guid.entityId = c_EntityId_SEDPPubWriter;
         publications_reader_.first->matched_writer_remove(tmp_guid);
     }
     auxendp = endp;
-    auxendp &=DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR;
+    auxendp &= DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR;
     //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
     //auxendp = 1;
-    if(auxendp!=0 && publications_writer_.first!=nullptr) //Exist Pub Detector
+    if (auxendp != 0 && publications_writer_.first != nullptr) //Exist Pub Detector
     {
         tmp_guid.entityId = c_EntityId_SEDPPubReader;
         publications_writer_.first->matched_reader_remove(tmp_guid);
@@ -854,9 +880,9 @@ void EDPSimple::removeRemoteEndpoints(ParticipantProxyData* pdata)
     auxendp &= DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER;
     //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
     //auxendp = 1;
-    if(auxendp!=0 && subscriptions_reader_.first!=nullptr) //Exist Pub Announcer
+    if (auxendp != 0 && subscriptions_reader_.first != nullptr) //Exist Pub Announcer
     {
-        logInfo(RTPS_EDP,"Adding SEDP Sub Writer to my Sub Reader");
+        logInfo(RTPS_EDP, "Adding SEDP Sub Writer to my Sub Reader");
         tmp_guid.entityId = c_EntityId_SEDPSubWriter;
         subscriptions_reader_.first->matched_writer_remove(tmp_guid);
     }
@@ -864,9 +890,9 @@ void EDPSimple::removeRemoteEndpoints(ParticipantProxyData* pdata)
     auxendp &= DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_DETECTOR;
     //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
     //auxendp = 1;
-    if(auxendp!=0 && subscriptions_writer_.first!=nullptr) //Exist Pub Announcer
+    if (auxendp != 0 && subscriptions_writer_.first != nullptr) //Exist Pub Announcer
     {
-        logInfo(RTPS_EDP,"Adding SEDP Sub Reader to my Sub Writer");
+        logInfo(RTPS_EDP, "Adding SEDP Sub Reader to my Sub Writer");
         tmp_guid.entityId = c_EntityId_SEDPSubReader;
         subscriptions_writer_.first->matched_reader_remove(tmp_guid);
     }
@@ -876,13 +902,13 @@ void EDPSimple::removeRemoteEndpoints(ParticipantProxyData* pdata)
     auxendp &= DISC_BUILTIN_ENDPOINT_PUBLICATION_SECURE_ANNOUNCER;
     //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
     //auxendp = 1;
-    if(auxendp != 0 && publications_secure_reader_.first != nullptr)
+    if (auxendp != 0 && publications_secure_reader_.first != nullptr)
     {
         tmp_guid.entityId = sedp_builtin_publications_secure_writer;
-        if(publications_secure_reader_.first->matched_writer_remove(tmp_guid))
+        if (publications_secure_reader_.first->matched_writer_remove(tmp_guid))
         {
             mp_RTPSParticipant->security_manager().remove_writer(
-                    publications_secure_reader_.first->getGuid(), pdata->m_guid, tmp_guid);
+                publications_secure_reader_.first->getGuid(), pdata->m_guid, tmp_guid);
         }
     }
 
@@ -890,13 +916,13 @@ void EDPSimple::removeRemoteEndpoints(ParticipantProxyData* pdata)
     auxendp &= DISC_BUILTIN_ENDPOINT_PUBLICATION_SECURE_DETECTOR;
     //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
     //auxendp = 1;
-    if(auxendp != 0 && publications_secure_writer_.first != nullptr)
+    if (auxendp != 0 && publications_secure_writer_.first != nullptr)
     {
         tmp_guid.entityId = sedp_builtin_publications_secure_reader;
-        if(publications_secure_writer_.first->matched_reader_remove(tmp_guid))
+        if (publications_secure_writer_.first->matched_reader_remove(tmp_guid))
         {
             mp_RTPSParticipant->security_manager().remove_reader(
-                    publications_secure_writer_.first->getGuid(), pdata->m_guid, tmp_guid);
+                publications_secure_writer_.first->getGuid(), pdata->m_guid, tmp_guid);
         }
     }
 
@@ -904,34 +930,35 @@ void EDPSimple::removeRemoteEndpoints(ParticipantProxyData* pdata)
     auxendp &= DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_SECURE_ANNOUNCER;
     //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
     //auxendp = 1;
-    if(auxendp != 0 && subscriptions_secure_reader_.first != nullptr)
+    if (auxendp != 0 && subscriptions_secure_reader_.first != nullptr)
     {
-        logInfo(RTPS_EDP,"Adding SEDP Sub Writer to my Sub Reader");
+        logInfo(RTPS_EDP, "Adding SEDP Sub Writer to my Sub Reader");
         tmp_guid.entityId = sedp_builtin_subscriptions_secure_writer;
-        if(subscriptions_secure_reader_.first->matched_writer_remove(tmp_guid))
+        if (subscriptions_secure_reader_.first->matched_writer_remove(tmp_guid))
         {
             mp_RTPSParticipant->security_manager().remove_writer(
-                    subscriptions_secure_reader_.first->getGuid(), pdata->m_guid, tmp_guid);
+                subscriptions_secure_reader_.first->getGuid(), pdata->m_guid, tmp_guid);
         }
     }
     auxendp = endp;
     auxendp &= DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_SECURE_DETECTOR;
     //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
     //auxendp = 1;
-    if(auxendp != 0 && subscriptions_secure_writer_.first!=nullptr)
+    if (auxendp != 0 && subscriptions_secure_writer_.first != nullptr)
     {
-        logInfo(RTPS_EDP,"Adding SEDP Sub Reader to my Sub Writer");
+        logInfo(RTPS_EDP, "Adding SEDP Sub Reader to my Sub Writer");
         tmp_guid.entityId = sedp_builtin_subscriptions_secure_reader;
-        if(subscriptions_secure_writer_.first->matched_reader_remove(tmp_guid))
+        if (subscriptions_secure_writer_.first->matched_reader_remove(tmp_guid))
         {
             mp_RTPSParticipant->security_manager().remove_reader(
-                    subscriptions_secure_writer_.first->getGuid(), pdata->m_guid, tmp_guid);
+                subscriptions_secure_writer_.first->getGuid(), pdata->m_guid, tmp_guid);
         }
     }
-#endif
+#endif // if HAVE_SECURITY
 }
 
-bool EDPSimple::areRemoteEndpointsMatched(const ParticipantProxyData* pdata)
+bool EDPSimple::areRemoteEndpointsMatched(
+        const ParticipantProxyData* pdata)
 {
     uint32_t endp = pdata->m_availableBuiltinEndpoints;
 
@@ -944,7 +971,9 @@ bool EDPSimple::areRemoteEndpointsMatched(const ParticipantProxyData* pdata)
         wguid.entityId = c_EntityId_SEDPPubWriter;
 
         if (!publications_reader_.first->matched_writer_is_matched(wguid))
+        {
             return false;
+        }
     }
 
     auxendp = endp;
@@ -956,7 +985,9 @@ bool EDPSimple::areRemoteEndpointsMatched(const ParticipantProxyData* pdata)
         rguid.entityId = c_EntityId_SEDPPubReader;
 
         if (!publications_writer_.first->matched_reader_is_matched(rguid))
+        {
             return false;
+        }
     }
 
     auxendp = endp;
@@ -968,7 +999,9 @@ bool EDPSimple::areRemoteEndpointsMatched(const ParticipantProxyData* pdata)
         wguid.entityId = c_EntityId_SEDPSubWriter;
 
         if (!subscriptions_reader_.first->matched_writer_is_matched(wguid))
+        {
             return false;
+        }
     }
 
     auxendp = endp;
@@ -980,24 +1013,27 @@ bool EDPSimple::areRemoteEndpointsMatched(const ParticipantProxyData* pdata)
         rguid.entityId = c_EntityId_SEDPSubReader;
 
         if (!subscriptions_writer_.first->matched_reader_is_matched(rguid))
+        {
             return false;
+        }
     }
 
     return true;
 }
 
 #if HAVE_SECURITY
-bool EDPSimple::pairing_remote_writer_with_local_builtin_reader_after_security(const GUID_t& local_reader,
+bool EDPSimple::pairing_remote_writer_with_local_builtin_reader_after_security(
+        const GUID_t& local_reader,
         const WriterProxyData& remote_writer_data)
 {
     bool returned_value = false;
 
-    if(local_reader.entityId == sedp_builtin_publications_secure_reader)
+    if (local_reader.entityId == sedp_builtin_publications_secure_reader)
     {
         publications_secure_reader_.first->matched_writer_add(remote_writer_data);
         returned_value = true;
     }
-    else if(local_reader.entityId == sedp_builtin_subscriptions_secure_reader)
+    else if (local_reader.entityId == sedp_builtin_subscriptions_secure_reader)
     {
         subscriptions_secure_reader_.first->matched_writer_add(remote_writer_data);
         returned_value = true;
@@ -1006,17 +1042,18 @@ bool EDPSimple::pairing_remote_writer_with_local_builtin_reader_after_security(c
     return returned_value;
 }
 
-bool EDPSimple::pairing_remote_reader_with_local_builtin_writer_after_security(const GUID_t& local_writer,
+bool EDPSimple::pairing_remote_reader_with_local_builtin_writer_after_security(
+        const GUID_t& local_writer,
         const ReaderProxyData& remote_reader_data)
 {
     bool returned_value = false;
 
-    if(local_writer.entityId == sedp_builtin_publications_secure_writer)
+    if (local_writer.entityId == sedp_builtin_publications_secure_writer)
     {
         publications_secure_writer_.first->matched_reader_add(remote_reader_data);
         returned_value = true;
     }
-    else if(local_writer.entityId == sedp_builtin_subscriptions_secure_writer)
+    else if (local_writer.entityId == sedp_builtin_subscriptions_secure_writer)
     {
         subscriptions_secure_writer_.first->matched_reader_add(remote_reader_data);
         returned_value = true;
@@ -1024,7 +1061,8 @@ bool EDPSimple::pairing_remote_reader_with_local_builtin_writer_after_security(c
 
     return returned_value;
 }
-#endif
+
+#endif // if HAVE_SECURITY
 
 } /* namespace rtps */
 } /* namespace fastrtps */

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -37,6 +37,8 @@
 #include <fastrtps/log/Log.h>
 
 #include <mutex>
+#include <forward_list>
+#include <algorithm>
 
 namespace eprosima {
 namespace fastrtps {
@@ -152,15 +154,58 @@ bool EDPSimple::initEDP(
 //! Process the info recorded in the persistence database
 void EDPSimple::processPersistentData(
         t_p_StatefulReader& reader,
-        t_p_StatefulWriter& writer)
+        t_p_StatefulWriter& writer,
+        key_list& demises)
 {
     std::lock_guard<RecursiveTimedMutex> guardR(reader.first->getMutex());
     std::lock_guard<RecursiveTimedMutex> guardW(writer.first->getMutex());
 
+    // own server instance
+    InstanceHandle_t server_key = mp_PDP->getLocalParticipantProxyData()->m_key;
+
+    // reference own references from writer history
+    std::forward_list<CacheChange_t*> removal;
+
+    // List known participants
+    key_list known_participants;
+
+    std::for_each(
+        mp_PDP->ParticipantProxiesBegin(),
+        mp_PDP->ParticipantProxiesEnd(),
+        [&known_participants](const ParticipantProxyData* pD)
+        {
+            known_participants.insert(pD->m_key);
+        });
+
+    // We have not processed any PDP message yet
+    assert(demises.empty());
+
     std::for_each(writer.second->changesBegin(),
             writer.second->changesEnd(),
-            [&reader](CacheChange_t* change)
+            [&reader, &known_participants, &demises, &removal, &server_key](CacheChange_t* change)
             {
+                // Get Participant InstanceHandle
+                InstanceHandle_t handle;
+                {
+                    GUID_t guid = iHandle2GUID(change->instanceHandle);
+                    guid.entityId = c_EntityId_RTPSParticipant;
+                    handle = guid;
+                }
+
+                // mark for removal endpoints from unknown participants
+                if ( known_participants.find(handle) == known_participants.end() )
+                {
+                    demises.insert(change->instanceHandle);
+                    return;
+                }
+
+                // check if its own data: mark for removal and ignore
+                if ( handle == server_key)
+                {
+                    removal.push_front(change);
+                    return;
+                }
+
                 CacheChange_t* change_to_add = nullptr;
 
                 if (!reader.first->reserveCache(&change_to_add, change->serializedPayload.length)) //Reserve a new cache from the corresponding cache pool
@@ -188,6 +233,14 @@ void EDPSimple::processPersistentData(
 
                 // change_to_add would be released within change_received
             });
+
+    // remove our own old server samples
+    for (auto pC : removal)
+    {
+        writer.second->remove_change(pC);
+    }
+
+    // We don't need to awake the server thread because we are in it
 }
 
 void EDPSimple::set_builtin_reader_history_attributes(

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -159,6 +159,7 @@ void EDPSimple::processPersistentData(
 {
     std::lock_guard<RecursiveTimedMutex> guardR(reader.first->getMutex());
     std::lock_guard<RecursiveTimedMutex> guardW(writer.first->getMutex());
+    std::lock_guard<std::recursive_mutex> guardP(*mp_PDP->getMutex());
 
     // own server instance
     InstanceHandle_t server_key = mp_PDP->getLocalParticipantProxyData()->m_key;

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -188,38 +188,38 @@ void EDPSimple::processPersistentData(
     ChangeKind_t kind;
 
     auto param_process = [&si, &kind](const Parameter_t* param)
-    {
-        // we use the PID_PARTICIPANT_GUID to identify a DATA(r|w)
-        if (param->Pid == PID_PARTICIPANT_GUID )
-        {
-            kind = ALIVE;
-            return true;
-        }
-
-        if (param->Pid == PID_PROPERTY_LIST)
-        {
-            si = SampleIdentity::unknown();
-            const ParameterPropertyList_t* p = dynamic_cast<const ParameterPropertyList_t*>(param);
-            assert(p != nullptr);
-
-            const auto & properties = p->properties;
-            auto it = properties.begin();
-
-            it = std::find_if( it, properties.end(),
-                    [](const std::pair<std::string, std::string>& p)
-                    {
-                    return "PID_CLIENT_SERVER_KEY" == p.first;
-                    });
-
-            if (it != properties.end())
             {
-                std::istringstream in(it->second);
-                in >> si;
-            }
-        }
+                // we use the PID_PARTICIPANT_GUID to identify a DATA(r|w)
+                if (param->Pid == PID_PARTICIPANT_GUID )
+                {
+                    kind = ALIVE;
+                    return true;
+                }
 
-        return true;
-    };
+                if (param->Pid == PID_PROPERTY_LIST)
+                {
+                    si = SampleIdentity::unknown();
+                    const ParameterPropertyList_t* p = dynamic_cast<const ParameterPropertyList_t*>(param);
+                    assert(p != nullptr);
+
+                    const auto& properties = p->properties;
+                    auto it = properties.begin();
+
+                    it = std::find_if( it, properties.end(),
+                                    [](const std::pair<std::string, std::string>& p)
+                                    {
+                                        return "PID_CLIENT_SERVER_KEY" == p.first;
+                                    });
+
+                    if (it != properties.end())
+                    {
+                        std::istringstream in(it->second);
+                        in >> si;
+                    }
+                }
+
+                return true;
+            };
 
 
     std::for_each(writer.second->changesBegin(),
@@ -244,7 +244,7 @@ void EDPSimple::processPersistentData(
                     change->write_params.related_sample_identity(si);
                 }
 
-               // Get Participant InstanceHandle
+                // Get Participant InstanceHandle
                 InstanceHandle_t handle;
                 {
                     GUID_t guid = iHandle2GUID(change->instanceHandle);

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.cpp
@@ -56,7 +56,7 @@ void EDPBasePUBListener::add_writer_from_change(
     {
         change->instanceHandle = temp_writer_data_.key();
         if (temp_writer_data_.guid().guidPrefix == edp->mp_RTPSParticipant->getGuid().guidPrefix
-            && !ongoingDeserialization(edp))
+                && !ongoingDeserialization(edp))
         {
             logInfo(RTPS_EDP, "Message from own RTPSParticipant, ignoring");
             return;
@@ -67,23 +67,24 @@ void EDPBasePUBListener::add_writer_from_change(
             WriterProxyData* data,
             bool updating,
             const ParticipantProxyData& participant_data)
-        {
-            if (!temp_writer_data_.has_locators())
-            {
-                temp_writer_data_.set_remote_locators(participant_data.default_locators, network, true);
-            }
+                {
+                    if (!temp_writer_data_.has_locators())
+                    {
+                        temp_writer_data_.set_remote_locators(participant_data.default_locators, network, true);
+                    }
 
-            if (updating && !data->is_update_allowed(temp_writer_data_))
-            {
-                logWarning(RTPS_EDP, "Received incompatible update for WriterQos. writer_guid = " << data->guid());
-            }
-            *data = temp_writer_data_;
-            return true;
-        };
+                    if (updating && !data->is_update_allowed(temp_writer_data_))
+                    {
+                        logWarning(RTPS_EDP,
+                                "Received incompatible update for WriterQos. writer_guid = " << data->guid());
+                    }
+                    *data = temp_writer_data_;
+                    return true;
+                };
 
         GUID_t participant_guid;
         WriterProxyData* writer_data =
-            edp->mp_PDP->addWriterProxyData(temp_writer_data_.guid(), participant_guid, copy_data_fun);
+                edp->mp_PDP->addWriterProxyData(temp_writer_data_.guid(), participant_guid, copy_data_fun);
         if (writer_data != nullptr)
         {
             // At this point we can release reader lock, cause change is not used
@@ -103,31 +104,31 @@ void EDPBasePUBListener::add_writer_from_change(
 
 void EDPSimplePUBListener::onNewCacheChangeAdded(
         RTPSReader* reader,
-        const CacheChange_t * const change_in)
+        const CacheChange_t* const change_in)
 {
     CacheChange_t* change = (CacheChange_t*)change_in;
     //std::lock_guard<std::recursive_mutex> guard(*this->sedp_->publications_reader_.first->getMutex());
-    logInfo(RTPS_EDP,"");
-    if(!computeKey(change))
+    logInfo(RTPS_EDP, "");
+    if (!computeKey(change))
     {
-        logWarning(RTPS_EDP,"Received change with no Key");
+        logWarning(RTPS_EDP, "Received change with no Key");
     }
 
     ReaderHistory* reader_history =
 #if HAVE_SECURITY
-        reader == sedp_->publications_secure_reader_.first ?
-        sedp_->publications_secure_reader_.second :
-#endif
-        sedp_->publications_reader_.second;
+            reader == sedp_->publications_secure_reader_.first ?
+            sedp_->publications_secure_reader_.second :
+#endif // if HAVE_SECURITY
+            sedp_->publications_reader_.second;
 
-    if(change->kind == ALIVE)
+    if (change->kind == ALIVE)
     {
         add_writer_from_change(reader, change, sedp_);
     }
     else
     {
         //REMOVE WRITER FROM OUR READERS:
-        logInfo(RTPS_EDP,"Disposed Remote Writer, removing...");
+        logInfo(RTPS_EDP, "Disposed Remote Writer, removing...");
         GUID_t writer_guid = iHandle2GUID(change->instanceHandle);
         this->sedp_->mp_PDP->removeWriterProxyData(writer_guid);
     }
@@ -138,17 +139,18 @@ void EDPSimplePUBListener::onNewCacheChangeAdded(
     return;
 }
 
-bool EDPListener::computeKey(CacheChange_t* change)
+bool EDPListener::computeKey(
+        CacheChange_t* change)
 {
     return ParameterList::readInstanceHandleFromCDRMsg(change, PID_ENDPOINT_GUID);
 }
 
 bool EDPListener::ongoingDeserialization(
-    EDP* edp)
+        EDP* edp)
 {
-    EDPServer * pServer = dynamic_cast<EDPServer*>(edp);
+    EDPServer* pServer = dynamic_cast<EDPServer*>(edp);
 
-    if(pServer)
+    if (pServer)
     {
         return pServer->ongoingDeserialization();
     }
@@ -168,7 +170,7 @@ void EDPBaseSUBListener::add_reader_from_change(
     {
         change->instanceHandle = temp_reader_data_.key();
         if (temp_reader_data_.guid().guidPrefix == edp->mp_RTPSParticipant->getGuid().guidPrefix
-            && !ongoingDeserialization(edp))
+                && !ongoingDeserialization(edp))
         {
             logInfo(RTPS_EDP, "From own RTPSParticipant, ignoring");
             return;
@@ -178,24 +180,25 @@ void EDPBaseSUBListener::add_reader_from_change(
             ReaderProxyData* data,
             bool updating,
             const ParticipantProxyData& participant_data)
-        {
-            if (!temp_reader_data_.has_locators())
-            {
-                temp_reader_data_.set_remote_locators(participant_data.default_locators, network, true);
-            }
+                {
+                    if (!temp_reader_data_.has_locators())
+                    {
+                        temp_reader_data_.set_remote_locators(participant_data.default_locators, network, true);
+                    }
 
-            if (updating && !data->is_update_allowed(temp_reader_data_))
-            {
-                logWarning(RTPS_EDP, "Received incompatible update for ReaderQos. reader_guid = " << data->guid());
-            }
-            *data = temp_reader_data_;
-            return true;
-        };
+                    if (updating && !data->is_update_allowed(temp_reader_data_))
+                    {
+                        logWarning(RTPS_EDP,
+                                "Received incompatible update for ReaderQos. reader_guid = " << data->guid());
+                    }
+                    *data = temp_reader_data_;
+                    return true;
+                };
 
         //LOOK IF IS AN UPDATED INFORMATION
         GUID_t participant_guid;
         ReaderProxyData* reader_data =
-            edp->mp_PDP->addReaderProxyData(temp_reader_data_.guid(), participant_guid, copy_data_fun);
+                edp->mp_PDP->addReaderProxyData(temp_reader_data_.guid(), participant_guid, copy_data_fun);
         if (reader_data != nullptr) //ADDED NEW DATA
         {
             // At this point we can release reader lock, cause change is not used
@@ -212,34 +215,34 @@ void EDPBaseSUBListener::add_reader_from_change(
         }
     }
 }
-    
+
 void EDPSimpleSUBListener::onNewCacheChangeAdded(
         RTPSReader* reader,
-        const CacheChange_t * const change_in)
+        const CacheChange_t* const change_in)
 {
     CacheChange_t* change = (CacheChange_t*)change_in;
     //std::lock_guard<std::recursive_mutex> guard(*this->sedp_->subscriptions_reader_.first->getMutex());
-    logInfo(RTPS_EDP,"");
-    if(!computeKey(change))
+    logInfo(RTPS_EDP, "");
+    if (!computeKey(change))
     {
-        logWarning(RTPS_EDP,"Received change with no Key");
+        logWarning(RTPS_EDP, "Received change with no Key");
     }
 
     ReaderHistory* reader_history =
 #if HAVE_SECURITY
-        reader == sedp_->subscriptions_secure_reader_.first ?
-        sedp_->subscriptions_secure_reader_.second :
-#endif
-        sedp_->subscriptions_reader_.second;
+            reader == sedp_->subscriptions_secure_reader_.first ?
+            sedp_->subscriptions_secure_reader_.second :
+#endif // if HAVE_SECURITY
+            sedp_->subscriptions_reader_.second;
 
-    if(change->kind == ALIVE)
+    if (change->kind == ALIVE)
     {
         add_reader_from_change(reader, change, sedp_);
     }
     else
     {
         //REMOVE WRITER FROM OUR READERS:
-        logInfo(RTPS_EDP,"Disposed Remote Reader, removing...");
+        logInfo(RTPS_EDP, "Disposed Remote Reader, removing...");
 
         GUID_t reader_guid = iHandle2GUID(change->instanceHandle);
         this->sedp_->mp_PDP->removeReaderProxyData(reader_guid);
@@ -251,35 +254,39 @@ void EDPSimpleSUBListener::onNewCacheChangeAdded(
     return;
 }
 
-void EDPSimplePUBListener::onWriterChangeReceivedByAll(RTPSWriter* writer, CacheChange_t* change)
+void EDPSimplePUBListener::onWriterChangeReceivedByAll(
+        RTPSWriter* writer,
+        CacheChange_t* change)
 {
     (void)writer;
 
-    if(ChangeKind_t::NOT_ALIVE_DISPOSED_UNREGISTERED == change->kind)
+    if (ChangeKind_t::NOT_ALIVE_DISPOSED_UNREGISTERED == change->kind)
     {
         WriterHistory* writer_history =
 #if HAVE_SECURITY
-            writer == sedp_->publications_secure_writer_.first ?
-            sedp_->publications_secure_writer_.second :
-#endif
-            sedp_->publications_writer_.second;
+                writer == sedp_->publications_secure_writer_.first ?
+                sedp_->publications_secure_writer_.second :
+#endif // if HAVE_SECURITY
+                sedp_->publications_writer_.second;
 
         writer_history->remove_change(change);
     }
 }
 
-void EDPSimpleSUBListener::onWriterChangeReceivedByAll(RTPSWriter* writer, CacheChange_t* change)
+void EDPSimpleSUBListener::onWriterChangeReceivedByAll(
+        RTPSWriter* writer,
+        CacheChange_t* change)
 {
     (void)writer;
 
-    if(ChangeKind_t::NOT_ALIVE_DISPOSED_UNREGISTERED == change->kind)
+    if (ChangeKind_t::NOT_ALIVE_DISPOSED_UNREGISTERED == change->kind)
     {
         WriterHistory* writer_history =
 #if HAVE_SECURITY
-            writer == sedp_->subscriptions_secure_writer_.first ?
-            sedp_->subscriptions_secure_writer_.second :
-#endif
-            sedp_->subscriptions_writer_.second;
+                writer == sedp_->subscriptions_secure_writer_.first ?
+                sedp_->subscriptions_secure_writer_.second :
+#endif // if HAVE_SECURITY
+                sedp_->subscriptions_writer_.second;
 
         writer_history->remove_change(change);
     }
@@ -287,5 +294,5 @@ void EDPSimpleSUBListener::onWriterChangeReceivedByAll(RTPSWriter* writer, Cache
 }
 
 } /* namespace rtps */
-}
+} // namespace fastrtps
 } /* namespace eprosima */

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.h
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.h
@@ -48,7 +48,13 @@ public:
     /**
      * @param change
      */
-    bool computeKey(CacheChange_t* change);
+    bool computeKey(
+            CacheChange_t* change);
+
+protected:
+
+    //! returns true if loading info from persistency database
+    static bool ongoingDeserialization(EDP* edp);
 };
 
 /**

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.h
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.h
@@ -38,13 +38,14 @@ class RTPSReader;
 struct CacheChange_t;
 
 /*!
- * Placeholder class EDPListener 
+ * Placeholder class EDPListener
  * @ingroup DISCOVERY_MODULE
  */
 
 class EDPListener : public ReaderListener, public WriterListener
 {
 public:
+
     /**
      * @param change
      */
@@ -54,7 +55,8 @@ public:
 protected:
 
     //! returns true if loading info from persistency database
-    static bool ongoingDeserialization(EDP* edp);
+    static bool ongoingDeserialization(
+            EDP* edp);
 };
 
 /**
@@ -64,7 +66,9 @@ protected:
 class EDPBasePUBListener : public EDPListener
 {
 public:
-    EDPBasePUBListener(const RemoteLocatorsAllocationAttributes& locators_allocation)
+
+    EDPBasePUBListener(
+            const RemoteLocatorsAllocationAttributes& locators_allocation)
         : temp_writer_data_(
             locators_allocation.max_unicast_locators,
             locators_allocation.max_multicast_locators)
@@ -91,7 +95,9 @@ protected:
 class EDPBaseSUBListener : public EDPListener
 {
 public:
-    EDPBaseSUBListener(const RemoteLocatorsAllocationAttributes& locators_allocation)
+
+    EDPBaseSUBListener(
+            const RemoteLocatorsAllocationAttributes& locators_allocation)
         : temp_reader_data_(
             locators_allocation.max_unicast_locators,
             locators_allocation.max_multicast_locators)
@@ -103,9 +109,9 @@ public:
 protected:
 
     void add_reader_from_change(
-        RTPSReader* reader,
-        CacheChange_t* change,
-        EDP* edp);
+            RTPSReader* reader,
+            CacheChange_t* change,
+            EDP* edp);
 
     //!Temporary structure to avoid allocations
     ReaderProxyData temp_reader_data_;
@@ -117,43 +123,45 @@ protected:
  */
 class EDPSimplePUBListener : public EDPBasePUBListener
 {
-    public:
+public:
 
-        /*!
-          Constructor
-         * @param sedp Pointer to the EDPSimple associated with this listener.
-         */
-        EDPSimplePUBListener(EDPSimple* sedp)
-            : EDPBasePUBListener(sedp->mp_RTPSParticipant->getAttributes().allocation.locators)
-            , sedp_(sedp) 
-        {}
+    /*!
+       Constructor
+     * @param sedp Pointer to the EDPSimple associated with this listener.
+     */
+    EDPSimplePUBListener(
+            EDPSimple* sedp)
+        : EDPBasePUBListener(sedp->mp_RTPSParticipant->getAttributes().allocation.locators)
+        , sedp_(sedp)
+    {
+    }
 
-        virtual ~EDPSimplePUBListener() = default;
+    virtual ~EDPSimplePUBListener() = default;
 
-        /**
-         * Virtual method, 
-         * @param reader
-         * @param change
-         */
-        void onNewCacheChangeAdded(
-                RTPSReader* reader,
-                const CacheChange_t* const  change) override;
+    /**
+     * Virtual method,
+     * @param reader
+     * @param change
+     */
+    void onNewCacheChangeAdded(
+            RTPSReader* reader,
+            const CacheChange_t* const change) override;
 
 
-        /*!
-         * This method is called when all the readers matched with this Writer acknowledge that a cache 
-         * change has been received.
-         * @param writer Pointer to the RTPSWriter.
-         * @param change Pointer to the affected CacheChange_t.
-         */
-        void onWriterChangeReceivedByAll(
-                RTPSWriter* writer,
-                CacheChange_t* change) override;
+    /*!
+     * This method is called when all the readers matched with this Writer acknowledge that a cache
+     * change has been received.
+     * @param writer Pointer to the RTPSWriter.
+     * @param change Pointer to the affected CacheChange_t.
+     */
+    void onWriterChangeReceivedByAll(
+            RTPSWriter* writer,
+            CacheChange_t* change) override;
 
-    protected:
+protected:
 
-        //!Pointer to the EDPSimple
-        EDPSimple* sedp_;
+    //!Pointer to the EDPSimple
+    EDPSimple* sedp_;
 };
 
 /*!
@@ -162,47 +170,48 @@ class EDPSimplePUBListener : public EDPBasePUBListener
  */
 class EDPSimpleSUBListener : public EDPBaseSUBListener
 {
-    public:
+public:
 
-        /*!
-          Constructor
-         * @param sedp Pointer to the EDPSimple associated with this listener.
-         */
-        EDPSimpleSUBListener(EDPSimple* sedp) 
-            : EDPBaseSUBListener(sedp->mp_RTPSParticipant->getAttributes().allocation.locators)
-            , sedp_(sedp)
-        {
-        }
+    /*!
+       Constructor
+     * @param sedp Pointer to the EDPSimple associated with this listener.
+     */
+    EDPSimpleSUBListener(
+            EDPSimple* sedp)
+        : EDPBaseSUBListener(sedp->mp_RTPSParticipant->getAttributes().allocation.locators)
+        , sedp_(sedp)
+    {
+    }
 
-        virtual ~EDPSimpleSUBListener() = default;
+    virtual ~EDPSimpleSUBListener() = default;
 
-        /**
-         * @param reader
-         * @param change
-         */
-        void onNewCacheChangeAdded(
-                RTPSReader* reader,
-                const CacheChange_t* const change) override;
+    /**
+     * @param reader
+     * @param change
+     */
+    void onNewCacheChangeAdded(
+            RTPSReader* reader,
+            const CacheChange_t* const change) override;
 
-        /*!
-         * This method is called when all the readers matched with this Writer acknowledge that a cache 
-         * change has been received.
-         * @param writer Pointer to the RTPSWriter.
-         * @param change Pointer to the affected CacheChange_t.
-         */
-        void onWriterChangeReceivedByAll(
-                RTPSWriter* writer,
-                CacheChange_t* change) override;
+    /*!
+     * This method is called when all the readers matched with this Writer acknowledge that a cache
+     * change has been received.
+     * @param writer Pointer to the RTPSWriter.
+     * @param change Pointer to the affected CacheChange_t.
+     */
+    void onWriterChangeReceivedByAll(
+            RTPSWriter* writer,
+            CacheChange_t* change) override;
 
-    private:
+private:
 
-        //!Pointer to the EDPSimple
-        EDPSimple* sedp_;
+    //!Pointer to the EDPSimple
+    EDPSimple* sedp_;
 };
 
 } /* namespace rtps */
 } /* namespace fastrtps */
 } /* namespace eprosima */
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif /* EDPSIMPLELISTENER_H_ */

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -516,14 +516,12 @@ bool PDPServer::trimPDPWriterHistory()
     std::lock_guard<RecursiveTimedMutex> guardW(mp_PDPWriter->getMutex());
 
     std::copy_if(mp_PDPWriterHistory->changesBegin(),
-        mp_PDPWriterHistory->changesBegin(), std::front_inserter(removal),
-        [this](const CacheChange_t* chan) 
-        { 
+
+    mp_PDPWriterHistory->changesEnd(), std::front_inserter(removal),
+    [this](const CacheChange_t* chan)
+        {
             return _demises.find(chan->instanceHandle) != _demises.cend();
         });
-
-    logInfo(RTPS_PDPSERVER_TRIM,"I've classified the following PDP history data for removal "
-        << std::distance(removal.begin(), removal.end()) );
 
     if (removal.empty())
         return true;
@@ -563,6 +561,12 @@ bool PDPServer::addRelayedChangeToHistory( CacheChange_t& c)
 {
     assert(mp_PDPWriter && c.serializedPayload.max_size);
 
+    // If we are deserializing data then allow process
+    if(ongoingDeserialization())
+    {
+        return true;
+    }
+
     std::lock_guard<RecursiveTimedMutex> lock(mp_PDPWriter->getMutex());
     CacheChange_t * pCh = nullptr;
 
@@ -573,8 +577,11 @@ bool PDPServer::addRelayedChangeToHistory( CacheChange_t& c)
     {
         sid.writer_guid(c.writerGUID);
         sid.sequence_number(c.sequenceNumber);
-        logError(RTPS_PDP, "A DATA(p) received by server " << mp_PDPWriter->getGuid()
-            << " from participant " << c.writerGUID << " without a valid SampleIdentity");
+        logError(RTPS_PDP,
+                "A DATA(p) received by server " << mp_PDPWriter->getGuid()
+                    << " from participant " << c.writerGUID
+                    << " without a valid SampleIdentity");
+        return false;
     }
 
     if (wp.related_sample_identity() == SampleIdentity::unknown())
@@ -667,6 +674,61 @@ std::string PDPServer::GetPersistenceFileName()
 
    return filename.str();
 
+}
+
+//! returns true if loading info from persistency database
+bool PDPServer::ongoingDeserialization()
+{
+    return !mp_sync->messages_enabled_;
+}
+
+void PDPServer::processPersistentData()
+{
+    // Protect the writer, reader doesn't need to be protected because message
+    // reception has not yet been enabled but we must take the mutex because
+    // it's unlock by the listener
+    {
+        StatefulReader* p_PDPReader = static_cast<StatefulReader*>(mp_PDPReader);
+        std::lock_guard<RecursiveTimedMutex> guardR(p_PDPReader->getMutex());
+        std::lock_guard<RecursiveTimedMutex> guardW(mp_PDPWriter->getMutex());
+
+        std::for_each(mp_PDPWriterHistory->changesBegin(),
+            mp_PDPWriterHistory->changesEnd(),
+            [p_PDPReader](CacheChange_t* change)
+        {
+            CacheChange_t* change_to_add = nullptr;
+
+            if (!p_PDPReader->reserveCache(&change_to_add, change->serializedPayload.length)) //Reserve a new cache from the corresponding cache pool
+            {
+                logError(RTPS_PDP, "Problem reserving CacheChange in PDPServer reader");
+                return;
+            }
+
+            if (!change_to_add->copy(change))
+            {
+                logWarning(RTPS_PDP,"Problem copying CacheChange, received data is: " 
+                    << change->serializedPayload.length << " bytes and max size in PDPServer reader"
+                    << " is " << change_to_add->serializedPayload.max_size);
+
+                p_PDPReader->releaseCache(change_to_add);
+                return ;
+            }
+
+            if (!p_PDPReader->change_received(change_to_add, nullptr))
+            {
+                logInfo(RTPS_PDP, "PDPServer couldn't process database data not add change "
+                    << change_to_add->sequenceNumber);
+                p_PDPReader->releaseCache(change_to_add);
+            }
+
+            // change_to_add would be released within change_received
+        });
+    }
+
+    EDPServer* pEDP = dynamic_cast<EDPServer*>(mp_EDP);
+    assert(pEDP);
+
+    pEDP->processPersistentData();
 }
 
 bool PDPServer::all_servers_acknowledge_PDP()

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -498,8 +498,9 @@ bool PDPServer::trimWriterHistory()
 
 bool PDPServer::trimPDPWriterHistory()
 {
-    logInfo(RTPS_PDPSERVER_TRIM, "In trimPDPWriteHistory PDP history count: " << mp_PDPWriterHistory->getHistorySize()
-                                                                              << " demises:" << _demises.size() );
+    std::lock_guard<std::recursive_mutex> guardPDP(*mp_mutex);
+
+    logInfo(RTPS_PDPSERVER_TRIM, "In trimPDPWriteHistory PDP history count: " << mp_PDPWriterHistory->getHistorySize())
 
     // trim demises container
     key_list disposal, aux;
@@ -712,6 +713,7 @@ void PDPServer::processPersistentData()
         StatefulReader* p_PDPReader = static_cast<StatefulReader*>(mp_PDPReader);
         std::lock_guard<RecursiveTimedMutex> guardR(p_PDPReader->getMutex());
         std::lock_guard<RecursiveTimedMutex> guardW(mp_PDPWriter->getMutex());
+        std::lock_guard<std::recursive_mutex> guardP(*getMutex());
 
         // own server instance
         InstanceHandle_t server_key = getLocalParticipantProxyData()->m_key;

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -1062,6 +1062,9 @@ bool PDPServer::remove_remote_participant(
     key_list disposed_publishers, disposed_subscribers;
 
     {
+        // protect reader and writers collections
+        std::lock_guard<std::recursive_mutex> lock(*mp_mutex);
+
         for (ReaderProxyData* rit : pdata->m_readers)
         {
             if (rit->guid() != c_Guid_Unknown)

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -622,9 +622,9 @@ bool PDPServer::addRelayedChangeToHistory(
         // mp_PDPWriterHistory->reserve_Cache(&pCh, DISCOVERY_PARTICIPANT_DATA_MAX_SIZE)
         if (mp_PDPWriterHistory->reserve_Cache(&pCh, c.serializedPayload.max_size) && pCh )
         {
-            if ( _durability == DurabilityKind_t::TRANSIENT_LOCAL )
+            if ( mp_PDPWriter->getAttributes().durabilityKind == DurabilityKind_t::TRANSIENT_LOCAL )
             {
-                // an ordinary server just copy the payload to history
+                // an ordinary server just copies the payload to history
                 pCh->copy(&c);
                 pCh->writerGUID = mp_PDPWriter->getGuid();
                 // keep the original sample identity by using wp

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -560,6 +560,8 @@ bool PDPServer::trimPDPWriterHistory()
             logInfo(RTPS_PDPSERVER_TRIM, "PDPServer is procrastinating DATA("
                     << (pC->kind == ALIVE ? "p" : "p[UD]" ) << ") " "of participant "
                     << pC->instanceHandle << " from history");
+
+            pending.insert(pC->instanceHandle);
         }
     }
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
@@ -39,10 +39,11 @@
 
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
-PDPServerListener::PDPServerListener(PDPServer* in_PDP)
+PDPServerListener::PDPServerListener(
+        PDPServer* in_PDP)
     : PDPListener(in_PDP)
     , parent_server_pdp_(in_PDP)
 {
@@ -54,13 +55,13 @@ void PDPServerListener::onNewCacheChangeAdded(
 {
     CacheChange_t* change = (CacheChange_t*)(change_in);
     GUID_t writer_guid = change->writerGUID;
-    logInfo(RTPS_PDP,"SPDP Message received");
+    logInfo(RTPS_PDP, "SPDP Message received");
 
-    if(change->instanceHandle == c_InstanceHandle_Unknown)
+    if (change->instanceHandle == c_InstanceHandle_Unknown)
     {
-        if(!this->get_key(change))
+        if (!this->get_key(change))
         {
-            logWarning(RTPS_PDP,"Problem getting the key of the change, removing");
+            logWarning(RTPS_PDP, "Problem getting the key of the change, removing");
             parent_pdp_->mp_PDPReaderHistory->remove_change(change);
             return;
         }
@@ -79,11 +80,11 @@ void PDPServerListener::onNewCacheChangeAdded(
     GUID_t guid;
     iHandle2GUID(guid, change->instanceHandle);
 
-    if(change->kind == ALIVE)
+    if (change->kind == ALIVE)
     {
         // Ignore announcement from own RTPSParticipant
         if (guid == parent_pdp_->getRTPSParticipant()->getGuid()
-            && !parent_server_pdp_->ongoingDeserialization() )
+                && !parent_server_pdp_->ongoingDeserialization() )
         {
             logInfo(RTPS_PDP, "Message from own RTPSParticipant, removing");
             parent_pdp_->mp_PDPReaderHistory->remove_change(change);
@@ -94,7 +95,7 @@ void PDPServerListener::onNewCacheChangeAdded(
 
         // Load information on local_data
         CDRMessage_t msg(change->serializedPayload);
-        if(local_data.readFromCDRMessage(&msg, true, parent_pdp_->getRTPSParticipant()->network_factory()))
+        if (local_data.readFromCDRMessage(&msg, true, parent_pdp_->getRTPSParticipant()->network_factory()))
         {
             change->instanceHandle = local_data.m_key;
             guid = local_data.m_guid;
@@ -107,7 +108,7 @@ void PDPServerListener::onNewCacheChangeAdded(
             std::unique_lock<std::recursive_mutex> lock(*parent_pdp_->getMutex());
             for (ParticipantProxyData* it : parent_pdp_->participant_proxies_)
             {
-                if(guid == it->m_guid)
+                if (guid == it->m_guid)
                 {
                     pdata = it;
                     break;
@@ -115,9 +116,9 @@ void PDPServerListener::onNewCacheChangeAdded(
             }
 
             auto status = (pdata == nullptr) ? ParticipantDiscoveryInfo::DISCOVERED_PARTICIPANT :
-                ParticipantDiscoveryInfo::CHANGED_QOS_PARTICIPANT;
+                    ParticipantDiscoveryInfo::CHANGED_QOS_PARTICIPANT;
 
-            if(pdata == nullptr)
+            if (pdata == nullptr)
             {
                 logInfo(RTPS_PDP, "Registering a new participant: " << writer_guid);
 
@@ -184,7 +185,7 @@ void PDPServerListener::onNewCacheChangeAdded(
 
         std::unique_ptr<PDPServer::InPDPCallback> guard = parent_server_pdp_->signalCallback();
 
-        if(parent_pdp_->remove_remote_participant(guid, ParticipantDiscoveryInfo::REMOVED_PARTICIPANT))
+        if (parent_pdp_->remove_remote_participant(guid, ParticipantDiscoveryInfo::REMOVED_PARTICIPANT))
         {
             return; // all changes related with this participant have been removed from history by removeRemoteParticipant
         }
@@ -195,7 +196,6 @@ void PDPServerListener::onNewCacheChangeAdded(
 
     return;
 }
-
 
 } /* namespace rtps */
 } /* namespace fastrtps */

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
@@ -119,20 +119,18 @@ void PDPServerListener::onNewCacheChangeAdded(
 
             if (pdata == nullptr)
             {
-                // On deserialization we must pretend the CacheChange was send by the client
-                GUID_t aux_writer_guid =
-                        parent_server_pdp_->ongoingDeserialization() ? local_data.m_guid : writer_guid;
-
-                logInfo(RTPS_PDP, "Registering a new participant: " << aux_writer_guid);
+                logInfo(RTPS_PDP, "Registering a new participant: " <<
+                        change->write_params.sample_identity().writer_guid());
 
                 // Create a new one when not found
-                pdata = parent_pdp_->createParticipantProxyData(local_data, aux_writer_guid);
+                pdata = parent_pdp_->createParticipantProxyData(local_data, writer_guid);
+                lock.unlock();
+
                 if (pdata != nullptr)
                 {
-                    lock.unlock();
 
                     // Dismiss any client data relayed by a server
-                    if (pdata->m_guid.guidPrefix == aux_writer_guid.guidPrefix)
+                    if (pdata->m_guid.guidPrefix == writer_guid.guidPrefix)
                     {
                         // This call would be needed again if the clients known not the server prefix
                         //  parent_pdp_->announceParticipantState(false);

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
@@ -69,6 +69,8 @@ void PDPServerListener::onNewCacheChangeAdded(
     // update the PDP Writer with this reader info
     if (!parent_server_pdp_->addRelayedChangeToHistory(*change))
     {
+        logInfo(RTPS_PDP, "Ignoring a DATA(p) that was already received");
+
         parent_pdp_->mp_PDPReaderHistory->remove_change(change);
         return; // already there
     }
@@ -116,6 +118,8 @@ void PDPServerListener::onNewCacheChangeAdded(
 
             if(pdata == nullptr)
             {
+                logInfo(RTPS_PDP, "Registering a new participant: " << writer_guid);
+
                 // Create a new one when not found
                 pdata = parent_pdp_->createParticipantProxyData(local_data, writer_guid);
                 if (pdata != nullptr)

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
@@ -184,8 +184,6 @@ void PDPServerListener::onNewCacheChangeAdded(
             return;
         }
 
-        std::unique_ptr<PDPServer::InPDPCallback> guard = parent_server_pdp_->signalCallback();
-
         if (parent_pdp_->remove_remote_participant(guid, ParticipantDiscoveryInfo::REMOVED_PARTICIPANT))
         {
             return; // all changes related with this participant have been removed from history by removeRemoteParticipant

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
@@ -82,7 +82,8 @@ void PDPServerListener::onNewCacheChangeAdded(
     if(change->kind == ALIVE)
     {
         // Ignore announcement from own RTPSParticipant
-        if (guid == parent_pdp_->getRTPSParticipant()->getGuid())
+        if (guid == parent_pdp_->getRTPSParticipant()->getGuid()
+            && !parent_server_pdp_->ongoingDeserialization() )
         {
             logInfo(RTPS_PDP, "Message from own RTPSParticipant, removing");
             parent_pdp_->mp_PDPReaderHistory->remove_change(change);

--- a/src/cpp/rtps/builtin/discovery/participant/timedevent/DServerEvent.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/timedevent/DServerEvent.cpp
@@ -29,31 +29,32 @@
 #include <fastrtps/rtps/builtin/discovery/participant/PDPServer.h>
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
 
 DServerEvent::DServerEvent(
         PDPServer* p_PDP,
         double interval)
-    : TimedEvent(p_PDP->getRTPSParticipant()->getEventResource(), 
-        [this](EventCode code)
-        {
-            return event(code);
-        }, interval)
+    : TimedEvent(p_PDP->getRTPSParticipant()->getEventResource(),
+            [this](EventCode code)
+            {
+                return event(code);
+            }, interval)
     , mp_PDP(p_PDP)
     , messages_enabled_(false)
-    {
+{
 
-    }
+}
 
 DServerEvent::~DServerEvent()
 {
 }
 
-bool DServerEvent::event(EventCode code)
+bool DServerEvent::event(
+        EventCode code)
 {
-    if(code == EVENT_SUCCESS)
+    if (code == EVENT_SUCCESS)
     {
         logInfo(SERVER_PDP_THREAD, "Server " << mp_PDP->getRTPSParticipant()->getGuid() << " DServerEvent Period");
 
@@ -62,7 +63,7 @@ bool DServerEvent::event(EventCode code)
         // messges_enabled is only modified from this thread
         if (!messages_enabled_)
         {
-            if(mp_PDP->_durability == TRANSIENT)
+            if (mp_PDP->_durability == TRANSIENT)
             {
                 // backup servers must process its own data before before receiving any callbacks
                 mp_PDP->processPersistentData();
@@ -84,12 +85,15 @@ bool DServerEvent::event(EventCode code)
             }
             else
             {
-                logInfo(SERVER_PDP_THREAD, "Server " << mp_PDP->getRTPSParticipant()->getGuid() << " not all servers acknowledge PDP info")
+                logInfo(SERVER_PDP_THREAD,
+                        "Server " << mp_PDP->getRTPSParticipant()->getGuid() <<
+                        " not all servers acknowledge PDP info")
                 restart = true;
             }
         }
         else
-        {   // awake the other servers
+        {
+            // awake the other servers
             mp_PDP->announceParticipantState(false);
             restart = true;
         }
@@ -104,15 +108,20 @@ bool DServerEvent::event(EventCode code)
                 // Whenever new clients appear restart_timer()
                 // see PDPServer::queueParticipantForEDPMatch
 
-                logInfo(SERVER_PDP_THREAD, "Server " << mp_PDP->getRTPSParticipant()->getGuid() << " clients EDP points matched")
+                logInfo(SERVER_PDP_THREAD,
+                        "Server " << mp_PDP->getRTPSParticipant()->getGuid() <<
+                        " clients EDP points matched")
             }
             else
-            {   // keep trying the match
-                restart = true;  
+            {
+                // keep trying the match
+                restart = true;
 
-                logInfo(SERVER_PDP_THREAD, "Server " << mp_PDP->getRTPSParticipant()->getGuid() << " not all clients acknowledge PDP info")
+                logInfo(SERVER_PDP_THREAD,
+                        "Server " << mp_PDP->getRTPSParticipant()->getGuid() <<
+                        " not all clients acknowledge PDP info")
             }
-        }  
+        }
 
         if (mp_PDP->pendingHistoryCleaning())
         {
@@ -124,9 +133,9 @@ bool DServerEvent::event(EventCode code)
         return restart;
 
     }
-    else if(code == EVENT_ABORT)
+    else if (code == EVENT_ABORT)
     {
-        logInfo(SERVER_PDP_THREAD,"DServerEvent aborted");
+        logInfo(SERVER_PDP_THREAD, "DServerEvent aborted");
     }
 
     return false;

--- a/src/cpp/rtps/builtin/discovery/participant/timedevent/DServerEvent.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/timedevent/DServerEvent.cpp
@@ -62,6 +62,12 @@ bool DServerEvent::event(EventCode code)
         // messges_enabled is only modified from this thread
         if (!messages_enabled_)
         {
+            if(mp_PDP->_durability == TRANSIENT)
+            {
+                // backup servers must process its own data before before receiving any callbacks
+                mp_PDP->processPersistentData();
+            }
+
             messages_enabled_ = true;
             mp_PDP->getRTPSParticipant()->enableReader(mp_PDP->mp_PDPReader);
         }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -56,10 +56,11 @@
 #include <fastrtps/log/Log.h>
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
-static EntityId_t TrustedWriter(const EntityId_t& reader)
+static EntityId_t TrustedWriter(
+        const EntityId_t& reader)
 {
     return
         (reader == c_EntityId_SPDPReader) ? c_EntityId_SPDPWriter :
@@ -69,7 +70,8 @@ static EntityId_t TrustedWriter(const EntityId_t& reader)
         c_EntityId_Unknown;
 }
 
-Locator_t& RTPSParticipantImpl::applyLocatorAdaptRule(Locator_t& loc)
+Locator_t& RTPSParticipantImpl::applyLocatorAdaptRule(
+        Locator_t& loc)
 {
     // This is a completely made up rule
     // It is transport responsability to interpret this new port.
@@ -91,7 +93,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     , IdCounter(0)
 #if HAVE_SECURITY
     , m_security_manager(this)
-#endif
+#endif // if HAVE_SECURITY
     , mp_participantListener(plisten)
     , mp_userParticipant(par)
     , mp_mutex(new std::recursive_mutex())
@@ -114,21 +116,22 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     // Client-server discovery protocol requires that every TCP transport has a listening port
     switch (PParam.builtin.discovery_config.discoveryProtocol)
     {
-    case DiscoveryProtocol::CLIENT:
-    case DiscoveryProtocol::SERVER:
-    case DiscoveryProtocol::BACKUP:
-        // Verify if listening ports are provided
-        for (auto& transportDescriptor : PParam.userTransports)
-        {
-            TCPTransportDescriptor * pT = dynamic_cast<TCPTransportDescriptor *>(transportDescriptor.get());
-            if (pT && pT->listening_ports.empty())
+        case DiscoveryProtocol::CLIENT:
+        case DiscoveryProtocol::SERVER:
+        case DiscoveryProtocol::BACKUP:
+            // Verify if listening ports are provided
+            for (auto& transportDescriptor : PParam.userTransports)
             {
-                logError(RTPS_PARTICIPANT, "Participant " << m_att.getName() << " with GUID " << m_guid
-                    << " tries to use discovery server over TCP without providing a proper listening port");
+                TCPTransportDescriptor* pT = dynamic_cast<TCPTransportDescriptor*>(transportDescriptor.get());
+                if (pT && pT->listening_ports.empty())
+                {
+                    logError(RTPS_PARTICIPANT,
+                            "Participant " << m_att.getName() << " with GUID " << m_guid
+                                           << " tries to use discovery server over TCP without providing a proper listening port");
+                }
             }
-        }
-    default:
-        break;
+        default:
+            break;
     }
 
 
@@ -154,33 +157,33 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     // Creation of metatraffic locator and receiver resources
     uint32_t metatraffic_multicast_port = m_att.port.getMulticastPort(m_att.builtin.domainId);
     uint32_t metatraffic_unicast_port = m_att.port.getUnicastPort(m_att.builtin.domainId,
-        static_cast<uint32_t>(m_att.participantID));
+                    static_cast<uint32_t>(m_att.participantID));
 
     /* INSERT DEFAULT MANDATORY MULTICAST LOCATORS HERE */
     if (m_att.builtin.metatrafficMulticastLocatorList.empty() && m_att.builtin.metatrafficUnicastLocatorList.empty())
     {
         m_network_Factory.getDefaultMetatrafficMulticastLocators(m_att.builtin.metatrafficMulticastLocatorList,
-            metatraffic_multicast_port);
+                metatraffic_multicast_port);
         m_network_Factory.NormalizeLocators(m_att.builtin.metatrafficMulticastLocatorList);
 
         m_network_Factory.getDefaultMetatrafficUnicastLocators(m_att.builtin.metatrafficUnicastLocatorList,
-            metatraffic_unicast_port);
+                metatraffic_unicast_port);
         m_network_Factory.NormalizeLocators(m_att.builtin.metatrafficUnicastLocatorList);
     }
     else
     {
         std::for_each(m_att.builtin.metatrafficMulticastLocatorList.begin(),
-            m_att.builtin.metatrafficMulticastLocatorList.end(), [&](Locator_t& locator)
-        {
-            m_network_Factory.fillMetatrafficMulticastLocator(locator, metatraffic_multicast_port);
-        });
+                m_att.builtin.metatrafficMulticastLocatorList.end(), [&](Locator_t& locator)
+                {
+                    m_network_Factory.fillMetatrafficMulticastLocator(locator, metatraffic_multicast_port);
+                });
         m_network_Factory.NormalizeLocators(m_att.builtin.metatrafficMulticastLocatorList);
 
         std::for_each(m_att.builtin.metatrafficUnicastLocatorList.begin(),
-            m_att.builtin.metatrafficUnicastLocatorList.end(), [&](Locator_t& locator)
-        {
-            m_network_Factory.fillMetatrafficUnicastLocator(locator, metatraffic_unicast_port);
-        });
+                m_att.builtin.metatrafficUnicastLocatorList.end(), [&](Locator_t& locator)
+                {
+                    m_network_Factory.fillMetatrafficUnicastLocator(locator, metatraffic_unicast_port);
+                });
         m_network_Factory.NormalizeLocators(m_att.builtin.metatrafficUnicastLocatorList);
     }
 
@@ -195,10 +198,10 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         initial_peers.swap(m_att.builtin.initialPeersList);
 
         std::for_each(initial_peers.begin(), initial_peers.end(),
-            [&](Locator_t& locator)
-            {
-               m_network_Factory.configureInitialPeerLocator(locator, m_att);
-            });
+                [&](Locator_t& locator)
+                {
+                    m_network_Factory.configureInitialPeerLocator(locator, m_att);
+                });
     }
 
     // Creation of user locator and receiver resources
@@ -209,7 +212,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
        of Endpoints, we make some for Unicast only.
        If there is at least one listen locator of any kind, we do not create any default ones.
        If there are no sending locators defined, we create default ones for the transports we implement.
-       */
+     */
     if (m_att.defaultUnicastLocatorList.empty() && m_att.defaultMulticastLocatorList.empty())
     {
         //Default Unicast Locators in case they have not been provided
@@ -222,22 +225,22 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     {
         // Locator with port 0, calculate port.
         std::for_each(m_att.defaultUnicastLocatorList.begin(), m_att.defaultUnicastLocatorList.end(),
-            [&](Locator_t& loc)
-        {
-            m_network_Factory.fillDefaultUnicastLocator(loc, m_att);
-        });
+                [&](Locator_t& loc)
+                {
+                    m_network_Factory.fillDefaultUnicastLocator(loc, m_att);
+                });
 
     }
 
     // Normalize unicast locators.
     m_network_Factory.NormalizeLocators(m_att.defaultUnicastLocatorList);
-    
+
     if (!hasLocatorsDefined)
     {
         logInfo(RTPS_PARTICIPANT, m_att.getName() << " Created with NO default Unicast Locator List, adding Locators:"
-            << m_att.defaultUnicastLocatorList);
+                                                  << m_att.defaultUnicastLocatorList);
     }
-    
+
     createReceiverResources(m_att.builtin.metatrafficMulticastLocatorList, true);
     createReceiverResources(m_att.builtin.metatrafficUnicastLocatorList, true);
 
@@ -247,8 +250,9 @@ RTPSParticipantImpl::RTPSParticipantImpl(
 #if HAVE_SECURITY
     // Start security
     // TODO(Ricardo) Get returned value in future.
-    m_security_manager_initialized = m_security_manager.init(security_attributes_, PParam.properties, m_is_security_active);
-#endif
+    m_security_manager_initialized = m_security_manager.init(security_attributes_, PParam.properties,
+                    m_is_security_active);
+#endif // if HAVE_SECURITY
 
     mp_builtinProtocols = new BuiltinProtocols();
 
@@ -279,18 +283,18 @@ void RTPSParticipantImpl::disable()
     m_network_Factory.Shutdown();
 
     // Safely abort threads.
-    for(auto& block : m_receiverResourcelist)
+    for (auto& block : m_receiverResourcelist)
     {
         block.Receiver->UnregisterReceiver(block.mp_receiver);
         block.disable();
     }
 
-    while(m_userReaderList.size() > 0)
+    while (m_userReaderList.size() > 0)
     {
         deleteUserEndpoint(static_cast<Endpoint*>(*m_userReaderList.begin()));
     }
 
-    while(m_userWriterList.size() > 0)
+    while (m_userWriterList.size() > 0)
     {
         deleteUserEndpoint(static_cast<Endpoint*>(*m_userWriterList.begin()));
     }
@@ -317,7 +321,7 @@ RTPSParticipantImpl::~RTPSParticipantImpl()
 
 #if HAVE_SECURITY
     m_security_manager.destroy();
-#endif
+#endif // if HAVE_SECURITY
 
     // Destruct message receivers
     for (auto& block : m_receiverResourcelist)
@@ -347,20 +351,20 @@ bool RTPSParticipantImpl::createWriter(
         bool isBuiltin)
 {
     std::string type = (param.endpoint.reliabilityKind == RELIABLE) ? "RELIABLE" :"BEST_EFFORT";
-    logInfo(RTPS_PARTICIPANT," of type " << type);
+    logInfo(RTPS_PARTICIPANT, " of type " << type);
     EntityId_t entId;
-    if(entityId == c_EntityId_Unknown)
+    if (entityId == c_EntityId_Unknown)
     {
-        if(param.endpoint.topicKind == NO_KEY)
+        if (param.endpoint.topicKind == NO_KEY)
         {
             entId.value[3] = 0x03;
         }
-        else if(param.endpoint.topicKind == WITH_KEY)
+        else if (param.endpoint.topicKind == WITH_KEY)
         {
             entId.value[3] = 0x02;
         }
         uint32_t idnum;
-        if(param.endpoint.getEntityID() > 0)
+        if (param.endpoint.getEntityID() > 0)
         {
             idnum = static_cast<uint32_t>(param.endpoint.getEntityID());
         }
@@ -374,9 +378,9 @@ bool RTPSParticipantImpl::createWriter(
         entId.value[2] = c[0];
         entId.value[1] = c[1];
         entId.value[0] = c[2];
-        if(this->existsEntityId(entId, WRITER))
+        if (this->existsEntityId(entId, WRITER))
         {
-            logError(RTPS_PARTICIPANT,"A writer with the same entityId already exists in this RTPSParticipant");
+            logError(RTPS_PARTICIPANT, "A writer with the same entityId already exists in this RTPSParticipant");
             return false;
         }
     }
@@ -384,26 +388,28 @@ bool RTPSParticipantImpl::createWriter(
     {
         entId = entityId;
     }
-    if(!param.endpoint.unicastLocatorList.isValid())
+    if (!param.endpoint.unicastLocatorList.isValid())
     {
-        logError(RTPS_PARTICIPANT,"Unicast Locator List for Writer contains invalid Locator");
+        logError(RTPS_PARTICIPANT, "Unicast Locator List for Writer contains invalid Locator");
         return false;
     }
-    if(!param.endpoint.multicastLocatorList.isValid())
+    if (!param.endpoint.multicastLocatorList.isValid())
     {
-        logError(RTPS_PARTICIPANT,"Multicast Locator List for Writer contains invalid Locator");
+        logError(RTPS_PARTICIPANT, "Multicast Locator List for Writer contains invalid Locator");
         return false;
     }
-    if(!param.endpoint.remoteLocatorList.isValid())
+    if (!param.endpoint.remoteLocatorList.isValid())
     {
-        logError(RTPS_PARTICIPANT,"Remote Locator List for Writer contains invalid Locator");
+        logError(RTPS_PARTICIPANT, "Remote Locator List for Writer contains invalid Locator");
         return false;
     }
     if (((param.throughputController.bytesPerPeriod != UINT32_MAX && param.throughputController.periodMillisecs != 0) ||
-        (m_att.throughputController.bytesPerPeriod != UINT32_MAX && m_att.throughputController.periodMillisecs != 0))
-        && param.mode != ASYNCHRONOUS_WRITER)
+            (m_att.throughputController.bytesPerPeriod != UINT32_MAX &&
+            m_att.throughputController.periodMillisecs != 0))
+            && param.mode != ASYNCHRONOUS_WRITER)
     {
-        logError(RTPS_PARTICIPANT, "Writer has to be configured to publish asynchronously, because a flowcontroller was configured");
+        logError(RTPS_PARTICIPANT,
+                "Writer has to be configured to publish asynchronously, because a flowcontroller was configured");
         return false;
     }
 
@@ -412,8 +418,8 @@ bool RTPSParticipantImpl::createWriter(
     if (param.endpoint.persistence_guid == c_Guid_Unknown && m_persistence_guid != c_Guid_Unknown)
     {
         param.endpoint.persistence_guid = GUID_t(
-                                                m_persistence_guid.guidPrefix,
-                                                entityId);
+            m_persistence_guid.guidPrefix,
+            entityId);
     }
 
     // Get persistence service
@@ -431,18 +437,18 @@ bool RTPSParticipantImpl::createWriter(
     normalize_endpoint_locators(param.endpoint);
 
     RTPSWriter* SWriter = nullptr;
-    GUID_t guid(m_guid.guidPrefix,entId);
+    GUID_t guid(m_guid.guidPrefix, entId);
     if (param.endpoint.reliabilityKind == BEST_EFFORT)
     {
         SWriter = (persistence == nullptr) ?
-            new StatelessWriter(this, guid, param, hist, listen) :
-            new StatelessPersistentWriter(this, guid, param, hist, listen, persistence);
+                new StatelessWriter(this, guid, param, hist, listen) :
+                new StatelessPersistentWriter(this, guid, param, hist, listen, persistence);
     }
     else if (param.endpoint.reliabilityKind == RELIABLE)
     {
         SWriter = (persistence == nullptr) ?
-            new StatefulWriter(this, guid, param, hist, listen) :
-            new StatefulPersistentWriter(this, guid, param, hist, listen, persistence);
+                new StatefulWriter(this, guid, param, hist, listen) :
+                new StatefulPersistentWriter(this, guid, param, hist, listen, persistence);
     }
 
     // restore attributes
@@ -454,10 +460,10 @@ bool RTPSParticipantImpl::createWriter(
     }
 
 #if HAVE_SECURITY
-    if(!isBuiltin)
+    if (!isBuiltin)
     {
-        if(!m_security_manager.register_local_writer(SWriter->getGuid(),
-                    param.endpoint.properties, SWriter->getAttributes().security_attributes()))
+        if (!m_security_manager.register_local_writer(SWriter->getGuid(),
+                param.endpoint.properties, SWriter->getAttributes().security_attributes()))
         {
             delete(SWriter);
             return false;
@@ -465,14 +471,14 @@ bool RTPSParticipantImpl::createWriter(
     }
     else
     {
-        if(!m_security_manager.register_local_builtin_writer(SWriter->getGuid(),
-                    SWriter->getAttributes().security_attributes()))
+        if (!m_security_manager.register_local_builtin_writer(SWriter->getGuid(),
+                SWriter->getAttributes().security_attributes()))
         {
             delete(SWriter);
             return false;
         }
     }
-#endif
+#endif // if HAVE_SECURITY
 
     createSendResources(SWriter);
     if (param.endpoint.reliabilityKind == RELIABLE)
@@ -502,7 +508,6 @@ bool RTPSParticipantImpl::createWriter(
     return true;
 }
 
-
 bool RTPSParticipantImpl::createReader(
         RTPSReader** ReaderOut,
         ReaderAttributes& param,
@@ -513,9 +518,9 @@ bool RTPSParticipantImpl::createReader(
         bool enable)
 {
     std::string type = (param.endpoint.reliabilityKind == RELIABLE) ? "RELIABLE" :"BEST_EFFORT";
-    logInfo(RTPS_PARTICIPANT," of type " << type);
+    logInfo(RTPS_PARTICIPANT, " of type " << type);
     EntityId_t entId;
-    if(entityId== c_EntityId_Unknown)
+    if (entityId == c_EntityId_Unknown)
     {
         if (param.endpoint.topicKind == NO_KEY)
         {
@@ -540,9 +545,9 @@ bool RTPSParticipantImpl::createReader(
         entId.value[2] = c[0];
         entId.value[1] = c[1];
         entId.value[0] = c[2];
-        if(this->existsEntityId(entId,WRITER))
+        if (this->existsEntityId(entId, WRITER))
         {
-            logError(RTPS_PARTICIPANT,"A reader with the same entityId already exists in this RTPSParticipant");
+            logError(RTPS_PARTICIPANT, "A reader with the same entityId already exists in this RTPSParticipant");
             return false;
         }
     }
@@ -550,19 +555,19 @@ bool RTPSParticipantImpl::createReader(
     {
         entId = entityId;
     }
-    if(!param.endpoint.unicastLocatorList.isValid())
+    if (!param.endpoint.unicastLocatorList.isValid())
     {
-        logError(RTPS_PARTICIPANT,"Unicast Locator List for Reader contains invalid Locator");
+        logError(RTPS_PARTICIPANT, "Unicast Locator List for Reader contains invalid Locator");
         return false;
     }
-    if(!param.endpoint.multicastLocatorList.isValid())
+    if (!param.endpoint.multicastLocatorList.isValid())
     {
-        logError(RTPS_PARTICIPANT,"Multicast Locator List for Reader contains invalid Locator");
+        logError(RTPS_PARTICIPANT, "Multicast Locator List for Reader contains invalid Locator");
         return false;
     }
-    if(!param.endpoint.remoteLocatorList.isValid())
+    if (!param.endpoint.remoteLocatorList.isValid())
     {
-        logError(RTPS_PARTICIPANT,"Remote Locator List for Reader contains invalid Locator");
+        logError(RTPS_PARTICIPANT, "Remote Locator List for Reader contains invalid Locator");
         return false;
     }
 
@@ -581,18 +586,18 @@ bool RTPSParticipantImpl::createReader(
     normalize_endpoint_locators(param.endpoint);
 
     RTPSReader* SReader = nullptr;
-    GUID_t guid(m_guid.guidPrefix,entId);
+    GUID_t guid(m_guid.guidPrefix, entId);
     if (param.endpoint.reliabilityKind == BEST_EFFORT)
     {
         SReader = (persistence == nullptr) ?
-            new StatelessReader(this, guid, param, hist, listen) :
-            new StatelessPersistentReader(this, guid, param, hist, listen, persistence);
+                new StatelessReader(this, guid, param, hist, listen) :
+                new StatelessPersistentReader(this, guid, param, hist, listen, persistence);
     }
     else if (param.endpoint.reliabilityKind == RELIABLE)
     {
         SReader = (persistence == nullptr) ?
-            new StatefulReader(this, guid, param, hist, listen) :
-            new StatefulPersistentReader(this, guid, param, hist, listen, persistence);
+                new StatefulReader(this, guid, param, hist, listen) :
+                new StatefulPersistentReader(this, guid, param, hist, listen, persistence);
     }
 
     if (SReader == nullptr)
@@ -602,10 +607,10 @@ bool RTPSParticipantImpl::createReader(
 
 #if HAVE_SECURITY
 
-    if(!isBuiltin)
+    if (!isBuiltin)
     {
-        if(!m_security_manager.register_local_reader(SReader->getGuid(),
-                    param.endpoint.properties, SReader->getAttributes().security_attributes()))
+        if (!m_security_manager.register_local_reader(SReader->getGuid(),
+                param.endpoint.properties, SReader->getAttributes().security_attributes()))
         {
             delete(SReader);
             return false;
@@ -613,14 +618,14 @@ bool RTPSParticipantImpl::createReader(
     }
     else
     {
-        if(!m_security_manager.register_local_builtin_reader(SReader->getGuid(),
-                    SReader->getAttributes().security_attributes()))
+        if (!m_security_manager.register_local_builtin_reader(SReader->getGuid(),
+                SReader->getAttributes().security_attributes()))
         {
             delete(SReader);
             return false;
         }
     }
-#endif
+#endif // if HAVE_SECURITY
 
     if (param.endpoint.reliabilityKind == RELIABLE)
     {
@@ -688,7 +693,8 @@ RTPSWriter* RTPSParticipantImpl::find_local_writer(
     return nullptr;
 }
 
-bool RTPSParticipantImpl::enableReader(RTPSReader *reader)
+bool RTPSParticipantImpl::enableReader(
+        RTPSReader* reader)
 {
     if (!assignEndpointListenResources(reader))
     {
@@ -698,7 +704,8 @@ bool RTPSParticipantImpl::enableReader(RTPSReader *reader)
 }
 
 // Avoid to receive PDPSimple reader a DATA while calling ~PDPSimple and EDP was destroy already.
-void RTPSParticipantImpl::disableReader(RTPSReader *reader)
+void RTPSParticipantImpl::disableReader(
+        RTPSReader* reader)
 {
     m_receiverResourcelistMutex.lock();
     for (auto it = m_receiverResourcelist.begin(); it != m_receiverResourcelist.end(); ++it)
@@ -708,26 +715,37 @@ void RTPSParticipantImpl::disableReader(RTPSReader *reader)
     m_receiverResourcelistMutex.unlock();
 }
 
-bool RTPSParticipantImpl::registerWriter(RTPSWriter* Writer, const TopicAttributes& topicAtt, const WriterQos& wqos)
+bool RTPSParticipantImpl::registerWriter(
+        RTPSWriter* Writer,
+        const TopicAttributes& topicAtt,
+        const WriterQos& wqos)
 {
     return this->mp_builtinProtocols->addLocalWriter(Writer, topicAtt, wqos);
 }
 
-bool RTPSParticipantImpl::registerReader(RTPSReader* reader, const TopicAttributes& topicAtt, const ReaderQos& rqos)
+bool RTPSParticipantImpl::registerReader(
+        RTPSReader* reader,
+        const TopicAttributes& topicAtt,
+        const ReaderQos& rqos)
 {
     return this->mp_builtinProtocols->addLocalReader(reader, topicAtt, rqos);
 }
 
-bool RTPSParticipantImpl::updateLocalWriter(RTPSWriter* Writer, const TopicAttributes& topicAtt, const WriterQos& wqos)
+bool RTPSParticipantImpl::updateLocalWriter(
+        RTPSWriter* Writer,
+        const TopicAttributes& topicAtt,
+        const WriterQos& wqos)
 {
     return this->mp_builtinProtocols->updateLocalWriter(Writer, topicAtt, wqos);
 }
 
-bool RTPSParticipantImpl::updateLocalReader(RTPSReader* reader, const TopicAttributes& topicAtt, const ReaderQos& rqos)
+bool RTPSParticipantImpl::updateLocalReader(
+        RTPSReader* reader,
+        const TopicAttributes& topicAtt,
+        const ReaderQos& rqos)
 {
     return this->mp_builtinProtocols->updateLocalReader(reader, topicAtt, rqos);
 }
-
 
 /*
  *
@@ -737,7 +755,9 @@ bool RTPSParticipantImpl::updateLocalReader(RTPSReader* reader, const TopicAttri
  */
 
 
-bool RTPSParticipantImpl::existsEntityId(const EntityId_t& ent,EndpointKind_t kind) const
+bool RTPSParticipantImpl::existsEntityId(
+        const EntityId_t& ent,
+        EndpointKind_t kind) const
 {
     if (kind == WRITER)
     {
@@ -762,20 +782,20 @@ bool RTPSParticipantImpl::existsEntityId(const EntityId_t& ent,EndpointKind_t ki
     return false;
 }
 
-
 /*
  *
  * RECEIVER RESOURCE METHODS
  *
  */
-bool RTPSParticipantImpl::assignEndpointListenResources(Endpoint* endp)
+bool RTPSParticipantImpl::assignEndpointListenResources(
+        Endpoint* endp)
 {
     //Tag the endpoint with the ReceiverResources
     bool valid = true;
 
     /* No need to check for emptiness on the lists, as it was already done on part function
        In case are using the default list of Locators they have already been embedded to the parameters
-    */
+     */
 
     //UNICAST
     assignEndpoint2LocatorList(endp, endp->getAttributes().unicastLocatorList);
@@ -784,17 +804,18 @@ bool RTPSParticipantImpl::assignEndpointListenResources(Endpoint* endp)
     return valid;
 }
 
-bool RTPSParticipantImpl::createAndAssociateReceiverswithEndpoint(Endpoint * pend)
+bool RTPSParticipantImpl::createAndAssociateReceiverswithEndpoint(
+        Endpoint* pend)
 {
     /*	This function...
         - Asks the network factory for new resources
         - Encapsulates the new resources within the ReceiverControlBlock list
         - Associated the endpoint to the new elements in the list
         - Launches the listener thread
-    */
+     */
     // 1 - Ask the network factory to generate the elements that do still not exist
-    std::vector<ReceiverResource> newItems;							//Store the newly created elements
-    std::vector<ReceiverResource> newItemsBuffer;					//Store intermediate results
+    std::vector<ReceiverResource> newItems;                         //Store the newly created elements
+    std::vector<ReceiverResource> newItemsBuffer;                   //Store intermediate results
     //Iterate through the list of unicast and multicast locators the endpoint has... unless its empty
     //In that case, just use the standard
     if (pend->getAttributes().unicastLocatorList.empty() && pend->getAttributes().multicastLocatorList.empty())
@@ -810,7 +831,9 @@ bool RTPSParticipantImpl::createAndAssociateReceiverswithEndpoint(Endpoint * pen
     return true;
 }
 
-bool RTPSParticipantImpl::assignEndpoint2LocatorList(Endpoint* endp, LocatorList_t& list)
+bool RTPSParticipantImpl::assignEndpoint2LocatorList(
+        Endpoint* endp,
+        LocatorList_t& list)
 {
     /* Note:
        The previous version of this function associated (or created) ListenResources and added the endpoint to them.
@@ -819,7 +842,7 @@ bool RTPSParticipantImpl::assignEndpoint2LocatorList(Endpoint* endp, LocatorList
        This has been removed because it is considered redundant. For ReceiveResources that listen on multiple interfaces, only
        one of the supported Locators is needed to make the match, and the case of new ListenResources being created has been removed
        since its the NetworkFactory the one that takes care of Resource creation.
-       */
+     */
     LocatorList_t finalList;
     for (auto lit = list.begin(); lit != list.end(); ++lit)
     {
@@ -844,7 +867,8 @@ bool RTPSParticipantImpl::assignEndpoint2LocatorList(Endpoint* endp, LocatorList
     return true;
 }
 
-bool RTPSParticipantImpl::createSendResources(Endpoint *pend)
+bool RTPSParticipantImpl::createSendResources(
+        Endpoint* pend)
 {
     if (pend->m_att.remoteLocatorList.empty())
     {
@@ -857,7 +881,7 @@ bool RTPSParticipantImpl::createSendResources(Endpoint *pend)
     //Output locators have been specified, create them
     for (auto it = pend->m_att.remoteLocatorList.begin(); it != pend->m_att.remoteLocatorList.end(); ++it)
     {
-        if(!m_network_Factory.build_send_resources(send_resource_list_, (*it)))
+        if (!m_network_Factory.build_send_resources(send_resource_list_, (*it)))
         {
             logWarning(RTPS_PARTICIPANT, "Cannot create send resource for endpoint remote locator (" <<
                     pend->getGuid() << ", " << (*it) << ")");
@@ -867,9 +891,11 @@ bool RTPSParticipantImpl::createSendResources(Endpoint *pend)
     return true;
 }
 
-void RTPSParticipantImpl::createReceiverResources(LocatorList_t& Locator_list, bool ApplyMutation)
+void RTPSParticipantImpl::createReceiverResources(
+        LocatorList_t& Locator_list,
+        bool ApplyMutation)
 {
-    std::vector<std::shared_ptr<ReceiverResource>> newItemsBuffer;
+    std::vector<std::shared_ptr<ReceiverResource> > newItemsBuffer;
 
     uint32_t size = m_network_Factory.get_max_message_size_between_transports();
     for (auto it_loc = Locator_list.begin(); it_loc != Locator_list.end(); ++it_loc)
@@ -901,7 +927,8 @@ void RTPSParticipantImpl::createReceiverResources(LocatorList_t& Locator_list, b
     }
 }
 
-void RTPSParticipantImpl::createSenderResources(const LocatorList_t& locator_list)
+void RTPSParticipantImpl::createSenderResources(
+        const LocatorList_t& locator_list)
 {
     std::unique_lock<std::timed_mutex> lock(m_send_resources_mutex_);
 
@@ -911,14 +938,16 @@ void RTPSParticipantImpl::createSenderResources(const LocatorList_t& locator_lis
     }
 }
 
-void RTPSParticipantImpl::createSenderResources(const Locator_t& locator)
+void RTPSParticipantImpl::createSenderResources(
+        const Locator_t& locator)
 {
     std::unique_lock<std::timed_mutex> lock(m_send_resources_mutex_);
 
     m_network_Factory.build_send_resources(send_resource_list_, locator);
 }
 
-bool RTPSParticipantImpl::deleteUserEndpoint(Endpoint* p_endpoint)
+bool RTPSParticipantImpl::deleteUserEndpoint(
+        Endpoint* p_endpoint)
 {
     m_receiverResourcelistMutex.lock();
     for (auto it = m_receiverResourcelist.begin(); it != m_receiverResourcelist.end(); ++it)
@@ -929,7 +958,7 @@ bool RTPSParticipantImpl::deleteUserEndpoint(Endpoint* p_endpoint)
 
     bool found = false, found_in_users = false;
     {
-        if(p_endpoint->getAttributes().endpointKind == WRITER)
+        if (p_endpoint->getAttributes().endpointKind == WRITER)
         {
             std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
             for (auto wit = m_userWriterList.begin(); wit != m_userWriterList.end(); ++wit)
@@ -979,7 +1008,7 @@ bool RTPSParticipantImpl::deleteUserEndpoint(Endpoint* p_endpoint)
         }
 
         //REMOVE FOR BUILTINPROTOCOLS
-        if(p_endpoint->getAttributes().endpointKind == WRITER)
+        if (p_endpoint->getAttributes().endpointKind == WRITER)
         {
             if (found_in_users)
             {
@@ -987,12 +1016,12 @@ bool RTPSParticipantImpl::deleteUserEndpoint(Endpoint* p_endpoint)
             }
 
 #if HAVE_SECURITY
-            if(p_endpoint->getAttributes().security_attributes().is_submessage_protected ||
+            if (p_endpoint->getAttributes().security_attributes().is_submessage_protected ||
                     p_endpoint->getAttributes().security_attributes().is_payload_protected)
             {
                 m_security_manager.unregister_local_writer(p_endpoint->getGuid());
             }
-#endif
+#endif // if HAVE_SECURITY
         }
         else
         {
@@ -1002,12 +1031,12 @@ bool RTPSParticipantImpl::deleteUserEndpoint(Endpoint* p_endpoint)
             }
 
 #if HAVE_SECURITY
-            if(p_endpoint->getAttributes().security_attributes().is_submessage_protected ||
+            if (p_endpoint->getAttributes().security_attributes().is_submessage_protected ||
                     p_endpoint->getAttributes().security_attributes().is_payload_protected)
             {
                 m_security_manager.unregister_local_reader(p_endpoint->getGuid());
             }
-#endif
+#endif // if HAVE_SECURITY
         }
     }
     //	std::lock_guard<std::recursive_mutex> guardEndpoint(*p_endpoint->getMutex());
@@ -1015,7 +1044,8 @@ bool RTPSParticipantImpl::deleteUserEndpoint(Endpoint* p_endpoint)
     return true;
 }
 
-void RTPSParticipantImpl::normalize_endpoint_locators(EndpointAttributes& endpoint_att)
+void RTPSParticipantImpl::normalize_endpoint_locators(
+        EndpointAttributes& endpoint_att)
 {
     // Locators with port 0, calculate port.
     for (Locator_t& loc : endpoint_att.unicastLocatorList)
@@ -1053,7 +1083,7 @@ bool RTPSParticipantImpl::sendSync(
     bool ret_code = false;
     std::unique_lock<std::timed_mutex> lock(m_send_resources_mutex_, std::defer_lock);
 
-    if(lock.try_lock_until(max_blocking_time_point))
+    if (lock.try_lock_until(max_blocking_time_point))
     {
         ret_code = true;
 
@@ -1061,8 +1091,8 @@ bool RTPSParticipantImpl::sendSync(
         {
             // Calculate next timeout.
             std::chrono::microseconds timeout =
-                std::chrono::duration_cast<std::chrono::microseconds>(
-                        max_blocking_time_point - std::chrono::steady_clock::now());
+                    std::chrono::duration_cast<std::chrono::microseconds>(
+                max_blocking_time_point - std::chrono::steady_clock::now());
 
             send_resource->send(msg->buffer, msg->length, destination_loc, timeout);
         }
@@ -1071,7 +1101,8 @@ bool RTPSParticipantImpl::sendSync(
     return ret_code;
 }
 
-void RTPSParticipantImpl::setGuid(GUID_t& guid)
+void RTPSParticipantImpl::setGuid(
+        GUID_t& guid)
 {
     m_guid = guid;
 }
@@ -1097,16 +1128,20 @@ void RTPSParticipantImpl::loose_next_change()
     //this->mp_send_thr->loose_next_change();
 }
 
-bool RTPSParticipantImpl::newRemoteEndpointDiscovered(const GUID_t& pguid, int16_t userDefinedId, EndpointKind_t kind)
+bool RTPSParticipantImpl::newRemoteEndpointDiscovered(
+        const GUID_t& pguid,
+        int16_t userDefinedId,
+        EndpointKind_t kind)
 {
     if (m_att.builtin.discovery_config.discoveryProtocol != DiscoveryProtocol::SIMPLE ||
-        m_att.builtin.discovery_config.use_STATIC_EndpointDiscoveryProtocol == false)
+            m_att.builtin.discovery_config.use_STATIC_EndpointDiscoveryProtocol == false)
     {
-        logWarning(RTPS_PARTICIPANT, "Remote Endpoints can only be activated with static discovery protocol over PDP simple protocol");
+        logWarning(RTPS_PARTICIPANT,
+                "Remote Endpoints can only be activated with static discovery protocol over PDP simple protocol");
         return false;
     }
 
-    if (PDPSimple * pS = dynamic_cast<PDPSimple*>(mp_builtinProtocols->mp_PDP))
+    if (PDPSimple* pS = dynamic_cast<PDPSimple*>(mp_builtinProtocols->mp_PDP))
     {
         return pS->newRemoteEndpointStaticallyDiscovered(pguid, userDefinedId, kind);
     }
@@ -1149,18 +1184,19 @@ uint32_t RTPSParticipantImpl::getMaxDataSize()
     return calculateMaxDataSize(getMaxMessageSize());
 }
 
-uint32_t RTPSParticipantImpl::calculateMaxDataSize(uint32_t length)
+uint32_t RTPSParticipantImpl::calculateMaxDataSize(
+        uint32_t length)
 {
     uint32_t maxDataSize = length;
 
 #if HAVE_SECURITY
     // If there is rtps messsage protection, reduce max size for messages,
     // because extra data is added on encryption.
-    if(security_attributes_.is_rtps_protected)
+    if (security_attributes_.is_rtps_protected)
     {
         maxDataSize -= m_security_manager.calculate_extra_size_for_rtps_message();
     }
-#endif
+#endif // if HAVE_SECURITY
 
     // RTPS header
     maxDataSize -= RTPSMESSAGE_HEADER_SIZE;
@@ -1173,8 +1209,9 @@ bool RTPSParticipantImpl::networkFactoryHasRegisteredTransports() const
 }
 
 #if HAVE_SECURITY
-bool RTPSParticipantImpl::pairing_remote_reader_with_local_writer_after_security(const GUID_t& local_writer,
-    const ReaderProxyData& remote_reader_data)
+bool RTPSParticipantImpl::pairing_remote_reader_with_local_writer_after_security(
+        const GUID_t& local_writer,
+        const ReaderProxyData& remote_reader_data)
 {
     bool return_value;
 
@@ -1189,8 +1226,9 @@ bool RTPSParticipantImpl::pairing_remote_reader_with_local_writer_after_security
     return return_value;
 }
 
-bool RTPSParticipantImpl::pairing_remote_writer_with_local_reader_after_security(const GUID_t& local_reader,
-    const WriterProxyData& remote_writer_data)
+bool RTPSParticipantImpl::pairing_remote_writer_with_local_reader_after_security(
+        const GUID_t& local_reader,
+        const WriterProxyData& remote_writer_data)
 {
     bool return_value;
 
@@ -1205,7 +1243,7 @@ bool RTPSParticipantImpl::pairing_remote_writer_with_local_reader_after_security
     return return_value;
 }
 
-#endif
+#endif // if HAVE_SECURITY
 
 PDPSimple* RTPSParticipantImpl::pdpsimple()
 {
@@ -1217,7 +1255,9 @@ WLP* RTPSParticipantImpl::wlp()
     return mp_builtinProtocols->mp_WLP;
 }
 
-bool RTPSParticipantImpl::get_remote_writer_info(const GUID_t& writerGuid, WriterProxyData& returnedInfo)
+bool RTPSParticipantImpl::get_remote_writer_info(
+        const GUID_t& writerGuid,
+        WriterProxyData& returnedInfo)
 {
     if (this->mp_builtinProtocols->mp_PDP->lookupWriterProxyData(writerGuid, returnedInfo))
     {
@@ -1226,7 +1266,9 @@ bool RTPSParticipantImpl::get_remote_writer_info(const GUID_t& writerGuid, Write
     return false;
 }
 
-bool RTPSParticipantImpl::get_remote_reader_info(const GUID_t& readerGuid, ReaderProxyData& returnedInfo)
+bool RTPSParticipantImpl::get_remote_reader_info(
+        const GUID_t& readerGuid,
+        ReaderProxyData& returnedInfo)
 {
     if (this->mp_builtinProtocols->mp_PDP->lookupReaderProxyData(readerGuid, returnedInfo))
     {
@@ -1235,14 +1277,15 @@ bool RTPSParticipantImpl::get_remote_reader_info(const GUID_t& readerGuid, Reade
     return false;
 }
 
-IPersistenceService* RTPSParticipantImpl::get_persistence_service(const EndpointAttributes& param)
+IPersistenceService* RTPSParticipantImpl::get_persistence_service(
+        const EndpointAttributes& param)
 {
     IPersistenceService* ret_val;
 
     ret_val = PersistenceFactory::create_persistence_service(param.properties);
     return ret_val != nullptr ?
-        ret_val :
-        PersistenceFactory::create_persistence_service(m_att.properties);
+           ret_val :
+           PersistenceFactory::create_persistence_service(m_att.properties);
 }
 
 } /* namespace rtps */

--- a/src/cpp/rtps/writer/PersistentWriter.cpp
+++ b/src/cpp/rtps/writer/PersistentWriter.cpp
@@ -64,14 +64,7 @@ void PersistentWriter::add_persistent_change(CacheChange_t* cptr)
 
 void PersistentWriter::remove_persistent_change(CacheChange_t* change)
 {
-    bool ret;
-    int count = 100;
-
-    do
-    {
-        ret = persistence_->remove_writer_change_from_storage(persistence_guid_, *change);
-    } while (!ret && --count);
-
+    persistence_->remove_writer_change_from_storage(persistence_guid_, *change);
 }
 
 } /* namespace rtps */

--- a/src/cpp/rtps/writer/PersistentWriter.cpp
+++ b/src/cpp/rtps/writer/PersistentWriter.cpp
@@ -64,7 +64,14 @@ void PersistentWriter::add_persistent_change(CacheChange_t* cptr)
 
 void PersistentWriter::remove_persistent_change(CacheChange_t* change)
 {
-    persistence_->remove_writer_change_from_storage(persistence_guid_, *change);
+    bool ret;
+    int count = 100;
+
+    do
+    {
+        ret = persistence_->remove_writer_change_from_storage(persistence_guid_, *change);
+    } while (!ret && --count);
+
 }
 
 } /* namespace rtps */

--- a/test/mock/rtps/TCPv4TransportDescriptor/fastrtps/transport/TCPv4TransportDescriptor.h
+++ b/test/mock/rtps/TCPv4TransportDescriptor/fastrtps/transport/TCPv4TransportDescriptor.h
@@ -17,17 +17,20 @@
 
 #include <fastrtps/transport/TCPTransportDescriptor.h>
 
-namespace eprosima{
-namespace fastrtps{
-namespace rtps{
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
 
 class TCPTransportInterface;
 /**
  * Transport configuration
  * @ingroup TRANSPORT_MODULE
  */
-typedef struct TCPv4TransportDescriptor: public TCPTransportDescriptor {
-    virtual ~TCPv4TransportDescriptor(){}
+typedef struct TCPv4TransportDescriptor : public TCPTransportDescriptor
+{
+    virtual ~TCPv4TransportDescriptor()
+    {
+    }
 
     TCPv4TransportDescriptor& operator =(
             const TCPv4TransportDescriptor& ) = default;
@@ -35,21 +38,30 @@ typedef struct TCPv4TransportDescriptor: public TCPTransportDescriptor {
     TCPv4TransportDescriptor& operator =(
             TCPv4TransportDescriptor&& ) = default;
 
-    virtual TransportInterface* create_transport() const override   {   return nullptr; }
+    virtual TransportInterface* create_transport() const override
+    {
+        return nullptr;
+    }
 
     octet wan_addr[4];
 
-    void set_WAN_address(octet o1,octet o2,octet o3,octet o4){
+    void set_WAN_address(
+            octet o1,
+            octet o2,
+            octet o3,
+            octet o4)
+    {
         wan_addr[0] = o1;
         wan_addr[1] = o2;
         wan_addr[2] = o3;
         wan_addr[3] = o4;
     }
 
-    void set_WAN_address(const std::string& in_address)
+    void set_WAN_address(
+            const std::string& in_address)
     {
         std::stringstream ss(in_address);
-        int a,b,c,d; //to store the 4 ints
+        int a, b, c, d; //to store the 4 ints
         char ch; //to temporarily store the '.'
         ss >> a >> ch >> b >> ch >> c >> ch >> d;
         wan_addr[0] = (octet)a;
@@ -63,7 +75,9 @@ typedef struct TCPv4TransportDescriptor: public TCPTransportDescriptor {
 
     }
 
-    RTPS_DllAPI TCPv4TransportDescriptor(const TCPv4TransportDescriptor& /*t*/) : TCPv4TransportDescriptor()
+    RTPS_DllAPI TCPv4TransportDescriptor(
+            const TCPv4TransportDescriptor& /*t*/)
+        : TCPv4TransportDescriptor()
     {
 
     }
@@ -74,4 +88,4 @@ typedef struct TCPv4TransportDescriptor: public TCPTransportDescriptor {
 } // namespace fastrtps
 } // namespace eprosima
 
-#endif
+#endif // ifndef TCPV4_TRANSPORT_DESCRIPTOR

--- a/test/mock/rtps/TCPv4TransportDescriptor/fastrtps/transport/TCPv4TransportDescriptor.h
+++ b/test/mock/rtps/TCPv4TransportDescriptor/fastrtps/transport/TCPv4TransportDescriptor.h
@@ -29,6 +29,12 @@ class TCPTransportInterface;
 typedef struct TCPv4TransportDescriptor: public TCPTransportDescriptor {
     virtual ~TCPv4TransportDescriptor(){}
 
+    TCPv4TransportDescriptor& operator =(
+            const TCPv4TransportDescriptor& ) = default;
+
+    TCPv4TransportDescriptor& operator =(
+            TCPv4TransportDescriptor&& ) = default;
+
     virtual TransportInterface* create_transport() const override   {   return nullptr; }
 
     octet wan_addr[4];

--- a/utils/doxygen/complete_doxyfile_api
+++ b/utils/doxygen/complete_doxyfile_api
@@ -1987,7 +1987,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = DOXYGEN_SHOULD_SKIP_THIS __DEBUG
+PREDEFINED             = DOXYGEN_SHOULD_SKIP_THIS DOXYGEN_SHOULD_SKIP_THIS_PUBLIC __DEBUG
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
Includes the commits:
- Repairing client-server BACKUP operation (#1091)
- Server-Client trimming form discovery info update (#1102)
- Updating from microseconds to milliseconds the pdp stateful writer events. (#995)