### PR TITLE
Refs #8913 Avoid exporting "openssl_init". [8917]

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -193,7 +193,7 @@ set(${PROJECT_NAME}_source_files
     rtps/reader/StatelessPersistentReader.cpp
     rtps/reader/StatefulPersistentReader.cpp
     rtps/persistence/PersistenceFactory.cpp
-    
+
     utils/IPFinder.cpp
     utils/md5.cpp
     utils/StringMatching.cpp
@@ -239,7 +239,6 @@ set(${PROJECT_NAME}_security_source_files
     rtps/security/logging/Logging.cpp
     rtps/security/SecurityManager.cpp
     rtps/security/SecurityPluginFactory.cpp
-    security/OpenSSLInit.cpp
     security/authentication/PKIDH.cpp
     security/accesscontrol/Permissions.cpp
     security/cryptography/AESGCMGMAC.cpp
@@ -355,7 +354,7 @@ elseif(NOT EPROSIMA_INSTALLER)
     set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR})
 
     option(INTERNAL_DEBUG "Activate developer debug messages" OFF)
-    
+
     target_compile_definitions(${PROJECT_NAME} PRIVATE
         ${PROJECT_NAME_UPPER}_SOURCE
         BOOST_ASIO_STANDALONE

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <rtps/security/SecurityManager.h>
+#include <security/OpenSSLInit.hpp>
 
 // TODO Include relative path and fix SecurityTest
 //#include <fastrtps_deprecated/participant/ParticipantImpl.h>
@@ -114,6 +115,7 @@ SecurityManager::SecurityManager(
         participant->getRTPSParticipantAttributes().allocation.data_limits)
 {
     assert(participant != nullptr);
+    static OpenSSLInit openssl_init;
 }
 
 SecurityManager::~SecurityManager()

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -149,7 +149,8 @@ bool SecurityManager::init(
             log_options.log_level = LoggingLevel::ERROR_LEVEL;
             log_options.log_file = "";
 
-            const auto init_logging_fail = [this](SecurityException& exception){
+            const auto init_logging_fail = [this](SecurityException& exception)
+                    {
                         logError(SECURITY, "Logging plugin not configured. Security logging will be disabled. ("
                                 << exception.what() << ").");
                         delete logging_plugin_;
@@ -343,9 +344,9 @@ bool SecurityManager::init(
                     {
                         SecurityException logging_exception;
                         logging_plugin_->log(LoggingLevel::INFORMATIONAL_LEVEL,
-                                             "Cryptography plugin not configured",
-                                             "SecurityManager,init",
-                                             logging_exception);
+                                "Cryptography plugin not configured",
+                                "SecurityManager,init",
+                                logging_exception);
                     }
                     else
                     {
@@ -377,9 +378,9 @@ bool SecurityManager::init(
         {
             SecurityException logging_exception;
             logging_plugin_->log(LoggingLevel::INFORMATIONAL_LEVEL,
-                                 "Authentication plugin not configured. Security will be disable",
-                                 "SecurityManager,init",
-                                 logging_exception);
+                    "Authentication plugin not configured. Security will be disable",
+                    "SecurityManager,init",
+                    logging_exception);
         }
         else
         {
@@ -840,10 +841,10 @@ bool SecurityManager::on_process_handshake(
                         participant_data.m_guid, *handshake_message);
 
         CacheChange_t* change = participant_stateless_message_writer_->new_change([&message]() -> uint32_t
-        {
-            return static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message)
-            + 4 /*encapsulation*/);
-        }
+                        {
+                            return static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message)
+                            + 4 /*encapsulation*/);
+                        }
                         , ALIVE, c_InstanceHandle_Unknown);
 
         if (change != nullptr)
@@ -865,7 +866,7 @@ bool SecurityManager::on_process_handshake(
             aux_msg.msg_endian = LITTLEEND;
             change->serializedPayload.encapsulation = PL_CDR_LE;
             CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif
+#endif // if __BIG_ENDIAN__
             CDRMessage::addUInt16(&aux_msg, 0);
 
             if (CDRMessage::addParticipantGenericMessage(&aux_msg, message))
@@ -941,10 +942,10 @@ bool SecurityManager::on_process_handshake(
                     const GUID_t guid = participant_data.m_guid;
                     remote_participant_info->event_ = new TimedEvent(participant_->getEventResource(),
                                     [&, guid]() -> bool
-                    {
-                        resend_handshake_message_token(guid);
-                        return true;
-                    },
+                                    {
+                                        resend_handshake_message_token(guid);
+                                        return true;
+                                    },
                                     500); // TODO (Ricardo) Configurable
                     remote_participant_info->event_->restart_timer();
                 }
@@ -2014,10 +2015,10 @@ void SecurityManager::exchange_participant_crypto(
 
         CacheChange_t* change = participant_volatile_message_secure_writer_->new_change(
             [&message]() -> uint32_t
-        {
-            return static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message)
-            + 4 /*encapsulation*/);
-        }
+            {
+                return static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message)
+                + 4 /*encapsulation*/);
+            }
             , ALIVE, c_InstanceHandle_Unknown);
 
         if (change != nullptr)
@@ -2039,7 +2040,7 @@ void SecurityManager::exchange_participant_crypto(
             aux_msg.msg_endian = LITTLEEND;
             change->serializedPayload.encapsulation = PL_CDR_LE;
             CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif
+#endif // if __BIG_ENDIAN__
             CDRMessage::addUInt16(&aux_msg, 0);
 
             if (CDRMessage::addParticipantGenericMessage(&aux_msg, message))
@@ -2781,11 +2782,11 @@ bool SecurityManager::discovered_reader(
 
                                 CacheChange_t* change = participant_volatile_message_secure_writer_->new_change(
                                     [&message]() -> uint32_t
-                                {
-                                    return static_cast<uint32_t>(
-                                        ParticipantGenericMessageHelper::serialized_size(message)
-                                        + 4 /*encapsulation*/);
-                                }
+                                    {
+                                        return static_cast<uint32_t>(
+                                            ParticipantGenericMessageHelper::serialized_size(message)
+                                            + 4 /*encapsulation*/);
+                                    }
                                     , ALIVE, c_InstanceHandle_Unknown);
 
                                 if (change != nullptr)
@@ -2807,7 +2808,7 @@ bool SecurityManager::discovered_reader(
                                     aux_msg.msg_endian = LITTLEEND;
                                     change->serializedPayload.encapsulation = PL_CDR_LE;
                                     CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif
+#endif // if __BIG_ENDIAN__
                                     CDRMessage::addUInt16(&aux_msg, 0);
 
                                     if (CDRMessage::addParticipantGenericMessage(&aux_msg, message))
@@ -3118,11 +3119,11 @@ bool SecurityManager::discovered_writer(
 
                                 CacheChange_t* change = participant_volatile_message_secure_writer_->new_change(
                                     [&message]() -> uint32_t
-                                {
-                                    return static_cast<uint32_t>(
-                                        ParticipantGenericMessageHelper::serialized_size(message)
-                                        + 4 /*encapsulation*/);
-                                }
+                                    {
+                                        return static_cast<uint32_t>(
+                                            ParticipantGenericMessageHelper::serialized_size(message)
+                                            + 4 /*encapsulation*/);
+                                    }
                                     , ALIVE, c_InstanceHandle_Unknown);
 
                                 if (change != nullptr)
@@ -3144,7 +3145,7 @@ bool SecurityManager::discovered_writer(
                                     aux_msg.msg_endian = LITTLEEND;
                                     change->serializedPayload.encapsulation = PL_CDR_LE;
                                     CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif
+#endif // if __BIG_ENDIAN__
                                     CDRMessage::addUInt16(&aux_msg, 0);
 
                                     if (CDRMessage::addParticipantGenericMessage(&aux_msg, message))

--- a/src/cpp/security/OpenSSLInit.hpp
+++ b/src/cpp/security/OpenSSLInit.hpp
@@ -3,13 +3,20 @@
 #include <openssl/rand.h>
 #include <openssl/err.h>
 
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+namespace security {
+
 class OpenSSLInit
 {
 public:
 
     OpenSSLInit()
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         OpenSSL_add_all_algorithms();
+#endif
     }
 
     ~OpenSSLInit()
@@ -28,4 +35,7 @@ public:
 
 };
 
-OpenSSLInit openssl_init;
+} // namespace security
+} // namespace rtps
+} // namespace fastrtps
+} // namespace eprosima

--- a/src/cpp/security/OpenSSLInit.hpp
+++ b/src/cpp/security/OpenSSLInit.hpp
@@ -16,7 +16,7 @@ public:
     {
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
         OpenSSL_add_all_algorithms();
-#endif
+#endif // if OPENSSL_VERSION_NUMBER < 0x10100000L
     }
 
     ~OpenSSLInit()
@@ -25,7 +25,7 @@ public:
         ERR_remove_state(0);
 #elif OPENSSL_VERSION_NUMBER < 0x10100000L
         ERR_remove_thread_state(NULL);
-#endif
+#endif // if OPENSSL_VERSION_NUMBER < 0x10000000L
         ENGINE_cleanup();
         RAND_cleanup();
         CRYPTO_cleanup_all_ex_data();

--- a/test/unittest/rtps/network/CMakeLists.txt
+++ b/test/unittest/rtps/network/CMakeLists.txt
@@ -69,7 +69,6 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
                 ${NETWORKFACTORYTESTS_SOURCE}
                 ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
                 ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPAcceptorSecure.cpp
-                ${PROJECT_SOURCE_DIR}/src/cpp/security/OpenSSLInit.cpp
             )
         endif()
 

--- a/test/unittest/rtps/security/CMakeLists.txt
+++ b/test/unittest/rtps/security/CMakeLists.txt
@@ -58,6 +58,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         target_compile_definitions(SecurityAuthentication PRIVATE FASTRTPS_NO_LIB)
         target_include_directories(SecurityAuthentication PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
+            ${OPENSSL_INCLUDE_DIR}
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/SecurityPluginFactory
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/Endpoint
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/RTPSParticipantImpl
@@ -79,7 +80,11 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
             ${PROJECT_SOURCE_DIR}/src/cpp
             )
-        target_link_libraries(SecurityAuthentication fastcdr ${GTEST_LIBRARIES} ${GMOCK_LIBRARIES})
+        target_link_libraries(SecurityAuthentication fastcdr
+            ${GTEST_LIBRARIES}
+            ${GMOCK_LIBRARIES}
+            ${OPENSSL_LIBRARIES}
+            )
         add_gtest(SecurityAuthentication
             SOURCES
             ${CMAKE_CURRENT_SOURCE_DIR}/SecurityInitializationTests.cpp

--- a/test/unittest/security/authentication/AuthenticationPluginTests.hpp
+++ b/test/unittest/security/authentication/AuthenticationPluginTests.hpp
@@ -16,6 +16,7 @@
 #define _UNITTEST_SECURITY_AUTHENTICATION_AUTHENTICATIONPLUGINTESTS_HPP_
 
 #include <security/authentication/PKIDH.h>
+#include <security/OpenSSLInit.hpp>
 
 // Include first necessary mocks
 #include <fastrtps/rtps/builtin/data/ParticipantProxyData.h>
@@ -38,7 +39,10 @@ class AuthenticationPluginTest : public ::testing::Test
 
     public:
 
-        AuthenticationPluginTest() {}
+        AuthenticationPluginTest()
+        {
+            static eprosima::fastrtps::rtps::security::OpenSSLInit openssl_init;
+        }
 
         static eprosima::fastrtps::rtps::PropertyPolicy get_valid_policy();
         static eprosima::fastrtps::rtps::PropertyPolicy get_wrong_policy();

--- a/test/unittest/security/authentication/AuthenticationPluginTests.hpp
+++ b/test/unittest/security/authentication/AuthenticationPluginTests.hpp
@@ -27,40 +27,51 @@
 
 class AuthenticationPluginTest : public ::testing::Test
 {
-    protected:
+protected:
 
-        virtual void SetUp()
-        {
-        }
+    virtual void SetUp()
+    {
+    }
 
-        virtual void TearDown()
-        {
-        }
+    virtual void TearDown()
+    {
+    }
 
-    public:
+public:
 
-        AuthenticationPluginTest()
-        {
-            static eprosima::fastrtps::rtps::security::OpenSSLInit openssl_init;
-        }
+    AuthenticationPluginTest()
+    {
+        static eprosima::fastrtps::rtps::security::OpenSSLInit openssl_init;
+    }
 
-        static eprosima::fastrtps::rtps::PropertyPolicy get_valid_policy();
-        static eprosima::fastrtps::rtps::PropertyPolicy get_wrong_policy();
-        static eprosima::fastrtps::rtps::IdentityToken generate_remote_identity_token_ok(const eprosima::fastrtps::rtps::security::IdentityHandle& local_identity_handle);
-        static void check_local_identity_handle(const eprosima::fastrtps::rtps::security::IdentityHandle& handle);
-        static void check_remote_identity_handle(const eprosima::fastrtps::rtps::security::IdentityHandle& handle);
-        static void check_handshake_request_message(const eprosima::fastrtps::rtps::security::HandshakeHandle& handle, const eprosima::fastrtps::rtps::security::HandshakeMessageToken& message);
-        static void check_handshake_reply_message(const eprosima::fastrtps::rtps::security::HandshakeHandle& handle, const eprosima::fastrtps::rtps::security::HandshakeMessageToken& message,
-                const eprosima::fastrtps::rtps::security::HandshakeMessageToken& request_message);
-        static void check_handshake_final_message(const eprosima::fastrtps::rtps::security::HandshakeHandle& handle, const eprosima::fastrtps::rtps::security::HandshakeMessageToken& message,
-                const eprosima::fastrtps::rtps::security::HandshakeMessageToken& reply_message);
-        static void check_shared_secrets(const eprosima::fastrtps::rtps::security::SharedSecretHandle& sharedsecret1,
-                const eprosima::fastrtps::rtps::security::SharedSecretHandle& sharedsecret2);
+    static eprosima::fastrtps::rtps::PropertyPolicy get_valid_policy();
+    static eprosima::fastrtps::rtps::PropertyPolicy get_wrong_policy();
+    static eprosima::fastrtps::rtps::IdentityToken generate_remote_identity_token_ok(
+            const eprosima::fastrtps::rtps::security::IdentityHandle& local_identity_handle);
+    static void check_local_identity_handle(
+            const eprosima::fastrtps::rtps::security::IdentityHandle& handle);
+    static void check_remote_identity_handle(
+            const eprosima::fastrtps::rtps::security::IdentityHandle& handle);
+    static void check_handshake_request_message(
+            const eprosima::fastrtps::rtps::security::HandshakeHandle& handle,
+            const eprosima::fastrtps::rtps::security::HandshakeMessageToken& message);
+    static void check_handshake_reply_message(
+            const eprosima::fastrtps::rtps::security::HandshakeHandle& handle,
+            const eprosima::fastrtps::rtps::security::HandshakeMessageToken& message,
+            const eprosima::fastrtps::rtps::security::HandshakeMessageToken& request_message);
+    static void check_handshake_final_message(
+            const eprosima::fastrtps::rtps::security::HandshakeHandle& handle,
+            const eprosima::fastrtps::rtps::security::HandshakeMessageToken& message,
+            const eprosima::fastrtps::rtps::security::HandshakeMessageToken& reply_message);
+    static void check_shared_secrets(
+            const eprosima::fastrtps::rtps::security::SharedSecretHandle& sharedsecret1,
+            const eprosima::fastrtps::rtps::security::SharedSecretHandle& sharedsecret2);
 
-        eprosima::fastrtps::rtps::security::PKIDH plugin;
+    eprosima::fastrtps::rtps::security::PKIDH plugin;
 };
 
-void fill_candidate_participant_key(eprosima::fastrtps::rtps::GUID_t& candidate_participant_key)
+void fill_candidate_participant_key(
+        eprosima::fastrtps::rtps::GUID_t& candidate_participant_key)
 {
     candidate_participant_key.guidPrefix.value[0] = 1;
     candidate_participant_key.guidPrefix.value[1] = 2;
@@ -88,17 +99,18 @@ TEST_F(AuthenticationPluginTest, validate_local_identity_validation_ok)
     eprosima::fastrtps::rtps::RTPSParticipantAttributes participant_attr;
     eprosima::fastrtps::rtps::GUID_t candidate_participant_key;
     eprosima::fastrtps::rtps::security::SecurityException exception;
-    eprosima::fastrtps::rtps::security::ValidationResult_t result= eprosima::fastrtps::rtps::security::ValidationResult_t::VALIDATION_FAILED;
+    eprosima::fastrtps::rtps::security::ValidationResult_t result =
+            eprosima::fastrtps::rtps::security::ValidationResult_t::VALIDATION_FAILED;
 
     fill_candidate_participant_key(candidate_participant_key);
     participant_attr.properties = AuthenticationPluginTest::get_valid_policy();
 
     result = plugin.validate_local_identity(&local_identity_handle,
-            adjusted_participant_key,
-            domain_id,
-            participant_attr,
-            candidate_participant_key,
-            exception);
+                    adjusted_participant_key,
+                    domain_id,
+                    participant_attr,
+                    candidate_participant_key,
+                    exception);
 
     ASSERT_TRUE(result == eprosima::fastrtps::rtps::security::ValidationResult_t::VALIDATION_OK);
     ASSERT_TRUE(local_identity_handle != nullptr);
@@ -116,17 +128,18 @@ TEST_F(AuthenticationPluginTest, validate_local_identity_wrong_validation)
     eprosima::fastrtps::rtps::RTPSParticipantAttributes participant_attr;
     eprosima::fastrtps::rtps::GUID_t candidate_participant_key;
     eprosima::fastrtps::rtps::security::SecurityException exception;
-    eprosima::fastrtps::rtps::security::ValidationResult_t result= eprosima::fastrtps::rtps::security::ValidationResult_t::VALIDATION_FAILED;
+    eprosima::fastrtps::rtps::security::ValidationResult_t result =
+            eprosima::fastrtps::rtps::security::ValidationResult_t::VALIDATION_FAILED;
 
     fill_candidate_participant_key(candidate_participant_key);
     participant_attr.properties = get_wrong_policy();
 
     result = plugin.validate_local_identity(&local_identity_handle,
-            adjusted_participant_key,
-            domain_id,
-            participant_attr,
-            candidate_participant_key,
-            exception);
+                    adjusted_participant_key,
+                    domain_id,
+                    participant_attr,
+                    candidate_participant_key,
+                    exception);
 
     ASSERT_TRUE(result == eprosima::fastrtps::rtps::security::ValidationResult_t::VALIDATION_FAILED);
     ASSERT_TRUE(local_identity_handle == nullptr);
@@ -143,16 +156,17 @@ TEST_F(AuthenticationPluginTest, handshake_process_ok)
     eprosima::fastrtps::rtps::GUID_t candidate_participant_key1;
     eprosima::fastrtps::rtps::GUID_t candidate_participant_key2;
     eprosima::fastrtps::rtps::security::SecurityException exception;
-    eprosima::fastrtps::rtps::security::ValidationResult_t result= eprosima::fastrtps::rtps::security::ValidationResult_t::VALIDATION_FAILED;
+    eprosima::fastrtps::rtps::security::ValidationResult_t result =
+            eprosima::fastrtps::rtps::security::ValidationResult_t::VALIDATION_FAILED;
 
     participant_attr.properties = get_valid_policy();
 
     result = plugin.validate_local_identity(&local_identity_handle1,
-            adjusted_participant_key1,
-            domain_id,
-            participant_attr,
-            candidate_participant_key1,
-            exception);
+                    adjusted_participant_key1,
+                    domain_id,
+                    participant_attr,
+                    candidate_participant_key1,
+                    exception);
 
     ASSERT_TRUE(result == eprosima::fastrtps::rtps::security::ValidationResult_t::VALIDATION_OK);
     ASSERT_TRUE(local_identity_handle1 != nullptr);
@@ -160,55 +174,58 @@ TEST_F(AuthenticationPluginTest, handshake_process_ok)
 
     eprosima::fastrtps::rtps::security::IdentityHandle* local_identity_handle2 = nullptr;
     result = plugin.validate_local_identity(&local_identity_handle2,
-            adjusted_participant_key2,
-            domain_id,
-            participant_attr,
-            candidate_participant_key2,
-            exception);
+                    adjusted_participant_key2,
+                    domain_id,
+                    participant_attr,
+                    candidate_participant_key2,
+                    exception);
 
     ASSERT_TRUE(result == eprosima::fastrtps::rtps::security::ValidationResult_t::VALIDATION_OK);
     ASSERT_TRUE(local_identity_handle2 != nullptr);
     AuthenticationPluginTest::check_local_identity_handle(*local_identity_handle2);
 
     eprosima::fastrtps::rtps::security::IdentityHandle* remote_identity_handle1 = nullptr;
-    eprosima::fastrtps::rtps::IdentityToken remote_identity_token1 = generate_remote_identity_token_ok(*local_identity_handle1);
+    eprosima::fastrtps::rtps::IdentityToken remote_identity_token1 = generate_remote_identity_token_ok(
+        *local_identity_handle1);
     eprosima::fastrtps::rtps::GUID_t remote_participant_key;
 
     result = plugin.validate_remote_identity(&remote_identity_handle1,
-            *local_identity_handle1,
-            std::move(remote_identity_token1),
-            remote_participant_key,
-            exception);
+                    *local_identity_handle1,
+                    std::move(remote_identity_token1),
+                    remote_participant_key,
+                    exception);
 
     ASSERT_TRUE(remote_identity_handle1 != nullptr);
     AuthenticationPluginTest::check_remote_identity_handle(*remote_identity_handle1);
 
     eprosima::fastrtps::rtps::security::IdentityHandle* remote_identity_handle2 = nullptr;
-    eprosima::fastrtps::rtps::IdentityToken remote_identity_token2 = generate_remote_identity_token_ok(*local_identity_handle2);
+    eprosima::fastrtps::rtps::IdentityToken remote_identity_token2 = generate_remote_identity_token_ok(
+        *local_identity_handle2);
 
     result = plugin.validate_remote_identity(&remote_identity_handle2,
-            *local_identity_handle2,
-            std::move(remote_identity_token2),
-            remote_participant_key,
-            exception);
+                    *local_identity_handle2,
+                    std::move(remote_identity_token2),
+                    remote_participant_key,
+                    exception);
 
     ASSERT_TRUE(remote_identity_handle2 != nullptr);
     AuthenticationPluginTest::check_remote_identity_handle(*remote_identity_handle2);
 
     eprosima::fastrtps::rtps::security::HandshakeHandle* handshake_handle = nullptr;
-    eprosima::fastrtps::rtps::security::HandshakeMessageToken *handshake_message = nullptr;
-    eprosima::fastrtps::rtps::ParticipantProxyData participant_data1(eprosima::fastrtps::rtps::c_default_RTPSParticipantAllocationAttributes);
+    eprosima::fastrtps::rtps::security::HandshakeMessageToken* handshake_message = nullptr;
+    eprosima::fastrtps::rtps::ParticipantProxyData participant_data1(eprosima::fastrtps::rtps::
+            c_default_RTPSParticipantAllocationAttributes);
     participant_data1.m_guid = adjusted_participant_key1;
     eprosima::fastrtps::rtps::CDRMessage_t auxMsg(RTPSMESSAGE_DEFAULT_SIZE);
     auxMsg.msg_endian = eprosima::fastrtps::rtps::BIGEND;
     ASSERT_TRUE(participant_data1.writeToCDRMessage(&auxMsg, false));
 
     result = plugin.begin_handshake_request(&handshake_handle,
-            &handshake_message,
-            *local_identity_handle1,
-            *remote_identity_handle1,
-            auxMsg,
-            exception);
+                    &handshake_message,
+                    *local_identity_handle1,
+                    *remote_identity_handle1,
+                    auxMsg,
+                    exception);
 
     ASSERT_TRUE(result == eprosima::fastrtps::rtps::security::ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE);
     ASSERT_TRUE(handshake_handle != nullptr);
@@ -217,7 +234,8 @@ TEST_F(AuthenticationPluginTest, handshake_process_ok)
 
     eprosima::fastrtps::rtps::security::HandshakeHandle* handshake_handle_reply = nullptr;
     eprosima::fastrtps::rtps::security::HandshakeMessageToken* handshake_message_reply = nullptr;
-    eprosima::fastrtps::rtps::ParticipantProxyData participant_data2(eprosima::fastrtps::rtps::c_default_RTPSParticipantAllocationAttributes);
+    eprosima::fastrtps::rtps::ParticipantProxyData participant_data2(eprosima::fastrtps::rtps::
+            c_default_RTPSParticipantAllocationAttributes);
     participant_data2.m_guid = adjusted_participant_key2;
 
     auxMsg.length = 0;
@@ -226,12 +244,12 @@ TEST_F(AuthenticationPluginTest, handshake_process_ok)
     ASSERT_TRUE(participant_data2.writeToCDRMessage(&auxMsg, false));
 
     result = plugin.begin_handshake_reply(&handshake_handle_reply,
-            &handshake_message_reply,
-            eprosima::fastrtps::rtps::security::HandshakeMessageToken(*handshake_message),
-            *remote_identity_handle2,
-            *local_identity_handle2,
-            auxMsg,
-            exception);
+                    &handshake_message_reply,
+                    eprosima::fastrtps::rtps::security::HandshakeMessageToken(*handshake_message),
+                    *remote_identity_handle2,
+                    *local_identity_handle2,
+                    auxMsg,
+                    exception);
 
     ASSERT_TRUE(result == eprosima::fastrtps::rtps::security::ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE);
     ASSERT_TRUE(handshake_handle_reply != nullptr);
@@ -241,9 +259,9 @@ TEST_F(AuthenticationPluginTest, handshake_process_ok)
     eprosima::fastrtps::rtps::security::HandshakeMessageToken* handshake_message_final = nullptr;
 
     result = plugin.process_handshake(&handshake_message_final,
-            eprosima::fastrtps::rtps::security::HandshakeMessageToken(*handshake_message_reply),
-            *handshake_handle,
-            exception);
+                    eprosima::fastrtps::rtps::security::HandshakeMessageToken(*handshake_message_reply),
+                    *handshake_handle,
+                    exception);
 
     ASSERT_TRUE(result == eprosima::fastrtps::rtps::security::ValidationResult_t::VALIDATION_OK_WITH_FINAL_MESSAGE);
     ASSERT_TRUE(handshake_message_final != nullptr);
@@ -252,16 +270,18 @@ TEST_F(AuthenticationPluginTest, handshake_process_ok)
     eprosima::fastrtps::rtps::security::HandshakeMessageToken* handshake_message_aux = nullptr;
 
     result = plugin.process_handshake(&handshake_message_aux,
-            eprosima::fastrtps::rtps::security::HandshakeMessageToken(*handshake_message_final),
-            *handshake_handle_reply,
-            exception);
+                    eprosima::fastrtps::rtps::security::HandshakeMessageToken(*handshake_message_final),
+                    *handshake_handle_reply,
+                    exception);
 
     ASSERT_TRUE(result == eprosima::fastrtps::rtps::security::ValidationResult_t::VALIDATION_OK);
 
-    eprosima::fastrtps::rtps::security::SharedSecretHandle* sharedsecret1 = plugin.get_shared_secret(*handshake_handle, exception);
+    eprosima::fastrtps::rtps::security::SharedSecretHandle* sharedsecret1 = plugin.get_shared_secret(*handshake_handle,
+                    exception);
     ASSERT_TRUE(sharedsecret1 != nullptr);
 
-    eprosima::fastrtps::rtps::security::SharedSecretHandle* sharedsecret2 = plugin.get_shared_secret(*handshake_handle_reply, exception);
+    eprosima::fastrtps::rtps::security::SharedSecretHandle* sharedsecret2 = plugin.get_shared_secret(
+        *handshake_handle_reply, exception);
     ASSERT_TRUE(sharedsecret2 != nullptr);
     check_shared_secrets(*sharedsecret1, *sharedsecret2);
 

--- a/test/unittest/security/authentication/CMakeLists.txt
+++ b/test/unittest/security/authentication/CMakeLists.txt
@@ -49,7 +49,6 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/security/authentication/PKIDH.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/security/authentication/PKIIdentityHandle.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/security/authentication/PKIHandshakeHandle.cpp
-            ${PROJECT_SOURCE_DIR}/src/cpp/security/OpenSSLInit.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/md5.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPFinder.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPLocator.cpp
@@ -65,7 +64,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         target_link_libraries(BuiltinPKIDH ${GTEST_LIBRARIES} ${OPENSSL_LIBRARIES} fastcdr foonathan_memory $<$<BOOL:${WIN32}>:ws2_32>)
         add_gtest(BuiltinPKIDH
             SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/BuiltinPKIDHTests.cpp
-			${CMAKE_CURRENT_SOURCE_DIR}/AuthenticationPluginTests.hpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/AuthenticationPluginTests.hpp
             ENVIRONMENTS "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
     endif()
 endif()

--- a/test/unittest/security/cryptography/CMakeLists.txt
+++ b/test/unittest/security/cryptography/CMakeLists.txt
@@ -30,7 +30,6 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/exceptions/Exception.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/security/exceptions/SecurityException.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/security/common/SharedSecretHandle.cpp
-            ${PROJECT_SOURCE_DIR}/src/cpp/security/OpenSSLInit.cpp
             )
 
         add_executable(BuiltinAESGCMGMAC ${COMMON_SOURCES_CRYPTO_PLUGIN_TEST_SOURCE}
@@ -41,7 +40,6 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/security/cryptography/AESGCMGMAC_Types.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/security/authentication/PKIIdentityHandle.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/security/accesscontrol/AccessPermissionsHandle.cpp
-            ${PROJECT_SOURCE_DIR}/src/cpp/security/OpenSSLInit.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/builtinAESGCMGMACTests.cpp)
 
         target_compile_definitions(BuiltinAESGCMGMAC PRIVATE FASTRTPS_NO_LIB)
@@ -58,7 +56,6 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/security/cryptography/AESGCMGMAC_KeyFactory.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/security/cryptography/AESGCMGMAC_Transform.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/security/cryptography/AESGCMGMAC_Types.cpp
-            ${PROJECT_SOURCE_DIR}/src/cpp/security/OpenSSLInit.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/builtinAESGCMGMACTests.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/CryptographyPluginTests.hpp
             ENVIRONMENTS "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")

--- a/test/unittest/security/cryptography/builtinAESGCMGMACTests.cpp
+++ b/test/unittest/security/cryptography/builtinAESGCMGMACTests.cpp
@@ -15,8 +15,10 @@
 #include <iostream>
 #include <algorithm>
 #include "CryptographyPluginTests.hpp"
+#include "security/OpenSSLInit.hpp"
 
 TEST_F(CryptographyPluginTest, mocktest){
+    static eprosima::fastrtps::rtps::security::OpenSSLInit openssl_init;
     uint8_t mock = 7;
 
     ASSERT_TRUE(mock == 7);

--- a/test/unittest/security/cryptography/builtinAESGCMGMACTests.cpp
+++ b/test/unittest/security/cryptography/builtinAESGCMGMACTests.cpp
@@ -25,10 +25,11 @@ TEST_F(CryptographyPluginTest, mocktest){
 
 }
 
-int main(int argc, char **argv)
+int main(
+        int argc,
+        char** argv)
 {
     testing::InitGoogleTest(&argc, argv);
 
     return RUN_ALL_TESTS();
 }
-

--- a/test/unittest/transport/CMakeLists.txt
+++ b/test/unittest/transport/CMakeLists.txt
@@ -114,7 +114,6 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
                 ${TCPV4TESTS_SOURCE}
                 ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
                 ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPAcceptorSecure.cpp
-                ${PROJECT_SOURCE_DIR}/src/cpp/security/OpenSSLInit.cpp
             )
         endif()
 
@@ -151,7 +150,6 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
                 ${TCPV6TESTS_SOURCE}
                 ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
                 ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPAcceptorSecure.cpp
-                ${PROJECT_SOURCE_DIR}/src/cpp/security/OpenSSLInit.cpp
             )
         endif()
 
@@ -290,7 +288,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
 
         if(IS_THIRDPARTY_BOOST_OK)
             add_executable(SharedMemTests ${SHAREDMEMTESTS_SOURCE})
-            
+
             target_compile_definitions(SharedMemTests PRIVATE FASTRTPS_NO_LIB
             $<$<BOOL:${WIN32}>:_ENABLE_ATOMIC_ALIGNMENT_FIX>)
 


### PR DESCRIPTION
This PR avoids exporting the "openss_init" symbol in *nix systems.