### PR TITLE
 Garbage collect remote SHM segments when origin Participant is closed / dead <master> [8607]

### DIFF
--- a/src/cpp/rtps/transport/shared_mem/RobustExclusiveLock.hpp
+++ b/src/cpp/rtps/transport/shared_mem/RobustExclusiveLock.hpp
@@ -75,6 +75,24 @@ public:
     }
 
     /**
+     * Checks whether the file is locked.
+     * @param in name Is the object interprocess global name, visible for all processes in the same machine.
+     */
+    static bool is_locked(const std::string& name)
+    {
+        try
+        {
+            RobustExclusiveLock locked_test(name);
+        }
+        catch(const std::exception& e)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      *  Unlock the interprocess lock.
      */
     ~RobustExclusiveLock()

--- a/src/cpp/rtps/transport/shared_mem/RobustExclusiveLock.hpp
+++ b/src/cpp/rtps/transport/shared_mem/RobustExclusiveLock.hpp
@@ -52,7 +52,10 @@ public:
     {
         auto file_path = RobustLock::get_file_path(name);
 
-        fd_ = open_and_lock_file(file_path, was_lock_created);
+        if ((fd_ = open_and_lock_file(file_path, was_lock_created)) == -1)
+        {
+            throw std::runtime_error("open_and_lock_file failed");
+        }
 
         name_ = name;
     }
@@ -69,7 +72,10 @@ public:
 
         auto file_path = RobustLock::get_file_path(name);
 
-        fd_ = open_and_lock_file(file_path, &was_lock_created);
+        if ((fd_ = open_and_lock_file(file_path, &was_lock_created)) == -1)
+        {
+            throw std::runtime_error("open_and_lock_file failed");
+        }
 
         name_ = name;
     }
@@ -81,15 +87,18 @@ public:
     static bool is_locked(
             const std::string& name)
     {
-        try
-        {
-            RobustExclusiveLock locked_test(name);
-        }
-        catch (const std::exception&)
+        bool was_lock_created;
+
+        auto file_path = RobustLock::get_file_path(name);
+
+        int fd;
+        if ((fd = open_and_lock_file(file_path, &was_lock_created)) == -1)
         {
             return true;
         }
 
+        unlock_and_close(fd, name);
+        
         return false;
     }
 
@@ -98,7 +107,7 @@ public:
      */
     ~RobustExclusiveLock()
     {
-        unlock_and_close();
+        unlock_and_close(fd_, name_);
     }
 
     /**
@@ -118,9 +127,9 @@ private:
 
 #ifdef _MSC_VER
 
-    int open_and_lock_file(
+    static int open_and_lock_file(
             const std::string& file_path,
-            bool* was_lock_created) const
+            bool* was_lock_created)
     {
         int test_exist;
         auto ret = _sopen_s(&test_exist, file_path.c_str(), O_RDONLY, _SH_DENYRW, _S_IREAD | _S_IWRITE);
@@ -138,7 +147,7 @@ private:
         {
             char errmsg[1024];
             strerror_s(errmsg, sizeof(errmsg), errno);
-            throw std::runtime_error("failed to open/create " + file_path + " " + std::string(errmsg));
+            return -1;
         }
 
         *was_lock_created = true;
@@ -146,21 +155,23 @@ private:
         return fd;
     }
 
-    void unlock_and_close()
+    static void unlock_and_close(
+            int fd,
+            const std::string& name)
     {
-        _close(fd_);
+        _close(fd);
 
-        if (0 != std::remove(RobustLock::get_file_path(name_).c_str()))
+        if (0 != std::remove(RobustLock::get_file_path(name).c_str()))
         {
-            logWarning(RTPS_TRANSPORT_SHM, "Failed to remove " << RobustLock::get_file_path(name_));
+            logWarning(RTPS_TRANSPORT_SHM, "Failed to remove " << RobustLock::get_file_path(name));
         }
     }
 
 #else
 
-    int open_and_lock_file(
+    static int open_and_lock_file(
             const std::string& file_path,
-            bool* was_lock_created) const
+            bool* was_lock_created)
     {
         auto fd = open(file_path.c_str(), O_RDONLY, 0666);
 
@@ -176,27 +187,27 @@ private:
 
         if (fd == -1)
         {
-            throw std::runtime_error(("failed to open/create " + file_path + " " + std::strerror(errno)).c_str());
+            return -1;
         }
 
         // Lock the file
         if (0 != flock(fd, LOCK_EX | LOCK_NB))
         {
             close(fd);
-            throw std::runtime_error(("failed to lock " + file_path).c_str());
+            return -1;
         }
 
         return fd;
     }
 
-    void unlock_and_close()
+    static void unlock_and_close(int fd, const std::string& name)
     {
-        flock(fd_, LOCK_UN | LOCK_NB);
-        close(fd_);
+        flock(fd, LOCK_UN | LOCK_NB);
+        close(fd);
 
-        if (0 != std::remove(RobustLock::get_file_path(name_).c_str()))
+        if (0 != std::remove(RobustLock::get_file_path(name).c_str()))
         {
-            logWarning(RTPS_TRANSPORT_SHM, "Failed to remove " << RobustLock::get_file_path(name_));
+            logWarning(RTPS_TRANSPORT_SHM, "Failed to remove " << RobustLock::get_file_path(name));
         }
     }
 

--- a/src/cpp/rtps/transport/shared_mem/RobustExclusiveLock.hpp
+++ b/src/cpp/rtps/transport/shared_mem/RobustExclusiveLock.hpp
@@ -85,7 +85,7 @@ public:
         {
             RobustExclusiveLock locked_test(name);
         }
-        catch (const std::exception& e)
+        catch (const std::exception&)
         {
             return true;
         }

--- a/src/cpp/rtps/transport/shared_mem/RobustExclusiveLock.hpp
+++ b/src/cpp/rtps/transport/shared_mem/RobustExclusiveLock.hpp
@@ -98,7 +98,7 @@ public:
         }
 
         unlock_and_close(fd, name);
-        
+
         return false;
     }
 
@@ -200,7 +200,9 @@ private:
         return fd;
     }
 
-    static void unlock_and_close(int fd, const std::string& name)
+    static void unlock_and_close(
+            int fd,
+            const std::string& name)
     {
         flock(fd, LOCK_UN | LOCK_NB);
         close(fd);

--- a/src/cpp/rtps/transport/shared_mem/RobustExclusiveLock.hpp
+++ b/src/cpp/rtps/transport/shared_mem/RobustExclusiveLock.hpp
@@ -19,7 +19,7 @@
 #include <io.h>
 #else
 #include <sys/file.h>
-#endif
+#endif // ifdef  _MSC_VER
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -42,7 +42,7 @@ public:
     /**
      * Open or create and acquire the interprocess lock.
      * @param in name Is the object's interprocess global name, visible for all processes in the same machine.
-     * @param out was_lock_created If the lock succeeded, this parameter return whether the lock has been created 
+     * @param out was_lock_created If the lock succeeded, this parameter return whether the lock has been created
      * or it already exist.
      * @throw std::exception if lock coulnd't be acquired
      */
@@ -78,13 +78,14 @@ public:
      * Checks whether the file is locked.
      * @param in name Is the object interprocess global name, visible for all processes in the same machine.
      */
-    static bool is_locked(const std::string& name)
+    static bool is_locked(
+            const std::string& name)
     {
         try
         {
             RobustExclusiveLock locked_test(name);
         }
-        catch(const std::exception& e)
+        catch (const std::exception& e)
         {
             return true;
         }
@@ -199,7 +200,7 @@ private:
         }
     }
 
-#endif
+#endif // ifdef _MSC_VER
 
 };
 

--- a/src/cpp/rtps/transport/shared_mem/RobustExclusiveLock.hpp
+++ b/src/cpp/rtps/transport/shared_mem/RobustExclusiveLock.hpp
@@ -145,8 +145,6 @@ private:
 
         if (ret != 0)
         {
-            char errmsg[1024];
-            strerror_s(errmsg, sizeof(errmsg), errno);
             return -1;
         }
 

--- a/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
@@ -121,7 +121,7 @@ public:
     {
         friend class MockPortSharedMemGlobal;
 
-    private: // Port
+    private:
 
         std::shared_ptr<SharedMemSegment> port_segment_;
 
@@ -154,7 +154,7 @@ public:
          */
         class WatchTask : public SharedMemWatchdog::Task
         {
-        public: // WatchTask
+        public:
 
             struct PortContext
             {
@@ -202,7 +202,7 @@ public:
 
             }
 
-        private: // WatchTask
+        private:
 
             std::vector<std::shared_ptr<PortContext> > watched_ports_;
             std::mutex watched_ports_mutex_;
@@ -339,7 +339,7 @@ public:
             return (listeners_found == node_->num_listeners);
         }
 
-    public: // Port
+    public:
 
         /**
          * Defines open sharing mode of a shared-memory port:

--- a/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
@@ -121,7 +121,7 @@ public:
     {
         friend class MockPortSharedMemGlobal;
 
-    private:
+    private: // Port
 
         std::shared_ptr<SharedMemSegment> port_segment_;
 
@@ -154,7 +154,7 @@ public:
          */
         class WatchTask : public SharedMemWatchdog::Task
         {
-        public:
+        public: // WatchTask
 
             struct PortContext
             {
@@ -202,7 +202,7 @@ public:
 
             }
 
-        private:
+        private: // WatchTask
 
             std::vector<std::shared_ptr<PortContext> > watched_ports_;
             std::mutex watched_ports_mutex_;
@@ -339,7 +339,7 @@ public:
             return (listeners_found == node_->num_listeners);
         }
 
-        public:
+    public: // Port
 
         /**
          * Defines open sharing mode of a shared-memory port:

--- a/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
@@ -21,6 +21,7 @@
 
 #include <rtps/transport/shared_mem/SharedMemGlobal.hpp>
 #include <rtps/transport/shared_mem/RobustSharedLock.hpp>
+#include <rtps/transport/shared_mem/SharedMemWatchdog.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -34,7 +35,8 @@ using Log = fastdds::dds::Log;
  *  Open shared-memory ports.
  *  Create shared memory segments.
  */
-class SharedMemManager
+class SharedMemManager : 
+    public std::enable_shared_from_this<SharedMemManager>
 {
 private:
 
@@ -220,10 +222,7 @@ private:
 
             return (listener_validity_id == s.validity_id);
         }
-
     };
-
-public:
 
     SharedMemManager(
             const std::string& domain_name)
@@ -243,6 +242,18 @@ public:
         per_allocation_extra_size_ =
                 SharedMemSegment::compute_per_allocation_extra_size(std::alignment_of<BufferNode>::value,
                         domain_name);
+    }
+
+public:
+
+    static std::shared_ptr<SharedMemManager> create(const std::string& domain_name)
+    {
+        return std::shared_ptr<SharedMemManager>(new SharedMemManager(domain_name));
+    }
+
+    ~SharedMemManager()
+    {
+        remove_segments_from_watch();
     }
 
     class Buffer
@@ -938,38 +949,162 @@ private:
         }
 
         SegmentWrapper(
+                std::weak_ptr<SharedMemManager> shared_mem_manager,
                 std::shared_ptr<SharedMemSegment> segment_,
+                SharedMemSegment::Id segment_id,
                 const std::string& segment_name)
-            : segment_(segment_)
+            : shared_mem_manager_(shared_mem_manager)
+            , segment_(segment_)
+            , segment_id_(segment_id)
             , segment_name_(segment_name)
         {
+            lock_file_name_ = segment_name + "_el";
         }
 
-        SegmentWrapper& operator =(
-                SegmentWrapper&& other)
+        std::shared_ptr<SharedMemSegment> segment() { return segment_; }
+
+        /**
+         * Singleton task, for SharedMemWatchdog, that periodically checks opened segments
+         * to garbage collect those closed by the origin
+         */
+        class WatchTask : public SharedMemWatchdog::Task
         {
-            segment_ = other.segment_;
-            segment_name_ = other.segment_name_;
+        public:
 
-            other.segment_.reset();
+            static WatchTask& get()
+            {
+                static WatchTask watch_task;
+                return watch_task;
+            }
 
-            return *this;
-        }
+            void add_segment(std::shared_ptr<SegmentWrapper> segment)
+            {
+                // Add added segments to the watched set
+                std::lock_guard<std::mutex> lock(to_add_remove_mutex_);
 
-        std::shared_ptr<SharedMemSegment> segment()
-        {
-            return segment_;
-        }
+                to_add_.push_back(segment);
+            }
+
+            void remove_segment(std::shared_ptr<SegmentWrapper> segment)
+            {
+                // Add added segments to the watched set
+                std::lock_guard<std::mutex> lock(to_add_remove_mutex_);
+
+                to_remove_.push_back(segment);
+            }
+
+        private:
+
+            std::unordered_map<std::shared_ptr<SegmentWrapper>, uint32_t> watched_segments_;
+            
+            std::mutex to_add_remove_mutex_;
+            std::vector<std::shared_ptr<SegmentWrapper>> to_add_;
+            std::vector<std::shared_ptr<SegmentWrapper>> to_remove_;
+
+            WatchTask()
+            {
+                SharedMemWatchdog::get().add_task(this);
+            }
+
+            ~WatchTask()
+            {
+                SharedMemWatchdog::get().remove_task(this);
+            }
+
+            void update_watched_segments()
+            {
+                // Add / remove segments to the watched map
+                std::lock_guard<std::mutex> lock(to_add_remove_mutex_);
+
+                for (auto& segment : to_add_)
+                {
+                    auto segment_it = watched_segments_.find(segment);
+                    if (segment_it != watched_segments_.end())
+                    {
+                        // The segment already exists, just increase the references
+                        (*segment_it).second++;
+                    }
+                    else // New segment
+                    {
+                        watched_segments_.insert({segment, 1});
+                    }
+                }
+
+                to_add_.clear();
+
+                for (auto& segment : to_remove_)
+                {
+                    auto segment_it = watched_segments_.find(segment);
+                    if (segment_it != watched_segments_.end())
+                    {
+                        (*segment_it).second--;
+
+                        if ((*segment_it).second == 0)
+                        {
+                            watched_segments_.erase(segment_it);
+                        }
+                    }
+                }
+
+                to_remove_.clear();
+            }
+
+            void run()
+            {
+                update_watched_segments();
+
+                // Watch every segment
+                auto segment_it =  watched_segments_.begin();
+                while(segment_it != watched_segments_.end())
+                {
+                    if (!(*segment_it).first->check_alive())
+                    {
+                        segment_it = watched_segments_.erase(segment_it);
+                    }
+                    else
+                    {
+                        segment_it++;
+                    }
+                }
+            }
+        };
 
     private:
 
+        std::weak_ptr<SharedMemManager> shared_mem_manager_;
         std::shared_ptr<SharedMemSegment> segment_;
+        SharedMemSegment::Id segment_id_;
         std::string segment_name_;
+        std::string lock_file_name_;
+
+        bool check_alive()
+        {
+            if (!RobustExclusiveLock::is_locked(lock_file_name_))
+            {
+                // The segment is not locked so the origin is no longer active
+                close_and_remove();
+
+                return false;
+            }
+
+            return true;
+        }
+
+        void close_and_remove()
+        {
+            // Remove from the namespace (just in case the origin didn't do it)
+            SharedMemSegment::remove(segment_name_.c_str());
+
+            if (auto shared_mem_manager = shared_mem_manager_.lock())
+            {
+                shared_mem_manager->release_segment(segment_id_);
+            }
+        }
     };
 
     uint32_t per_allocation_extra_size_;
 
-    std::unordered_map<SharedMemSegment::Id::type, SegmentWrapper,
+    std::unordered_map<SharedMemSegment::Id::type, std::shared_ptr<SegmentWrapper>,
             std::hash<SharedMemSegment::Id::type> > ids_segments_;
     std::mutex ids_segments_mutex_;
 
@@ -978,29 +1113,59 @@ private:
     std::shared_ptr<SharedMemSegment> find_segment(
             SharedMemSegment::Id id)
     {
+        std::shared_ptr<SharedMemSegment> segment;
         std::lock_guard<std::mutex> lock(ids_segments_mutex_);
 
-        std::shared_ptr<SharedMemSegment> segment;
+        auto segment_it = ids_segments_.find(id.get());
 
-        // TODO(Adolfo): Garbage collector for opened but unused segments????
-
-        try
+        if (segment_it != ids_segments_.end())
         {
-            SegmentWrapper& segment_wrapper = ids_segments_.at(id.get());
-            segment = segment_wrapper.segment();
+            segment = (*segment_it).second->segment();
         }
-        catch (std::out_of_range&)
+        else // Is a new segment
         {
             auto segment_name = global_segment_.domain_name() + "_" + id.to_string();
             segment = std::make_shared<SharedMemSegment>(boost::interprocess::open_only, segment_name);
-            SegmentWrapper segment_wrapper(segment, segment_name);
+            auto s = shared_from_this();
+            std::weak_ptr<SharedMemManager> p(s);
+            auto segment_wrapper = std::make_shared<SegmentWrapper>(p, segment, id, segment_name);
 
-            ids_segments_[id.get()] = std::move(segment_wrapper);
+            ids_segments_[id.get()] = segment_wrapper;
+
+            SegmentWrapper::WatchTask::get().add_segment(segment_wrapper);
         }
-
+        
         return segment;
     }
 
+    void release_segment(
+            SharedMemSegment::Id id)
+    {
+        std::lock_guard<std::mutex> lock(ids_segments_mutex_);
+
+        auto segment_it = ids_segments_.find(id.get());
+
+        if (segment_it != ids_segments_.end())
+        {
+            ids_segments_.erase(segment_it);
+        }
+    }
+
+    /**
+     * Remove all the opened remote segments from the watchdog.
+     * This function should be called before destroying the SharedMemManager.
+     * Because ids_segments_ is about to be clear, all the segments will be released.
+     */
+    void remove_segments_from_watch()
+    {
+        std::lock_guard<std::mutex> lock(ids_segments_mutex_);
+
+        for (auto segment : ids_segments_)
+        {
+            SegmentWrapper::WatchTask::get().remove_segment(segment.second);
+        }
+    }
+    
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
@@ -246,7 +246,7 @@ private:
                         domain_name);
     }
 
-public: // SharedMemManager
+public:
 
     static std::shared_ptr<SharedMemManager> create(
             const std::string& domain_name)
@@ -261,11 +261,11 @@ public: // SharedMemManager
 
     class Buffer
     {
-    protected: // SharedMemManager::Buffer
+    protected:
 
         virtual ~Buffer() = default;
 
-    public: // SharedMemManager::Buffer
+    public:
 
         virtual void* data() = 0;
         virtual uint32_t size() = 0;
@@ -273,7 +273,7 @@ public: // SharedMemManager
 
     class SharedMemBuffer : public Buffer
     {
-    public: // SharedMemManager::SharedMemBuff
+    public:
 
         SharedMemBuffer(
                 std::shared_ptr<SharedMemSegment>& segment,
@@ -330,7 +330,7 @@ public: // SharedMemManager
             buffer_node_->dec_enqueued_count(validity_id);
         }
 
-    private: // SharedMemManager::SharedMemBuff
+    private:
 
         std::shared_ptr<SharedMemSegment> segment_;
         SharedMemSegment::Id segment_id_;
@@ -345,7 +345,7 @@ public: // SharedMemManager
      */
     class Segment
     {
-    public: // SharedMemManager::Segment
+    public:
 
         Segment(
                 uint32_t size,
@@ -482,7 +482,7 @@ public: // SharedMemManager
             return segment_->mem_size();
         }
 
-    private: // SharedMemManager::Segment
+    private:
 
         std::string segment_name_;
 
@@ -609,7 +609,7 @@ public: // SharedMemManager
      */
     class Listener
     {
-    public: // SharedMemManager::Listener
+    public:
 
         Listener(
                 SharedMemManager* shared_mem_manager,
@@ -763,7 +763,7 @@ public: // SharedMemManager
             global_port_->close_listener(&is_closed_);
         }
 
-    private: // SharedMemManager::Listener
+    private:
 
         std::shared_ptr<SharedMemGlobal::Port> global_port_;
 
@@ -781,7 +781,7 @@ public: // SharedMemManager
      */
     class Port
     {
-    public: // SharedMemManager::Port
+    public:
 
         Port(
                 SharedMemManager* shared_mem_manager,
@@ -858,7 +858,7 @@ public: // SharedMemManager
             return std::make_shared<Listener>(shared_mem_manager_, global_port_);
         }
 
-    private: // SharedMemManager::Port
+    private:
 
         void regenerate_port()
         {
@@ -939,14 +939,14 @@ public: // SharedMemManager
     /**
      * @return The total mem size, in bytes, used by remote mapped segments.
      */
-    uint64_t segments_mem() 
+    uint64_t segments_mem()
     {
         std::lock_guard<std::mutex> lock(ids_segments_mutex_);
 
         return segments_mem_;
     }
 
-private: // SharedMemManager
+private:
 
     std::shared_ptr<Port> regenerate_port(
             std::shared_ptr<SharedMemGlobal::Port> port,
@@ -960,7 +960,7 @@ private: // SharedMemManager
      */
     class SegmentWrapper
     {
-    public: // SharedMemManager::SegmentWrapper
+    public:
 
         SegmentWrapper()
         {
@@ -990,7 +990,7 @@ private: // SharedMemManager
          */
         class WatchTask : public SharedMemWatchdog::Task
         {
-        public: // SharedMemManager::SegmentWrapper::WatchTask
+        public:
 
             static WatchTask& get()
             {
@@ -1016,7 +1016,7 @@ private: // SharedMemManager
                 to_remove_.push_back(segment);
             }
 
-        private: // SharedMemManager::SegmentWrapper::WatchTask
+        private:
 
             std::unordered_map<std::shared_ptr<SegmentWrapper>, uint32_t> watched_segments_;
 
@@ -1093,7 +1093,7 @@ private: // SharedMemManager
 
         };
 
-    private: // SharedMemManager::SegmentWrapper
+    private:
 
         std::weak_ptr<SharedMemManager> shared_mem_manager_;
         std::shared_ptr<SharedMemSegment> segment_;

--- a/src/cpp/rtps/transport/shared_mem/SharedMemSegment.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemSegment.hpp
@@ -262,6 +262,14 @@ public:
     }
 
     /**
+     * @return The segment's size in bytes, including internal structures overhead.
+     */
+    Offset mem_size() const
+    {
+        return segment_->get_size();
+    }
+
+    /**
      * Unique ID of the memory segment
      */
     class Id

--- a/src/cpp/rtps/transport/shared_mem/SharedMemSegment.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemSegment.hpp
@@ -23,13 +23,13 @@
 #pragma GCC diagnostic error "-Wdeprecated-copy"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-copy"
-#endif
+#endif // if defined(__GNUC__) && ( __GNUC__ >= 9)
 
 #include <boost/interprocess/managed_shared_memory.hpp>
-            
+
 #if defined (__GNUC__) && ( __GNUC__ >= 9)
 #pragma GCC diagnostic pop
-#endif
+#endif // if defined (__GNUC__) && ( __GNUC__ >= 9)
 
 #include <boost/interprocess/sync/interprocess_condition.hpp>
 #include <boost/interprocess/sync/named_mutex.hpp>
@@ -53,7 +53,7 @@ using Log = fastdds::dds::Log;
 class SharedMemSegment
 {
 public:
-    
+
     typedef RobustInterprocessCondition condition_variable;
     typedef boost::interprocess::interprocess_mutex mutex;
     typedef boost::interprocess::named_mutex named_mutex;
@@ -62,11 +62,11 @@ public:
     // Offset must be the same size for 32/64-bit versions, so no size_t used here.
     typedef std::uint32_t Offset;
     typedef boost::interprocess::offset_ptr<void, Offset, std::uint64_t> VoidPointerT;
-	typedef boost::interprocess::basic_managed_shared_memory<
-        char, 
-        boost::interprocess::rbtree_best_fit<boost::interprocess::mutex_family, 
-        VoidPointerT>, 
-        boost::interprocess::iset_index> managed_shared_memory_type;
+    typedef boost::interprocess::basic_managed_shared_memory<
+                char,
+                boost::interprocess::rbtree_best_fit<boost::interprocess::mutex_family,
+                VoidPointerT>,
+                boost::interprocess::iset_index> managed_shared_memory_type;
 
     static constexpr boost::interprocess::open_only_t open_only = boost::interprocess::open_only_t();
     static constexpr boost::interprocess::create_only_t create_only = boost::interprocess::create_only_t();
@@ -84,8 +84,8 @@ public:
         : name_(name)
     {
         segment_ = std::unique_ptr<managed_shared_memory_type>(
-            new managed_shared_memory_type(boost::interprocess::create_only, name.c_str(), 
-                static_cast<Offset>(size + EXTRA_SEGMENT_SIZE)));
+            new managed_shared_memory_type(boost::interprocess::create_only, name.c_str(),
+            static_cast<Offset>(size + EXTRA_SEGMENT_SIZE)));
     }
 
     SharedMemSegment(
@@ -113,7 +113,7 @@ public:
         {
             segment_.reset();
         }
-        catch(const std::exception& e)
+        catch (const std::exception& e)
         {
             logWarning(RTPS_TRANSPORT_SHM, e.what());
         }
@@ -131,7 +131,10 @@ public:
         return segment_->get_handle_from_address(address);
     }
 
-    managed_shared_memory_type& get() { return *segment_;}
+    managed_shared_memory_type& get()
+    {
+        return *segment_;
+    }
 
     static void remove(
             const std::string& name)
@@ -168,7 +171,7 @@ public:
                 {
                     boost::interprocess::managed_shared_memory
                             test_segment(boost::interprocess::create_only, name.c_str(),
-                                (std::max)((size_t)1024, allocation_alignment* 4));
+                            (std::max)((size_t)1024, allocation_alignment * 4));
 
                     auto m1 = test_segment.get_free_memory();
                     test_segment.allocate_aligned(1, allocation_alignment);
@@ -201,7 +204,7 @@ public:
 
         boost::posix_time::ptime wait_time
             = boost::posix_time::microsec_clock::universal_time()
-                + boost::posix_time::milliseconds(BOOST_INTERPROCESS_TIMEOUT_WHEN_LOCKING_DURATION_MS*2);
+                + boost::posix_time::milliseconds(BOOST_INTERPROCESS_TIMEOUT_WHEN_LOCKING_DURATION_MS * 2);
         if (!named_mutex->timed_lock(wait_time))
         {
             // Interprocess mutex timeout when locking. Possible deadlock: owner died without unlocking?
@@ -230,7 +233,7 @@ public:
 
         boost::posix_time::ptime wait_time
             = boost::posix_time::microsec_clock::universal_time()
-                + boost::posix_time::milliseconds(BOOST_INTERPROCESS_TIMEOUT_WHEN_LOCKING_DURATION_MS*2);
+                + boost::posix_time::milliseconds(BOOST_INTERPROCESS_TIMEOUT_WHEN_LOCKING_DURATION_MS * 2);
         if (!named_mutex->timed_lock(wait_time))
         {
             throw std::runtime_error("Couldn't lock name_mutex: " + mutex_name);
@@ -343,7 +346,9 @@ private:
         {
             SharedMemEnvironment::get().init();
         }
-    } shared_mem_environment_initializer_;
+
+    }
+    shared_mem_environment_initializer_;
 
     std::unique_ptr<managed_shared_memory_type> segment_;
 

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
@@ -80,7 +80,7 @@ bool SharedMemTransport::getDefaultMetatrafficMulticastLocators(
         uint32_t metatraffic_multicast_port) const
 {
     locators.push_back(SHMLocator::create_locator(metatraffic_multicast_port, SHMLocator::Type::MULTICAST));
-    
+
     return true;
 }
 
@@ -173,7 +173,8 @@ bool SharedMemTransport::is_local_locator(
     return true;
 }
 
-void SharedMemTransport::delete_input_channel(SharedMemChannelResource* channel)
+void SharedMemTransport::delete_input_channel(
+        SharedMemChannelResource* channel)
 {
     channel->disable();
     channel->release();
@@ -190,7 +191,7 @@ bool SharedMemTransport::CloseInputChannel(
     {
         if ( (*it)->locator() == locator)
         {
-            delete_input_channel((*it));            
+            delete_input_channel((*it));
             input_channels_.erase(it);
 
             return true;
@@ -206,7 +207,7 @@ void SharedMemTransport::clean_up()
     {
         // Delete send ports
         opened_ports_.clear();
-        
+
         // Delete input channels
         {
             std::lock_guard<std::recursive_mutex> lock(input_channels_mutex_);
@@ -221,7 +222,7 @@ void SharedMemTransport::clean_up()
 
         shared_mem_segment_.reset();
     }
-    catch(const std::exception& e)
+    catch (const std::exception& e)
     {
         logWarning(RTPS_MSG_OUT, e.what());
     }
@@ -239,12 +240,12 @@ bool SharedMemTransport::init()
     // TODO(Adolfo): Calculate this value from UDP sockets buffers size.
     static constexpr uint32_t shm_default_segment_size = 512 * 1024;
 
-    if(configuration_.segment_size() == 0)
+    if (configuration_.segment_size() == 0)
     {
         configuration_.segment_size(shm_default_segment_size);
     }
 
-    if(configuration_.segment_size() < configuration_.max_message_size())
+    if (configuration_.segment_size() < configuration_.max_message_size())
     {
         logError(RTPS_MSG_OUT, "max_message_size cannot be greater than segment_size");
         return false;
@@ -258,7 +259,7 @@ bool SharedMemTransport::init()
 
         // Memset the whole segment to zero in order to force physical map of the buffer
         auto buffer = shared_mem_segment_->alloc_buffer(configuration_.segment_size(),
-                        (std::chrono::steady_clock::now()+std::chrono::milliseconds(100)));
+                        (std::chrono::steady_clock::now() + std::chrono::milliseconds(100)));
         memset(buffer->data(), 0, configuration_.segment_size());
         buffer.reset();
 
@@ -287,9 +288,10 @@ bool SharedMemTransport::IsInputChannelOpen(
 
     return IsLocatorSupported(locator) && (std::find_if(
                input_channels_.begin(), input_channels_.end(),
-               [&](const SharedMemChannelResource* resource) {
-        return locator == resource->locator();
-    }) != input_channels_.end());
+               [&](const SharedMemChannelResource* resource)
+               {
+                   return locator == resource->locator();
+               }) != input_channels_.end());
 }
 
 bool SharedMemTransport::IsLocatorSupported(
@@ -505,7 +507,7 @@ bool SharedMemTransport::send(
     }
 
     logInfo(RTPS_MSG_OUT,
-            "(ID:" << std::this_thread::get_id() <<") " << "SharedMemTransport: " << buffer->size() << " bytes to port " <<
+            "(ID:" << std::this_thread::get_id() << ") " << "SharedMemTransport: " << buffer->size() << " bytes to port " <<
             remote_locator.port);
 
     return true;

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
@@ -252,7 +252,7 @@ bool SharedMemTransport::init()
 
     try
     {
-        shared_mem_manager_ = std::make_shared<SharedMemManager>(SHM_MANAGER_DOMAIN);
+        shared_mem_manager_ = SharedMemManager::create(SHM_MANAGER_DOMAIN);
         shared_mem_segment_ = shared_mem_manager_->create_segment(configuration_.segment_size(),
                         configuration_.port_queue_capacity());
 

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
@@ -431,7 +431,7 @@ bool SharedMemTransport::send(
 
                 if (packet_logger_ && ret)
                 {
-                    packet_logger_->QueueLog({packet_logger_->now(), Locator_t(), * it, shared_buffer});
+                    packet_logger_->QueueLog({packet_logger_->now(), Locator_t(), *it, shared_buffer});
                 }
             }
 
@@ -473,7 +473,7 @@ std::shared_ptr<SharedMemManager::Port> SharedMemTransport::find_port(
     std::shared_ptr<SharedMemManager::Port> port = shared_mem_manager_->
             open_port(port_id, configuration_.port_queue_capacity(), configuration_.healthy_check_timeout_ms(),
                     SharedMemGlobal::Port::OpenMode::Write);
-                    
+
     opened_ports_[port_id] = port;
 
     return port;

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
@@ -461,20 +461,22 @@ bool SharedMemTransport::send(
 std::shared_ptr<SharedMemManager::Port> SharedMemTransport::find_port(
         uint32_t port_id)
 {
-    try
-    {
-        return opened_ports_.at(port_id);
-    }
-    catch (const std::out_of_range&)
-    {
-        // The port is not opened
-        std::shared_ptr<SharedMemManager::Port> port = shared_mem_manager_->
-                open_port(port_id, configuration_.port_queue_capacity(), configuration_.healthy_check_timeout_ms(),
-                        SharedMemGlobal::Port::OpenMode::Write);
-        opened_ports_[port_id] = port;
+    auto ports_it = opened_ports_.find(port_id);
 
-        return port;
+    // The port is already opened
+    if (ports_it != opened_ports_.end())
+    {
+        return (*ports_it).second;
     }
+
+    // The port is not opened
+    std::shared_ptr<SharedMemManager::Port> port = shared_mem_manager_->
+            open_port(port_id, configuration_.port_queue_capacity(), configuration_.healthy_check_timeout_ms(),
+                    SharedMemGlobal::Port::OpenMode::Write);
+                    
+    opened_ports_[port_id] = port;
+
+    return port;
 }
 
 bool SharedMemTransport::push_discard(

--- a/src/cpp/rtps/transport/shared_mem/SharedMemWatchdog.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemWatchdog.hpp
@@ -74,6 +74,11 @@ public:
         }
     }
 
+    static constexpr std::chrono::milliseconds period()
+    {
+        return std::chrono::milliseconds(1000);
+    }
+
 private:
 
     std::unordered_set<Task*> tasks_;
@@ -122,7 +127,7 @@ private:
 
                 wake_run_cv_.wait_for(
                     lock,
-                    std::chrono::seconds(1),
+                    period(),
                     [&]
                     {
                         return wake_run_;

--- a/test/unittest/transport/SharedMemTests.cpp
+++ b/test/unittest/transport/SharedMemTests.cpp
@@ -1024,9 +1024,11 @@ TEST_F(SHMTransportTests, robust_exclusive_lock)
 
     // A second lock fail
     ASSERT_THROW(std::make_shared<RobustExclusiveLock>(lock_name), std::exception);
+    ASSERT_TRUE(RobustExclusiveLock::is_locked(lock_name));
 
     // Remove lock
     el1.reset();
+    ASSERT_FALSE(RobustExclusiveLock::is_locked(lock_name));
 
     bool was_created;
     el1 = std::make_shared<RobustExclusiveLock>(lock_name, &was_created);

--- a/test/unittest/transport/SharedMemTests.cpp
+++ b/test/unittest/transport/SharedMemTests.cpp
@@ -1007,7 +1007,7 @@ TEST_F(SHMTransportTests, port_lock_read_exclusive)
 
     auto port = shared_mem_manager->open_port(0, 1, 1000, SharedMemGlobal::Port::OpenMode::ReadExclusive);
     ASSERT_THROW(shared_mem_manager->open_port(0, 1, 1000, SharedMemGlobal::Port::OpenMode::ReadExclusive),
-        std::exception);
+            std::exception);
 
     port.reset();
     port = shared_mem_manager->open_port(0, 1, 1000, SharedMemGlobal::Port::OpenMode::ReadExclusive);
@@ -1378,7 +1378,7 @@ TEST_F(SHMTransportTests, dead_listener_sender_port_recover)
 
     auto shared_mem_manager = SharedMemManager::create(domain_name);
     SharedMemGlobal* shared_mem_global = shared_mem_manager->global_segment();
-    
+
     shared_mem_global->remove_port(0);
     auto deadlocked_port = shared_mem_global->open_port(0, 1, 1000);
     uint32_t listener_index;
@@ -1442,7 +1442,7 @@ TEST_F(SHMTransportTests, port_not_ok_listener_recover)
     auto port = shared_mem_global->open_port(0, 1, 1000, SharedMemGlobal::Port::OpenMode::Write);
     auto managed_port = shared_mem_manager->open_port(0, 1, 1000, SharedMemGlobal::Port::OpenMode::Write);
     auto data_segment = shared_mem_manager->create_segment(1, 1);
-    
+
     MockPortSharedMemGlobal port_mocker;
     port_mocker.set_port_not_ok(*port);
     (void)port_mocker; // Removes an inexplicable warning when compiling with VC(v140 toolset)
@@ -1466,19 +1466,19 @@ TEST_F(SHMTransportTests, buffer_recover)
     const std::string domain_name("SHMTests");
 
     auto shared_mem_manager = SharedMemManager::create(domain_name);
-    
-    auto segment = shared_mem_manager->create_segment(3,3);
+
+    auto segment = shared_mem_manager->create_segment(3, 3);
 
     shared_mem_manager->remove_port(1);
     auto pub_sub1_write = shared_mem_manager->open_port(1, 8, 1000, SharedMemGlobal::Port::OpenMode::Write);
 
     shared_mem_manager->remove_port(2);
-    auto pub_sub2_write = shared_mem_manager->open_port(2, 8, 1000,SharedMemGlobal::Port::OpenMode::Write);
+    auto pub_sub2_write = shared_mem_manager->open_port(2, 8, 1000, SharedMemGlobal::Port::OpenMode::Write);
 
     auto sub1_read = shared_mem_manager->open_port(1, 8, 1000, SharedMemGlobal::Port::OpenMode::ReadExclusive);
 
     auto sub2_read = shared_mem_manager->open_port(2, 8, 1000, SharedMemGlobal::Port::OpenMode::ReadExclusive);
-    
+
     bool exit_listeners = false;
 
     uint32_t listener1_sleep_ms = 400u;

--- a/test/unittest/transport/SharedMemTests.cpp
+++ b/test/unittest/transport/SharedMemTests.cpp
@@ -1125,7 +1125,7 @@ TEST_F(SHMTransportTests, robust_shared_lock)
 TEST_F(SHMTransportTests, memory_bounds)
 {
     const std::string domain_name("SHMTests");
-    SharedMemManager shared_mem_manager(domain_name);
+    auto shared_mem_manager = SharedMemManager::create(domain_name);
     auto shm_path = RobustLock::get_file_path("");
 
     uint64_t max_file_system_free_size;
@@ -1191,12 +1191,12 @@ TEST_F(SHMTransportTests, memory_bounds)
     // Fist allocation must succeed
     for (uint32_t i = 0; i < allocations; i++)
     {
-        segments.push_back(shared_mem_manager.create_segment(allocation_size, 1));
+        segments.push_back(shared_mem_manager->create_segment(allocation_size, 1));
         zero_mem();
     }
     if (extra_allocation)
     {
-        segments.push_back(shared_mem_manager.create_segment(extra_allocation, 1));
+        segments.push_back(shared_mem_manager->create_segment(extra_allocation, 1));
         zero_mem();
     }
 
@@ -1208,12 +1208,12 @@ TEST_F(SHMTransportTests, memory_bounds)
         ASSERT_THROW(
             for (uint32_t i = 0; i < allocations; i++)
         {
-            segments.push_back(shared_mem_manager.create_segment(allocation_size, 1));
+            segments.push_back(shared_mem_manager->create_segment(allocation_size, 1));
             zero_mem();
         }
             if (extra_allocation)
         {
-            segments.push_back(shared_mem_manager.create_segment(extra_allocation, 1));
+            segments.push_back(shared_mem_manager->create_segment(extra_allocation, 1));
             zero_mem();
         }
             , std::exception);
@@ -1224,12 +1224,12 @@ TEST_F(SHMTransportTests, memory_bounds)
         {
             for (uint32_t i = 0; i < allocations; i++)
             {
-                segments.push_back(shared_mem_manager.create_segment(allocation_size, 1));
+                segments.push_back(shared_mem_manager->create_segment(allocation_size, 1));
                 zero_mem();
             }
             if (extra_allocation)
             {
-                segments.push_back(shared_mem_manager.create_segment(extra_allocation, 1));
+                segments.push_back(shared_mem_manager->create_segment(extra_allocation, 1));
                 zero_mem();
             }
         }
@@ -1237,12 +1237,12 @@ TEST_F(SHMTransportTests, memory_bounds)
         {
             for (uint32_t i = 0; i < allocations; i++)
             {
-                segments.push_back(shared_mem_manager.create_segment(allocation_size, 1));
+                segments.push_back(shared_mem_manager->create_segment(allocation_size, 1));
                 zero_mem();
             }
             if (extra_allocation)
             {
-                segments.push_back(shared_mem_manager.create_segment(extra_allocation, 1));
+                segments.push_back(shared_mem_manager->create_segment(extra_allocation, 1));
                 zero_mem();
             }
         }

--- a/test/unittest/transport/SharedMemTests.cpp
+++ b/test/unittest/transport/SharedMemTests.cpp
@@ -963,8 +963,8 @@ TEST_F(SHMTransportTests, port_mutex_deadlock_recover)
 {
     const std::string domain_name("SHMTests");
 
-    SharedMemManager shared_mem_manager(domain_name);
-    SharedMemGlobal* shared_mem_global = shared_mem_manager.global_segment();
+    auto shared_mem_manager = SharedMemManager::create(domain_name);
+    SharedMemGlobal* shared_mem_global = shared_mem_manager->global_segment();
     MockPortSharedMemGlobal port_mocker;
 
     port_mocker.remove_port_mutex(domain_name, 0);
@@ -1001,16 +1001,16 @@ TEST_F(SHMTransportTests, port_lock_read_exclusive)
 {
     const std::string domain_name("SHMTests");
 
-    SharedMemManager shared_mem_manager(domain_name);
+    auto shared_mem_manager = SharedMemManager::create(domain_name);
 
-    shared_mem_manager.remove_port(0);
+    shared_mem_manager->remove_port(0);
 
-    auto port = shared_mem_manager.open_port(0, 1, 1000, SharedMemGlobal::Port::OpenMode::ReadExclusive);
-    ASSERT_THROW(shared_mem_manager.open_port(0, 1, 1000, SharedMemGlobal::Port::OpenMode::ReadExclusive),
-            std::exception);
+    auto port = shared_mem_manager->open_port(0, 1, 1000, SharedMemGlobal::Port::OpenMode::ReadExclusive);
+    ASSERT_THROW(shared_mem_manager->open_port(0, 1, 1000, SharedMemGlobal::Port::OpenMode::ReadExclusive),
+        std::exception);
 
     port.reset();
-    port = shared_mem_manager.open_port(0, 1, 1000, SharedMemGlobal::Port::OpenMode::ReadExclusive);
+    port = shared_mem_manager->open_port(0, 1, 1000, SharedMemGlobal::Port::OpenMode::ReadExclusive);
 }
 
 TEST_F(SHMTransportTests, robust_exclusive_lock)
@@ -1251,14 +1251,14 @@ TEST_F(SHMTransportTests, port_listener_dead_recover)
 {
     const std::string domain_name("SHMTests");
 
-    SharedMemManager shared_mem_manager(domain_name);
-    SharedMemGlobal* shared_mem_global = shared_mem_manager.global_segment();
+    auto shared_mem_manager = SharedMemManager::create(domain_name);
+    SharedMemGlobal* shared_mem_global = shared_mem_manager->global_segment();
 
     uint32_t listener1_index;
     auto port1 = shared_mem_global->open_port(0, 1, 1000);
     auto listener1 = port1->create_listener(&listener1_index);
 
-    auto listener2 = shared_mem_manager.open_port(0, 1, 1000)->create_listener();
+    auto listener2 = shared_mem_manager->open_port(0, 1, 1000)->create_listener();
 
     std::atomic<uint32_t> thread_listener2_state(0);
     std::thread thread_listener2([&]
@@ -1284,8 +1284,8 @@ TEST_F(SHMTransportTests, port_listener_dead_recover)
             }
             );
 
-    auto port_sender = shared_mem_manager.open_port(0, 1, 1000, SharedMemGlobal::Port::OpenMode::Write);
-    auto segment = shared_mem_manager.create_segment(1024, 16);
+    auto port_sender = shared_mem_manager->open_port(0, 1, 1000, SharedMemGlobal::Port::OpenMode::Write);
+    auto segment = shared_mem_manager->create_segment(1024, 16);
     auto buf = segment->alloc_buffer(1, std::chrono::steady_clock::now() + std::chrono::milliseconds(100));
     ASSERT_TRUE(buf != nullptr);
     memset(buf->data(), 0, buf->size());
@@ -1338,8 +1338,8 @@ TEST_F(SHMTransportTests, empty_cv_mutex_deadlocked_try_push)
 {
     const std::string domain_name("SHMTests");
 
-    SharedMemManager shared_mem_manager(domain_name);
-    SharedMemGlobal* shared_mem_global = shared_mem_manager.global_segment();
+    auto shared_mem_manager = SharedMemManager::create(domain_name);
+    SharedMemGlobal* shared_mem_global = shared_mem_manager->global_segment();
     MockPortSharedMemGlobal port_mocker;
 
     auto global_port = shared_mem_global->open_port(0, 1, 1000);
@@ -1376,9 +1376,9 @@ TEST_F(SHMTransportTests, dead_listener_sender_port_recover)
 {
     const std::string domain_name("SHMTests");
 
-    SharedMemManager shared_mem_manager(domain_name);
-    SharedMemGlobal* shared_mem_global = shared_mem_manager.global_segment();
-
+    auto shared_mem_manager = SharedMemManager::create(domain_name);
+    SharedMemGlobal* shared_mem_global = shared_mem_manager->global_segment();
+    
     shared_mem_global->remove_port(0);
     auto deadlocked_port = shared_mem_global->open_port(0, 1, 1000);
     uint32_t listener_index;
@@ -1418,11 +1418,11 @@ TEST_F(SHMTransportTests, port_not_ok_listener_recover)
 {
     const std::string domain_name("SHMTests");
 
-    SharedMemManager shared_mem_manager(domain_name);
-    SharedMemGlobal* shared_mem_global = shared_mem_manager.global_segment();
+    auto shared_mem_manager = SharedMemManager::create(domain_name);
+    SharedMemGlobal* shared_mem_global = shared_mem_manager->global_segment();
 
     shared_mem_global->remove_port(0);
-    auto read_port = shared_mem_manager.open_port(0, 1, 1000, SharedMemGlobal::Port::OpenMode::ReadExclusive);
+    auto read_port = shared_mem_manager->open_port(0, 1, 1000, SharedMemGlobal::Port::OpenMode::ReadExclusive);
     auto listener = read_port->create_listener();
 
     std::atomic<uint32_t> stage(0u);
@@ -1440,9 +1440,9 @@ TEST_F(SHMTransportTests, port_not_ok_listener_recover)
 
     // Open the deadlocked port
     auto port = shared_mem_global->open_port(0, 1, 1000, SharedMemGlobal::Port::OpenMode::Write);
-    auto managed_port = shared_mem_manager.open_port(0, 1, 1000, SharedMemGlobal::Port::OpenMode::Write);
-    auto data_segment = shared_mem_manager.create_segment(1, 1);
-
+    auto managed_port = shared_mem_manager->open_port(0, 1, 1000, SharedMemGlobal::Port::OpenMode::Write);
+    auto data_segment = shared_mem_manager->create_segment(1, 1);
+    
     MockPortSharedMemGlobal port_mocker;
     port_mocker.set_port_not_ok(*port);
     (void)port_mocker; // Removes an inexplicable warning when compiling with VC(v140 toolset)
@@ -1465,20 +1465,20 @@ TEST_F(SHMTransportTests, buffer_recover)
 {
     const std::string domain_name("SHMTests");
 
-    SharedMemManager shared_mem_manager(domain_name);
+    auto shared_mem_manager = SharedMemManager::create(domain_name);
+    
+    auto segment = shared_mem_manager->create_segment(3,3);
 
-    auto segment = shared_mem_manager.create_segment(3, 3);
+    shared_mem_manager->remove_port(1);
+    auto pub_sub1_write = shared_mem_manager->open_port(1, 8, 1000, SharedMemGlobal::Port::OpenMode::Write);
 
-    shared_mem_manager.remove_port(1);
-    auto pub_sub1_write = shared_mem_manager.open_port(1, 8, 1000, SharedMemGlobal::Port::OpenMode::Write);
+    shared_mem_manager->remove_port(2);
+    auto pub_sub2_write = shared_mem_manager->open_port(2, 8, 1000,SharedMemGlobal::Port::OpenMode::Write);
 
-    shared_mem_manager.remove_port(2);
-    auto pub_sub2_write = shared_mem_manager.open_port(2, 8, 1000, SharedMemGlobal::Port::OpenMode::Write);
+    auto sub1_read = shared_mem_manager->open_port(1, 8, 1000, SharedMemGlobal::Port::OpenMode::ReadExclusive);
 
-    auto sub1_read = shared_mem_manager.open_port(1, 8, 1000, SharedMemGlobal::Port::OpenMode::ReadExclusive);
-
-    auto sub2_read = shared_mem_manager.open_port(2, 8, 1000, SharedMemGlobal::Port::OpenMode::ReadExclusive);
-
+    auto sub2_read = shared_mem_manager->open_port(2, 8, 1000, SharedMemGlobal::Port::OpenMode::ReadExclusive);
+    
     bool exit_listeners = false;
 
     uint32_t listener1_sleep_ms = 400u;


### PR DESCRIPTION
When a SHM listener receives a message from an origin, the origin SHM segment is opened to read the message. The segment is kept open in order to read next messages from the same origin. But when the origin is closed the segment is not closed by the listener so the memory is not freed.

This PR adds the following feature:

* Remote SHM segments are watched by the SharedMemWatchdog to be closed when the origin segment has been closed or is in zombie state.