### PR TITLE
Perform payload protection on messages module. [8973]

### DIFF
--- a/include/fastdds/rtps/messages/MessageReceiver.h
+++ b/include/fastdds/rtps/messages/MessageReceiver.h
@@ -90,6 +90,7 @@ private:
 
 #if HAVE_SECURITY
     CDRMessage_t crypto_msg_;
+    SerializedPayload_t crypto_payload_;
 #endif
 
     //!Reset the MessageReceiver to process a new message.
@@ -117,7 +118,8 @@ private:
      * to the given entity ID.
      */
     bool willAReaderAcceptMsgDirectedTo(
-            const EntityId_t& readerID);
+            const EntityId_t& readerID,
+            RTPSReader*& first_reader);
 
     /**
      * Find all readers (in associated_readers_), with the given entity ID, and call the

--- a/include/fastdds/rtps/messages/MessageReceiver.h
+++ b/include/fastdds/rtps/messages/MessageReceiver.h
@@ -91,7 +91,7 @@ private:
 #if HAVE_SECURITY
     CDRMessage_t crypto_msg_;
     SerializedPayload_t crypto_payload_;
-#endif
+#endif // if HAVE_SECURITY
 
     //!Reset the MessageReceiver to process a new message.
     void reset();
@@ -185,5 +185,5 @@ private:
 } /* namespace fastrtps */
 } /* namespace eprosima */
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif /* _FASTDDS_RTPS_MESSAGERECEIVER_H_ */

--- a/include/fastdds/rtps/writer/RTPSWriter.h
+++ b/include/fastdds/rtps/writer/RTPSWriter.h
@@ -78,9 +78,10 @@ public:
             ChangeKind_t changeKind,
             InstanceHandle_t handle = c_InstanceHandle_Unknown)
     {
-        return new_change([data]() -> uint32_t {
-                        return (uint32_t)T::getCdrSerializedSize(data);
-                    }, changeKind, handle);
+        return new_change([data]() -> uint32_t
+                       {
+                           return (uint32_t)T::getCdrSerializedSize(data);
+                       }, changeKind, handle);
     }
 
     RTPS_DllAPI CacheChange_t* new_change(
@@ -423,8 +424,8 @@ private:
     RTPSWriter* next_[2];
 };
 
-}
 } /* namespace rtps */
+} /* namespace fastrtps */
 } /* namespace eprosima */
 
 #endif /* _FASTDDS_RTPS_RTPSWRITER_H_ */

--- a/include/fastdds/rtps/writer/RTPSWriter.h
+++ b/include/fastdds/rtps/writer/RTPSWriter.h
@@ -408,13 +408,6 @@ protected:
     virtual bool change_removed_by_history(
             CacheChange_t* a_change) = 0;
 
-#if HAVE_SECURITY
-    SerializedPayload_t encrypt_payload_;
-
-    bool encrypt_cachechange(
-            CacheChange_t* change);
-#endif
-
     //! The liveliness kind of this writer
     LivelinessQosPolicyKind liveliness_kind_;
     //! The liveliness lease duration of this writer

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -54,7 +54,7 @@ MessageReceiver::MessageReceiver(
 #if HAVE_SECURITY
     , crypto_msg_(participant->is_secure() ? rec_buffer_size : 0)
     , crypto_payload_(participant->is_secure() ? rec_buffer_size : 0)
-#endif
+#endif // if HAVE_SECURITY
 {
     (void)rec_buffer_size;
     logInfo(RTPS_MSG_IN, "Created with CDRMessage of size: " << rec_buffer_size);
@@ -201,7 +201,7 @@ void MessageReceiver::processCDRMsg(
         // Swap
         std::swap(msg, auxiliary_buffer);
     }
-#endif
+#endif // if HAVE_SECURITY
 
     // Loop until there are no more submessages
     bool valid;
@@ -224,7 +224,7 @@ void MessageReceiver::processCDRMsg(
         {
             submessage = auxiliary_buffer;
         }
-#endif
+#endif // if HAVE_SECURITY
 
         //First 4 bytes must contain: ID | flags | octets to next header
         if (!readSubmessageHeader(submessage, &submsgh))
@@ -650,7 +650,7 @@ bool MessageReceiver::proc_Submsg_Data(
             else
             {
                 logWarning(RTPS_MSG_IN, IDSTRING "Ignoring Serialized Payload for too large key-only data (" <<
-                    payload_size << ")");
+                        payload_size << ")");
             }
             msg->pos += payload_size;
         }
@@ -665,7 +665,8 @@ bool MessageReceiver::proc_Submsg_Data(
 #if HAVE_SECURITY
     if (first_reader->getAttributes().security_attributes().is_payload_protected)
     {
-        if (participant_->security_manager().decode_serialized_payload(ch.serializedPayload, crypto_payload_, first_reader->getGuid(), ch.writerGUID))
+        if (participant_->security_manager().decode_serialized_payload(ch.serializedPayload, crypto_payload_,
+                first_reader->getGuid(), ch.writerGUID))
         {
             ch.serializedPayload.data = crypto_payload_.data;
             ch.serializedPayload.length = crypto_payload_.length;
@@ -674,14 +675,14 @@ bool MessageReceiver::proc_Submsg_Data(
 #endif  // HAVE_SECURITY
 
     logInfo(RTPS_MSG_IN, IDSTRING "from Writer " << ch.writerGUID << "; possible RTPSReader entities: " <<
-        associated_readers_.size());
+            associated_readers_.size());
 
     //Look for the correct reader to add the change
-    findAllReaders(readerID, 
-        [&ch] (RTPSReader* reader)
-        {
-            reader->processDataMsg(&ch);
-        });
+    findAllReaders(readerID,
+            [&ch](RTPSReader* reader)
+            {
+                reader->processDataMsg(&ch);
+            });
 
     //TODO(Ricardo) If a exception is thrown (ex, by fastcdr), this line is not executed -> segmentation fault
     ch.serializedPayload.data = nullptr;
@@ -852,7 +853,8 @@ bool MessageReceiver::proc_Submsg_DataFrag(
 #if HAVE_SECURITY
     if (first_reader->getAttributes().security_attributes().is_payload_protected)
     {
-        if (participant_->security_manager().decode_serialized_payload(ch.serializedPayload, crypto_payload_, first_reader->getGuid(), ch.writerGUID))
+        if (participant_->security_manager().decode_serialized_payload(ch.serializedPayload, crypto_payload_,
+                first_reader->getGuid(), ch.writerGUID))
         {
             ch.serializedPayload.data = crypto_payload_.data;
             ch.serializedPayload.length = crypto_payload_.length;
@@ -862,14 +864,14 @@ bool MessageReceiver::proc_Submsg_DataFrag(
 
     //FIXME: DO SOMETHING WITH PARAMETERLIST CREATED.
     logInfo(RTPS_MSG_IN, IDSTRING "from Writer " << ch.writerGUID << "; possible RTPSReader entities: " <<
-        associated_readers_.size());
+            associated_readers_.size());
 
     //Look for the correct reader to add the change
     findAllReaders(readerID,
-        [&ch, sampleSize, fragmentStartingNum, fragmentsInSubmessage] (RTPSReader* reader)
-        {
-            reader->processDataFragMsg(&ch, sampleSize, fragmentStartingNum, fragmentsInSubmessage);
-        });
+            [&ch, sampleSize, fragmentStartingNum, fragmentsInSubmessage](RTPSReader* reader)
+            {
+                reader->processDataFragMsg(&ch, sampleSize, fragmentStartingNum, fragmentsInSubmessage);
+            });
 
     ch.serializedPayload.data = nullptr;
 
@@ -917,10 +919,10 @@ bool MessageReceiver::proc_Submsg_Heartbeat(
     std::lock_guard<std::mutex> guard(mtx_);
     //Look for the correct reader and writers:
     findAllReaders(readerGUID.entityId,
-        [&writerGUID, &HBCount, &firstSN, &lastSN, finalFlag, livelinessFlag] (RTPSReader* reader)
-        {
-            reader->processHeartbeatMsg(writerGUID, HBCount, firstSN, lastSN, finalFlag, livelinessFlag);
-        });
+            [&writerGUID, &HBCount, &firstSN, &lastSN, finalFlag, livelinessFlag](RTPSReader* reader)
+            {
+                reader->processHeartbeatMsg(writerGUID, HBCount, firstSN, lastSN, finalFlag, livelinessFlag);
+            });
 
     return true;
 }
@@ -1002,10 +1004,10 @@ bool MessageReceiver::proc_Submsg_Gap(
 
     std::lock_guard<std::mutex> guard(mtx_);
     findAllReaders(readerGUID.entityId,
-        [&writerGUID, &gapStart, &gapList] (RTPSReader* reader)
-        {
-            reader->processGapMsg(writerGUID, gapStart, gapList);
-        });
+            [&writerGUID, &gapStart, &gapList](RTPSReader* reader)
+            {
+                reader->processGapMsg(writerGUID, gapStart, gapList);
+            });
 
     return true;
 }
@@ -1190,6 +1192,6 @@ bool MessageReceiver::proc_Submsg_HeartbeatFrag(
     return true;
 }
 
-}
 } /* namespace rtps */
+} /* namespace fastrtps */
 } /* namespace eprosima */

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -849,6 +849,17 @@ bool MessageReceiver::proc_Submsg_DataFrag(
         ch.sourceTimestamp = timestamp_;
     }
 
+#if HAVE_SECURITY
+    if (first_reader->getAttributes().security_attributes().is_payload_protected)
+    {
+        if (participant_->security_manager().decode_serialized_payload(ch.serializedPayload, crypto_payload_, first_reader->getGuid(), ch.writerGUID))
+        {
+            ch.serializedPayload.data = crypto_payload_.data;
+            ch.serializedPayload.length = crypto_payload_.length;
+        }
+    }
+#endif  // HAVE_SECURITY
+
     //FIXME: DO SOMETHING WITH PARAMETERLIST CREATED.
     logInfo(RTPS_MSG_IN, IDSTRING "from Writer " << ch.writerGUID << "; possible RTPSReader entities: " <<
         associated_readers_.size());

--- a/src/cpp/rtps/messages/RTPSMessageGroup.cpp
+++ b/src/cpp/rtps/messages/RTPSMessageGroup.cpp
@@ -47,7 +47,7 @@ bool sort_SeqNum(
     return(s1 < s2);
 }
 
-typedef std::pair<SequenceNumber_t,SequenceNumberSet_t> pair_T;
+typedef std::pair<SequenceNumber_t, SequenceNumberSet_t> pair_T;
 
 bool compare_remote_participants(
         const std::vector<GUID_t>& remote_participants1,
@@ -105,7 +105,8 @@ const EntityId_t& get_entity_id(
 
     const EntityId_t& entityid = endpoints.at(0).entityId;
 
-    for (auto it = endpoints.begin() + 1; it != endpoints.end(); ++it){
+    for (auto it = endpoints.begin() + 1; it != endpoints.end(); ++it)
+    {
         if (entityid != it->entityId)
         {
             return c_EntityId_Unknown;
@@ -128,7 +129,7 @@ RTPSMessageGroup::RTPSMessageGroup(
     , participant_(participant)
 #if HAVE_SECURITY
     , encrypt_msg_(nullptr)
-#endif
+#endif // if HAVE_SECURITY
     , max_blocking_time_point_(max_blocking_time_point)
     , send_buffer_(participant->get_send_buffer())
 {
@@ -152,7 +153,7 @@ RTPSMessageGroup::RTPSMessageGroup(
         encrypt_msg_ = &(send_buffer_->rtpsmsg_encrypt_);
         CDRMessage::initCDRMsg(encrypt_msg_);
     }
-#endif
+#endif // if HAVE_SECURITY
 }
 
 RTPSMessageGroup::~RTPSMessageGroup() noexcept(false)
@@ -203,13 +204,13 @@ void RTPSMessageGroup::send()
             if (!participant_->security_manager().encode_rtps_message(*full_msg_, *encrypt_msg_,
                     sender_.remote_participants()))
             {
-                logError(RTPS_WRITER,"Error encoding rtps message.");
+                logError(RTPS_WRITER, "Error encoding rtps message.");
                 return;
             }
 
             msgToSend = encrypt_msg_;
         }
-#endif
+#endif // if HAVE_SECURITY
 
         if (!sender_.send(msgToSend, max_blocking_time_point_))
         {
@@ -253,13 +254,13 @@ bool RTPSMessageGroup::insert_submessage(
 
         if (!add_info_dst_in_buffer(full_msg_, destination_guid_prefix))
         {
-            logError(RTPS_WRITER,"Cannot add INFO_DST submessage to the CDRMessage. Buffer too small");
+            logError(RTPS_WRITER, "Cannot add INFO_DST submessage to the CDRMessage. Buffer too small");
             return false;
         }
 
         if (!CDRMessage::appendMsg(full_msg_, submessage_msg_))
         {
-            logError(RTPS_WRITER,"Cannot add RTPS submesage to the CDRMessage. Buffer too small");
+            logError(RTPS_WRITER, "Cannot add RTPS submesage to the CDRMessage. Buffer too small");
             return false;
         }
     }
@@ -285,7 +286,7 @@ bool RTPSMessageGroup::add_info_dst_in_buffer(
         RTPSMessageCreator::addSubmessageInfoSRC(buffer, c_ProtocolVersion, c_VendorId_eProsima,
                 participant_->getGuid().guidPrefix);
     }
-#endif
+#endif // if HAVE_SECURITY
 
     if (current_dst_ != destination_guid_prefix)
     {
@@ -303,7 +304,7 @@ bool RTPSMessageGroup::add_info_ts_in_buffer(
 
 #if HAVE_SECURITY
     uint32_t from_buffer_position = submessage_msg_->pos;
-#endif
+#endif // if HAVE_SECURITY
 
     if (!RTPSMessageCreator::addSubmessageInfoTS(submessage_msg_, timestamp, false))
     {
@@ -335,7 +336,7 @@ bool RTPSMessageGroup::add_info_ts_in_buffer(
             return false;
         }
     }
-#endif
+#endif // if HAVE_SECURITY
 
     return true;
 }
@@ -344,7 +345,7 @@ bool RTPSMessageGroup::add_data(
         const CacheChange_t& change,
         bool expectsInlineQos)
 {
-    logInfo(RTPS_WRITER,"Sending relevant changes as DATA/DATA_FRAG messages");
+    logInfo(RTPS_WRITER, "Sending relevant changes as DATA/DATA_FRAG messages");
 
     // Check preconditions. If fail flush and reset.
     check_and_maybe_flush();
@@ -359,7 +360,7 @@ bool RTPSMessageGroup::add_data(
 
 #if HAVE_SECURITY
     uint32_t from_buffer_position = submessage_msg_->pos;
-#endif
+#endif // if HAVE_SECURITY
     const EntityId_t& readerId = get_entity_id(sender_.remote_guids());
 
     CacheChange_t change_to_add;
@@ -376,7 +377,7 @@ bool RTPSMessageGroup::add_data(
 
         // If payload protection, encode payload
         if (!participant_->security_manager().encode_serialized_payload(change_to_add.serializedPayload,
-            encrypt_payload, endpoint_->getGuid()))
+                encrypt_payload, endpoint_->getGuid()))
         {
             logError(RTPS_WRITER, "Error encoding change " << change.sequenceNumber);
             change_to_add.serializedPayload.data = nullptr;
@@ -388,7 +389,7 @@ bool RTPSMessageGroup::add_data(
         encrypt_payload.data = nullptr;
         change_to_add.serializedPayload.length = encrypt_payload.length;
     }
-#endif
+#endif // if HAVE_SECURITY
 
     // TODO (Ricardo). Check to create special wrapper.
     bool is_big_submessage;
@@ -425,7 +426,7 @@ bool RTPSMessageGroup::add_data(
             return false;
         }
     }
-#endif
+#endif // if HAVE_SECURITY
 
     return insert_submessage(is_big_submessage);
 }
@@ -435,7 +436,7 @@ bool RTPSMessageGroup::add_data_frag(
         const uint32_t fragment_number,
         bool expectsInlineQos)
 {
-    logInfo(RTPS_WRITER,"Sending relevant changes as DATA/DATA_FRAG messages");
+    logInfo(RTPS_WRITER, "Sending relevant changes as DATA/DATA_FRAG messages");
 
     // Check preconditions. If fail flush and reset.
     check_and_maybe_flush();
@@ -450,7 +451,7 @@ bool RTPSMessageGroup::add_data_frag(
 
 #if HAVE_SECURITY
     uint32_t from_buffer_position = submessage_msg_->pos;
-#endif
+#endif // if HAVE_SECURITY
     const EntityId_t& readerId = get_entity_id(sender_.remote_guids());
 
     // Calculate fragment start
@@ -486,7 +487,7 @@ bool RTPSMessageGroup::add_data_frag(
         encrypt_payload.data = nullptr;
         change_to_add.serializedPayload.length = encrypt_payload.length;
     }
-#endif
+#endif // if HAVE_SECURITY
 
     if (!RTPSMessageCreator::addSubmessageDataFrag(submessage_msg_, &change_to_add, fragment_number,
             change.serializedPayload.length, endpoint_->getAttributes().topicKind, readerId,
@@ -522,7 +523,7 @@ bool RTPSMessageGroup::add_data_frag(
             return false;
         }
     }
-#endif
+#endif // if HAVE_SECURITY
 
     return insert_submessage(false);
 }
@@ -538,7 +539,7 @@ bool RTPSMessageGroup::add_heartbeat(
 
 #if HAVE_SECURITY
     uint32_t from_buffer_position = submessage_msg_->pos;
-#endif
+#endif // if HAVE_SECURITY
 
     const EntityId_t& readerId = get_entity_id(sender_.remote_guids());
 
@@ -573,7 +574,7 @@ bool RTPSMessageGroup::add_heartbeat(
             return false;
         }
     }
-#endif
+#endif // if HAVE_SECURITY
 
     return insert_submessage(false);
 }
@@ -636,7 +637,7 @@ bool RTPSMessageGroup::create_gap_submessage(
 {
 #if HAVE_SECURITY
     uint32_t from_buffer_position = submessage_msg_->pos;
-#endif
+#endif // if HAVE_SECURITY
 
     if (!RTPSMessageCreator::addSubmessageGap(submessage_msg_, gap_initial_sequence, gap_bitmap,
             reader_id, endpoint_->getGuid().entityId))
@@ -669,7 +670,7 @@ bool RTPSMessageGroup::create_gap_submessage(
             return false;
         }
     }
-#endif
+#endif // if HAVE_SECURITY
 
     return true;
 }
@@ -691,7 +692,7 @@ bool RTPSMessageGroup::add_acknack(
 
 #if HAVE_SECURITY
     uint32_t from_buffer_position = submessage_msg_->pos;
-#endif
+#endif // if HAVE_SECURITY
 
     if (!RTPSMessageCreator::addSubmessageAcknack(submessage_msg_, endpoint_->getGuid().entityId,
             sender_.remote_guids().front().entityId, SNSet, count, finalFlag))
@@ -724,7 +725,7 @@ bool RTPSMessageGroup::add_acknack(
             return false;
         }
     }
-#endif
+#endif // if HAVE_SECURITY
 
     return insert_submessage(false);
 }
@@ -741,7 +742,7 @@ bool RTPSMessageGroup::add_nackfrag(
 
 #if HAVE_SECURITY
     uint32_t from_buffer_position = submessage_msg_->pos;
-#endif
+#endif // if HAVE_SECURITY
 
     if (!RTPSMessageCreator::addSubmessageNackFrag(submessage_msg_, endpoint_->getGuid().entityId,
             sender_.remote_guids().front().entityId, writerSN, fnState, count))
@@ -774,7 +775,7 @@ bool RTPSMessageGroup::add_nackfrag(
             return false;
         }
     }
-#endif
+#endif // if HAVE_SECURITY
 
     return insert_submessage(false);
 }

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -405,24 +405,6 @@ bool StatefulReader::processDataFragMsg(
 
             CacheChange_t* change_to_add = incomingChange;
 
-#if HAVE_SECURITY
-            if (getAttributes().security_attributes().is_payload_protected)
-            {
-                if (reserveCache(&change_to_add, incomingChange->serializedPayload.length)) //Reserve a new cache from the corresponding cache pool
-                {
-                    change_to_add->copy_not_memcpy(incomingChange);
-                    if (!getRTPSParticipant()->security_manager().decode_serialized_payload(incomingChange->
-                            serializedPayload,
-                            change_to_add->serializedPayload, m_guid, incomingChange->writerGUID))
-                    {
-                        releaseCache(change_to_add);
-                        logWarning(RTPS_MSG_IN, "Cannont decode serialized payload");
-                        return false;
-                    }
-                }
-            }
-#endif // if HAVE_SECURITY
-
             CacheChange_t* change_created = nullptr;
             CacheChange_t* work_change = nullptr;
             if (!mp_history->get_change(change_to_add->sequenceNumber, change_to_add->writerGUID, &work_change))
@@ -450,13 +432,6 @@ bool StatefulReader::processDataFragMsg(
                 work_change->add_fragments(change_to_add->serializedPayload, fragmentStartingNum,
                         fragmentsInSubmessage);
             }
-
-#if HAVE_SECURITY
-            if (getAttributes().security_attributes().is_payload_protected)
-            {
-                releaseCache(change_to_add);
-            }
-#endif // if HAVE_SECURITY
 
             // If this is the first time we have received fragments for this change, add it to history
             if (change_created != nullptr)

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -334,21 +334,6 @@ bool StatefulReader::processDataMsg(
 
             if (reserveCache(&change_to_add, change->serializedPayload.length)) //Reserve a new cache from the corresponding cache pool
             {
-#if HAVE_SECURITY
-                if (getAttributes().security_attributes().is_payload_protected)
-                {
-                    change_to_add->copy_not_memcpy(change);
-                    if (!getRTPSParticipant()->security_manager().decode_serialized_payload(change->serializedPayload,
-                            change_to_add->serializedPayload, m_guid, change->writerGUID))
-                    {
-                        releaseCache(change_to_add);
-                        logWarning(RTPS_MSG_IN, "Cannont decode serialized payload");
-                        return false;
-                    }
-                }
-                else
-                {
-#endif // if HAVE_SECURITY
                 if (!change_to_add->copy(change))
                 {
                     logWarning(RTPS_MSG_IN, IDSTRING "Problem copying CacheChange, received data is: " << change->serializedPayload.length
@@ -357,9 +342,6 @@ bool StatefulReader::processDataMsg(
                     releaseCache(change_to_add);
                     return false;
                 }
-#if HAVE_SECURITY
-            }
-#endif // if HAVE_SECURITY
             }
             else
             {

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -266,22 +266,6 @@ bool StatelessReader::processDataMsg(
         //Reserve a new cache from the corresponding cache pool
         if (reserveCache(&change_to_add, change->serializedPayload.length))
         {
-#if HAVE_SECURITY
-            if (getAttributes().security_attributes().is_payload_protected)
-            {
-                change_to_add->copy_not_memcpy(change);
-                if (!getRTPSParticipant()->security_manager().decode_serialized_payload(
-                            change->serializedPayload,
-                            change_to_add->serializedPayload, m_guid, change->writerGUID))
-                {
-                    releaseCache(change_to_add);
-                    logWarning(RTPS_MSG_IN, "Cannont decode serialized payload");
-                    return false;
-                }
-            }
-            else
-            {
-#endif // if HAVE_SECURITY
             if (!change_to_add->copy(change))
             {
                 logWarning(RTPS_MSG_IN, IDSTRING "Problem copying CacheChange, received data is: "
@@ -290,9 +274,6 @@ bool StatelessReader::processDataMsg(
                 releaseCache(change_to_add);
                 return false;
             }
-#if HAVE_SECURITY
-        }
-#endif // if HAVE_SECURITY
         }
         else
         {

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -323,25 +323,6 @@ bool StatelessReader::processDataFragMsg(
 
                 CacheChange_t* change_to_add = incomingChange;
 
-#if HAVE_SECURITY
-                if (getAttributes().security_attributes().is_payload_protected)
-                {
-                    // Reserve a new cache from the corresponding cache pool
-                    if (reserveCache(&change_to_add, incomingChange->serializedPayload.length))
-                    {
-                        change_to_add->copy_not_memcpy(incomingChange);
-                        if (!getRTPSParticipant()->security_manager().decode_serialized_payload(
-                                    incomingChange->serializedPayload,
-                                    change_to_add->serializedPayload, m_guid, writer_guid))
-                        {
-                            releaseCache(change_to_add);
-                            logWarning(RTPS_MSG_IN, "Cannont decode serialized payload");
-                            return false;
-                        }
-                    }
-                }
-#endif // if HAVE_SECURITY
-
                 // Check if pending fragmented change should be dropped
                 if (work_change != nullptr)
                 {
@@ -396,13 +377,6 @@ bool StatelessReader::processDataFragMsg(
                 }
 
                 writer.fragmented_change = work_change;
-
-#if HAVE_SECURITY
-                if (getAttributes().security_attributes().is_payload_protected)
-                {
-                    releaseCache(change_to_add);
-                }
-#endif // if HAVE_SECURITY
 
                 // If the change was completed, process it.
                 if (change_completed != nullptr)

--- a/src/cpp/rtps/writer/RTPSWriter.cpp
+++ b/src/cpp/rtps/writer/RTPSWriter.cpp
@@ -170,7 +170,7 @@ uint32_t RTPSWriter::calculateMaxDataSize(
     {
         maxDataSize -= mp_RTPSParticipant->security_manager().calculate_extra_size_for_encoded_payload(m_guid);
     }
-#endif
+#endif // if HAVE_SECURITY
 
     return maxDataSize;
 }

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -232,10 +232,6 @@ void StatefulWriter::unsent_change_added_to_history(
             liveliness_lease_duration_);
     }
 
-#if HAVE_SECURITY
-    encrypt_cachechange(change);
-#endif // if HAVE_SECURITY
-
     if (!matched_readers_.empty())
     {
         if (!isAsync())

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -200,10 +200,6 @@ void StatelessWriter::unsent_change_added_to_history(
             liveliness_lease_duration_);
     }
 
-#if HAVE_SECURITY
-    encrypt_cachechange(change);
-#endif
-
     if (!fixed_locators_.empty() || matched_readers_.size() > 0)
     {
         if (!isAsync())

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -133,7 +133,7 @@ void StatelessWriter::get_builtin_guid()
     {
         add_guid(GUID_t { GuidPrefix_t(), participant_stateless_message_reader_entity_id });
     }
-#endif
+#endif // if HAVE_SECURITY
 }
 
 bool StatelessWriter::has_builtin_guid()
@@ -147,7 +147,7 @@ bool StatelessWriter::has_builtin_guid()
     {
         return true;
     }
-#endif
+#endif // if HAVE_SECURITY
     return false;
 }
 
@@ -174,9 +174,9 @@ void StatelessWriter::update_reader_info(
     {
         RTPSParticipantImpl* part = mp_RTPSParticipant;
         locator_selector_.for_each([part](const Locator_t& loc)
-                    {
-                        part->createSenderResources(loc);
-                    });
+                {
+                    part->createSenderResources(loc);
+                });
     }
 }
 
@@ -328,10 +328,10 @@ bool StatelessWriter::change_removed_by_history(
 
     unsent_changes_.remove_if(
         [change](ChangeForReader_t& cptr)
-                {
-                    return cptr.getChange() == change ||
-                    cptr.getChange()->sequenceNumber == change->sequenceNumber;
-                });
+        {
+            return cptr.getChange() == change ||
+            cptr.getChange()->sequenceNumber == change->sequenceNumber;
+        });
 
     return true;
 }
@@ -348,9 +348,9 @@ bool StatelessWriter::is_acked_by_all(
         auto it = std::find_if(unsent_changes_.begin(),
                         unsent_changes_.end(),
                         [change](const ChangeForReader_t& unsent_change)
-                    {
-                        return change == unsent_change.getChange();
-                    });
+                        {
+                            return change == unsent_change.getChange();
+                        });
 
         return it == unsent_changes_.end();
     }
@@ -736,7 +736,7 @@ bool StatelessWriter::set_fixed_locators(
         logError(RTPS_WRITER, "A secure besteffort writer cannot add a lonely locator");
         return false;
     }
-#endif
+#endif // if HAVE_SECURITY
 
     std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
 
@@ -779,9 +779,9 @@ bool StatelessWriter::matched_reader_is_matched(
     std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
     return std::any_of(matched_readers_.begin(), matched_readers_.end(),
                    [reader_guid](const ReaderLocator& item)
-                {
-                    return item.remote_guid() == reader_guid;
-                });
+                   {
+                       return item.remote_guid() == reader_guid;
+                   });
 }
 
 void StatelessWriter::unsent_changes_reset()

--- a/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
@@ -342,6 +342,8 @@ public:
         // By default, heartbeat period delay is 100 milliseconds.
         datareader_qos_.reliable_reader_qos().times.heartbeatResponseDelay.seconds = 0;
         datareader_qos_.reliable_reader_qos().times.heartbeatResponseDelay.nanosec = 100000000;
+
+        datareader_qos_.reliability().kind = ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS;
     }
 
     ~PubSubWriterReader()

--- a/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
@@ -626,6 +626,20 @@ public:
 
 #endif // if HAVE_SECURITY
 
+    PubSubWriterReader& pub_durability_kind(
+            const eprosima::fastrtps::DurabilityQosPolicyKind kind)
+    {
+        datawriter_qos_.durability().kind = kind;
+        return *this;
+    }
+
+    PubSubWriterReader& sub_durability_kind(
+            const eprosima::fastrtps::DurabilityQosPolicyKind kind)
+    {
+        datareader_qos_.durability().kind = kind;
+        return *this;
+    }
+
     PubSubWriterReader& pub_reliability(
             const eprosima::fastrtps::ReliabilityQosPolicyKind kind)
     {

--- a/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
@@ -342,9 +342,6 @@ public:
         // By default, heartbeat period delay is 100 milliseconds.
         datareader_qos_.reliable_reader_qos().times.heartbeatResponseDelay.seconds = 0;
         datareader_qos_.reliable_reader_qos().times.heartbeatResponseDelay.nanosec = 100000000;
-
-        datareader_qos_.reliability().kind =
-                eprosima::fastdds::dds::ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS;
     }
 
     ~PubSubWriterReader()
@@ -628,6 +625,48 @@ public:
     }
 
 #endif // if HAVE_SECURITY
+
+    PubSubWriterReader& pub_reliability(
+            const eprosima::fastrtps::ReliabilityQosPolicyKind kind)
+    {
+        datawriter_qos_.reliability().kind = kind;
+        return *this;
+    }
+
+    PubSubWriterReader& sub_reliability(
+            const eprosima::fastrtps::ReliabilityQosPolicyKind kind)
+    {
+        datareader_qos_.reliability().kind = kind;
+        return *this;
+    }
+
+    PubSubWriterReader& pub_history_kind(
+            const eprosima::fastrtps::HistoryQosPolicyKind kind)
+    {
+        datawriter_qos_.history().kind = kind;
+        return *this;
+    }
+
+    PubSubWriterReader& sub_history_kind(
+            const eprosima::fastrtps::HistoryQosPolicyKind kind)
+    {
+        datareader_qos_.history().kind = kind;
+        return *this;
+    }
+
+    PubSubWriterReader& pub_history_depth(
+            const int32_t depth)
+    {
+        datawriter_qos_.history().depth = depth;
+        return *this;
+    }
+
+    PubSubWriterReader& sub_history_depth(
+            const int32_t depth)
+    {
+        datareader_qos_.history().depth = depth;
+        return *this;
+    }
 
     PubSubWriterReader& property_policy(
             const eprosima::fastrtps::rtps::PropertyPolicy property_policy)

--- a/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
@@ -343,7 +343,8 @@ public:
         datareader_qos_.reliable_reader_qos().times.heartbeatResponseDelay.seconds = 0;
         datareader_qos_.reliable_reader_qos().times.heartbeatResponseDelay.nanosec = 100000000;
 
-        datareader_qos_.reliability().kind = ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS;
+        datareader_qos_.reliability().kind =
+                eprosima::fastdds::dds::ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS;
     }
 
     ~PubSubWriterReader()

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriterReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriterReader.hpp
@@ -339,6 +339,8 @@ public:
         // By default, heartbeat period delay is 100 milliseconds.
         subscriber_attr_.times.heartbeatResponseDelay.seconds = 0;
         subscriber_attr_.times.heartbeatResponseDelay.nanosec = 100000000;
+
+        subscriber_attr_.qos.m_reliability.kind = ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS;
     }
 
     ~PubSubWriterReader()

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriterReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriterReader.hpp
@@ -343,7 +343,7 @@ public:
         subscriber_attr_.times.heartbeatResponseDelay.seconds = 0;
         subscriber_attr_.times.heartbeatResponseDelay.nanosec = 100000000;
 
-        subscriber_attr_.qos.m_reliability.kind = ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS;
+        subscriber_attr_.qos.m_reliability.kind = eprosima::fastrtps::RELIABLE_RELIABILITY_QOS;
     }
 
     ~PubSubWriterReader()

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriterReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriterReader.hpp
@@ -562,6 +562,20 @@ public:
 
 #endif // if HAVE_SECURITY
 
+    PubSubWriterReader& pub_durability_kind(
+            const eprosima::fastrtps::DurabilityQosPolicyKind kind)
+    {
+        publisher_attr_.qos.m_durability.kind = kind;
+        return *this;
+    }
+
+    PubSubWriterReader& sub_durability_kind(
+            const eprosima::fastrtps::DurabilityQosPolicyKind kind)
+    {
+        subscriber_attr_.qos.m_durability.kind = kind;
+        return *this;
+    }
+
     PubSubWriterReader& pub_reliability(
             const eprosima::fastrtps::ReliabilityQosPolicyKind kind)
     {

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriterReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriterReader.hpp
@@ -45,7 +45,7 @@ class PubSubWriterReader
 {
     class ParticipantListener : public eprosima::fastrtps::ParticipantListener
     {
-public:
+    public:
 
         ParticipantListener(
                 PubSubWriterReader& wreader)
@@ -72,7 +72,7 @@ public:
             }
         }
 
-#endif
+#endif // if HAVE_SECURITY
         void onParticipantDiscovery(
                 eprosima::fastrtps::Participant* participant,
                 eprosima::fastrtps::rtps::ParticipantDiscoveryInfo&& info) override
@@ -159,7 +159,7 @@ public:
             return discovered_subscribers_.size();
         }
 
-private:
+    private:
 
         //! Mutex guarding all info collections
         mutable std::mutex info_mutex_;
@@ -192,11 +192,12 @@ private:
         //! Pointer to the pub sub writer reader
         PubSubWriterReader& wreader_;
 
-    } participant_listener_;
+    }
+    participant_listener_;
 
     class PubListener : public eprosima::fastrtps::PublisherListener
     {
-public:
+    public:
 
         PubListener(
                 PubSubWriterReader& wreader)
@@ -222,18 +223,19 @@ public:
             }
         }
 
-private:
+    private:
 
         PubListener& operator =(
                 const PubListener&) = delete;
 
         PubSubWriterReader& wreader_;
 
-    } pub_listener_;
+    }
+    pub_listener_;
 
     class SubListener : public eprosima::fastrtps::SubscriberListener
     {
-public:
+    public:
 
         SubListener(
                 PubSubWriterReader& wreader)
@@ -274,13 +276,14 @@ public:
             }
         }
 
-private:
+    private:
 
         SubListener& operator =(
                 const SubListener&) = delete;
 
         PubSubWriterReader& wreader_;
-    } sub_listener_;
+    }
+    sub_listener_;
 
     friend class PubListener;
     friend class SubListener;
@@ -305,7 +308,7 @@ public:
 #if HAVE_SECURITY
         , authorized_(0)
         , unauthorized_(0)
-#endif
+#endif // if HAVE_SECURITY
     {
         publisher_attr_.topic.topicDataType = type_.getName();
         subscriber_attr_.topic.topicDataType = type_.getName();
@@ -483,9 +486,10 @@ public:
 
     void block_for_all()
     {
-        block([this]() -> bool {
-            return number_samples_expected_ == current_received_count_;
-        });
+        block([this]() -> bool
+                {
+                    return number_samples_expected_ == current_received_count_;
+                });
     }
 
     void block(
@@ -558,7 +562,7 @@ public:
         std::cout << "WReader unauthorization finished..." << std::endl;
     }
 
-#endif
+#endif // if HAVE_SECURITY
 
     PubSubWriterReader& property_policy(
             const eprosima::fastrtps::rtps::PropertyPolicy property_policy)
@@ -689,7 +693,7 @@ private:
         cvAuthentication_.notify_all();
     }
 
-#endif
+#endif // if HAVE_SECURITY
 
     PubSubWriterReader& operator =(
             const PubSubWriterReader&) = delete;
@@ -722,7 +726,7 @@ private:
     std::condition_variable cvAuthentication_;
     unsigned int authorized_;
     unsigned int unauthorized_;
-#endif
+#endif // if HAVE_SECURITY
 };
 
 #endif // _TEST_BLACKBOX_PUBSUBWRITER_HPP_

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriterReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriterReader.hpp
@@ -342,8 +342,6 @@ public:
         // By default, heartbeat period delay is 100 milliseconds.
         subscriber_attr_.times.heartbeatResponseDelay.seconds = 0;
         subscriber_attr_.times.heartbeatResponseDelay.nanosec = 100000000;
-
-        subscriber_attr_.qos.m_reliability.kind = eprosima::fastrtps::RELIABLE_RELIABILITY_QOS;
     }
 
     ~PubSubWriterReader()
@@ -563,6 +561,48 @@ public:
     }
 
 #endif // if HAVE_SECURITY
+
+    PubSubWriterReader& pub_reliability(
+            const eprosima::fastrtps::ReliabilityQosPolicyKind kind)
+    {
+        publisher_attr_.qos.m_reliability.kind = kind;
+        return *this;
+    }
+
+    PubSubWriterReader& sub_reliability(
+            const eprosima::fastrtps::ReliabilityQosPolicyKind kind)
+    {
+        subscriber_attr_.qos.m_reliability.kind = kind;
+        return *this;
+    }
+
+    PubSubWriterReader& pub_history_kind(
+            const eprosima::fastrtps::HistoryQosPolicyKind kind)
+    {
+        publisher_attr_.topic.historyQos.kind = kind;
+        return *this;
+    }
+
+    PubSubWriterReader& sub_history_kind(
+            const eprosima::fastrtps::HistoryQosPolicyKind kind)
+    {
+        subscriber_attr_.topic.historyQos.kind = kind;
+        return *this;
+    }
+
+    PubSubWriterReader& pub_history_depth(
+            const int32_t depth)
+    {
+        publisher_attr_.topic.historyQos.depth = depth;
+        return *this;
+    }
+
+    PubSubWriterReader& sub_history_depth(
+            const int32_t depth)
+    {
+        subscriber_attr_.topic.historyQos.depth = depth;
+        return *this;
+    }
 
     PubSubWriterReader& property_policy(
             const eprosima::fastrtps::rtps::PropertyPolicy property_policy)

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -1473,6 +1473,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_payload_ok_same_participan
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     wreader.sub_history_depth(10).sub_reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS);
+    wreader.sub_durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS);
+    wreader.pub_durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS);
     wreader.property_policy(property_policy).
     pub_property_policy(pub_property_policy).
     sub_property_policy(sub_property_policy).init();

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -1451,6 +1451,47 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_payload_ok_same_participan
     wreader.block_for_all();
 }
 
+TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_payload_ok_same_participant_300kb)
+{
+    PubSubWriterReader<Data1mbType> wreader(TEST_TOPIC_NAME);
+
+    PropertyPolicy pub_property_policy, sub_property_policy,
+        property_policy;
+
+    property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
+        "builtin.PKI-DH"));
+    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
+        "file://" + std::string(certs_path) + "/maincacert.pem"));
+    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
+        "file://" + std::string(certs_path) + "/mainpubcert.pem"));
+    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
+        "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
+        "builtin.AES-GCM-GMAC"));
+    pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
+    sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
+
+    wreader.property_policy(property_policy).
+        pub_property_policy(pub_property_policy).
+        sub_property_policy(sub_property_policy).init();
+
+    ASSERT_TRUE(wreader.isInitialized());
+
+    // Wait for discovery.
+    wreader.wait_discovery();
+
+    auto data = default_data300kb_data_generator();
+
+    wreader.startReception(data);
+
+    // Send data
+    wreader.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+    // Block reader until reception finished or timeout.
+    wreader.block_for_all();
+}
+
 TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_large_string)
 {
     PubSubReader<StringType> reader(TEST_TOPIC_NAME);

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -129,6 +129,7 @@ TEST_P(Security, BuiltinAuthenticationPlugin_PKIDH_validation_ok_same_participan
     property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
             "file://" + std::string(certs_path) + "/mainpubkey.pem"));
 
+    wreader.sub_history_depth(10).sub_reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS);
     wreader.property_policy(property_policy).init();
 
     ASSERT_TRUE(wreader.isInitialized());
@@ -984,6 +985,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_submessage_ok_same_partici
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
+    wreader.sub_history_depth(10).sub_reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS);
     wreader.property_policy(property_policy).
     pub_property_policy(pub_property_policy).
     sub_property_policy(sub_property_policy).init();
@@ -1430,6 +1432,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_payload_ok_same_participan
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
+    wreader.sub_history_depth(10).sub_reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS);
     wreader.property_policy(property_policy).
     pub_property_policy(pub_property_policy).
     sub_property_policy(sub_property_policy).init();
@@ -1469,6 +1472,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_payload_ok_same_participan
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
+    wreader.sub_history_depth(10).sub_reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS);
     wreader.property_policy(property_policy).
     pub_property_policy(pub_property_policy).
     sub_property_policy(sub_property_policy).init();

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -1455,25 +1455,23 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_payload_ok_same_participan
 {
     PubSubWriterReader<Data1mbType> wreader(TEST_TOPIC_NAME);
 
-    PropertyPolicy pub_property_policy, sub_property_policy,
-        property_policy;
+    PropertyPolicy pub_property_policy, sub_property_policy, property_policy;
 
-    property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-        "builtin.PKI-DH"));
+    property_policy.properties().emplace_back(Property("dds.sec.auth.plugin", "builtin.PKI-DH"));
     property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-        "file://" + std::string(certs_path) + "/maincacert.pem"));
+            "file://" + std::string(certs_path) + "/maincacert.pem"));
     property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-        "file://" + std::string(certs_path) + "/mainpubcert.pem"));
+            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
     property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-        "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
     property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-        "builtin.AES-GCM-GMAC"));
+            "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     wreader.property_policy(property_policy).
-        pub_property_policy(pub_property_policy).
-        sub_property_policy(sub_property_policy).init();
+    pub_property_policy(pub_property_policy).
+    sub_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(wreader.isInitialized());
 


### PR DESCRIPTION
This PR makes the payload protection behavior consistent on all cases.

Before this PR, encoding was performed on different places depending on fragmentation:
* Fragmented data was protected by code on `RTPSMessageGroup`
* Non-fragmented data was protected by code on `RTPSWriter`

Decoding was always done by code on descendants of `RTPSReader`

This produced a bug when using payload protection between endpoints on the same participant for big data types.

This PR leaves the responsibility of encoding to `RTPSMessageGroup`, and the decoding to `MessageReceiver`, both on the messages module.