### PR TITLE
Refs 9117. Initialize serialized payload buffer on realloc

### DIFF
--- a/include/fastdds/rtps/common/SerializedPayload.h
+++ b/include/fastdds/rtps/common/SerializedPayload.h
@@ -170,6 +170,7 @@ struct RTPS_DllAPI SerializedPayload_t
                 free(old_data);
                 throw std::bad_alloc();
             }
+            memset(data + max_size, 0, (new_size - max_size) * sizeof(octet));
         }
         max_size = new_size;
     }

--- a/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
@@ -364,7 +364,7 @@ inline bool ParameterSerializer<ParameterProtocolVersion_t>::read_content_from_c
     parameter.length = parameter_length;
     bool valid = fastrtps::rtps::CDRMessage::readOctet(cdr_message, &parameter.protocolVersion.m_major);
     valid &= fastrtps::rtps::CDRMessage::readOctet(cdr_message, &parameter.protocolVersion.m_minor);
-    valid &= fastrtps::rtps::CDRMessage::addUInt16(cdr_message, 0); //padding
+    cdr_message->pos += 2; //padding
     return valid;
 }
 
@@ -392,7 +392,7 @@ inline bool ParameterSerializer<ParameterVendorId_t>::read_content_from_cdr_mess
     parameter.length = parameter_length;
     bool valid = fastrtps::rtps::CDRMessage::readOctet(cdr_message, &parameter.vendorId[0]);
     valid &= fastrtps::rtps::CDRMessage::readOctet(cdr_message, &parameter.vendorId[1]);
-    valid &= fastrtps::rtps::CDRMessage::addUInt16(cdr_message, 0); //padding
+    cdr_message->pos += 2; //padding
     return valid;
 }
 

--- a/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
@@ -364,7 +364,7 @@ inline bool ParameterSerializer<ParameterProtocolVersion_t>::read_content_from_c
     parameter.length = parameter_length;
     bool valid = fastrtps::rtps::CDRMessage::readOctet(cdr_message, &parameter.protocolVersion.m_major);
     valid &= fastrtps::rtps::CDRMessage::readOctet(cdr_message, &parameter.protocolVersion.m_minor);
-    cdr_message->pos += 2; //padding
+    valid &= fastrtps::rtps::CDRMessage::addUInt16(cdr_message, 0); //padding
     return valid;
 }
 
@@ -392,7 +392,7 @@ inline bool ParameterSerializer<ParameterVendorId_t>::read_content_from_cdr_mess
     parameter.length = parameter_length;
     bool valid = fastrtps::rtps::CDRMessage::readOctet(cdr_message, &parameter.vendorId[0]);
     valid &= fastrtps::rtps::CDRMessage::readOctet(cdr_message, &parameter.vendorId[1]);
-    cdr_message->pos += 2; //padding
+    valid &= fastrtps::rtps::CDRMessage::addUInt16(cdr_message, 0); //padding
     return valid;
 }
 


### PR DESCRIPTION
This prevents memcheck complaining about uninitialized memory access
if the serialization skips writing some bytes due to memory alignment.
