### PR TITLE
Support large data in persistence [8890]

### DIFF
--- a/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
@@ -92,6 +92,11 @@ class ParameterSerializer<Parameter_t>
 {
 public:
 
+    static constexpr uint32_t PARAMETER_STATUS_SIZE = 8;
+    static constexpr uint32_t PARAMETER_KEY_SIZE = 20;
+    static constexpr uint32_t PARAMETER_SENTINEL_SIZE = 4;
+    static constexpr uint32_t PARAMETER_SAMPLE_IDENTITY_SIZE = 28;
+
     static bool add_parameter_status(
             fastrtps::rtps::CDRMessage_t* cdr_message,
             fastrtps::rtps::octet status)

--- a/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
@@ -806,7 +806,7 @@ inline bool ParameterSerializer<ParameterEndpointSecurityInfo_t>::read_content_f
     return valid;
 }
 
-#endif
+#endif // if HAVE_SECURITY
 
 } //namespace dds
 } //namespace fastdds

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -167,7 +167,7 @@ ReturnCode_t DataWriterImpl::enable()
         high_mark_for_frag_ &= ~3;
     }
 
-    for(PublisherHistory::iterator it = history_.changesBegin(); it != history_.changesEnd(); it++)
+    for (PublisherHistory::iterator it = history_.changesBegin(); it != history_.changesEnd(); it++)
     {
         WriteParams wparams;
         set_fragment_size_on_change(wparams, *it, high_mark_for_frag_);

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -37,6 +37,7 @@
 #include <fastdds/rtps/resources/ResourceEvent.h>
 #include <fastdds/rtps/resources/TimedEvent.h>
 #include <fastdds/rtps/builtin/liveliness/WLP.h>
+#include <fastdds/core/policy/ParameterSerializer.hpp>
 
 #include <functional>
 #include <iostream>
@@ -1149,7 +1150,9 @@ void DataWriterImpl::set_fragment_size_on_change(
     // If needed inlineqos for related_sample_identity, then remove the inlinqos size from final fragment size.
     if (wparams.related_sample_identity() != SampleIdentity::unknown())
     {
-        final_high_mark_for_frag -= 32;
+        final_high_mark_for_frag -= (
+            ParameterSerializer<Parameter_t>::PARAMETER_SENTINEL_SIZE +
+            ParameterSerializer<Parameter_t>::PARAMETER_SAMPLE_IDENTITY_SIZE);
     }
 
     // If it is big data, fragment it.

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -396,6 +396,11 @@ protected:
      */
     DataWriterListener* get_listener_for(
             const StatusMask& status);
+
+    void set_fragment_size_on_change(
+            fastrtps::rtps::WriteParams& wparams,
+            fastrtps::rtps::CacheChange_t* ch,
+            const uint32_t& high_mark_for_frag);
 };
 
 } /* namespace dds */

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -1151,6 +1151,20 @@ public:
         datawriter_profile_ = profile;
     }
 
+#if HAVE_SQLITE3
+    PubSubWriter& make_persistent(
+            const std::string& filename,
+            const std::string& persistence_guid)
+    {
+        participant_qos_.properties().properties().emplace_back("dds.persistence.plugin", "builtin.SQLITE3");
+        participant_qos_.properties().properties().emplace_back("dds.persistence.sqlite3.filename", filename);
+        datawriter_qos_.durability().kind = eprosima::fastrtps::TRANSIENT_DURABILITY_QOS;
+        datawriter_qos_.properties().properties().emplace_back("dds.persistence.guid", persistence_guid);
+
+        return *this;
+    }
+#endif // if HAVE_SQLITE3
+
 private:
 
     void participant_matched()

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -1163,6 +1163,7 @@ public:
 
         return *this;
     }
+
 #endif // if HAVE_SQLITE3
 
 private:

--- a/test/blackbox/common/BlackboxTests.hpp
+++ b/test/blackbox/common/BlackboxTests.hpp
@@ -133,6 +133,9 @@ std::list<String> default_large_string_data_generator(
 std::list<Data64kb> default_data64kb_data_generator(
         size_t max = 0);
 
+std::list<Data1mb> default_data16kb_data_generator(
+        size_t max = 0);
+
 std::list<Data1mb> default_data300kb_data_generator(
         size_t max = 0);
 

--- a/test/blackbox/common/BlackboxTests.hpp
+++ b/test/blackbox/common/BlackboxTests.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2018, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -83,8 +83,6 @@ protected:
         testTransport->maxMessageSize = 32768;
         testTransport->receiveBufferSize = 32768;
 
-        std::cout << db_file_name() << std::endl;
-
         writer
         .history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS)
         .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
@@ -129,20 +127,18 @@ protected:
 
         reader.startReception(unreceived_data);
 
-        std::cout << "After start reception." << std::endl;
-
         // Block reader until reception finished or timeout.
         reader.block_for_all();
     }
 
 };
 
-TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentLargeData)
+TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithFrag)
 {
     fragment_data(true);
 }
 
-TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentSmallData)
+TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentNoFrag)
 {
     fragment_data(false);
 }

--- a/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
@@ -100,6 +100,7 @@ protected:
         {
             data = default_data300kb_data_generator();
         }
+        auto unreceived_data = data;
 
         // Send data
         writer.send(data);
@@ -113,9 +114,11 @@ protected:
         ASSERT_TRUE(writer.isInitialized());
 
         reader
-        .socket_buffer_size(1048576)
-        .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
+        .history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS)
+        .history_depth(10)
         .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+        .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
+        .socket_buffer_size(1048576)
         .init();
 
         ASSERT_TRUE(reader.isInitialized());
@@ -124,11 +127,6 @@ protected:
         writer.wait_discovery();
         reader.wait_discovery();
 
-        auto unreceived_data = default_data16kb_data_generator();
-        if (large_data)
-        {
-            unreceived_data = default_data300kb_data_generator();
-        }
         reader.startReception(unreceived_data);
 
         // Block reader until reception finished or timeout.

--- a/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
@@ -135,7 +135,6 @@ protected:
         reader.block_for_all();
     }
 
-
 };
 
 TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentLargeData)

--- a/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
@@ -86,6 +86,7 @@ protected:
         std::cout << db_file_name() << std::endl;
 
         writer
+        .history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS)
         .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
         .make_persistent(db_file_name(), "77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64")
         .disable_builtin_transport()

--- a/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
@@ -129,6 +129,8 @@ protected:
 
         reader.startReception(unreceived_data);
 
+        std::cout << "After start reception." << std::endl;
+
         // Block reader until reception finished or timeout.
         reader.block_for_all();
     }

--- a/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
@@ -1,0 +1,160 @@
+// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "BlackboxTests.hpp"
+
+#include "PubSubReader.hpp"
+#include "PubSubWriter.hpp"
+#include "ReqRepAsReliableHelloWorldRequester.hpp"
+#include "ReqRepAsReliableHelloWorldReplier.hpp"
+#include <fastrtps/xmlparser/XMLProfileManager.h>
+
+#include <gtest/gtest.h>
+
+using namespace eprosima::fastrtps;
+using namespace eprosima::fastrtps::rtps;
+
+class PersistenceLargeData : public testing::TestWithParam<bool>
+{
+public:
+
+    const std::string& db_file_name() const
+    {
+        return db_file_name_;
+    }
+
+protected:
+
+    std::string db_file_name_;
+
+    void SetUp() override
+    {
+        LibrarySettingsAttributes library_settings;
+        if (GetParam())
+        {
+            library_settings.intraprocess_delivery = IntraprocessDeliveryType::INTRAPROCESS_FULL;
+            xmlparser::XMLProfileManager::library_settings(library_settings);
+        }
+
+        // Get info about current test
+        auto info = ::testing::UnitTest::GetInstance()->current_test_info();
+
+        // Create DB file name from test name and PID
+        std::ostringstream ss;
+        std::string test_case_name(info->test_case_name());
+        std::string test_name(info->name());
+        ss <<
+            test_case_name.replace(test_case_name.find_first_of('/'), 1, "_") << "_" <<
+            test_name.replace(test_name.find_first_of('/'), 1, "_")  << "_" << GET_PID() << ".db";
+        db_file_name_ = ss.str();
+
+    }
+
+    void TearDown() override
+    {
+        LibrarySettingsAttributes library_settings;
+        if (GetParam())
+        {
+            library_settings.intraprocess_delivery = IntraprocessDeliveryType::INTRAPROCESS_OFF;
+            xmlparser::XMLProfileManager::library_settings(library_settings);
+        }
+        std::remove(db_file_name_.c_str());
+    }
+
+    void fragment_data(
+            bool large_data)
+    {
+        PubSubWriter<Data1mbType> writer(TEST_TOPIC_NAME);
+        PubSubReader<Data1mbType> reader(TEST_TOPIC_NAME);
+
+        auto testTransport = std::make_shared<UDPv4TransportDescriptor>();
+        testTransport->sendBufferSize = 32768;
+        testTransport->maxMessageSize = 32768;
+        testTransport->receiveBufferSize = 32768;
+
+        std::cout << db_file_name() << std::endl;
+
+        writer
+        .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+        .make_persistent(db_file_name(), "77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64")
+        .disable_builtin_transport()
+        .add_user_transport_to_pparams(testTransport)
+        .init();
+
+        ASSERT_TRUE(writer.isInitialized());
+
+        auto data = default_data16kb_data_generator();
+        if (large_data)
+        {
+            data = default_data300kb_data_generator();
+        }
+
+        // Send data
+        writer.send(data);
+        // All data should be sent
+        ASSERT_TRUE(data.empty());
+        // Destroy the DataWriter
+        writer.destroy();
+        // Load the persistent DataWriter with the changes saved in the database
+        writer.init();
+
+        ASSERT_TRUE(writer.isInitialized());
+
+        reader
+        .socket_buffer_size(1048576)
+        .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
+        .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+        .init();
+
+        ASSERT_TRUE(reader.isInitialized());
+
+        // Wait for discovery.
+        writer.wait_discovery();
+        reader.wait_discovery();
+
+        auto unreceived_data = default_data16kb_data_generator();
+        if (large_data)
+        {
+            unreceived_data = default_data300kb_data_generator();
+        }
+        reader.startReception(unreceived_data);
+
+        // Block reader until reception finished or timeout.
+        reader.block_for_all();
+    }
+
+
+};
+
+TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentLargeData)
+{
+    fragment_data(true);
+}
+
+TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentSmallData)
+{
+    fragment_data(false);
+}
+
+INSTANTIATE_TEST_CASE_P(PersistenceLargeData,
+        PersistenceLargeData,
+        testing::Values(false, true),
+        [](const testing::TestParamInfo<PersistenceLargeData::ParamType>& info)
+        {
+            if (info.param)
+            {
+                return "Intraprocess";
+            }
+            return "NonIntraprocess";
+        });

--- a/test/blackbox/utils/data_generators.cpp
+++ b/test/blackbox/utils/data_generators.cpp
@@ -125,6 +125,30 @@ std::list<Data64kb> default_data64kb_data_generator(
     return returnedValue;
 }
 
+const size_t data16kb_length = 16384;
+std::list<Data1mb> default_data16kb_data_generator(
+        size_t max)
+{
+    unsigned char index = 1;
+    size_t maximum = max ? max : 10;
+    std::list<Data1mb> returnedValue(maximum);
+
+    std::generate(returnedValue.begin(), returnedValue.end(), [&index]
+            {
+                Data1mb data;
+                data.data().resize(data16kb_length);
+                data.data()[0] = index;
+                for (size_t i = 1; i < data16kb_length; ++i)
+                {
+                    data.data()[i] = static_cast<unsigned char>(i + data.data()[0]);
+                }
+                ++index;
+                return data;
+            });
+
+    return returnedValue;
+}
+
 const size_t data300kb_length = 307201;
 std::list<Data1mb> default_data300kb_data_generator(
         size_t max)

--- a/test/blackbox/utils/data_generators.cpp
+++ b/test/blackbox/utils/data_generators.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.h
+++ b/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.h
@@ -137,12 +137,15 @@ public:
                 const TopicAttributes& topicAtt,
                 const ReaderQos& rqos));
 
-    MOCK_CONST_METHOD0(getRTPSParticipantAttributes, const RTPSParticipantAttributes& ());
-
+    const RTPSParticipantAttributes& getRTPSParticipantAttributes()
+    {
+        return attributes_;
+    }
 
     RTPSParticipantListener* listener_;
     const GUID_t m_guid;
     ResourceEvent mp_event_thr;
+    RTPSParticipantAttributes attributes_;
 };
 
 } /* namespace rtps */

--- a/test/mock/rtps/WriterHistory/fastdds/rtps/history/WriterHistory.h
+++ b/test/mock/rtps/WriterHistory/fastdds/rtps/history/WriterHistory.h
@@ -126,13 +126,25 @@ public:
         return last_sequence_number_ + 1;
     }
 
-    MOCK_METHOD0(changesBegin, std::vector<CacheChange_t*>::iterator());
+    std::vector<CacheChange_t*>::iterator changesBegin()
+    {
+        return m_changes.begin();
+    }
 
-    MOCK_METHOD0(changesRbegin, std::vector<CacheChange_t*>::reverse_iterator());
+    std::vector<CacheChange_t*>::reverse_iterator changesRbegin()
+    {
+        return m_changes.rbegin();
+    }
 
-    MOCK_METHOD0(changesEnd, std::vector<CacheChange_t*>::iterator());
+    std::vector<CacheChange_t*>::iterator changesEnd()
+    {
+        return m_changes.end();
+    }
 
-    MOCK_METHOD0(changesRend, std::vector<CacheChange_t*>::reverse_iterator());
+    std::vector<CacheChange_t*>::reverse_iterator changesRend()
+    {
+        return m_changes.rend();
+    }
 
     inline RecursiveTimedMutex* getMutex()
     {

--- a/test/mock/rtps/WriterHistory/fastdds/rtps/history/WriterHistory.h
+++ b/test/mock/rtps/WriterHistory/fastdds/rtps/history/WriterHistory.h
@@ -50,6 +50,8 @@ public:
     {
     }
 
+    using iterator = std::vector<CacheChange_t*>::iterator;
+
     // *INDENT-OFF* Uncrustify makes a mess with MOCK_METHOD macros
     MOCK_METHOD1(release_Cache, bool(CacheChange_t* change));
 


### PR DESCRIPTION
**Do not merge until #1291 is merged.**

This pull request supports the transmission of large data in cases of persistent DataWriter. When a persistent DataWriter is closed and restored, the history changes saved in the writer's database are restored to the writer's history along with the corresponding fragment size. This way, if the data is larger than the DataWriter transport sending socket, the fragment size is set.
This pull request also adds various Blackbox tests for the verification of the implemented functionality.