### PR TITLE
Fix Writer history behavior when there are no matched readers <ros2_eloquent> [9032]

### DIFF
--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -290,15 +290,13 @@ void StatefulWriter::unsent_change_added_to_history(
                 {
                     periodic_hb_event_->restart_timer(max_blocking_time);
                 }
-                if ( (mp_listener != nullptr) && this->is_acked_by_all(change) )
-                {
-                    mp_listener->onWriterChangeReceivedByAll(this, change);
-                }
 
                 if (disable_positive_acks_ && last_sequence_number_ == SequenceNumber_t())
                 {
                     last_sequence_number_ = change->sequenceNumber;
                 }
+
+                check_acked_status();
             }
             catch (const RTPSMessageGroup::timeout&)
             {

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -745,7 +745,7 @@ void StatefulWriter::send_any_unsent_changes()
                     }
 
                     for (std::pair<std::vector<ReaderProxy*>,
-                            std::set<SequenceNumber_t> > pair : notRelevantChanges.elements())
+                            std::set<SequenceNumber_t>> pair : notRelevantChanges.elements())
                     {
                         locator_selector_.reset(false);
 

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -83,41 +83,41 @@ StatefulWriter::StatefulWriter(
     const RTPSParticipantAttributes& part_att = pimpl->getRTPSParticipantAttributes();
 
     periodic_hb_event_ = new TimedEvent(pimpl->getEventResource(), [&](TimedEvent::EventCode code) -> bool
-    {
-        if (TimedEvent::EVENT_SUCCESS == code)
-        {
-            if (send_periodic_heartbeat())
-            {
-                return true;
-            }
-        }
+                    {
+                        if (TimedEvent::EVENT_SUCCESS == code)
+                        {
+                            if (send_periodic_heartbeat())
+                            {
+                                return true;
+                            }
+                        }
 
-        return false;
-    },
+                        return false;
+                    },
                     TimeConv::Time_t2MilliSecondsDouble(m_times.heartbeatPeriod));
 
     nack_response_event_ = new TimedEvent(pimpl->getEventResource(), [&](TimedEvent::EventCode code) -> bool
-    {
-        if (TimedEvent::EVENT_SUCCESS == code)
-        {
-            perform_nack_response();
-        }
+                    {
+                        if (TimedEvent::EVENT_SUCCESS == code)
+                        {
+                            perform_nack_response();
+                        }
 
-        return false;
-    },
+                        return false;
+                    },
                     TimeConv::Time_t2MilliSecondsDouble(m_times.nackResponseDelay));
 
     if (disable_positive_acks_)
     {
         ack_event_ = new TimedEvent(pimpl->getEventResource(), [&](TimedEvent::EventCode code) -> bool
-        {
-            if (TimedEvent::EVENT_SUCCESS == code)
-            {
-                return ack_timer_expired();
-            }
+                        {
+                            if (TimedEvent::EVENT_SUCCESS == code)
+                            {
+                                return ack_timer_expired();
+                            }
 
-            return false;
-        },
+                            return false;
+                        },
                         att.keep_duration.to_ns() * 1e-6); // in milliseconds
     }
 
@@ -193,7 +193,7 @@ void StatefulWriter::unsent_change_added_to_history(
 
 #if HAVE_SECURITY
     encrypt_cachechange(change);
-#endif
+#endif // if HAVE_SECURITY
 
     if (!matched_readers_.empty())
     {
@@ -351,10 +351,7 @@ void StatefulWriter::unsent_change_added_to_history(
     else
     {
         logInfo(RTPS_WRITER, "No reader proxy to add change.");
-        if (mp_listener != nullptr)
-        {
-            mp_listener->onWriterChangeReceivedByAll(this, change);
-        }
+        check_acked_status();
     }
 }
 
@@ -815,9 +812,9 @@ void StatefulWriter::update_reader_info(
     {
         RTPSParticipantImpl* part = getRTPSParticipant();
         locator_selector_.for_each([part](const Locator_t& loc)
-        {
-            part->createSenderResources(loc);
-        });
+                {
+                    part->createSenderResources(loc);
+                });
     }
 
     there_are_remote_readers_ = false;
@@ -1097,9 +1094,9 @@ bool StatefulWriter::is_acked_by_all(
     assert(mp_history->next_sequence_number() > change->sequenceNumber);
     return std::all_of(matched_readers_.begin(), matched_readers_.end(),
                    [change](const ReaderProxy* reader)
-    {
-        return reader->change_is_acked(change->sequenceNumber);
-    });
+                   {
+                       return reader->change_is_acked(change->sequenceNumber);
+                   });
 }
 
 bool StatefulWriter::all_readers_updated()
@@ -1125,17 +1122,18 @@ bool StatefulWriter::wait_for_all_acked(
 
     all_acked_ = std::none_of(matched_readers_.begin(), matched_readers_.end(),
                     [](const ReaderProxy* reader)
-    {
-        return reader->has_changes();
-    });
+                    {
+                        return reader->has_changes();
+                    });
     lock.unlock();
 
     if (!all_acked_)
     {
         std::chrono::microseconds max_w(::TimeConv::Duration_t2MicroSecondsInt64(max_wait));
-        all_acked_cond_.wait_for(all_acked_lock, max_w, [&]() {
-            return all_acked_;
-        });
+        all_acked_cond_.wait_for(all_acked_lock, max_w, [&]()
+                {
+                    return all_acked_;
+                });
     }
 
     return all_acked_;
@@ -1147,7 +1145,8 @@ void StatefulWriter::check_acked_status()
 
     bool all_acked = true;
     bool has_min_low_mark = false;
-    SequenceNumber_t min_low_mark;
+    // #8945 If no readers matched, notify all old changes.
+    SequenceNumber_t min_low_mark = mp_history->next_sequence_number() - 1;
 
     for (const ReaderProxy* it : matched_readers_)
     {
@@ -1180,9 +1179,9 @@ void StatefulWriter::check_acked_status()
                                 [](
                                     const CacheChange_t* change,
                                     const SequenceNumber_t& seq)
-                {
-                    return change->sequenceNumber < seq;
-                });
+                                {
+                                    return change->sequenceNumber < seq;
+                                });
                 if (cit != history_end && (*cit)->sequenceNumber == current_seq)
                 {
                     mp_listener->onWriterChangeReceivedByAll(this, *cit);
@@ -1219,14 +1218,7 @@ bool StatefulWriter::try_remove_change(
 
     {
         std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
-        for (ReaderProxy* it : matched_readers_)
-        {
-            SequenceNumber_t reader_low_mark = it->changes_low_mark();
-            if (min_low_mark == SequenceNumber_t() || reader_low_mark < min_low_mark)
-            {
-                min_low_mark = reader_low_mark;
-            }
-        }
+        min_low_mark = next_all_acked_notify_sequence_;
     }
 
     SequenceNumber_t calc = min_low_mark < get_seq_num_min() ? SequenceNumber_t() :
@@ -1237,9 +1229,10 @@ bool StatefulWriter::try_remove_change(
     {
         may_remove_change_ = 0;
         may_remove_change_cond_.wait_until(lock, max_blocking_time_point,
-                [&]() {
-            return may_remove_change_ > 0;
-        });
+                [&]()
+                {
+                    return may_remove_change_ > 0;
+                });
         may_remove_change = may_remove_change_;
     }
 
@@ -1341,9 +1334,9 @@ bool StatefulWriter::send_periodic_heartbeat(
 
             unacked_changes = std::any_of(matched_readers_.begin(), matched_readers_.end(),
                             [](const ReaderProxy* reader)
-            {
-                return reader->has_unacknowledged();
-            });
+                            {
+                                return reader->has_unacknowledged();
+                            });
 
             if (unacked_changes)
             {

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1218,7 +1218,7 @@ bool StatefulWriter::try_remove_change(
 
     {
         std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
-        min_low_mark = next_all_acked_notify_sequence_;
+        min_low_mark = next_all_acked_notify_sequence_ - 1;
     }
 
     SequenceNumber_t calc = min_low_mark < get_seq_num_min() ? SequenceNumber_t() :

--- a/test/blackbox/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/BlackboxTestsPubSubHistory.cpp
@@ -582,6 +582,70 @@ TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1Data300Kb)
     ASSERT_EQ(reader.get_last_sequence_received().low, 10u);
 }
 
+// Test created to check bug #8945
+/*!
+ * @fn TEST(PubSubHistory, WriterWithoutReadersTransientLocal)
+ * @brief This test checks that the writer doesn't fill its history while there are no readers matched.
+ *
+ * The test creates a Reliable, Transient Local Writer with a Keep All history, and its resources limited to
+ * 1300 samples.
+ * Then it creates a Reliable, Transient Local Reader with a Keep Last 1 history and waits until both of them discover
+ * each other.
+ * When both of them are matched, the writer sends 13 samples, asserting that all of them have been sent and the
+ * reader starts its reception.
+ * After that, the reader is destroyed, meaning that the writer runs out of readers. Even if there are no readers,
+ * it has to continue sending the remaining samples, deleting the old ones if the history is fulled.
+ */
+TEST_P(PubSubHistory, WriterWithoutReadersTransientLocal)
+{
+    PubSubWriter<Data1mbType> writer(TEST_TOPIC_NAME);
+
+    writer
+    .history_kind(KEEP_ALL_HISTORY_QOS)
+    .durability_kind(TRANSIENT_LOCAL_DURABILITY_QOS)
+    .asynchronously(ASYNCHRONOUS_PUBLISH_MODE)
+    .reliability(RELIABLE_RELIABILITY_QOS)
+    .resource_limits_allocated_samples(13)
+    .resource_limits_max_samples(13)
+    .init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Remove the reader
+    PubSubReader<Data1mbType> reader(TEST_TOPIC_NAME);
+    reader
+    .reliability(RELIABLE_RELIABILITY_QOS)
+    .durability_kind(TRANSIENT_LOCAL_DURABILITY_QOS)
+    .init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    auto data1 = default_data300kb_data_generator(13);
+    auto data2 = default_data300kb_data_generator(3);
+
+    auto unreceived_data = default_data300kb_data_generator(16);
+
+    // Send data
+    writer.send(data1);
+
+    // In this test all data should be sent.
+    ASSERT_TRUE(data1.empty());
+
+    reader.startReception(unreceived_data);
+
+    reader.destroy();
+
+    // Send data
+    writer.send(data2);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data2.empty());
+
+}
+
 INSTANTIATE_TEST_CASE_P(PubSubHistory,
         PubSubHistory,
         testing::Values(false, true),

--- a/test/blackbox/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/BlackboxTestsPubSubHistory.cpp
@@ -588,7 +588,7 @@ TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1Data300Kb)
  * @brief This test checks that the writer doesn't fill its history while there are no readers matched.
  *
  * The test creates a Reliable, Transient Local Writer with a Keep All history, and its resources limited to
- * 1300 samples.
+ * 13 samples.
  * Then it creates a Reliable, Transient Local Reader with a Keep Last 1 history and waits until both of them discover
  * each other.
  * When both of them are matched, the writer sends 13 samples, asserting that all of them have been sent and the

--- a/test/blackbox/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/BlackboxTestsPubSubHistory.cpp
@@ -594,7 +594,7 @@ TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1Data300Kb)
  * When both of them are matched, the writer sends 13 samples, asserting that all of them have been sent and the
  * reader starts its reception.
  * After that, the reader is destroyed, meaning that the writer runs out of readers. Even if there are no readers,
- * it has to continue sending the remaining samples, deleting the old ones if the history is fulled.
+ * it has to continue sending the remaining samples, deleting the old ones if the history is filled up.
  */
 TEST_P(PubSubHistory, WriterWithoutReadersTransientLocal)
 {
@@ -625,9 +625,9 @@ TEST_P(PubSubHistory, WriterWithoutReadersTransientLocal)
     reader.wait_discovery();
 
     auto data1 = default_data300kb_data_generator(13);
-    auto data2 = default_data300kb_data_generator(3);
+    auto data2 = default_data300kb_data_generator(14);
 
-    auto unreceived_data = default_data300kb_data_generator(16);
+    auto unreceived_data = default_data300kb_data_generator(27);
 
     // Send data
     writer.send(data1);


### PR DESCRIPTION
This is a backport of #1324 to ros2_eloquent