### PR TITLE
Persistence guid property [8858]

### DIFF
--- a/include/fastdds/rtps/common/Guid.h
+++ b/include/fastdds/rtps/common/Guid.h
@@ -240,8 +240,13 @@ inline std::istream& operator >>(
         {
             input.exceptions(excp_mask | std::ios_base::failbit | std::ios_base::badbit);
 
-            input >> guid.guidPrefix;
-            input >> guid.entityId;
+            char sep;
+            input >> guid.guidPrefix >> sep >> guid.entityId;
+
+            if (sep != '|')
+            {
+                input.setstate(std::ios_base::failbit);
+            }
         }
         catch (std::ios_base::failure&)
         {

--- a/include/fastdds/rtps/common/Guid.h
+++ b/include/fastdds/rtps/common/Guid.h
@@ -114,13 +114,14 @@ struct RTPS_DllAPI GUID_t
     static GUID_t unknown() noexcept
     {
         return GUID_t();
-    };
+    }
 
     // TODO Review this conversion once InstanceHandle_t is implemented as DDS standard defines
     explicit operator const InstanceHandle_t&() const
     {
         return *reinterpret_cast<const InstanceHandle_t*>(this);
     }
+
 };
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
@@ -193,7 +194,8 @@ inline bool operator <(
     }
     return false;
 }
-#endif
+
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 const GUID_t c_Guid_Unknown;
 
@@ -209,7 +211,7 @@ inline std::ostream& operator <<(
         std::ostream& output,
         const GUID_t& guid)
 {
-    if (guid !=c_Guid_Unknown)
+    if (guid != c_Guid_Unknown)
     {
         output << guid.guidPrefix << "|" << guid.entityId;
     }
@@ -260,7 +262,7 @@ inline std::istream& operator >>(
     return input;
 }
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 } // namespace rtps
 } // namespace fastrtps

--- a/include/fastdds/rtps/common/Property.h
+++ b/include/fastdds/rtps/common/Property.h
@@ -27,149 +27,187 @@ namespace rtps {
 
 class Property
 {
-    public:
+public:
 
-        Property() {}
+    Property()
+    {
+    }
 
-        Property(const Property& property) :
-            name_(property.name_),
-            value_(property.value_),
-            propagate_(property.propagate_) {}
+    Property(
+            const Property& property)
+        : name_(property.name_)
+        , value_(property.value_)
+        , propagate_(property.propagate_)
+    {
+    }
 
-        Property(Property&& property) :
-            name_(std::move(property.name_)),
-            value_(std::move(property.value_)),
-            propagate_(property.propagate_) {}
+    Property(
+            Property&& property)
+        : name_(std::move(property.name_))
+        , value_(std::move(property.value_))
+        , propagate_(property.propagate_)
+    {
+    }
 
-        Property(const std::string& name,
-                const std::string& value) :
-            name_(name), value_(value) {}
+    Property(
+            const std::string& name,
+            const std::string& value)
+        : name_(name)
+        , value_(value)
+    {
+    }
 
-        Property(std::string&& name,
-                std::string&& value) :
-            name_(std::move(name)), value_(std::move(value)) {}
+    Property(
+            std::string&& name,
+            std::string&& value)
+        : name_(std::move(name))
+        , value_(std::move(value))
+    {
+    }
 
-        Property& operator=(const Property& property)
-        {
-            name_ = property.name_;
-            value_ = property.value_;
-            propagate_ = property.propagate_;
-            return *this;
-        }
+    Property& operator =(
+            const Property& property)
+    {
+        name_ = property.name_;
+        value_ = property.value_;
+        propagate_ = property.propagate_;
+        return *this;
+    }
 
-        Property& operator=(Property&& property)
-        {
-            name_ = std::move(property.name_);
-            value_ = std::move(property.value_);
-            propagate_ = property.propagate_;
-            return *this;
-        }
+    Property& operator =(
+            Property&& property)
+    {
+        name_ = std::move(property.name_);
+        value_ = std::move(property.value_);
+        propagate_ = property.propagate_;
+        return *this;
+    }
 
-        bool operator==(const Property& b) const
-        {
-            return (this->name_ == b.name_) &&
-                   (this->value_ == b.value_);
-        }
+    bool operator ==(
+            const Property& b) const
+    {
+        return (this->name_ == b.name_) &&
+               (this->value_ == b.value_);
+    }
 
-        void name(const std::string& name)
-        {
-            name_ = name;
-        }
+    void name(
+            const std::string& name)
+    {
+        name_ = name;
+    }
 
-        void name(std::string&& name)
-        {
-            name_ = std::move(name);
-        }
+    void name(
+            std::string&& name)
+    {
+        name_ = std::move(name);
+    }
 
-        const std::string& name() const
-        {
-            return name_;
-        }
+    const std::string& name() const
+    {
+        return name_;
+    }
 
-        std::string& name()
-        {
-            return name_;
-        }
+    std::string& name()
+    {
+        return name_;
+    }
 
-        void value(const std::string& value)
-        {
-            value_ = value;
-        }
+    void value(
+            const std::string& value)
+    {
+        value_ = value;
+    }
 
-        void value(std::string&& value)
-        {
-            value_ = std::move(value);
-        }
+    void value(
+            std::string&& value)
+    {
+        value_ = std::move(value);
+    }
 
-        const std::string& value() const
-        {
-            return value_;
-        }
+    const std::string& value() const
+    {
+        return value_;
+    }
 
-        std::string& value()
-        {
-            return value_;
-        }
+    std::string& value()
+    {
+        return value_;
+    }
 
-        void propagate(bool propagate)
-        {
-            propagate_ = propagate;
-        }
+    void propagate(
+            bool propagate)
+    {
+        propagate_ = propagate;
+    }
 
-        bool propagate() const
-        {
-            return propagate_;
-        }
+    bool propagate() const
+    {
+        return propagate_;
+    }
 
-        bool& propagate()
-        {
-            return propagate_;
-        }
+    bool& propagate()
+    {
+        return propagate_;
+    }
 
-    private:
+private:
 
-        std::string name_;
+    std::string name_;
 
-        std::string value_;
+    std::string value_;
 
-        bool propagate_ = false;
+    bool propagate_ = false;
 };
 
 typedef std::vector<Property> PropertySeq;
 
 class PropertyHelper
 {
-    public:
+public:
 
-        static size_t serialized_size(const Property& property, size_t current_alignment = 0)
-        {
-            if(property.propagate())
-            {
-                size_t initial_alignment = current_alignment;
-
-                current_alignment += 4 + alignment(current_alignment, 4) + property.name().size() + 1;
-                current_alignment += 4 + alignment(current_alignment, 4) + property.value().size() + 1;
-
-                return current_alignment - initial_alignment;
-            }
-            else
-                return 0;
-        }
-
-        static size_t serialized_size(const PropertySeq& properties, size_t current_alignment = 0)
+    static size_t serialized_size(
+            const Property& property,
+            size_t current_alignment = 0)
+    {
+        if (property.propagate())
         {
             size_t initial_alignment = current_alignment;
 
-            current_alignment += 4 + alignment(current_alignment, 4);
-            for(auto property = properties.begin(); property != properties.end(); ++property)
-                current_alignment += serialized_size(*property, current_alignment);
+            current_alignment += 4 + alignment(current_alignment, 4) + property.name().size() + 1;
+            current_alignment += 4 + alignment(current_alignment, 4) + property.value().size() + 1;
 
             return current_alignment - initial_alignment;
         }
+        else
+        {
+            return 0;
+        }
+    }
 
-    private:
+    static size_t serialized_size(
+            const PropertySeq& properties,
+            size_t current_alignment = 0)
+    {
+        size_t initial_alignment = current_alignment;
 
-        inline static size_t alignment(size_t current_alignment, size_t dataSize) { return (dataSize - (current_alignment % dataSize)) & (dataSize-1);}
+        current_alignment += 4 + alignment(current_alignment, 4);
+        for (auto property = properties.begin(); property != properties.end(); ++property)
+        {
+            current_alignment += serialized_size(*property, current_alignment);
+        }
+
+        return current_alignment - initial_alignment;
+    }
+
+private:
+
+    inline static size_t alignment(
+            size_t current_alignment,
+            size_t dataSize)
+    {
+        return (dataSize - (current_alignment % dataSize)) & (dataSize - 1);
+    }
+
 };
 
 } //namespace eprosima

--- a/include/fastdds/rtps/common/Property.h
+++ b/include/fastdds/rtps/common/Property.h
@@ -29,7 +29,7 @@ class Property
 {
     public:
 
-        Property() : propagate_(false) {}
+        Property() {}
 
         Property(const Property& property) :
             name_(property.name_),
@@ -132,7 +132,7 @@ class Property
 
         std::string value_;
 
-        bool propagate_;
+        bool propagate_ = false;
 };
 
 typedef std::vector<Property> PropertySeq;

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -113,7 +113,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     , type_check_fn_(nullptr)
 #if HAVE_SECURITY
     , m_security_manager(this)
-#endif
+#endif // if HAVE_SECURITY
     , mp_participantListener(plisten)
     , mp_userParticipant(par)
     , mp_mutex(new std::recursive_mutex())
@@ -133,12 +133,12 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         // We assume (Linux) UDP doubles the user socket buffer size in kernel, so
         // the equivalent segment size in SHM would be socket buffer size x 2
         auto segment_size_udp_equivalent =
-            std::max(m_att.sendSocketBufferSize, m_att.listenSocketBufferSize) * 2;
+                std::max(m_att.sendSocketBufferSize, m_att.listenSocketBufferSize) * 2;
         shm_transport.segment_size(segment_size_udp_equivalent);
         // Use same default max_message_size on both UDP and SHM
         shm_transport.max_message_size(descriptor.max_message_size());
         has_shm_transport_ |= m_network_Factory.RegisterTransport(&shm_transport);
-#endif
+#endif // ifdef SHM_TRANSPORT_BUILTIN
     }
 
     // BACKUP servers guid is its persistence one
@@ -233,16 +233,16 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     {
         std::for_each(m_att.builtin.metatrafficMulticastLocatorList.begin(),
                 m_att.builtin.metatrafficMulticastLocatorList.end(), [&](Locator_t& locator)
-                    {
-                        m_network_Factory.fillMetatrafficMulticastLocator(locator, metatraffic_multicast_port);
-                    });
+                {
+                    m_network_Factory.fillMetatrafficMulticastLocator(locator, metatraffic_multicast_port);
+                });
         m_network_Factory.NormalizeLocators(m_att.builtin.metatrafficMulticastLocatorList);
 
         std::for_each(m_att.builtin.metatrafficUnicastLocatorList.begin(),
                 m_att.builtin.metatrafficUnicastLocatorList.end(), [&](Locator_t& locator)
-                    {
-                        m_network_Factory.fillMetatrafficUnicastLocator(locator, metatraffic_unicast_port);
-                    });
+                {
+                    m_network_Factory.fillMetatrafficUnicastLocator(locator, metatraffic_unicast_port);
+                });
         m_network_Factory.NormalizeLocators(m_att.builtin.metatrafficUnicastLocatorList);
     }
 
@@ -258,9 +258,9 @@ RTPSParticipantImpl::RTPSParticipantImpl(
 
         std::for_each(initial_peers.begin(), initial_peers.end(),
                 [&](Locator_t& locator)
-                    {
-                        m_network_Factory.configureInitialPeerLocator(domain_id_, locator, m_att);
-                    });
+                {
+                    m_network_Factory.configureInitialPeerLocator(domain_id_, locator, m_att);
+                });
     }
 
     // Creation of user locator and receiver resources
@@ -285,9 +285,9 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         // Locator with port 0, calculate port.
         std::for_each(m_att.defaultUnicastLocatorList.begin(), m_att.defaultUnicastLocatorList.end(),
                 [&](Locator_t& loc)
-                    {
-                        m_network_Factory.fillDefaultUnicastLocator(domain_id_, loc, m_att);
-                    });
+                {
+                    m_network_Factory.fillDefaultUnicastLocator(domain_id_, loc, m_att);
+                });
 
     }
 
@@ -310,7 +310,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         // Participant will be deleted, no need to allocate buffers or create builtin endpoints
         return;
     }
-#endif
+#endif // if HAVE_SECURITY
 
     if (is_intraprocess_only())
     {
@@ -349,7 +349,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
             return;
         }
     }
-#endif
+#endif // if HAVE_SECURITY
 
     mp_builtinProtocols = new BuiltinProtocols();
 
@@ -429,7 +429,7 @@ RTPSParticipantImpl::~RTPSParticipantImpl()
 
 #if HAVE_SECURITY
     m_security_manager.destroy();
-#endif
+#endif // if HAVE_SECURITY
 
     // Destruct message receivers
     for (auto& block : m_receiverResourcelist)
@@ -536,7 +536,7 @@ bool RTPSParticipantImpl::createWriter(
             {
                 // Wrongly configured property
                 logError(RTPS_PARTICIPANT, "Cannot configure writer's persistence GUID from '"
-                    << persistence_guid_property->c_str() << "'. Wrong input");
+                        << persistence_guid_property->c_str() << "'. Wrong input");
                 return false;
             }
             // Make sure the persistence guid sticks
@@ -612,7 +612,7 @@ bool RTPSParticipantImpl::createWriter(
             return false;
         }
     }
-#endif
+#endif // if HAVE_SECURITY
 
     createSendResources(SWriter);
     if (param.endpoint.reliabilityKind == RELIABLE)
@@ -723,7 +723,7 @@ bool RTPSParticipantImpl::createReader(
                 {
                     // Wrongly configured property
                     logError(RTPS_PARTICIPANT, "Cannot configure readers's persistence GUID from '"
-                        << persistence_guid_property->c_str() << "'. Wrong input");
+                            << persistence_guid_property->c_str() << "'. Wrong input");
                     return false;
                 }
             }
@@ -784,7 +784,7 @@ bool RTPSParticipantImpl::createReader(
             return false;
         }
     }
-#endif
+#endif // if HAVE_SECURITY
 
     if (param.endpoint.reliabilityKind == RELIABLE)
     {
@@ -1064,7 +1064,7 @@ void RTPSParticipantImpl::createReceiverResources(
             is_secure() ? std::numeric_limits<uint16_t>::max() : std::numeric_limits<uint32_t>::max();
 #else
     uint32_t max_receiver_buffer_size = std::numeric_limits<uint32_t>::max();
-#endif
+#endif // if HAVE_SECURITY
 
     for (auto it_loc = Locator_list.begin(); it_loc != Locator_list.end(); ++it_loc)
     {
@@ -1192,7 +1192,7 @@ bool RTPSParticipantImpl::deleteUserEndpoint(
             {
                 m_security_manager.unregister_local_writer(p_endpoint->getGuid());
             }
-#endif
+#endif // if HAVE_SECURITY
         }
         else
         {
@@ -1207,7 +1207,7 @@ bool RTPSParticipantImpl::deleteUserEndpoint(
             {
                 m_security_manager.unregister_local_reader(p_endpoint->getGuid());
             }
-#endif
+#endif // if HAVE_SECURITY
         }
     }
     //	std::lock_guard<std::recursive_mutex> guardEndpoint(*p_endpoint->getMutex());
@@ -1329,7 +1329,7 @@ uint32_t RTPSParticipantImpl::getMaxMessageSize() const
             is_secure() ? std::numeric_limits<uint16_t>::max() : std::numeric_limits<uint32_t>::max();
 #else
     uint32_t max_receiver_buffer_size = std::numeric_limits<uint32_t>::max();
-#endif
+#endif // if HAVE_SECURITY
 
     return (std::min)(
         m_network_Factory.get_max_message_size_between_transports(),
@@ -1353,7 +1353,7 @@ uint32_t RTPSParticipantImpl::calculateMaxDataSize(
     {
         maxDataSize -= m_security_manager.calculate_extra_size_for_rtps_message();
     }
-#endif
+#endif // if HAVE_SECURITY
 
     // RTPS header
     maxDataSize -= RTPSMESSAGE_HEADER_SIZE;
@@ -1400,7 +1400,7 @@ bool RTPSParticipantImpl::pairing_remote_writer_with_local_reader_after_security
     return return_value;
 }
 
-#endif
+#endif // if HAVE_SECURITY
 
 PDPSimple* RTPSParticipantImpl::pdpsimple()
 {
@@ -1472,11 +1472,11 @@ uint32_t RTPSParticipantImpl::get_domain_id() const
 
 //!Compare metatraffic locators list searching for mutations
 bool RTPSParticipantImpl::did_mutation_took_place_on_meta(
-    const LocatorList_t& MulticastLocatorList,
-    const LocatorList_t& UnicastLocatorList) const
+        const LocatorList_t& MulticastLocatorList,
+        const LocatorList_t& UnicastLocatorList) const
 {
-    if(m_att.builtin.metatrafficMulticastLocatorList == MulticastLocatorList
-        && m_att.builtin.metatrafficUnicastLocatorList == UnicastLocatorList)
+    if (m_att.builtin.metatrafficMulticastLocatorList == MulticastLocatorList
+            && m_att.builtin.metatrafficUnicastLocatorList == UnicastLocatorList)
     {
         // no mutation
         return false;
@@ -1497,51 +1497,52 @@ bool RTPSParticipantImpl::did_mutation_took_place_on_meta(
         std::copy(old_it, it, std::back_inserter(unicast_real_locators));
 
         // transform new ones if needed
-        if(it != UnicastLocatorList.end())
+        if (it != UnicastLocatorList.end())
         {
-            const Locator_t & an_any = *it;
+            const Locator_t& an_any = *it;
 
             // load interfaces if needed
-            if(locals.empty())
+            if (locals.empty())
             {
                 IPFinder::getIP4Address(&locals);
             }
 
             // add a locator for each local
             std::transform(locals.begin(),
-                locals.end(),
-                std::back_inserter(unicast_real_locators),
-                [&an_any](const Locator_t & loc) -> Locator_t
-                {
-                    Locator_t specific(loc);
-                    specific.port = an_any.port;
-                    specific.kind = an_any.kind;
-                    return specific;
-                });
+                    locals.end(),
+                    std::back_inserter(unicast_real_locators),
+                    [&an_any](const Locator_t& loc) -> Locator_t
+                    {
+                        Locator_t specific(loc);
+                        specific.port = an_any.port;
+                        specific.kind = an_any.kind;
+                        return specific;
+                    });
 
             // search for the next if any
             ++it;
         }
-    } while(it != UnicastLocatorList.end());
+    } while (it != UnicastLocatorList.end());
 
     // TCP is a special case because physical ports are taken from the TransportDescriptors
     struct ResetLogical : public std::unary_function<Locator_t, const Locator_t&>
     {
-        typedef std::vector<std::shared_ptr<fastdds::rtps::TransportDescriptorInterface>> Transports;
+        typedef std::vector<std::shared_ptr<fastdds::rtps::TransportDescriptorInterface> > Transports;
 
-        ResetLogical(const Transports& tp)
+        ResetLogical(
+                const Transports& tp)
             : Transports_(tp)
             , tcp4(nullptr)
             , tcp6(nullptr)
         {
-            for(auto desc : Transports_)
+            for (auto desc : Transports_)
             {
-                if(nullptr == tcp4)
+                if (nullptr == tcp4)
                 {
                     tcp4 = dynamic_cast<fastdds::rtps::TCPv4TransportDescriptor*>(desc.get());
                 }
 
-                if(nullptr == tcp6)
+                if (nullptr == tcp6)
                 {
                     tcp6 = dynamic_cast<fastdds::rtps::TCPv6TransportDescriptor*>(desc.get());
                 }
@@ -1558,51 +1559,53 @@ bool RTPSParticipantImpl::did_mutation_took_place_on_meta(
             return tcp6 ? ( tcp6->listening_ports.empty() ? 0 : tcp6->listening_ports[0]) : 0;
         }
 
-        Locator_t operator()(const Locator_t& loc) const
+        Locator_t operator ()(
+                const Locator_t& loc) const
         {
             Locator_t ret(loc);
-            switch(loc.kind)
+            switch (loc.kind)
             {
-            case LOCATOR_KIND_TCPv4:
-                IPLocator::setPhysicalPort(ret, Tcp4ListeningPort());
-                break;
-            case LOCATOR_KIND_TCPv6:
-                IPLocator::setPhysicalPort(ret, Tcp6ListeningPort());
-                break;
+                case LOCATOR_KIND_TCPv4:
+                    IPLocator::setPhysicalPort(ret, Tcp4ListeningPort());
+                    break;
+                case LOCATOR_KIND_TCPv6:
+                    IPLocator::setPhysicalPort(ret, Tcp6ListeningPort());
+                    break;
             }
             return ret;
         }
 
         // reference to the transports
         const Transports& Transports_;
-        TCPTransportDescriptor *tcp4, *tcp6;
+        TCPTransportDescriptor* tcp4, * tcp6;
 
-    } transform_functor(m_att.userTransports);
+    }
+    transform_functor(m_att.userTransports);
 
     // transform-copy
     std::set<Locator_t> update_attributes;
 
     std::transform(m_att.builtin.metatrafficMulticastLocatorList.begin(),
             m_att.builtin.metatrafficMulticastLocatorList.end(),
-            std::inserter(update_attributes,update_attributes.begin()),
+            std::inserter(update_attributes, update_attributes.begin()),
             transform_functor);
 
     std::transform(m_att.builtin.metatrafficUnicastLocatorList.begin(),
             m_att.builtin.metatrafficUnicastLocatorList.end(),
-            std::inserter(update_attributes,update_attributes.begin()),
+            std::inserter(update_attributes, update_attributes.begin()),
             transform_functor);
 
     std::set<Locator_t> original_ones;
 
     std::transform(MulticastLocatorList.begin(),
-        MulticastLocatorList.end(),
-        std::inserter(original_ones,original_ones.begin()),
-        transform_functor);
+            MulticastLocatorList.end(),
+            std::inserter(original_ones, original_ones.begin()),
+            transform_functor);
 
     std::transform(unicast_real_locators.begin(),
-        unicast_real_locators.end(),
-        std::inserter(original_ones, original_ones.begin()),
-        transform_functor);
+            unicast_real_locators.end(),
+            std::inserter(original_ones, original_ones.begin()),
+            transform_functor);
 
     // if equal then no mutation took place on physical ports
     return !(update_attributes == original_ones);

--- a/test/blackbox/CMakeLists.txt
+++ b/test/blackbox/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -233,6 +233,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
             ${CMAKE_CURRENT_BINARY_DIR}/PubSubWriter.xml)
         configure_file(${CMAKE_CURRENT_SOURCE_DIR}/PubSubReader.xml.in
             ${CMAKE_CURRENT_BINARY_DIR}/PubSubReader.xml)
+        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/persistence.xml
+            ${CMAKE_CURRENT_BINARY_DIR}/persistence.xml)
+        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/utils/check_guid.py
+            ${CMAKE_CURRENT_BINARY_DIR}/check_guid.py)
 
         if(FASTRTPS_API_TESTS)
             set(BLACKBOXTESTS_FASTRTPS_SOURCE

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2016, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -284,11 +284,28 @@ public:
 
     void init()
     {
-        participant_ = DomainParticipantFactory::get_instance()->create_participant(
-            (uint32_t)GET_PID() % 230,
-            participant_qos_,
-            &participant_listener_,
-            eprosima::fastdds::dds::StatusMask::none());
+        if (!xml_file_.empty())
+        {
+            DomainParticipantFactory::get_instance()->load_XML_profiles_file(xml_file_);
+            if (!participant_profile_.empty())
+            {
+                participant_ = DomainParticipantFactory::get_instance()->create_participant_with_profile(
+                    (uint32_t)GET_PID() % 230,
+                    participant_profile_,
+                    &participant_listener_,
+                    eprosima::fastdds::dds::StatusMask::none());
+                ASSERT_NE(participant_, nullptr);
+                ASSERT_TRUE(participant_->is_enabled());
+            }
+        }
+        if (participant_ == nullptr)
+        {
+            participant_ = DomainParticipantFactory::get_instance()->create_participant(
+                (uint32_t)GET_PID() % 230,
+                participant_qos_,
+                &participant_listener_,
+                eprosima::fastdds::dds::StatusMask::none());
+        }
 
         if (participant_ != nullptr)
         {
@@ -299,37 +316,41 @@ public:
             // Register type
             ASSERT_EQ(participant_->register_type(type_), ReturnCode_t::RETCODE_OK);
 
-            // Create subscriber
+            // Create publisher
             publisher_ = participant_->create_publisher(publisher_qos_);
+            ASSERT_NE(publisher_, nullptr);
+            ASSERT_TRUE(publisher_->is_enabled());
 
             // Create topic
             topic_ = participant_->create_topic(topic_name_, type_->getName(),
                             eprosima::fastdds::dds::TOPIC_QOS_DEFAULT);
+            ASSERT_NE(topic_, nullptr);
+            ASSERT_TRUE(topic_->is_enabled());
 
-            if (publisher_ != nullptr && topic_ != nullptr)
+            if (!xml_file_.empty())
             {
-                datawriter_ = publisher_->create_datawriter(topic_, datawriter_qos_, &listener_, status_mask_);
-                if (datawriter_ != nullptr)
+                if (!datawriter_profile_.empty())
                 {
-                    std::cout << "Created datawriter " << datawriter_->guid() << " for topic " <<
-                        topic_name_ << std::endl;
-                    initialized_ = datawriter_->is_enabled();
-                    return;
+                    datawriter_ = publisher_->create_datawriter_with_profile(topic_, datawriter_profile_, &listener_,
+                                    status_mask_);
+                    ASSERT_NE(datawriter_, nullptr);
+                    ASSERT_TRUE(datawriter_->is_enabled());
                 }
             }
-            if (publisher_ != nullptr)
+            if (datawriter_ == nullptr)
             {
-                participant_->delete_publisher(publisher_);
-                publisher_ = nullptr;
+                datawriter_ = publisher_->create_datawriter(topic_, datawriter_qos_, &listener_, status_mask_);
             }
-            if (topic_ != nullptr)
+
+            if (datawriter_ != nullptr)
             {
-                participant_->delete_topic(topic_);
-                topic_ = nullptr;
+                std::cout << "Created datawriter " << datawriter_->guid() << " for topic " <<
+                    topic_name_ << std::endl;
+
+                initialized_ = datawriter_->is_enabled();
             }
-            DomainParticipantFactory::get_instance()->delete_participant(participant_);
-            participant_ = nullptr;
         }
+        return;
     }
 
     bool isInitialized() const
@@ -1112,6 +1133,24 @@ public:
         return status;
     }
 
+    void set_xml_filename(
+            const std::string& name)
+    {
+        xml_file_ = name;
+    }
+
+    void set_participant_profile(
+            const std::string& profile)
+    {
+        participant_profile_ = profile;
+    }
+
+    void set_datawriter_profile(
+            const std::string& profile)
+    {
+        datawriter_profile_ = profile;
+    }
+
 private:
 
     void participant_matched()
@@ -1384,6 +1423,10 @@ private:
     std::map<std::string,  int> mapTopicCountList_;
     std::map<std::string,  int> mapPartitionCountList_;
     bool discovery_result_;
+
+    std::string xml_file_ = "";
+    std::string participant_profile_ = "";
+    std::string datawriter_profile_ = "";
 
     std::function<bool(const eprosima::fastrtps::rtps::ParticipantDiscoveryInfo& info)> onDiscovery_;
 

--- a/test/blackbox/common/DDSBlackboxTestsPersistenceGuid.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPersistenceGuid.cpp
@@ -1,0 +1,200 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "BlackboxTests.hpp"
+
+#if HAVE_SQLITE3
+
+#include "PubSubReader.hpp"
+#include "PubSubWriter.hpp"
+
+#include <cstring>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+using namespace eprosima::fastrtps::rtps;
+using namespace eprosima::fastdds::dds;
+
+class PersistenceGuid : public ::testing::TestWithParam<bool>
+{
+protected:
+
+    virtual void SetUp()
+    {
+    }
+
+    virtual void TearDown()
+    {
+        std::remove("persistence.db");
+    }
+
+};
+
+/*!
+ * @fn TEST(PersistenceGuid, SetPersistenceGuidThroughDDSLayer)
+ * @brief This test checks if the persistence guid is set correctly on the DataWriter and DataReader when it is specified using
+ * the property "dds.persistence.guid" through DDS-layer API.
+ *
+ * This test creates a DataReader and DataWriter configuring for each of them the persistence plugin to use SQLITE3,
+ * the database filename, a specific persistence guid, and the durability and reliability QoS.
+ * Once both are discovered, it generates a new data message to send, since every time a new message is sent the middleware inserts
+ * a new entry on the persistence database.
+ * In order to check if the persistence guid specified is applied correctly, the test uses the python file 'check_guid.py'
+ * that returns the number of apparitions of a guid, on a specific database and table.
+ */
+TEST_P(PersistenceGuid, SetPersistenceGuidThroughDDSLayer)
+{
+    // Configure Writer Properties
+    PropertyPolicy writer_policy;
+    writer_policy.properties().emplace_back("dds.persistence.plugin", "builtin.SQLITE3");
+    writer_policy.properties().emplace_back("dds.persistence.sqlite3.filename", "persistence.db");
+    writer_policy.properties().emplace_back("dds.persistence.guid", "77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64");
+
+    // Create DataWriter and configure the durability and reliability QoS
+    PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+    writer.entity_property_policy(writer_policy);
+    writer.durability_kind(TRANSIENT_DURABILITY_QOS);
+    writer.reliability(RELIABLE_RELIABILITY_QOS);
+
+    writer.init();
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Configure Reader Properties
+    PropertyPolicy reader_policy;
+    reader_policy.properties().emplace_back("dds.persistence.plugin", "builtin.SQLITE3");
+    reader_policy.properties().emplace_back("dds.persistence.sqlite3.filename", "persistence.db");
+    reader_policy.properties().emplace_back("dds.persistence.guid", "77.65.61.64.65.72.5f.70.65.72.73.5f|68.76.70.65");
+
+    // Create DataReader and configure the durability and reliability QoS
+    PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
+    reader.entity_property_policy(reader_policy);
+    reader.durability_kind(TRANSIENT_DURABILITY_QOS);
+    reader.reliability(RELIABLE_RELIABILITY_QOS);
+
+    reader.init();
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Wait until both of them are discovered
+    reader.wait_discovery();
+    writer.wait_discovery();
+
+    // Generate a new data message to send
+    auto data = default_helloworld_data_generator(1);
+    auto aux = data;
+    writer.send(data);
+    reader.startReception(aux);
+    reader.block_for_all();
+#ifdef WIN32
+    // Check if there is one entry in the writers database table with the stated persistence guid
+    int result1 = system(
+        "python check_guid.py \"persistence.db\" \"writers\" \"77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64\"");
+    ASSERT_EQ(result1, 1);
+
+    // Check if there is one entry in the readers database table with the stated persistence guid
+    int result2 = system(
+        "python check_guid.py \"persistence.db\" \"readers\" \"77.65.61.64.65.72.5f.70.65.72.73.5f|68.76.70.65\"");
+    ASSERT_EQ(result2, 1);
+#else
+    // Check if there is one entry in the writers database table with the stated persistence guid
+    int result1 = system(
+        "python3 check_guid.py 'persistence.db' 'writers' '77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64'");
+    ASSERT_EQ((result1 >> 8), 1);
+
+    // Check if there is one entry in the readers database table with the stated persistence guid
+    int result2 = system(
+        "python3 check_guid.py 'persistence.db' 'readers' '77.65.61.64.65.72.5f.70.65.72.73.5f|68.76.70.65'");
+    ASSERT_EQ((result2 >> 8), 1);
+#endif // WIN32
+
+}
+
+
+/*!
+ * @fn TEST(PersistenceGuid, SetPersistenceGuidByXML)
+ * @brief This test checks if the persistence guid is set correctly on the DataWriter and DataReader when it is specified using
+ * the property "dds.persistence.guid" through an XML file.
+ *
+ * This test creates a DataReader and DataWriter using the XML file persitence.xml, which configures for each of them the persistence
+ * plugin to use SQLITE3, the database filename, a specific persistence guid, and several QoS.
+ * Once both are discovered, it generates a new data message to send, since every time a new message is sent the middleware inserts
+ * a new entry on the persistence database.
+ * In order to check if the persistence guid specified is applied correctly, the test uses the python file 'check_guid.py'
+ * that returns the number of apparitions of a guid, on a specific database and table.
+ */
+TEST_P(PersistenceGuid, SetPersistenceGuidByXML)
+{
+    // Create DataWriter using XML Profile
+    PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+    writer.set_xml_filename("persistence.xml");
+    writer.set_participant_profile("persistence_participant");
+    writer.set_datawriter_profile("persistence_data_writer");
+
+    writer.init();
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Create DataReader using XML Profile
+    PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
+    reader.set_xml_filename("persistence.xml");
+    reader.set_participant_profile("persistence_participant");
+    reader.set_datareader_profile("persistence_data_reader");
+
+    reader.init();
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Wait until both of them are discovered
+    reader.wait_discovery();
+    writer.wait_discovery();
+
+    // Generate a new data message to send
+    auto data = default_helloworld_data_generator(1);
+    auto aux = data;
+    writer.send(data);
+    reader.startReception(aux);
+    reader.block_for_all();
+#ifdef WIN32
+    // Check if there is one entry in the writers database table with the stated persistence guid
+    int result1 = system(
+        "python check_guid.py \"persistence.db\" \"writers\" \"77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64\"");
+    ASSERT_EQ(result1, 1);
+
+    // Check if there is one entry in the readers database table with the stated persistence guid
+    int result2 = system(
+        "python check_guid.py \"persistence.db\" \"readers\" \"77.65.61.64.65.72.5f.70.65.72.73.5f|68.76.70.65\"");
+    ASSERT_EQ(result2, 1);
+#else
+    // Check if there is one entry in the writers database table with the stated persistence guid
+    int result1 = system(
+        "python3 check_guid.py 'persistence.db' 'writers' '77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64'");
+    ASSERT_EQ((result1 >> 8), 1);
+
+    // Check if there is one entry in the readers database table with the stated persistence guid
+    int result2 = system(
+        "python3 check_guid.py 'persistence.db' 'readers' '77.65.61.64.65.72.5f.70.65.72.73.5f|68.76.70.65'");
+    ASSERT_EQ((result2 >> 8), 1);
+#endif // WIN32
+}
+
+INSTANTIATE_TEST_CASE_P(PersistenceGuid,
+        PersistenceGuid,
+        testing::Values(false, true),
+        [](const testing::TestParamInfo<PersistenceGuid::ParamType>& info)
+        {
+            if (info.param)
+            {
+                return "Intraprocess";
+            }
+            return "NonIntraprocess";
+        });
+#endif // if HAVE_SQLITE3

--- a/test/blackbox/common/RTPSBlackboxTestsPersistenceGuid.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsPersistenceGuid.cpp
@@ -1,0 +1,228 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "BlackboxTests.hpp"
+
+#if HAVE_SQLITE3
+
+#include <cstring>
+#include <thread>
+
+#include "RTPSWithRegistrationWriter.hpp"
+#include "RTPSWithRegistrationReader.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace eprosima::fastrtps;
+using namespace eprosima::fastrtps::rtps;
+
+class PersistenceGuid : public ::testing::TestWithParam<bool>
+{
+protected:
+
+    virtual void SetUp()
+    {
+    }
+
+    virtual void TearDown()
+    {
+        std::remove("persistence.db");
+    }
+
+};
+
+/*!
+ * @fn TEST_P(PersistenceGuid, SetPersistenceGuidThroughRTPSLayer)
+ * @brief This test checks if the persistence guid is set correctly on the RTPSWriter and RTPSReader when it is specified using the
+ * property "dds.persistence.guid" through RTPS-layer API.
+ *
+ * This test creates a RTPSReader and RTPSWriter configuring for each of them the persistence plugin to use SQLITE3,
+ * the database filename and a specific persistence guid.
+ * Once both are discovered, it generates a new data message to send, since every time a new message is sent the middleware inserts
+ * a new entry on the persistence database.
+ * In order to check if the persistence guid specified is applied correctly, the test uses the python file 'check_guid.py'
+ * that returns the number of apparitions of a guid, on a specific database and table.
+ */
+TEST_P(PersistenceGuid, SetPersistenceGuidThroughRTPSLayer)
+{
+    // Create RTPSWriter and configure the durability and property list
+    RTPSWithRegistrationWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+    writer.durability(TRANSIENT);
+    writer.reliability(RELIABLE);
+    writer.add_property("dds.persistence.plugin", "builtin.SQLITE3");
+    writer.add_property("dds.persistence.sqlite3.filename", "persistence.db");
+    writer.add_property("dds.persistence.guid", "77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64");
+
+    writer.init();
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Create RTPSReader and configure the durability and property list
+    RTPSWithRegistrationReader<HelloWorldType> reader(TEST_TOPIC_NAME);
+    reader.durability(TRANSIENT);
+    reader.reliability(RELIABLE);
+    reader.add_property("dds.persistence.plugin", "builtin.SQLITE3");
+    reader.add_property("dds.persistence.sqlite3.filename", "persistence.db");
+    reader.add_property("dds.persistence.guid", "77.65.61.64.65.72.5f.70.65.72.73.5f|68.76.70.65");
+
+    reader.init();
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Wait until both of them are discovered
+    reader.wait_discovery();
+    writer.wait_discovery();
+
+    // Generate a new data message to send
+    auto data = default_helloworld_data_generator(1);
+    auto aux = data;
+    writer.send(data);
+    reader.expected_data(aux);
+    reader.startReception(1);
+    reader.block_for_all();
+
+#ifdef WIN32
+    // Check if there is one entry in the writers database table with the stated persistence guid
+    int result1 = system(
+        "python check_guid.py \"persistence.db\" \"writers\" \"77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64\"");
+    ASSERT_EQ(result1, 1);
+
+    // Check if there is one entry in the readers database table with the stated persistence guid
+    int result2 = system(
+        "python check_guid.py \"persistence.db\" \"readers\" \"77.65.61.64.65.72.5f.70.65.72.73.5f|68.76.70.65\"");
+    ASSERT_EQ(result2, 1);
+#else
+    // Check if there is one entry in the writers database table with the stated persistence guid
+    int result1 = system(
+        "python3 check_guid.py 'persistence.db' 'writers' '77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64'");
+    ASSERT_EQ((result1 >> 8), 1);
+
+    // Check if there is one entry in the readers database table with the stated persistence guid
+    int result2 = system(
+        "python3 check_guid.py 'persistence.db' 'readers' '77.65.61.64.65.72.5f.70.65.72.73.5f|68.76.70.65'");
+    ASSERT_EQ((result2 >> 8), 1);
+#endif // WIN32
+
+}
+
+/*!
+ * @fn TEST(PersistenceGuid, CheckPrevalenceBetweenManualAndPropertyConfiguration)
+ * @brief This test checks which persistence guid prevails, the one set manually or the one set using the "dds.persistence.guid"
+ * property.
+ *
+ * This test creates a RTPSReader and RTPSWriter configuring for each of them the persistence plugin to use SQLITE3,
+ * the database filename. In this case, the persistence guid is set both manually and using the property.
+ * Once both are discovered, it generates a new data message to send, since every time a new message is sent the middleware
+ * inserts a new entry on the persistence database.
+ * In order to check that the persistence guid that prevails among the two configured is the manual one, the test uses the python
+ * file 'check_guid.py' that returns the number of apparitions of a guid, on a specific database and table.
+ * It checks both the one set manually and the one set using the property, verifying that the manual one appears at least
+ * once for readers and writers, and the property one doesn't appear.
+ */
+TEST_P(PersistenceGuid, CheckPrevalenceBetweenManualAndPropertyConfiguration)
+{
+    // Create the persistence guid to set manually
+    eprosima::fastrtps::rtps::GuidPrefix_t guidPrefix;
+    guidPrefix.value[11] = 1;
+    eprosima::fastrtps::rtps::EntityId_t entityId;
+    entityId.value[3] = 1;
+
+    // Create RTPSWriter that use the already created attributes
+    RTPSWithRegistrationWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+    writer.durability(TRANSIENT);
+    writer.reliability(RELIABLE);
+    writer.add_property("dds.persistence.plugin", "builtin.SQLITE3");
+    writer.add_property("dds.persistence.sqlite3.filename", "persistence.db");
+    writer.add_property("dds.persistence.guid", "77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64");
+    writer.persistence_guid_att(guidPrefix, entityId);
+
+    writer.init();
+    ASSERT_TRUE(writer.isInitialized());
+
+    guidPrefix.value[11] = 2;
+
+    // Create RTPSReader that use the already created attributes
+    RTPSWithRegistrationReader<HelloWorldType> reader(TEST_TOPIC_NAME);
+    reader.durability(TRANSIENT);
+    reader.reliability(RELIABLE);
+    reader.add_property("dds.persistence.plugin", "builtin.SQLITE3");
+    reader.add_property("dds.persistence.sqlite3.filename", "persistence.db");
+    reader.add_property("dds.persistence.guid", "77.65.61.64.65.72.5f.70.65.72.73.5f|68.76.70.65");
+    reader.persistence_guid_att(guidPrefix, entityId);
+
+    reader.init();
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Wait until both of them are discovered
+    reader.wait_discovery();
+    writer.wait_discovery();
+
+    // Generate a new data message to send
+    auto data = default_helloworld_data_generator(1);
+    auto aux = data;
+    writer.send(data);
+    reader.expected_data(aux);
+    reader.startReception(1);
+    reader.block_for_all();
+
+#ifdef WIN32
+    // Check if that there is no entry in the writers database table with the stated persistence guid
+    int result1 = system(
+        "python check_guid.py \"persistence.db\" \"writers\" \"77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64\"");
+    ASSERT_EQ(result1, 0);
+
+    // Check if there is one entry in the writers database table with the stated persistence guid
+    result1 = system("python check_guid.py \"persistence.db\" \"writers\" \"0.0.0.0.0.0.0.0.0.0.0.1|0.0.0.1\"");
+    ASSERT_EQ(result1, 1);
+
+    // Check if that there is no entry in the readers database table with the stated persistence guid
+    int result2 = system(
+        "python check_guid.py \"persistence.db\" \"readers\" \"77.65.61.64.65.72.5f.70.65.72.73.5f|68.76.70.65\"");
+    ASSERT_EQ(result2, 0);
+
+    // Check if there is one entry in the readers database table with the stated persistence guid
+    result2 = system("python check_guid.py \"persistence.db\" \"readers\" \"0.0.0.0.0.0.0.0.0.0.0.2|0.0.0.1\"");
+    ASSERT_EQ(result2, 1);
+#else
+
+    // Check if that there is no entry in the writers database table with the stated persistence guid
+    int result1 = system(
+        "python3 check_guid.py 'persistence.db' 'writers' '77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64'");
+    ASSERT_EQ((result1 >> 8), 0);
+
+    // Check if there is one entry in the writers database table with the stated persistence guid
+    result1 = system("python3 check_guid.py 'persistence.db' 'writers' '0.0.0.0.0.0.0.0.0.0.0.1|0.0.0.1'");
+    ASSERT_EQ((result1 >> 8), 1);
+
+    // Check if that there is no entry in the readers database table with the stated persistence guid
+    int result2 = system(
+        "python3 check_guid.py 'persistence.db' 'readers' '77.65.61.64.65.72.5f.70.65.72.73.5f|68.76.70.65'");
+    ASSERT_EQ((result2 >> 8), 0);
+
+    // Check if there is one entry in the readers database table with the stated persistence guid
+    result2 = system("python3 check_guid.py 'persistence.db' 'readers' '0.0.0.0.0.0.0.0.0.0.0.2|0.0.0.1'");
+    ASSERT_EQ((result2 >> 8), 1);
+#endif // WIN32
+}
+
+INSTANTIATE_TEST_CASE_P(PersistenceGuid,
+        PersistenceGuid,
+        testing::Values(false, true),
+        [](const testing::TestParamInfo<PersistenceGuid::ParamType>& info)
+        {
+            if (info.param)
+            {
+                return "Intraprocess";
+            }
+            return "NonIntraprocess";
+        });
+#endif // if HAVE_SQLITE3

--- a/test/blackbox/common/RTPSWithRegistrationReader.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationReader.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2016, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -354,6 +354,15 @@ public:
     {
         reader_attr_.endpoint.properties.properties().emplace_back(prop, value);
 
+        return *this;
+    }
+
+    RTPSWithRegistrationReader& persistence_guid_att(
+            const eprosima::fastrtps::rtps::GuidPrefix_t& guidPrefix,
+            const eprosima::fastrtps::rtps::EntityId_t& entityId)
+    {
+        reader_attr_.endpoint.persistence_guid.guidPrefix = guidPrefix;
+        reader_attr_.endpoint.persistence_guid.entityId = entityId;
         return *this;
     }
 

--- a/test/blackbox/common/RTPSWithRegistrationWriter.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationWriter.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2016, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@
 
 #include <string>
 #include <list>
+#include <asio.hpp>
 #include <condition_variable>
 #include <gtest/gtest.h>
 
@@ -297,6 +298,15 @@ public:
             const std::string& value)
     {
         writer_attr_.endpoint.properties.properties().emplace_back(prop, value);
+        return *this;
+    }
+
+    RTPSWithRegistrationWriter& persistence_guid_att(
+            const eprosima::fastrtps::rtps::GuidPrefix_t& guidPrefix,
+            const eprosima::fastrtps::rtps::EntityId_t& entityId)
+    {
+        writer_attr_.endpoint.persistence_guid.guidPrefix = guidPrefix;
+        writer_attr_.endpoint.persistence_guid.entityId = entityId;
         return *this;
     }
 

--- a/test/blackbox/persistence.xml
+++ b/test/blackbox/persistence.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"  ?>
+<dds xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles">
+    <profiles>          
+        <participant profile_name="persistence_participant">
+            <rtps>
+                <propertiesPolicy>
+                    <properties>
+                        <property>
+                            <name>dds.persistence.plugin</name>
+                            <value>builtin.SQLITE3</value>
+                        </property>
+                        <property>
+                            <name>dds.persistence.sqlite3.filename</name>
+                            <value>persistence.db</value>
+                        </property>
+                    </properties>
+                </propertiesPolicy>
+            </rtps>
+        </participant>
+
+        <data_writer profile_name="persistence_data_writer">
+            <qos>
+                <durability>
+                    <kind>TRANSIENT</kind>
+                </durability>
+                <reliability>
+                    <kind>RELIABLE</kind>
+                    <max_blocking_time>
+                        <sec>1</sec>
+                        <nanosec>0</nanosec>
+                    </max_blocking_time>
+                </reliability>
+            </qos>
+            <times>
+                <heartbeatPeriod>
+                    <sec>0</sec>
+                    <nanosec>100000000</nanosec>
+                </heartbeatPeriod>
+                <nackResponseDelay>
+                    <sec>0</sec>
+                    <nanosec>100000000</nanosec>
+                </nackResponseDelay>
+            </times>
+            <historyMemoryPolicy>PREALLOCATED</historyMemoryPolicy>
+            <propertiesPolicy>
+                <properties>
+                    <property>
+                        <name>dds.persistence.guid</name>
+                        <value>77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64</value>
+                    </property>
+                </properties>
+            </propertiesPolicy>
+        </data_writer>
+
+        <data_reader profile_name="persistence_data_reader">
+            <qos>
+                <durability>
+                    <kind>TRANSIENT</kind>
+                </durability>
+                <reliability>
+                    <kind>RELIABLE</kind>
+                </reliability>
+            </qos>
+            <historyMemoryPolicy>PREALLOCATED</historyMemoryPolicy>
+            <times>
+                <heartbeatResponseDelay>
+                    <sec>0</sec>
+                    <nanosec>100000000</nanosec>
+                </heartbeatResponseDelay>
+            </times>
+            <propertiesPolicy>
+                <properties>
+                    <property>
+                        <name>dds.persistence.guid</name>
+                        <value>77.65.61.64.65.72.5f.70.65.72.73.5f|68.76.70.65</value>
+                    </property>
+                </properties>
+            </propertiesPolicy>
+        </data_reader>
+    </profiles>
+</dds>

--- a/test/blackbox/utils/check_guid.py
+++ b/test/blackbox/utils/check_guid.py
@@ -1,0 +1,46 @@
+# Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sqlite3
+import sys
+
+""" 
+Return the number of apparitions of a guid, on a specific table and database.
+
+It takes three arguments: 
+    * database_name: The filename of the database
+    * table_name: The name of the table within the database
+    * check_guid: The guid of the entity that you want to look for in the 
+      stated table and database.
+
+"""
+
+if __name__ == '__main__':
+    if len(sys.argv) != 4:
+        sys.exit(255)
+    database_name = str(sys.argv[1])
+    table_name = str(sys.argv[2])
+    check_guid = str(sys.argv[3])
+
+    command = f"SELECT guid FROM {table_name} WHERE guid='{check_guid}'"
+    try:
+        connection = sqlite3.connect(database_name)
+        c = connection.cursor()
+        c.execute(command)
+        num = len(c.fetchall())
+        connection.close()
+    except sqlite3.DatabaseError as e:
+        sys.exit(255)
+
+    sys.exit(num)


### PR DESCRIPTION
This is a Work In Progress PR, do not merge until tests are added.

Adds a property `dds.persistence.guid` which value is a string representing a `GUID_t`, where the octets are dot-separated, and a `|` is used to mark the separation between guid prefix and entity id.