### PR TITLE
Fix for late-joiners KEEP_LAST, RELIABLE, TRANSIENT_LOCAL [8986]

### DIFF
--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -57,17 +57,19 @@ SubscriberHistory::SubscriberHistory(
         uint32_t payloadMaxSize,
         MemoryManagementPolicy_t mempolicy)
     : ReaderHistory(HistoryAttributes(mempolicy, payloadMaxSize,
+    // *INDENT-OFF* uncrustify does not recognize the ? operator
             topic_att.historyQos.kind == KEEP_ALL_HISTORY_QOS ?
-            topic_att.resourceLimitsQos.allocated_samples :
-            topic_att.getTopicKind() == NO_KEY ?
-            std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth) :
-            std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth
-            * topic_att.resourceLimitsQos.max_instances),
+                topic_att.resourceLimitsQos.allocated_samples :
+                topic_att.getTopicKind() == NO_KEY ?
+                    std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth) :
+                    std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth
+                            * topic_att.resourceLimitsQos.max_instances),
             topic_att.historyQos.kind == KEEP_ALL_HISTORY_QOS ?
-            topic_att.resourceLimitsQos.max_samples :
-            topic_att.getTopicKind() == NO_KEY ?
-            topic_att.historyQos.depth :
-            topic_att.historyQos.depth * topic_att.resourceLimitsQos.max_instances))
+                topic_att.resourceLimitsQos.max_samples :
+                topic_att.getTopicKind() == NO_KEY ?
+                    topic_att.historyQos.depth :
+                    topic_att.historyQos.depth * topic_att.resourceLimitsQos.max_instances))
+    // *INDENT-ON*
     , history_qos_(topic_att.historyQos)
     , resource_limited_qos_(topic_att.resourceLimitsQos)
     , topic_att_(topic_att)

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -57,17 +57,17 @@ SubscriberHistory::SubscriberHistory(
         uint32_t payloadMaxSize,
         MemoryManagementPolicy_t mempolicy)
     : ReaderHistory(HistoryAttributes(mempolicy, payloadMaxSize,
-                topic_att.historyQos.kind == KEEP_ALL_HISTORY_QOS ?
-                        topic_att.resourceLimitsQos.allocated_samples :
-                        topic_att.getTopicKind() == NO_KEY ?
-                            std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth) :
-                            std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth
-                                     * topic_att.resourceLimitsQos.max_instances),
-                topic_att.historyQos.kind == KEEP_ALL_HISTORY_QOS ?
-                        topic_att.resourceLimitsQos.max_samples :
-                        topic_att.getTopicKind() == NO_KEY ?
-                            topic_att.historyQos.depth :
-                            topic_att.historyQos.depth * topic_att.resourceLimitsQos.max_instances))
+            topic_att.historyQos.kind == KEEP_ALL_HISTORY_QOS ?
+            topic_att.resourceLimitsQos.allocated_samples :
+            topic_att.getTopicKind() == NO_KEY ?
+            std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth) :
+            std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth
+            * topic_att.resourceLimitsQos.max_instances),
+            topic_att.historyQos.kind == KEEP_ALL_HISTORY_QOS ?
+            topic_att.resourceLimitsQos.max_samples :
+            topic_att.getTopicKind() == NO_KEY ?
+            topic_att.historyQos.depth :
+            topic_att.historyQos.depth * topic_att.resourceLimitsQos.max_instances))
     , history_qos_(topic_att.historyQos)
     , resource_limited_qos_(topic_att.resourceLimitsQos)
     , topic_att_(topic_att)
@@ -220,7 +220,7 @@ bool SubscriberHistory::add_received_change(
 
     if (add_change(a_change))
     {
-        if (m_changes.size() == static_cast<size_t>(resource_limited_qos_.max_samples) )
+        if (m_changes.size() == static_cast<size_t>(m_att.maximumReservedCaches))
         {
             m_isHistoryFull = true;
         }
@@ -248,7 +248,7 @@ bool SubscriberHistory::add_received_change_with_key(
 
     if (add_change(a_change))
     {
-        if (m_changes.size() == static_cast<size_t>(resource_limited_qos_.max_samples))
+        if (m_changes.size() == static_cast<size_t>(m_att.maximumReservedCaches))
         {
             m_isHistoryFull = true;
         }
@@ -280,7 +280,7 @@ bool SubscriberHistory::find_key_for_change(
         bool is_key_protected = false;
 #if HAVE_SECURITY
         is_key_protected = mp_reader->getAttributes().security_attributes().is_key_protected;
-#endif
+#endif // if HAVE_SECURITY
         if (!type_->getKey(get_key_object_, &a_change->instanceHandle, is_key_protected))
         {
             return false;
@@ -314,13 +314,13 @@ bool SubscriberHistory::deserialize_change(
     if (info != nullptr)
     {
         if (topic_att_.topicKind == WITH_KEY &&
-            change->instanceHandle == c_InstanceHandle_Unknown &&
-            change->kind == ALIVE)
+                change->instanceHandle == c_InstanceHandle_Unknown &&
+                change->kind == ALIVE)
         {
             bool is_key_protected = false;
 #if HAVE_SECURITY
             is_key_protected = mp_reader->getAttributes().security_attributes().is_key_protected;
-#endif
+#endif // if HAVE_SECURITY
             type_->getKey(data, &change->instanceHandle, is_key_protected);
         }
 
@@ -534,9 +534,9 @@ bool SubscriberHistory::get_next_deadline(
                         [](
                             const std::pair<InstanceHandle_t, KeyedChanges>& lhs,
                             const std::pair<InstanceHandle_t, KeyedChanges>& rhs)
-                {
-                    return lhs.second.next_deadline_us < rhs.second.next_deadline_us;
-                });
+                        {
+                            return lhs.second.next_deadline_us < rhs.second.next_deadline_us;
+                        });
         handle = min->first;
         next_deadline_us = min->second.next_deadline_us;
         return true;

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -377,7 +377,7 @@ public:
         return total_msgs_;
     }
 
-    void startReception(
+    eprosima::fastrtps::rtps::SequenceNumber_t startReception(
             std::list<type>& msgs)
     {
         mutex_.lock();
@@ -395,6 +395,7 @@ public:
         while (ret);
 
         receiving_.store(true);
+        return last_seq;
     }
 
     void stopReception()
@@ -407,6 +408,15 @@ public:
         block([this]() -> bool
                 {
                     return number_samples_expected_ == current_received_count_;
+                });
+    }
+
+    void block_for_seq(
+            eprosima::fastrtps::rtps::SequenceNumber_t seq)
+    {
+        block([this, seq]() -> bool
+                {
+                    return last_seq == seq;
                 });
     }
 
@@ -596,6 +606,11 @@ public:
     size_t getReceivedCount() const
     {
         return current_received_count_;
+    }
+
+    eprosima::fastrtps::rtps::SequenceNumber_t get_last_sequence_received()
+    {
+        return last_seq;
     }
 
     PubSubReader& deactivate_status_listener(

--- a/test/blackbox/common/BlackboxTestsPubSubFragments.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubFragments.cpp
@@ -56,6 +56,8 @@ protected:
             std::list<Data1mb>& data,
             bool asynchronous,
             bool reliable,
+            bool volatile_reader,
+            bool volatile_writer,
             bool small_fragments)
     {
         PubSubReader<Data1mbType> reader(topic_name);
@@ -67,6 +69,9 @@ protected:
         .reliability(reliable ?
                 eprosima::fastrtps::RELIABLE_RELIABILITY_QOS :
                 eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS)
+        .durability_kind(volatile_reader ?
+                eprosima::fastrtps::VOLATILE_DURABILITY_QOS :
+                eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
         .init();
 
         ASSERT_TRUE(reader.isInitialized());
@@ -91,6 +96,9 @@ protected:
         .reliability(reliable ?
                 eprosima::fastrtps::RELIABLE_RELIABILITY_QOS :
                 eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS)
+        .durability_kind(volatile_writer ?
+                eprosima::fastrtps::VOLATILE_DURABILITY_QOS :
+                eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
         .init();
 
         ASSERT_TRUE(writer.isInitialized());
@@ -121,49 +129,145 @@ protected:
 TEST_P(PubSubFragments, PubSubAsNonReliableData300kb)
 {
     auto data = default_data300kb_data_generator();
-    do_fragment_test(TEST_TOPIC_NAME, data, false, false, false);
+    do_fragment_test(TEST_TOPIC_NAME, data, false, false, true, false, false);
+}
+
+TEST_P(PubSubFragments, PubSubAsNonReliableVolatileData300kb)
+{
+    auto data = default_data300kb_data_generator();
+    do_fragment_test(TEST_TOPIC_NAME, data, false, false, true, true, false);
+}
+
+TEST_P(PubSubFragments, PubSubAsNonReliableTransientLocalData300kb)
+{
+    auto data = default_data300kb_data_generator();
+    do_fragment_test(TEST_TOPIC_NAME, data, false, false, false, false, false);
 }
 
 TEST_P(PubSubFragments, PubSubAsNonReliableData300kbSmallFragments)
 {
     auto data = default_data300kb_data_generator();
-    do_fragment_test(TEST_TOPIC_NAME, data, false, false, true);
+    do_fragment_test(TEST_TOPIC_NAME, data, false, false, true, false, true);
+}
+
+TEST_P(PubSubFragments, PubSubAsNonReliableVolatileData300kbSmallFragments)
+{
+    auto data = default_data300kb_data_generator();
+    do_fragment_test(TEST_TOPIC_NAME, data, false, false, true, true, true);
+}
+
+TEST_P(PubSubFragments, PubSubAsNonReliableTransientLocalData300kbSmallFragments)
+{
+    auto data = default_data300kb_data_generator();
+    do_fragment_test(TEST_TOPIC_NAME, data, false, false, false, false, true);
 }
 
 TEST_P(PubSubFragments, PubSubAsReliableData300kb)
 {
     auto data = default_data300kb_data_generator();
-    do_fragment_test(TEST_TOPIC_NAME, data, false, true, false);
+    do_fragment_test(TEST_TOPIC_NAME, data, false, true, true, false, false);
+}
+
+TEST_P(PubSubFragments, PubSubAsReliableVolatileData300kb)
+{
+    auto data = default_data300kb_data_generator();
+    do_fragment_test(TEST_TOPIC_NAME, data, false, true, true, true, false);
+}
+
+TEST_P(PubSubFragments, PubSubAsReliableTransientLocalData300kb)
+{
+    auto data = default_data300kb_data_generator();
+    do_fragment_test(TEST_TOPIC_NAME, data, false, true, false, false, false);
 }
 
 TEST_P(PubSubFragments, PubSubAsReliableData300kbSmallFragments)
 {
     auto data = default_data300kb_data_generator();
-    do_fragment_test(TEST_TOPIC_NAME, data, false, true, true);
+    do_fragment_test(TEST_TOPIC_NAME, data, false, true, true, false, true);
+}
+
+TEST_P(PubSubFragments, PubSubAsReliableVolatileData300kbSmallFragments)
+{
+    auto data = default_data300kb_data_generator();
+    do_fragment_test(TEST_TOPIC_NAME, data, false, true, true, true, true);
+}
+
+TEST_P(PubSubFragments, PubSubAsReliableTransientLocalData300kbSmallFragments)
+{
+    auto data = default_data300kb_data_generator();
+    do_fragment_test(TEST_TOPIC_NAME, data, false, true, false, false, true);
 }
 
 TEST_P(PubSubFragments, AsyncPubSubAsNonReliableData300kb)
 {
     auto data = default_data300kb_data_generator();
-    do_fragment_test(TEST_TOPIC_NAME, data, true, false, false);
+    do_fragment_test(TEST_TOPIC_NAME, data, true, false, true, false, false);
+}
+
+TEST_P(PubSubFragments, AsyncPubSubAsNonReliableVolatileData300kb)
+{
+    auto data = default_data300kb_data_generator();
+    do_fragment_test(TEST_TOPIC_NAME, data, true, false, true, true, false);
+}
+
+TEST_P(PubSubFragments, AsyncPubSubAsNonReliableTransientLocalData300kb)
+{
+    auto data = default_data300kb_data_generator();
+    do_fragment_test(TEST_TOPIC_NAME, data, true, false, false, false, false);
 }
 
 TEST_P(PubSubFragments, AsyncPubSubAsNonReliableData300kbSmallFragments)
 {
     auto data = default_data300kb_data_generator();
-    do_fragment_test(TEST_TOPIC_NAME, data, true, false, true);
+    do_fragment_test(TEST_TOPIC_NAME, data, true, false, true, false, true);
+}
+
+TEST_P(PubSubFragments, AsyncPubSubAsNonReliableVolatileData300kbSmallFragments)
+{
+    auto data = default_data300kb_data_generator();
+    do_fragment_test(TEST_TOPIC_NAME, data, true, false, true, true, true);
+}
+
+TEST_P(PubSubFragments, AsyncPubSubAsNonReliableTransientLocalData300kbSmallFragments)
+{
+    auto data = default_data300kb_data_generator();
+    do_fragment_test(TEST_TOPIC_NAME, data, true, false, false, false, true);
 }
 
 TEST_P(PubSubFragments, AsyncPubSubAsReliableData300kb)
 {
     auto data = default_data300kb_data_generator();
-    do_fragment_test(TEST_TOPIC_NAME, data, true, true, false);
+    do_fragment_test(TEST_TOPIC_NAME, data, true, true, true, false, false);
+}
+
+TEST_P(PubSubFragments, AsyncPubSubAsReliableVolatileData300kb)
+{
+    auto data = default_data300kb_data_generator();
+    do_fragment_test(TEST_TOPIC_NAME, data, true, true, true, true, false);
+}
+
+TEST_P(PubSubFragments, AsyncPubSubAsReliableTransientLocalData300kb)
+{
+    auto data = default_data300kb_data_generator();
+    do_fragment_test(TEST_TOPIC_NAME, data, true, true, false, false, false);
 }
 
 TEST_P(PubSubFragments, AsyncPubSubAsReliableData300kbSmallFragments)
 {
     auto data = default_data300kb_data_generator();
-    do_fragment_test(TEST_TOPIC_NAME, data, true, true, true);
+    do_fragment_test(TEST_TOPIC_NAME, data, true, true, true, false, true);
+}
+
+TEST_P(PubSubFragments, AsyncPubSubAsReliableVolatileData300kbSmallFragments)
+{
+    auto data = default_data300kb_data_generator();
+    do_fragment_test(TEST_TOPIC_NAME, data, true, true, true, true, true);
+}
+
+TEST_P(PubSubFragments, AsyncPubSubAsReliableTransientLocalData300kbSmallFragments)
+{
+    auto data = default_data300kb_data_generator();
+    do_fragment_test(TEST_TOPIC_NAME, data, true, true, false, false, true);
 }
 
 TEST_P(PubSubFragments, AsyncPubSubAsNonReliableData300kbWithFlowControl)
@@ -295,6 +399,61 @@ TEST(PubSubFragments, AsyncPubSubAsReliableData300kbInLossyConditions)
         testTransport->dropLogLength);
 }
 
+TEST(PubSubFragments, AsyncPubSubAsReliableVolatileData300kbInLossyConditions)
+{
+    PubSubReader<Data1mbType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<Data1mbType> writer(TEST_TOPIC_NAME);
+
+    reader.history_depth(5).
+    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    // When doing fragmentation, it is necessary to have some degree of
+    // flow control not to overrun the receive buffer.
+    uint32_t bytesPerPeriod = 300000;
+    uint32_t periodInMs = 200;
+    writer.add_throughput_controller_descriptor_to_pparams(bytesPerPeriod, periodInMs);
+
+    // To simulate lossy conditions, we are going to remove the default
+    // bultin transport, and instead use a lossy shim layer variant.
+    auto testTransport = std::make_shared<test_UDPv4TransportDescriptor>();
+    testTransport->sendBufferSize = 65536;
+    testTransport->receiveBufferSize = 65536;
+    // We drop 20% of all data frags
+    testTransport->dropDataFragMessagesPercentage = 20;
+    testTransport->dropLogLength = 1;
+    writer.disable_builtin_transport();
+    writer.add_user_transport_to_pparams(testTransport);
+
+    writer.history_depth(5).
+    durability_kind(eprosima::fastrtps::VOLATILE_DURABILITY_QOS).
+    asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Because its volatile the durability
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    auto data = default_data300kb_data_generator(5);
+
+    reader.startReception(data);
+
+    // Send data
+    writer.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+    // Block reader until reception finished or timeout.
+    reader.block_for_all();
+
+    // Sanity check. Make sure we have dropped a few packets
+    ASSERT_EQ(
+        eprosima::fastrtps::rtps::test_UDPv4Transport::test_UDPv4Transport_DropLog.size(),
+        testTransport->dropLogLength);
+}
+
 TEST(PubSubFragments, AsyncPubSubAsReliableData300kbInLossyConditionsSmallFragments)
 {
     PubSubReader<Data1mbType> reader(TEST_TOPIC_NAME);
@@ -325,6 +484,63 @@ TEST(PubSubFragments, AsyncPubSubAsReliableData300kbInLossyConditionsSmallFragme
     writer.add_user_transport_to_pparams(testTransport);
 
     writer.history_depth(5).
+    asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Because its volatile the durability
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    auto data = default_data300kb_data_generator(5);
+
+    reader.startReception(data);
+
+    // Send data
+    writer.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+    // Block reader until reception finished or timeout.
+    reader.block_for_all();
+
+    // Sanity check. Make sure we have dropped a few packets
+    ASSERT_EQ(
+        eprosima::fastrtps::rtps::test_UDPv4Transport::test_UDPv4Transport_DropLog.size(),
+        testTransport->dropLogLength);
+}
+
+TEST(PubSubFragments, AsyncPubSubAsReliableVolatileData300kbInLossyConditionsSmallFragments)
+{
+    PubSubReader<Data1mbType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<Data1mbType> writer(TEST_TOPIC_NAME);
+
+    reader.history_depth(5).
+    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    // When doing fragmentation, it is necessary to have some degree of
+    // flow control not to overrun the receive buffer.
+    uint32_t bytesPerPeriod = 300000;
+    uint32_t periodInMs = 200;
+    writer.add_throughput_controller_descriptor_to_pparams(bytesPerPeriod, periodInMs);
+
+    // To simulate lossy conditions, we are going to remove the default
+    // bultin transport, and instead use a lossy shim layer variant.
+    auto testTransport = std::make_shared<test_UDPv4TransportDescriptor>();
+    testTransport->sendBufferSize = 1024;
+    testTransport->maxMessageSize = 1024;
+    testTransport->receiveBufferSize = 65536;
+    // We are sending around 300 fragments per sample.
+    // We drop 1% of all data frags
+    testTransport->dropDataFragMessagesPercentage = 1;
+    testTransport->dropLogLength = 1;
+    writer.disable_builtin_transport();
+    writer.add_user_transport_to_pparams(testTransport);
+
+    writer.history_depth(5).
+    durability_kind(eprosima::fastrtps::VOLATILE_DURABILITY_QOS).
     asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).init();
 
     ASSERT_TRUE(writer.isInitialized());

--- a/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
@@ -563,6 +563,110 @@ TEST(BlackBox, PubSubAsReliableKeepLastReaderSmallDepthWithKey)
     }
 }
 
+bool comparator(
+        HelloWorld first,
+        HelloWorld second)
+{
+    return first.index() < second.index();
+}
+
+/*!
+ * @fn TEST(PubSubHistory, ReliableTransientLocalKeepLast1)
+ * @brief This test checks the correct functionality of transient local, keep last 1 late-joiners.
+ *
+ * The test creates a Reliable, Transient Local Writer with a Keep Last 10 history, and send ten samples throughout the
+ * network.
+ * Then it creates a Reliable, Transient Local Reader with a Keep Last 1 history and waits until both of them discover
+ * each other.
+ * When the Writer discovers the late-joiner, resends the samples it has on the history (in this case all). And the
+ * reader upon receiving them, as it is Keep Last 1, discards all the samples except the last one.
+ * Finally, the test checks that the last sequence number received is the one corresponding to the tenth sample.
+ */
+TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1)
+{
+    PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
+
+    writer.reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+    .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
+    .history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS)
+    .history_depth(10)
+    .resource_limits_allocated_samples(10)
+    .resource_limits_max_samples(10).init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    auto data = default_helloworld_data_generator();
+    auto expected_data = data;
+    writer.send(data);
+
+    reader.reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+    .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
+    .history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS)
+    .history_depth(1).init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    ASSERT_FALSE(expected_data.empty());
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    reader.startReception(expected_data);
+    eprosima::fastrtps::rtps::SequenceNumber_t seq;
+    seq.low = 10;
+    reader.block_for_seq(seq);
+
+    ASSERT_EQ(reader.get_last_sequence_received().low, 10);
+}
+
+TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1Data300Kb)
+{
+    PubSubReader<Data1mbType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<Data1mbType> writer(TEST_TOPIC_NAME);
+
+    auto data = default_data300kb_data_generator();
+    auto reader_data = data;
+
+    writer
+    .history_depth(static_cast<int32_t>(data.size()))
+    .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+    .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
+    .init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Send data
+    writer.send(data);
+    ASSERT_TRUE(data.empty());
+    ASSERT_FALSE(reader_data.empty());
+
+    reader
+    .socket_buffer_size(1048576)        // accomodate large and fast fragments
+    .history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS)
+    .history_depth(1)
+    //.resource_limits_max_samples(1)
+    .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+    .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
+    .init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Because its volatile the durability
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    reader.startReception(reader_data);
+    eprosima::fastrtps::rtps::SequenceNumber_t seq;
+    seq.low = 10;
+    reader.block_for_seq(seq);
+
+    ASSERT_EQ(reader.get_last_sequence_received().low, 10);
+}
+
+
 INSTANTIATE_TEST_CASE_P(PubSubHistory,
         PubSubHistory,
         testing::Values(false, true),

--- a/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
@@ -618,7 +618,7 @@ TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1)
     seq.low = 10;
     reader.block_for_seq(seq);
 
-    ASSERT_EQ(reader.get_last_sequence_received().low, 10);
+    ASSERT_EQ(reader.get_last_sequence_received().low, 10u);
 }
 
 TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1Data300Kb)
@@ -643,10 +643,8 @@ TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1Data300Kb)
     ASSERT_FALSE(reader_data.empty());
 
     reader
-    .socket_buffer_size(1048576)        // accomodate large and fast fragments
     .history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS)
     .history_depth(1)
-    //.resource_limits_max_samples(1)
     .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
     .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
     .init();
@@ -663,7 +661,7 @@ TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1Data300Kb)
     seq.low = 10;
     reader.block_for_seq(seq);
 
-    ASSERT_EQ(reader.get_last_sequence_received().low, 10);
+    ASSERT_EQ(reader.get_last_sequence_received().low, 10u);
 }
 
 

--- a/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
+++ b/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
@@ -87,6 +87,7 @@ protected:
     std::mutex samples_number_mutex_;
     unsigned int samples_number_;
     SequenceNumber_t last_sequence_number_;
+    HistoryAttributes m_att;
 
 };
 


### PR DESCRIPTION
* New large data volatile blackbox tests
* New large data transient local blackbox tests
* New blackbox tests to check #8896 bug (Transient Local, Reliable, Keep Last 1)
* Change the Subscriber History condition to check if the History is Full (Fix for the #8896 bug)