### PR TITLE
Export DataReader::get_topicdescription

### DIFF
--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -208,7 +208,7 @@ public:
      * Get TopicDescription
      * @return TopicDescription pointer
      */
-    const TopicDescription* get_topicdescription() const;
+    RTPS_DllAPI const TopicDescription* get_topicdescription() const;
 
     /**
      * @brief Get the requested deadline missed status


### PR DESCRIPTION
Standard defined method `DataReader::get_topicdescription` was not being exported. This was resulting in linking errors in some platforms, i.e. #1344 

Signed-off-by: EduPonz <eduardoponz@eprosima.com>