### PR TITLE
Support colon in type name for dynamic data types 

### DIFF
--- a/src/cpp/dynamic-types/TypeDescriptor.cpp
+++ b/src/cpp/dynamic-types/TypeDescriptor.cpp
@@ -253,7 +253,7 @@ bool TypeDescriptor::is_type_name_consistent(
     if (!sName.empty() > 0 && std::isalpha(sName[0]))
     {
         // All characters must be letters, numbers, underscore, or colon.
-        for (uint32_t i = 1; i < sName.length(); ++i)
+        for (size_t i = 1; i < sName.length(); ++i)
         {
             if (!std::isalnum(sName[i]) && sName[i] != 95 && sName[i] != 58)
             {

--- a/src/cpp/dynamic-types/TypeDescriptor.cpp
+++ b/src/cpp/dynamic-types/TypeDescriptor.cpp
@@ -250,7 +250,7 @@ bool TypeDescriptor::is_type_name_consistent(
         const std::string& sName) const
 {
     // The first letter must start with a letter ( uppercase or lowercase )
-    if (!sName.empty() > 0 && std::isalpha(sName[0]))
+    if (!sName.empty() && std::isalpha(sName[0]))
     {
         // All characters must be letters, numbers, underscore, or colon.
         for (size_t i = 1; i < sName.length(); ++i)

--- a/src/cpp/dynamic-types/TypeDescriptor.cpp
+++ b/src/cpp/dynamic-types/TypeDescriptor.cpp
@@ -250,7 +250,7 @@ bool TypeDescriptor::is_type_name_consistent(
         const std::string& sName) const
 {
     // The first letter must start with a letter ( uppercase or lowercase )
-    if (sName.length() > 0 && std::isalpha(sName[0]))
+    if (!sName.empty() > 0 && std::isalpha(sName[0]))
     {
         // All characters must be letters, numbers, underscore, or colon.
         for (uint32_t i = 1; i < sName.length(); ++i)

--- a/src/cpp/dynamic-types/TypeDescriptor.cpp
+++ b/src/cpp/dynamic-types/TypeDescriptor.cpp
@@ -252,10 +252,10 @@ bool TypeDescriptor::is_type_name_consistent(
     // The first letter must start with a letter ( uppercase or lowercase )
     if (sName.length() > 0 && std::isalpha(sName[0]))
     {
-        // All characters must be letters, numbers or underscore.
+        // All characters must be letters, numbers, underscore, or colon.
         for (uint32_t i = 1; i < sName.length(); ++i)
         {
-            if (!std::isalnum(sName[i]) && sName[i] != 95)
+            if (!std::isalnum(sName[i]) && sName[i] != 95 && sName[i] != 58)
             {
                 return false;
             }


### PR DESCRIPTION
To solve #1342
This PR add support for colon ":" to data type name, to make it compatible with `module` keyword in FastDDS generator and works perfectly with ROS messages.

For example, The following XML dynamic data types will work now.

```
<types>
  <type>
    <struct name="sensor_msgs::msg::Image">
      <member name="height" type="uint32"/>
      <member name="width" type="uint32"/>
      ...
    </struct>
  </type>
</types>

```