### PR TITLE
[8632] Solving discover server issues on participant drop.

### DIFF
--- a/include/fastrtps/rtps/builtin/discovery/endpoint/EDPServer.h
+++ b/include/fastrtps/rtps/builtin/discovery/endpoint/EDPServer.h
@@ -131,6 +131,15 @@ public:
                        *subscriptions_writer_.first, *subscriptions_writer_.second, &ParticipantProxyData::m_readers);
     }
 
+    /**
+     * Trigger the participant CacheChange_t removal system
+     * @return True if successfully modified WriterHistory
+     */
+    void removePublisherFromHistory(
+            const InstanceHandle_t&);
+    void removeSubscriberFromHistory(
+            const InstanceHandle_t&);
+
 protected:
 
     /**
@@ -148,15 +157,6 @@ protected:
     {
         return addEndpointFromHistory(*subscriptions_writer_.first, *subscriptions_writer_.second, c);
     }
-
-    /**
-     * Trigger the participant CacheChange_t removal system
-     * @return True if successfully modified WriterHistory
-     */
-    void removePublisherFromHistory(
-            const InstanceHandle_t&);
-    void removeSubscriberFromHistory(
-            const InstanceHandle_t&);
 
 private:
 

--- a/include/fastrtps/rtps/builtin/discovery/endpoint/EDPServer.h
+++ b/include/fastrtps/rtps/builtin/discovery/endpoint/EDPServer.h
@@ -189,5 +189,5 @@ private:
 } /* namespace fastrtps */
 } /* namespace eprosima */
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif /* EDPSERVER_H_ */

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -547,6 +547,9 @@ bool PDPServer::trimPDPWriterHistory()
         }
         else
         {
+            logInfo(RTPS_PDPSERVER_TRIM, "PDPServer is procrastinating DATA("
+                    << (pC->kind == ALIVE ? "p" : "p[UD]" ) << ") " "of participant "
+                    << pC->instanceHandle << " from history");
             pending.insert(pC->instanceHandle);
         }
     }

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -506,9 +506,10 @@ bool PDPServer::trimPDPWriterHistory()
 
     // sweep away any resurrected participant
     std::for_each(ParticipantProxiesBegin(), ParticipantProxiesEnd(),
-            [&disposal](const ParticipantProxyData* pD) {
-                    disposal.insert(pD->m_key);
-                });
+            [&disposal](const ParticipantProxyData* pD)
+            {
+                disposal.insert(pD->m_key);
+            });
     std::set_difference(_demises.cbegin(), _demises.cend(), disposal.cbegin(), disposal.cend(),
             std::inserter(aux, aux.begin()));
     _demises.swap(aux);
@@ -525,9 +526,9 @@ bool PDPServer::trimPDPWriterHistory()
     std::copy_if(mp_PDPWriterHistory->changesBegin(),
             mp_PDPWriterHistory->changesBegin(), std::front_inserter(removal),
             [this](const CacheChange_t* chan)
-                {
-                    return _demises.find(chan->instanceHandle) != _demises.cend();
-                });
+            {
+                return _demises.find(chan->instanceHandle) != _demises.cend();
+            });
 
     if (removal.empty())
     {
@@ -575,7 +576,7 @@ bool PDPServer::addRelayedChangeToHistory(
         logError(RTPS_PDP,
                 "A DATA(p) received by server " << mp_PDPWriter->getGuid()
                                                 << " from participant " << c.writerGUID <<
-                            " without a valid SampleIdentity");
+                " without a valid SampleIdentity");
     }
 
     if (wp.related_sample_identity() == SampleIdentity::unknown())
@@ -588,9 +589,10 @@ bool PDPServer::addRelayedChangeToHistory(
     auto it = std::find_if(
         mp_PDPWriterHistory->changesRbegin(),
         mp_PDPWriterHistory->changesRend(),
-        [&sid] (CacheChange_t* c) {
-                    return sid == c->write_params.sample_identity();
-                });
+        [&sid](CacheChange_t* c)
+        {
+            return sid == c->write_params.sample_identity();
+        });
 
     if (it == mp_PDPWriterHistory->changesRend())
     {
@@ -766,15 +768,17 @@ void PDPServer::announceParticipantState(
             PDP::announceParticipantState(new_change, dispose, wp);
         }
         else
-        {   // we must assure when the server is dying that all client are send at least a DATA(p)
+        {
+            // we must assure when the server is dying that all client are send at least a DATA(p)
             // note here we can no longer receive and DATA or ACKNACK from clients.
             // In order to avoid that we send the message directly as in the standard stateless PDP
 
             CacheChange_t* change = nullptr;
 
-            if ((change = pW->new_change([this]() -> uint32_t {
-                            return mp_builtin->m_att.writerPayloadSize;
-                        },
+            if ((change = pW->new_change([this]() -> uint32_t
+                    {
+                        return mp_builtin->m_att.writerPayloadSize;
+                    },
                     NOT_ALIVE_DISPOSED_UNREGISTERED, getLocalParticipantProxyData()->m_key)))
             {
                 // update the sequence number
@@ -949,10 +953,12 @@ bool PDPServer::remove_remote_participant(
         if (!(mp_PDPReaderHistory->get_max_change(&pC) &&
                 pC->kind == NOT_ALIVE_DISPOSED_UNREGISTERED && // last message received is aun DATA(p[UD])
                 pC->instanceHandle == key )) // from the same participant I'm going to report
-        {   // We must create the DATA(p[UD])
-            if ((pC = mp_PDPWriter->new_change([this]() -> uint32_t {
-                            return mp_builtin->m_att.writerPayloadSize;
-                        },
+        {
+            // We must create the DATA(p[UD])
+            if ((pC = mp_PDPWriter->new_change([this]() -> uint32_t
+                    {
+                        return mp_builtin->m_att.writerPayloadSize;
+                    },
                     NOT_ALIVE_DISPOSED_UNREGISTERED, key)))
             {
                 // Use this server identity in order to hint clients it's a lease duration demise
@@ -1033,7 +1039,7 @@ bool PDPServer::remove_remote_participant(
     }
 
     return res;
-   // only DATA acknowledge by all clients would be actually removed
+    // only DATA acknowledge by all clients would be actually removed
 }
 
 bool PDPServer::pendingHistoryCleaning()

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -982,6 +982,9 @@ bool PDPServer::remove_remote_participant(
     key_list disposed_publishers, disposed_subscribers;
 
     {
+        // protect reader and writers collections
+        std::lock_guard<std::recursive_mutex> lock(*mp_mutex);
+
         for (ReaderProxyData* rit : pdata->m_readers)
         {
             if (rit->guid() != c_Guid_Unknown)

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -40,7 +40,6 @@
 #include <fastrtps/rtps/builtin/discovery/participant/PDPServer.h>
 #include <fastrtps/rtps/builtin/discovery/endpoint/EDPServer.h>
 
-
 #include <fastrtps/rtps/writer/ReaderProxy.h>
 
 #include <algorithm>
@@ -908,13 +907,37 @@ bool PDPServer::remove_remote_participant(
         ParticipantDiscoveryInfo::DISCOVERY_STATUS reason)
 {
     InstanceHandle_t key;
+    ParticipantProxyData* pdata = nullptr;
 
-    if (partGUID == getLocalParticipantProxyData()->m_guid
-            || !lookup_participant_key(partGUID, key))
-    {   // verify it's a known participant
+    // verify it's a known participant
+    if (partGUID != getLocalParticipantProxyData()->m_guid)
+    {
+        std::lock_guard<std::recursive_mutex> lock(*mp_mutex);
+
+        for (ResourceLimitedVector<ParticipantProxyData*>::iterator pit = participant_proxies_.begin();
+                pit != participant_proxies_.end(); ++pit)
+        {
+            if ((*pit)->m_guid == partGUID)
+            {
+                pdata = *pit;
+                break;
+            }
+        }
+
+        if ( nullptr == pdata )
+        {
+            return false;
+        }
+
+        // retrieve participant key
+        key = pdata->m_key;
+    }
+    else
+    {
         return false;
     }
 
+    if (ParticipantDiscoveryInfo::DROPPED_PARTICIPANT == reason)
     {
         // prevent mp_PDPReaderHistory from been clean up by the PDPServerListener
         std::lock_guard<RecursiveTimedMutex> lock(mp_PDPReader->getMutex());
@@ -942,9 +965,6 @@ bool PDPServer::remove_remote_participant(
 
                 if (mp_PDPWriterHistory->add_change(pC, wp))
                 {
-                    // Impersonate
-                    pC->writerGUID = GUID_t(partGUID.guidPrefix, c_EntityId_SPDPWriter);
-
                     logInfo(RTPS_PDP, "Server created a DATA(p[UD]) for a lease duration casualty.")
                 }
             }
@@ -952,14 +972,58 @@ bool PDPServer::remove_remote_participant(
 
     }
 
+    // Identify demise participant subscriber and publishers' history data for disposal
+    key_list disposed_publishers, disposed_subscribers;
+
+    {
+        for (ReaderProxyData* rit : pdata->m_readers)
+        {
+            if (rit->guid() != c_Guid_Unknown)
+            {
+                logInfo(RTPS_PDPSERVER_TRIM,
+                        "EDPServer mark the following Subscriber DATA for trimming " << rit->guid());
+                disposed_subscribers.insert(rit->key());
+            }
+        }
+
+        // Mark the demise participant publisher's history data for disposal
+        for (WriterProxyData* wit : pdata->m_writers)
+        {
+            if (wit->guid() != c_Guid_Unknown)
+            {
+                logInfo(RTPS_PDPSERVER_TRIM,
+                        "EDPServer mark the following Publisher DATA for trimming " << wit->guid());
+                disposed_publishers.insert(wit->key());
+            }
+        }
+    }
+
+    // call base class, this will effectively wipe out the endpoints data
+    bool res = PDP::remove_remote_participant(partGUID, reason);
+
+    // Mark the demise participant subscriber's history data for disposal. We must do it after removal this data from
+    // the server database to avoid confuse the trim mechanism that would consider this endpoints resurrect and avoid
+    // history cleaning
+    {
+        EDPServer* pEDP = dynamic_cast<EDPServer*>(getEDP());
+        assert(pEDP);
+
+        for (auto sub_key : disposed_subscribers)
+        {
+            pEDP->removeSubscriberFromHistory(sub_key);
+        }
+
+        for (auto pub_key : disposed_publishers)
+        {
+            pEDP->removePublisherFromHistory(pub_key);
+        }
+    }
+
     // Trigger the WriterHistory cleaning mechanism of demised participants DATA. Note that
     // only DATA acknowledge by all clients would be actually removed
+    if (res)
     {
-        std::lock_guard<std::recursive_mutex> lock(*getMutex());
-
-        InstanceHandle_t ih;
-
-        removeParticipantFromHistory(ih = partGUID);
+        removeParticipantFromHistory(key);
         removeParticipantForEDPMatch(partGUID);
 
         // awake server event thread
@@ -968,7 +1032,8 @@ bool PDPServer::remove_remote_participant(
         // and queueParticipantForEDPMatch
     }
 
-    return PDP::remove_remote_participant(partGUID, reason);
+    return res;
+   // only DATA acknowledge by all clients would be actually removed
 }
 
 bool PDPServer::pendingHistoryCleaning()


### PR DESCRIPTION
This is a backport from master to solve a client-server discovery issue.

When a client was dropped the server reported it to all other clients but didn't remove the demise client information from the PDP and EDP history. This commit fixes this issue.