### PR TITLE
Fix Writer history behavior when there are no matched readers <2.0.x> [9031]

### DIFF
--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -356,15 +356,12 @@ void StatefulWriter::unsent_change_added_to_history(
                     periodic_hb_event_->restart_timer(max_blocking_time);
                 }
 
-                if ( (mp_listener != nullptr) && this->is_acked_by_all(change) )
-                {
-                    mp_listener->onWriterChangeReceivedByAll(this, change);
-                }
-
                 if (disable_positive_acks_ && last_sequence_number_ == SequenceNumber_t())
                 {
                     last_sequence_number_ = change->sequenceNumber;
                 }
+
+                check_acked_status();
             }
             catch (const RTPSMessageGroup::timeout&)
             {

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1655,7 +1655,7 @@ bool StatefulWriter::try_remove_change(
 
     {
         std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
-        min_low_mark = next_all_acked_notify_sequence_;
+        min_low_mark = next_all_acked_notify_sequence_ - 1;
     }
 
     SequenceNumber_t calc = min_low_mark < get_seq_num_min() ? SequenceNumber_t() :

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1452,7 +1452,6 @@ bool StatefulWriter::matched_reader_remove(
         return true;
     }
 
-    check_acked_status();
     logInfo(RTPS_HISTORY, "Reader Proxy doesn't exist in this writer");
     return false;
 }

--- a/test/blackbox/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/BlackboxTestsPubSubHistory.cpp
@@ -664,6 +664,69 @@ TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1Data300Kb)
     ASSERT_EQ(reader.get_last_sequence_received().low, 10u);
 }
 
+// Test created to check bug #8945
+/*!
+ * @fn TEST(PubSubHistory, WriterWithoutReadersTransientLocal)
+ * @brief This test checks that the writer doesn't fill its history while there are no readers matched.
+ *
+ * The test creates a Reliable, Transient Local Writer with a Keep All history, and its resources limited to
+ * 1300 samples.
+ * Then it creates a Reliable, Transient Local Reader with a Keep Last 1 history and waits until both of them discover
+ * each other.
+ * When both of them are matched, the writer sends 1300 samples, asserting that all of them have been sent and the
+ * reader starts its reception.
+ * After that, the reader is destroyed, meaning that the writer runs out of readers. Even if there are no readers,
+ * it has to continue sending the remaining samples, deleting the old ones if the history is fulled.
+ */
+TEST_P(PubSubHistory, WriterWithoutReadersTransientLocal)
+{
+    PubSubWriter<Data1mbType> writer(TEST_TOPIC_NAME);
+
+    writer
+    .history_kind(KEEP_ALL_HISTORY_QOS)
+    .durability_kind(TRANSIENT_LOCAL_DURABILITY_QOS)
+    .reliability(RELIABLE_RELIABILITY_QOS)
+    .resource_limits_allocated_samples(1300)
+    .resource_limits_max_samples(1300)
+    .init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Remove the reader
+    PubSubReader<Data1mbType> reader(TEST_TOPIC_NAME);
+    reader
+    .reliability(RELIABLE_RELIABILITY_QOS)
+    .durability_kind(TRANSIENT_LOCAL_DURABILITY_QOS)
+    .init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    auto data1 = default_data300kb_data_generator(1300);
+    auto data2 = default_data300kb_data_generator(300);
+
+    auto unreceived_data = default_data300kb_data_generator(1600);
+
+    // Send data
+    writer.send(data1);
+
+    // In this test all data should be sent.
+    ASSERT_TRUE(data1.empty());
+
+    reader.startReception(unreceived_data);
+
+    reader.destroy();
+
+    // Send data
+    writer.send(data2);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data2.empty());
+
+}
+
 
 INSTANTIATE_TEST_CASE_P(PubSubHistory,
         PubSubHistory,

--- a/test/blackbox/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/BlackboxTestsPubSubHistory.cpp
@@ -676,7 +676,7 @@ TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1Data300Kb)
  * When both of them are matched, the writer sends 13 samples, asserting that all of them have been sent and the
  * reader starts its reception.
  * After that, the reader is destroyed, meaning that the writer runs out of readers. Even if there are no readers,
- * it has to continue sending the remaining samples, deleting the old ones if the history is fulled.
+ * it has to continue sending the remaining samples, deleting the old ones if the history is filled up.
  */
 TEST_P(PubSubHistory, WriterWithoutReadersTransientLocal)
 {
@@ -706,9 +706,9 @@ TEST_P(PubSubHistory, WriterWithoutReadersTransientLocal)
     reader.wait_discovery();
 
     auto data1 = default_data300kb_data_generator(13);
-    auto data2 = default_data300kb_data_generator(3);
+    auto data2 = default_data300kb_data_generator(14);
 
-    auto unreceived_data = default_data300kb_data_generator(16);
+    auto unreceived_data = default_data300kb_data_generator(27);
 
     // Send data
     writer.send(data1);

--- a/test/blackbox/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/BlackboxTestsPubSubHistory.cpp
@@ -686,8 +686,8 @@ TEST_P(PubSubHistory, WriterWithoutReadersTransientLocal)
     .history_kind(KEEP_ALL_HISTORY_QOS)
     .durability_kind(TRANSIENT_LOCAL_DURABILITY_QOS)
     .reliability(RELIABLE_RELIABILITY_QOS)
-    .resource_limits_allocated_samples(1300)
-    .resource_limits_max_samples(1300)
+    .resource_limits_allocated_samples(13)
+    .resource_limits_max_samples(13)
     .init();
 
     ASSERT_TRUE(writer.isInitialized());
@@ -705,10 +705,10 @@ TEST_P(PubSubHistory, WriterWithoutReadersTransientLocal)
     writer.wait_discovery();
     reader.wait_discovery();
 
-    auto data1 = default_data300kb_data_generator(1300);
-    auto data2 = default_data300kb_data_generator(300);
+    auto data1 = default_data300kb_data_generator(13);
+    auto data2 = default_data300kb_data_generator(3);
 
-    auto unreceived_data = default_data300kb_data_generator(1600);
+    auto unreceived_data = default_data300kb_data_generator(16);
 
     // Send data
     writer.send(data1);

--- a/test/blackbox/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/BlackboxTestsPubSubHistory.cpp
@@ -670,10 +670,10 @@ TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1Data300Kb)
  * @brief This test checks that the writer doesn't fill its history while there are no readers matched.
  *
  * The test creates a Reliable, Transient Local Writer with a Keep All history, and its resources limited to
- * 1300 samples.
+ * 13 samples.
  * Then it creates a Reliable, Transient Local Reader with a Keep Last 1 history and waits until both of them discover
  * each other.
- * When both of them are matched, the writer sends 1300 samples, asserting that all of them have been sent and the
+ * When both of them are matched, the writer sends 13 samples, asserting that all of them have been sent and the
  * reader starts its reception.
  * After that, the reader is destroyed, meaning that the writer runs out of readers. Even if there are no readers,
  * it has to continue sending the remaining samples, deleting the old ones if the history is fulled.


### PR DESCRIPTION
This is a backport of #1324 to 2.0.x