### PR TITLE
adds compiler id and removes librt for QNX

### DIFF
--- a/cmake/common/check_configuration.cmake
+++ b/cmake/common/check_configuration.cmake
@@ -16,7 +16,7 @@ macro(check_stdcxx)
     # Check C++11
     include(CheckCXXCompilerFlag)
     if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
-        CMAKE_CXX_COMPILER_ID MATCHES "Clang"OR
+        CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
         CMAKE_CXX_COMPILER_ID MATCHES "QCC")
         check_cxx_compiler_flag(-std=c++14 SUPPORTS_CXX14)
         set(HAVE_CXX14 0)

--- a/cmake/common/check_configuration.cmake
+++ b/cmake/common/check_configuration.cmake
@@ -16,7 +16,8 @@ macro(check_stdcxx)
     # Check C++11
     include(CheckCXXCompilerFlag)
     if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
-        CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        CMAKE_CXX_COMPILER_ID MATCHES "Clang"OR
+        CMAKE_CXX_COMPILER_ID MATCHES "QCC")
         check_cxx_compiler_flag(-std=c++14 SUPPORTS_CXX14)
         set(HAVE_CXX14 0)
         set(HAVE_CXX1Y 0)

--- a/cmake/modules/FindThirdpartyBoost.cmake
+++ b/cmake/modules/FindThirdpartyBoost.cmake
@@ -1,19 +1,19 @@
 # Test compilation of boost on thirdparty directory
-# and set 
+# and set
 
 # (This file is almost an identical copy of the original FindGTest.cmake file,
 #  feel free to use it as it is or modify it for your own needs.)
 
-set(THIRDPARTY_BOOST_INCLUDE_DIR 
-    ${PROJECT_SOURCE_DIR}/thirdparty/boost/include 
-    CACHE 
+set(THIRDPARTY_BOOST_INCLUDE_DIR
+    ${PROJECT_SOURCE_DIR}/thirdparty/boost/include
+    CACHE
     FILEPATH
     "Path to thirdparty/boost"
 )
 
 find_package(Threads REQUIRED)
 
-if(WIN32 OR APPLE)
+if(WIN32 OR APPLE OR QNX)
     set(THIRDPARTY_BOOST_LINK_LIBS ${CMAKE_THREAD_LIBS_INIT})
 else() # Posix
     set(THIRDPARTY_BOOST_LINK_LIBS ${CMAKE_THREAD_LIBS_INIT} rt)


### PR DESCRIPTION
Fixes #1308 
adds compiler id for QNX when checking for compiler configuration
Fixes #1309 
prevents linking against librt when cross compiling for QNX