### PR TITLE
Fixed behavior of get_liveliness_changed_status [8812]

### DIFF
--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -415,19 +415,19 @@ void DataReaderImpl::InnerDataReaderListener::on_liveliness_changed(
         RTPSReader* /*reader*/,
         const fastrtps::LivelinessChangedStatus& status)
 {
-    data_reader_->update_liveliness_status(status);
+    LivelinessChangedStatus& reader_status = data_reader_->update_liveliness_status(status);
     DataReader* user_reader = data_reader_->user_datareader_;
 
     if ( (data_reader_->listener_ != nullptr) &&
             (user_reader->get_status_mask().is_active(StatusMask::liveliness_changed())))
     {
-        LivelinessChangedStatus reader_status;
-        data_reader_->get_liveliness_changed_status(reader_status);
-        data_reader_->listener_->on_liveliness_changed(user_reader, reader_status);
+        LivelinessChangedStatus callback_status;
+        data_reader_->get_liveliness_changed_status(callback_status);
+        data_reader_->listener_->on_liveliness_changed(user_reader, callback_status);
     }
     else
     {
-        data_reader_->subscriber_->subscriber_listener_.on_liveliness_changed(user_reader, status);
+        data_reader_->subscriber_->subscriber_listener_.on_liveliness_changed(user_reader, reader_status);
     }
 }
 

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -164,7 +164,7 @@ public:
      */
 
     ReturnCode_t get_liveliness_changed_status(
-            fastrtps::LivelinessChangedStatus& status) const;
+            fastrtps::LivelinessChangedStatus& status);
 
     ReturnCode_t get_requested_incompatible_qos_status(
             RequestedIncompatibleQosStatus& status);
@@ -278,6 +278,9 @@ private:
     //! The current timer owner, i.e. the instance which started the deadline timer
     fastrtps::rtps::InstanceHandle_t timer_owner_;
 
+    //! Liveliness changed status
+    LivelinessChangedStatus liveliness_changed_status_;
+
     //! Requested deadline missed status
     fastrtps::RequestedDeadlineMissedStatus deadline_missed_status_;
 
@@ -321,6 +324,9 @@ private:
 
     RequestedIncompatibleQosStatus& update_requested_incompatible_qos(
             PolicyMask incompatible_policies);
+
+    LivelinessChangedStatus& update_liveliness_status(
+            const fastrtps::LivelinessChangedStatus& status);
 
 };
 

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -153,7 +153,7 @@ ReturnCode_t SubscriberImpl::set_qos(
 {
     bool enabled = user_subscriber_->is_enabled();
     const SubscriberQos& qos_to_set = (&qos == &SUBSCRIBER_QOS_DEFAULT) ?
-        participant_->get_default_subscriber_qos() : qos;
+            participant_->get_default_subscriber_qos() : qos;
 
     if (&qos != &SUBSCRIBER_QOS_DEFAULT)
     {
@@ -471,9 +471,13 @@ void SubscriberImpl::SubscriberReaderListener::on_liveliness_changed(
         DataReader* reader,
         const fastrtps::LivelinessChangedStatus& status)
 {
+    (void)status;
+
     if (subscriber_->listener_ != nullptr)
     {
-        subscriber_->listener_->on_liveliness_changed(reader, status);
+        LivelinessChangedStatus reader_status;
+        reader->get_liveliness_changed_status(reader_status);
+        subscriber_->listener_->on_liveliness_changed(reader, reader_status);
     }
 }
 
@@ -533,7 +537,6 @@ bool SubscriberImpl::type_in_use(
     }
     return false;
 }
-
 
 void SubscriberImpl::set_qos(
         SubscriberQos& to,

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -477,7 +477,7 @@ void SubscriberImpl::SubscriberReaderListener::on_liveliness_changed(
     (void)status;
 
     SubscriberListener* listener = subscriber_->listener_;
-    if (!subscriber_->user_subscriber_->get_status_mask().is_active(StatusMask::liveliness_changed()))
+    if (listener == nullptr || !subscriber_->user_subscriber_->get_status_mask().is_active(StatusMask::liveliness_changed()))
     {
         auto participant = subscriber_->get_participant();
         auto part_listener = const_cast<DomainParticipantListener*>(participant->get_listener());

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -477,7 +477,8 @@ void SubscriberImpl::SubscriberReaderListener::on_liveliness_changed(
     (void)status;
 
     SubscriberListener* listener = subscriber_->listener_;
-    if (listener == nullptr || !subscriber_->user_subscriber_->get_status_mask().is_active(StatusMask::liveliness_changed()))
+    if (listener == nullptr ||
+            !subscriber_->user_subscriber_->get_status_mask().is_active(StatusMask::liveliness_changed()))
     {
         auto participant = subscriber_->get_participant();
         auto part_listener = const_cast<DomainParticipantListener*>(participant->get_listener());

--- a/test/blackbox/CMakeLists.txt
+++ b/test/blackbox/CMakeLists.txt
@@ -272,7 +272,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
                 api/dds-pim
                 ${GTEST_INCLUDE_DIRS})
             target_link_libraries(BlackboxTests_DDS_PIM fastrtps fastcdr foonathan_memory ${GTEST_LIBRARIES})
-            add_blackbox_gtest(BlackboxTests_DDS_PIM SOURCES ${BLACKBOXTESTS_TEST_SOURCE}
+            add_blackbox_gtest(BlackboxTests_DDS_PIM SOURCES ${DDS_BLACKBOXTESTS_SOURCE}
                 ENVIRONMENTS "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs"
                 "TOPIC_RANDOM_NUMBER=${TOPIC_RANDOM_NUMBER}"
                 "W_UNICAST_PORT_RANDOM_NUMBER=${W_UNICAST_PORT_RANDOM_NUMBER}"

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -50,7 +50,7 @@ class PubSubParticipant
     {
         friend class PubSubParticipant;
 
-public:
+    public:
 
         PubListener(
                 PubSubParticipant* participant)
@@ -77,7 +77,7 @@ public:
             participant_->pub_liveliness_lost();
         }
 
-private:
+    private:
 
         PubListener& operator =(
                 const PubListener&) = delete;
@@ -89,7 +89,7 @@ private:
     {
         friend class PubSubParticipant;
 
-public:
+    public:
 
         SubListener(
                 PubSubParticipant* participant)
@@ -117,7 +117,7 @@ public:
 
         }
 
-private:
+    private:
 
         SubListener& operator =(
                 const SubListener&) = delete;
@@ -157,7 +157,7 @@ public:
         datawriter_qos_.historyMemoryPolicy = rtps::DYNAMIC_RESERVE_MEMORY_MODE;
 #else
         datawriter_qos_.endpoint().history_memory_policy = eprosima::fastrtps::rtps::PREALLOCATED_MEMORY_MODE;
-#endif
+#endif // if defined(PREALLOCATED_WITH_REALLOC_MEMORY_MODE_TEST)
 
         // By default, heartbeat period and nack response delay are 100 milliseconds.
         datawriter_qos_.reliable_writer_qos().times.heartbeatPeriod.seconds = 0;
@@ -326,15 +326,17 @@ public:
 
         if (timeout == std::chrono::seconds::zero())
         {
-            pub_cv_.wait(lock, [&](){
-                return pub_matched_ == num_expected_publishers_;
-            });
+            pub_cv_.wait(lock, [&]()
+                    {
+                        return pub_matched_ == num_expected_publishers_;
+                    });
         }
         else
         {
-            pub_cv_.wait_for(lock, timeout, [&](){
-                return pub_matched_ == num_expected_publishers_;
-            });
+            pub_cv_.wait_for(lock, timeout, [&]()
+                    {
+                        return pub_matched_ == num_expected_publishers_;
+                    });
         }
 
         std::cout << "Publisher discovery finished " << std::endl;
@@ -349,15 +351,17 @@ public:
 
         if (timeout == std::chrono::seconds::zero())
         {
-            sub_cv_.wait(lock, [&](){
-                return sub_matched_ == num_expected_subscribers_;
-            });
+            sub_cv_.wait(lock, [&]()
+                    {
+                        return sub_matched_ == num_expected_subscribers_;
+                    });
         }
         else
         {
-            sub_cv_.wait_for(lock, timeout, [&](){
-                return sub_matched_ == num_expected_subscribers_;
-            });
+            sub_cv_.wait_for(lock, timeout, [&]()
+                    {
+                        return sub_matched_ == num_expected_subscribers_;
+                    });
         }
 
         std::cout << "Subscriber discovery finished " << std::endl;
@@ -367,27 +371,30 @@ public:
             unsigned int times = 1)
     {
         std::unique_lock<std::mutex> lock(pub_liveliness_mutex_);
-        pub_liveliness_cv_.wait(lock, [&]() {
-            return pub_times_liveliness_lost_ >= times;
-        });
+        pub_liveliness_cv_.wait(lock, [&]()
+                {
+                    return pub_times_liveliness_lost_ >= times;
+                });
     }
 
     void sub_wait_liveliness_recovered(
             unsigned int num_recovered)
     {
         std::unique_lock<std::mutex> lock(sub_liveliness_mutex_);
-        sub_liveliness_cv_.wait(lock, [&]() {
-            return sub_times_liveliness_recovered_ >= num_recovered;
-        });
+        sub_liveliness_cv_.wait(lock, [&]()
+                {
+                    return sub_times_liveliness_recovered_ >= num_recovered;
+                });
     }
 
     void sub_wait_liveliness_lost(
             unsigned int num_lost)
     {
         std::unique_lock<std::mutex> lock(sub_liveliness_mutex_);
-        sub_liveliness_cv_.wait(lock, [&]() {
-            return sub_times_liveliness_lost_ >= num_lost;
-        });
+        sub_liveliness_cv_.wait(lock, [&]()
+                {
+                    return sub_times_liveliness_lost_ >= num_lost;
+                });
     }
 
     PubSubParticipant& pub_topic_name(

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -393,14 +393,20 @@ public:
     PubSubParticipant& pub_topic_name(
             std::string topicName)
     {
-        publisher_topicname_ = topicName;
+        // Generate topic name
+        std::ostringstream t;
+        t << topicName << "_" << asio::ip::host_name() << "_" << GET_PID();
+        publisher_topicname_ = t.str();
         return *this;
     }
 
     PubSubParticipant& sub_topic_name(
             std::string topicName)
     {
-        subscriber_topicname_ = topicName;
+        // Generate topic name
+        std::ostringstream t;
+        t << topicName << "_" << asio::ip::host_name() << "_" << GET_PID();
+        subscriber_topicname_ = t.str();
         return *this;
     }
 

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -413,7 +413,8 @@ public:
     }
 
     void wait_discovery(
-            std::chrono::seconds timeout = std::chrono::seconds::zero())
+            std::chrono::seconds timeout = std::chrono::seconds::zero(),
+            unsigned int min_writers = 1)
     {
         std::unique_lock<std::mutex> lock(mutexDiscovery_);
 
@@ -423,14 +424,14 @@ public:
         {
             cvDiscovery_.wait(lock, [&]()
                     {
-                        return matched_ != 0;
+                        return matched_ >= min_writers;
                     });
         }
         else
         {
             cvDiscovery_.wait_for(lock, timeout, [&]()
                     {
-                        return matched_ != 0;
+                        return matched_ >= min_writers;
                     });
         }
 
@@ -1109,6 +1110,13 @@ public:
         std::unique_lock<std::mutex> lock(liveliness_mutex_);
 
         return liveliness_changed_status_;
+    }
+
+    eprosima::fastdds::dds::LivelinessChangedStatus get_liveliness_changed_status() const
+    {
+        eprosima::fastdds::dds::LivelinessChangedStatus status;
+        datareader_->get_liveliness_changed_status(status);
+        return status;
     }
 
     bool is_matched() const

--- a/test/blackbox/api/fastrtps_deprecated/PubSubParticipant.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubParticipant.hpp
@@ -50,7 +50,7 @@ class PubSubParticipant
     {
         friend class PubSubParticipant;
 
-public:
+    public:
 
         PubListener(
                 PubSubParticipant* participant)
@@ -79,7 +79,7 @@ public:
             participant_->pub_liveliness_lost();
         }
 
-private:
+    private:
 
         PubListener& operator =(
                 const PubListener&) = delete;
@@ -91,7 +91,7 @@ private:
     {
         friend class PubSubParticipant;
 
-public:
+    public:
 
         SubListener(
                 PubSubParticipant* participant)
@@ -121,7 +121,7 @@ public:
 
         }
 
-private:
+    private:
 
         SubListener& operator =(
                 const SubListener&) = delete;
@@ -163,7 +163,7 @@ public:
         publisher_attr_.historyMemoryPolicy = rtps::DYNAMIC_RESERVE_MEMORY_MODE;
 #else
         publisher_attr_.historyMemoryPolicy = rtps::PREALLOCATED_MEMORY_MODE;
-#endif
+#endif // if defined(PREALLOCATED_WITH_REALLOC_MEMORY_MODE_TEST)
 
         // By default, heartbeat period and nack response delay are 100 milliseconds.
         publisher_attr_.times.heartbeatPeriod.seconds = 0;
@@ -265,13 +265,15 @@ public:
 
         if (timeout == std::chrono::seconds::zero())
         {
-            pub_cv_.wait(lock, [&](){
+            pub_cv_.wait(lock, [&]()
+                    {
                         return pub_matched_ == num_expected_publishers_;
                     });
         }
         else
         {
-            pub_cv_.wait_for(lock, timeout, [&](){
+            pub_cv_.wait_for(lock, timeout, [&]()
+                    {
                         return pub_matched_ == num_expected_publishers_;
                     });
         }
@@ -288,13 +290,15 @@ public:
 
         if (timeout == std::chrono::seconds::zero())
         {
-            sub_cv_.wait(lock, [&](){
+            sub_cv_.wait(lock, [&]()
+                    {
                         return sub_matched_ == num_expected_subscribers_;
                     });
         }
         else
         {
-            sub_cv_.wait_for(lock, timeout, [&](){
+            sub_cv_.wait_for(lock, timeout, [&]()
+                    {
                         return sub_matched_ == num_expected_subscribers_;
                     });
         }
@@ -306,7 +310,8 @@ public:
             unsigned int times = 1)
     {
         std::unique_lock<std::mutex> lock(pub_liveliness_mutex_);
-        pub_liveliness_cv_.wait(lock, [&]() {
+        pub_liveliness_cv_.wait(lock, [&]()
+                {
                     return pub_times_liveliness_lost_ >= times;
                 });
     }
@@ -315,7 +320,8 @@ public:
             unsigned int num_recovered)
     {
         std::unique_lock<std::mutex> lock(sub_liveliness_mutex_);
-        sub_liveliness_cv_.wait(lock, [&]() {
+        sub_liveliness_cv_.wait(lock, [&]()
+                {
                     return sub_times_liveliness_recovered_ >= num_recovered;
                 });
     }
@@ -324,7 +330,8 @@ public:
             unsigned int num_lost)
     {
         std::unique_lock<std::mutex> lock(sub_liveliness_mutex_);
-        sub_liveliness_cv_.wait(lock, [&]() {
+        sub_liveliness_cv_.wait(lock, [&]()
+                {
                     return sub_times_liveliness_lost_ >= num_lost;
                 });
     }
@@ -550,7 +557,7 @@ private:
     type_support type_;
 };
 
-}
-}
+} // namespace fastrtps
+} // namespace eprosima
 
 #endif // _TEST_BLACKBOX_PUBSUBPARTICIPANT_HPP_

--- a/test/blackbox/api/fastrtps_deprecated/PubSubParticipant.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubParticipant.hpp
@@ -332,16 +332,22 @@ public:
     PubSubParticipant& pub_topic_name(
             std::string topicName)
     {
+        // Generate topic name
+        std::ostringstream t;
+        t << topicName << "_" << asio::ip::host_name() << "_" << GET_PID();
+        publisher_attr_.topic.topicName = t.str();
         publisher_attr_.topic.topicDataType = type_.getName();
-        publisher_attr_.topic.topicName = topicName;
         return *this;
     }
 
     PubSubParticipant& sub_topic_name(
             std::string topicName)
     {
+        // Generate topic name
+        std::ostringstream t;
+        t << topicName << "_" << asio::ip::host_name() << "_" << GET_PID();
+        subscriber_attr_.topic.topicName = t.str();
         subscriber_attr_.topic.topicDataType = type_.getName();
-        subscriber_attr_.topic.topicName = topicName;
         return *this;
     }
 

--- a/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
@@ -1,0 +1,150 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "BlackboxTests.hpp"
+
+#include "PubSubParticipant.hpp"
+#include "PubSubReader.hpp"
+#include "PubSubWriter.hpp"
+#include <fastrtps/xmlparser/XMLProfileManager.h>
+
+#include <gtest/gtest.h>
+
+using namespace eprosima::fastrtps;
+using namespace eprosima::fastrtps::rtps;
+
+#define INCOMPATIBLE_TEST_TOPIC_NAME std::string( \
+        std::string("incompatible_") + TEST_TOPIC_NAME)
+
+
+class DDSDataReader : public testing::TestWithParam<bool>
+{
+public:
+
+    void SetUp() override
+    {
+        LibrarySettingsAttributes library_settings;
+        if (GetParam())
+        {
+            library_settings.intraprocess_delivery = IntraprocessDeliveryType::INTRAPROCESS_FULL;
+            xmlparser::XMLProfileManager::library_settings(library_settings);
+        }
+
+    }
+
+    void TearDown() override
+    {
+        LibrarySettingsAttributes library_settings;
+        if (GetParam())
+        {
+            library_settings.intraprocess_delivery = IntraprocessDeliveryType::INTRAPROCESS_OFF;
+            xmlparser::XMLProfileManager::library_settings(library_settings);
+        }
+    }
+
+};
+
+TEST_P(DDSDataReader, LivelinessChangedStatusGet)
+{
+    static constexpr int32_t num_times = 3u;
+
+    static const Duration_t lease_duration(60, 0);
+    static const Duration_t announcement_period(0, 100 * 1000);
+
+    // Create and start reader that will not invoke listener for liveliness_changed
+    PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
+    reader.liveliness_kind(AUTOMATIC_LIVELINESS_QOS)
+        .liveliness_lease_duration(lease_duration)
+        .deactivate_status_listener(eprosima::fastdds::dds::StatusMask::liveliness_changed());
+    reader.init();
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Create a participant for the writers
+    auto writers = std::make_unique<PubSubParticipant<HelloWorldType>> (num_times, 0, num_times, 0);
+    writers->pub_topic_name(TEST_TOPIC_NAME)
+        .pub_liveliness_kind(AUTOMATIC_LIVELINESS_QOS)
+        .pub_liveliness_announcement_period(announcement_period)
+        .pub_liveliness_lease_duration(lease_duration);
+    ASSERT_TRUE(writers->init_participant());
+    
+    // Ensure initial status is 'there are no writers'
+    eprosima::fastdds::dds::LivelinessChangedStatus status;
+    status = reader.get_liveliness_changed_status();
+    EXPECT_EQ(status.alive_count, 0);
+    EXPECT_EQ(status.alive_count_change, 0);
+    EXPECT_EQ(status.not_alive_count, 0);
+    EXPECT_EQ(status.not_alive_count_change, 0);
+
+    // Start all writers
+    for (unsigned int i = 0; i < num_times; i++)
+    {
+        ASSERT_TRUE(writers->init_publisher(i));
+    }
+
+    // Wait for discovery to finish
+    reader.wait_discovery(std::chrono::seconds::zero(), num_times);
+    writers->pub_wait_discovery();
+
+    // Assert liveliness by sending a sample
+    auto messages = default_helloworld_data_generator(1);
+    reader.startReception(messages);
+    writers->send_sample(messages.front(), 0);
+    reader.block_for_at_least(1);
+
+    // Check we have 'num_times' NEW alive writers
+    status = reader.get_liveliness_changed_status();
+    EXPECT_EQ(status.alive_count, num_times);
+    EXPECT_EQ(status.alive_count_change, num_times);
+    EXPECT_EQ(status.not_alive_count, 0);
+    EXPECT_EQ(status.not_alive_count_change, 0);
+
+    // Reading status again should reset count changes
+    status = reader.get_liveliness_changed_status();
+    EXPECT_EQ(status.alive_count, num_times);
+    EXPECT_EQ(status.alive_count_change, 0);
+    EXPECT_EQ(status.not_alive_count, 0);
+    EXPECT_EQ(status.not_alive_count_change, 0);
+
+    // Stop writers and wait till reader is aware
+    writers.reset(nullptr);
+    reader.wait_writer_undiscovery();
+
+    // Check we have lost 'num_times' alive writers
+    status = reader.get_liveliness_changed_status();
+    EXPECT_EQ(status.alive_count, 0);
+    EXPECT_EQ(status.alive_count_change, -num_times);
+    EXPECT_EQ(status.not_alive_count, 0);
+    EXPECT_EQ(status.not_alive_count_change, 0);
+
+    // Reading status again should reset count changes
+    status = reader.get_liveliness_changed_status();
+    EXPECT_EQ(status.alive_count, 0);
+    EXPECT_EQ(status.alive_count_change, 0);
+    EXPECT_EQ(status.not_alive_count, 0);
+    EXPECT_EQ(status.not_alive_count_change, 0);
+
+}
+
+INSTANTIATE_TEST_CASE_P(DDSDataReader,
+        DDSDataReader,
+        testing::Values(false, true),
+        [](const testing::TestParamInfo<DDSDataReader::ParamType>& info)
+        {
+            if (info.param)
+            {
+                return "Intraprocess";
+            }
+            return "NonIntraprocess";
+        });
+

--- a/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
@@ -65,19 +65,19 @@ TEST_P(DDSDataReader, LivelinessChangedStatusGet)
     // Create and start reader that will not invoke listener for liveliness_changed
     PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
     reader.liveliness_kind(AUTOMATIC_LIVELINESS_QOS)
-        .liveliness_lease_duration(lease_duration)
-        .deactivate_status_listener(eprosima::fastdds::dds::StatusMask::liveliness_changed());
+    .liveliness_lease_duration(lease_duration)
+    .deactivate_status_listener(eprosima::fastdds::dds::StatusMask::liveliness_changed());
     reader.init();
     ASSERT_TRUE(reader.isInitialized());
 
     // Create a participant for the writers
-    auto writers = std::make_unique<PubSubParticipant<HelloWorldType>> (num_times, 0, num_times, 0);
+    auto writers = std::make_unique<PubSubParticipant<HelloWorldType> > (num_times, 0, num_times, 0);
     writers->pub_topic_name(TEST_TOPIC_NAME)
-        .pub_liveliness_kind(AUTOMATIC_LIVELINESS_QOS)
-        .pub_liveliness_announcement_period(announcement_period)
-        .pub_liveliness_lease_duration(lease_duration);
+    .pub_liveliness_kind(AUTOMATIC_LIVELINESS_QOS)
+    .pub_liveliness_announcement_period(announcement_period)
+    .pub_liveliness_lease_duration(lease_duration);
     ASSERT_TRUE(writers->init_participant());
-    
+
     // Ensure initial status is 'there are no writers'
     eprosima::fastdds::dds::LivelinessChangedStatus status;
     status = reader.get_liveliness_changed_status();

--- a/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
@@ -71,7 +71,8 @@ TEST_P(DDSDataReader, LivelinessChangedStatusGet)
     ASSERT_TRUE(reader.isInitialized());
 
     // Create a participant for the writers
-    auto writers = std::make_unique<PubSubParticipant<HelloWorldType> > (num_times, 0, num_times, 0);
+    std::unique_ptr<PubSubParticipant<HelloWorldType>> writers;
+    writers.reset(new PubSubParticipant<HelloWorldType>(num_times, 0, num_times, 0));
     writers->pub_topic_name(TEST_TOPIC_NAME)
     .pub_liveliness_kind(AUTOMATIC_LIVELINESS_QOS)
     .pub_liveliness_announcement_period(announcement_period)

--- a/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
@@ -71,7 +71,7 @@ TEST_P(DDSDataReader, LivelinessChangedStatusGet)
     ASSERT_TRUE(reader.isInitialized());
 
     // Create a participant for the writers
-    std::unique_ptr<PubSubParticipant<HelloWorldType>> writers;
+    std::unique_ptr<PubSubParticipant<HelloWorldType> > writers;
     writers.reset(new PubSubParticipant<HelloWorldType>(num_times, 0, num_times, 0));
     writers->pub_topic_name(TEST_TOPIC_NAME)
     .pub_liveliness_kind(AUTOMATIC_LIVELINESS_QOS)


### PR DESCRIPTION
It was detected that when no listener is set to a DataReader, `xxx_count_change` fields of `LivelinessChangedStatus` where always being read as 0.

A Blackbox test is added to reproduce the problem.

DataReaderImpl now has a copy of its `LivelinessChangedStatus` independent of the one in RTPSReader.

Status mask is checked before calling `on_liveliness_changed`.