### PR TITLE
Fix sending GAPs to late joiners [8880]

### DIFF
--- a/include/fastdds/rtps/writer/ReaderProxy.h
+++ b/include/fastdds/rtps/writer/ReaderProxy.h
@@ -479,5 +479,5 @@ private:
 } /* namespace fastrtps */
 } /* namespace eprosima */
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif /* _FASTDDS_RTPS_WRITER_READERPROXY_H_ */

--- a/include/fastdds/rtps/writer/ReaderProxy.h
+++ b/include/fastdds/rtps/writer/ReaderProxy.h
@@ -379,16 +379,12 @@ public:
 
     /**
      * Adds gaps to message group if there are holes / irrelevant changes on this proxy.
-     *
-     * @pre min_seq should be strictly less than next_seq (i.e. history should not be empty)
-     *
+
      * @param group Message group where gaps will be added.
-     * @param min_seq Sequence number of first sample in history.
      * @param next_seq Sequence number of next sample to be added to history.
      */
     void send_gaps(
             RTPSMessageGroup& group,
-            SequenceNumber_t min_seq,
             SequenceNumber_t next_seq);
 
     LocatorSelectorEntry* locator_selector_entry()

--- a/include/fastdds/rtps/writer/ReaderProxy.h
+++ b/include/fastdds/rtps/writer/ReaderProxy.h
@@ -377,6 +377,20 @@ public:
      */
     bool are_there_gaps();
 
+    /**
+     * Adds gaps to message group if there are holes / irrelevant changes on this proxy.
+     *
+     * @pre min_seq should be strictly less than next_seq (i.e. history should not be empty)
+     *
+     * @param group Message group where gaps will be added.
+     * @param min_seq Sequence number of first sample in history.
+     * @param next_seq Sequence number of next sample to be added to history.
+     */
+    void send_gaps(
+            RTPSMessageGroup& group,
+            SequenceNumber_t min_seq,
+            SequenceNumber_t next_seq);
+
     LocatorSelectorEntry* locator_selector_entry()
     {
         return locator_info_.locator_selector_entry();

--- a/include/fastdds/rtps/writer/StatefulWriter.h
+++ b/include/fastdds/rtps/writer/StatefulWriter.h
@@ -348,6 +348,10 @@ private:
     bool send_hole_gaps_to_group(
             RTPSMessageGroup& group);
 
+    void select_all_readers_with_lowmark_below(
+            SequenceNumber_t seq,
+            RTPSMessageGroup& group);
+
     //! True to disable piggyback heartbeats
     bool disable_heartbeat_piggyback_;
     //! True to disable positive ACKs

--- a/include/fastdds/rtps/writer/StatefulWriter.h
+++ b/include/fastdds/rtps/writer/StatefulWriter.h
@@ -83,6 +83,8 @@ private:
 
     //!To avoid notifying twice of the same sequence number
     SequenceNumber_t next_all_acked_notify_sequence_;
+    SequenceNumber_t min_readers_low_mark_;
+
     // TODO Join this mutex when main mutex would not be recursive.
     std::mutex all_acked_mutex_;
     std::condition_variable all_acked_cond_;

--- a/include/fastdds/rtps/writer/StatefulWriter.h
+++ b/include/fastdds/rtps/writer/StatefulWriter.h
@@ -374,5 +374,5 @@ private:
 } /* namespace fastrtps */
 } /* namespace eprosima */
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif /* _FASTDDS_RTPS_STATEFULWRITER_H_ */

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -61,18 +61,18 @@ ReaderProxy::ReaderProxy(
 {
     nack_supression_event_ = new TimedEvent(writer_->getRTPSParticipant()->getEventResource(),
                     [&]() -> bool
-                {
-                    writer_->perform_nack_supression(guid());
-                    return false;
-                },
+                    {
+                        writer_->perform_nack_supression(guid());
+                        return false;
+                    },
                     TimeConv::Time_t2MilliSecondsDouble(times.nackSupressionDuration));
 
     initial_heartbeat_event_ = new TimedEvent(writer_->getRTPSParticipant()->getEventResource(),
                     [&]() -> bool
-                {
-                    writer_->intraprocess_heartbeat(this);
-                    return false;
-                }, 0);
+                    {
+                        writer_->intraprocess_heartbeat(this);
+                        return false;
+                    }, 0);
 
     stop();
 }
@@ -361,15 +361,15 @@ bool ReaderProxy::requested_changes_set(
     bool isSomeoneWasSetRequested = false;
 
     seq_num_set.for_each([&](SequenceNumber_t sit)
+            {
+                ChangeIterator chit = find_change(sit, true);
+                if (chit != changes_for_reader_.end() && UNACKNOWLEDGED == chit->getStatus())
                 {
-                    ChangeIterator chit = find_change(sit, true);
-                    if (chit != changes_for_reader_.end() && UNACKNOWLEDGED == chit->getStatus())
-                    {
-                        chit->setStatus(REQUESTED);
-                        chit->markAllFragmentsAsUnsent();
-                        isSomeoneWasSetRequested = true;
-                    }
-                });
+                    chit->setStatus(REQUESTED);
+                    chit->markAllFragmentsAsUnsent();
+                    isSomeoneWasSetRequested = true;
+                }
+            });
 
     if (isSomeoneWasSetRequested)
     {

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -637,12 +637,13 @@ void ReaderProxy::send_gaps(
         try
         {
             if (are_there_gaps() ||
-                (0 < changes_for_reader_.size() && next_seq != changes_for_reader_.rbegin()->getSequenceNumber()))
+                    (0 < changes_for_reader_.size() && next_seq != changes_for_reader_.rbegin()->getSequenceNumber()))
             {
                 RTPSGapBuilder gap_builder(group);
                 SequenceNumber_t current_seq = changes_low_mark_ + 1;
 
-                for (ReaderProxy::ChangeConstIterator cit = changes_for_reader_.begin(); cit != changes_for_reader_.end(); ++cit)
+                for (ReaderProxy::ChangeConstIterator cit = changes_for_reader_.begin();
+                        cit != changes_for_reader_.end(); ++cit)
                 {
                     SequenceNumber_t seq_num = cit->getSequenceNumber();
                     while (current_seq != seq_num)

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -630,18 +630,12 @@ bool ReaderProxy::are_there_gaps()
 
 void ReaderProxy::send_gaps(
         RTPSMessageGroup& group,
-        SequenceNumber_t min_seq,
         SequenceNumber_t next_seq)
 {
     if (is_remote_and_reliable())
     {
         try
         {
-            if (durability_kind_ == VOLATILE && min_seq <= changes_low_mark_)
-            {
-                group.add_gap(min_seq, SequenceNumberSet_t(changes_low_mark_ + 1));
-            }
-
             if (are_there_gaps() ||
                 (0 < changes_for_reader_.size() && next_seq != changes_for_reader_.rbegin()->getSequenceNumber()))
             {

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -843,6 +843,7 @@ void StatefulWriter::send_all_unsent_changes(
 
             if (locator_selector_.state_has_changed())
             {
+                gap_builder.flush();
                 group.flush_and_reset();
                 network.select_locators(locator_selector_);
                 compute_selected_guids();

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -42,7 +42,7 @@
 
 #include <rtps/writer/RTPSWriterCollector.h>
 #include "rtps/RTPSDomainImpl.hpp"
-#include "../messages/RTPSGapBuilder.hpp"
+#include "rtps/messages/RTPSGapBuilder.hpp"
 
 #include <mutex>
 #include <vector>
@@ -1100,7 +1100,7 @@ bool StatefulWriter::send_hole_gaps_to_group(
     SequenceNumber_t last_sequence = mp_history->next_sequence_number();
     SequenceNumber_t min_history_seq = get_seq_num_min();
     uint32_t history_size = static_cast<uint32_t>(mp_history->getHistorySize());
-    if ((next_all_acked_notify_sequence_ < max_removed) &&    // some holes pending acknowledgement
+    if ( (min_readers_low_mark_ < max_removed) &&    // some holes pending acknowledgement
             (min_history_seq + history_size != last_sequence)) // There is a hole in the history
     {
         try
@@ -1602,6 +1602,7 @@ void StatefulWriter::check_acked_status()
             may_remove_change_ = 1;
             may_remove_change_cond_.notify_one();
         }
+        min_readers_low_mark_ = min_low_mark;
     }
 
     if (all_acked)

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1800,16 +1800,7 @@ void StatefulWriter::send_heartbeat_to_nts(
         SequenceNumber_t first_seq = get_seq_num_min();
         if (first_seq != c_SequenceNumber_Unknown)
         {
-            if (remoteReaderProxy.durability_kind() < TRANSIENT_LOCAL ||
-                    getAttributes().durabilityKind < TRANSIENT_LOCAL)
-            {
-                SequenceNumber_t last_irrelevance = remoteReaderProxy.changes_low_mark();
-                if (first_seq <= last_irrelevance)
-                {
-                    group.add_gap(first_seq, SequenceNumberSet_t(last_irrelevance + 1));
-                }
-            }
-
+            remoteReaderProxy.send_gaps(group, first_seq, mp_history->next_sequence_number());
         }
     }
     catch (const RTPSMessageGroup::timeout&)

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -133,24 +133,24 @@ StatefulWriter::StatefulWriter(
     const RTPSParticipantAttributes& part_att = pimpl->getRTPSParticipantAttributes();
 
     periodic_hb_event_ = new TimedEvent(pimpl->getEventResource(), [&]() -> bool
-                {
-                    return send_periodic_heartbeat();
-                },
+                    {
+                        return send_periodic_heartbeat();
+                    },
                     TimeConv::Time_t2MilliSecondsDouble(m_times.heartbeatPeriod));
 
     nack_response_event_ = new TimedEvent(pimpl->getEventResource(), [&]() -> bool
-                {
-                    perform_nack_response();
-                    return false;
-                },
+                    {
+                        perform_nack_response();
+                        return false;
+                    },
                     TimeConv::Time_t2MilliSecondsDouble(m_times.nackResponseDelay));
 
     if (disable_positive_acks_)
     {
         ack_event_ = new TimedEvent(pimpl->getEventResource(), [&]() -> bool
-                    {
-                        return ack_timer_expired();
-                    },
+                        {
+                            return ack_timer_expired();
+                        },
                         att.keep_duration.to_ns() * 1e-6); // in milliseconds
     }
 
@@ -234,7 +234,7 @@ void StatefulWriter::unsent_change_added_to_history(
 
 #if HAVE_SECURITY
     encrypt_cachechange(change);
-#endif
+#endif // if HAVE_SECURITY
 
     if (!matched_readers_.empty())
     {
@@ -1157,9 +1157,9 @@ void StatefulWriter::update_reader_info(
     {
         RTPSParticipantImpl* part = getRTPSParticipant();
         locator_selector_.for_each([part](const Locator_t& loc)
-                    {
-                        part->createSenderResources(loc);
-                    });
+                {
+                    part->createSenderResources(loc);
+                });
     }
 
     // Check if we have local or remote readers
@@ -1469,9 +1469,9 @@ bool StatefulWriter::is_acked_by_all(
     assert(mp_history->next_sequence_number() > change->sequenceNumber);
     return std::all_of(matched_readers_.begin(), matched_readers_.end(),
                    [change](const ReaderProxy* reader)
-                {
-                    return reader->change_is_acked(change->sequenceNumber);
-                });
+                   {
+                       return reader->change_is_acked(change->sequenceNumber);
+                   });
 }
 
 bool StatefulWriter::all_readers_updated()
@@ -1497,17 +1497,18 @@ bool StatefulWriter::wait_for_all_acked(
 
     all_acked_ = std::none_of(matched_readers_.begin(), matched_readers_.end(),
                     [](const ReaderProxy* reader)
-                {
-                    return reader->has_changes();
-                });
+                    {
+                        return reader->has_changes();
+                    });
     lock.unlock();
 
     if (!all_acked_)
     {
         std::chrono::microseconds max_w(TimeConv::Duration_t2MicroSecondsInt64(max_wait));
-        all_acked_cond_.wait_for(all_acked_lock, max_w, [&]() {
-                        return all_acked_;
-                    });
+        all_acked_cond_.wait_for(all_acked_lock, max_w, [&]()
+                {
+                    return all_acked_;
+                });
     }
 
     return all_acked_;
@@ -1555,9 +1556,9 @@ void StatefulWriter::check_acked_status()
                                 [](
                                     const CacheChange_t* change,
                                     const SequenceNumber_t& seq)
-                            {
-                                return change->sequenceNumber < seq;
-                            });
+                                {
+                                    return change->sequenceNumber < seq;
+                                });
                 if (cit != history_end && (*cit)->sequenceNumber == min_low_mark)
                 {
                     ++cit;
@@ -1639,9 +1640,10 @@ bool StatefulWriter::try_remove_change(
     {
         may_remove_change_ = 0;
         may_remove_change_cond_.wait_until(lock, max_blocking_time_point,
-                [&]() {
-                        return may_remove_change_ > 0;
-                    });
+                [&]()
+                {
+                    return may_remove_change_ > 0;
+                });
         may_remove_change = may_remove_change_;
     }
 
@@ -1743,9 +1745,9 @@ bool StatefulWriter::send_periodic_heartbeat(
 
             unacked_changes = std::any_of(matched_readers_.begin(), matched_readers_.end(),
                             [](const ReaderProxy* reader)
-                        {
-                            return reader->has_unacknowledged();
-                        });
+                            {
+                                return reader->has_unacknowledged();
+                            });
 
             if (unacked_changes)
             {

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -929,7 +929,14 @@ void StatefulWriter::send_unsent_changes_with_flow_control(
 
     RTPSMessageGroup group(mp_RTPSParticipant, this, *this);
 
-    heartbeat_has_been_sent = send_hole_gaps_to_group(group);
+    // GAP for holes in history sent to the readers that need it
+    send_hole_gaps_to_group(group);
+
+    // Reset the state of locator_selector to select all readers
+    group.flush_and_reset();
+    locator_selector_.reset(true);
+    network.select_locators(locator_selector_);
+    compute_selected_guids();
 
     for (ReaderProxy* remoteReader : matched_readers_)
     {

--- a/test/blackbox/RTPSBlackboxTestsBasic.cpp
+++ b/test/blackbox/RTPSBlackboxTestsBasic.cpp
@@ -51,6 +51,7 @@ public:
             xmlparser::XMLProfileManager::library_settings(library_settings);
         }
     }
+
 };
 
 TEST_P(RTPS, RTPSAsNonReliableSocket)
@@ -447,7 +448,8 @@ TEST_P(RTPS, RTPSAsReliableWithRegistrationAndHolesInHistory)
 INSTANTIATE_TEST_CASE_P(RTPS,
         RTPS,
         testing::Values(false, true),
-        [](const testing::TestParamInfo<RTPS::ParamType>& info) {
+        [](const testing::TestParamInfo<RTPS::ParamType>& info)
+        {
             if (info.param)
             {
                 return "Intraprocess";

--- a/test/blackbox/RTPSBlackboxTestsBasic.cpp
+++ b/test/blackbox/RTPSBlackboxTestsBasic.cpp
@@ -386,8 +386,8 @@ TEST_P(RTPS, RTPSAsReliableWithRegistrationAndHolesInHistory)
     ASSERT_TRUE(reader.isInitialized());
 
     writer.durability(eprosima::fastrtps::rtps::DurabilityKind_t::TRANSIENT_LOCAL).
-            disable_builtin_transport().
-            add_user_transport_to_pparams(testTransport).init();
+    disable_builtin_transport().
+    add_user_transport_to_pparams(testTransport).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -415,7 +415,7 @@ TEST_P(RTPS, RTPSAsReliableWithRegistrationAndHolesInHistory)
     {
         if ((it->index() % 2) == 0)
         {
-            eprosima::fastrtps::rtps::SequenceNumber_t seq {0,it->index()};
+            eprosima::fastrtps::rtps::SequenceNumber_t seq {0, it->index()};
             writer.remove_change(seq);
             it = data.erase(it);
         }

--- a/test/blackbox/RTPSWithRegistrationWriter.hpp
+++ b/test/blackbox/RTPSWithRegistrationWriter.hpp
@@ -106,7 +106,8 @@ public:
         writer_attr_.times.nackResponseDelay.seconds = 0;
         writer_attr_.times.nackResponseDelay.nanosec = 100000000;
 
-        participant_attr_.builtin.discovery_config.discoveryProtocol = eprosima::fastrtps::rtps::DiscoveryProtocol::SIMPLE;
+        participant_attr_.builtin.discovery_config.discoveryProtocol =
+                eprosima::fastrtps::rtps::DiscoveryProtocol::SIMPLE;
         participant_attr_.builtin.use_WriterLivelinessProtocol = true;
     }
 
@@ -125,7 +126,8 @@ public:
     void init()
     {
         //Create participant
-        participant_ = eprosima::fastrtps::rtps::RTPSDomain::createParticipant((uint32_t)GET_PID() % 230, participant_attr_);
+        participant_ = eprosima::fastrtps::rtps::RTPSDomain::createParticipant(
+            (uint32_t)GET_PID() % 230, participant_attr_);
         ASSERT_NE(participant_, nullptr);
 
         //Create writerhistory
@@ -186,7 +188,8 @@ public:
         }
     }
 
-    bool remove_change (const eprosima::fastrtps::rtps::SequenceNumber_t& sequence_number)
+    bool remove_change (
+            const eprosima::fastrtps::rtps::SequenceNumber_t& sequence_number)
     {
         return history_->remove_change(sequence_number);
     }

--- a/test/blackbox/RTPSWithRegistrationWriter.hpp
+++ b/test/blackbox/RTPSWithRegistrationWriter.hpp
@@ -52,7 +52,7 @@ private:
 
     class Listener : public eprosima::fastrtps::rtps::WriterListener
     {
-public:
+    public:
 
         Listener(
                 RTPSWithRegistrationWriter& writer)
@@ -74,14 +74,15 @@ public:
             }
         }
 
-private:
+    private:
 
         Listener& operator =(
                 const Listener&) = delete;
 
         RTPSWithRegistrationWriter& writer_;
 
-    } listener_;
+    }
+    listener_;
 
 public:
 
@@ -207,9 +208,10 @@ public:
 
         if (matched_ == 0)
         {
-            cv_.wait(lock, [this]() -> bool {
-                return matched_ != 0;
-            });
+            cv_.wait(lock, [this]() -> bool
+                    {
+                        return matched_ != 0;
+                    });
         }
 
         ASSERT_NE(matched_, 0u);
@@ -314,7 +316,7 @@ public:
                .add_property("dds.persistence.sqlite3.filename", filename);
     }
 
-#endif
+#endif // HAVE_SQLITE3
 
     RTPSWithRegistrationWriter& history_depth(
             const int32_t depth)

--- a/test/blackbox/RTPSWithRegistrationWriter.hpp
+++ b/test/blackbox/RTPSWithRegistrationWriter.hpp
@@ -30,6 +30,7 @@
 #include <fastrtps/rtps/writer/RTPSWriter.h>
 #include <fastrtps/rtps/attributes/HistoryAttributes.h>
 #include <fastrtps/rtps/history/WriterHistory.h>
+#include <fastrtps/transport/TransportDescriptorInterface.h>
 
 #include <fastcdr/FastBuffer.h>
 #include <fastcdr/Cdr.h>
@@ -104,6 +105,9 @@ public:
         writer_attr_.times.heartbeatPeriod.nanosec = 100000000;
         writer_attr_.times.nackResponseDelay.seconds = 0;
         writer_attr_.times.nackResponseDelay.nanosec = 100000000;
+
+        participant_attr_.builtin.discovery_config.discoveryProtocol = eprosima::fastrtps::rtps::DiscoveryProtocol::SIMPLE;
+        participant_attr_.builtin.use_WriterLivelinessProtocol = true;
     }
 
     virtual ~RTPSWithRegistrationWriter()
@@ -121,10 +125,7 @@ public:
     void init()
     {
         //Create participant
-        eprosima::fastrtps::rtps::RTPSParticipantAttributes pattr;
-        pattr.builtin.discovery_config.discoveryProtocol = eprosima::fastrtps::rtps::DiscoveryProtocol::SIMPLE;
-        pattr.builtin.use_WriterLivelinessProtocol = true;
-        participant_ = eprosima::fastrtps::rtps::RTPSDomain::createParticipant((uint32_t)GET_PID() % 230, pattr);
+        participant_ = eprosima::fastrtps::rtps::RTPSDomain::createParticipant((uint32_t)GET_PID() % 230, participant_attr_);
         ASSERT_NE(participant_, nullptr);
 
         //Create writerhistory
@@ -185,6 +186,11 @@ public:
         }
     }
 
+    bool remove_change (const eprosima::fastrtps::rtps::SequenceNumber_t& sequence_number)
+    {
+        return history_->remove_change(sequence_number);
+    }
+
     void matched()
     {
         std::unique_lock<std::mutex> lock(mutex_);
@@ -204,6 +210,15 @@ public:
         }
 
         ASSERT_NE(matched_, 0u);
+    }
+
+    template<class _Rep,
+            class _Period
+            >
+    bool waitForAllAcked(
+            const std::chrono::duration<_Rep, _Period>& max_wait)
+    {
+        return writer_->wait_for_all_acked(eprosima::fastrtps::Time_t((int32_t)max_wait.count(), 0));
     }
 
     /*** Function to change QoS ***/
@@ -305,6 +320,19 @@ public:
         return *this;
     }
 
+    RTPSWithRegistrationWriter& disable_builtin_transport()
+    {
+        participant_attr_.useBuiltinTransports = false;
+        return *this;
+    }
+
+    RTPSWithRegistrationWriter& add_user_transport_to_pparams(
+            std::shared_ptr<eprosima::fastrtps::rtps::TransportDescriptorInterface> userTransportDescriptor)
+    {
+        participant_attr_.userTransports.push_back(userTransportDescriptor);
+        return *this;
+    }
+
 private:
 
     RTPSWithRegistrationWriter& operator =(
@@ -315,6 +343,7 @@ private:
     eprosima::fastrtps::rtps::WriterAttributes writer_attr_;
     eprosima::fastrtps::WriterQos writer_qos_;
     eprosima::fastrtps::TopicAttributes topic_attr_;
+    eprosima::fastrtps::rtps::RTPSParticipantAttributes participant_attr_;
     eprosima::fastrtps::rtps::WriterHistory* history_;
     eprosima::fastrtps::rtps::HistoryAttributes hattr_;
     bool initialized_;

--- a/test/mock/rtps/RTPSGapBuilder/rtps/messages/RTPSGapBuilder.hpp
+++ b/test/mock/rtps/RTPSGapBuilder/rtps/messages/RTPSGapBuilder.hpp
@@ -1,0 +1,95 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RTPSGapBuilder.hpp
+ *
+ */
+
+#ifndef RTPSGAPBUILDER_HPP
+#define RTPSGAPBUILDER_HPP
+#ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+
+#include <fastrtps/rtps/messages/RTPSMessageGroup.h>
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+
+/**
+ * A helper class to add GAP messages to a @ref RTPSMessageGroup.
+ * @ingroup WRITER_MODULE
+ */
+class RTPSGapBuilder
+{
+public:
+
+    /**
+     * RTPSGapBuilder constructor.
+     *
+     * @param group Reference to the @ref RTPSMessageGroup that will be used to send GAP messages.
+     */
+    explicit RTPSGapBuilder(
+            RTPSMessageGroup& /*group*/)
+    {
+    }
+
+    /**
+     * RTPSGapBuilder constructor.
+     *
+     * @param group Reference to the @ref RTPSMessageGroup that will be used to send GAP messages.
+     * @param reader_guid Specific destination reader guid
+     */
+    explicit RTPSGapBuilder(
+            RTPSMessageGroup& /*group*/,
+            const GUID_t& /*reader_guid*/)
+    {
+    }
+
+    ~RTPSGapBuilder()
+    {
+    }
+
+    /**
+     * Adds a sequence number to the GAP list.
+     *
+     * @remark Sequence numbers should be added in strict increasing order.
+     * 
+     * @param gap_sequence Sequence number to be added to the GAP list.
+     * @return false if a GAP message couldn't be added to the message group,
+     *         true if no GAP message was needed or it was successfully added.
+     *
+     * @throws RTPSMessageGroup::timeout if a network operation was necessary and
+     *         it blocked for more than the maximum time allowed.
+     */
+    MOCK_METHOD1(add, bool(const SequenceNumber_t& gap_sequence));
+
+    /**
+     * Adds a GAP message to the message group if necessary.
+     *
+     * @return false if a GAP message couldn't be added to the message group,
+     *         true if no GAP message was needed or it was successfully added.
+     *
+     * @throws RTPSMessageGroup::timeout if a network operation was necessary and
+     *         it blocked for more than the maximum time allowed.
+     */
+    MOCK_METHOD0(flush, bool());
+};
+
+} /* namespace rtps */
+} /* namespace fastrtps */
+} /* namespace eprosima */
+
+#endif
+#endif /* RTPSGAPBUILDER_HPP */

--- a/test/mock/rtps/RTPSGapBuilder/rtps/messages/RTPSGapBuilder.hpp
+++ b/test/mock/rtps/RTPSGapBuilder/rtps/messages/RTPSGapBuilder.hpp
@@ -19,7 +19,6 @@
 
 #ifndef RTPSGAPBUILDER_HPP
 #define RTPSGAPBUILDER_HPP
-#ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 #include <fastrtps/rtps/messages/RTPSMessageGroup.h>
 
@@ -65,7 +64,7 @@ public:
      * Adds a sequence number to the GAP list.
      *
      * @remark Sequence numbers should be added in strict increasing order.
-     * 
+     *
      * @param gap_sequence Sequence number to be added to the GAP list.
      * @return false if a GAP message couldn't be added to the message group,
      *         true if no GAP message was needed or it was successfully added.
@@ -91,5 +90,4 @@ public:
 } /* namespace fastrtps */
 } /* namespace eprosima */
 
-#endif
 #endif /* RTPSGAPBUILDER_HPP */

--- a/test/unittest/rtps/writer/CMakeLists.txt
+++ b/test/unittest/rtps/writer/CMakeLists.txt
@@ -48,6 +48,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/ReaderProxyData
             ${PROJECT_SOURCE_DIR}/test/mock/dds/QosPolicies
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/ReaderLocator
+            ${PROJECT_SOURCE_DIR}/test/mock/rtps/RTPSGapBuilder
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/TimedEvent
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
             ${PROJECT_SOURCE_DIR}/src/cpp


### PR DESCRIPTION
After the optimizations on #1190, when a reliable writer with holes in its history matches with a reliable reader, there were some cases where GAP messages were not being sent. 

This was particularly problematic with the builtin endpoints used for discovery, and is related with ros-planning/navigation2#1772, ros-planning/navigation2#1788, ros2/ros2#931 and ros2/rmw_fastrtps#932