### PR TITLE
[8632] Solving discover server issues on participant drop.

### DIFF
--- a/include/fastdds/dds/core/policy/ParameterTypes.hpp
+++ b/include/fastdds/dds/core/policy/ParameterTypes.hpp
@@ -998,7 +998,7 @@ public:
 
         typedef iterator self_type;
         typedef ParameterProperty_t value_type;
-        typedef ParameterProperty_t reference;
+        typedef ParameterProperty_t& reference;
         typedef ParameterProperty_t* pointer;
         typedef size_t difference_type;
         typedef std::forward_iterator_tag iterator_category;
@@ -1084,7 +1084,7 @@ public:
 
         typedef const_iterator self_type;
         typedef const ParameterProperty_t value_type;
-        typedef const ParameterProperty_t reference;
+        typedef const ParameterProperty_t& reference;
         typedef const ParameterProperty_t* pointer;
         typedef size_t difference_type;
         typedef std::forward_iterator_tag iterator_category;
@@ -1573,6 +1573,66 @@ public:
 #endif
 
 ///@}
+
+template<class T, class PL>
+void set_proxy_property(const T& p, const char* PID, PL& properties)
+{
+    // only valid values
+    if (p == T::unknown())
+    {
+        return;
+    }
+
+    // generate pair
+    std::pair<std::string, std::string> pair;
+    pair.first = PID;
+
+    std::ostringstream data;
+    data << p;
+    pair.second = data.str();
+
+    // if exists replace
+    auto it = std::find_if(
+        properties.begin(),
+        properties.end(),
+        [&pair](const PL::const_iterator::reference p)
+                {
+                    return pair.first == p.first();
+                });
+
+    if (it != properties.end())
+    {
+        // it->modify(pair);
+        properties.set_property(it,pair);
+    }
+    else
+    {
+        // if not exists add
+        properties.push_back(pair);
+    }
+}
+
+template<class T, class PL>
+T get_proxy_property(const char* const PID, PL& properties)
+{
+    T property;
+
+    auto it = std::find_if(
+        properties.begin(),
+        properties.end(),
+        [PID](const PL::const_iterator::reference p)
+                {
+                    return PID == p.first();
+                });
+
+    if (it != properties.end())
+    {
+        std::istringstream in(it->second());
+        in >> property;
+    }
+
+    return property;
+}
 
 } //namespace dds
 } //namespace fastdds

--- a/include/fastdds/dds/core/policy/ParameterTypes.hpp
+++ b/include/fastdds/dds/core/policy/ParameterTypes.hpp
@@ -30,7 +30,7 @@
 #if HAVE_SECURITY
 #include <fastdds/rtps/security/accesscontrol/ParticipantSecurityAttributes.h>
 #include <fastdds/rtps/security/accesscontrol/EndpointSecurityAttributes.h>
-#endif
+#endif // if HAVE_SECURITY
 
 #include <string>
 #include <vector>
@@ -40,8 +40,8 @@ namespace eprosima {
 namespace fastrtps {
 namespace rtps {
 struct CDRMessage_t;
-}
-}
+} // namespace rtps
+} // namespace fastrtps
 
 namespace fastdds {
 namespace dds {
@@ -994,7 +994,7 @@ public:
 
     class iterator
     {
-public:
+    public:
 
         typedef iterator self_type;
         typedef ParameterProperty_t value_type;
@@ -1050,7 +1050,7 @@ public:
             return ptr_ != rhs.ptr_;
         }
 
-protected:
+    protected:
 
         /**
          * @brief Shift the pointer to the next value
@@ -1070,7 +1070,7 @@ protected:
             return ptr_;
         }
 
-private:
+    private:
 
         //!Pointer
         fastrtps::rtps::octet* ptr_;
@@ -1080,7 +1080,7 @@ private:
 
     class const_iterator
     {
-public:
+    public:
 
         typedef const_iterator self_type;
         typedef const ParameterProperty_t value_type;
@@ -1136,7 +1136,7 @@ public:
             return ptr_ != rhs.ptr_;
         }
 
-protected:
+    protected:
 
         /**
          * @brief Shift the pointer to the next value
@@ -1156,7 +1156,7 @@ protected:
             return ptr_;
         }
 
-private:
+    private:
 
         //!Pointer
         const fastrtps::rtps::octet* ptr_;
@@ -1570,12 +1570,15 @@ public:
 
 };
 
-#endif
+#endif // if HAVE_SECURITY
 
 ///@}
 
 template<class T, class PL>
-void set_proxy_property(const T& p, const char* PID, PL& properties)
+void set_proxy_property(
+        const T& p,
+        const char* PID,
+        PL& properties)
 {
     // only valid values
     if (p == T::unknown())
@@ -1596,14 +1599,14 @@ void set_proxy_property(const T& p, const char* PID, PL& properties)
         properties.begin(),
         properties.end(),
         [&pair](const typename PL::const_iterator::reference p)
-                {
-                    return pair.first == p.first();
-                });
+        {
+            return pair.first == p.first();
+        });
 
     if (it != properties.end())
     {
         // it->modify(pair);
-        properties.set_property(it,pair);
+        properties.set_property(it, pair);
     }
     else
     {
@@ -1613,7 +1616,9 @@ void set_proxy_property(const T& p, const char* PID, PL& properties)
 }
 
 template<class T, class PL>
-T get_proxy_property(const char* const PID, PL& properties)
+T get_proxy_property(
+        const char* const PID,
+        PL& properties)
 {
     T property;
 
@@ -1621,9 +1626,9 @@ T get_proxy_property(const char* const PID, PL& properties)
         properties.begin(),
         properties.end(),
         [PID](const typename PL::const_iterator::reference p)
-                {
-                    return PID == p.first();
-                });
+        {
+            return PID == p.first();
+        });
 
     if (it != properties.end())
     {
@@ -1638,5 +1643,5 @@ T get_proxy_property(const char* const PID, PL& properties)
 } //namespace fastdds
 } //namespace eprosima
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif // _FASTDDS_DDS_QOS_PARAMETERTYPES_HPP_

--- a/include/fastdds/dds/core/policy/ParameterTypes.hpp
+++ b/include/fastdds/dds/core/policy/ParameterTypes.hpp
@@ -1595,7 +1595,7 @@ void set_proxy_property(const T& p, const char* PID, PL& properties)
     auto it = std::find_if(
         properties.begin(),
         properties.end(),
-        [&pair](const PL::const_iterator::reference p)
+        [&pair](const typename PL::const_iterator::reference p)
                 {
                     return pair.first == p.first();
                 });
@@ -1620,7 +1620,7 @@ T get_proxy_property(const char* const PID, PL& properties)
     auto it = std::find_if(
         properties.begin(),
         properties.end(),
-        [PID](const PL::const_iterator::reference p)
+        [PID](const typename PL::const_iterator::reference p)
                 {
                     return PID == p.first();
                 });

--- a/include/fastdds/rtps/builtin/data/ParticipantProxyData.h
+++ b/include/fastdds/rtps/builtin/data/ParticipantProxyData.h
@@ -31,7 +31,7 @@
 
 #if HAVE_SECURITY
 #include <fastdds/rtps/security/accesscontrol/ParticipantSecurityAttributes.h>
-#endif
+#endif // if HAVE_SECURITY
 
 #include <chrono>
 
@@ -126,7 +126,7 @@ public:
     security::ParticipantSecurityAttributesMask security_attributes_;
     //!
     security::PluginParticipantSecurityAttributesMask plugin_security_attributes_;
-#endif
+#endif // if HAVE_SECURITY
     //!
     bool isAlive;
     //!
@@ -204,7 +204,7 @@ public:
      * @param sid valid SampleIdentity
      */
     void set_sample_identity(
-        const SampleIdentity& sid);
+            const SampleIdentity& sid);
 
     /**
      * Retrieve participant SampleIdentity
@@ -217,7 +217,7 @@ public:
      * @param guid valid backup server GUID
      */
     void set_backup_stamp(
-        const GUID_t& guid);
+            const GUID_t& guid);
 
     /**
      * Retrieves BACKUP server stamp. On deserialization hints if lease duration must be enforced
@@ -250,6 +250,6 @@ private:
 } /* namespace fastrtps */
 } /* namespace eprosima */
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 #endif // _FASTDDS_RTPS_BUILTIN_DATA_PARTICIPANTPROXYDATA_H_

--- a/include/fastdds/rtps/builtin/data/ParticipantProxyData.h
+++ b/include/fastdds/rtps/builtin/data/ParticipantProxyData.h
@@ -199,6 +199,32 @@ public:
      */
     GUID_t get_persistence_guid() const;
 
+    /**
+     * Set participant client server sample identity
+     * @param sid valid SampleIdentity
+     */
+    void set_sample_identity(
+        const SampleIdentity& sid);
+
+    /**
+     * Retrieve participant SampleIdentity
+     * @return SampleIdentity
+     */
+    SampleIdentity get_sample_identity() const;
+
+    /**
+     * Identifies the participant as client of the given server
+     * @param guid valid backup server GUID
+     */
+    void set_backup_stamp(
+        const GUID_t& guid);
+
+    /**
+     * Retrieves BACKUP server stamp. On deserialization hints if lease duration must be enforced
+     * @return GUID
+     */
+    GUID_t get_backup_stamp() const;
+
     void assert_liveliness();
 
     const std::chrono::steady_clock::time_point& last_received_message_tm() const

--- a/include/fastdds/rtps/builtin/data/ReaderProxyData.h
+++ b/include/fastdds/rtps/builtin/data/ReaderProxyData.h
@@ -29,7 +29,7 @@
 
 #if HAVE_SECURITY
 #include <fastdds/rtps/security/accesscontrol/EndpointSecurityAttributes.h>
-#endif
+#endif // if HAVE_SECURITY
 
 #include <fastdds/rtps/common/RemoteLocators.hpp>
 
@@ -400,7 +400,7 @@ public:
 
     //!EndpointSecurityInfo.plugin_endpoint_security_attributes
     security::PluginEndpointSecurityAttributesMask plugin_security_attributes_;
-#endif
+#endif // if HAVE_SECURITY
 
     /**
      * Clear (put to default) the information.
@@ -459,9 +459,9 @@ private:
     ParameterPropertyList_t m_properties;
 };
 
-}
+} // namespace rtps
 } /* namespace rtps */
 } /* namespace eprosima */
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif // _FASTDDS_RTPS_BUILTIN_DATA_READERPROXYDATA_H_

--- a/include/fastdds/rtps/builtin/data/ReaderProxyData.h
+++ b/include/fastdds/rtps/builtin/data/ReaderProxyData.h
@@ -343,6 +343,25 @@ public:
     }
 
     /**
+     * Set participant client server sample identity
+     * @param sid valid SampleIdentity
+     */
+    void set_sample_identity(
+            const SampleIdentity& sid)
+    {
+        fastdds::dds::set_proxy_property(sid, "PID_CLIENT_SERVER_KEY", m_properties);
+    }
+
+    /**
+     * Retrieve participant SampleIdentity
+     * @return SampleIdentity
+     */
+    SampleIdentity get_sample_identity() const
+    {
+        return fastdds::dds::get_proxy_property<SampleIdentity>("PID_CLIENT_SERVER_KEY", m_properties);
+    }
+
+    /**
      * Get the size in bytes of the CDR serialization of this object.
      * @param include_encapsulation Whether to include the size of the encapsulation info.
      * @return size in bytes of the CDR serialization.
@@ -436,6 +455,8 @@ private:
     TypeObjectV1* m_type;
     //!Type Information
     xtypes::TypeInformation* m_type_information;
+    //!
+    ParameterPropertyList_t m_properties;
 };
 
 }

--- a/include/fastdds/rtps/builtin/data/WriterProxyData.h
+++ b/include/fastdds/rtps/builtin/data/WriterProxyData.h
@@ -367,6 +367,25 @@ public:
     //!WriterQOS
     WriterQos m_qos;
 
+    /**
+     * Set participant client server sample identity
+     * @param sid valid SampleIdentity
+     */
+    void set_sample_identity(
+            const SampleIdentity& sid)
+    {
+        fastdds::dds::set_proxy_property(sid, "PID_CLIENT_SERVER_KEY", m_properties);
+    }
+
+    /**
+     * Retrieve participant SampleIdentity
+     * @return SampleIdentity
+     */
+    SampleIdentity get_sample_identity() const
+    {
+        return fastdds::dds::get_proxy_property<SampleIdentity>("PID_CLIENT_SERVER_KEY", m_properties);
+    }
+
 #if HAVE_SECURITY
     //!EndpointSecurityInfo.endpoint_security_attributes
     security::EndpointSecurityAttributesMask security_attributes_;
@@ -456,6 +475,9 @@ private:
 
     //!Type Information
     xtypes::TypeInformation* m_type_information;
+
+    //!
+    ParameterPropertyList_t m_properties;
 };
 
 } /* namespace rtps */

--- a/include/fastdds/rtps/builtin/data/WriterProxyData.h
+++ b/include/fastdds/rtps/builtin/data/WriterProxyData.h
@@ -29,7 +29,7 @@
 
 #if HAVE_SECURITY
 #include <fastdds/rtps/security/accesscontrol/EndpointSecurityAttributes.h>
-#endif
+#endif // if HAVE_SECURITY
 
 #include <fastdds/rtps/common/RemoteLocators.hpp>
 
@@ -392,7 +392,7 @@ public:
 
     //!EndpointSecurityInfo.plugin_endpoint_security_attributes
     security::PluginEndpointSecurityAttributesMask plugin_security_attributes_;
-#endif
+#endif // if HAVE_SECURITY
 
     //!Clear the information and return the object to the default state.
     void clear();
@@ -484,5 +484,5 @@ private:
 } /* namespace fastrtps */
 } /* namespace eprosima */
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif // _FASTDDS_RTPS_BUILTIN_DATA_WRITERPROXYDATA_H_

--- a/include/fastdds/rtps/builtin/discovery/endpoint/EDPServer.h
+++ b/include/fastdds/rtps/builtin/discovery/endpoint/EDPServer.h
@@ -44,8 +44,6 @@ class EDPServer : public EDPSimple
     friend class EDPServerPUBListener;
     friend class EDPServerSUBListener;
 
-    typedef std::set<InstanceHandle_t> key_list;
-
     //! Keys to wipe out from WriterHistory because its related Participants have been removed
     key_list _PUBdemises, _SUBdemises;
 
@@ -107,7 +105,7 @@ public:
             RTPSWriter* W) override;
 
     /**
-     * Some History data is flag for defer removal till every client
+     * Some History data is flagged for deferred removal till every client
      * acknowledges reception
      * @return True if trimming must be done
      */
@@ -117,17 +115,8 @@ public:
     }
 
     //! Callback to remove unnecesary WriterHistory info
-    bool trimPUBWriterHistory()
-    {
-        return trimWriterHistory<ProxyHashTable<WriterProxyData>*>(_PUBdemises,
-                       *publications_writer_.first, *publications_writer_.second, &ParticipantProxyData::m_writers);
-    }
-
-    bool trimSUBWriterHistory()
-    {
-        return trimWriterHistory<ProxyHashTable<ReaderProxyData>*>(_SUBdemises,
-                       *subscriptions_writer_.first, *subscriptions_writer_.second, &ParticipantProxyData::m_readers);
-    }
+    bool trimPUBWriterHistory();
+    bool trimSUBWriterHistory();
 
     //! returns true if loading info from persistency database
     bool ongoingDeserialization();
@@ -144,23 +133,15 @@ public:
     void removeSubscriberFromHistory(
             const InstanceHandle_t&);
 
-protected:
-
     /**
      * Add participant CacheChange_ts from reader to writer
      * @return True if successfully modified WriterHistory
      */
     bool addPublisherFromHistory(
-            CacheChange_t& c)
-    {
-        return addEndpointFromHistory(*publications_writer_.first, *publications_writer_.second, c);
-    }
+            CacheChange_t& c);
 
     bool addSubscriberFromHistory(
-            CacheChange_t& c)
-    {
-        return addEndpointFromHistory(*subscriptions_writer_.first, *subscriptions_writer_.second, c);
-    }
+            CacheChange_t& c);
 
 private:
 
@@ -173,9 +154,10 @@ private:
             key_list& _demises,
             StatefulWriter& writer,
             WriterHistory& history,
-            ProxyCont ParticipantProxyData::* pCont);
+            ProxyCont* ParticipantProxyData::* pCont);
 
     //! addPublisherFromHistory and addSubscriberFromHistory common implementation
+    template<class Proxy>
     bool addEndpointFromHistory(
             StatefulWriter& writer,
             WriterHistory& history,

--- a/include/fastdds/rtps/builtin/discovery/endpoint/EDPSimple.h
+++ b/include/fastdds/rtps/builtin/discovery/endpoint/EDPSimple.h
@@ -83,7 +83,7 @@ public:
     t_p_StatefulWriter subscriptions_secure_writer_;
 
     t_p_StatefulReader subscriptions_secure_reader_;
-#endif
+#endif // if HAVE_SECURITY
 
     //!Pointer to the listener associated with PubReader and PubWriter.
     EDPListener* publications_listener_;
@@ -139,14 +139,14 @@ public:
      * @return True if correct.
      */
     bool removeLocalReader(
-            RTPSReader*R) override;
+            RTPSReader* R) override;
     /**
      * This methods generates the change disposing of the local Writer and calls the unpairing and removal methods of the base class.
      * @param W Pointer to the RTPSWriter object.
      * @return True if correct.
      */
     bool removeLocalWriter(
-            RTPSWriter*W) override;
+            RTPSWriter* W) override;
 
 protected:
 
@@ -223,6 +223,7 @@ protected:
             key_list& demises);
 
 private:
+
     /**
      * Create a cache change on a builtin writer and serialize a ProxyData on it.
      * @param [in] data The ProxyData object to be serialized.
@@ -248,7 +249,7 @@ private:
     bool pairing_remote_reader_with_local_builtin_writer_after_security(
             const GUID_t& local_writer,
             const ReaderProxyData& remote_reader_data) override;
-#endif
+#endif // if HAVE_SECURITY
 
     std::mutex temp_data_lock_;
     ReaderProxyData temp_reader_proxy_data_;
@@ -259,5 +260,5 @@ private:
 } /* namespace fastrtps */
 } /* namespace eprosima */
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif /* _FASTDDS_RTPS_EDPSIMPLE_H_ */

--- a/include/fastdds/rtps/builtin/discovery/endpoint/EDPSimple.h
+++ b/include/fastdds/rtps/builtin/discovery/endpoint/EDPSimple.h
@@ -52,6 +52,8 @@ class EDPSimple : public EDP
 
 public:
 
+    typedef std::set<InstanceHandle_t> key_list;
+
     /**
      * Constructor.
      * @param p Pointer to the PDP
@@ -215,7 +217,10 @@ protected:
             CacheChange_t** created_change);
 
     //! Process the info recorded in the persistence database
-    static void processPersistentData(t_p_StatefulReader & reader, t_p_StatefulWriter & writer);
+    void processPersistentData(
+            t_p_StatefulReader& reader,
+            t_p_StatefulWriter& writer,
+            key_list& demises);
 
 private:
     /**

--- a/include/fastdds/rtps/builtin/discovery/participant/PDPServer.h
+++ b/include/fastdds/rtps/builtin/discovery/participant/PDPServer.h
@@ -25,11 +25,11 @@
 #include <fastdds/rtps/messages/RTPSMessageGroup.h>
 #include <fastdds/rtps/builtin/discovery/participant/timedevent/DServerEvent.h>
 
- // TODO: remove when the Writer API issue is resolved
+// TODO: remove when the Writer API issue is resolved
 #include <fastdds/rtps/attributes/WriterAttributes.h>
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
 class StatefulWriter;
@@ -75,14 +75,16 @@ public:
             DurabilityKind_t durability_kind = TRANSIENT_LOCAL);
     ~PDPServer();
 
-    void initializeParticipantProxyData(ParticipantProxyData* participant_data) override;
+    void initializeParticipantProxyData(
+            ParticipantProxyData* participant_data) override;
 
     /**
      * Initialize the PDP.
      * @param part Pointer to the RTPSParticipant.
      * @return True on success
      */
-    bool init(RTPSParticipantImpl* part) override;
+    bool init(
+            RTPSParticipantImpl* part) override;
 
     /**
      * Creates an initializes a new participant proxy from a DATA(p) raw info
@@ -91,8 +93,8 @@ public:
      * @return new ParticipantProxyData * or nullptr on failure
      */
     ParticipantProxyData* createParticipantProxyData(
-        const ParticipantProxyData& p,
-        const GUID_t& writer_guid) override;
+            const ParticipantProxyData& p,
+            const GUID_t& writer_guid) override;
 
     /**
      * Create the SPDP Writer and Reader
@@ -132,14 +134,16 @@ public:
      * @param c metatraffic CacheChange_t
      * @return True if successfully modified WriterHistory
      */
-    bool addRelayedChangeToHistory(CacheChange_t& c);
+    bool addRelayedChangeToHistory(
+            CacheChange_t& c);
 
     /**
      * Trigger the participant CacheChange_t removal system
      * @param h instanceHandle associated with participants CacheChange_ts
      * @return True if successfully modified WriterHistory
      */
-    void removeParticipantFromHistory(const InstanceHandle_t& h);
+    void removeParticipantFromHistory(
+            const InstanceHandle_t& h);
 
     /**
      * Methods to synchronize EDP matching
@@ -149,13 +153,15 @@ public:
      * Add a participant to the queue of pending participants to EDP matching
      * @param p ParticipantProxyData associated with the new participant
      */
-    void queueParticipantForEDPMatch(const ParticipantProxyData* p);
+    void queueParticipantForEDPMatch(
+            const ParticipantProxyData* p);
 
     /**
      * Remove a participant from the queue of pending participants to EDP matching
      * @param guid GUID associated with the new participant
      */
-    void removeParticipantForEDPMatch(const GUID_t& guid);
+    void removeParticipantForEDPMatch(
+            const GUID_t& guid);
 
     /**
      * Check if all client have acknowledge the server PDP data
@@ -182,10 +188,10 @@ public:
      */
 
     /**
-    * Check if all servers have acknowledge this server PDP data
-    * This method must be called from a mutex protected context.
-    * @return True if all can reach the client
-    */
+     * Check if all servers have acknowledge this server PDP data
+     * This method must be called from a mutex protected context.
+     * @return True if all can reach the client
+     */
     bool all_servers_acknowledge_PDP();
 
     /**
@@ -208,23 +214,26 @@ public:
      * @param wparams allows to identify the change
      */
     void announceParticipantState(
-        bool new_change,
-        bool dispose = false,
-        WriteParams& wparams = WriteParams::WRITE_PARAM_DEFAULT) override;
+            bool new_change,
+            bool dispose = false,
+            WriteParams& wparams = WriteParams::WRITE_PARAM_DEFAULT) override;
 
     /**
      * These methods wouldn't be needed under perfect server operation (no need of dynamic endpoint allocation)
      * but must be implemented to solve server shutdown situations.
      * @param pdata Pointer to the RTPSParticipantProxyData object.
      */
-    void assignRemoteEndpoints(ParticipantProxyData* pdata) override;
-    void removeRemoteEndpoints(ParticipantProxyData * pdata) override;
-    void notifyAboveRemoteEndpoints(const ParticipantProxyData& pdata) override;
+    void assignRemoteEndpoints(
+            ParticipantProxyData* pdata) override;
+    void removeRemoteEndpoints(
+            ParticipantProxyData* pdata) override;
+    void notifyAboveRemoteEndpoints(
+            const ParticipantProxyData& pdata) override;
 
 #if HAVE_SQLITE3
     //! Get filename for persistence database file
     std::string GetPersistenceFileName();
-#endif
+#endif // if HAVE_SQLITE3
 
     //! returns true if loading info from persistency database
     bool ongoingDeserialization();
@@ -233,13 +242,18 @@ public:
     void processPersistentData();
 
     //! adds identity info to DATA(p[UD])s in order to keep it through persistance serialization process
-    static bool set_data_disposal_payload(CDRMessage_t* msg, const SampleIdentity& sid);
+    static bool set_data_disposal_payload(
+            CDRMessage_t* msg,
+            const SampleIdentity& sid);
 
     //! returns the DATA(p[UD])s size to hint payload allocation
     static uint32_t get_data_disposal_payload_serialized_size();
 
     //! Wakes up the DServerEvent for new matching or trimming
-    void awakeServerThread() { mp_sync->restart_timer(); }
+    void awakeServerThread()
+    {
+        mp_sync->restart_timer();
+    }
 
 private:
 
@@ -250,15 +264,15 @@ private:
     bool trimPDPWriterHistory();
 
     /**
-    * TimedEvent for server synchronization:
-    *   first stage: periodically resend the local RTPSParticipant information until all servers have acknowledge reception
-    *   second stage: waiting PDP info is up to date before allowing EDP matching
-    */
+     * TimedEvent for server synchronization:
+     *   first stage: periodically resend the local RTPSParticipant information until all servers have acknowledge reception
+     *   second stage: waiting PDP info is up to date before allowing EDP matching
+     */
     DServerEvent* mp_sync;
 };
 
-}
+} // namespace rtps
 } /* namespace rtps */
 } /* namespace eprosima */
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif /* _FASTDDS_RTPS_PDPSERVER_H_ */

--- a/include/fastdds/rtps/builtin/discovery/participant/PDPServer.h
+++ b/include/fastdds/rtps/builtin/discovery/participant/PDPServer.h
@@ -236,7 +236,7 @@ public:
     static bool set_data_disposal_payload(CDRMessage_t* msg, const SampleIdentity& sid);
 
     //! returns the DATA(p[UD])s size to hint payload allocation
-    static uint32_t get_data_disposal_payload_serialized_size();
+    static const uint32_t get_data_disposal_payload_serialized_size();
 
     //! Wakes up the DServerEvent for new matching or trimming
     void awakeServerThread() { mp_sync->restart_timer(); }

--- a/include/fastdds/rtps/builtin/discovery/participant/PDPServer.h
+++ b/include/fastdds/rtps/builtin/discovery/participant/PDPServer.h
@@ -45,8 +45,6 @@ class PDPServer : public PDP
     friend class DServerEvent;
     friend class PDPServerListener;
 
-    friend class InPDPCallback;
-
     typedef std::set<const ParticipantProxyData*> pending_matches_list;
     typedef std::set<InstanceHandle_t> key_list;
 
@@ -234,27 +232,14 @@ public:
     //! Process the info recorded in the persistence database
     void processPersistentData();
 
+    //! adds identity info to DATA(p[UD])s in order to keep it through persistance serialization process
+    static bool set_data_disposal_payload(CDRMessage_t* msg, const SampleIdentity& sid);
+
+    //! returns the DATA(p[UD])s size to hint payload allocation
+    static uint32_t get_data_disposal_payload_serialized_size();
+
     //! Wakes up the DServerEvent for new matching or trimming
     void awakeServerThread() { mp_sync->restart_timer(); }
-
-    // The following struct and two methods solve a callback synchronization issue
-
-    class InPDPCallback
-    {
-        friend class PDPServer;
-        PDPServer & server_;
-
-    public:
-
-        InPDPCallback(PDPServer & svr);
-        ~InPDPCallback();
-    };
-
-    // ! returns a unique_ptr to an object that handles PDP_callback_ in a RAII fashion
-    std::unique_ptr<InPDPCallback> signalCallback();
-
-    // ! calls PDP Reader matched_writer_remove preventing deadlocks
-    bool safe_PDP_matched_writer_remove(const GUID_t& wguid);
 
 private:
 
@@ -270,10 +255,6 @@ private:
     *   second stage: waiting PDP info is up to date before allowing EDP matching
     */
     DServerEvent* mp_sync;
-
-    // ! on PDP DATA(p[UD]) callback. Only modified by transport threads which are
-    // serialized for PDP reader
-    volatile bool PDP_callback_;
 };
 
 }

--- a/include/fastdds/rtps/builtin/discovery/participant/PDPServer.h
+++ b/include/fastdds/rtps/builtin/discovery/participant/PDPServer.h
@@ -236,7 +236,7 @@ public:
     static bool set_data_disposal_payload(CDRMessage_t* msg, const SampleIdentity& sid);
 
     //! returns the DATA(p[UD])s size to hint payload allocation
-    static const uint32_t get_data_disposal_payload_serialized_size();
+    static uint32_t get_data_disposal_payload_serialized_size();
 
     //! Wakes up the DServerEvent for new matching or trimming
     void awakeServerThread() { mp_sync->restart_timer(); }

--- a/include/fastdds/rtps/common/Guid.h
+++ b/include/fastdds/rtps/common/Guid.h
@@ -240,8 +240,13 @@ inline std::istream& operator >>(
         {
             input.exceptions(excp_mask | std::ios_base::failbit | std::ios_base::badbit);
 
-            input >> guid.guidPrefix;
-            input >> guid.entityId;
+            char sep;
+            input >> guid.guidPrefix >> sep >> guid.entityId;
+
+            if (sep != '|')
+            {
+                input.setstate(std::ios_base::failbit);
+            }
         }
         catch (std::ios_base::failure&)
         {

--- a/include/fastdds/rtps/common/Guid.h
+++ b/include/fastdds/rtps/common/Guid.h
@@ -114,13 +114,14 @@ struct RTPS_DllAPI GUID_t
     static GUID_t unknown() noexcept
     {
         return GUID_t();
-    };
+    }
 
     // TODO Review this conversion once InstanceHandle_t is implemented as DDS standard defines
     explicit operator const InstanceHandle_t&() const
     {
         return *reinterpret_cast<const InstanceHandle_t*>(this);
     }
+
 };
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
@@ -193,7 +194,8 @@ inline bool operator <(
     }
     return false;
 }
-#endif
+
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 const GUID_t c_Guid_Unknown;
 
@@ -209,7 +211,7 @@ inline std::ostream& operator <<(
         std::ostream& output,
         const GUID_t& guid)
 {
-    if (guid !=c_Guid_Unknown)
+    if (guid != c_Guid_Unknown)
     {
         output << guid.guidPrefix << "|" << guid.entityId;
     }
@@ -260,7 +262,7 @@ inline std::istream& operator >>(
     return input;
 }
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 } // namespace rtps
 } // namespace fastrtps

--- a/include/fastdds/rtps/common/SampleIdentity.h
+++ b/include/fastdds/rtps/common/SampleIdentity.h
@@ -174,7 +174,70 @@ private:
     GUID_t writer_guid_;
 
     SequenceNumber_t sequence_number_;
+
+    friend std::istream& operator >>(std::istream& input, SampleIdentity& sid);
+    friend std::ostream& operator <<(std::ostream& output, const SampleIdentity& sid);
 };
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+
+/**
+ * Stream operator, retrieves a GUID.
+ * @param input Input stream.
+ * @param sid SampleIdentity to read.
+ * @return Stream operator.
+ */
+inline std::istream& operator >>(
+        std::istream& input,
+        SampleIdentity& sid)
+{
+    std::istream::sentry s(input);
+
+    if (s)
+    {
+        std::ios_base::iostate excp_mask = input.exceptions();
+
+        try
+        {
+            input.exceptions(excp_mask | std::ios_base::failbit | std::ios_base::badbit);
+
+            char sep;
+            input >> sid.writer_guid_ >> sep >> sid.sequence_number_;
+
+            if (sep != '|')
+            {
+                input.setstate(std::ios_base::failbit);
+            }
+        }
+        catch (std::ios_base::failure&)
+        {
+            // maybe is unknown or just invalid
+            sid.writer_guid_ = GUID_t::unknown();
+            sid.sequence_number_ = SequenceNumber_t::unknown();
+        }
+
+        input.exceptions(excp_mask);
+    }
+
+    return input;
+}
+
+/**
+ * Stream operator, prints a GUID.
+ * @param output Output stream.
+ * @param sid SampleIdentity to print.
+ * @return Stream operator.
+ */
+inline std::ostream& operator <<(
+        std::ostream& output,
+        const SampleIdentity& sid)
+{
+    output << sid.writer_guid_ << '|' << sid.sequence_number_;
+
+    return output;
+}
+
+#endif // DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 } //namespace rtps
 } //namespace fastrtps

--- a/include/fastdds/rtps/common/SampleIdentity.h
+++ b/include/fastdds/rtps/common/SampleIdentity.h
@@ -66,7 +66,7 @@ public:
     /*!
      * @brief Assignment operator.
      */
-    SampleIdentity& operator=(
+    SampleIdentity& operator =(
             const SampleIdentity& sample_id)
     {
         writer_guid_ = sample_id.writer_guid_;
@@ -77,7 +77,7 @@ public:
     /*!
      * @brief Move constructor.
      */
-    SampleIdentity& operator=(
+    SampleIdentity& operator =(
             SampleIdentity&& sample_id)
     {
         writer_guid_ = std::move(sample_id.writer_guid_);
@@ -88,7 +88,7 @@ public:
     /*!
      * @brief
      */
-    bool operator==(
+    bool operator ==(
             const SampleIdentity& sample_id) const
     {
         return (writer_guid_ == sample_id.writer_guid_) && (sequence_number_ == sample_id.sequence_number_);
@@ -97,7 +97,7 @@ public:
     /*!
      * @brief
      */
-    bool operator!=(
+    bool operator !=(
             const SampleIdentity& sample_id) const
     {
         return !(*this == sample_id);
@@ -108,12 +108,12 @@ public:
      * @param sample
      * @return
      */
-    bool operator<(
+    bool operator <(
             const SampleIdentity& sample) const
     {
         return writer_guid_ < sample.writer_guid_
-            || (writer_guid_ == sample.writer_guid_
-                   && sequence_number_ < sample.sequence_number_);
+               || (writer_guid_ == sample.writer_guid_
+               && sequence_number_ < sample.sequence_number_);
     }
 
     SampleIdentity& writer_guid(
@@ -175,8 +175,12 @@ private:
 
     SequenceNumber_t sequence_number_;
 
-    friend std::istream& operator >>(std::istream& input, SampleIdentity& sid);
-    friend std::ostream& operator <<(std::ostream& output, const SampleIdentity& sid);
+    friend std::istream& operator >>(
+            std::istream& input,
+            SampleIdentity& sid);
+    friend std::ostream& operator <<(
+            std::ostream& output,
+            const SampleIdentity& sid);
 };
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC

--- a/include/fastdds/rtps/common/SequenceNumber.h
+++ b/include/fastdds/rtps/common/SequenceNumber.h
@@ -59,6 +59,17 @@ struct RTPS_DllAPI SequenceNumber_t
     {
     }
 
+    /*!
+     * @param 64long
+     */
+    explicit
+    SequenceNumber_t(
+            uint64_t u) noexcept
+        : high( static_cast<int32_t>(u >> 32u) )
+        , low( static_cast<uint32_t>(u) )
+    {
+    }
+
     /*! Convert the number to 64 bit.
      * @return 64 bit representation of the SequenceNumber
      */
@@ -371,7 +382,27 @@ inline std::ostream& operator <<(
     return output;
 }
 
-#endif
+/**
+ *
+ * @param input
+ * @param seqNum
+ * @return
+ */
+inline std::istream& operator >>(
+        std::istream& input,
+        SequenceNumber_t& seqNum)
+{
+    uint64_t aux;
+
+    if (input >> aux)
+    {
+        seqNum = SequenceNumber_t(aux);
+    }
+
+    return input;
+}
+
+#endif // DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 } // namespace rtps
 } // namespace fastrtps

--- a/include/fastdds/rtps/common/SequenceNumber.h
+++ b/include/fastdds/rtps/common/SequenceNumber.h
@@ -90,7 +90,8 @@ struct RTPS_DllAPI SequenceNumber_t
         return *this;
     }
 
-    SequenceNumber_t operator ++(int) noexcept
+    SequenceNumber_t operator ++(
+            int) noexcept
     {
         SequenceNumber_t result(*this);
         ++(*this);
@@ -214,7 +215,7 @@ inline bool operator >=(
  */
 inline bool operator <=(
         const SequenceNumber_t& seq1,
-        const  SequenceNumber_t& seq2) noexcept
+        const SequenceNumber_t& seq2) noexcept
 {
     if (seq1.high == seq2.high)
     {
@@ -287,9 +288,9 @@ inline SequenceNumber_t operator -(
     return res;
 }
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
-const SequenceNumber_t c_SequenceNumber_Unknown(-1,0);
+const SequenceNumber_t c_SequenceNumber_Unknown(-1, 0);
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
@@ -323,7 +324,7 @@ inline std::ostream& operator <<(
         std::ostream& output,
         const std::vector<SequenceNumber_t>& seqNumSet)
 {
-    for(const SequenceNumber_t& sn : seqNumSet)
+    for (const SequenceNumber_t& sn : seqNumSet)
     {
         output << sn << " ";
     }
@@ -341,6 +342,7 @@ struct SequenceNumberHash
     {
         return static_cast<std::size_t>(sequence_number.to64long());
     }
+
 };
 
 struct SequenceNumberDiff
@@ -352,9 +354,10 @@ struct SequenceNumberDiff
         SequenceNumber_t diff = a - b;
         return diff.low;
     }
+
 };
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 //!Structure SequenceNumberSet_t, contains a group of sequencenumbers.
 //!@ingroup COMMON_MODULE
@@ -374,10 +377,10 @@ inline std::ostream& operator <<(
 {
     output << sns.base().to64long() << ":";
     sns.for_each([&output](
-            SequenceNumber_t it)
-    {
-        output << it.to64long() << "-";
-    });
+                SequenceNumber_t it)
+            {
+                output << it.to64long() << "-";
+            });
 
     return output;
 }

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -398,7 +398,7 @@ elseif(NOT EPROSIMA_INSTALLER)
     # Link library to external libraries.
     target_link_libraries(${PROJECT_NAME} ${PRIVACY} fastcdr foonathan_memory
         ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS}
-        ${TINYXML2_LIBRARY}
+        $<$<BOOL:${TINYXML2_LIBRARY}>:${TINYXML2_LIBRARY}>
         $<$<BOOL:${LINK_SSL}>:OpenSSL::SSL$<SEMICOLON>OpenSSL::Crypto>
         $<$<BOOL:${WIN32}>:iphlpapi$<SEMICOLON>Shlwapi>
         ${THIRDPARTY_BOOST_LINK_LIBS}

--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
@@ -826,6 +826,27 @@ GUID_t ParticipantProxyData::get_persistence_guid() const
     return persistent;
 }
 
+void ParticipantProxyData::set_sample_identity(
+        const SampleIdentity& sid)
+{
+    fastdds::dds::set_proxy_property(sid, "PID_CLIENT_SERVER_KEY", m_properties);
+}
+
+SampleIdentity ParticipantProxyData::get_sample_identity() const
+{
+    return fastdds::dds::get_proxy_property<SampleIdentity>("PID_CLIENT_SERVER_KEY", m_properties);
+}
+
+void ParticipantProxyData::set_backup_stamp(const GUID_t& guid)
+{
+    fastdds::dds::set_proxy_property(guid,"PID_BACKUP_STAMP", m_properties);
+}
+
+GUID_t ParticipantProxyData::get_backup_stamp() const
+{
+    return fastdds::dds::get_proxy_property<GUID_t>("PID_BACKUP_STAMP", m_properties);
+}
+
 void ParticipantProxyData::assert_liveliness()
 {
     last_received_message_tm_ = std::chrono::steady_clock::now();

--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
@@ -59,7 +59,7 @@ ParticipantProxyData::ParticipantProxyData(
 #if HAVE_SECURITY
     , security_attributes_(0UL)
     , plugin_security_attributes_(0UL)
-#endif
+#endif // if HAVE_SECURITY
     , isAlive(false)
     , m_properties(static_cast<uint32_t>(allocation.data_limits.max_properties))
     , lease_duration_event(nullptr)
@@ -88,7 +88,7 @@ ParticipantProxyData::ParticipantProxyData(
     , permissions_token_(pdata.permissions_token_)
     , security_attributes_(pdata.security_attributes_)
     , plugin_security_attributes_(pdata.plugin_security_attributes_)
-#endif
+#endif // if HAVE_SECURITY
     , isAlive(pdata.isAlive)
     , m_properties(pdata.m_properties)
     , m_userData(pdata.m_userData)
@@ -209,7 +209,7 @@ uint32_t ParticipantProxyData::get_serialized_size(
         // PID_PARTICIPANT_SECURITY_INFO
         ret_val += 4 + PARAMETER_PARTICIPANT_SECURITY_INFO_LENGTH;
     }
-#endif
+#endif // if HAVE_SECURITY
 
     // PID_SENTINEL
     return ret_val + 4;
@@ -365,7 +365,7 @@ bool ParticipantProxyData::writeToCDRMessage(
             return false;
         }
     }
-#endif
+#endif // if HAVE_SECURITY
 
     return fastdds::dds::ParameterSerializer<Parameter_t>::add_parameter_sentinel(msg);
 }
@@ -611,7 +611,7 @@ bool ParticipantProxyData::readFromCDRMessage(
                         identity_token_ = std::move(p.token);
 #else
                         logWarning(RTPS_PARTICIPANT, "Received PID_IDENTITY_TOKEN but security is disabled");
-#endif
+#endif // if HAVE_SECURITY
                         break;
                     }
                     case fastdds::dds::PID_PERMISSIONS_TOKEN:
@@ -627,7 +627,7 @@ bool ParticipantProxyData::readFromCDRMessage(
                         permissions_token_ = std::move(p.token);
 #else
                         logWarning(RTPS_PARTICIPANT, "Received PID_PERMISSIONS_TOKEN but security is disabled");
-#endif
+#endif // if HAVE_SECURITY
                         break;
                     }
 
@@ -646,7 +646,7 @@ bool ParticipantProxyData::readFromCDRMessage(
 #else
                         logWarning(RTPS_PARTICIPANT,
                                 "Received PID_PARTICIPANT_SECURITY_INFO but security is disabled");
-#endif
+#endif // if HAVE_SECURITY
                         break;
                     }
                     default:
@@ -693,7 +693,7 @@ void ParticipantProxyData::clear()
     permissions_token_ = PermissionsToken();
     security_attributes_ = 0UL;
     plugin_security_attributes_ = 0UL;
-#endif
+#endif // if HAVE_SECURITY
     m_properties.clear();
     m_properties.length = 0;
     m_userData.clear();
@@ -727,7 +727,7 @@ void ParticipantProxyData::copy(
     permissions_token_ = pdata.permissions_token_;
     security_attributes_ = pdata.security_attributes_;
     plugin_security_attributes_ = pdata.plugin_security_attributes_;
-#endif
+#endif // if HAVE_SECURITY
 }
 
 bool ParticipantProxyData::updateData(
@@ -744,7 +744,7 @@ bool ParticipantProxyData::updateData(
     permissions_token_ = pdata.permissions_token_;
     security_attributes_ = pdata.security_attributes_;
     plugin_security_attributes_ = pdata.plugin_security_attributes_;
-#endif
+#endif // if HAVE_SECURITY
     auto new_lease_duration = std::chrono::microseconds(TimeConv::Duration_t2MicroSecondsInt64(m_leaseDuration));
     if (lease_duration_event != nullptr)
     {
@@ -785,9 +785,9 @@ void ParticipantProxyData::set_persistence_guid(
         m_properties.begin(),
         m_properties.end(),
         [&persistent_guid](const fastdds::dds::ParameterProperty_t& p)
-                {
-                    return persistent_guid.first == p.first();
-                });
+        {
+            return persistent_guid.first == p.first();
+        });
 
     if (it != m_properties.end())
     {
@@ -813,9 +813,9 @@ GUID_t ParticipantProxyData::get_persistence_guid() const
         m_properties.begin(),
         m_properties.end(),
         [](const fastdds::dds::ParameterProperty_t p)
-                {
-                    return "PID_PERSISTENCE_GUID" == p.first();
-                });
+        {
+            return "PID_PERSISTENCE_GUID" == p.first();
+        });
 
     if (it != m_properties.end())
     {
@@ -837,9 +837,10 @@ SampleIdentity ParticipantProxyData::get_sample_identity() const
     return fastdds::dds::get_proxy_property<SampleIdentity>("PID_CLIENT_SERVER_KEY", m_properties);
 }
 
-void ParticipantProxyData::set_backup_stamp(const GUID_t& guid)
+void ParticipantProxyData::set_backup_stamp(
+        const GUID_t& guid)
 {
-    fastdds::dds::set_proxy_property(guid,"PID_BACKUP_STAMP", m_properties);
+    fastdds::dds::set_proxy_property(guid, "PID_BACKUP_STAMP", m_properties);
 }
 
 GUID_t ParticipantProxyData::get_backup_stamp() const

--- a/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
@@ -42,7 +42,7 @@ ReaderProxyData::ReaderProxyData (
 #if HAVE_SECURITY
     , security_attributes_(0UL)
     , plugin_security_attributes_(0UL)
-#endif
+#endif // if HAVE_SECURITY
     , remote_locators_(max_unicast_locators, max_multicast_locators)
     , m_userDefinedId(0)
     , m_isAlive(true)
@@ -82,7 +82,7 @@ ReaderProxyData::ReaderProxyData(
 #if HAVE_SECURITY
     , security_attributes_(readerInfo.security_attributes_)
     , plugin_security_attributes_(readerInfo.plugin_security_attributes_)
-#endif
+#endif // if HAVE_SECURITY
     , m_guid(readerInfo.m_guid)
     , remote_locators_(readerInfo.remote_locators_)
     , m_key(readerInfo.m_key)
@@ -122,7 +122,7 @@ ReaderProxyData& ReaderProxyData::operator =(
 #if HAVE_SECURITY
     security_attributes_ = readerInfo.security_attributes_;
     plugin_security_attributes_ = readerInfo.plugin_security_attributes_;
-#endif
+#endif // if HAVE_SECURITY
     m_guid = readerInfo.m_guid;
     remote_locators_ = readerInfo.remote_locators_;
     m_key = readerInfo.m_key;
@@ -304,7 +304,7 @@ uint32_t ReaderProxyData::get_serialized_size(
     {
         ret_val += 4 + PARAMETER_ENDPOINT_SECURITY_INFO_LENGTH;
     }
-#endif
+#endif // if HAVE_SECURITY
 
     // PID_SENTINEL
     return ret_val + 4;
@@ -548,7 +548,7 @@ bool ReaderProxyData::writeToCDRMessage(
             return false;
         }
     }
-#endif
+#endif // if HAVE_SECURITY
 
     /* TODO - Enable when implement XCDR, XCDR2 and/or XML
        if (m_qos.representation.send_always() || m_qos.representation.hasChanged)
@@ -928,7 +928,7 @@ bool ReaderProxyData::readFromCDRMessage(
                         plugin_security_attributes_ = p.plugin_security_attributes;
                         break;
                     }
-#endif
+#endif // if HAVE_SECURITY
                     case fastdds::dds::PID_PROPERTY_LIST:
                     {
                         if (!fastdds::dds::ParameterSerializer<ParameterPropertyList_t>::read_from_cdr_message(
@@ -980,7 +980,7 @@ void ReaderProxyData::clear()
 #if HAVE_SECURITY
     security_attributes_ = 0UL;
     plugin_security_attributes_ = 0UL;
-#endif
+#endif // if HAVE_SECURITY
     m_guid = c_Guid_Unknown;
     remote_locators_.unicast.clear();
     remote_locators_.multicast.clear();
@@ -1016,7 +1016,7 @@ bool ReaderProxyData::is_update_allowed(
 #if HAVE_SECURITY
             (security_attributes_ != rdata.security_attributes_) ||
             (plugin_security_attributes_ != rdata.security_attributes_) ||
-#endif
+#endif // if HAVE_SECURITY
             (m_typeName != rdata.m_typeName) ||
             (m_topicName != rdata.m_topicName) )
     {

--- a/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.cpp
@@ -60,6 +60,7 @@ WriterProxyData::WriterProxyData(
 {
     m_qos.m_userData.set_max_size(static_cast<uint32_t>(data_limits.max_user_data));
     m_qos.m_partition.set_max_size(static_cast<uint32_t>(data_limits.max_partitions));
+    m_properties.set_max_size(static_cast<uint32_t>(data_limits.max_properties));
 }
 
 WriterProxyData::WriterProxyData(
@@ -83,6 +84,7 @@ WriterProxyData::WriterProxyData(
     , m_type_id(nullptr)
     , m_type(nullptr)
     , m_type_information(nullptr)
+    , m_properties(writerInfo.m_properties)
 {
     if (writerInfo.m_type_id)
     {
@@ -129,6 +131,7 @@ WriterProxyData& WriterProxyData::operator =(
     m_topicKind = writerInfo.m_topicKind;
     persistence_guid_ = writerInfo.persistence_guid_;
     m_qos.setQos(writerInfo.m_qos, true);
+    m_properties = writerInfo.m_properties;
 
     if (writerInfo.m_type_id)
     {
@@ -290,6 +293,12 @@ uint32_t WriterProxyData::get_serialized_size(
     {
         ret_val +=
                 fastdds::dds::QosPoliciesSerializer<xtypes::TypeInformation>::cdr_serialized_size(*m_type_information);
+    }
+
+    if (m_properties.size() > 0)
+    {
+        // PID_PROPERTY_LIST
+        ret_val += fastdds::dds::ParameterSerializer<ParameterPropertyList_t>::cdr_serialized_size(m_properties);
     }
 
 #if HAVE_SECURITY
@@ -533,6 +542,14 @@ bool WriterProxyData::writeToCDRMessage(
     if (m_type && m_type->m_type_object._d() != 0)
     {
         if (!fastdds::dds::QosPoliciesSerializer<TypeObjectV1>::add_to_cdr_message(*m_type, msg))
+        {
+            return false;
+        }
+    }
+
+    if (m_properties.size() > 0)
+    {
+        if (!fastdds::dds::ParameterSerializer<ParameterPropertyList_t>::add_to_cdr_message(m_properties, msg))
         {
             return false;
         }
@@ -922,6 +939,17 @@ bool WriterProxyData::readFromCDRMessage(
                                 "Received TypeConsistencyEnforcementQos from a writer, but they haven't.");
                         break;
                     }
+
+                    case fastdds::dds::PID_PROPERTY_LIST:
+                    {
+                        if (!fastdds::dds::ParameterSerializer<ParameterPropertyList_t>::read_from_cdr_message(
+                                    m_properties, msg, plength))
+                        {
+                            return false;
+                        }
+                        break;
+                    }
+
                     default:
                     {
                         break;
@@ -970,6 +998,8 @@ void WriterProxyData::clear()
     m_typeMaxSerialized = 0;
     m_topicKind = NO_KEY;
     persistence_guid_ = c_Guid_Unknown;
+    m_properties.clear();
+    m_properties.length = 0;
 
     if (m_type_id)
     {
@@ -999,6 +1029,7 @@ void WriterProxyData::copy(
     m_typeMaxSerialized = wdata->m_typeMaxSerialized;
     m_topicKind = wdata->m_topicKind;
     persistence_guid_ = wdata->persistence_guid_;
+    m_properties = wdata->m_properties;
 
     if (wdata->m_type_id)
     {

--- a/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.cpp
@@ -42,7 +42,7 @@ WriterProxyData::WriterProxyData(
     , remote_locators_(max_unicast_locators, max_multicast_locators)
 #else
     : remote_locators_(max_unicast_locators, max_multicast_locators)
-#endif
+#endif // if HAVE_SECURITY
     , m_userDefinedId(0)
     , m_typeMaxSerialized(0)
     , m_topicKind(NO_KEY)
@@ -71,7 +71,7 @@ WriterProxyData::WriterProxyData(
     , m_guid(writerInfo.m_guid)
 #else
     : m_guid(writerInfo.m_guid)
-#endif
+#endif // if HAVE_SECURITY
     , remote_locators_(writerInfo.remote_locators_)
     , m_key(writerInfo.m_key)
     , m_RTPSParticipantKey(writerInfo.m_RTPSParticipantKey)
@@ -119,7 +119,7 @@ WriterProxyData& WriterProxyData::operator =(
 #if HAVE_SECURITY
     security_attributes_ = writerInfo.security_attributes_;
     plugin_security_attributes_ = writerInfo.plugin_security_attributes_;
-#endif
+#endif // if HAVE_SECURITY
     m_guid = writerInfo.m_guid;
     remote_locators_ = writerInfo.remote_locators_;
     m_key = writerInfo.m_key;
@@ -306,7 +306,7 @@ uint32_t WriterProxyData::get_serialized_size(
     {
         ret_val += 4 + PARAMETER_ENDPOINT_SECURITY_INFO_LENGTH;
     }
-#endif
+#endif // if HAVE_SECURITY
 
     // PID_SENTINEL
     return ret_val + 4;
@@ -566,7 +566,7 @@ bool WriterProxyData::writeToCDRMessage(
             return false;
         }
     }
-#endif
+#endif // if HAVE_SECURITY
 
     /* TODO - Enable when implement XCDR, XCDR2 and/or XML
        if (m_qos.representation.send_always() || m_qos.representation.hasChanged)
@@ -923,7 +923,7 @@ bool WriterProxyData::readFromCDRMessage(
                         plugin_security_attributes_ = p.plugin_security_attributes;
                         break;
                     }
-#endif
+#endif // if HAVE_SECURITY
                     case fastdds::dds::PID_DATA_REPRESENTATION:
                     {
                         if (!fastdds::dds::QosPoliciesSerializer<DataRepresentationQosPolicy>::read_from_cdr_message(
@@ -1070,7 +1070,7 @@ bool WriterProxyData::is_update_allowed(
 #if HAVE_SECURITY
             (security_attributes_ != wdata.security_attributes_) ||
             (plugin_security_attributes_ != wdata.security_attributes_) ||
-#endif
+#endif // if HAVE_SECURITY
             (m_typeName != wdata.m_typeName) ||
             (m_topicName != wdata.m_topicName))
     {

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
@@ -177,9 +177,9 @@ bool EDPServer::trimWriterHistory(
     // sweep away any resurrected endpoint
     for (auto iD = mp_PDP->ParticipantProxiesBegin(); iD != mp_PDP->ParticipantProxiesEnd(); ++iD)
     {
-        ProxyCont& readers = *(*iD->*pC);
+        ProxyCont& endpoints = *(*iD->*pC);
 
-        for (auto iE : readers)
+        for (auto iE : endpoints)
         {
             disposal.insert(iE.second->key());
         }

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners.cpp
@@ -62,7 +62,7 @@ void EDPServerPUBListener::onNewCacheChangeAdded(
 
     ReaderHistory* reader_history = sedp_->publications_reader_.second;
 
-    // update the PDP Writer with this reader info
+    // update the EDP Writer with this reader info
     if (!sedp_->addPublisherFromHistory(*change))
     {
         reader_history->remove_change(change);

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners.cpp
@@ -102,7 +102,7 @@ void EDPServerPUBListener::onWriterChangeReceivedByAll(
 #if HAVE_SECURITY
                 writer == sedp_->publications_secure_writer_.first ?
                 sedp_->publications_secure_writer_.second :
-#endif
+#endif // if HAVE_SECURITY
                 sedp_->publications_writer_.second;
 
         writer_history->remove_change(change);
@@ -169,7 +169,7 @@ void EDPServerSUBListener::onWriterChangeReceivedByAll(
 #if HAVE_SECURITY
                 writer == sedp_->subscriptions_secure_writer_.first ?
                 sedp_->subscriptions_secure_writer_.second :
-#endif
+#endif // if HAVE_SECURITY
                 sedp_->subscriptions_writer_.second;
 
         writer_history->remove_change(change);
@@ -178,6 +178,6 @@ void EDPServerSUBListener::onWriterChangeReceivedByAll(
 }
 
 } /* namespace rtps */
-}
+} // namespace fastrtps
 } /* namespace eprosima */
 

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -184,8 +184,8 @@ void EDPSimple::processPersistentData(
             known_participants.insert(pD->m_key);
         });
 
-    // We have not processed any PDP message yet
-    assert(demises.empty());
+    // We have not processed any PDP message yet but any lease duration callback may have modified demises
+    // already
 
     // aux lambda to retrieve sample identity
     // update format for 2.0.x port
@@ -284,7 +284,7 @@ void EDPSimple::processPersistentData(
 
         if (!change_to_add->copy(change))
         {
-            logWarning(RTPS_EDP,"Problem copying CacheChange, received data is: " 
+            logWarning(RTPS_EDP,"Problem copying CacheChange, received data is: "
                 << change->serializedPayload.length << " bytes and max size in EDPServer reader"
                 << " is " << change_to_add->serializedPayload.max_size);
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -175,11 +175,11 @@ ParticipantProxyData* PDP::add_participant_proxy_data(
             if (participant_guid != mp_RTPSParticipant->getGuid())
             {
                 ret_val->lease_duration_event = new TimedEvent(mp_RTPSParticipant->getEventResource(),
-                        [this, ret_val]() -> bool
-                        {
-                            check_remote_participant_liveliness(ret_val);
-                            return false;
-                        }, 0.0);
+                                [this, ret_val]() -> bool
+                                {
+                                    check_remote_participant_liveliness(ret_val);
+                                    return false;
+                                }, 0.0);
             }
         }
         else
@@ -217,7 +217,7 @@ void PDP::initializeParticipantProxyData(
 #if HAVE_SECURITY
     participant_data->m_availableBuiltinEndpoints |= DISC_BUILTIN_ENDPOINT_PARTICIPANT_SECURE_ANNOUNCER;
     participant_data->m_availableBuiltinEndpoints |= DISC_BUILTIN_ENDPOINT_PARTICIPANT_SECURE_DETECTOR;
-#endif
+#endif // if HAVE_SECURITY
 
     if (mp_RTPSParticipant->getAttributes().builtin.use_WriterLivelinessProtocol)
     {
@@ -227,7 +227,7 @@ void PDP::initializeParticipantProxyData(
 #if HAVE_SECURITY
         participant_data->m_availableBuiltinEndpoints |= BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_SECURE_DATA_WRITER;
         participant_data->m_availableBuiltinEndpoints |= BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_SECURE_DATA_READER;
-#endif
+#endif // if HAVE_SECURITY
     }
 
     if (mp_RTPSParticipant->getAttributes().builtin.typelookup_config.use_server)
@@ -244,7 +244,7 @@ void PDP::initializeParticipantProxyData(
 
 #if HAVE_SECURITY
     participant_data->m_availableBuiltinEndpoints |= mp_RTPSParticipant->security_manager().builtin_endpoints();
-#endif
+#endif // if HAVE_SECURITY
 
     for (const Locator_t& loc : mp_RTPSParticipant->getAttributes().defaultUnicastLocatorList)
     {
@@ -318,7 +318,7 @@ void PDP::initializeParticipantProxyData(
         participant_data->security_attributes_ = 0UL;
         participant_data->plugin_security_attributes_ = 0UL;
     }
-#endif
+#endif // if HAVE_SECURITY
 }
 
 bool PDP::initPDP(
@@ -350,21 +350,21 @@ bool PDP::initPDP(
     for (ParticipantProxyData* pool_item : participant_proxies_pool_)
     {
         pool_item->lease_duration_event = new TimedEvent(mp_RTPSParticipant->getEventResource(),
-                [this, pool_item]() -> bool
-                {
-                    check_remote_participant_liveliness(pool_item);
-                    return false;
-                }, 0.0);
+                        [this, pool_item]() -> bool
+                        {
+                            check_remote_participant_liveliness(pool_item);
+                            return false;
+                        }, 0.0);
     }
 
     resend_participant_info_event_ = new TimedEvent(mp_RTPSParticipant->getEventResource(),
-            [&]() -> bool
-            {
-                announceParticipantState(false);
-                set_next_announcement_interval();
-                return true;
-            },
-            0);
+                    [&]() -> bool
+                    {
+                        announceParticipantState(false);
+                        set_next_announcement_interval();
+                        return true;
+                    },
+                    0);
 
     set_initial_announcement_interval();
 
@@ -416,7 +416,7 @@ void PDP::announceParticipantState(
 #else
                 change->serializedPayload.encapsulation = (uint16_t)PL_CDR_LE;
                 aux_msg.msg_endian =  LITTLEEND;
-#endif
+#endif // if __BIG_ENDIAN__
 
                 if (proxy_data_copy.writeToCDRMessage(&aux_msg, true))
                 {
@@ -444,10 +444,10 @@ void PDP::announceParticipantState(
         }
         uint32_t cdr_size = proxy_data_copy.get_serialized_size(true);
         change = mp_PDPWriter->new_change([cdr_size]() -> uint32_t
-            {
-                return cdr_size;
-            },
-            NOT_ALIVE_DISPOSED_UNREGISTERED, getLocalParticipantProxyData()->m_key);
+                        {
+                            return cdr_size;
+                        },
+                        NOT_ALIVE_DISPOSED_UNREGISTERED, getLocalParticipantProxyData()->m_key);
 
         if (change != nullptr)
         {
@@ -459,7 +459,7 @@ void PDP::announceParticipantState(
 #else
             change->serializedPayload.encapsulation = (uint16_t)PL_CDR_LE;
             aux_msg.msg_endian =  LITTLEEND;
-#endif
+#endif // if __BIG_ENDIAN__
 
             if (proxy_data_copy.writeToCDRMessage(&aux_msg, true))
             {
@@ -852,7 +852,8 @@ bool PDP::remove_remote_participant(
         ParticipantDiscoveryInfo::DISCOVERY_STATUS reason)
 {
     if (partGUID == getLocalParticipantProxyData()->m_guid)
-    {   // avoid removing our own data
+    {
+        // avoid removing our own data
         return false;
     }
 
@@ -928,7 +929,7 @@ bool PDP::remove_remote_participant(
 
 #if HAVE_SECURITY
         mp_builtin->mp_participantImpl->security_manager().remove_participant(*pdata);
-#endif
+#endif // if HAVE_SECURITY
 
         this->mp_PDPReaderHistory->getMutex()->lock();
         for (std::vector<CacheChange_t*>::iterator it = this->mp_PDPReaderHistory->changesBegin();

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -337,7 +337,7 @@ bool PDP::initPDP(
     mp_builtin->updateMetatrafficLocators(this->mp_PDPReader->getAttributes().unicastLocatorList);
 
     mp_mutex->lock();
-    ParticipantProxyData* pdata = add_participant_proxy_data(part->getGuid(), true);
+    ParticipantProxyData* pdata = add_participant_proxy_data(part->getGuid(), false);
     mp_mutex->unlock();
 
     if (pdata == nullptr)
@@ -1027,8 +1027,9 @@ void PDP::check_remote_participant_liveliness(
 {
     std::unique_lock<std::recursive_mutex> guard(*this->mp_mutex);
 
-    if (GUID_t::unknown() != remote_participant->m_guid)
+    if (remote_participant->should_check_lease_duration)
     {
+        assert(GUID_t::unknown() != remote_participant->m_guid);
         // Check last received message's time_point plus lease duration time doesn't overcome now().
         // If overcame, remove participant.
         auto now = std::chrono::steady_clock::now();

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -16,13 +16,13 @@
  * @file PDPServer.cpp
  *
  */
+#include <fastdds/core/policy/ParameterSerializer.hpp>
 
 #include <fastdds/rtps/builtin/BuiltinProtocols.h>
 #include <fastdds/rtps/builtin/liveliness/WLP.h>
 
 #include <fastdds/rtps/participant/RTPSParticipantListener.h>
 #include <fastdds/rtps/reader/StatefulReader.h>
-
 #include <fastdds/rtps/writer/StatefulWriter.h>
 
 #include <fastdds/rtps/history/WriterHistory.h>
@@ -60,7 +60,6 @@ PDPServer::PDPServer(
     : PDP(builtin, allocation)
     , _durability(durability_kind)
     , mp_sync(nullptr)
-    , PDP_callback_(false)
 {
 
 }
@@ -398,7 +397,7 @@ void PDPServer::removeRemoteEndpoints(
         wguid.guidPrefix = pdata->m_guid.guidPrefix;
         wguid.entityId = c_EntityId_SPDPWriter;
 
-        safe_PDP_matched_writer_remove(wguid);
+        mp_PDPReader->matched_writer_remove(wguid);
 
         /*
             When a server acts like a client to another server it should never
@@ -467,20 +466,25 @@ void PDPServer::match_all_clients_EDP_endpoints()
     // PDP must have been initialize
     assert(mp_EDP);
 
+    // In order to assign remote endpoints the reader mutex is taken
+    // thus we must release previously the PDP mutex
+    pending_matches_list temp;
+
+    {
     std::lock_guard<std::recursive_mutex> guardPDP(*mp_mutex);
 
     if (!pendingEDPMatches())
     {
         return;
     }
+        temp.swap(_p2match);
+    }
 
-    for (auto p: _p2match)
+    for (auto p: temp)
     {
         assert( p != nullptr);
         mp_EDP->assignRemoteEndpoints(*p);
     }
-
-    _p2match.clear();
 }
 
 bool PDPServer::trimWriterHistory()
@@ -592,7 +596,7 @@ bool PDPServer::addRelayedChangeToHistory(
         return true;
     }
 
-    std::lock_guard<RecursiveTimedMutex> lock(mp_PDPWriter->getMutex());
+    std::unique_lock<RecursiveTimedMutex> lock(mp_PDPWriter->getMutex());
     CacheChange_t* pCh = nullptr;
 
     // validate the sample, if no sample data update it
@@ -625,13 +629,97 @@ bool PDPServer::addRelayedChangeToHistory(
 
     if (it == mp_PDPWriterHistory->changesRend())
     {
-        if (mp_PDPWriterHistory->reserve_Cache(&pCh, c.serializedPayload.max_size) && pCh && pCh->copy(&c))
+        if (mp_PDPWriterHistory->reserve_Cache(&pCh, c.serializedPayload.max_size) && pCh )
         {
+            if ( mp_PDPWriter->getAttributes().durabilityKind == DurabilityKind_t::TRANSIENT_LOCAL )
+            {
+                // an ordinary server just copies the payload to history
+                pCh->copy(&c);
             pCh->writerGUID = mp_PDPWriter->getGuid();
             // keep the original sample identity by using wp
             return mp_PDPWriterHistory->add_change(pCh, wp);
         }
+            else
+            {
+               pCh->copy_not_memcpy(&c);
+
+               if (c.kind == ALIVE)
+               {
+                   // a backup server must add extra context properties to replace WriteParams functionality
+                   ParticipantProxyData local_data(getRTPSParticipant()->getRTPSParticipantAttributes().allocation);
+                   CDRMessage_t deserialization_msg(c.serializedPayload);
+                   if (local_data.readFromCDRMessage(&deserialization_msg,
+                        true,
+                        getRTPSParticipant()->network_factory(),
+                        getRTPSParticipant()->has_shm_transport()))
+                   {
+                       // insert identity within the payload
+                       // deserialized payload
+                       local_data.set_sample_identity(wp.sample_identity());
+
+                       // if is this server's client, stamp it
+                       if (pCh->writerGUID == wp.sample_identity().writer_guid())
+                       {
+                           local_data.set_backup_stamp(mp_PDPWriter->getGuid());
+                       }
+
+                       // Update the payload
+                       pCh->serializedPayload.reserve(local_data.get_serialized_size(true));
+
+                       // serialized payload
+                       CDRMessage_t serialization_msg(pCh->serializedPayload);
+                       if (local_data.writeToCDRMessage(&serialization_msg,true))
+                       {
+                           pCh->writerGUID = mp_PDPWriter->getGuid();
+                           pCh->serializedPayload.length = (uint16_t)serialization_msg.length;
+                           // keep the original sample identity by using wp
+                           return mp_PDPWriterHistory->add_change(pCh, wp);
+                       }
+                   }
+               }
+               else
+               {
+                   // It's a DATA(p[UD]) generate the payload
+                   pCh->serializedPayload.reserve(get_data_disposal_payload_serialized_size());
+                   CDRMessage_t msg(pCh->serializedPayload);
+                   if (set_data_disposal_payload(&msg,wp.sample_identity()))
+                   {
+                       pCh->writerGUID = mp_PDPWriter->getGuid();
+                       pCh->serializedPayload.length = (uint16_t)msg.length;
+                       // keep the original sample identity by using wp
+                       return mp_PDPWriterHistory->add_change(pCh, wp);
+                   }
+               }
+            }
+        }
     }
+
+    // Already in the history
+
+#ifdef __INTERNALDEBUG
+
+    if( c.kind == ALIVE )
+    {
+        // Check if participant already exists (updated info)
+        lock.unlock();
+        std::lock_guard<std::recursive_mutex> pdp_lock(*getMutex());
+
+        for (ParticipantProxyData* pp : participant_proxies_)
+        {
+            if (sid.writer_guid().guidPrefix == pp->m_guid.guidPrefix)
+            {
+                // already also in the database
+                return false;
+            }
+        }
+        // Writer history and proxies are not in sync, this may happen if a participant is dropped been alived because the
+        // trimming mechanism may not had time enough to remove all its samples.
+        logInfo(SERVER_PDP_THREAD, "Server " << getRTPSParticipant()->getGuid() <<
+                " mismatch in discovery database and writer history cache on sample " << sid.writer_guid());
+     }
+
+#endif // __INTERNALDEBUG
+
     return false;
 }
 
@@ -719,11 +807,108 @@ void PDPServer::processPersistentData()
         StatefulReader* p_PDPReader = static_cast<StatefulReader*>(mp_PDPReader);
         std::lock_guard<RecursiveTimedMutex> guardR(p_PDPReader->getMutex());
         std::lock_guard<RecursiveTimedMutex> guardW(mp_PDPWriter->getMutex());
+        std::lock_guard<std::recursive_mutex> guardP(*getMutex());
+
+        // own server instance
+        InstanceHandle_t server_key = getLocalParticipantProxyData()->m_key;
+
+        // reference own references from writer history
+        std::forward_list<CacheChange_t*> removal;
+
+        // keep a record of referenced participants
+        key_list referenced_participants;
+
+        // aux lambda to retrieve sample identity
+        // update format for 2.0.x port
+        uint32_t qos_size;
+        SampleIdentity si;
+        ChangeKind_t kind;
+        GUID_t guid;
+
+        auto param_process = [&si, &guid, &kind](CDRMessage_t* msg, const ParameterId_t& pid, uint16_t plength)
+        {
+            // we use the PID_PARTICIPANT_GUID to identify a DATA(p)
+            if (pid == fastdds::dds::PID_PARTICIPANT_GUID )
+            {
+                kind = ALIVE;
+                return true;
+            }
+
+            if (pid == fastdds::dds::PID_PROPERTY_LIST)
+            {
+                si = SampleIdentity::unknown();
+                guid = GUID_t::unknown();
+                ParameterPropertyList_t pl;
+
+                if (!fastdds::dds::ParameterSerializer<ParameterPropertyList_t>::read_from_cdr_message(pl, msg, plength))
+                {
+                    return false;
+                }
+
+                auto it = pl.begin();
+                const std::string server_key("PID_CLIENT_SERVER_KEY"), stamp("PID_BACKUP_STAMP");
+
+                while (true)
+                {
+                    it = std::find_if( it, pl.end(),
+                            [&,server_key,stamp](ParameterPropertyList_t::iterator::reference p)
+                            {
+                                return server_key == p.first() || stamp == p.first();
+                            });
+
+                    if (it == pl.end())
+                    {
+                        return true;
+                    }
+
+                    std::istringstream in(it->second());
+                    if (it++->first() == server_key)
+                    {
+                        in >> si;
+                    }
+                    else
+                    {
+                        in >> guid;
+                    }
+                }
+            }
+
+            return true;
+        };
 
         std::for_each(mp_PDPWriterHistory->changesBegin(),
-                mp_PDPWriterHistory->changesEnd(),
-                [p_PDPReader](CacheChange_t* change)
-                {
+            mp_PDPWriterHistory->changesEnd(),
+                [&](CacheChange_t* change)
+        {
+                    // Reset the variables referenced by the lambda
+                    si = SampleIdentity::unknown();
+                    kind = NOT_ALIVE_DISPOSED_UNREGISTERED;
+                    guid = GUID_t::unknown();
+
+                    // We must retrieve the identity info from the payload and update the WriteParams
+                    CDRMessage_t msg(change->serializedPayload);
+                    fastdds::dds::ParameterList::readParameterListfromCDRMsg(msg, param_process, true, qos_size);
+
+                    // determine kind
+                    change->kind = kind;
+
+                    // recover sample identity
+                    if (si != SampleIdentity::unknown())
+                    {
+                        change->write_params.sample_identity(si);
+                        change->write_params.related_sample_identity(si);
+                    }
+
+                    // this participant is referenced
+                    referenced_participants.insert(change->instanceHandle);
+
+                    // check if its own data and mark for removal
+                    if (change->instanceHandle == server_key)
+                    {
+                        removal.push_front(change);
+                        return;
+                    }
+
                     CacheChange_t* change_to_add = nullptr;
 
                     //Reserve a new cache from the corresponding cache pool
@@ -743,15 +928,56 @@ void PDPServer::processPersistentData()
                         return;
                     }
 
-                    if (!p_PDPReader->change_received(change_to_add, nullptr))
+                    // Only DATA(p)s directly received from a client would have the PID_BACKUP_STAMP property
+                    // The CacheChange_t pass to the server simulates a client's DATA(p)
+                    if ( guid != GUID_t::unknown() && guid == mp_PDPWriter->getGuid() )
                     {
-                        logInfo(RTPS_PDP, "PDPServer couldn't process database data not add change "
-                            << change_to_add->sequenceNumber);
-                        p_PDPReader->releaseCache(change_to_add);
+                        assert(si != SampleIdentity::unknown());
+                        change_to_add->writerGUID = si.writer_guid();
+                        change_to_add->sequenceNumber = si.sequence_number();
                     }
 
-                    // change_to_add would be released within change_received
-                });
+            if (!p_PDPReader->change_received(change_to_add, nullptr))
+            {
+                logInfo(RTPS_PDP, "PDPServer couldn't process database data not add change "
+                    << change_to_add->sequenceNumber);
+                p_PDPReader->releaseCache(change_to_add);
+            }
+
+            // change_to_add would be released within change_received
+        });
+
+            // remove our own old server samples
+            removal.pop_front(); // we keep the new one
+
+            for (auto pC : removal)
+            {
+                mp_PDPWriterHistory->remove_change(pC);
+            }
+
+            // marked for removal all samples linked with unknown participants
+            key_list known_participants;
+
+            std::for_each(
+                    ParticipantProxiesBegin(),
+                    ParticipantProxiesEnd(),
+                    [&known_participants](const ParticipantProxyData* pD)
+                    {
+                    known_participants.insert(pD->m_key);
+                    });
+
+            // We have not processed any PDP message yet but any lease duration callback may have modified _demises
+            // already
+
+            // identify unknown participants, mark them for trimming
+            std::set_difference(
+                    referenced_participants.cbegin(),
+                    referenced_participants.cend(),
+                    known_participants.cbegin(),
+                    known_participants.cend(),
+                    std::inserter(_demises, _demises.begin()));
+
+            // We don't need to awake the server thread because we are in it
     }
 
     EDPServer* pEDP = dynamic_cast<EDPServer*>(mp_EDP);
@@ -931,9 +1157,21 @@ void PDPServer::announceParticipantState(
     }
     else
     {
-        // retrieve the participant discovery data
-        CacheChange_t* pPD;
-        if (mp_PDPWriterHistory->get_min_change(&pPD))
+        // retrieve the participant discovery data, deserialization trimming (see processPersistentData) invalidates
+        // the assumption that own discovery data is the first one.
+        CacheChange_t* pPD = nullptr;
+        // we search in reverse order to get the last update if multiple
+        for (auto it = mp_PDPWriterHistory->changesRbegin(); it != mp_PDPWriterHistory->changesRend(); ++it, pPD = nullptr)
+        {
+            pPD = *it;
+            if (pPD->write_params.sample_identity().writer_guid() == mp_PDPWriter->getGuid())
+            {
+                // located
+                break;
+            }
+        }
+
+        if (pPD)
         {
             std::lock_guard<std::recursive_mutex> lock(*getMutex());
 
@@ -1149,56 +1387,35 @@ bool PDPServer::pendingHistoryCleaning()
     return !_demises.empty() || pEDP->pendingHistoryCleaning();
 }
 
-// ! returns a unique_ptr to an object that handles PDP_callback_ in a RAII fashion
-std::unique_ptr<PDPServer::InPDPCallback> PDPServer::signalCallback()
-{
-    // TODO: change when C++14 available
-    //return std::make_unique<PDPServer::InPDPCallback>(*this);
-    return std::unique_ptr<InPDPCallback>(new InPDPCallback(*this));
-}
-
-// ! calls PDP Reader matched_writer_remove preventing deadlocks
-bool PDPServer::safe_PDP_matched_writer_remove(
-        const GUID_t& wguid)
-{
-    bool res;
-    std::unique_lock<std::recursive_mutex> guardP(*getMutex());
-
-    if (PDP_callback_)
+//static
+bool PDPServer::set_data_disposal_payload(
+        CDRMessage_t* msg,
+        const SampleIdentity& sid)
     {
-        // If we are in a transport callback the reader mutex is already lock
-        // and we cannot remove the writer proxies
-        RecursiveTimedMutex& mtx = mp_PDPReader->getMutex();
+    using namespace fastdds::dds;
 
-        mtx.unlock();
-        res = mp_PDPReader->matched_writer_remove(wguid);
-        mtx.lock();
-    }
-    else
+    if (!ParameterList::writeEncapsulationToCDRMsg(msg))
     {
-        // if a lease callback takes place while transport callback is going on
-        // an before it has the unmatch done we must prevent a deadlock in PDP mutex
-        guardP.unlock();
-        res = mp_PDPReader->matched_writer_remove(wguid);
+        return false;
     }
 
-    return res;
+    ParameterPropertyList_t properties;
+    set_proxy_property(sid, "PID_CLIENT_SERVER_KEY", properties);
+
+    if (!ParameterSerializer<ParameterPropertyList_t>::add_to_cdr_message(properties, msg))
+{
+        return false;
+    }
+
+    return ParameterSerializer<Parameter_t>::add_parameter_sentinel(msg);
 }
 
-PDPServer::InPDPCallback::InPDPCallback(
-        PDPServer& svr)
-    : server_(svr)
+//static
+uint32_t PDPServer::get_data_disposal_payload_serialized_size()
 {
-    std::lock_guard<std::recursive_mutex> lock(*server_.getMutex());
-
-    server_.PDP_callback_ = true;
-}
-
-PDPServer::InPDPCallback::~InPDPCallback()
-{
-    std::lock_guard<std::recursive_mutex> lock(*server_.getMutex());
-
-    server_.PDP_callback_ = false;
+   // |GUID UNKNOWN| lenght 14
+   // ff.ff.ff.ff.ff.ff.ff.ff.ff.ff.ff.ff|ff.ff.ff.ff lenght 47
+   return 47;
 }
 
 } /* namespace rtps */

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -627,7 +627,20 @@ bool PDPServer::addRelayedChangeToHistory(
             return sid == c->write_params.sample_identity();
         });
 
-    if (it == mp_PDPWriterHistory->changesRend())
+    if (it != mp_PDPWriterHistory->changesRend())
+    {
+        // already there, check if we must activate liveliness because we received a direct announcement from a client
+        // reported by another server
+        if ( c.writerGUID == (*it)->write_params.sample_identity().writer_guid()
+            && c.writerGUID != (*it)->writerGUID )
+        {
+            // directly send from the client, reprocess...
+            // note that once the DATA(p) is directly receive from the client the WriterProxy::change_was_received would
+            // prevent it from be processed again
+            return true;
+        }
+    }
+    else
     {
         if (mp_PDPWriterHistory->reserve_Cache(&pCh, c.serializedPayload.max_size) && pCh )
         {

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -853,7 +853,8 @@ void PDPServer::processPersistentData()
                 // remember to reset guid and sid before calling the lambda
                 ParameterPropertyList_t pl;
 
-                if (!fastdds::dds::ParameterSerializer<ParameterPropertyList_t>::read_from_cdr_message(pl, msg, plength))
+                        if (!fastdds::dds::ParameterSerializer<ParameterPropertyList_t>::read_from_cdr_message(pl, msg,
+                                plength))
                 {
                     return false;
                 }
@@ -1180,7 +1181,8 @@ void PDPServer::announceParticipantState(
         // the assumption that own discovery data is the first one.
         CacheChange_t* pPD = nullptr;
         // we search in reverse order to get the last update if multiple
-        for (auto it = mp_PDPWriterHistory->changesRbegin(); it != mp_PDPWriterHistory->changesRend(); ++it, pPD = nullptr)
+        for (auto it = mp_PDPWriterHistory->changesRbegin(); it != mp_PDPWriterHistory->changesRend();
+                ++it, pPD = nullptr)
         {
             pPD = *it;
             if (pPD->write_params.sample_identity().writer_guid() == mp_PDPWriter->getGuid())

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -804,6 +804,7 @@ std::string PDPServer::GetPersistenceFileName()
 
     return filename.str();
 }
+
 #endif // if HAVE_SQLITE3
 
 //! returns true if loading info from persistency database

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -49,6 +49,7 @@
 
 using namespace eprosima::fastrtps;
 
+
 namespace eprosima {
 namespace fastrtps {
 namespace rtps {
@@ -909,6 +910,8 @@ void PDPServer::processPersistentData()
                     change->kind = kind;
 
                     // recover sample identity
+
+
                     if (si != SampleIdentity::unknown())
                     {
                         change->write_params.sample_identity(si);

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -40,7 +40,6 @@
 #include <fastdds/rtps/builtin/discovery/participant/PDPServer.h>
 #include <fastdds/rtps/builtin/discovery/endpoint/EDPServer.h>
 
-
 #include <fastdds/rtps/writer/ReaderProxy.h>
 #include <rtps/builtin/data/ProxyHashTables.hpp>
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -1414,7 +1414,7 @@ bool PDPServer::set_data_disposal_payload(
 }
 
 //static
-const uint32_t PDPServer::get_data_disposal_payload_serialized_size()
+uint32_t PDPServer::get_data_disposal_payload_serialized_size()
 {
    // GUID_t sizes
    // |GUID UNKNOWN| lenght 14

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
@@ -122,16 +122,17 @@ void PDPServerListener::onNewCacheChangeAdded(
 
             if (pdata == nullptr)
             {
-                logInfo(RTPS_PDP, "Registering a new participant: " << writer_guid);
+                logInfo(RTPS_PDP, "Registering a new participant: " <<
+                        change->write_params.sample_identity().writer_guid());
 
                 // Create a new one when not found
                 pdata = parent_pdp_->createParticipantProxyData(local_data, writer_guid);
-                if (pdata != nullptr)
-                {
                     lock.unlock();
 
+                if (pdata != nullptr)
+                {
                     // Dismiss any client data relayed by a server
-                    if (pdata->m_guid.guidPrefix == change->writerGUID.guidPrefix)
+                    if (pdata->m_guid.guidPrefix == writer_guid.guidPrefix)
                     {
                         // This call would be needed again if the clients known not the server prefix
                         //  parent_pdp_->announceParticipantState(false);
@@ -185,9 +186,7 @@ void PDPServerListener::onNewCacheChangeAdded(
             return;
         }
 
-        std::unique_ptr<PDPServer::InPDPCallback> guard = parent_server_pdp_->signalCallback();
-
-        if (parent_pdp_->remove_remote_participant(guid, ParticipantDiscoveryInfo::REMOVED_PARTICIPANT))
+        if(parent_pdp_->remove_remote_participant(guid, ParticipantDiscoveryInfo::REMOVED_PARTICIPANT))
         {
             // all changes related with this participant have been removed from history by removeRemoteParticipant
             return;

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
@@ -126,7 +126,7 @@ void PDPServerListener::onNewCacheChangeAdded(
 
                 // Create a new one when not found
                 pdata = parent_pdp_->createParticipantProxyData(local_data, writer_guid);
-                    lock.unlock();
+                lock.unlock();
 
                 if (pdata != nullptr)
                 {
@@ -152,10 +152,10 @@ void PDPServerListener::onNewCacheChangeAdded(
                 // Included for symmetry with PDPListener to profit from a future updateInfoMatchesEDP override
                 // right now servers update matching on clients that were previously relayed by a server
                 if ( previous_lease_check_status != pdata->should_check_lease_duration
-                     || parent_pdp_->updateInfoMatchesEDP() )
+                        || parent_pdp_->updateInfoMatchesEDP() )
                 {
-                        parent_pdp_->assignRemoteEndpoints(pdata);
-                        parent_server_pdp_->queueParticipantForEDPMatch(pdata);
+                    parent_pdp_->assignRemoteEndpoints(pdata);
+                    parent_server_pdp_->queueParticipantForEDPMatch(pdata);
                 }
             }
 
@@ -189,7 +189,7 @@ void PDPServerListener::onNewCacheChangeAdded(
             return;
         }
 
-        if(parent_pdp_->remove_remote_participant(guid, ParticipantDiscoveryInfo::REMOVED_PARTICIPANT))
+        if (parent_pdp_->remove_remote_participant(guid, ParticipantDiscoveryInfo::REMOVED_PARTICIPANT))
         {
             // all changes related with this participant have been removed from history by removeRemoteParticipant
             return;

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
@@ -83,8 +83,7 @@ void PDPServerListener::onNewCacheChangeAdded(
     if (change->kind == ALIVE)
     {
         // Ignore announcement from own RTPSParticipant
-        if (guid == parent_pdp_->getRTPSParticipant()->getGuid()
-                && !parent_server_pdp_->ongoingDeserialization() )
+        if (guid == parent_pdp_->getRTPSParticipant()->getGuid())
         {
             logInfo(RTPS_PDP, "Message from own RTPSParticipant, removing");
             parent_pdp_->mp_PDPReaderHistory->remove_change(change);

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -710,7 +710,13 @@ bool StatefulReader::change_received(
                     if (mp_history->received_change(a_change, 0))
                     {
                         Time_t::now(a_change->receptionTimestamp);
-                        update_last_notified(a_change->writerGUID, a_change->sequenceNumber);
+
+                        // If we use the real a_change->sequenceNumber no DATA(p) with a lower one will ever be received.
+                        // That happens because the WriterProxy created when the listener matches the PDP endpoints is
+                        // initialized using this SequenceNumber_t. Note that on a SERVER the own DATA(p) may be in any
+                        // position within the WriterHistory preventing effective data exchange.
+                        update_last_notified(a_change->writerGUID, SequenceNumber_t(0,1));
+
                         if (getListener() != nullptr)
                         {
                             getListener()->onNewCacheChangeAdded((RTPSReader*)this, a_change);

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -715,7 +715,7 @@ bool StatefulReader::change_received(
                         // That happens because the WriterProxy created when the listener matches the PDP endpoints is
                         // initialized using this SequenceNumber_t. Note that on a SERVER the own DATA(p) may be in any
                         // position within the WriterHistory preventing effective data exchange.
-                        update_last_notified(a_change->writerGUID, SequenceNumber_t(0,1));
+                        update_last_notified(a_change->writerGUID, SequenceNumber_t(0, 1));
 
                         if (getListener() != nullptr)
                         {

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1636,6 +1636,7 @@ void StatefulWriter::check_acked_status()
             may_remove_change_ = 1;
             may_remove_change_cond_.notify_one();
         }
+
         min_readers_low_mark_ = min_low_mark;
     }
 


### PR DESCRIPTION
This is a backport from master to solve a client-server discovery issue.

When a client was dropped the server reported it to all other clients but didn't remove the demise client information from the PDP and EDP history. This commit fixes this issue.