### PR TITLE
Fix for late-joiners KEEP_LAST, RELIABLE, TRANSIENT_LOCAL <ros2_eloquent> [9016]

### DIFF
--- a/src/cpp/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/subscriber/SubscriberHistory.cpp
@@ -33,23 +33,37 @@ namespace fastrtps {
 
 using namespace rtps;
 
+static HistoryAttributes to_history_attributes(
+        const HistoryQosPolicy& history,
+        const ResourceLimitsQosPolicy& resource,
+        SubscriberImpl* simpl,
+        uint32_t payloadMaxSize,
+        MemoryManagementPolicy_t mempolicy)
+{
+    auto initial_samples = resource.allocated_samples;
+    auto max_samples = resource.max_samples;
+
+    if (history.kind != KEEP_ALL_HISTORY_QOS)
+    {
+        max_samples = history.depth;
+        if (simpl->getAttributes().topic.getTopicKind() != NO_KEY)
+        {
+            max_samples *= resource.max_instances;
+        }
+
+        initial_samples = std::min(initial_samples, max_samples);
+    }
+
+    return HistoryAttributes(mempolicy, payloadMaxSize, initial_samples, max_samples);
+}
+
 SubscriberHistory::SubscriberHistory(
         SubscriberImpl* simpl,
         uint32_t payloadMaxSize,
         const HistoryQosPolicy& history,
         const ResourceLimitsQosPolicy& resource,
         MemoryManagementPolicy_t mempolicy)
-    : ReaderHistory(HistoryAttributes(mempolicy, payloadMaxSize,
-                history.kind == KEEP_ALL_HISTORY_QOS ?
-                        resource.allocated_samples :
-                        simpl->getAttributes().topic.getTopicKind() == NO_KEY ?
-                            std::min(resource.allocated_samples, history.depth) :
-                            std::min(resource.allocated_samples, history.depth * resource.max_instances),
-                history.kind == KEEP_ALL_HISTORY_QOS ?
-                        resource.max_samples :
-                        simpl->getAttributes().topic.getTopicKind() == NO_KEY ?
-                            history.depth :
-                            history.depth * resource.max_instances))
+    : ReaderHistory(to_history_attributes(history, resource, simpl, payloadMaxSize, mempolicy))
     , m_historyQos(history)
     , m_resourceLimitsQos(resource)
     , mp_subImpl(simpl)
@@ -65,15 +79,15 @@ SubscriberHistory::SubscriberHistory(
 
     if (simpl->getAttributes().topic.getTopicKind() == NO_KEY)
     {
-        receive_fn_ = history.kind == KEEP_ALL_HISTORY_QOS ? 
-            std::bind(&SubscriberHistory::received_change_keep_all_no_key, this, _1, _2) :
-            std::bind(&SubscriberHistory::received_change_keep_last_no_key, this, _1, _2);
+        receive_fn_ = history.kind == KEEP_ALL_HISTORY_QOS ?
+                std::bind(&SubscriberHistory::received_change_keep_all_no_key, this, _1, _2) :
+                std::bind(&SubscriberHistory::received_change_keep_last_no_key, this, _1, _2);
     }
     else
     {
-        receive_fn_ = history.kind == KEEP_ALL_HISTORY_QOS ? 
-            std::bind(&SubscriberHistory::received_change_keep_all_with_key, this, _1, _2) :
-            std::bind(&SubscriberHistory::received_change_keep_last_with_key, this, _1, _2);
+        receive_fn_ = history.kind == KEEP_ALL_HISTORY_QOS ?
+                std::bind(&SubscriberHistory::received_change_keep_all_with_key, this, _1, _2) :
+                std::bind(&SubscriberHistory::received_change_keep_last_with_key, this, _1, _2);
     }
 }
 
@@ -152,7 +166,7 @@ bool SubscriberHistory::received_change_keep_all_with_key(
             return add_received_change_with_key(a_change, vit->second.cache_changes);
         }
 
-        logWarning(SUBSCRIBER, "Change not added due to maximum number of samples per instance";);
+        logWarning(SUBSCRIBER, "Change not added due to maximum number of samples per instance"; );
     }
 
     return false;
@@ -200,14 +214,14 @@ bool SubscriberHistory::add_received_change(
 
     if (add_change(a_change))
     {
-        if (m_changes.size() == static_cast<size_t>(m_resourceLimitsQos.max_samples) )
+        if (m_changes.size() == static_cast<size_t>(m_att.maximumReservedCaches))
         {
             m_isHistoryFull = true;
         }
 
         logInfo(SUBSCRIBER, mp_subImpl->getGuid().entityId
-            << ": Change " << a_change->sequenceNumber << " added from: "
-            << a_change->writerGUID;);
+                << ": Change " << a_change->sequenceNumber << " added from: "
+                << a_change->writerGUID; );
 
         return true;
     }
@@ -228,7 +242,7 @@ bool SubscriberHistory::add_received_change_with_key(
 
     if (add_change(a_change))
     {
-        if (m_changes.size() == static_cast<size_t>(m_resourceLimitsQos.max_samples))
+        if (m_changes.size() == static_cast<size_t>(m_att.maximumReservedCaches))
         {
             m_isHistoryFull = true;
         }
@@ -240,8 +254,8 @@ bool SubscriberHistory::add_received_change_with_key(
         instance_changes.push_back(a_change);
 
         logInfo(SUBSCRIBER, mp_reader->getGuid().entityId
-            << ": Change " << a_change->sequenceNumber << " added from: "
-            << a_change->writerGUID << " with KEY: " << a_change->instanceHandle;);
+                << ": Change " << a_change->sequenceNumber << " added from: "
+                << a_change->writerGUID << " with KEY: " << a_change->instanceHandle; );
 
         return true;
     }
@@ -260,7 +274,7 @@ bool SubscriberHistory::find_key_for_change(
         bool is_key_protected = false;
 #if HAVE_SECURITY
         is_key_protected = mp_reader->getAttributes().security_attributes().is_key_protected;
-#endif
+#endif // if HAVE_SECURITY
         if (!mp_subImpl->getType()->getKey(mp_getKeyObject, &a_change->instanceHandle, is_key_protected))
         {
             return false;
@@ -269,7 +283,7 @@ bool SubscriberHistory::find_key_for_change(
     else if (!a_change->instanceHandle.isDefined())
     {
         logWarning(RTPS_HISTORY, "NO KEY in topic: " << mp_subImpl->getAttributes().topic.topicName
-            << " and no method to obtain it";);
+                                                     << " and no method to obtain it"; );
         return false;
     }
 
@@ -295,13 +309,13 @@ void SubscriberHistory::deserialize_change(
         info->sourceTimestamp = change->sourceTimestamp;
         info->ownershipStrength = ownership_strength;
         if (mp_subImpl->getAttributes().topic.topicKind == WITH_KEY &&
-            change->instanceHandle == c_InstanceHandle_Unknown &&
-            change->kind == ALIVE)
+                change->instanceHandle == c_InstanceHandle_Unknown &&
+                change->kind == ALIVE)
         {
             bool is_key_protected = false;
 #if HAVE_SECURITY
             is_key_protected = mp_reader->getAttributes().security_attributes().is_key_protected;
-#endif
+#endif // if HAVE_SECURITY
             mp_subImpl->getType()->getKey(data, &change->instanceHandle, is_key_protected);
         }
         info->iHandle = change->instanceHandle;
@@ -322,22 +336,21 @@ bool SubscriberHistory::readNextData(
 
     std::unique_lock<RecursiveTimedMutex> lock(*mp_mutex, std::defer_lock);
 
-    if(lock.try_lock_until(max_blocking_time))
+    if (lock.try_lock_until(max_blocking_time))
     {
         CacheChange_t* change;
-        WriterProxy * wp;
+        WriterProxy* wp;
         if (mp_reader->nextUnreadCache(&change, &wp))
         {
             logInfo(SUBSCRIBER, mp_reader->getGuid().entityId << ": reading " << change->sequenceNumber);
             uint32_t ownership = wp && mp_subImpl->getAttributes().qos.m_ownership.kind == EXCLUSIVE_OWNERSHIP_QOS ?
-                wp->ownership_strength() : 0;
+                    wp->ownership_strength() : 0;
             deserialize_change(change, ownership, data, info);
             return true;
         }
     }
     return false;
 }
-
 
 bool SubscriberHistory::takeNextData(
         void* data,
@@ -352,16 +365,16 @@ bool SubscriberHistory::takeNextData(
 
     std::unique_lock<RecursiveTimedMutex> lock(*mp_mutex, std::defer_lock);
 
-    if(lock.try_lock_until(max_blocking_time))
+    if (lock.try_lock_until(max_blocking_time))
     {
         CacheChange_t* change;
-        WriterProxy * wp;
+        WriterProxy* wp;
         if (mp_reader->nextUntakenCache(&change, &wp))
         {
             logInfo(SUBSCRIBER, mp_reader->getGuid().entityId << ": taking seqNum" << change->sequenceNumber <<
                     " from writer: " << change->writerGUID);
             uint32_t ownership = wp && mp_subImpl->getAttributes().qos.m_ownership.kind == EXCLUSIVE_OWNERSHIP_QOS ?
-                wp->ownership_strength() : 0;
+                    wp->ownership_strength() : 0;
             deserialize_change(change, ownership, data, info);
             remove_change_sub(change);
             return true;
@@ -390,7 +403,7 @@ bool SubscriberHistory::find_key(
     }
     else
     {
-        for (vit = keyed_changes_.begin(); vit!= keyed_changes_.end(); ++vit)
+        for (vit = keyed_changes_.begin(); vit != keyed_changes_.end(); ++vit)
         {
             if (vit->second.cache_changes.size() == 0)
             {
@@ -403,7 +416,6 @@ bool SubscriberHistory::find_key(
     }
     return false;
 }
-
 
 bool SubscriberHistory::remove_change_sub(
         CacheChange_t* change)
@@ -480,8 +492,8 @@ bool SubscriberHistory::set_next_deadline(
 }
 
 bool SubscriberHistory::get_next_deadline(
-        InstanceHandle_t &handle,
-        std::chrono::steady_clock::time_point &next_deadline_us)
+        InstanceHandle_t& handle,
+        std::chrono::steady_clock::time_point& next_deadline_us)
 {
     if (mp_reader == nullptr || mp_mutex == nullptr)
     {
@@ -498,11 +510,13 @@ bool SubscriberHistory::get_next_deadline(
     else if (mp_subImpl->getAttributes().topic.getTopicKind() == WITH_KEY)
     {
         auto min = std::min_element(keyed_changes_.begin(),
-                                    keyed_changes_.end(),
-                                    [](
-                                    const std::pair<InstanceHandle_t, KeyedChanges> &lhs,
-                                    const std::pair<InstanceHandle_t, KeyedChanges> &rhs)
-        { return lhs.second.next_deadline_us < rhs.second.next_deadline_us; });
+                        keyed_changes_.end(),
+                        [](
+                            const std::pair<InstanceHandle_t, KeyedChanges>& lhs,
+                            const std::pair<InstanceHandle_t, KeyedChanges>& rhs)
+                        {
+                            return lhs.second.next_deadline_us < rhs.second.next_deadline_us;
+                        });
         handle = min->first;
         next_deadline_us = min->second.next_deadline_us;
         return true;

--- a/src/cpp/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/subscriber/SubscriberHistory.cpp
@@ -34,21 +34,19 @@ namespace fastrtps {
 using namespace rtps;
 
 static HistoryAttributes to_history_attributes(
-        const HistoryQosPolicy& history,
-        const ResourceLimitsQosPolicy& resource,
-        SubscriberImpl* simpl,
+        const TopicAttributes& topic_att,
         uint32_t payloadMaxSize,
         MemoryManagementPolicy_t mempolicy)
 {
-    auto initial_samples = resource.allocated_samples;
-    auto max_samples = resource.max_samples;
+    auto initial_samples = topic_att.resourceLimitsQos.allocated_samples;
+    auto max_samples = topic_att.resourceLimitsQos.max_samples;
 
-    if (history.kind != KEEP_ALL_HISTORY_QOS)
+    if (topic_att.historyQos.kind != KEEP_ALL_HISTORY_QOS)
     {
-        max_samples = history.depth;
-        if (simpl->getAttributes().topic.getTopicKind() != NO_KEY)
+        max_samples = topic_att.historyQos.depth;
+        if (topic_att.getTopicKind() != NO_KEY)
         {
-            max_samples *= resource.max_instances;
+            max_samples *= topic_att.resourceLimitsQos.max_instances;
         }
 
         initial_samples = std::min(initial_samples, max_samples);
@@ -63,7 +61,7 @@ SubscriberHistory::SubscriberHistory(
         const HistoryQosPolicy& history,
         const ResourceLimitsQosPolicy& resource,
         MemoryManagementPolicy_t mempolicy)
-    : ReaderHistory(to_history_attributes(history, resource, simpl, payloadMaxSize, mempolicy))
+    : ReaderHistory(to_history_attributes(simpl->getAttributes().topic, payloadMaxSize, mempolicy))
     , m_historyQos(history)
     , m_resourceLimitsQos(resource)
     , mp_subImpl(simpl)

--- a/test/blackbox/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/BlackboxTestsPubSubHistory.cpp
@@ -45,6 +45,7 @@ public:
             xmlparser::XMLProfileManager::library_settings(library_settings);
         }
     }
+
 };
 
 
@@ -55,9 +56,9 @@ TEST_P(PubSubHistory, PubSubAsNonReliableKeepLastReaderSmallDepth)
     PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
 
     reader.history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).
-        history_depth(2).
-        resource_limits_allocated_samples(2).
-        resource_limits_max_samples(2).init();
+    history_depth(2).
+    resource_limits_allocated_samples(2).
+    resource_limits_max_samples(2).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -72,7 +73,7 @@ TEST_P(PubSubHistory, PubSubAsNonReliableKeepLastReaderSmallDepth)
 
     auto data = default_helloworld_data_generator();
 
-    while(data.size() > 1)
+    while (data.size() > 1)
     {
         auto expected_data(data);
 
@@ -138,10 +139,10 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepLastReaderSmallDepth)
     PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
 
     reader.reliability(RELIABLE_RELIABILITY_QOS).
-        history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).
-        history_depth(2).
-        resource_limits_allocated_samples(2).
-        resource_limits_max_samples(2).init();
+    history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).
+    history_depth(2).
+    resource_limits_allocated_samples(2).
+    resource_limits_max_samples(2).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -156,7 +157,7 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepLastReaderSmallDepth)
 
     auto data = default_helloworld_data_generator();
 
-    while(data.size() > 1)
+    while (data.size() > 1)
     {
         auto data_backup(data);
         decltype(data) expected_data;
@@ -188,8 +189,8 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepLastWriterSmallDepth)
     ASSERT_TRUE(reader.isInitialized());
 
     writer.
-        history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).
-        history_depth(2).init();
+    history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).
+    history_depth(2).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -217,16 +218,16 @@ TEST(PubSubHistory, PubSubKeepAll)
     PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
 
     reader.reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-        history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
-        resource_limits_allocated_samples(2).
-        resource_limits_max_samples(2).init();
+    history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
+    resource_limits_allocated_samples(2).
+    resource_limits_max_samples(2).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
     writer.history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
-        max_blocking_time({0, 0}).
-        resource_limits_allocated_samples(2).
-        resource_limits_max_samples(2).init();
+    max_blocking_time({0, 0}).
+    resource_limits_allocated_samples(2).
+    resource_limits_max_samples(2).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -237,15 +238,17 @@ TEST(PubSubHistory, PubSubKeepAll)
 
     auto data = default_helloworld_data_generator();
 
-    while(!data.empty())
+    while (!data.empty())
     {
         auto expected_data(data);
 
         // Send data
         writer.send(data);
 
-        for(auto& value : data)
+        for (auto& value : data)
+        {
             expected_data.remove(value);
+        }
 
         // In this test the history has 20 max_samples.
         ASSERT_LE(expected_data.size(), 2u);
@@ -264,17 +267,17 @@ TEST(PubSubHistory, PubSubKeepAllTransient)
     PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
 
     reader.reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-        history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
-        resource_limits_allocated_samples(2).
-        resource_limits_max_samples(2).init();
+    history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
+    resource_limits_allocated_samples(2).
+    resource_limits_max_samples(2).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
     writer.history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
-        durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS).
-        max_blocking_time({0, 0}).
-        resource_limits_allocated_samples(2).
-        resource_limits_max_samples(2).init();
+    durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS).
+    max_blocking_time({0, 0}).
+    resource_limits_allocated_samples(2).
+    resource_limits_max_samples(2).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -285,15 +288,17 @@ TEST(PubSubHistory, PubSubKeepAllTransient)
 
     auto data = default_helloworld_data_generator();
 
-    while(!data.empty())
+    while (!data.empty())
     {
         auto expected_data(data);
 
         // Send data
         writer.send(data);
 
-        for(auto& value : data)
+        for (auto& value : data)
+        {
             expected_data.remove(value);
+        }
 
         // In this test the history has 20 max_samples.
         ASSERT_LE(expected_data.size(), 2u);
@@ -315,9 +320,9 @@ TEST_P(PubSubHistory, PubReliableKeepAllSubNonReliable)
     ASSERT_TRUE(reader.isInitialized());
 
     writer.reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-        history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
-        resource_limits_allocated_samples(1).
-        resource_limits_max_samples(1).init();
+    history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
+    resource_limits_allocated_samples(1).
+    resource_limits_max_samples(1).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -343,10 +348,10 @@ TEST_P(PubSubHistory, StatefulReaderCacheChangeRelease)
     PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
 
     reader.history_depth(2).
-        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
+    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
     ASSERT_TRUE(reader.isInitialized());
     writer.history_depth(2).
-        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
+    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
     ASSERT_TRUE(writer.isInitialized());
 
     writer.wait_discovery();
@@ -366,7 +371,9 @@ TEST_P(PubSubHistory, StatefulReaderCacheChangeRelease)
 }
 
 template<typename T>
-void send_async_data(PubSubWriter<T>& writer, std::list<typename T::type> data_to_send)
+void send_async_data(
+        PubSubWriter<T>& writer,
+        std::list<typename T::type> data_to_send)
 {
     // Send data
     writer.send(data_to_send);
@@ -380,7 +387,7 @@ TEST_P(PubSubHistory, PubSubAsReliableMultithreadKeepLast1)
     PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
 
     reader.history_depth(1).
-        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
+    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -420,11 +427,11 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepLastReaderSmallDepthTwoPublishers)
     PubSubWriter<HelloWorldType> writer2(TEST_TOPIC_NAME);
 
     reader
-        .reliability(RELIABLE_RELIABILITY_QOS)
-        .history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS)
-        .history_depth(1)
-        .resource_limits_allocated_samples(1)
-        .resource_limits_max_samples(1);
+    .reliability(RELIABLE_RELIABILITY_QOS)
+    .history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS)
+    .history_depth(1)
+    .resource_limits_allocated_samples(1)
+    .resource_limits_max_samples(1);
 
     writer.max_blocking_time({ 120, 0 });
     writer2.max_blocking_time({ 120, 0 });
@@ -472,10 +479,114 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepLastReaderSmallDepthTwoPublishers)
     ASSERT_EQ(received.index(), 3u);
 }
 
+bool comparator(
+        HelloWorld first,
+        HelloWorld second)
+{
+    return first.index() < second.index();
+}
+
+/*!
+ * @fn TEST(PubSubHistory, ReliableTransientLocalKeepLast1)
+ * @brief This test checks the correct functionality of transient local, keep last 1 late-joiners.
+ *
+ * The test creates a Reliable, Transient Local Writer with a Keep Last 10 history, and send ten samples throughout the
+ * network.
+ * Then it creates a Reliable, Transient Local Reader with a Keep Last 1 history and waits until both of them discover
+ * each other.
+ * When the Writer discovers the late-joiner, resends the samples it has on the history (in this case all). And the
+ * reader upon receiving them, as it is Keep Last 1, discards all the samples except the last one.
+ * Finally, the test checks that the last sequence number received is the one corresponding to the tenth sample.
+ */
+TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1)
+{
+    PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
+
+    writer.reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+    .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
+    .asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE)
+    .history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS)
+    .history_depth(10)
+    .resource_limits_allocated_samples(10)
+    .resource_limits_max_samples(10).init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    auto data = default_helloworld_data_generator();
+    auto expected_data = data;
+    writer.send(data);
+
+    reader.reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+    .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
+    .history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS)
+    .history_depth(1).init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    ASSERT_FALSE(expected_data.empty());
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    reader.startReception(expected_data);
+    eprosima::fastrtps::rtps::SequenceNumber_t seq;
+    seq.low = 10;
+    reader.block_for_seq(seq);
+
+    ASSERT_EQ(reader.get_last_sequence_received().low, 10u);
+}
+
+TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1Data300Kb)
+{
+    PubSubReader<Data1mbType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<Data1mbType> writer(TEST_TOPIC_NAME);
+
+    auto data = default_data300kb_data_generator();
+    auto reader_data = data;
+
+    writer
+    .history_depth(static_cast<int32_t>(data.size()))
+    .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+    .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
+    .asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE)
+    .init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Send data
+    writer.send(data);
+    ASSERT_TRUE(data.empty());
+    ASSERT_FALSE(reader_data.empty());
+
+    reader
+    .history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS)
+    .history_depth(1)
+    .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+    .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
+    .init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Because its volatile the durability
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    reader.startReception(reader_data);
+    eprosima::fastrtps::rtps::SequenceNumber_t seq;
+    seq.low = 10;
+    reader.block_for_seq(seq);
+
+    ASSERT_EQ(reader.get_last_sequence_received().low, 10u);
+}
+
 INSTANTIATE_TEST_CASE_P(PubSubHistory,
         PubSubHistory,
         testing::Values(false, true),
-        [](const testing::TestParamInfo<PubSubHistory::ParamType>& info) {
+        [](const testing::TestParamInfo<PubSubHistory::ParamType>& info)
+        {
             if (info.param)
             {
                 return "Intraprocess";

--- a/test/blackbox/PubSubReader.hpp
+++ b/test/blackbox/PubSubReader.hpp
@@ -59,29 +59,32 @@ private:
     public:
 
         ParticipantListener(
-                PubSubReader &reader)
+                PubSubReader& reader)
             : reader_(reader)
-        {}
+        {
+        }
 
-        ~ParticipantListener() {}
+        ~ParticipantListener()
+        {
+        }
 
         void onParticipantDiscovery(
                 eprosima::fastrtps::Participant*,
                 eprosima::fastrtps::rtps::ParticipantDiscoveryInfo&& info) override
         {
-            if(reader_.onDiscovery_!= nullptr)
+            if (reader_.onDiscovery_ != nullptr)
             {
                 std::unique_lock<std::mutex> lock(reader_.mutexDiscovery_);
                 reader_.discovery_result_ |= reader_.onDiscovery_(info);
                 reader_.cvDiscovery_.notify_one();
             }
 
-            if(info.status == eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::DISCOVERED_PARTICIPANT)
+            if (info.status == eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::DISCOVERED_PARTICIPANT)
             {
                 reader_.participant_matched();
 
             }
-            else if(info.status == eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::REMOVED_PARTICIPANT ||
+            else if (info.status == eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::REMOVED_PARTICIPANT ||
                     info.status == eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::DROPPED_PARTICIPANT)
             {
                 reader_.participant_unmatched();
@@ -93,47 +96,54 @@ private:
                 eprosima::fastrtps::Participant*,
                 eprosima::fastrtps::rtps::ParticipantAuthenticationInfo&& info) override
         {
-            if(info.status == eprosima::fastrtps::rtps::ParticipantAuthenticationInfo::AUTHORIZED_PARTICIPANT)
+            if (info.status == eprosima::fastrtps::rtps::ParticipantAuthenticationInfo::AUTHORIZED_PARTICIPANT)
             {
                 reader_.authorized();
             }
-            else if(info.status == eprosima::fastrtps::rtps::ParticipantAuthenticationInfo::UNAUTHORIZED_PARTICIPANT)
+            else if (info.status == eprosima::fastrtps::rtps::ParticipantAuthenticationInfo::UNAUTHORIZED_PARTICIPANT)
             {
                 reader_.unauthorized();
             }
         }
-#endif
+
+#endif // if HAVE_SECURITY
 
     private:
 
-        ParticipantListener& operator=(const ParticipantListener&) = delete;
+        ParticipantListener& operator =(
+                const ParticipantListener&) = delete;
         PubSubReader& reader_;
 
-    } participant_listener_;
+    }
+    participant_listener_;
 
-    class Listener: public eprosima::fastrtps::SubscriberListener
+    class Listener : public eprosima::fastrtps::SubscriberListener
     {
     public:
 
         Listener(
-                PubSubReader &reader)
+                PubSubReader& reader)
             : reader_(reader)
             , times_deadline_missed_(0)
-        {}
+        {
+        }
 
-        ~Listener(){}
+        ~Listener()
+        {
+        }
 
-        void onNewDataMessage(eprosima::fastrtps::Subscriber *sub) override
+        void onNewDataMessage(
+                eprosima::fastrtps::Subscriber* sub) override
         {
             ASSERT_NE(sub, nullptr);
 
-            if(reader_.receiving_.load())
+            if (reader_.receiving_.load())
             {
                 bool ret = false;
                 do
                 {
                     reader_.receive_one(sub, ret);
-                } while(ret);
+                } while (ret);
             }
         }
 
@@ -189,14 +199,16 @@ private:
 
     private:
 
-        Listener& operator=(const Listener&) = delete;
+        Listener& operator =(
+                const Listener&) = delete;
 
         PubSubReader& reader_;
 
         //! Number of times deadline was missed
         unsigned int times_deadline_missed_;
 
-    } listener_;
+    }
+    listener_;
 
     friend class Listener;
 
@@ -222,29 +234,29 @@ public:
 #if HAVE_SECURITY
         , authorized_(0)
         , unauthorized_(0)
-#endif
+#endif // if HAVE_SECURITY
         , liveliness_mutex_()
         , liveliness_cv_()
         , times_liveliness_lost_(0)
         , times_liveliness_recovered_(0)
-        {
-            subscriber_attr_.topic.topicDataType = type_.getName();
-            // Generate topic name
-            std::ostringstream t;
-            t << topic_name_ << "_" << asio::ip::host_name() << "_" << GET_PID();
-            subscriber_attr_.topic.topicName = t.str();
+    {
+        subscriber_attr_.topic.topicDataType = type_.getName();
+        // Generate topic name
+        std::ostringstream t;
+        t << topic_name_ << "_" << asio::ip::host_name() << "_" << GET_PID();
+        subscriber_attr_.topic.topicName = t.str();
 
-            // By default, memory mode is preallocated (the most restritive)
-            subscriber_attr_.historyMemoryPolicy = eprosima::fastrtps::rtps::PREALLOCATED_MEMORY_MODE;
+        // By default, memory mode is preallocated (the most restritive)
+        subscriber_attr_.historyMemoryPolicy = eprosima::fastrtps::rtps::PREALLOCATED_MEMORY_MODE;
 
-            // By default, heartbeat period delay is 100 milliseconds.
-            subscriber_attr_.times.heartbeatResponseDelay.seconds = 0;
-            subscriber_attr_.times.heartbeatResponseDelay.nanosec = 100000000;
-        }
+        // By default, heartbeat period delay is 100 milliseconds.
+        subscriber_attr_.times.heartbeatResponseDelay.seconds = 0;
+        subscriber_attr_.times.heartbeatResponseDelay.nanosec = 100000000;
+    }
 
     ~PubSubReader()
     {
-        if(participant_ != nullptr)
+        if (participant_ != nullptr)
         {
             eprosima::fastrtps::Domain::removeParticipant(participant_);
         }
@@ -272,11 +284,14 @@ public:
         initialized_ = true;
     }
 
-    bool isInitialized() const { return initialized_; }
+    bool isInitialized() const
+    {
+        return initialized_;
+    }
 
     void destroy()
     {
-        if(participant_ != nullptr)
+        if (participant_ != nullptr)
         {
             eprosima::fastrtps::Domain::removeParticipant(participant_);
             participant_ = nullptr;
@@ -289,11 +304,13 @@ public:
         return total_msgs_;
     }
 
-    void startReception(std::list<type>& msgs)
+    eprosima::fastrtps::rtps::SequenceNumber_t startReception(
+            std::list<type>& msgs)
     {
         mutex_.lock();
         total_msgs_ = msgs;
         number_samples_expected_ = total_msgs_.size();
+        last_seq = eprosima::fastrtps::rtps::SequenceNumber_t();
         current_received_count_ = 0;
         mutex_.unlock();
 
@@ -302,9 +319,10 @@ public:
         {
             receive_one(subscriber_, ret);
         }
-        while(ret);
+        while (ret);
 
         receiving_.store(true);
+        return last_seq;
     }
 
     void stopReception()
@@ -314,70 +332,99 @@ public:
 
     void block_for_all()
     {
-        block([this]() -> bool {
-                return number_samples_expected_ == current_received_count_;
+        block([this]() -> bool
+                {
+                    return number_samples_expected_ == current_received_count_;
                 });
     }
 
-    size_t block_for_at_least(size_t at_least)
+    size_t block_for_at_least(
+            size_t at_least)
     {
-        block([this, at_least]() -> bool {
-                return current_received_count_ >= at_least;
+        block([this, at_least]() -> bool
+                {
+                    return current_received_count_ >= at_least;
                 });
         return current_received_count_;
     }
 
-    void block(std::function<bool()> checker)
+    void block(
+            std::function<bool()> checker)
     {
         std::unique_lock<std::mutex> lock(mutex_);
         cv_.wait(lock, checker);
     }
 
+    void block_for_seq(
+            eprosima::fastrtps::rtps::SequenceNumber_t seq)
+    {
+        block([this, seq]() -> bool
+                {
+                    return last_seq == seq;
+                });
+    }
+
     template<class _Rep,
-        class _Period
+            class _Period
             >
-            size_t block_for_all(const std::chrono::duration<_Rep, _Period>& max_wait)
-            {
-                std::unique_lock<std::mutex> lock(mutex_);
-                cv_.wait_for(lock, max_wait, [this]() -> bool {
-                        return number_samples_expected_ == current_received_count_;
-                        });
+    size_t block_for_all(
+            const std::chrono::duration<_Rep, _Period>& max_wait)
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        cv_.wait_for(lock, max_wait, [this]() -> bool
+                {
+                    return number_samples_expected_ == current_received_count_;
+                });
 
-                return current_received_count_;
-            }
+        return current_received_count_;
+    }
 
-    void wait_discovery(std::chrono::seconds timeout = std::chrono::seconds::zero())
+    void wait_discovery(
+            std::chrono::seconds timeout = std::chrono::seconds::zero())
     {
         std::unique_lock<std::mutex> lock(mutexDiscovery_);
 
         std::cout << "Reader is waiting discovery..." << std::endl;
 
-        if(timeout == std::chrono::seconds::zero())
+        if (timeout == std::chrono::seconds::zero())
         {
-            cvDiscovery_.wait(lock, [&](){return matched_ != 0;});
+            cvDiscovery_.wait(lock, [&]()
+                    {
+                        return matched_ != 0;
+                    });
         }
         else
         {
-            cvDiscovery_.wait_for(lock, timeout, [&](){return matched_ != 0;});
+            cvDiscovery_.wait_for(lock, timeout, [&]()
+                    {
+                        return matched_ != 0;
+                    });
         }
 
         std::cout << "Reader discovery finished..." << std::endl;
     }
 
-    bool wait_participant_undiscovery(std::chrono::seconds timeout = std::chrono::seconds::zero())
+    bool wait_participant_undiscovery(
+            std::chrono::seconds timeout = std::chrono::seconds::zero())
     {
         bool ret_value = true;
         std::unique_lock<std::mutex> lock(mutexDiscovery_);
 
         std::cout << "Reader is waiting undiscovery..." << std::endl;
 
-        if(timeout == std::chrono::seconds::zero())
+        if (timeout == std::chrono::seconds::zero())
         {
-            cvDiscovery_.wait(lock, [&](){return participant_matched_ == 0;});
+            cvDiscovery_.wait(lock, [&]()
+                    {
+                        return participant_matched_ == 0;
+                    });
         }
         else
         {
-            if (!cvDiscovery_.wait_for(lock, timeout, [&](){return participant_matched_ == 0;}))
+            if (!cvDiscovery_.wait_for(lock, timeout, [&]()
+                    {
+                        return participant_matched_ == 0;
+                    }))
             {
                 ret_value = false;
             }
@@ -401,23 +448,34 @@ public:
 
         std::cout << "Reader is waiting removal..." << std::endl;
 
-        cvDiscovery_.wait(lock, [&](){return matched_ == 0;});
+        cvDiscovery_.wait(lock, [&]()
+                {
+                    return matched_ == 0;
+                });
 
         std::cout << "Reader removal finished..." << std::endl;
     }
 
-    void wait_liveliness_recovered(unsigned int times = 1)
+    void wait_liveliness_recovered(
+            unsigned int times = 1)
     {
         std::unique_lock<std::mutex> lock(liveliness_mutex_);
 
-        liveliness_cv_.wait(lock, [&](){ return times_liveliness_recovered_ == times; });
+        liveliness_cv_.wait(lock, [&]()
+                {
+                    return times_liveliness_recovered_ == times;
+                });
     }
 
-    void wait_liveliness_lost(unsigned int times = 1)
+    void wait_liveliness_lost(
+            unsigned int times = 1)
     {
         std::unique_lock<std::mutex> lock(liveliness_mutex_);
 
-        liveliness_cv_.wait(lock, [&](){ return times_liveliness_lost_ == times; });
+        liveliness_cv_.wait(lock, [&]()
+                {
+                    return times_liveliness_lost_ == times;
+                });
     }
 
 #if HAVE_SECURITY
@@ -427,7 +485,10 @@ public:
 
         std::cout << "Reader is waiting authorization..." << std::endl;
 
-        cvAuthentication_.wait(lock, [&]() -> bool { return authorized_ > 0; });
+        cvAuthentication_.wait(lock, [&]() -> bool
+                {
+                    return authorized_ > 0;
+                });
 
         std::cout << "Reader authorization finished..." << std::endl;
     }
@@ -438,37 +499,50 @@ public:
 
         std::cout << "Reader is waiting unauthorization..." << std::endl;
 
-        cvAuthentication_.wait(lock, [&]() -> bool { return unauthorized_ > 0; });
+        cvAuthentication_.wait(lock, [&]() -> bool
+                {
+                    return unauthorized_ > 0;
+                });
 
         std::cout << "Reader unauthorization finished..." << std::endl;
     }
-#endif
+
+#endif // if HAVE_SECURITY
 
     size_t getReceivedCount() const
     {
         return current_received_count_;
     }
 
+    eprosima::fastrtps::rtps::SequenceNumber_t get_last_sequence_received()
+    {
+        return last_seq;
+    }
+
     /*** Function to change QoS ***/
-    PubSubReader& reliability(const eprosima::fastrtps::ReliabilityQosPolicyKind kind)
+    PubSubReader& reliability(
+            const eprosima::fastrtps::ReliabilityQosPolicyKind kind)
     {
         subscriber_attr_.qos.m_reliability.kind = kind;
         return *this;
     }
 
-    PubSubReader& mem_policy(const eprosima::fastrtps::rtps::MemoryManagementPolicy mem_policy)
+    PubSubReader& mem_policy(
+            const eprosima::fastrtps::rtps::MemoryManagementPolicy mem_policy)
     {
         subscriber_attr_.historyMemoryPolicy = mem_policy;
         return *this;
     }
 
-    PubSubReader& deadline_period(const eprosima::fastrtps::Duration_t deadline_period)
+    PubSubReader& deadline_period(
+            const eprosima::fastrtps::Duration_t deadline_period)
     {
         subscriber_attr_.qos.m_deadline.period = deadline_period;
         return *this;
     }
 
-    bool update_deadline_period(const eprosima::fastrtps::Duration_t& deadline_period)
+    bool update_deadline_period(
+            const eprosima::fastrtps::Duration_t& deadline_period)
     {
         eprosima::fastrtps::SubscriberAttributes attr;
         attr = subscriber_attr_;
@@ -477,19 +551,22 @@ public:
         return subscriber_->updateAttributes(attr);
     }
 
-    PubSubReader& liveliness_kind(const eprosima::fastrtps::LivelinessQosPolicyKind& kind)
+    PubSubReader& liveliness_kind(
+            const eprosima::fastrtps::LivelinessQosPolicyKind& kind)
     {
         subscriber_attr_.qos.m_liveliness.kind = kind;
         return *this;
     }
 
-    PubSubReader& liveliness_lease_duration(const eprosima::fastrtps::Duration_t lease_duration)
+    PubSubReader& liveliness_lease_duration(
+            const eprosima::fastrtps::Duration_t lease_duration)
     {
         subscriber_attr_.qos.m_liveliness.lease_duration = lease_duration;
         return *this;
     }
 
-    PubSubReader& key(bool keyed)
+    PubSubReader& key(
+            bool keyed)
     {
         subscriber_attr_.topic.topicKind = keyed
             ? eprosima::fastrtps::rtps::TopicKind_t::WITH_KEY
@@ -497,32 +574,37 @@ public:
         return *this;
     }
 
-    PubSubReader& lifespan_period(const eprosima::fastrtps::Duration_t lifespan_period)
+    PubSubReader& lifespan_period(
+            const eprosima::fastrtps::Duration_t lifespan_period)
     {
         subscriber_attr_.qos.m_lifespan.duration = lifespan_period;
         return *this;
     }
 
-    PubSubReader& topic_kind(const eprosima::fastrtps::rtps::TopicKind_t kind)
+    PubSubReader& topic_kind(
+            const eprosima::fastrtps::rtps::TopicKind_t kind)
     {
         subscriber_attr_.topic.topicKind = kind;
         return *this;
     }
 
-    PubSubReader& keep_duration(const eprosima::fastrtps::Duration_t duration)
+    PubSubReader& keep_duration(
+            const eprosima::fastrtps::Duration_t duration)
     {
         subscriber_attr_.qos.m_disablePositiveACKs.enabled = true;
         subscriber_attr_.qos.m_disablePositiveACKs.duration = duration;
         return *this;
     }
 
-    PubSubReader& history_kind(const eprosima::fastrtps::HistoryQosPolicyKind kind)
+    PubSubReader& history_kind(
+            const eprosima::fastrtps::HistoryQosPolicyKind kind)
     {
         subscriber_attr_.topic.historyQos.kind = kind;
         return *this;
     }
 
-    PubSubReader& history_depth(const int32_t depth)
+    PubSubReader& history_depth(
+            const int32_t depth)
     {
         subscriber_attr_.topic.historyQos.depth = depth;
         return *this;
@@ -534,25 +616,30 @@ public:
         return *this;
     }
 
-    PubSubReader& add_user_transport_to_pparams(std::shared_ptr<eprosima::fastrtps::rtps::TransportDescriptorInterface> userTransportDescriptor)
+    PubSubReader& add_user_transport_to_pparams(
+            std::shared_ptr<eprosima::fastrtps::rtps::TransportDescriptorInterface> userTransportDescriptor)
     {
         participant_attr_.rtps.userTransports.push_back(userTransportDescriptor);
         return *this;
     }
 
-    PubSubReader& resource_limits_allocated_samples(const int32_t initial)
+    PubSubReader& resource_limits_allocated_samples(
+            const int32_t initial)
     {
         subscriber_attr_.topic.resourceLimitsQos.allocated_samples = initial;
         return *this;
     }
 
-    PubSubReader& resource_limits_max_samples(const int32_t max)
+    PubSubReader& resource_limits_max_samples(
+            const int32_t max)
     {
         subscriber_attr_.topic.resourceLimitsQos.max_samples = max;
         return *this;
     }
 
-    PubSubReader& matched_writers_allocation(size_t initial, size_t maximum)
+    PubSubReader& matched_writers_allocation(
+            size_t initial,
+            size_t maximum)
     {
         subscriber_attr_.matched_publisher_allocation.initial = initial;
         subscriber_attr_.matched_publisher_allocation.maximum = maximum;
@@ -565,20 +652,25 @@ public:
         return *this;
     }
 
-    PubSubReader& heartbeatResponseDelay(const int32_t secs, const int32_t frac)
+    PubSubReader& heartbeatResponseDelay(
+            const int32_t secs,
+            const int32_t frac)
     {
         subscriber_attr_.times.heartbeatResponseDelay.seconds = secs;
         subscriber_attr_.times.heartbeatResponseDelay.fraction(frac);
         return *this;
     }
 
-    PubSubReader& unicastLocatorList(eprosima::fastrtps::rtps::LocatorList_t unicastLocators)
+    PubSubReader& unicastLocatorList(
+            eprosima::fastrtps::rtps::LocatorList_t unicastLocators)
     {
         subscriber_attr_.unicastLocatorList = unicastLocators;
         return *this;
     }
 
-    PubSubReader& add_to_unicast_locator_list(const std::string& ip, uint32_t port)
+    PubSubReader& add_to_unicast_locator_list(
+            const std::string& ip,
+            uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
         IPLocator::setIPv4(loc, ip);
@@ -588,13 +680,16 @@ public:
         return *this;
     }
 
-    PubSubReader& multicastLocatorList(eprosima::fastrtps::rtps::LocatorList_t multicastLocators)
+    PubSubReader& multicastLocatorList(
+            eprosima::fastrtps::rtps::LocatorList_t multicastLocators)
     {
         subscriber_attr_.multicastLocatorList = multicastLocators;
         return *this;
     }
 
-    PubSubReader& add_to_multicast_locator_list(const std::string& ip, uint32_t port)
+    PubSubReader& add_to_multicast_locator_list(
+            const std::string& ip,
+            uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
         IPLocator::setIPv4(loc, ip);
@@ -604,13 +699,16 @@ public:
         return *this;
     }
 
-    PubSubReader& metatraffic_unicast_locator_list(eprosima::fastrtps::rtps::LocatorList_t unicastLocators)
+    PubSubReader& metatraffic_unicast_locator_list(
+            eprosima::fastrtps::rtps::LocatorList_t unicastLocators)
     {
         participant_attr_.rtps.builtin.metatrafficUnicastLocatorList = unicastLocators;
         return *this;
     }
 
-    PubSubReader& add_to_metatraffic_unicast_locator_list(const std::string& ip, uint32_t port)
+    PubSubReader& add_to_metatraffic_unicast_locator_list(
+            const std::string& ip,
+            uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
         IPLocator::setIPv4(loc, ip);
@@ -620,13 +718,16 @@ public:
         return *this;
     }
 
-    PubSubReader& metatraffic_multicast_locator_list(eprosima::fastrtps::rtps::LocatorList_t unicastLocators)
+    PubSubReader& metatraffic_multicast_locator_list(
+            eprosima::fastrtps::rtps::LocatorList_t unicastLocators)
     {
         participant_attr_.rtps.builtin.metatrafficMulticastLocatorList = unicastLocators;
         return *this;
     }
 
-    PubSubReader& add_to_metatraffic_multicast_locator_list(const std::string& ip, uint32_t port)
+    PubSubReader& add_to_metatraffic_multicast_locator_list(
+            const std::string& ip,
+            uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
         IPLocator::setIPv4(loc, ip);
@@ -636,19 +737,22 @@ public:
         return *this;
     }
 
-    PubSubReader& initial_peers(eprosima::fastrtps::rtps::LocatorList_t initial_peers)
+    PubSubReader& initial_peers(
+            eprosima::fastrtps::rtps::LocatorList_t initial_peers)
     {
         participant_attr_.rtps.builtin.initialPeersList = initial_peers;
         return *this;
     }
 
-    PubSubReader& durability_kind(const eprosima::fastrtps::DurabilityQosPolicyKind kind)
+    PubSubReader& durability_kind(
+            const eprosima::fastrtps::DurabilityQosPolicyKind kind)
     {
         subscriber_attr_.qos.m_durability.kind = kind;
         return *this;
     }
 
-    PubSubReader& static_discovery(const char* filename)
+    PubSubReader& static_discovery(
+            const char* filename)
     {
         participant_attr_.rtps.builtin.discovery_config.use_SIMPLE_EndpointDiscoveryProtocol = false;
         participant_attr_.rtps.builtin.discovery_config.use_STATIC_EndpointDiscoveryProtocol = true;
@@ -656,7 +760,9 @@ public:
         return *this;
     }
 
-    PubSubReader& setSubscriberIDs(uint8_t UserID, uint8_t EntityID)
+    PubSubReader& setSubscriberIDs(
+            uint8_t UserID,
+            uint8_t EntityID)
     {
         subscriber_attr_.setUserDefinedID(UserID);
         subscriber_attr_.setEntityID(EntityID);
@@ -664,13 +770,15 @@ public:
 
     }
 
-    PubSubReader& setManualTopicName(std::string topicName)
+    PubSubReader& setManualTopicName(
+            std::string topicName)
     {
-        subscriber_attr_.topic.topicName=topicName;
+        subscriber_attr_.topic.topicName = topicName;
         return *this;
     }
 
-    PubSubReader& disable_multicast(int32_t participantId)
+    PubSubReader& disable_multicast(
+            int32_t participantId)
     {
         participant_attr_.rtps.participantID = participantId;
 
@@ -686,25 +794,29 @@ public:
         return *this;
     }
 
-    PubSubReader& property_policy(const eprosima::fastrtps::rtps::PropertyPolicy property_policy)
+    PubSubReader& property_policy(
+            const eprosima::fastrtps::rtps::PropertyPolicy property_policy)
     {
         participant_attr_.rtps.properties = property_policy;
         return *this;
     }
 
-    PubSubReader& entity_property_policy(const eprosima::fastrtps::rtps::PropertyPolicy property_policy)
+    PubSubReader& entity_property_policy(
+            const eprosima::fastrtps::rtps::PropertyPolicy property_policy)
     {
         subscriber_attr_.properties = property_policy;
         return *this;
     }
 
-    PubSubReader& partition(const std::string& partition)
+    PubSubReader& partition(
+            const std::string& partition)
     {
         subscriber_attr_.qos.m_partition.push_back(partition.c_str());
         return *this;
     }
 
-    PubSubReader& userData(std::vector<eprosima::fastrtps::rtps::octet> user_data)
+    PubSubReader& userData(
+            std::vector<eprosima::fastrtps::rtps::octet> user_data)
     {
         participant_attr_.rtps.userData = user_data;
         return *this;
@@ -719,39 +831,50 @@ public:
         return *this;
     }
 
-    PubSubReader& load_participant_attr(const std::string& xml)
+    PubSubReader& load_participant_attr(
+            const std::string& xml)
     {
         std::unique_ptr<eprosima::fastrtps::xmlparser::BaseNode> root;
-        if (eprosima::fastrtps::xmlparser::XMLParser::loadXML(xml.data(), xml.size(), root) == eprosima::fastrtps::xmlparser::XMLP_ret::XML_OK)
+        if (eprosima::fastrtps::xmlparser::XMLParser::loadXML(xml.data(), xml.size(),
+                root) == eprosima::fastrtps::xmlparser::XMLP_ret::XML_OK)
         {
             for (const auto& profile : root->getChildren())
             {
                 if (profile->getType() == eprosima::fastrtps::xmlparser::NodeType::PARTICIPANT)
                 {
-                    participant_attr_ = *(dynamic_cast<eprosima::fastrtps::xmlparser::DataNode<eprosima::fastrtps::ParticipantAttributes>*>(profile.get())->get());
+                    participant_attr_ =
+                            *(dynamic_cast<eprosima::fastrtps::xmlparser::DataNode<eprosima::fastrtps::ParticipantAttributes>
+                            *>(
+                                profile.get())->get());
                 }
             }
         }
         return *this;
     }
 
-    PubSubReader& load_subscriber_attr(const std::string& xml)
+    PubSubReader& load_subscriber_attr(
+            const std::string& xml)
     {
         std::unique_ptr<eprosima::fastrtps::xmlparser::BaseNode> root;
-        if (eprosima::fastrtps::xmlparser::XMLParser::loadXML(xml.data(), xml.size(), root) == eprosima::fastrtps::xmlparser::XMLP_ret::XML_OK)
+        if (eprosima::fastrtps::xmlparser::XMLParser::loadXML(xml.data(), xml.size(),
+                root) == eprosima::fastrtps::xmlparser::XMLP_ret::XML_OK)
         {
             for (const auto& profile : root->getChildren())
             {
                 if (profile->getType() == eprosima::fastrtps::xmlparser::NodeType::SUBSCRIBER)
                 {
-                    subscriber_attr_ = *(dynamic_cast<eprosima::fastrtps::xmlparser::DataNode<eprosima::fastrtps::SubscriberAttributes>*>(profile.get())->get());
+                    subscriber_attr_ =
+                            *(dynamic_cast<eprosima::fastrtps::xmlparser::DataNode<eprosima::fastrtps::SubscriberAttributes>
+                            *>(
+                                profile.get())->get());
                 }
             }
         }
         return *this;
     }
 
-    PubSubReader& max_initial_peers_range(uint32_t maxInitialPeerRange)
+    PubSubReader& max_initial_peers_range(
+            uint32_t maxInitialPeerRange)
     {
         participant_attr_.rtps.useBuiltinTransports = false;
         std::shared_ptr<UDPv4TransportDescriptor> descriptor = std::make_shared<UDPv4TransportDescriptor>();
@@ -760,13 +883,15 @@ public:
         return *this;
     }
 
-    PubSubReader& participant_id(int32_t participantId)
+    PubSubReader& participant_id(
+            int32_t participantId)
     {
         participant_attr_.rtps.participantID = participantId;
         return *this;
     }
 
-    bool update_partition(const std::string& partition)
+    bool update_partition(
+            const std::string& partition)
     {
         subscriber_attr_.qos.m_partition.clear();
         subscriber_attr_.qos.m_partition.push_back(partition.c_str());
@@ -781,17 +906,23 @@ public:
 
         std::cout << "Reader is waiting discovery result..." << std::endl;
 
-        cvDiscovery_.wait(lock, [&](){return discovery_result_;});
+        cvDiscovery_.wait(lock, [&]()
+                {
+                    return discovery_result_;
+                });
 
         std::cout << "Reader gets discovery result..." << std::endl;
     }
 
-    void setOnDiscoveryFunction(std::function<bool(const eprosima::fastrtps::rtps::ParticipantDiscoveryInfo&)> f)
+    void setOnDiscoveryFunction(
+            std::function<bool(const eprosima::fastrtps::rtps::ParticipantDiscoveryInfo&)> f)
     {
         onDiscovery_ = f;
     }
 
-    bool takeNextData(void* data, eprosima::fastrtps::SampleInfo_t* info)
+    bool takeNextData(
+            void* data,
+            eprosima::fastrtps::SampleInfo_t* info)
     {
         if (subscriber_->takeNextData(data, info))
         {
@@ -820,7 +951,8 @@ public:
         liveliness_cv_.notify_one();
     }
 
-    void set_liveliness_changed_status(const eprosima::fastrtps::LivelinessChangedStatus& status)
+    void set_liveliness_changed_status(
+            const eprosima::fastrtps::LivelinessChangedStatus& status)
     {
         std::unique_lock<std::mutex> lock(liveliness_mutex_);
 
@@ -862,15 +994,17 @@ private:
 
 private:
 
-    void receive_one(eprosima::fastrtps::Subscriber* subscriber, bool& returnedValue)
+    void receive_one(
+            eprosima::fastrtps::Subscriber* subscriber,
+            bool& returnedValue)
     {
         returnedValue = false;
         type data;
         eprosima::fastrtps::SampleInfo_t info;
 
         bool success = take_ ?
-                    subscriber->takeNextData((void*)&data, &info) :
-                    subscriber->readNextData((void*)&data, &info);
+                subscriber->takeNextData((void*)&data, &info) :
+                subscriber->readNextData((void*)&data, &info);
         if (success)
         {
             returnedValue = true;
@@ -881,7 +1015,7 @@ private:
             ASSERT_LT(last_seq, info.sample_identity.sequence_number());
             last_seq = info.sample_identity.sequence_number();
 
-            if(info.sampleKind == eprosima::fastrtps::rtps::ALIVE)
+            if (info.sampleKind == eprosima::fastrtps::rtps::ALIVE)
             {
                 auto it = std::find(total_msgs_.begin(), total_msgs_.end(), data);
                 ASSERT_NE(it, total_msgs_.end());
@@ -937,13 +1071,15 @@ private:
         mutexAuthentication_.unlock();
         cvAuthentication_.notify_all();
     }
-#endif
 
-    PubSubReader& operator=(const PubSubReader&)= delete;
+#endif // if HAVE_SECURITY
 
-    eprosima::fastrtps::Participant *participant_;
+    PubSubReader& operator =(
+            const PubSubReader&) = delete;
+
+    eprosima::fastrtps::Participant* participant_;
     eprosima::fastrtps::ParticipantAttributes participant_attr_;
-    eprosima::fastrtps::Subscriber *subscriber_;
+    eprosima::fastrtps::Subscriber* subscriber_;
     eprosima::fastrtps::SubscriberAttributes subscriber_attr_;
     std::string topic_name_;
     eprosima::fastrtps::rtps::GUID_t participant_guid_;
@@ -972,7 +1108,7 @@ private:
     std::condition_variable cvAuthentication_;
     unsigned int authorized_;
     unsigned int unauthorized_;
-#endif
+#endif // if HAVE_SECURITY
 
     //! A mutex for liveliness status
     std::mutex liveliness_mutex_;

--- a/test/mock/rtps/ReaderHistory/fastrtps/rtps/history/ReaderHistory.h
+++ b/test/mock/rtps/ReaderHistory/fastrtps/rtps/history/ReaderHistory.h
@@ -34,23 +34,28 @@ class ReaderHistory
 {
     friend class RTPSReader;
 
-    public:
+public:
 
-        ReaderHistory(const HistoryAttributes& /*att*/){}
+    ReaderHistory(
+            const HistoryAttributes& /*att*/)
+    {
+    }
 
-        MOCK_METHOD1(remove_change_mock, bool(CacheChange_t*));
+    MOCK_METHOD1(remove_change_mock, bool(CacheChange_t*));
 
-        bool remove_change(CacheChange_t* change)
-        {
-            bool ret = remove_change_mock(change);
-            delete change;
-            return ret;
-        }
+    bool remove_change(
+            CacheChange_t* change)
+    {
+        bool ret = remove_change_mock(change);
+        delete change;
+        return ret;
+    }
 
-    protected:
+protected:
 
-        RTPSReader* mp_reader;
-        RecursiveTimedMutex* mp_mutex;
+    RTPSReader* mp_reader;
+    RecursiveTimedMutex* mp_mutex;
+    HistoryAttributes m_att;
 };
 
 } // namespace rtps


### PR DESCRIPTION
This is #1314 to `ros2_eloquent`

* Large data volatile tests
* Large data transient local tests
* Tests to check #8896 bug (Transient Local, Reliable, Keep Last 1)

Signed-off-by: Laura Martin <laura@eprosima.com>