### PR TITLE
Log - StdoutErrConsumer [9069]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,21 @@ if(EPROSIMA_BUILD AND NOT EPROSIMA_INSTALLER)
 endif()
 
 ###############################################################################
+# LogConsumer default setup
+###############################################################################
+set(STDOUT_LOG_CONSUMER OFF CACHE BOOL "Stdout LogConsumer as default" FORCE)
+set(STDOUTERR_LOG_CONSUMER OFF CACHE BOOL "StdoutErr LogConsumer as default" FORCE)
+set(LOG_CONSUMER_DEFAULT AUTO CACHE STRING "Selects default LogConsumer")
+
+set_property(CACHE LOG_CONSUMER_DEFAULT PROPERTY STRINGS AUTO STDOUT STDOUTERR)
+
+if (LOG_CONSUMER_DEFAULT STREQUAL "AUTO" OR LOG_CONSUMER_DEFAULT STREQUAL "STDOUT")
+    set(STDOUT_LOG_CONSUMER ON CACHE BOOL "Stdout LogConsumer as default" FORCE)
+elseif(LOG_CONSUMER_DEFAULT STREQUAL "STDOUTERR")
+    set(STDOUTERR_LOG_CONSUMER ON CACHE BOOL "StdoutErr LogConsumer as default" FORCE)
+endif()
+
+###############################################################################
 # Tools default setup
 ###############################################################################
 option(COMPILE_TOOLS "Build tools" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,16 +269,11 @@ endif()
 ###############################################################################
 # LogConsumer default setup
 ###############################################################################
-set(STDOUT_LOG_CONSUMER OFF CACHE BOOL "Stdout LogConsumer as default" FORCE)
-set(STDOUTERR_LOG_CONSUMER OFF CACHE BOOL "StdoutErr LogConsumer as default" FORCE)
 set(LOG_CONSUMER_DEFAULT AUTO CACHE STRING "Selects default LogConsumer")
-
 set_property(CACHE LOG_CONSUMER_DEFAULT PROPERTY STRINGS AUTO STDOUT STDOUTERR)
 
-if (LOG_CONSUMER_DEFAULT STREQUAL "AUTO" OR LOG_CONSUMER_DEFAULT STREQUAL "STDOUT")
-    set(STDOUT_LOG_CONSUMER ON CACHE BOOL "Stdout LogConsumer as default" FORCE)
-elseif(LOG_CONSUMER_DEFAULT STREQUAL "STDOUTERR")
-    set(STDOUTERR_LOG_CONSUMER ON CACHE BOOL "StdoutErr LogConsumer as default" FORCE)
+if(LOG_CONSUMER_DEFAULT STREQUAL "STDOUTERR")
+    set(STDOUTERR_LOG_CONSUMER ON)
 endif()
 
 ###############################################################################

--- a/include/fastdds/dds/log/Colors.hpp
+++ b/include/fastdds/dds/log/Colors.hpp
@@ -16,8 +16,8 @@
  * @file Colors.hpp
  */
 
-#ifndef _FASTRTPS_LOG_COLORS_H_
-#define _FASTRTPS_LOG_COLORS_H_
+#ifndef _FASTDDS_DDS_LOG_COLORS_H_
+#define _FASTDDS_DDS_LOG_COLORS_H_
 
 
 #if defined(_WIN32)
@@ -57,4 +57,4 @@
 #endif
 
 
-#endif /* _FASTRTPS_LOG_COLORS_H_ */
+#endif /* _FASTDDS_DDS_LOG_COLORS_H_ */

--- a/include/fastdds/dds/log/Colors.hpp
+++ b/include/fastdds/dds/log/Colors.hpp
@@ -54,7 +54,7 @@
     #define C_WHITE "\033[37m"
     #define C_B_WHITE "\033[37;1m"
     #define C_BRIGHT "\033[1m"
-#endif
+#endif // if defined(_WIN32)
 
 
 #endif /* _FASTDDS_DDS_LOG_COLORS_H_ */

--- a/include/fastdds/dds/log/FileConsumer.hpp
+++ b/include/fastdds/dds/log/FileConsumer.hpp
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef _FASTDDS_FILE_CONSUMER_HPP_
-#define _FASTDDS_FILE_CONSUMER_HPP_
+#ifndef _FASTDDS_DDS_LOG_FILECONSUMER_HPP_
+#define _FASTDDS_DDS_LOG_FILECONSUMER_HPP_
 
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/dds/log/OStreamConsumer.hpp>
@@ -69,4 +69,4 @@ private:
 } // namespace fastdds
 } // namespace eprosima
 
-#endif // _FASTDDS_FILE_CONSUMER_HPP_
+#endif // _FASTDDS_DDS_LOG_FILECONSUMER_HPP_

--- a/include/fastdds/dds/log/FileConsumer.hpp
+++ b/include/fastdds/dds/log/FileConsumer.hpp
@@ -21,6 +21,7 @@
 #define _FASTDDS_FILE_CONSUMER_HPP_
 
 #include <fastdds/dds/log/Log.hpp>
+#include <fastdds/dds/log/OStreamConsumer.hpp>
 
 #include <fstream>
 
@@ -33,7 +34,7 @@ namespace dds {
  *
  * @file FileConsumer.hpp
  */
-class FileConsumer : public LogConsumer
+class FileConsumer : public OStreamConsumer
 {
 public:
 
@@ -48,22 +49,16 @@ public:
             const std::string& filename,
             bool append = false);
 
-    /** \internal
-     * Called by Log to ask us to consume the Entry.
-     * @param Log::Entry to consume.
-     */
-    RTPS_DllAPI virtual void Consume(
-            const Log::Entry& entry);
-
     virtual ~FileConsumer();
 
 private:
 
-    void print_header(
-            const Log::Entry& entry);
-
-    void print_context(
-            const Log::Entry& entry);
+    /** \internal
+     * Called by Log consume to get the correct stream
+     * @param entry Log::Entry to consume.
+     */
+    RTPS_DllAPI virtual std::ostream& get_stream(
+            const Log::Entry& entry) override;
 
     std::string output_file_;
     std::ofstream file_;

--- a/include/fastdds/dds/log/FileConsumer.hpp
+++ b/include/fastdds/dds/log/FileConsumer.hpp
@@ -66,7 +66,7 @@ private:
             const Log::Entry& entry);
 
     std::string output_file_;
-    std::ofstream* file_;
+    std::ofstream file_;
     bool append_;
 };
 

--- a/include/fastdds/dds/log/FileConsumer.hpp
+++ b/include/fastdds/dds/log/FileConsumer.hpp
@@ -53,20 +53,20 @@ public:
      * @param Log::Entry to consume.
      */
     RTPS_DllAPI virtual void Consume(
-            const Log::Entry&);
+            const Log::Entry& entry);
 
     virtual ~FileConsumer();
 
 private:
 
     void print_header(
-            const Log::Entry&);
+            const Log::Entry& entry);
 
     void print_context(
-            const Log::Entry&);
+            const Log::Entry& entry);
 
     std::string output_file_;
-    std::ofstream file_;
+    std::ofstream* file_;
     bool append_;
 };
 

--- a/include/fastdds/dds/log/Log.hpp
+++ b/include/fastdds/dds/log/Log.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/fastdds/dds/log/Log.hpp
+++ b/include/fastdds/dds/log/Log.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#ifndef _FASTDDS_LOG_LOG_HPP_
-#define _FASTDDS_LOG_LOG_HPP_
+#ifndef _FASTDDS_DDS_LOG_LOG_HPP_
+#define _FASTDDS_DDS_LOG_LOG_HPP_
 
 #include <fastrtps/utils/DBQueue.h>
 #include <fastrtps/fastrtps_dll.h>
@@ -315,4 +315,4 @@ protected:
 } // namespace fastdds
 } // namespace eprosima
 
-#endif // ifndef _FASTDDS_LOG_LOG_HPP_
+#endif // ifndef _FASTDDS_DDS_LOG_LOG_HPP_

--- a/include/fastdds/dds/log/Log.hpp
+++ b/include/fastdds/dds/log/Log.hpp
@@ -202,9 +202,7 @@ class LogConsumer
 {
 public:
 
-    virtual ~LogConsumer()
-    {
-    }
+    virtual ~LogConsumer() = default;
 
     virtual void Consume(
             const Log::Entry&) = 0;
@@ -212,27 +210,27 @@ public:
 protected:
 
     void print_timestamp(
-            std::ostream* stream,
+            std::ostream& stream,
             const Log::Entry&,
             bool color) const;
 
     void print_header(
-            std::ostream* stream,
+            std::ostream& stream,
             const Log::Entry&,
             bool color) const;
 
     void print_context(
-            std::ostream* stream,
+            std::ostream& stream,
             const Log::Entry&,
             bool color) const;
 
     void print_message(
-            std::ostream* stream,
+            std::ostream& stream,
             const Log::Entry&,
             bool color) const;
 
     void print_new_line(
-            std::ostream* stream,
+            std::ostream& stream,
             bool color) const;
 };
 

--- a/include/fastdds/dds/log/Log.hpp
+++ b/include/fastdds/dds/log/Log.hpp
@@ -1,5 +1,4 @@
-
-// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -213,27 +212,27 @@ public:
 protected:
 
     void print_timestamp(
-            std::ostream& stream,
+            std::ostream* stream,
             const Log::Entry&,
             bool color) const;
 
     void print_header(
-            std::ostream& stream,
+            std::ostream* stream,
             const Log::Entry&,
             bool color) const;
 
     void print_context(
-            std::ostream& stream,
+            std::ostream* stream,
             const Log::Entry&,
             bool color) const;
 
     void print_message(
-            std::ostream& stream,
+            std::ostream* stream,
             const Log::Entry&,
             bool color) const;
 
     void print_new_line(
-            std::ostream& stream,
+            std::ostream* stream,
             bool color) const;
 };
 

--- a/include/fastdds/dds/log/Log.hpp
+++ b/include/fastdds/dds/log/Log.hpp
@@ -156,7 +156,7 @@ private:
     struct Resources
     {
         fastrtps::DBQueue<Entry> logs;
-        std::vector<std::unique_ptr<LogConsumer> > consumers;
+        std::vector<std::unique_ptr<LogConsumer>> consumers;
         std::unique_ptr<std::thread> logging_thread;
 
         // Condition variable segment.
@@ -236,7 +236,7 @@ protected:
 
 #if defined(WIN32)
 #define __func__ __FUNCTION__
-#endif
+#endif // if defined(WIN32)
 
 #ifndef LOG_NO_ERROR
 #define logError_(cat, msg)                                                                          \
@@ -258,7 +258,7 @@ protected:
     }
 #else
 #define logError_(cat, msg)
-#endif
+#endif // ifndef LOG_NO_ERROR
 
 #ifndef LOG_NO_WARNING
 #define logWarning_(cat, msg)                                                                              \
@@ -283,7 +283,7 @@ protected:
     }
 #else
 #define logWarning_(cat, msg)
-#endif
+#endif // ifndef LOG_NO_WARNING
 
 #if (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG)) && (defined(_DEBUG) || defined(__DEBUG)) && \
     (!defined(LOG_NO_INFO))
@@ -309,10 +309,10 @@ protected:
     }
 #else
 #define logInfo_(cat, msg)
-#endif
+#endif // if (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG)) && (defined(_DEBUG) || defined(__DEBUG)) && (!defined(LOG_NO_INFO))
 
 } // namespace dds
 } // namespace fastdds
 } // namespace eprosima
 
-#endif
+#endif // ifndef _FASTDDS_LOG_LOG_HPP_

--- a/include/fastdds/dds/log/OStreamConsumer.hpp
+++ b/include/fastdds/dds/log/OStreamConsumer.hpp
@@ -55,4 +55,4 @@ protected:
 } // namespace fastdds
 } // namespace eprosima
 
-#endif
+#endif // ifndef _FASTDDS_OSTREAM_CONSUMER_HPP_

--- a/include/fastdds/dds/log/OStreamConsumer.hpp
+++ b/include/fastdds/dds/log/OStreamConsumer.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _FASTDDS_OSTREAM_CONSUMER_HPP_
-#define _FASTDDS_OSTREAM_CONSUMER_HPP_
+#ifndef _FASTDDS_DDS_LOG_OSTREAMCONSUMER_HPP_
+#define _FASTDDS_DDS_LOG_OSTREAMCONSUMER_HPP_
 
 #include <iostream>
 
@@ -55,4 +55,4 @@ protected:
 } // namespace fastdds
 } // namespace eprosima
 
-#endif // ifndef _FASTDDS_OSTREAM_CONSUMER_HPP_
+#endif // ifndef _FASTDDS_DDS_LOG_OSTREAMCONSUMER_HPP_

--- a/include/fastdds/dds/log/OStreamConsumer.hpp
+++ b/include/fastdds/dds/log/OStreamConsumer.hpp
@@ -1,0 +1,58 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _FASTDDS_OSTREAM_CONSUMER_HPP_
+#define _FASTDDS_OSTREAM_CONSUMER_HPP_
+
+#include <iostream>
+
+#include <fastdds/dds/log/Log.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+
+/**
+ * Log consumer interface for std::ostream objects
+ *
+ * @file OStreamConsumer.hpp
+ */
+class OStreamConsumer : public LogConsumer
+{
+public:
+
+    virtual ~OStreamConsumer() = default;
+
+    /** \internal
+     * Called by Log to ask us to consume the Entry.
+     * @param Log::Entry to consume.
+     */
+    RTPS_DllAPI void Consume(
+            const Log::Entry& entry) override;
+
+protected:
+
+    /** \internal
+     * Called by Log consume to get the correct stream
+     * @param Log::Entry to consume.
+     */
+    RTPS_DllAPI virtual std::ostream& get_stream(
+            const Log::Entry& entry) = 0;
+};
+
+} // namespace dds
+} // namespace fastdds
+} // namespace eprosima
+
+#endif

--- a/include/fastdds/dds/log/StdoutConsumer.hpp
+++ b/include/fastdds/dds/log/StdoutConsumer.hpp
@@ -26,9 +26,7 @@ class StdoutConsumer : public OStreamConsumer
 {
 public:
 
-    virtual ~StdoutConsumer()
-    {
-    }
+    virtual ~StdoutConsumer() = default;
 
 private:
 

--- a/include/fastdds/dds/log/StdoutConsumer.hpp
+++ b/include/fastdds/dds/log/StdoutConsumer.hpp
@@ -16,31 +16,32 @@
 #define _FASTDDS_STDOUT_CONSUMER_HPP_
 
 #include <fastdds/dds/log/Log.hpp>
+#include <fastdds/dds/log/OStreamConsumer.hpp>
 
 namespace eprosima {
 namespace fastdds {
 namespace dds {
 
-class StdoutConsumer : public LogConsumer
+class StdoutConsumer : public OStreamConsumer
 {
 public:
 
-    virtual ~StdoutConsumer() {}
-
-    RTPS_DllAPI virtual void Consume(
-            const Log::Entry& entry);
+    virtual ~StdoutConsumer()
+    {
+    }
 
 private:
 
-    void print_header(
-            const Log::Entry& entry) const;
-
-    void print_context(
-            const Log::Entry& entry) const;
+    /** \internal
+     * Called by Log consume to get the correct stream
+     * @param Log::Entry to consume.
+     */
+    RTPS_DllAPI virtual std::ostream& get_stream(
+            const Log::Entry& entry) override;
 };
 
 } // namespace dds
 } // namespace fastdds
 } // namespace eprosima
 
-#endif
+#endif // ifndef _FASTDDS_STDOUT_CONSUMER_HPP_

--- a/include/fastdds/dds/log/StdoutConsumer.hpp
+++ b/include/fastdds/dds/log/StdoutConsumer.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _FASTDDS_STDOUT_CONSUMER_HPP_
-#define _FASTDDS_STDOUT_CONSUMER_HPP_
+#ifndef _FASTDDS_DDS_LOG_STDOUTCONSUMER_HPP_
+#define _FASTDDS_DDS_LOG_STDOUTCONSUMER_HPP_
 
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/dds/log/OStreamConsumer.hpp>
@@ -42,4 +42,4 @@ private:
 } // namespace fastdds
 } // namespace eprosima
 
-#endif // ifndef _FASTDDS_STDOUT_CONSUMER_HPP_
+#endif // ifndef _FASTDDS_DDS_LOG_STDOUTCONSUMER_HPP_

--- a/include/fastdds/dds/log/StdoutErrConsumer.hpp
+++ b/include/fastdds/dds/log/StdoutErrConsumer.hpp
@@ -1,0 +1,83 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _FASTDDS_STDOUTERR_CONSUMER_HPP_
+#define _FASTDDS_STDOUTERR_CONSUMER_HPP_
+
+#include <fastdds/dds/log/Log.hpp>
+#include <iostream>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+
+/**
+ * Log consumer that writes the log events with a Log::Kind equal to or more severe than a threshold (defaults to
+ * Log::Kind::Warning) to the STDERR, and events with a Log::Kind less severe than the threshold to the STDOUT.
+ *
+ * @file StdoutErrConsumer.hpp
+ */
+class StdoutErrConsumer : public LogConsumer
+{
+public:
+
+    virtual ~StdoutErrConsumer() {}
+
+    /** \internal
+     * Called by Log to ask us to consume the Entry.
+     * @param Log::Entry to consume.
+     */
+    RTPS_DllAPI virtual void Consume(
+            const Log::Entry& entry);
+
+    /**
+     * @brief Set the stderr_threshold to a Log::Kind.
+     * This threshold decides which log messages are output on STDOUT, and which are output to STDERR.
+     * Log messages with a Log::Kind equal to or more severe than the stderr_threshold are output to STDERR using
+     * std::cerr.
+     * Log messages with a Log::Kind less severe than the stderr_threshold are output to STDOUT using
+     * std::cout.
+     * @param kind The Log::Kind to which stderr_threshold is set.
+     */
+    RTPS_DllAPI virtual void stderr_threshold(
+            const Log::Kind& kind);
+
+    /**
+     * @brief Retrieve the stderr_threshold.
+     * @return The Log::Kind to which stderr_threshold is set.
+     */
+    RTPS_DllAPI virtual Log::Kind stderr_threshold() const;
+
+    /**
+     * @brief Default value of stderr_threshold.
+     */
+    RTPS_DllAPI static const Log::Kind STDERR_THRESHOLD_DEFAULT = Log::Kind::Warning;
+
+private:
+
+    void print_header(
+            const Log::Entry& entry) const;
+
+    void print_context(
+            const Log::Entry& entry) const;
+
+    std::ostream* stream_;
+    Log::Kind stderr_threshold_ = STDERR_THRESHOLD_DEFAULT;
+};
+
+} // namespace dds
+} // namespace fastdds
+} // namespace eprosima
+
+#endif

--- a/include/fastdds/dds/log/StdoutErrConsumer.hpp
+++ b/include/fastdds/dds/log/StdoutErrConsumer.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _FASTDDS__DDS_LOG_STDOUTERRCONSUMER_HPP_
-#define _FASTDDS__DDS_LOG_STDOUTERRCONSUMER_HPP_
+#ifndef _FASTDDS_DDS_LOG_STDOUTERRCONSUMER_HPP_
+#define _FASTDDS_DDS_LOG_STDOUTERRCONSUMER_HPP_
 
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/dds/log/OStreamConsumer.hpp>
@@ -77,4 +77,4 @@ private:
 } // namespace fastdds
 } // namespace eprosima
 
-#endif // ifndef _FASTDDS__DDS_LOG_STDOUTERRCONSUMER_HPP_
+#endif // ifndef _FASTDDS_DDS_LOG_STDOUTERRCONSUMER_HPP_

--- a/include/fastdds/dds/log/StdoutErrConsumer.hpp
+++ b/include/fastdds/dds/log/StdoutErrConsumer.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _FASTDDS_STDOUTERR_CONSUMER_HPP_
-#define _FASTDDS_STDOUTERR_CONSUMER_HPP_
+#ifndef _FASTDDS__DDS_LOG_STDOUTERRCONSUMER_HPP_
+#define _FASTDDS__DDS_LOG_STDOUTERRCONSUMER_HPP_
 
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/dds/log/OStreamConsumer.hpp>
@@ -77,4 +77,4 @@ private:
 } // namespace fastdds
 } // namespace eprosima
 
-#endif // ifndef _FASTDDS_STDOUTERR_CONSUMER_HPP_
+#endif // ifndef _FASTDDS__DDS_LOG_STDOUTERRCONSUMER_HPP_

--- a/include/fastdds/dds/log/StdoutErrConsumer.hpp
+++ b/include/fastdds/dds/log/StdoutErrConsumer.hpp
@@ -56,7 +56,7 @@ public:
     /**
      * @brief Default value of stderr_threshold.
      */
-    RTPS_DllAPI static const Log::Kind STDERR_THRESHOLD_DEFAULT = Log::Kind::Warning;
+    static constexpr Log::Kind STDERR_THRESHOLD_DEFAULT = Log::Kind::Warning;
 
 protected:
 

--- a/include/fastdds/dds/log/StdoutErrConsumer.hpp
+++ b/include/fastdds/dds/log/StdoutErrConsumer.hpp
@@ -16,6 +16,7 @@
 #define _FASTDDS_STDOUTERR_CONSUMER_HPP_
 
 #include <fastdds/dds/log/Log.hpp>
+#include <fastdds/dds/log/OStreamConsumer.hpp>
 #include <iostream>
 
 namespace eprosima {
@@ -28,18 +29,11 @@ namespace dds {
  *
  * @file StdoutErrConsumer.hpp
  */
-class StdoutErrConsumer : public LogConsumer
+class StdoutErrConsumer : public OStreamConsumer
 {
 public:
 
-    virtual ~StdoutErrConsumer() {}
-
-    /** \internal
-     * Called by Log to ask us to consume the Entry.
-     * @param Log::Entry to consume.
-     */
-    RTPS_DllAPI virtual void Consume(
-            const Log::Entry& entry);
+    virtual ~StdoutErrConsumer() = default;
 
     /**
      * @brief Set the stderr_threshold to a Log::Kind.
@@ -64,16 +58,19 @@ public:
      */
     RTPS_DllAPI static const Log::Kind STDERR_THRESHOLD_DEFAULT = Log::Kind::Warning;
 
+protected:
+
+    /** \internal
+     * Called by Log consume to get the correct stream
+     * @param Log::Entry to consume.
+     */
+    RTPS_DllAPI virtual std::ostream& get_stream(
+            const Log::Entry& entry) override;
+
 private:
 
-    void print_header(
-            const Log::Entry& entry) const;
-
-    void print_context(
-            const Log::Entry& entry) const;
-
-    std::ostream* stream_;
     Log::Kind stderr_threshold_ = STDERR_THRESHOLD_DEFAULT;
+
 };
 
 } // namespace dds

--- a/include/fastdds/dds/log/StdoutErrConsumer.hpp
+++ b/include/fastdds/dds/log/StdoutErrConsumer.hpp
@@ -77,4 +77,4 @@ private:
 } // namespace fastdds
 } // namespace eprosima
 
-#endif
+#endif // ifndef _FASTDDS_STDOUTERR_CONSUMER_HPP_

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -372,6 +372,7 @@ elseif(NOT EPROSIMA_INSTALLER)
         $<$<BOOL:${WIN32}>:_ENABLE_ATOMIC_ALIGNMENT_FIX>
         $<$<NOT:$<BOOL:${IS_THIRDPARTY_BOOST_SUPPORTED}>>:FASTDDS_SHM_TRANSPORT_DISABLED> # Do not compile SHM Transport
         $<$<BOOL:${SHM_TRANSPORT_DEFAULT}>:SHM_TRANSPORT_BUILTIN> # Enable SHM as built-in transport
+        $<$<BOOL:${STDOUTERR_LOG_CONSUMER}>:STDOUTERR_LOG_CONSUMER> # Enable StdoutErrConsumer as default LogConsumer
         )
 
     # Define public headers

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -34,6 +34,7 @@ set(${PROJECT_NAME}_source_files
     ${ALL_HEADERS}
 
     fastdds/log/Log.cpp
+    fastdds/log/OStreamConsumer.cpp
     fastdds/log/StdoutErrConsumer.cpp
     fastdds/log/StdoutConsumer.cpp
     fastdds/log/FileConsumer.cpp

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ set(${PROJECT_NAME}_source_files
     ${ALL_HEADERS}
 
     fastdds/log/Log.cpp
+    fastdds/log/StdoutErrConsumer.cpp
     fastdds/log/StdoutConsumer.cpp
     fastdds/log/FileConsumer.cpp
 

--- a/src/cpp/fastdds/log/FileConsumer.cpp
+++ b/src/cpp/fastdds/log/FileConsumer.cpp
@@ -1,3 +1,17 @@
+// Copyright 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <fastdds/dds/log/FileConsumer.hpp>
 #include <iomanip>
 
@@ -18,17 +32,20 @@ FileConsumer::FileConsumer(
 {
     if (append_)
     {
-        file_.open(output_file_, std::ios::out | std::ios::app);
+        file_ = new std::ofstream(output_file_, std::ios::out | std::ios::app);
     }
     else
     {
-        file_.open(output_file_, std::ios::out);
+        file_ = new std::ofstream(output_file_, std::ios::out);
     }
 }
 
 FileConsumer::~FileConsumer()
 {
-    file_.close();
+    if (file_ != nullptr)
+    {
+        file_->close();
+    }
 }
 
 void FileConsumer::Consume(
@@ -38,7 +55,7 @@ void FileConsumer::Consume(
     print_message(file_, entry, false);
     print_context(entry);
     print_new_line(file_, false);
-    file_.flush();
+    file_->flush();
 }
 
 void FileConsumer::print_header(

--- a/src/cpp/fastdds/log/FileConsumer.cpp
+++ b/src/cpp/fastdds/log/FileConsumer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/cpp/fastdds/log/FileConsumer.cpp
+++ b/src/cpp/fastdds/log/FileConsumer.cpp
@@ -32,20 +32,17 @@ FileConsumer::FileConsumer(
 {
     if (append_)
     {
-        file_ = new std::ofstream(output_file_, std::ios::out | std::ios::app);
+        file_.open(output_file_, std::ios::out | std::ios::app);
     }
     else
     {
-        file_ = new std::ofstream(output_file_, std::ios::out);
+        file_.open(output_file_, std::ios::out);
     }
 }
 
 FileConsumer::~FileConsumer()
 {
-    if (file_ != nullptr)
-    {
-        file_->close();
-    }
+    file_.close();
 }
 
 void FileConsumer::Consume(
@@ -55,7 +52,7 @@ void FileConsumer::Consume(
     print_message(file_, entry, false);
     print_context(entry);
     print_new_line(file_, false);
-    file_->flush();
+    file_.flush();
 }
 
 void FileConsumer::print_header(

--- a/src/cpp/fastdds/log/FileConsumer.cpp
+++ b/src/cpp/fastdds/log/FileConsumer.cpp
@@ -45,27 +45,11 @@ FileConsumer::~FileConsumer()
     file_.close();
 }
 
-void FileConsumer::Consume(
+std::ostream& FileConsumer::get_stream(
         const Log::Entry& entry)
 {
-    print_header(entry);
-    print_message(file_, entry, false);
-    print_context(entry);
-    print_new_line(file_, false);
-    file_.flush();
-}
-
-void FileConsumer::print_header(
-        const Log::Entry& entry)
-{
-    print_timestamp(file_, entry, false);
-    LogConsumer::print_header(file_, entry, false);
-}
-
-void FileConsumer::print_context(
-        const Log::Entry& entry)
-{
-    LogConsumer::print_context(file_, entry, false);
+    (void) entry;
+    return file_;
 }
 
 } // Namespace dds

--- a/src/cpp/fastdds/log/Log.cpp
+++ b/src/cpp/fastdds/log/Log.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/cpp/fastdds/log/Log.cpp
+++ b/src/cpp/fastdds/log/Log.cpp
@@ -1,9 +1,24 @@
+// Copyright 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <chrono>
 #include <iomanip>
 #include <mutex>
 
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/dds/log/StdoutConsumer.hpp>
+#include <fastdds/dds/log/StdoutErrConsumer.hpp>
 #include <fastdds/dds/log/Colors.hpp>
 #include <iostream>
 
@@ -22,7 +37,7 @@ Log::Resources::Resources()
     ,functions(true)
     ,verbosity(Log::Error)
 {
-    resources_.consumers.emplace_back(new StdoutConsumer);
+    resources_.consumers.emplace_back(new StdoutErrConsumer);
 }
 
 Log::Resources::~Resources()
@@ -59,7 +74,7 @@ void Log::Reset()
     resources_.functions = true;
     resources_.verbosity = Log::Error;
     resources_.consumers.clear();
-    resources_.consumers.emplace_back(new StdoutConsumer);
+    resources_.consumers.emplace_back(new StdoutErrConsumer);
 }
 
 void Log::Flush()
@@ -287,16 +302,16 @@ void Log::get_timestamp(
 }
 
 void LogConsumer::print_timestamp(
-        std::ostream& stream,
+        std::ostream* stream,
         const Log::Entry& entry,
         bool color) const
 {
     std::string white = (color) ? C_B_WHITE : "";
-    stream << white << entry.timestamp;
+    *stream << white << entry.timestamp;
 }
 
 void LogConsumer::print_header(
-        std::ostream& stream,
+        std::ostream* stream,
         const Log::Entry& entry,
         bool color) const
 {
@@ -311,49 +326,49 @@ void LogConsumer::print_header(
             (entry.kind == Log::Kind::Warning) ? "Warning" :
             (entry.kind == Log::Kind::Info) ? "Info" : "";
 
-    stream << c_b_color << "[" << white << entry.context.category << c_b_color << " " << kind << "] ";
+    *stream << c_b_color << "[" << white << entry.context.category << c_b_color << " " << kind << "] ";
 }
 
 void LogConsumer::print_context(
-        std::ostream& stream,
+        std::ostream* stream,
         const Log::Entry& entry,
         bool color) const
 {
     if (color)
     {
-        stream << C_B_BLUE;
+        *stream << C_B_BLUE;
     }
     if (entry.context.filename)
     {
-        stream << " (" << entry.context.filename;
-        stream << ":" << entry.context.line << ")";
+        *stream << " (" << entry.context.filename;
+        *stream << ":" << entry.context.line << ")";
     }
     if (entry.context.function)
     {
-        stream << " -> Function ";
+        *stream << " -> Function ";
         if (color)
         {
-            stream << C_CYAN;
+            *stream << C_CYAN;
         }
-        stream << entry.context.function;
+        *stream << entry.context.function;
     }
 }
 
 void LogConsumer::print_message(
-        std::ostream& stream,
+        std::ostream* stream,
         const Log::Entry& entry,
         bool color) const
 {
     std::string white = (color) ? C_WHITE : "";
-    stream << white << entry.message;
+    *stream << white << entry.message;
 }
 
 void LogConsumer::print_new_line(
-        std::ostream& stream,
+        std::ostream* stream,
         bool color) const
 {
     std::string def = (color) ? C_DEF : "";
-    stream << def << std::endl;
+    *stream << def << std::endl;
 }
 
 } //namespace dds

--- a/src/cpp/fastdds/log/Log.cpp
+++ b/src/cpp/fastdds/log/Log.cpp
@@ -38,7 +38,11 @@ Log::Resources::Resources()
     , functions(true)
     , verbosity(Log::Error)
 {
+#if STDOUTERR_LOG_CONSUMER
     resources_.consumers.emplace_back(new StdoutErrConsumer);
+#else
+    resources_.consumers.emplace_back(new StdoutConsumer);
+#endif // STDOUTERR_LOG_CONSUMER
 }
 
 Log::Resources::~Resources()
@@ -75,7 +79,11 @@ void Log::Reset()
     resources_.functions = true;
     resources_.verbosity = Log::Error;
     resources_.consumers.clear();
+#if STDOUTERR_LOG_CONSUMER
     resources_.consumers.emplace_back(new StdoutErrConsumer);
+#else
+    resources_.consumers.emplace_back(new StdoutConsumer);
+#endif
 }
 
 void Log::Flush()

--- a/src/cpp/fastdds/log/Log.cpp
+++ b/src/cpp/fastdds/log/Log.cpp
@@ -83,7 +83,7 @@ void Log::Reset()
     resources_.consumers.emplace_back(new StdoutErrConsumer);
 #else
     resources_.consumers.emplace_back(new StdoutConsumer);
-#endif
+#endif // if STDOUTERR_LOG_CONSUMER
 }
 
 void Log::Flush()

--- a/src/cpp/fastdds/log/Log.cpp
+++ b/src/cpp/fastdds/log/Log.cpp
@@ -32,11 +32,11 @@ struct Log::Resources Log::resources_;
 
 Log::Resources::Resources()
     : logging(false)
-    ,work(false)
-    ,current_loop(0)
-    ,filenames(false)
-    ,functions(true)
-    ,verbosity(Log::Error)
+    , work(false)
+    , current_loop(0)
+    , filenames(false)
+    , functions(true)
+    , verbosity(Log::Error)
 {
     resources_.consumers.emplace_back(new StdoutErrConsumer);
 }
@@ -57,10 +57,10 @@ void Log::ClearConsumers()
 {
     std::unique_lock<std::mutex> working(resources_.cv_mutex);
     resources_.cv.wait(working,
-        [&]()
-        {
-            return resources_.logs.BothEmpty();
-        });
+            [&]()
+            {
+                return resources_.logs.BothEmpty();
+            });
     std::unique_lock<std::mutex> guard(resources_.config_mutex);
     resources_.consumers.clear();
 }
@@ -101,16 +101,16 @@ void Log::Flush()
     for (int i = 0; i < 2; ++i)
     {
         resources_.cv.wait(guard,
-            [&]()
-            {
-                /* I must avoid:
-                 + the two calls be processed without an intermediate Run() loop (by using last_loop sequence number)
-                 + deadlock by absence of Run() loop activity (by using BothEmpty() call)
-                 */
-                return !resources_.logging ||
-                ( resources_.logs.Empty() &&
-                ( last_loop != resources_.current_loop || resources_.logs.BothEmpty()) );
-            });
+                [&]()
+                {
+                    /* I must avoid:
+                     + the two calls be processed without an intermediate Run() loop (by using last_loop sequence number)
+                     + deadlock by absence of Run() loop activity (by using BothEmpty() call)
+                     */
+                    return !resources_.logging ||
+                    ( resources_.logs.Empty() &&
+                    ( last_loop != resources_.current_loop || resources_.logs.BothEmpty()));
+                });
 
         last_loop = resources_.current_loop;
 
@@ -124,10 +124,10 @@ void Log::run()
     while (resources_.logging)
     {
         resources_.cv.wait(guard,
-            [&]()
-            {
-                return !resources_.logging || resources_.work;
-            });
+                [&]()
+                {
+                    return !resources_.logging || resources_.work;
+                });
 
         resources_.work = false;
 
@@ -217,7 +217,7 @@ void Log::KillThread()
         // Each VS version deals with post-main deallocation of threads in a very different way.
 #if !defined(_WIN32) || defined(FASTRTPS_STATIC_LINK) || _MSC_VER >= 1800
         resources_.logging_thread->join();
-#endif
+#endif // if !defined(_WIN32) || defined(FASTRTPS_STATIC_LINK) || _MSC_VER >= 1800
         resources_.logging_thread.reset();
     }
 }
@@ -298,7 +298,7 @@ void Log::get_timestamp(
     //    (void)ms;
 #else
     stream << std::put_time(localtime(&now_c), "%F %T") << "." << std::setw(3) << std::setfill('0') << ms << " ";
-#endif
+#endif // if defined(_WIN32)
     timestamp = stream.str();
 }
 

--- a/src/cpp/fastdds/log/Log.cpp
+++ b/src/cpp/fastdds/log/Log.cpp
@@ -17,6 +17,7 @@
 #include <mutex>
 
 #include <fastdds/dds/log/Log.hpp>
+#include <fastdds/dds/log/OStreamConsumer.hpp>
 #include <fastdds/dds/log/StdoutConsumer.hpp>
 #include <fastdds/dds/log/StdoutErrConsumer.hpp>
 #include <fastdds/dds/log/Colors.hpp>
@@ -302,16 +303,16 @@ void Log::get_timestamp(
 }
 
 void LogConsumer::print_timestamp(
-        std::ostream* stream,
+        std::ostream& stream,
         const Log::Entry& entry,
         bool color) const
 {
     std::string white = (color) ? C_B_WHITE : "";
-    *stream << white << entry.timestamp;
+    stream << white << entry.timestamp;
 }
 
 void LogConsumer::print_header(
-        std::ostream* stream,
+        std::ostream& stream,
         const Log::Entry& entry,
         bool color) const
 {
@@ -326,49 +327,49 @@ void LogConsumer::print_header(
             (entry.kind == Log::Kind::Warning) ? "Warning" :
             (entry.kind == Log::Kind::Info) ? "Info" : "";
 
-    *stream << c_b_color << "[" << white << entry.context.category << c_b_color << " " << kind << "] ";
+    stream << c_b_color << "[" << white << entry.context.category << c_b_color << " " << kind << "] ";
 }
 
 void LogConsumer::print_context(
-        std::ostream* stream,
+        std::ostream& stream,
         const Log::Entry& entry,
         bool color) const
 {
     if (color)
     {
-        *stream << C_B_BLUE;
+        stream << C_B_BLUE;
     }
     if (entry.context.filename)
     {
-        *stream << " (" << entry.context.filename;
-        *stream << ":" << entry.context.line << ")";
+        stream << " (" << entry.context.filename;
+        stream << ":" << entry.context.line << ")";
     }
     if (entry.context.function)
     {
-        *stream << " -> Function ";
+        stream << " -> Function ";
         if (color)
         {
-            *stream << C_CYAN;
+            stream << C_CYAN;
         }
-        *stream << entry.context.function;
+        stream << entry.context.function;
     }
 }
 
 void LogConsumer::print_message(
-        std::ostream* stream,
+        std::ostream& stream,
         const Log::Entry& entry,
         bool color) const
 {
     std::string white = (color) ? C_WHITE : "";
-    *stream << white << entry.message;
+    stream << white << entry.message;
 }
 
 void LogConsumer::print_new_line(
-        std::ostream* stream,
+        std::ostream& stream,
         bool color) const
 {
     std::string def = (color) ? C_DEF : "";
-    *stream << def << std::endl;
+    stream << def << std::endl;
 }
 
 } //namespace dds

--- a/src/cpp/fastdds/log/OStreamConsumer.cpp
+++ b/src/cpp/fastdds/log/OStreamConsumer.cpp
@@ -27,6 +27,7 @@ void OStreamConsumer::Consume(
     print_message(stream, entry, true);
     print_context(stream, entry, true);
     print_new_line(stream, true);
+    stream.flush();
 }
 
 } // Namespace dds

--- a/src/cpp/fastdds/log/OStreamConsumer.cpp
+++ b/src/cpp/fastdds/log/OStreamConsumer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,34 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <fastdds/dds/log/StdoutConsumer.hpp>
-#include <iostream>
-#include <iomanip>
+#include <fastdds/dds/log/OStreamConsumer.hpp>
 
 namespace eprosima {
 namespace fastdds {
 namespace dds {
 
-void StdoutConsumer::Consume(
+void OStreamConsumer::Consume(
         const Log::Entry& entry)
 {
-    print_header(entry);
-    print_message(std::cout, entry, true);
-    print_context(entry);
-    print_new_line(std::cout, true);
-}
-
-void StdoutConsumer::print_header(
-        const Log::Entry& entry) const
-{
-    print_timestamp(std::cout, entry, true);
-    LogConsumer::print_header(std::cout, entry, true);
-}
-
-void StdoutConsumer::print_context(
-        const Log::Entry& entry) const
-{
-    LogConsumer::print_context(std::cout, entry, true);
+    std::ostream& stream = get_stream(entry);
+    print_timestamp(stream, entry, true);
+    print_header(stream, entry, true);
+    print_message(stream, entry, true);
+    print_context(stream, entry, true);
+    print_new_line(stream, true);
 }
 
 } // Namespace dds

--- a/src/cpp/fastdds/log/StdoutConsumer.cpp
+++ b/src/cpp/fastdds/log/StdoutConsumer.cpp
@@ -20,26 +20,11 @@ namespace eprosima {
 namespace fastdds {
 namespace dds {
 
-void StdoutConsumer::Consume(
+std::ostream& StdoutConsumer::get_stream(
         const Log::Entry& entry)
 {
-    print_header(entry);
-    print_message(std::cout, entry, true);
-    print_context(entry);
-    print_new_line(std::cout, true);
-}
-
-void StdoutConsumer::print_header(
-        const Log::Entry& entry) const
-{
-    print_timestamp(std::cout, entry, true);
-    LogConsumer::print_header(std::cout, entry, true);
-}
-
-void StdoutConsumer::print_context(
-        const Log::Entry& entry) const
-{
-    LogConsumer::print_context(std::cout, entry, true);
+    (void) entry;
+    return std::cout;
 }
 
 } // Namespace dds

--- a/src/cpp/fastdds/log/StdoutConsumer.cpp
+++ b/src/cpp/fastdds/log/StdoutConsumer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/cpp/fastdds/log/StdoutErrConsumer.cpp
+++ b/src/cpp/fastdds/log/StdoutErrConsumer.cpp
@@ -38,10 +38,7 @@ std::ostream& StdoutErrConsumer::get_stream(
     {
         return std::cerr;
     }
-    else
-    {
-        return std::cout;
-    }
+    return std::cout;
 }
 
 } // Namespace dds

--- a/src/cpp/fastdds/log/StdoutErrConsumer.cpp
+++ b/src/cpp/fastdds/log/StdoutErrConsumer.cpp
@@ -31,7 +31,7 @@ Log::Kind StdoutErrConsumer::stderr_threshold() const
 }
 
 std::ostream& StdoutErrConsumer::get_stream(
-            const Log::Entry& entry)
+        const Log::Entry& entry)
 {
     // If Log::Kind is stderr_threshold_ or more severe, then use STDERR, else use STDOUT
     if (entry.kind <= stderr_threshold_)

--- a/src/cpp/fastdds/log/StdoutErrConsumer.cpp
+++ b/src/cpp/fastdds/log/StdoutErrConsumer.cpp
@@ -19,25 +19,6 @@ namespace eprosima {
 namespace fastdds {
 namespace dds {
 
-void StdoutErrConsumer::Consume(
-        const Log::Entry& entry)
-{
-    // If Log::Kind is stderr_threshold_ or more severe, then use STDERR, else use STDOUT
-    if (entry.kind <= stderr_threshold_)
-    {
-        stream_ = &std::cerr;
-    }
-    else
-    {
-        stream_ = &std::cout;
-    }
-
-    print_header(entry);
-    print_message(stream_, entry, true);
-    print_context(entry);
-    print_new_line(stream_, true);
-}
-
 void StdoutErrConsumer::stderr_threshold(
         const Log::Kind& kind)
 {
@@ -49,17 +30,18 @@ Log::Kind StdoutErrConsumer::stderr_threshold() const
     return stderr_threshold_;
 }
 
-void StdoutErrConsumer::print_header(
-        const Log::Entry& entry) const
+std::ostream& StdoutErrConsumer::get_stream(
+            const Log::Entry& entry)
 {
-    print_timestamp(stream_, entry, true);
-    LogConsumer::print_header(stream_, entry, true);
-}
-
-void StdoutErrConsumer::print_context(
-        const Log::Entry& entry) const
-{
-    LogConsumer::print_context(stream_, entry, true);
+    // If Log::Kind is stderr_threshold_ or more severe, then use STDERR, else use STDOUT
+    if (entry.kind <= stderr_threshold_)
+    {
+        return std::cerr;
+    }
+    else
+    {
+        return std::cout;
+    }
 }
 
 } // Namespace dds

--- a/src/cpp/fastdds/log/StdoutErrConsumer.cpp
+++ b/src/cpp/fastdds/log/StdoutErrConsumer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,34 +12,54 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <fastdds/dds/log/StdoutConsumer.hpp>
-#include <iostream>
+#include <fastdds/dds/log/StdoutErrConsumer.hpp>
 #include <iomanip>
 
 namespace eprosima {
 namespace fastdds {
 namespace dds {
 
-void StdoutConsumer::Consume(
+void StdoutErrConsumer::Consume(
         const Log::Entry& entry)
 {
+    // If Log::Kind is stderr_threshold_ or more severe, then use STDERR, else use STDOUT
+    if (entry.kind <= stderr_threshold_)
+    {
+        stream_ = &std::cerr;
+    }
+    else
+    {
+        stream_ = &std::cout;
+    }
+
     print_header(entry);
-    print_message(&std::cout, entry, true);
+    print_message(stream_, entry, true);
     print_context(entry);
-    print_new_line(&std::cout, true);
+    print_new_line(stream_, true);
 }
 
-void StdoutConsumer::print_header(
-        const Log::Entry& entry) const
+void StdoutErrConsumer::stderr_threshold(
+        const Log::Kind& kind)
 {
-    print_timestamp(&std::cout, entry, true);
-    LogConsumer::print_header(&std::cout, entry, true);
+    stderr_threshold_ = kind;
 }
 
-void StdoutConsumer::print_context(
+Log::Kind StdoutErrConsumer::stderr_threshold() const
+{
+    return stderr_threshold_;
+}
+
+void StdoutErrConsumer::print_header(
         const Log::Entry& entry) const
 {
-    LogConsumer::print_context(&std::cout, entry, true);
+    print_timestamp(stream_, entry, true);
+    LogConsumer::print_header(stream_, entry, true);
+}
+
+void StdoutErrConsumer::print_context(
+        const Log::Entry& entry) const
+{
+    LogConsumer::print_context(stream_, entry, true);
 }
 
 } // Namespace dds

--- a/src/cpp/rtps/xmlparser/XMLParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLParser.cpp
@@ -2748,14 +2748,10 @@ XMLP_ret XMLParser::parseLogConfig(
             }
             else if (strcmp(tag, CONSUMER) == 0)
             {
-                XMLP_ret aux_ret = parseXMLConsumer(*p_element);
-                if (aux_ret != XMLP_ret::XML_OK)
+                ret = parseXMLConsumer(*p_element);
+                if (ret == XMLP_ret::XML_ERROR)
                 {
-                    ret = aux_ret;
-                    if (ret == XMLP_ret::XML_ERROR)
-                    {
-                        return ret;
-                    }
+                    return ret;
                 }
             }
             else

--- a/src/cpp/rtps/xmlparser/XMLParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLParser.cpp
@@ -2871,9 +2871,9 @@ XMLP_ret XMLParser::parseXMLConsumer(
                 }
 
                 // Create consumer with the specified `stderr_threshold` and register it.
-                StdoutErrConsumer* consumer = new StdoutErrConsumer;
-                consumer->stderr_threshold(threshold);
-                Log::RegisterConsumer(std::unique_ptr<LogConsumer>(consumer));
+                StdoutErrConsumer* log_consumer = new StdoutErrConsumer;
+                log_consumer->stderr_threshold(threshold);
+                Log::RegisterConsumer(std::unique_ptr<LogConsumer>(log_consumer));
             }
         }
         else if (std::strcmp(classStr.c_str(), "FileConsumer") == 0)

--- a/src/cpp/rtps/xmlparser/XMLParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLParser.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2017 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/cpp/rtps/xmlparser/XMLParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLParser.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@
 
 #include <fastdds/dds/log/FileConsumer.hpp>
 #include <fastdds/dds/log/StdoutConsumer.hpp>
+#include <fastdds/dds/log/StdoutErrConsumer.hpp>
 
 #include <tinyxml2.h>
 #include <iostream>
@@ -131,11 +132,19 @@ XMLP_ret XMLParser::parseXML(
                 }
                 else if (strcmp(tag, TYPES) == 0)
                 {
-                    ret = parseXMLTypes(node);
+                    up_base_node_t types_node = up_base_node_t{ new BaseNode{NodeType::TYPES} };
+                    if (XMLP_ret::XML_OK == (ret = parseXMLTypes(node)))
+                    {
+                        root->addChild(std::move(types_node));
+                    }
                 }
                 else if (strcmp(tag, LOG) == 0)
                 {
-                    ret = parseLogConfig(node);
+                    up_base_node_t log_node = up_base_node_t{ new BaseNode{NodeType::LOG} };
+                    if (XMLP_ret::XML_OK == (ret = parseLogConfig(node)))
+                    {
+                        root->addChild(std::move(log_node));
+                    }
                 }
                 else
                 {
@@ -2739,10 +2748,14 @@ XMLP_ret XMLParser::parseLogConfig(
             }
             else if (strcmp(tag, CONSUMER) == 0)
             {
-                ret = parseXMLConsumer(*p_element);
-                if (ret != XMLP_ret::XML_OK)
+                XMLP_ret aux_ret = parseXMLConsumer(*p_element);
+                if (aux_ret != XMLP_ret::XML_OK)
                 {
-                    return ret;
+                    ret = aux_ret;
+                    if (ret == XMLP_ret::XML_ERROR)
+                    {
+                        return ret;
+                    }
                 }
             }
             else
@@ -2771,6 +2784,95 @@ XMLP_ret XMLParser::parseXMLConsumer(
         if (std::strcmp(classStr.c_str(), "StdoutConsumer") == 0)
         {
             Log::RegisterConsumer(std::unique_ptr<LogConsumer>(new StdoutConsumer));
+        }
+        else if (std::strcmp(classStr.c_str(), "StdoutErrConsumer") == 0)
+        {
+            /* Register a StdoutErrConsumer */
+
+            // Get first property
+            tinyxml2::XMLElement* property = consumer.FirstChildElement(PROPERTY);
+            if (nullptr == property)
+            {
+                // If no properties are specified, create the consumer with default values
+                Log::RegisterConsumer(std::unique_ptr<LogConsumer>(new StdoutErrConsumer));
+            }
+            else
+            {
+                // Only one property is supported. Its name is `stderr_threshold`, and its value is a log kind specified
+                // as a string in the form `Log::Kind::<Kind>`.
+                tinyxml2::XMLElement* p_auxName = nullptr;    // Property name
+                tinyxml2::XMLElement* p_auxValue = nullptr;   // Property value
+                uint8_t stderr_threshold_property_count = 0;  // Occurrences count. Only one is allowed
+
+                // Get default threshold
+                Log::Kind threshold = StdoutErrConsumer::STDERR_THRESHOLD_DEFAULT;
+
+                // Iterate over the properties
+                while (nullptr != property)
+                {
+                    if (nullptr != (p_auxName = property->FirstChildElement(NAME)))
+                    {
+                        // Get property name
+                        std::string s = p_auxName->GetText();
+
+                        if (std::strcmp(s.c_str(), "stderr_threshold") == 0)
+                        {
+                            /* Property is a `stderr_threshold` */
+
+                            // Update occurrence count and check how many encountered. Only the first one applies, the
+                            // rest are ignored.
+                            stderr_threshold_property_count++;
+                            if (stderr_threshold_property_count > 1)
+                            {
+                                // Continue with the next property if `stderr_threshold` had been already specified.
+                                logError(XMLParser, classStr << " only supports one occurrence of 'stderr_threshold'."
+                                        << " Only the first one is applied.")
+                                property = property->NextSiblingElement(PROPERTY);
+                                ret = XMLP_ret::XML_NOK;
+                                continue;
+                            }
+
+                            // Get the property value. It should be a Log::Kind.
+                            if (nullptr != (p_auxValue = property->FirstChildElement(VALUE)))
+                            {
+                                // Get property value and use it to set the threshold.
+                                std::string threshold_str = p_auxValue->GetText();
+                                if (std::strcmp(threshold_str.c_str(), "Log::Kind::Error") == 0)
+                                {
+                                    threshold = Log::Kind::Error;
+                                }
+                                else if (std::strcmp(threshold_str.c_str(), "Log::Kind::Warning") == 0)
+                                {
+                                    threshold = Log::Kind::Warning;
+                                }
+                                else if (std::strcmp(threshold_str.c_str(), "Log::Kind::Info") == 0)
+                                {
+                                    threshold = Log::Kind::Info;
+                                }
+                                else
+                                {
+                                    logError(XMLParser, "Unkown Log::Kind '" << threshold_str
+                                            << "'. Using default threshold.")
+                                    ret = XMLP_ret::XML_NOK;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            logError(XMLParser, "Unkown property value '" << s << "' in " << classStr
+                                    << " log consumer");
+                            ret = XMLP_ret::XML_NOK;
+                        }
+                    }
+                    // Continue with the next property
+                    property = property->NextSiblingElement(PROPERTY);
+                }
+
+                // Create consumer with the specified `stderr_threshold` and register it.
+                StdoutErrConsumer* consumer = new StdoutErrConsumer;
+                consumer->stderr_threshold(threshold);
+                Log::RegisterConsumer(std::unique_ptr<LogConsumer>(consumer));
+            }
         }
         else if (std::strcmp(classStr.c_str(), "FileConsumer") == 0)
         {
@@ -2803,6 +2905,7 @@ XMLP_ret XMLParser::parseXMLConsumer(
                             {
                                 logError(XMLParser, "Filename value cannot be found for " << classStr
                                                                                           << " log consumer.");
+                                ret = XMLP_ret::XML_NOK;
                             }
                         }
                         else if (std::strcmp(s.c_str(), "append") == 0)
@@ -2819,12 +2922,14 @@ XMLP_ret XMLParser::parseXMLConsumer(
                             {
                                 logError(XMLParser, "Append value cannot be found for " << classStr
                                                                                         << " log consumer.");
+                                ret = XMLP_ret::XML_NOK;
                             }
                         }
                         else
                         {
                             logError(XMLParser, "Unknown property " << s << " in " << classStr
                                                                     << " log consumer.");
+                            ret = XMLP_ret::XML_NOK;
                         }
                     }
                     property = property->NextSiblingElement(PROPERTY);

--- a/src/cpp/rtps/xmlparser/XMLParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLParser.cpp
@@ -90,7 +90,7 @@ XMLP_ret XMLParser::parseXML(
         root.reset(new BaseNode{ NodeType::ROOT });
         tinyxml2::XMLElement* node = p_root->FirstChildElement();
         const char* tag = nullptr;
-        while ( (nullptr != node) && (ret == XMLP_ret::XML_OK))
+        while ((nullptr != node) && (ret == XMLP_ret::XML_OK))
         {
             if (nullptr != (tag = node->Value()))
             {
@@ -2826,7 +2826,7 @@ XMLP_ret XMLParser::parseXMLConsumer(
                             {
                                 // Continue with the next property if `stderr_threshold` had been already specified.
                                 logError(XMLParser, classStr << " only supports one occurrence of 'stderr_threshold'."
-                                        << " Only the first one is applied.")
+                                                             << " Only the first one is applied.")
                                 property = property->NextSiblingElement(PROPERTY);
                                 ret = XMLP_ret::XML_NOK;
                                 continue;
@@ -2852,7 +2852,7 @@ XMLP_ret XMLParser::parseXMLConsumer(
                                 else
                                 {
                                     logError(XMLParser, "Unkown Log::Kind '" << threshold_str
-                                            << "'. Using default threshold.")
+                                                                             << "'. Using default threshold.")
                                     ret = XMLP_ret::XML_NOK;
                                 }
                             }
@@ -2860,7 +2860,7 @@ XMLP_ret XMLParser::parseXMLConsumer(
                         else
                         {
                             logError(XMLParser, "Unkown property value '" << s << "' in " << classStr
-                                    << " log consumer");
+                                                                          << " log consumer");
                             ret = XMLP_ret::XML_NOK;
                         }
                     }

--- a/src/cpp/rtps/xmlparser/XMLParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLParser.cpp
@@ -132,6 +132,9 @@ XMLP_ret XMLParser::parseXML(
                 }
                 else if (strcmp(tag, TYPES) == 0)
                 {
+                    // TODO Workaround to propagate the return code upstream. A refactor is needed to propagate the
+                    // return code in some other more sensible way or populate the object and change code upstream to
+                    // read this new object.
                     up_base_node_t types_node = up_base_node_t{ new BaseNode{NodeType::TYPES} };
                     if (XMLP_ret::XML_OK == (ret = parseXMLTypes(node)))
                     {
@@ -140,6 +143,9 @@ XMLP_ret XMLParser::parseXML(
                 }
                 else if (strcmp(tag, LOG) == 0)
                 {
+                    // TODO Workaround to propagate the return code upstream. A refactor is needed to propagate the
+                    // return code in some other more sensible way or populate the object and change code upstream to
+                    // read this new object.
                     up_base_node_t log_node = up_base_node_t{ new BaseNode{NodeType::LOG} };
                     if (XMLP_ret::XML_OK == (ret = parseLogConfig(node)))
                     {

--- a/src/cpp/rtps/xmlparser/XMLProfileManager.cpp
+++ b/src/cpp/rtps/xmlparser/XMLProfileManager.cpp
@@ -324,6 +324,8 @@ XMLP_ret XMLProfileManager::loadXMLFile(
             {
                 return XMLProfileManager::extractProfiles(std::move(child), filename);
             }
+            // TODO Workaround when there is a ROOT tag without PROFILES. Return the corresponding error instead of
+            // XMLP_ret::XML_ERROR. Only the type is checked so the objects do not need to be populated.
             else if (NodeType::TYPES == child.get()->getType())
             {
                 return loaded_ret;

--- a/src/cpp/rtps/xmlparser/XMLProfileManager.cpp
+++ b/src/cpp/rtps/xmlparser/XMLProfileManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2017 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/cpp/rtps/xmlparser/XMLProfileManager.cpp
+++ b/src/cpp/rtps/xmlparser/XMLProfileManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -311,6 +311,11 @@ XMLP_ret XMLProfileManager::loadXMLFile(
         return loaded_ret;
     }
 
+    if (NodeType::LOG == root_node->getType())
+    {
+        return loaded_ret;
+    }
+
     if (NodeType::ROOT == root_node->getType())
     {
         for (auto&& child: root_node->getChildren())
@@ -318,6 +323,14 @@ XMLP_ret XMLProfileManager::loadXMLFile(
             if (NodeType::PROFILES == child.get()->getType())
             {
                 return XMLProfileManager::extractProfiles(std::move(child), filename);
+            }
+            else if (NodeType::TYPES == child.get()->getType())
+            {
+                return loaded_ret;
+            }
+            else if (NodeType::LOG == child.get()->getType())
+            {
+                return loaded_ret;
             }
         }
     }

--- a/src/cpp/rtps/xmlparser/XMLProfileManager.cpp
+++ b/src/cpp/rtps/xmlparser/XMLProfileManager.cpp
@@ -506,7 +506,7 @@ XMLP_ret XMLProfileManager::extractParticipantProfile(
     if (it != node_part->getAttributes().end() && it->second == "true") // Set as default profile
     {
         // +V+ TODO: LOG ERROR IN SECOND ATTEMPT
-        default_participant_attributes = *(emplace.first->second.get() );
+        default_participant_attributes = *(emplace.first->second.get());
     }
     return XMLP_ret::XML_OK;
 }
@@ -539,7 +539,7 @@ XMLP_ret XMLProfileManager::extractPublisherProfile(
     if (it != node_part->getAttributes().end() && it->second == "true") // Set as default profile
     {
         // +V+ TODO: LOG ERROR IN SECOND ATTEMPT
-        default_publisher_attributes = *(emplace.first->second.get() );
+        default_publisher_attributes = *(emplace.first->second.get());
     }
     return XMLP_ret::XML_OK;
 }
@@ -572,7 +572,7 @@ XMLP_ret XMLProfileManager::extractSubscriberProfile(
     if (it != node_part->getAttributes().end() && it->second == "true") // Set as default profile
     {
         // +V+ TODO: LOG ERROR IN SECOND ATTEMPT
-        default_subscriber_attributes = *(emplace.first->second.get() );
+        default_subscriber_attributes = *(emplace.first->second.get());
     }
     return XMLP_ret::XML_OK;
 }

--- a/test/mock/rtps/Log/fastdds/dds/log/FileConsumer.hpp
+++ b/test/mock/rtps/Log/fastdds/dds/log/FileConsumer.hpp
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef _FASTDDS_FILE_CONSUMER_HPP_
-#define _FASTDDS_FILE_CONSUMER_HPP_
+#ifndef _FASTDDS_DDS_LOG_FILECONSUMER_HPP_
+#define _FASTDDS_DDS_LOG_FILECONSUMER_HPP_
 
 #include <gmock/gmock.h>
 
@@ -54,4 +54,4 @@ MATCHER(IsFileConsumer, "Argument is a FileConsumer object?")
 } // namespace fastdds
 } // namespace eprosima
 
-#endif // _FASTDDS_FILE_CONSUMER_HPP_
+#endif // _FASTDDS_DDS_LOG_FILECONSUMER_HPP_

--- a/test/mock/rtps/Log/fastdds/dds/log/FileConsumer.hpp
+++ b/test/mock/rtps/Log/fastdds/dds/log/FileConsumer.hpp
@@ -23,20 +23,28 @@
 #include <gmock/gmock.h>
 
 #include <fastdds/dds/log/Log.hpp>
+#include <fastdds/dds/log/OStreamConsumer.hpp>
 
 namespace eprosima {
 namespace fastdds {
 namespace dds {
 
-class FileConsumer : public LogConsumer
+class FileConsumer : public OStreamConsumer
 {
-    public:
+public:
 
-        FileConsumer() = default;
+    FileConsumer() = default;
 
-        FileConsumer(const std::string &, bool = false) {};
+    FileConsumer(
+            const std::string&,
+            bool = false)
+    {
+    }
 
-        virtual ~FileConsumer() {}
+    virtual ~FileConsumer()
+    {
+    }
+
 };
 
 MATCHER(IsFileConsumer, "Argument is a FileConsumer object?")

--- a/test/mock/rtps/Log/fastdds/dds/log/FileConsumer.hpp
+++ b/test/mock/rtps/Log/fastdds/dds/log/FileConsumer.hpp
@@ -41,10 +41,7 @@ public:
     {
     }
 
-    virtual ~FileConsumer()
-    {
-    }
-
+    virtual ~FileConsumer() = default;
 };
 
 MATCHER(IsFileConsumer, "Argument is a FileConsumer object?")

--- a/test/mock/rtps/Log/fastdds/dds/log/Log.hpp
+++ b/test/mock/rtps/Log/fastdds/dds/log/Log.hpp
@@ -24,20 +24,26 @@
  * eProsima log mock.
  */
 
-#define logInfo(cat,msg)                                                                                \
+#define logInfo(cat, msg)                                                                                \
     {                                                                                                   \
         NulStreambuf null_buffer;                                                                       \
         std::ostream null_stream(&null_buffer);                                                         \
         null_stream << msg;                                                                             \
     }
 
-#define logWarning(cat,msg) logInfo(cat,msg)
-#define logError(cat,msg) logInfo(cat,msg)
+#define logWarning(cat, msg) logInfo(cat, msg)
+#define logError(cat, msg) logInfo(cat, msg)
 
 class NulStreambuf : public std::streambuf
 {
 protected:
-    int overflow(int c) { return c; }
+
+    int overflow(
+            int c)
+    {
+        return c;
+    }
+
 };
 
 namespace eprosima {
@@ -46,42 +52,53 @@ namespace dds {
 
 class LogConsumer
 {
-    public:
+public:
 
-        virtual ~LogConsumer() = default;
+    virtual ~LogConsumer() = default;
 };
 
 class Log
 {
-    public:
-        enum Kind
-        {
-            Error,
-            Warning,
-            Info,
-        };
+public:
 
-        static std::function<void(std::unique_ptr<LogConsumer>&&)> RegisterConsumerFunc;
-        static void RegisterConsumer(std::unique_ptr<LogConsumer>&& c) { RegisterConsumerFunc(std::move(c)); }
+    enum Kind
+    {
+        Error,
+        Warning,
+        Info,
+    };
 
-        static std::function<void()> ClearConsumersFunc;
-        static void ClearConsumers() { ClearConsumersFunc(); }
+    static std::function<void(std::unique_ptr<LogConsumer>&&)> RegisterConsumerFunc;
+    static void RegisterConsumer(
+            std::unique_ptr<LogConsumer>&& c)
+    {
+        RegisterConsumerFunc(std::move(c));
+    }
+
+    static std::function<void()> ClearConsumersFunc;
+    static void ClearConsumers()
+    {
+        ClearConsumersFunc();
+    }
+
 };
 
 using ::testing::_;
 using ::testing::Invoke;
 class LogMock
 {
-    public:
-        // r-value support for mocked function.
-        void RegisterConsumer(std::unique_ptr<LogConsumer>&& p)
-        {
-            RegisterConsumer(p);
-        }
+public:
 
-        MOCK_METHOD1(RegisterConsumer, void(std::unique_ptr<LogConsumer>&));
+    // r-value support for mocked function.
+    void RegisterConsumer(
+            std::unique_ptr<LogConsumer>&& p)
+    {
+        RegisterConsumer(p);
+    }
 
-        MOCK_METHOD0(ClearConsumers, void());
+    MOCK_METHOD1(RegisterConsumer, void(std::unique_ptr<LogConsumer>&));
+
+    MOCK_METHOD0(ClearConsumers, void());
 };
 
 } // namespace dds

--- a/test/mock/rtps/Log/fastdds/dds/log/Log.hpp
+++ b/test/mock/rtps/Log/fastdds/dds/log/Log.hpp
@@ -48,7 +48,7 @@ class LogConsumer
 {
     public:
 
-        virtual ~LogConsumer() {}
+        virtual ~LogConsumer() = default;
 };
 
 class Log

--- a/test/mock/rtps/Log/fastdds/dds/log/Log.hpp
+++ b/test/mock/rtps/Log/fastdds/dds/log/Log.hpp
@@ -54,6 +54,12 @@ class LogConsumer
 class Log
 {
     public:
+        enum Kind
+        {
+            Error,
+            Warning,
+            Info,
+        };
 
         static std::function<void(std::unique_ptr<LogConsumer>&&)> RegisterConsumerFunc;
         static void RegisterConsumer(std::unique_ptr<LogConsumer>&& c) { RegisterConsumerFunc(std::move(c)); }

--- a/test/mock/rtps/Log/fastdds/dds/log/Log.hpp
+++ b/test/mock/rtps/Log/fastdds/dds/log/Log.hpp
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#ifndef _FASTDDS_LOG_LOG_HPP_
-#define _FASTDDS_LOG_LOG_HPP_
+#ifndef _FASTDDS_DDS_LOG_LOG_HPP_
+#define _FASTDDS_DDS_LOG_LOG_HPP_
 
 #include <functional>
 #include <memory>
@@ -105,4 +105,4 @@ public:
 } // namespace fastdds
 } // namespace eprosima
 
-#endif // _FASTDDS_LOG_LOG_HPP_
+#endif // _FASTDDS_DDS_LOG_LOG_HPP_

--- a/test/mock/rtps/Log/fastdds/dds/log/OStreamConsumer.hpp
+++ b/test/mock/rtps/Log/fastdds/dds/log/OStreamConsumer.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,10 +21,12 @@ namespace eprosima {
 namespace fastdds {
 namespace dds {
 
-    class OStreamConsumer : public LogConsumer {};
+class OStreamConsumer : public LogConsumer
+{
+};
 
 } // namespace dds
 } // namespace fastdds
 } // namespace eprosima
 
-#endif
+#endif // ifndef _FASTDDS_OSTREAM_CONSUMER_HPP_

--- a/test/mock/rtps/Log/fastdds/dds/log/OStreamConsumer.hpp
+++ b/test/mock/rtps/Log/fastdds/dds/log/OStreamConsumer.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _FASTDDS_OSTREAM_CONSUMER_HPP_
-#define _FASTDDS_OSTREAM_CONSUMER_HPP_
+#ifndef _FASTDDS_DDS_LOG_OSTREAMCONSUMER_HPP_
+#define _FASTDDS_DDS_LOG_OSTREAMCONSUMER_HPP_
 
 #include <fastdds/dds/log/Log.hpp>
 
@@ -29,4 +29,4 @@ class OStreamConsumer : public LogConsumer
 } // namespace fastdds
 } // namespace eprosima
 
-#endif // ifndef _FASTDDS_OSTREAM_CONSUMER_HPP_
+#endif // ifndef _FASTDDS_DDS_LOG_OSTREAMCONSUMER_HPP_

--- a/test/mock/rtps/Log/fastdds/dds/log/OStreamConsumer.hpp
+++ b/test/mock/rtps/Log/fastdds/dds/log/OStreamConsumer.hpp
@@ -1,0 +1,30 @@
+// Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _FASTDDS_OSTREAM_CONSUMER_HPP_
+#define _FASTDDS_OSTREAM_CONSUMER_HPP_
+
+#include <fastdds/dds/log/Log.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+
+    class OStreamConsumer : public LogConsumer {};
+
+} // namespace dds
+} // namespace fastdds
+} // namespace eprosima
+
+#endif

--- a/test/mock/rtps/Log/fastdds/dds/log/StdoutConsumer.hpp
+++ b/test/mock/rtps/Log/fastdds/dds/log/StdoutConsumer.hpp
@@ -21,10 +21,18 @@ namespace eprosima {
 namespace fastdds {
 namespace dds {
 
-    class StdoutConsumer : public LogConsumer {};
+class StdoutConsumer : public LogConsumer
+{
+public:
+
+    virtual ~StdoutConsumer()
+    {
+    }
+
+};
 
 } // namespace dds
 } // namespace fastdds
 } // namespace eprosima
 
-#endif
+#endif // ifndef _FASTDDS_STDOUT_CONSUMER_HPP_

--- a/test/mock/rtps/Log/fastdds/dds/log/StdoutConsumer.hpp
+++ b/test/mock/rtps/Log/fastdds/dds/log/StdoutConsumer.hpp
@@ -25,10 +25,7 @@ class StdoutConsumer : public LogConsumer
 {
 public:
 
-    virtual ~StdoutConsumer()
-    {
-    }
-
+    virtual ~StdoutConsumer() = default;
 };
 
 } // namespace dds

--- a/test/mock/rtps/Log/fastdds/dds/log/StdoutConsumer.hpp
+++ b/test/mock/rtps/Log/fastdds/dds/log/StdoutConsumer.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _FASTDDS_STDOUT_CONSUMER_HPP_
-#define _FASTDDS_STDOUT_CONSUMER_HPP_
+#ifndef _FASTDDS_DDS_LOG_STDOUTCONSUMER_HPP_
+#define _FASTDDS_DDS_LOG_STDOUTCONSUMER_HPP_
 
 #include <fastdds/dds/log/Log.hpp>
 
@@ -32,4 +32,4 @@ public:
 } // namespace fastdds
 } // namespace eprosima
 
-#endif // ifndef _FASTDDS_STDOUT_CONSUMER_HPP_
+#endif // ifndef _FASTDDS_DDS_LOG_STDOUTCONSUMER_HPP_

--- a/test/mock/rtps/Log/fastdds/dds/log/StdoutErrConsumer.hpp
+++ b/test/mock/rtps/Log/fastdds/dds/log/StdoutErrConsumer.hpp
@@ -30,9 +30,7 @@ public:
 
     StdoutErrConsumer() = default;
 
-    virtual ~StdoutErrConsumer()
-    {
-    }
+    virtual ~StdoutErrConsumer() = default;
 
     void stderr_threshold(
             const Log::Kind& kind)

--- a/test/mock/rtps/Log/fastdds/dds/log/StdoutErrConsumer.hpp
+++ b/test/mock/rtps/Log/fastdds/dds/log/StdoutErrConsumer.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _FASTDDS_STDOUTERR_CONSUMER_HPP_
-#define _FASTDDS_STDOUTERR_CONSUMER_HPP_
+#ifndef _FASTDDS__DDS_LOG_STDOUTERRCONSUMER_HPP_
+#define _FASTDDS__DDS_LOG_STDOUTERRCONSUMER_HPP_
 
 #include <gmock/gmock.h>
 
@@ -51,4 +51,4 @@ MATCHER(IsStdoutErrConsumer, "Argument is a StdoutErrConsumer object?")
 } // namespace fastdds
 } // namespace eprosima
 
-#endif // _FASTDDS_STDOUTERR_CONSUMER_HPP_
+#endif // _FASTDDS__DDS_LOG_STDOUTERRCONSUMER_HPP_

--- a/test/mock/rtps/Log/fastdds/dds/log/StdoutErrConsumer.hpp
+++ b/test/mock/rtps/Log/fastdds/dds/log/StdoutErrConsumer.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _FASTDDS__DDS_LOG_STDOUTERRCONSUMER_HPP_
-#define _FASTDDS__DDS_LOG_STDOUTERRCONSUMER_HPP_
+#ifndef _FASTDDS_DDS_LOG_STDOUTERRCONSUMER_HPP_
+#define _FASTDDS_DDS_LOG_STDOUTERRCONSUMER_HPP_
 
 #include <gmock/gmock.h>
 
@@ -51,4 +51,4 @@ MATCHER(IsStdoutErrConsumer, "Argument is a StdoutErrConsumer object?")
 } // namespace fastdds
 } // namespace eprosima
 
-#endif // _FASTDDS__DDS_LOG_STDOUTERRCONSUMER_HPP_
+#endif // _FASTDDS_DDS_LOG_STDOUTERRCONSUMER_HPP_

--- a/test/mock/rtps/Log/fastdds/dds/log/StdoutErrConsumer.hpp
+++ b/test/mock/rtps/Log/fastdds/dds/log/StdoutErrConsumer.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _FASTDDS_STDOUT_CONSUMER_HPP_
-#define _FASTDDS_STDOUT_CONSUMER_HPP_
+#ifndef _FASTDDS_STDOUTERR_CONSUMER_HPP_
+#define _FASTDDS_STDOUTERR_CONSUMER_HPP_
+
+#include <gmock/gmock.h>
 
 #include <fastdds/dds/log/Log.hpp>
 
@@ -21,26 +23,30 @@ namespace eprosima {
 namespace fastdds {
 namespace dds {
 
-class StdoutConsumer : public LogConsumer
+class StdoutErrConsumer : public LogConsumer
 {
 public:
+    StdoutErrConsumer() = default;
 
-    virtual ~StdoutConsumer() {}
+    virtual ~StdoutErrConsumer() {}
 
-    RTPS_DllAPI virtual void Consume(
-            const Log::Entry& entry);
+    void stderr_threshold(
+            const Log::Kind& kind)
+    {
+        (void)kind;
+    }
 
-private:
-
-    void print_header(
-            const Log::Entry& entry) const;
-
-    void print_context(
-            const Log::Entry& entry) const;
+    static const Log::Kind STDERR_THRESHOLD_DEFAULT = Log::Kind::Warning;
 };
+
+MATCHER(IsStdoutErrConsumer, "Argument is a StdoutErrConsumer object?")
+{
+    *result_listener << (typeid(*arg.get()) == typeid(StdoutErrConsumer));
+    return typeid(*arg.get()) == typeid(StdoutErrConsumer);
+}
 
 } // namespace dds
 } // namespace fastdds
 } // namespace eprosima
 
-#endif
+#endif // _FASTDDS_STDOUTERR_CONSUMER_HPP_

--- a/test/mock/rtps/Log/fastdds/dds/log/StdoutErrConsumer.hpp
+++ b/test/mock/rtps/Log/fastdds/dds/log/StdoutErrConsumer.hpp
@@ -18,12 +18,13 @@
 #include <gmock/gmock.h>
 
 #include <fastdds/dds/log/Log.hpp>
+#include <fastdds/dds/log/OStreamConsumer.hpp>
 
 namespace eprosima {
 namespace fastdds {
 namespace dds {
 
-class StdoutErrConsumer : public LogConsumer
+class StdoutErrConsumer : public OStreamConsumer
 {
 public:
     StdoutErrConsumer() = default;
@@ -34,6 +35,20 @@ public:
             const Log::Kind& kind)
     {
         (void)kind;
+    }
+
+    std::ostream& get_stream(
+                const Log::Entry& entry)
+    {
+        // If Log::Kind is stderr_threshold_ or more severe, then use STDERR, else use STDOUT
+        if (entry.kind <= STDERR_THRESHOLD_DEFAULT)
+        {
+            return std::cerr;
+        }
+        else
+        {
+            return std::cout;
+        }
     }
 
     static const Log::Kind STDERR_THRESHOLD_DEFAULT = Log::Kind::Warning;

--- a/test/mock/rtps/Log/fastdds/dds/log/StdoutErrConsumer.hpp
+++ b/test/mock/rtps/Log/fastdds/dds/log/StdoutErrConsumer.hpp
@@ -27,28 +27,17 @@ namespace dds {
 class StdoutErrConsumer : public OStreamConsumer
 {
 public:
+
     StdoutErrConsumer() = default;
 
-    virtual ~StdoutErrConsumer() {}
+    virtual ~StdoutErrConsumer()
+    {
+    }
 
     void stderr_threshold(
             const Log::Kind& kind)
     {
         (void)kind;
-    }
-
-    std::ostream& get_stream(
-                const Log::Entry& entry)
-    {
-        // If Log::Kind is stderr_threshold_ or more severe, then use STDERR, else use STDOUT
-        if (entry.kind <= STDERR_THRESHOLD_DEFAULT)
-        {
-            return std::cerr;
-        }
-        else
-        {
-            return std::cout;
-        }
     }
 
     static const Log::Kind STDERR_THRESHOLD_DEFAULT = Log::Kind::Warning;

--- a/test/unittest/dds/status/CMakeLists.txt
+++ b/test/unittest/dds/status/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/unittest/dds/status/CMakeLists.txt
+++ b/test/unittest/dds/status/CMakeLists.txt
@@ -46,6 +46,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/topic/TypeSupport.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/policy/ParameterList.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/FileConsumer.cpp

--- a/test/unittest/dds/status/CMakeLists.txt
+++ b/test/unittest/dds/status/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/policy/ParameterList.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/FileConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/flowcontrol/ThroughputControllerDescriptor.cpp
@@ -84,13 +85,13 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
             )
 
-        # External sources 
+        # External sources
         if(TINYXML2_SOURCE_DIR)
             list(APPEND LISTENERTESTS_SOURCE
                 ${TINYXML2_SOURCE_DIR}/tinyxml2.cpp
                 )
         endif()
-        
+
         include_directories(${TINYXML2_INCLUDE_DIR})
 
         if(WIN32)
@@ -129,7 +130,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
             ${PROJECT_SOURCE_DIR}/src/cpp
             )
-            
+
         target_link_libraries(ListenerTests fastcdr foonathan_memory
             ${TINYXML2_LIBRARY}
             ${GTEST_LIBRARIES} ${GMOCK_LIBRARIES}

--- a/test/unittest/dynamic_types/CMakeLists.txt
+++ b/test/unittest/dynamic_types/CMakeLists.txt
@@ -54,6 +54,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPFinder.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/string_convert.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/FileConsumer.cpp

--- a/test/unittest/dynamic_types/CMakeLists.txt
+++ b/test/unittest/dynamic_types/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/unittest/dynamic_types/CMakeLists.txt
+++ b/test/unittest/dynamic_types/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -55,6 +55,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/string_convert.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/FileConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
         )

--- a/test/unittest/logging/CMakeLists.txt
+++ b/test/unittest/logging/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/unittest/logging/CMakeLists.txt
+++ b/test/unittest/logging/CMakeLists.txt
@@ -23,6 +23,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
 
         set(LOG_COMMON_SOURCE
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             )

--- a/test/unittest/logging/CMakeLists.txt
+++ b/test/unittest/logging/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         set(LOG_COMMON_SOURCE
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             )
 
         set(LOGTESTS_TEST_SOURCE LogTests.cpp)

--- a/test/unittest/logging/LogTests.cpp
+++ b/test/unittest/logging/LogTests.cpp
@@ -14,6 +14,7 @@
 //
 
 #include <fastdds/dds/log/Log.hpp>
+#include <fastdds/dds/log/OStreamConsumer.hpp>
 #include <fastdds/dds/log/StdoutConsumer.hpp>
 #include <fastdds/dds/log/StdoutErrConsumer.hpp>
 #include "mock/MockConsumer.h"

--- a/test/unittest/logging/LogTests.cpp
+++ b/test/unittest/logging/LogTests.cpp
@@ -356,7 +356,9 @@ TEST_F(LogTests, stdout_consumer_stream)
 
     // Redirect std::cout to a stream buffer
     std::stringstream out_stream_out;
+    std::stringstream out_stream_err;
     streambuf* stream_buffer_out = std::cout.rdbuf(out_stream_out.rdbuf());
+    streambuf* stream_buffer_err = std::cerr.rdbuf(out_stream_err.rdbuf());
 
     // Log messages on all levels and wait until they are all consumed
     logError(stdout_consumer_stream, "Error message");
@@ -366,10 +368,13 @@ TEST_F(LogTests, stdout_consumer_stream)
 
     // Reset std::cout to STDOUT
     std::cout.rdbuf(stream_buffer_out);
+    std::cerr.rdbuf(stream_buffer_err);
 
     // Count number of lines in the buffer. There is one line per each log message output to that buffer
     std::string out_string_out = out_stream_out.str();
+    std::string out_string_err = out_stream_err.str();
     std::string::difference_type lines_out = std::count(out_string_out.begin(), out_string_out.end(), '\n');
+    std::string::difference_type lines_err = std::count(out_string_err.begin(), out_string_err.end(), '\n');
 
     // If CMAKE_BUILD_TYPE is Debug, the INTERNAL_DEBUG flag was set, and the logInfo messages were not deactivated,
     // then there should be 3 messages in the out buffer, one for the logError, one for the logWarning, and another one
@@ -381,7 +386,9 @@ TEST_F(LogTests, stdout_consumer_stream)
 #else
     ASSERT_EQ(2u, lines_out);
 #endif // if (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG)) && (defined(_DEBUG) || defined(__DEBUG)) && (!defined(LOG_NO_INFO))
+    ASSERT_EQ(0u, lines_err);
     std::cout << "Number of messesages in the out buffer is correct: " << lines_out << std::endl;
+    std::cout << "No messages in the err buffer: " << lines_err << std::endl;
 
     // Reset the log module to the test default
     Reset();

--- a/test/unittest/logging/LogTests.cpp
+++ b/test/unittest/logging/LogTests.cpp
@@ -337,10 +337,11 @@ TEST_F(LogTests, validate_multithread_flush_calls)
 /*
  * This test checks that the log messages go to the appropriate buffer (STDOUT) when using a StdoutConsumer.
  * 1. Set a StdoutConsumer as the only log consumer.
- * 2. Redirect std::cout to a stream buffer.
+ * 2. Redirect std::cout and std::cerr to a stream buffer.
  * 3. Log a messages in every log level and wait until all logs are consumed.
- * 4. Reset std::cout to STDOUT.
- * 5. Check the number of messages in the stream buffer.
+ * 4. Reset std::cout to STDOUT and std::cerr to STDCERR.
+ * 5. Check the number of messages in both stream buffers.
+ * 6. Ensure that all the messages have been written to STDOUT and there is no message in STDERR.
  */
 TEST_F(LogTests, stdout_consumer_stream)
 {

--- a/test/unittest/logging/LogTests.cpp
+++ b/test/unittest/logging/LogTests.cpp
@@ -321,7 +321,7 @@ TEST_F(LogTests, validate_multithread_flush_calls)
                     logWarning(flush_ckecks,
                     "I'm thread " << this_thread::get_id() << " Flushing successful, consumed: "
                                   << consumed << " commited till flush " <<
-                    commited_before_flush);
+                        commited_before_flush);
 
                 }));
     }

--- a/test/unittest/logging/LogTests.cpp
+++ b/test/unittest/logging/LogTests.cpp
@@ -369,7 +369,7 @@ TEST_F(LogTests, stdout_consumer_stream)
 
     // Count number of lines in the buffer. There is one line per each log message output to that buffer
     std::string out_string_out = out_stream_out.str();
-    uint32_t lines_out = std::count(out_string_out.begin(), out_string_out.end(), '\n');
+    std::string::difference_type lines_out = std::count(out_string_out.begin(), out_string_out.end(), '\n');
 
     // If CMAKE_BUILD_TYPE is Debug, the INTERNAL_DEBUG flag was set, and the logInfo messages were not deactivated,
     // then there should be 3 messages in the out buffer, one for the logError, one for the logWarning, and another one
@@ -429,8 +429,8 @@ TEST_F(LogTests, stdouterr_consumer_stream)
     // Count number of lines in each of the buffers. There is one line per each log message output to that buffer
     std::string out_string_err = out_stream_err.str();
     std::string out_string_out = out_stream_out.str();
-    uint32_t lines_err = std::count(out_string_err.begin(), out_string_err.end(), '\n');
-    uint32_t lines_out = std::count(out_string_out.begin(), out_string_out.end(), '\n');
+    std::string::difference_type lines_err = std::count(out_string_err.begin(), out_string_err.end(), '\n');
+    std::string::difference_type lines_out = std::count(out_string_out.begin(), out_string_out.end(), '\n');
 
     // Only the logError message should be in the error buffer, since stderr_threshold was set to Log::Kind::Error.
     ASSERT_EQ(1u, lines_err);

--- a/test/unittest/rtps/common/CMakeLists.txt
+++ b/test/unittest/rtps/common/CMakeLists.txt
@@ -22,6 +22,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         set(SEQUENCENUMBERTESTS_SOURCE SequenceNumberTests.cpp)
         set(PORTPARAMETERSTESTS_SOURCE PortParametersTests.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp)
 

--- a/test/unittest/rtps/common/CMakeLists.txt
+++ b/test/unittest/rtps/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/unittest/rtps/common/CMakeLists.txt
+++ b/test/unittest/rtps/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,8 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         set(SEQUENCENUMBERTESTS_SOURCE SequenceNumberTests.cpp)
         set(PORTPARAMETERSTESTS_SOURCE PortParametersTests.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
-            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp)
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp)
 
         add_executable(CacheChangeTests ${CACHECHANGETESTS_SOURCE})
         target_compile_definitions(CacheChangeTests PRIVATE FASTRTPS_NO_LIB)

--- a/test/unittest/rtps/discovery/CMakeLists.txt
+++ b/test/unittest/rtps/discovery/CMakeLists.txt
@@ -25,6 +25,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/publisher/qos/WriterQos.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/subscriber/qos/ReaderQos.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp

--- a/test/unittest/rtps/discovery/CMakeLists.txt
+++ b/test/unittest/rtps/discovery/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/unittest/rtps/discovery/CMakeLists.txt
+++ b/test/unittest/rtps/discovery/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2020, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/subscriber/qos/ReaderQos.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/StringMatching.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/string_convert.cpp
@@ -88,7 +89,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         else()
             target_link_libraries(EdpTests ${PRIVACY} fastcdr)
         endif()
-            
+
         add_gtest(EdpTests SOURCES ${EDPTESTS_SOURCE})
     endif()
 endif()

--- a/test/unittest/rtps/history/CMakeLists.txt
+++ b/test/unittest/rtps/history/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/unittest/rtps/history/CMakeLists.txt
+++ b/test/unittest/rtps/history/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/history/CacheChangePool.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp)
 
         set(HISTORYTESTS_SOURCE HistoryTests.cpp
@@ -45,6 +46,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/history/CacheChangePool.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp)
 
         if(WIN32)

--- a/test/unittest/rtps/history/CMakeLists.txt
+++ b/test/unittest/rtps/history/CMakeLists.txt
@@ -25,6 +25,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/history/History.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/history/CacheChangePool.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp)

--- a/test/unittest/rtps/history/CMakeLists.txt
+++ b/test/unittest/rtps/history/CMakeLists.txt
@@ -34,18 +34,23 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/history/History.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/history/CacheChangePool.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp)
 
         set(BASICPOOLSTESTS_SOURCE BasicPoolsTests.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/history/CacheChangePool.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp)
 
         set(CACHECHANGEPOOLTESTS_SOURCE CacheChangePoolTests.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/history/CacheChangePool.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp)

--- a/test/unittest/rtps/network/CMakeLists.txt
+++ b/test/unittest/rtps/network/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/unittest/rtps/network/CMakeLists.txt
+++ b/test/unittest/rtps/network/CMakeLists.txt
@@ -28,6 +28,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             mock/MockTransport.cpp
 
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp

--- a/test/unittest/rtps/network/CMakeLists.txt
+++ b/test/unittest/rtps/network/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
 
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
 
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp

--- a/test/unittest/rtps/persistence/CMakeLists.txt
+++ b/test/unittest/rtps/persistence/CMakeLists.txt
@@ -23,6 +23,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/persistence/SQLite3PersistenceService.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/persistence/sqlite3.c
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/history/CacheChangePool.cpp

--- a/test/unittest/rtps/persistence/CMakeLists.txt
+++ b/test/unittest/rtps/persistence/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2018 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/unittest/rtps/persistence/CMakeLists.txt
+++ b/test/unittest/rtps/persistence/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/persistence/sqlite3.c
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/history/CacheChangePool.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/PropertyPolicy.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp)

--- a/test/unittest/rtps/reader/CMakeLists.txt
+++ b/test/unittest/rtps/reader/CMakeLists.txt
@@ -23,6 +23,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         set(WRITERPROXYTESTS_SOURCE WriterProxyTests.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/publisher/qos/WriterQos.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp

--- a/test/unittest/rtps/reader/CMakeLists.txt
+++ b/test/unittest/rtps/reader/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/publisher/qos/WriterQos.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
             )
 

--- a/test/unittest/rtps/reader/CMakeLists.txt
+++ b/test/unittest/rtps/reader/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/unittest/rtps/security/CMakeLists.txt
+++ b/test/unittest/rtps/security/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         set(SOURCES_SECURITY_TEST_SOURCE
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/security/logging/Logging.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/PropertyPolicy.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/flowcontrol/ThroughputControllerDescriptor.cpp

--- a/test/unittest/rtps/security/CMakeLists.txt
+++ b/test/unittest/rtps/security/CMakeLists.txt
@@ -26,6 +26,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
 
         set(SOURCES_SECURITY_TEST_SOURCE
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/security/logging/Logging.cpp

--- a/test/unittest/rtps/security/CMakeLists.txt
+++ b/test/unittest/rtps/security/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/unittest/rtps/writer/CMakeLists.txt
+++ b/test/unittest/rtps/writer/CMakeLists.txt
@@ -26,6 +26,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/writer/ReaderProxy.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/subscriber/qos/ReaderQos.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp

--- a/test/unittest/rtps/writer/CMakeLists.txt
+++ b/test/unittest/rtps/writer/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/unittest/rtps/writer/CMakeLists.txt
+++ b/test/unittest/rtps/writer/CMakeLists.txt
@@ -64,6 +64,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
 
     set(LIVELINESSMANAGERTESTS_SOURCE LivelinessManagerTests.cpp
           ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+          ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
           ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
           ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
           ${PROJECT_SOURCE_DIR}/src/cpp/rtps/writer/LivelinessManager.cpp

--- a/test/unittest/rtps/writer/CMakeLists.txt
+++ b/test/unittest/rtps/writer/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/subscriber/qos/ReaderQos.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
             )
 
@@ -63,6 +64,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
     set(LIVELINESSMANAGERTESTS_SOURCE LivelinessManagerTests.cpp
           ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
           ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+          ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
           ${PROJECT_SOURCE_DIR}/src/cpp/rtps/writer/LivelinessManager.cpp
           ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/ResourceEvent.cpp
           ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEvent.cpp

--- a/test/unittest/security/authentication/CMakeLists.txt
+++ b/test/unittest/security/authentication/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/unittest/security/authentication/CMakeLists.txt
+++ b/test/unittest/security/authentication/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         set(COMMON_SOURCES_AUTH_PLUGIN_TEST_SOURCE
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/PropertyPolicy.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/policy/ParameterList.cpp

--- a/test/unittest/security/authentication/CMakeLists.txt
+++ b/test/unittest/security/authentication/CMakeLists.txt
@@ -28,6 +28,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
 
         set(COMMON_SOURCES_AUTH_PLUGIN_TEST_SOURCE
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/PropertyPolicy.cpp

--- a/test/unittest/security/cryptography/CMakeLists.txt
+++ b/test/unittest/security/cryptography/CMakeLists.txt
@@ -23,6 +23,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
 
         set(COMMON_SOURCES_CRYPTO_PLUGIN_TEST_SOURCE
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/PropertyPolicy.cpp

--- a/test/unittest/security/cryptography/CMakeLists.txt
+++ b/test/unittest/security/cryptography/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         set(COMMON_SOURCES_CRYPTO_PLUGIN_TEST_SOURCE
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/PropertyPolicy.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Token.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp

--- a/test/unittest/security/cryptography/CMakeLists.txt
+++ b/test/unittest/security/cryptography/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/unittest/security/logging/CMakeLists.txt
+++ b/test/unittest/security/logging/CMakeLists.txt
@@ -24,6 +24,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         set(COMMON_SOURCES_LOGGING_PLUGIN_TEST_SOURCE
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/PropertyPolicy.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Token.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp

--- a/test/unittest/security/logging/CMakeLists.txt
+++ b/test/unittest/security/logging/CMakeLists.txt
@@ -23,6 +23,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
 
         set(COMMON_SOURCES_LOGGING_PLUGIN_TEST_SOURCE
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/PropertyPolicy.cpp

--- a/test/unittest/transport/CMakeLists.txt
+++ b/test/unittest/transport/CMakeLists.txt
@@ -55,6 +55,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             mock/MockReceiverResource.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPFinder.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/UDPv4Transport.cpp

--- a/test/unittest/transport/CMakeLists.txt
+++ b/test/unittest/transport/CMakeLists.txt
@@ -72,6 +72,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             mock/MockReceiverResource.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPFinder.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/UDPv6Transport.cpp
@@ -88,6 +89,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             mock/MockReceiverResource.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/messages/RTPSMessageCreator.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/policy/ParameterList.cpp
@@ -126,6 +128,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             mock/MockReceiverResource.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/messages/RTPSMessageCreator.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/policy/ParameterList.cpp
@@ -162,6 +165,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             test_UDPv4Tests.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/messages/RTPSMessageCreator.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/policy/ParameterList.cpp
@@ -181,6 +185,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             SharedMemTests.cpp
             mock/MockReceiverResource.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp

--- a/test/unittest/transport/CMakeLists.txt
+++ b/test/unittest/transport/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/unittest/transport/CMakeLists.txt
+++ b/test/unittest/transport/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -56,6 +56,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPFinder.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/UDPv4Transport.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/UDPTransportInterface.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
@@ -71,6 +72,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPFinder.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/UDPv6Transport.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/UDPTransportInterface.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
@@ -86,6 +88,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/messages/RTPSMessageCreator.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/policy/ParameterList.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPFinder.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPLocator.cpp
@@ -123,6 +126,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/messages/RTPSMessageCreator.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/policy/ParameterList.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPFinder.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPLocator.cpp
@@ -158,6 +162,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/messages/RTPSMessageCreator.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/policy/ParameterList.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPFinder.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPLocator.cpp
@@ -176,6 +181,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             mock/MockReceiverResource.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/shared_mem/SharedMemTransportDescriptor.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp

--- a/test/unittest/utils/CMakeLists.txt
+++ b/test/unittest/utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             StringMatchingTests.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/StringMatching.cpp)
 
         set(FIXEDSIZESTRINGTESTS_SOURCE

--- a/test/unittest/utils/CMakeLists.txt
+++ b/test/unittest/utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/unittest/utils/CMakeLists.txt
+++ b/test/unittest/utils/CMakeLists.txt
@@ -25,6 +25,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         set(STRINGMATCHINGTESTS_SOURCE
             StringMatchingTests.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/StringMatching.cpp)

--- a/test/unittest/xmlparser/CMakeLists.txt
+++ b/test/unittest/xmlparser/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,6 +39,18 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             COPYONLY)
         configure_file(${CMAKE_CURRENT_SOURCE_DIR}/test_xml_profiles_rooted.xml
             ${CMAKE_CURRENT_BINARY_DIR}/test_xml_profiles_rooted.xml
+            COPYONLY)
+            configure_file(${CMAKE_CURRENT_SOURCE_DIR}/log_stdouterr.xml
+            ${CMAKE_CURRENT_BINARY_DIR}/log_stdouterr.xml
+            COPYONLY)
+        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/log_stdouterr_wrong_property_name.xml
+            ${CMAKE_CURRENT_BINARY_DIR}/log_stdouterr_wrong_property_name.xml
+            COPYONLY)
+        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/log_stdouterr_wrong_property_value.xml
+            ${CMAKE_CURRENT_BINARY_DIR}/log_stdouterr_wrong_property_value.xml
+            COPYONLY)
+        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/log_stdouterr_two_thresholds.xml
+            ${CMAKE_CURRENT_BINARY_DIR}/log_stdouterr_two_thresholds.xml
             COPYONLY)
         configure_file(${CMAKE_CURRENT_SOURCE_DIR}/log_def_file.xml
             ${CMAKE_CURRENT_BINARY_DIR}/log_def_file.xml
@@ -140,6 +152,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/flowcontrol/ThroughputControllerDescriptor.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/FileConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPFinder.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPLocator.cpp

--- a/test/unittest/xmlparser/CMakeLists.txt
+++ b/test/unittest/xmlparser/CMakeLists.txt
@@ -151,6 +151,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/subscriber/qos/ReaderQos.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/flowcontrol/ThroughputControllerDescriptor.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/FileConsumer.cpp

--- a/test/unittest/xmlparser/CMakeLists.txt
+++ b/test/unittest/xmlparser/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/unittest/xmlparser/XMLProfileParserTests.cpp
+++ b/test/unittest/xmlparser/XMLProfileParserTests.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/unittest/xmlparser/XMLProfileParserTests.cpp
+++ b/test/unittest/xmlparser/XMLProfileParserTests.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <fastdds/dds/log/Log.hpp>
+#include <fastdds/dds/log/OStreamConsumer.hpp>
 #include <fastdds/dds/log/FileConsumer.hpp>
 #include <fastdds/dds/log/StdoutErrConsumer.hpp>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
@@ -692,12 +693,12 @@ TEST_F(XMLProfileParserTests, log_inactive)
 }
 
 /*
-* This test registers a StdoutErrConsumer using XML and setting the `use_default` flag to FALSE. Furthermore, it sets
-* a `stderr_threshold` to`Log::Kind::Error` using a property `stderr_threshold`. The test checks that:
-*    1. `ClearConsumers()` is called (because `use_default` is set to FALSE).
-*    2. `RegisterConsumer()` is called, meaning a `StdoutErrConsumer` was registered.
-*    3. The return code of `loadXMLFile` is `XMLP_ret::XML_OK`, meaning that the property was correctly set.
-*/
+ * This test registers a StdoutErrConsumer using XML and setting the `use_default` flag to FALSE. Furthermore, it sets
+ * a `stderr_threshold` to`Log::Kind::Error` using a property `stderr_threshold`. The test checks that:
+ *    1. `ClearConsumers()` is called (because `use_default` is set to FALSE).
+ *    2. `RegisterConsumer()` is called, meaning a `StdoutErrConsumer` was registered.
+ *    3. The return code of `loadXMLFile` is `XMLP_ret::XML_OK`, meaning that the property was correctly set.
+ */
 TEST_F(XMLProfileParserTests, log_register_stdouterr)
 {
     using namespace eprosima::fastdds::dds;
@@ -709,13 +710,13 @@ TEST_F(XMLProfileParserTests, log_register_stdouterr)
 }
 
 /*
-* This test registers a StdoutErrConsumer using XML and setting the `use_default` flag to FALSE. Furthermore, it
-* attempts to set a `stderr_threshold` to`Log::Kind::Error` using a property `threshold` (which is not the correct
-* property name). The test checks that:
-*    1. `ClearConsumers()` is called (because `use_default` is set to FALSE).
-*    2. `RegisterConsumer()` is called, meaning a `StdoutErrConsumer` was registered.
-*    3. The return code of `loadXMLFile` is `XMLP_ret::XML_ERROR`, meaning that the property was NOT correctly set.
-*/
+ * This test registers a StdoutErrConsumer using XML and setting the `use_default` flag to FALSE. Furthermore, it
+ * attempts to set a `stderr_threshold` to`Log::Kind::Error` using a property `threshold` (which is not the correct
+ * property name). The test checks that:
+ *    1. `ClearConsumers()` is called (because `use_default` is set to FALSE).
+ *    2. `RegisterConsumer()` is called, meaning a `StdoutErrConsumer` was registered.
+ *    3. The return code of `loadXMLFile` is `XMLP_ret::XML_ERROR`, meaning that the property was NOT correctly set.
+ */
 TEST_F(XMLProfileParserTests, log_register_stdouterr_wrong_property_name)
 {
     using namespace eprosima::fastdds::dds;
@@ -723,18 +724,18 @@ TEST_F(XMLProfileParserTests, log_register_stdouterr_wrong_property_name)
     EXPECT_CALL(*log_mock, ClearConsumers()).Times(1);
     EXPECT_CALL(*log_mock, RegisterConsumer(IsStdoutErrConsumer())).Times(1);
     eprosima::fastrtps::xmlparser::XMLP_ret ret = xmlparser::XMLProfileManager::loadXMLFile(
-            "log_stdouterr_wrong_property_name.xml");
+        "log_stdouterr_wrong_property_name.xml");
     ASSERT_EQ(eprosima::fastrtps::xmlparser::XMLP_ret::XML_ERROR, ret);
 }
 
 /*
-* This test registers a StdoutErrConsumer using XML and setting the `use_default` flag to FALSE. Furthermore, it
-* attempts to set a `stderr_threshold` to`Log::Kind::Error` using a property `stderr_threshold` with value `Error`
-* (which is not a correct property value). The test checks that:
-*    1. `ClearConsumers()` is called (because `use_default` is set to FALSE).
-*    2. `RegisterConsumer()` is called, meaning a `StdoutErrConsumer` was registered.
-*    3. The return code of `loadXMLFile` is `XMLP_ret::XML_ERROR`, meaning that the property was NOT correctly set.
-*/
+ * This test registers a StdoutErrConsumer using XML and setting the `use_default` flag to FALSE. Furthermore, it
+ * attempts to set a `stderr_threshold` to`Log::Kind::Error` using a property `stderr_threshold` with value `Error`
+ * (which is not a correct property value). The test checks that:
+ *    1. `ClearConsumers()` is called (because `use_default` is set to FALSE).
+ *    2. `RegisterConsumer()` is called, meaning a `StdoutErrConsumer` was registered.
+ *    3. The return code of `loadXMLFile` is `XMLP_ret::XML_ERROR`, meaning that the property was NOT correctly set.
+ */
 TEST_F(XMLProfileParserTests, log_register_stdouterr_wrong_property_value)
 {
     using namespace eprosima::fastdds::dds;
@@ -742,21 +743,21 @@ TEST_F(XMLProfileParserTests, log_register_stdouterr_wrong_property_value)
     EXPECT_CALL(*log_mock, ClearConsumers()).Times(1);
     EXPECT_CALL(*log_mock, RegisterConsumer(IsStdoutErrConsumer())).Times(1);
     eprosima::fastrtps::xmlparser::XMLP_ret ret = xmlparser::XMLProfileManager::loadXMLFile(
-            "log_stdouterr_wrong_property_value.xml");
+        "log_stdouterr_wrong_property_value.xml");
     ASSERT_EQ(eprosima::fastrtps::xmlparser::XMLP_ret::XML_ERROR, ret);
 }
 
 /*
-* This test registers a StdoutErrConsumer using XML and setting the `use_default` flag to FALSE. Furthermore, it
-* attempts to set a `stderr_threshold` to`Log::Kind::Error` using two properties `stderr_threshold` with different
-* values. However, this operation is not permited, since only one property with name `` can be present.
-* The test checks that:
-*    1. `ClearConsumers()` is called (because `use_default` is set to FALSE).
-*    2. `RegisterConsumer()` is called, meaning a `StdoutErrConsumer` was registered.
-*    3. The return code of `loadXMLFile` is `XMLP_ret::XML_ERROR`, meaning that the property was NOT correctly set. In
-*       this case, the first `stderr_threshold` property will be used, but the function will warn of an incorrect XML
-*       configuration.
-*/
+ * This test registers a StdoutErrConsumer using XML and setting the `use_default` flag to FALSE. Furthermore, it
+ * attempts to set a `stderr_threshold` to`Log::Kind::Error` using two properties `stderr_threshold` with different
+ * values. However, this operation is not permited, since only one property with name `` can be present.
+ * The test checks that:
+ *    1. `ClearConsumers()` is called (because `use_default` is set to FALSE).
+ *    2. `RegisterConsumer()` is called, meaning a `StdoutErrConsumer` was registered.
+ *    3. The return code of `loadXMLFile` is `XMLP_ret::XML_ERROR`, meaning that the property was NOT correctly set. In
+ *       this case, the first `stderr_threshold` property will be used, but the function will warn of an incorrect XML
+ *       configuration.
+ */
 TEST_F(XMLProfileParserTests, log_register_stdouterr_two_thresholds)
 {
     using namespace eprosima::fastdds::dds;
@@ -764,7 +765,7 @@ TEST_F(XMLProfileParserTests, log_register_stdouterr_two_thresholds)
     EXPECT_CALL(*log_mock, ClearConsumers()).Times(1);
     EXPECT_CALL(*log_mock, RegisterConsumer(IsStdoutErrConsumer())).Times(1);
     eprosima::fastrtps::xmlparser::XMLP_ret ret = xmlparser::XMLProfileManager::loadXMLFile(
-            "log_stdouterr_two_thresholds.xml");
+        "log_stdouterr_two_thresholds.xml");
     ASSERT_EQ(eprosima::fastrtps::xmlparser::XMLP_ret::XML_ERROR, ret);
 }
 

--- a/test/unittest/xmlparser/XMLProfileParserTests.cpp
+++ b/test/unittest/xmlparser/XMLProfileParserTests.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/dds/log/FileConsumer.hpp>
+#include <fastdds/dds/log/StdoutErrConsumer.hpp>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 #include <fastrtps/utils/IPLocator.h>
 #include <fastrtps/transport/TCPTransportDescriptor.h>
@@ -688,6 +689,83 @@ TEST_F(XMLProfileParserTests, log_inactive)
 {
     EXPECT_CALL(*log_mock, ClearConsumers()).Times(1);
     xmlparser::XMLProfileManager::loadXMLFile("log_inactive.xml");
+}
+
+/*
+* This test registers a StdoutErrConsumer using XML and setting the `use_default` flag to FALSE. Furthermore, it sets
+* a `stderr_threshold` to`Log::Kind::Error` using a property `stderr_threshold`. The test checks that:
+*    1. `ClearConsumers()` is called (because `use_default` is set to FALSE).
+*    2. `RegisterConsumer()` is called, meaning a `StdoutErrConsumer` was registered.
+*    3. The return code of `loadXMLFile` is `XMLP_ret::XML_OK`, meaning that the property was correctly set.
+*/
+TEST_F(XMLProfileParserTests, log_register_stdouterr)
+{
+    using namespace eprosima::fastdds::dds;
+
+    EXPECT_CALL(*log_mock, ClearConsumers()).Times(1);
+    EXPECT_CALL(*log_mock, RegisterConsumer(IsStdoutErrConsumer())).Times(1);
+    eprosima::fastrtps::xmlparser::XMLP_ret ret = xmlparser::XMLProfileManager::loadXMLFile("log_stdouterr.xml");
+    ASSERT_EQ(eprosima::fastrtps::xmlparser::XMLP_ret::XML_OK, ret);
+}
+
+/*
+* This test registers a StdoutErrConsumer using XML and setting the `use_default` flag to FALSE. Furthermore, it
+* attempts to set a `stderr_threshold` to`Log::Kind::Error` using a property `threshold` (which is not the correct
+* property name). The test checks that:
+*    1. `ClearConsumers()` is called (because `use_default` is set to FALSE).
+*    2. `RegisterConsumer()` is called, meaning a `StdoutErrConsumer` was registered.
+*    3. The return code of `loadXMLFile` is `XMLP_ret::XML_ERROR`, meaning that the property was NOT correctly set.
+*/
+TEST_F(XMLProfileParserTests, log_register_stdouterr_wrong_property_name)
+{
+    using namespace eprosima::fastdds::dds;
+
+    EXPECT_CALL(*log_mock, ClearConsumers()).Times(1);
+    EXPECT_CALL(*log_mock, RegisterConsumer(IsStdoutErrConsumer())).Times(1);
+    eprosima::fastrtps::xmlparser::XMLP_ret ret = xmlparser::XMLProfileManager::loadXMLFile(
+            "log_stdouterr_wrong_property_name.xml");
+    ASSERT_EQ(eprosima::fastrtps::xmlparser::XMLP_ret::XML_ERROR, ret);
+}
+
+/*
+* This test registers a StdoutErrConsumer using XML and setting the `use_default` flag to FALSE. Furthermore, it
+* attempts to set a `stderr_threshold` to`Log::Kind::Error` using a property `stderr_threshold` with value `Error`
+* (which is not a correct property value). The test checks that:
+*    1. `ClearConsumers()` is called (because `use_default` is set to FALSE).
+*    2. `RegisterConsumer()` is called, meaning a `StdoutErrConsumer` was registered.
+*    3. The return code of `loadXMLFile` is `XMLP_ret::XML_ERROR`, meaning that the property was NOT correctly set.
+*/
+TEST_F(XMLProfileParserTests, log_register_stdouterr_wrong_property_value)
+{
+    using namespace eprosima::fastdds::dds;
+
+    EXPECT_CALL(*log_mock, ClearConsumers()).Times(1);
+    EXPECT_CALL(*log_mock, RegisterConsumer(IsStdoutErrConsumer())).Times(1);
+    eprosima::fastrtps::xmlparser::XMLP_ret ret = xmlparser::XMLProfileManager::loadXMLFile(
+            "log_stdouterr_wrong_property_value.xml");
+    ASSERT_EQ(eprosima::fastrtps::xmlparser::XMLP_ret::XML_ERROR, ret);
+}
+
+/*
+* This test registers a StdoutErrConsumer using XML and setting the `use_default` flag to FALSE. Furthermore, it
+* attempts to set a `stderr_threshold` to`Log::Kind::Error` using two properties `stderr_threshold` with different
+* values. However, this operation is not permited, since only one property with name `` can be present.
+* The test checks that:
+*    1. `ClearConsumers()` is called (because `use_default` is set to FALSE).
+*    2. `RegisterConsumer()` is called, meaning a `StdoutErrConsumer` was registered.
+*    3. The return code of `loadXMLFile` is `XMLP_ret::XML_ERROR`, meaning that the property was NOT correctly set. In
+*       this case, the first `stderr_threshold` property will be used, but the function will warn of an incorrect XML
+*       configuration.
+*/
+TEST_F(XMLProfileParserTests, log_register_stdouterr_two_thresholds)
+{
+    using namespace eprosima::fastdds::dds;
+
+    EXPECT_CALL(*log_mock, ClearConsumers()).Times(1);
+    EXPECT_CALL(*log_mock, RegisterConsumer(IsStdoutErrConsumer())).Times(1);
+    eprosima::fastrtps::xmlparser::XMLP_ret ret = xmlparser::XMLProfileManager::loadXMLFile(
+            "log_stdouterr_two_thresholds.xml");
+    ASSERT_EQ(eprosima::fastrtps::xmlparser::XMLP_ret::XML_ERROR, ret);
 }
 
 TEST_F(XMLProfileParserTests, file_and_default)

--- a/test/unittest/xmlparser/log_stdouterr.xml
+++ b/test/unittest/xmlparser/log_stdouterr.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dds>
+    <log>
+        <use_default>FALSE</use_default>
+        <consumer>
+            <class>StdoutErrConsumer</class>
+            <property>
+                <name>stderr_threshold</name>
+                <value>Log::Kind::Error</value>
+            </property>
+        </consumer>
+    </log>
+</dds>

--- a/test/unittest/xmlparser/log_stdouterr_two_thresholds.xml
+++ b/test/unittest/xmlparser/log_stdouterr_two_thresholds.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dds>
+    <log>
+        <use_default>FALSE</use_default>
+        <consumer>
+            <class>StdoutErrConsumer</class>
+            <property>
+                <name>stderr_threshold</name>
+                <value>Log::Kind::Error</value>
+            </property>
+            <property>
+                <name>stderr_threshold</name>
+                <value>Log::Kind::Warning</value>
+            </property>
+        </consumer>
+    </log>
+</dds>

--- a/test/unittest/xmlparser/log_stdouterr_wrong_property_name.xml
+++ b/test/unittest/xmlparser/log_stdouterr_wrong_property_name.xml
@@ -5,7 +5,7 @@
         <consumer>
             <class>StdoutErrConsumer</class>
             <property>
-                <name>threshold</name>
+                <name>wrong_property_name</name>
                 <value>Log::Kind::Error</value>
             </property>
         </consumer>

--- a/test/unittest/xmlparser/log_stdouterr_wrong_property_name.xml
+++ b/test/unittest/xmlparser/log_stdouterr_wrong_property_name.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dds>
+    <log>
+        <use_default>FALSE</use_default>
+        <consumer>
+            <class>StdoutErrConsumer</class>
+            <property>
+                <name>threshold</name>
+                <value>Log::Kind::Error</value>
+            </property>
+        </consumer>
+    </log>
+</dds>

--- a/test/unittest/xmlparser/log_stdouterr_wrong_property_value.xml
+++ b/test/unittest/xmlparser/log_stdouterr_wrong_property_value.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dds>
+    <log>
+        <use_default>FALSE</use_default>
+        <consumer>
+            <class>StdoutErrConsumer</class>
+            <property>
+                <name>stderr_threshold</name>
+                <value>Error</value>
+            </property>
+        </consumer>
+    </log>
+</dds>

--- a/test/unittest/xtypes/CMakeLists.txt
+++ b/test/unittest/xtypes/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -54,6 +54,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
         )
 
         set(XTYPES_TEST_SOURCE

--- a/test/unittest/xtypes/CMakeLists.txt
+++ b/test/unittest/xtypes/CMakeLists.txt
@@ -53,6 +53,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/string_convert.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
         )

--- a/test/unittest/xtypes/CMakeLists.txt
+++ b/test/unittest/xtypes/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016, 2017, 2018, 2019, 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR adds a new Log consumer `StdoutErrConsumer` with the following features:
1. It outputs log messages to different streams depending on their severity. Log messages equal to or more severe than the threshold are output to `STDERR` using `std::cerr`. Log messages less severe than the threshold are output to `STDOUT` using `std::cout`.
1. The threshold can be set and retrieved using `StdoutErrConsumer::stderr_threshold()`.
1. Exposes a constant `STDERR_THRESHOLD_DEFAULT` that marks the default threshold value, which is `Log::Kind::Warning`.
1. `StdoutErrConsumer` consumers can also be registered using XML. In this case, the threshold is set using the property `stderr_threshold`.

The PR also:
1. Sets `StdoutErrConsumer` as the default log consumer.
1. Includes tests for `StdoutErrConsumer`.
1. Includes tests for registering `StdoutErrConsumer` using XML.
1. Better handling and propagation of different errors on parsing XML files.

Signed-off-by: EduPonz <eduardoponz@eprosima.com>