### PR TITLE
Update CMakeLists.txt not setting C++11 compiler flag [9212]

### DIFF
--- a/examples/C++/Benchmark/CMakeLists.txt
+++ b/examples/C++/Benchmark/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+# Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/Benchmark/README.txt
+++ b/examples/C++/Benchmark/README.txt
@@ -1,7 +1,7 @@
 To launch this test open two different consoles:
 
-In the first one launch: 'BenchMark publisher tcp' or 'BenchMark publisher udp' (or BenchMark.exe publisher on windows).
-In the second one: 'BenchMark subscriber tcp' or 'BenchMark subscriber udp'
+In the first one launch: './Benchmark publisher tcp' or './Benchmark publisher udp' (or Benchmark.exe publisher on windows).
+In the second one: './Benchmark subscriber tcp' or './Benchmark subscriber udp'
 
 
 

--- a/examples/C++/ClientServerTest/CMakeLists.txt
+++ b/examples/C++/ClientServerTest/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
 find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+# Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/ClientServerTest/README.txt
+++ b/examples/C++/ClientServerTest/README.txt
@@ -1,0 +1,4 @@
+To launch this test open two different consoles:
+
+In the first one launch: './ClientServerTest server' (or ClientServerTest.exe client on windows).
+In the second one: './ClientServerTest client'

--- a/examples/C++/ClientServerTest/README.txt
+++ b/examples/C++/ClientServerTest/README.txt
@@ -1,4 +1,4 @@
 To launch this test open two different consoles:
 
-In the first one launch: './ClientServerTest server' (or ClientServerTest.exe client on windows).
-In the second one: './ClientServerTest client'
+In the first one launch: './ClientServerTest server' (or ClientServerTest.exe server on windows).
+In the second one: './ClientServerTest client' (or ClientServerTest.exe client on windows).

--- a/examples/C++/Configurability/CMakeLists.txt
+++ b/examples/C++/Configurability/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/Configurability/README.txt
+++ b/examples/C++/Configurability/README.txt
@@ -161,6 +161,6 @@ In these cases it is important that all datagrams reach their destination
 To launch this test open two different consoles:
 
 In the first one launch: './UseCasePublisher' (or UseCasePublisher.exe on windows).
-In the second one: './UseCaseSubscriber'
+In the second one: './UseCaseSubscriber' (or UseCaseSubscriber.exe on windows).
 
 Select the configuration.

--- a/examples/C++/Configurability/README.txt
+++ b/examples/C++/Configurability/README.txt
@@ -1,11 +1,11 @@
 --------------------------------------------------------
-- Use Case Publisher-Subscriber for eProsima Fast RTPS -
+- Use Case Publisher-Subscriber for eProsima Fast DDS -
 --------------------------------------------------------
 
 1 - Application description
 ---------------------------
 
-eProsima Fast RTPS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
+eProsima Fast DDS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
 
 This example consists on two application, a configurable  publisher and a subscriber for you to run your own tests:
 
@@ -17,11 +17,11 @@ You can run any number of Publisher and Subscribers and use them to send a varia
 2 - Configuration options
 --------------------------
 
-These are the main parameters that affect the behaviour of eProsima Fast RTPS and that are used in this example:
+These are the main parameters that affect the behaviour of eProsima Fast DDS and that are used in this example:
 
 - Reliability Kind 
     
-    Defines how eProsima Fast RTPS deals upon possible packet loss during data exchanges.    
+    Defines how eProsima Fast DDS deals upon possible packet loss during data exchanges.    
 
     + Best Effort: No arrival confirmation. It is fast but lost samples are not re-sent.
     + Reliable: With arrival confirmation. It is slower but provides guarantee that all lost samples are re-sent and eventually received by the subscriber.
@@ -39,7 +39,7 @@ Since this application runs the Publisher and Subscriber on the same machine, da
 
     Defines the storage policy for past samples.
 
-    + Keep Last: The History will save and give access to the alst "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
+    + Keep Last: The History will save and give access to the last "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
     + Keep All: The History will save and give access to all received samples until the maximum samples size of the History is reached.
 
 This parameter affects cases of "late-joining" Subscribers: Subscribers that come online after data transfers on a topic have started.
@@ -49,7 +49,7 @@ This parameter affects cases of "late-joining" Subscribers: Subscribers that com
     Keys allow to have multiple data endpoints within a topic as opposed to all data published in a topic going into the same "inbox".
 
     + On a topic without keys, all pieces of data go into a single endpoint.
-    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima FastRTPS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
+    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima Fast DDS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
 
     It is important to note that even if you configure a Topic and your History to be able to hold items from multiple keys, this configuration does not take effect unless you explicitly enable Keys.
 
@@ -72,7 +72,7 @@ This parameter affects cases of "late-joining" Subscribers: Subscribers that com
 3. Recommended tests 
 ---------------------
 
-The following examples provide sample tests you can perform to see how the influence of configuration parameters affect the behaviour of eProsima Fast RTPS.
+The following examples provide sample tests you can perform to see how the influence of configuration parameters affect the behaviour of eProsima Fast DDS.
 
 - Testing Keep-All, Keep Last and the influence of Depth.
 
@@ -138,7 +138,7 @@ Audio and Video transmission have a common characteristic: Having a stable, high
 
 - Distributed measurement
 
-Lets say we have a factory with a network of distributed temperature sensors and we want to use eProsima Fast RTPS to send data from said sensors to an automation computer which
+Lets say we have a factory with a network of distributed temperature sensors and we want to use eProsima Fast DDS to send data from said sensors to an automation computer which
 makes decisions based on the temperature distribution. We would group all sensors within one single topic, 
 
 	Reliability: Reliable. We want to make sure samples are not lost. Furthermore, since reliable more ensures data delivery, it allows us to detect hardware problems when a sensor becomes silent
@@ -149,10 +149,18 @@ makes decisions based on the temperature distribution. We would group all sensor
 - Event-based transmission
 
 In some cases, you may want to transmit information only under certain circumstances that happen in your system, for example a photo from a surveillance camera when it detects movement.
-In these cases and due to the low  it is important that all datagrams reach their destination
+In these cases it is important that all datagrams reach their destination
 		
 	Reliability: Reliable. All samples must reach their destination.
-	Durability: Volatile. Since corrective actions are taken as events come, past triggers provide have no use.
+	Durability: Volatile. Since corrective actions are taken as events come, past triggers have no use.
 	History: Keep-Last. No past alarm information is necessary for present-time transmissions.
 	Additional Settings: Reduce heartbeat period, which dictates system response velocity when a sample is lost. A lower heartbeat period equals fast response on data delivery.
 
+6. Run example
+----------------------
+To launch this test open two different consoles:
+
+In the first one launch: './UseCasePublisher' (or UseCasePublisher.exe on windows).
+In the second one: './UseCaseSubscriber'
+
+Select the configuration.

--- a/examples/C++/DDS/Benchmark/CMakeLists.txt
+++ b/examples/C++/DDS/Benchmark/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/Benchmark/README.txt
+++ b/examples/C++/DDS/Benchmark/README.txt
@@ -1,7 +1,7 @@
 To launch this test open two different consoles:
 
-In the first one launch: 'BenchMark publisher tcp' or 'BenchMark publisher udp' (or BenchMark.exe publisher on windows).
-In the second one: 'BenchMark subscriber tcp' or 'BenchMark subscriber udp'
+In the first one launch: './DDSBenchmark publisher tcp' or './DDSBenchmark publisher udp' (or DDSBenchmark.exe publisher on windows).
+In the second one: './DDSBenchmark subscriber tcp' or './DDSBenchmark subscriber udp'
 
 
 

--- a/examples/C++/DDS/Benchmark/README.txt
+++ b/examples/C++/DDS/Benchmark/README.txt
@@ -1,7 +1,6 @@
 To launch this test open two different consoles:
 
 In the first one launch: './DDSBenchmark publisher tcp' or './DDSBenchmark publisher udp' (or DDSBenchmark.exe publisher on windows).
-In the second one: './DDSBenchmark subscriber tcp' or './DDSBenchmark subscriber udp'
-
+In the second one: './DDSBenchmark subscriber tcp' or './DDSBenchmark subscriber udp'  (or DDSBenchmark.exe subscriber on windows).
 
 

--- a/examples/C++/DDS/ClientServerTest/CMakeLists.txt
+++ b/examples/C++/DDS/ClientServerTest/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
 find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/ClientServerTest/README.txt
+++ b/examples/C++/DDS/ClientServerTest/README.txt
@@ -1,0 +1,4 @@
+To launch this test open two different consoles:
+
+In the first one launch: './DDSClientServerTest server' (or DDSClientServerTest.exe client on windows).
+In the second one: './DDSClientServerTest client'

--- a/examples/C++/DDS/ClientServerTest/README.txt
+++ b/examples/C++/DDS/ClientServerTest/README.txt
@@ -1,4 +1,4 @@
 To launch this test open two different consoles:
 
-In the first one launch: './DDSClientServerTest server' (or DDSClientServerTest.exe client on windows).
-In the second one: './DDSClientServerTest client'
+In the first one launch: './DDSClientServerTest server' (or DDSClientServerTest.exe server on windows).
+In the second one: './DDSClientServerTest client' (or DDSClientServerTest.exe client on windows).

--- a/examples/C++/DDS/Configurability/CMakeLists.txt
+++ b/examples/C++/DDS/Configurability/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/Configurability/README.txt
+++ b/examples/C++/DDS/Configurability/README.txt
@@ -161,6 +161,6 @@ In these cases it is important that all datagrams reach their destination
 To launch this test open two different consoles:
 
 In the first one launch: './DDSUseCasePublisher' (or DDSUseCasePublisher.exe on windows).
-In the second one: './DDSUseCaseSubscriber'
+In the second one: './DDSUseCaseSubscriber' (or DDSUseCaseSubscriber.exe on windows).
 
 Select the configuration.

--- a/examples/C++/DDS/Configurability/README.txt
+++ b/examples/C++/DDS/Configurability/README.txt
@@ -1,11 +1,11 @@
 --------------------------------------------------------
-- Use Case Publisher-Subscriber for eProsima Fast RTPS -
+- Use Case Publisher-Subscriber for eProsima Fast DDS -
 --------------------------------------------------------
 
 1 - Application description
 ---------------------------
 
-eProsima Fast RTPS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
+eProsima Fast DDS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
 
 This example consists on two application, a configurable  publisher and a subscriber for you to run your own tests:
 
@@ -17,11 +17,11 @@ You can run any number of Publisher and Subscribers and use them to send a varia
 2 - Configuration options
 --------------------------
 
-These are the main parameters that affect the behaviour of eProsima Fast RTPS and that are used in this example:
+These are the main parameters that affect the behaviour of eProsima Fast DDS and that are used in this example:
 
 - Reliability Kind 
     
-    Defines how eProsima Fast RTPS deals upon possible packet loss during data exchanges.    
+    Defines how eProsima Fast DDS deals upon possible packet loss during data exchanges.    
 
     + Best Effort: No arrival confirmation. It is fast but lost samples are not re-sent.
     + Reliable: With arrival confirmation. It is slower but provides guarantee that all lost samples are re-sent and eventually received by the subscriber.
@@ -39,7 +39,7 @@ Since this application runs the Publisher and Subscriber on the same machine, da
 
     Defines the storage policy for past samples.
 
-    + Keep Last: The History will save and give access to the alst "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
+    + Keep Last: The History will save and give access to the last "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
     + Keep All: The History will save and give access to all received samples until the maximum samples size of the History is reached.
 
 This parameter affects cases of "late-joining" Subscribers: Subscribers that come online after data transfers on a topic have started.
@@ -49,7 +49,7 @@ This parameter affects cases of "late-joining" Subscribers: Subscribers that com
     Keys allow to have multiple data endpoints within a topic as opposed to all data published in a topic going into the same "inbox".
 
     + On a topic without keys, all pieces of data go into a single endpoint.
-    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima FastRTPS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
+    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima Fast DDS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
 
     It is important to note that even if you configure a Topic and your History to be able to hold items from multiple keys, this configuration does not take effect unless you explicitly enable Keys.
 
@@ -72,7 +72,7 @@ This parameter affects cases of "late-joining" Subscribers: Subscribers that com
 3. Recommended tests 
 ---------------------
 
-The following examples provide sample tests you can perform to see how the influence of configuration parameters affect the behaviour of eProsima Fast RTPS.
+The following examples provide sample tests you can perform to see how the influence of configuration parameters affect the behaviour of eProsima Fast DDS.
 
 - Testing Keep-All, Keep Last and the influence of Depth.
 
@@ -138,7 +138,7 @@ Audio and Video transmission have a common characteristic: Having a stable, high
 
 - Distributed measurement
 
-Lets say we have a factory with a network of distributed temperature sensors and we want to use eProsima Fast RTPS to send data from said sensors to an automation computer which
+Lets say we have a factory with a network of distributed temperature sensors and we want to use eProsima Fast DDS to send data from said sensors to an automation computer which
 makes decisions based on the temperature distribution. We would group all sensors within one single topic, 
 
 	Reliability: Reliable. We want to make sure samples are not lost. Furthermore, since reliable more ensures data delivery, it allows us to detect hardware problems when a sensor becomes silent
@@ -149,10 +149,18 @@ makes decisions based on the temperature distribution. We would group all sensor
 - Event-based transmission
 
 In some cases, you may want to transmit information only under certain circumstances that happen in your system, for example a photo from a surveillance camera when it detects movement.
-In these cases and due to the low  it is important that all datagrams reach their destination
+In these cases it is important that all datagrams reach their destination
 		
 	Reliability: Reliable. All samples must reach their destination.
-	Durability: Volatile. Since corrective actions are taken as events come, past triggers provide have no use.
+	Durability: Volatile. Since corrective actions are taken as events come, past triggers have no use.
 	History: Keep-Last. No past alarm information is necessary for present-time transmissions.
 	Additional Settings: Reduce heartbeat period, which dictates system response velocity when a sample is lost. A lower heartbeat period equals fast response on data delivery.
 
+6. Run example
+----------------------
+To launch this test open two different consoles:
+
+In the first one launch: './DDSUseCasePublisher' (or DDSUseCasePublisher.exe on windows).
+In the second one: './DDSUseCaseSubscriber'
+
+Select the configuration.

--- a/examples/C++/DDS/CustomListenerExample/CMakeLists.txt
+++ b/examples/C++/DDS/CustomListenerExample/CMakeLists.txt
@@ -29,14 +29,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+# Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/DeadlineQoSExample/CMakeLists.txt
+++ b/examples/C++/DDS/DeadlineQoSExample/CMakeLists.txt
@@ -48,14 +48,12 @@ if(NOT Asio_FOUND)
     endif()
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/DeadlineQoSExample/README.md
+++ b/examples/C++/DDS/DeadlineQoSExample/README.md
@@ -2,12 +2,12 @@
 
 ## Application description
 
-This example illustrates the Deadline QoS feature on a FastRTPS Application.
+This example illustrates the Deadline QoS feature on a FastDDS Application.
 
 To launch this example open two different consoles:
 
-In the first one launch: ./DeadlineQoSExample publisher  
-In the second one launch: ./DeadlineQoSExample subscriber
+In the first one launch: ./DDSDeadlineQoSExample publisher  
+In the second one launch: ./DDSDeadlineQoSExample subscriber
 
 ## Application behaviour
 
@@ -19,12 +19,12 @@ that the third instance misses the deadline 50% of the time. The number of sampl
 
 The default behaviour can be changed by providing the following command line arguments:
 
-./DeadlineQoSExample publisher [--deadline &lt;deadline_ms&gt;] [--sleep &lt;writer_sleep_ms&gt;] [--samples &lt;samples&gt;]  
-./DeadlineQoSExample subscriber [--deadline &lt;deadline_ms&gt;]
+./DDSDeadlineQoSExample publisher [--deadline &lt;deadline_ms&gt;] [--sleep &lt;writer_sleep_ms&gt;] [--samples &lt;samples&gt;]  
+./DDSDeadlineQoSExample subscriber [--deadline &lt;deadline_ms&gt;]
 
 For example:
 
-./DeadlineQoSExample publisher --deadline 1000 --sleep 500 --samples 5  
-./DeadlineQosExample subscriber --deadline 1000
+./DDSDeadlineQoSExample publisher --deadline 1000 --sleep 500 --samples 5  
+./DDSDeadlineQosExample subscriber --deadline 1000
 
 will setup the publisher and subscriber to use a deadline period of 1000 ms, the publisher will write a new sample every 500 ms for the first two keys and every 1000 ms for the third one, and a total of 5 samples will be sent.

--- a/examples/C++/DDS/DisablePositiveACKs/CMakeLists.txt
+++ b/examples/C++/DDS/DisablePositiveACKs/CMakeLists.txt
@@ -29,14 +29,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/DisablePositiveACKs/README.md
+++ b/examples/C++/DDS/DisablePositiveACKs/README.md
@@ -1,11 +1,11 @@
 # Disable Positive ACKs QoS example
 
-This example illustrates how to use the Disable Positive ACKs QoS extension in a Fast-RTPS application. When using this QoS, Acknack messages are only sent by the reader if it is missing any samples. In this way, strict reliability is no longer maintained but the writer keeps samples in its history for a sufficient duration (or keep duration) so that readers can negatively acknowledge it. After this duration, the sample is considered to be acknowledged by all readers and is removed from the writer history.
+This example illustrates how to use the Disable Positive ACKs QoS extension in a Fast DDS application. When using this QoS, Acknack messages are only sent by the reader if it is missing any samples. In this way, strict reliability is no longer maintained but the writer keeps samples in its history for a sufficient duration (or keep duration) so that readers can negatively acknowledge it. After this duration, the sample is considered to be acknowledged by all readers and is removed from the writer history.
 
 To launch this test open two different consoles:
 
-In the first one launch: ./DisablePositiveACKsQoS publisher --disable  
-In the second one launch: ./DisablePositiveACKsQoS subscriber --disable
+In the first one launch: ./DDSDisablePositiveACKsQoS publisher --disable  
+In the second one launch: ./DDSDisablePositiveACKsQoS subscriber --disable
 
 The above will launch publisher and subscriber using this QoS, i.e. positive acks will not be sent.
 
@@ -15,7 +15,7 @@ In this application, the publisher sends a number of samples and periodic heartb
 
 By default the QoS is disabled, the publisher sends 20 samples every 1000 milliseconds and the keep duration is set to 5000 milliseconds. The subscriber waits until 20 samples are received. You can change these defaults by executing:
 
-./DisablePositiveACKsQoS publisher [--disable] [--keep_duration &lt;keep_duration_ms&gt;] [--sleep &lt;writer_sleep_ms&gt;] [--samples &lt;samples&gt;]  
-./DisablePositiveACKsQoS subscriber [--disable] [--samples &lt;samples&gt;]
+./DDSDisablePositiveACKsQoS publisher [--disable] [--keep_duration &lt;keep_duration_ms&gt;] [--sleep &lt;writer_sleep_ms&gt;] [--samples &lt;samples&gt;]  
+./DDSDisablePositiveACKsQoS subscriber [--disable] [--samples &lt;samples&gt;]
 
 for publisher and subscriber respectively, where the option &lt;enable_QoS&gt; will enable the QoS (i.e. positive akcs will not be sent), &lt;keep_duration_ms&gt; will set the duration for which to keep the samples, &lt;sleep_ms&gt; determines the amount of time to wait before the publisher sends a new sample, and &lt;samples&gt; sets the total number of samples to be sent/received.

--- a/examples/C++/DDS/DynamicHelloWorldExample/CMakeLists.txt
+++ b/examples/C++/DDS/DynamicHelloWorldExample/CMakeLists.txt
@@ -29,14 +29,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/DynamicHelloWorldExample/README.txt
+++ b/examples/C++/DDS/DynamicHelloWorldExample/README.txt
@@ -1,8 +1,8 @@
 To launch this test open two different consoles:
 
-In the first one launch: DDSDynamicHelloWorldExample publisher
+In the first one launch: ./DDSDynamicHelloWorldExample publisher
 (or DDSDynamicHelloWorldExample.exe publisher on windows).
-In the second one: DDSDynamicHelloWorldExample subscriber.
+In the second one: ./DDSDynamicHelloWorldExample subscriber.
 
 In this example, the publisher loads a type from the XML file "example_type.xml".
 The publisher shares the TypeObject so another participants can discover it.

--- a/examples/C++/DDS/DynamicHelloWorldExample/README.txt
+++ b/examples/C++/DDS/DynamicHelloWorldExample/README.txt
@@ -2,7 +2,8 @@ To launch this test open two different consoles:
 
 In the first one launch: ./DDSDynamicHelloWorldExample publisher
 (or DDSDynamicHelloWorldExample.exe publisher on windows).
-In the second one: ./DDSDynamicHelloWorldExample subscriber.
+In the second one: ./DDSDynamicHelloWorldExample subscriber
+(or DDSDynamicHelloWorldExample.exe subscriber on windows).
 
 In this example, the publisher loads a type from the XML file "example_type.xml".
 The publisher shares the TypeObject so another participants can discover it.

--- a/examples/C++/DDS/Filtering/CMakeLists.txt
+++ b/examples/C++/DDS/Filtering/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/Filtering/README.txt
+++ b/examples/C++/DDS/Filtering/README.txt
@@ -1,37 +1,37 @@
 Subscribing to a subset of the Topic updates: Filtering
 -------------------------------------------------------
 
-A typical use case on a Pub/Sub middleware is subscribing to a subset of the published samples, or filtering the data by content, by time, or both.
+A typical use case on a DDS middleware is subscribing to a subset of the published samples, or filtering the data by content, by time, or both.
 
 - Content Based Filter: The subscriber request a subset of the samples based on the content. As an example, imagine a Radar Track topic and a station (subscriber) monitoring a specific area: we can use the track coordinates to filter.
 
 - Time Based Filter: The subscriber requests just one sample in a given period. Imagine a Topic with a high frequency of updates, and a subscriber in charge of representing these updates in a GUI. This subscriber does not need all the updates, but just a reasonable rate of updates for the human eye.
 
-A straightforward solution is to just discard not required samples in the subscriber side, but that is not always a good solution. If your subscriber is using a wireless low bandwidth link, or is a low power device, you don’t want to spend valuable bandwidth or CPU time. In that case, you need publisher filtering.
+A straightforward solution is to just discard not required samples in the subscriber side, but that is not always a good solution. If your subscriber is using a wireless low bandwidth link, or is a low power device, you don't want to spend valuable bandwidth or CPU time. In that case, you need publisher filtering.
 
 Publisher filtering:
 --------------------
 
-To enable publisher filtering you should make use of the partition Qos (Quality of Service) of the publisher and subscriber. This QoS parameter allows you to “partition” your topic. The publisher and subscriber will match only if they have a common partition, and the partition QoS allows you to specify a list of partitions giving you full flexibility.
+To enable publisher filtering you should make use of the partition Qos (Quality of Service) of the publisher and subscriber. This QoS parameter allows you to "partition" your topic. The publisher and subscriber will match only if they have a common partition, and the partition QoS allows you to specify a list of partitions giving you full flexibility.
 
 The example:
 ------------
 
 In the example we will filter by time. We create two publishers on the same topic:
 
-- Fast Publisher: publishing on the partition “Fast_Partition”, a sample per second.
-- Slow Publisher: publishing on the partition “Slow_Partition”, a sample every 5 seconds.
+- Fast Publisher: publishing on the partition "Fast_Partition", a sample per second.
+- Slow Publisher: publishing on the partition "Slow_Partition", a sample every 5 seconds.
 
 And in the subscriber side, we create a subscriber on one of these partitions.
 
 To run the example, execute an instance of the publishers:
 
-	FilteringExamplePubliserSubscriber publisher
+	./DDSFilteringExample publisher
 
 And two instances of the subscriber, on the two different partitions:
 
-	FilteringExamplePubliserSubscriber subscriber slow
-	FilteringExamplePubliserSubscriber subscriber fast
+	./DDSFilteringExample subscriber slow
+	./DDSFilteringExample subscriber fast
 
-You will see the slow partition subscriber getting just one sample every 5 seconds, and the fast partition subscriber every second. You can now use wireshark to see that the filtering is happening in the publishing side, because the partitions mechanism.
+You will see the slow partition subscriber getting just one sample every 5 seconds, and the fast partition subscriber every second. You can now use wireshark to see that the filtering is happening in the publishing side, due to the partitions mechanism.
 

--- a/examples/C++/DDS/FlowControlExample/CMakeLists.txt
+++ b/examples/C++/DDS/FlowControlExample/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/FlowControlExample/README.txt
+++ b/examples/C++/DDS/FlowControlExample/README.txt
@@ -1,8 +1,8 @@
 To launch this example open two consoles:
 
- 1) "$ FlowControlExample subscriber" (or "FlowControlExample.exe subscriber" in Windows). 
+ 1) "$ ./DDSFlowControlExample subscriber" (or "DDSFlowControlExample.exe subscriber" in Windows). 
 
- 2..*) "$ FlowControlExample publisher" (or "FlowControlExample.exe publisher XX" in Windows).
+ 2..*) "$ ./DDSFlowControlExample publisher" (or "DDSFlowControlExample.exe publisher" in Windows).
 
 This example illustrates the flow control feature. 
 
@@ -10,7 +10,7 @@ This example illustrates the flow control feature.
                               = Flow Control =
                               ================
 
-In FastRTPS, Flow Control is implemented through objects called Flow Controllers. In 
+In Fast DDS, Flow Control is implemented through objects called Flow Controllers. In 
 particular, we will be looking at the simplest kind, the Throughput Controller.
 
 A throughput controller is univocally defined by a Throughput Controller Descriptor,

--- a/examples/C++/DDS/HelloWorldExample/CMakeLists.txt
+++ b/examples/C++/DDS/HelloWorldExample/CMakeLists.txt
@@ -29,14 +29,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/HelloWorldExample/README.txt
+++ b/examples/C++/DDS/HelloWorldExample/README.txt
@@ -1,6 +1,5 @@
 To launch this test open two different consoles:
 
 In the first one launch: ./DDSHelloWorldExample publisher (or DDSHelloWorldExample.exe publisher on windows).
-In the second one: ./DDSHelloWorldExample subscriber.
-
+In the second one: ./DDSHelloWorldExample subscriber (or DDSHelloWorldExample.exe subscriber on windows).
 

--- a/examples/C++/DDS/HelloWorldExample/README.txt
+++ b/examples/C++/DDS/HelloWorldExample/README.txt
@@ -1,6 +1,6 @@
 To launch this test open two different consoles:
 
-In the first one launch: HelloWorldExample publisher (or HelloWorldExample.exe publisher on windows).
-In the second one: HelloWorldExample subscriber.
+In the first one launch: ./DDSHelloWorldExample publisher (or DDSHelloWorldExample.exe publisher on windows).
+In the second one: ./DDSHelloWorldExample subscriber.
 
 

--- a/examples/C++/DDS/HelloWorldExampleSharedMem/CMakeLists.txt
+++ b/examples/C++/DDS/HelloWorldExampleSharedMem/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/HelloWorldExampleSharedMem/README.txt
+++ b/examples/C++/DDS/HelloWorldExampleSharedMem/README.txt
@@ -1,6 +1,6 @@
 To launch this test open two different consoles:
 
-In the first one launch: HelloWorldExample publisher (or HelloWorldExample.exe publisher on windows).
-In the second one: HelloWorldExample subscriber.
+In the first one launch: ./DDSHelloWorldExampleSharedMem publisher (or DDSHelloWorldExampleSharedMem.exe publisher on windows).
+In the second one: ./DDSHelloWorldExampleSharedMem subscriber.
 
 

--- a/examples/C++/DDS/HelloWorldExampleSharedMem/README.txt
+++ b/examples/C++/DDS/HelloWorldExampleSharedMem/README.txt
@@ -1,6 +1,5 @@
 To launch this test open two different consoles:
 
 In the first one launch: ./DDSHelloWorldExampleSharedMem publisher (or DDSHelloWorldExampleSharedMem.exe publisher on windows).
-In the second one: ./DDSHelloWorldExampleSharedMem subscriber.
-
+In the second one: ./DDSHelloWorldExampleSharedMem subscriber (or DDSHelloWorldExampleSharedMem.exe subscriber on windows).
 

--- a/examples/C++/DDS/HelloWorldExampleTCP/CMakeLists.txt
+++ b/examples/C++/DDS/HelloWorldExampleTCP/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/HelloWorldExampleTCP/README.txt
+++ b/examples/C++/DDS/HelloWorldExampleTCP/README.txt
@@ -1,7 +1,7 @@
 To launch this test open two different consoles:
 
 In the first one launch: ./DDSHelloWorldExampleTCP publisher (or DDSHelloWorldExampleTCP.exe publisher on windows).
-In the second one: ./DDSHelloWorldExampleTCP subscriber.
+In the second one: ./DDSHelloWorldExampleTCP subscriber (or DDSHelloWorldExampleTCP.exe subscriber on windows).
 
 
 This example includes additional options to show the capabilities of the TCP Transport on Fast DDS,

--- a/examples/C++/DDS/HelloWorldExampleTCP/README.txt
+++ b/examples/C++/DDS/HelloWorldExampleTCP/README.txt
@@ -1,14 +1,14 @@
 To launch this test open two different consoles:
 
-In the first one launch: HelloWorldExampleTCP publisher (or HelloWorldExampleTCP.exe publisher on windows).
-In the second one: HelloWorldExampleTCP subscriber.
+In the first one launch: ./DDSHelloWorldExampleTCP publisher (or DDSHelloWorldExampleTCP.exe publisher on windows).
+In the second one: ./DDSHelloWorldExampleTCP subscriber.
 
 
-This example includes additional options to show the capabilities of the TCP Transport on Fast-RPTS,
+This example includes additional options to show the capabilities of the TCP Transport on Fast DDS,
 such as WAN and TLS. In this example the publisher will work as a TCP server and the subscriber as a
 TCP client.
 
-Usage: HelloWorldExampleTCP <publisher|subscriber>
+Usage: DDSHelloWorldExampleTCP <publisher|subscriber>
 
 General options:
   -h            --help              Produce help message.
@@ -30,15 +30,15 @@ Subscriber options:
 
 WAN Example:
 
-HelloWorldExampleTCP publisher -a <PUBLIC_WAN_ADDR> -p <PORT>
-HelloWorldExampleTCP subscriber -a <SERVER_ADDR> -p <PORT>
+DDSHelloWorldExampleTCP publisher -a <PUBLIC_WAN_ADDR> -p <PORT>
+DDSHelloWorldExampleTCP subscriber -a <SERVER_ADDR> -p <PORT>
 
     For example:
-        HelloWorldExampleTCP publisher -a 80.88.150.120 -p 5500
-        HelloWorldExampleTCP subscriber -a 80.88.150.120 -p 5500
+        DDSHelloWorldExampleTCP publisher -a 80.88.150.120 -p 5500
+        DDSHelloWorldExampleTCP subscriber -a 80.88.150.120 -p 5500
 
 
 TLS Example:
 
-HelloWorldExampleTCP publisher -t
-HelloWorldExampleTCP subscriber -t
+DDSHelloWorldExampleTCP publisher -t
+DDSHelloWorldExampleTCP subscriber -t

--- a/examples/C++/DDS/HistoryKind/CMakeLists.txt
+++ b/examples/C++/DDS/HistoryKind/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/HistoryKind/README.txt
+++ b/examples/C++/DDS/HistoryKind/README.txt
@@ -1,22 +1,22 @@
 ------------------------------------------------
-- Use Case Example: History Kind for eProsima Fast RTPS -
+- Use Case Example: History Kind for eProsima Fast DDS -
 ------------------------------------------------
 
 1 - Application description
 ---------------------------
 
-eProsima Fast RTPS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
+eProsima Fast DDS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
 
 This example is a supplement to the UseCaseLauncher example, consisting on an application which illustrates the effect the different kinds of Subscriber Histories have on sample storage.
 
 2 - Configuration options
 --------------------------
 
-These are the main parameters that affect the behaviour of eProsima Fast RTPS and that are used in the Use Case set of example:
+These are the main parameters that affect the behaviour of eProsima Fast DDS and that are used in the Use Case set of example:
 
 - Reliability Kind
 
-    Defines how eProsima Fast RTPS deals upon possible packet loss during data exchanges.
+    Defines how eProsima Fast DDS deals upon possible packet loss during data exchanges.
 
     + Best Effort: No arrival confirmation. It is fast but lost samples are not re-sent.
     + Reliable: With arrival confirmation. It is slower but provides guarantee that all lost samples are re-sent and eventually received by the subscriber.
@@ -34,7 +34,7 @@ Since this application runs the Publisher and Subscriber on the same machine, da
 
     Defines the storage policy for past samples.
 
-    + Keep Last: The History will save and give access to the alst "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
+    + Keep Last: The History will save and give access to the last "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
     + Keep All: The History will save and give access to all received samples until the maximum samples size of the History is reached.
 
 This parameter affects cases of "late-joining" Subscribers: Subscribers that come online after data transfers on a topic have started.
@@ -44,7 +44,7 @@ This parameter affects cases of "late-joining" Subscribers: Subscribers that com
     Keys allow to have multiple data endpoints within a topic as opposed to all data published in a topic going into the same "inbox".
 
     + On a topic without keys, all pieces of data go into a single endpoint.
-    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima FastRTPS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
+    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima Fast DDS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
 
     It is important to note that even if you configure a Topic and your History to be able to hold items from multiple keys, this configuration does not take effect unless you explicitly enable Keys.
 
@@ -75,9 +75,12 @@ This application spawns a Publisher and two Subscribers, one Keep-All and one Ke
 4. Built-in tests
 -----------------
 
-Other than this application, he Use Case set of examples contains the following pre-defined demonstrators:
+Other than this application, the Use Case set of examples contains the following pre-defined demonstrators:
 
 * Late joiners: Shows how a Transient-Local Subscriber receives past samples while Volatile starts receiving from the moment of its creation.
 * Keys: Provides a working example of how data can be split into multiple endpoints based of keys.
 * SampleConfig: Provides a basic Publish-Subscribe example for the three sample configurations specified in section 5.
 
+5. Run example
+-----------------
+To launch this test execute: './DDSHistoryKind' (or DDSHistoryKind.exe on windows).

--- a/examples/C++/DDS/Keys/CMakeLists.txt
+++ b/examples/C++/DDS/Keys/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/Keys/README.txt
+++ b/examples/C++/DDS/Keys/README.txt
@@ -1,22 +1,22 @@
 -------------------------------------------------
-- Use Case Example: Keys for eProsima Fast RTPS -
+- Use Case Example: Keys for eProsima Fast DDS -
 -------------------------------------------------
 
 1 - Application description
 ---------------------------
 
-eProsima Fast RTPS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
+eProsima Fast DDS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
 
 This example is a supplement to the UseCaseLauncher example, consisting on an application which illustrates how keys work.
 
 2 - Configuration options
 --------------------------
 
-These are the main parameters that affect the behaviour of eProsima Fast RTPS and that are used in the Use Case set of example:
+These are the main parameters that affect the behaviour of eProsima Fast DDS and that are used in the Use Case set of example:
 
 - Reliability Kind
 
-    Defines how eProsima Fast RTPS deals upon possible packet loss during data exchanges.
+    Defines how eProsima Fast DDS deals upon possible packet loss during data exchanges.
 
     + Best Effort: No arrival confirmation. It is fast but lost samples are not re-sent.
     + Reliable: With arrival confirmation. It is slower but provides guarantee that all lost samples are re-sent and eventually received by the subscriber.
@@ -34,7 +34,7 @@ Since this application runs the Publisher and Subscriber on the same machine, da
 
     Defines the storage policy for past samples.
 
-    + Keep Last: The History will save and give access to the alst "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
+    + Keep Last: The History will save and give access to the last "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
     + Keep All: The History will save and give access to all received samples until the maximum samples size of the History is reached.
 
 This parameter affects cases of "late-joining" Subscribers: Subscribers that come online after data transfers on a topic have started.
@@ -44,7 +44,7 @@ This parameter affects cases of "late-joining" Subscribers: Subscribers that com
     Keys allow to have multiple data endpoints within a topic as opposed to all data published in a topic going into the same "inbox".
 
     + On a topic without keys, all pieces of data go into a single endpoint.
-    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima FastRTPS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
+    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima Fast DDS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
 
     It is important to note that even if you configure a Topic and your History to be able to hold items from multiple keys, this configuration does not take effect unless you explicitly enable Keys.
 
@@ -78,3 +78,6 @@ Other than this application, he Use Case set of examples contains the following 
 * Latejoiners: Shows how a Transient-Local Subscriber receives past samples while Volatile starts receiving from the moment of its creation.
 * SampleConfig: Provides a basic Publish-Subscribe example for the three sample configurations specified in section 5.
 
+5. Run example
+-----------------
+To launch this test execute './DDSKeys' (or DDSKeys.exe on windows).

--- a/examples/C++/DDS/LateJoiners/CMakeLists.txt
+++ b/examples/C++/DDS/LateJoiners/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/LateJoiners/README.txt
+++ b/examples/C++/DDS/LateJoiners/README.txt
@@ -1,22 +1,22 @@
 ---------------------------------------------------------
-- Use Case Example: Late Joiners for eProsima Fast RTPS -
+- Use Case Example: Late Joiners for eProsima Fast DDS -
 ---------------------------------------------------------
 
 1 - Application description
 ---------------------------
 
-eProsima Fast RTPS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
+eProsima Fast DDS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
 
 This example is a supplement to the UseCaseLauncher example, consisting on an application which illustrates the effect the different kinds of Subscriber Durability have on sample storage.
 
 2 - Configuration options
 --------------------------
 
-These are the main parameters that affect the behaviour of eProsima Fast RTPS and that are used in the Use Case set of example:
+These are the main parameters that affect the behaviour of eProsima Fast DDS and that are used in the Use Case set of example:
 
 - Reliability Kind
 
-    Defines how eProsima Fast RTPS deals upon possible packet loss during data exchanges.
+    Defines how eProsima Fast DDS deals upon possible packet loss during data exchanges.
 
     + Best Effort: No arrival confirmation. It is fast but lost samples are not re-sent.
     + Reliable: With arrival confirmation. It is slower but provides guarantee that all lost samples are re-sent and eventually received by the subscriber.
@@ -34,7 +34,7 @@ Since this application runs the Publisher and Subscriber on the same machine, da
 
     Defines the storage policy for past samples.
 
-    + Keep Last: The History will save and give access to the alst "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
+    + Keep Last: The History will save and give access to the last "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
     + Keep All: The History will save and give access to all received samples until the maximum samples size of the History is reached.
 
 This parameter affects cases of "late-joining" Subscribers: Subscribers that come online after data transfers on a topic have started.
@@ -44,7 +44,7 @@ This parameter affects cases of "late-joining" Subscribers: Subscribers that com
     Keys allow to have multiple data endpoints within a topic as opposed to all data published in a topic going into the same "inbox".
 
     + On a topic without keys, all pieces of data go into a single endpoint.
-    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima FastRTPS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
+    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima Fast DDS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
 
     It is important to note that even if you configure a Topic and your History to be able to hold items from multiple keys, this configuration does not take effect unless you explicitly enable Keys.
 
@@ -81,3 +81,6 @@ The use case launcher contains the following built-in examples:
 * Keys: Provides a working example of how data can be split into multiple endpoints based of keys.
 * SampleConfig: Provides a basic Publish-Subscribe example for the three sample configurations specified in section 5.
 
+5. Run example
+-----------------
+To launch this test execute './DDSLateJoiners' (or DDSLateJoiners.exe on windows).

--- a/examples/C++/DDS/LifespanQoSExample/CMakeLists.txt
+++ b/examples/C++/DDS/LifespanQoSExample/CMakeLists.txt
@@ -29,14 +29,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/LifespanQoSExample/README.md
+++ b/examples/C++/DDS/LifespanQoSExample/README.md
@@ -1,11 +1,11 @@
 # Lifespan QoS example
 
-This example illustrates how to use the Lifespan QoS in a Fast-RTPS application.
+This example illustrates how to use the Lifespan QoS in a Fast DDS application.
 
 To launch this test open two different consoles:
 
-In the first one launch: ./LifespanQoSExample publisher  
-In the second one launch: ./LifespanQoSExample subscriber
+In the first one launch: ./DDSLifespanQoSExample publisher  
+In the second one launch: ./DDSLifespanQoSExample subscriber
 
 ## Application behaviour
 
@@ -17,7 +17,7 @@ The subscriber waits until it receives a specified number of samples from the pu
 
 The default parameters are 500ms for the lifespan, 2000 ms for the wait time and 10 for the number of samples. You can change these defaults by executing:
 
-./LifespanQoSExample publisher &lt;lifespan_ms&gt; &lt;sleep_ms&gt; &lt;samples&gt;  
-./LifespanQoSExample subscriber &lt;lifespan_ms&gt; &lt;sleep_ms&gt;
+./DDSLifespanQoSExample publisher &lt;lifespan_ms&gt; &lt;sleep_ms&gt; &lt;samples&gt;  
+./DDSLifespanQoSExample subscriber &lt;lifespan_ms&gt; &lt;sleep_ms&gt;
 
 for publisher and subscriber respectively.

--- a/examples/C++/DDS/LivelinessQoS/CMakeLists.txt
+++ b/examples/C++/DDS/LivelinessQoS/CMakeLists.txt
@@ -29,14 +29,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/LivelinessQoS/README.md
+++ b/examples/C++/DDS/LivelinessQoS/README.md
@@ -1,11 +1,11 @@
 ## Liveliness QoS example
 
-This example illustrates the Liveliness QoS feature on a Fast-RTPS application.
+This example illustrates the Liveliness QoS feature on a Fast DDS application.
 
 To launch this example open two different consoles:
 
-In the first one launch: ./LivelinessQoS publisher
-In the second one launch: ./LivelinessQoS subscriber
+In the first one launch: ./DDSLivelinessQoS publisher
+In the second one launch: ./DDSLivelinessQoS subscriber
 
 ## Application behaviour
 
@@ -22,8 +22,8 @@ The default behaviour can be changed by providing the following command line arg
 
 For example:
 
-./LivelinessQoS publisher --lease_duration 1000 --kind AUTOMATIC --sleep 500 --samples 5  
-./LivelinessQoS subscriber --lease_duration 1000 --kind AUTOMATIC
+./DDSLivelinessQoS publisher --lease_duration 1000 --kind AUTOMATIC --sleep 500 --samples 5  
+./DDSLivelinessQoS subscriber --lease_duration 1000 --kind AUTOMATIC
 
 will setup the publisher and subscriber to use a lease duration of 1000 ms with kind AUTOMATIC, the publisher will
 write a new sample every 500 ms, and a total of 5 samples will be sent.
@@ -36,8 +36,8 @@ Possible values for liveliness kind are AUTOMATIC, MANUAL_BY_PARTICIPANT or MANU
 
 Execute the example with the following parameters:
 
-./LivelinessQoS publisher --lease_duration 100 --kind MANUAL_BY_TOPIC --sleep 500 --samples 5  
-./LivelinessQoS subscriber --lease_duration 300 --kind MANUAL_BY_TOPIC
+./DDSLivelinessQoS publisher --lease_duration 100 --kind MANUAL_BY_TOPIC --sleep 500 --samples 5  
+./DDSLivelinessQoS subscriber --lease_duration 300 --kind MANUAL_BY_TOPIC
 
 As the lease duration for both publisher and subscriber is smaller than the publisher write rate,
 liveliness will be lost after sending a sample and recovered when writing the next one.
@@ -46,8 +46,8 @@ liveliness will be lost after sending a sample and recovered when writing the ne
 
 Execute the example with the following parameters:
 
-./LivelinessQoS publisher --lease_duration 600 --kind MANUAL_BY_TOPIC --sleep 500 --samples 5  
-./LivelinessQoS subscriber --lease_duration 600 --kind MANUAL_BY_TOPIC
+./DDSLivelinessQoS publisher --lease_duration 600 --kind MANUAL_BY_TOPIC --sleep 500 --samples 5  
+./DDSLivelinessQoS subscriber --lease_duration 600 --kind MANUAL_BY_TOPIC
 
 In this case, as the lease duration is greater than the publishwer write rate, liveliness will only be lost after
 sending the last sample.

--- a/examples/C++/DDS/OwnershipStrengthQoSExample/CMakeLists.txt
+++ b/examples/C++/DDS/OwnershipStrengthQoSExample/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/OwnershipStrengthQoSExample/README.txt
+++ b/examples/C++/DDS/OwnershipStrengthQoSExample/README.txt
@@ -1,10 +1,10 @@
 To launch this test open two or more consoles:
 
-1) "$OwnershipStrengthQosExample subscriber" 
-    (or "OwnershipStrengthQosExample.exe subscriber" on Windows). 
+1) "$./DDSOwnershipStrengthQoSExample subscriber" 
+    (or "DDSOwnershipStrengthQoSExample.exe subscriber" on Windows). 
 
-2..*) "$OwnershipStrengthQosExample publisher XX" 
-      (or "OwnershipStrengthQosExample.exe publisher XX" on Windows).
+2..*) "$./DDSOwnershipStrengthQoSExample publisher XX" 
+      (or "DDSOwnershipStrengthQoSExample.exe publisher XX" on Windows).
 
 For the publishers, XX represents an Ownership Strength QoS number. 
 If left unspecified it will default to 10.

--- a/examples/C++/DDS/SampleConfig_Controller/CMakeLists.txt
+++ b/examples/C++/DDS/SampleConfig_Controller/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/SampleConfig_Controller/README.txt
+++ b/examples/C++/DDS/SampleConfig_Controller/README.txt
@@ -1,22 +1,22 @@
 ------------------------------------------------
-- Use Case Sample Configuration: Controller for eProsima Fast RTPS -
+- Use Case Sample Configuration: Controller for eProsima Fast DDS -
 ------------------------------------------------
 
 1 - Application description
 ---------------------------
 
-eProsima Fast RTPS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
+eProsima Fast DDS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
 
 This example is a supplement to the UseCaseLauncher example, consisting on a sample Publisher-Subscriber application with a configuration optimized to perform secure data transmission where not only the samples but the historic tendency matters. 
 
 2 - Configuration options
 --------------------------
 
-These are the main parameters that affect the behaviour of eProsima Fast RTPS and that are used in the Use Case set of example:
+These are the main parameters that affect the behaviour of eProsima Fast DDS and that are used in the Use Case set of example:
 
 - Reliability Kind 
     
-    Defines how eProsima Fast RTPS deals upon possible packet loss during data exchanges.    
+    Defines how eProsima Fast DDS deals upon possible packet loss during data exchanges.    
 
     + Best Effort: No arrival confirmation. It is fast but lost samples are not re-sent.
     + Reliable: With arrival confirmation. It is slower but provides guarantee that all lost samples are re-sent and eventually received by the subscriber.
@@ -34,7 +34,7 @@ Since this application runs the Publisher and Subscriber on the same machine, da
 
     Defines the storage policy for past samples.
 
-    + Keep Last: The History will save and give access to the alst "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
+    + Keep Last: The History will save and give access to the last "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
     + Keep All: The History will save and give access to all received samples until the maximum samples size of the History is reached.
 
 This parameter affects cases of "late-joining" Subscribers: Subscribers that come online after data transfers on a topic have started.
@@ -44,7 +44,7 @@ This parameter affects cases of "late-joining" Subscribers: Subscribers that com
     Keys allow to have multiple data endpoints within a topic as opposed to all data published in a topic going into the same "inbox".
 
     + On a topic without keys, all pieces of data go into a single endpoint.
-    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima FastRTPS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
+    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima Fast DDS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
 
     It is important to note that even if you configure a Topic and your History to be able to hold items from multiple keys, this configuration does not take effect unless you explicitly enable Keys.
 
@@ -80,7 +80,7 @@ Audio and Video transmission have a common characteristic: Having a stable, high
 
 - Distributed measurement: Controllers
 
-Lets say we have a factory with a network of distributed temperature sensors and we want to use eProsima Fast RTPS to send data from said sensors to an automation computer which
+Lets say we have a factory with a network of distributed temperature sensors and we want to use eProsima Fast DDS to send data from said sensors to an automation computer which
 makes decisions based on the temperature distribution. We would group all sensors within one single topic, 
 
 	Reliability: Reliable. We want to make sure samples are not lost. Furthermore, since reliable more ensures data delivery, it allows us to detect hardware problems when a sensor becomes silent
@@ -91,11 +91,13 @@ makes decisions based on the temperature distribution. We would group all sensor
 - Event-based transmission
 
 In some cases, you may want to transmit information only under certain circumstances that happen in your system, for example a photo from a surveillance camera when it detects movement.
-In these cases and due to the low  it is important that all datagrams reach their destination
+In these cases it is important that all datagrams reach their destination
 		
 	Reliability: Reliable. All samples must reach their destination.
-	Durability: Volatile. Since corrective actions are taken as events come, past triggers provide have no use.
+	Durability: Volatile. Since corrective actions are taken as events come, past triggers have no use.
 	History: Keep-Last. No past alarm information is necessary for present-time transmissions.
 	Additional Settings: Reduce heartbeat period, which dictates system response velocity when a sample is lost. A lower heartbeat period equals fast response on data delivery.
 
-
+6. Run example
+----------------------
+To launch this test execute: './DDSSampleConfigController' (or DDSSampleConfigController.exe on windows).

--- a/examples/C++/DDS/SampleConfig_Events/CMakeLists.txt
+++ b/examples/C++/DDS/SampleConfig_Events/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/SampleConfig_Events/README.txt
+++ b/examples/C++/DDS/SampleConfig_Events/README.txt
@@ -1,22 +1,22 @@
 ----------------------------------------------------------------
-- Use Case Sample Configuration: Events for eProsima Fast RTPS -
+- Use Case Sample Configuration: Events for eProsima Fast DDS -
 ----------------------------------------------------------------
 
 1 - Application description
 ---------------------------
 
-eProsima Fast RTPS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
+eProsima Fast DDS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
 
 This example is a supplement to the UseCaseLauncher example, consisting on a sample Publisher-Subscriber application with a configuration optimized to perform secure event-based transmissions. 
 
 2 - Configuration options
 --------------------------
 
-These are the main parameters that affect the behaviour of eProsima Fast RTPS and that are used in the Use Case set of example:
+These are the main parameters that affect the behaviour of eProsima Fast DDS and that are used in the Use Case set of example:
 
 - Reliability Kind 
     
-    Defines how eProsima Fast RTPS deals upon possible packet loss during data exchanges.    
+    Defines how eProsima Fast DDS deals upon possible packet loss during data exchanges.    
 
     + Best Effort: No arrival confirmation. It is fast but lost samples are not re-sent.
     + Reliable: With arrival confirmation. It is slower but provides guarantee that all lost samples are re-sent and eventually received by the subscriber.
@@ -34,7 +34,7 @@ Since this application runs the Publisher and Subscriber on the same machine, da
 
     Defines the storage policy for past samples.
 
-    + Keep Last: The History will save and give access to the alst "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
+    + Keep Last: The History will save and give access to the last "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
     + Keep All: The History will save and give access to all received samples until the maximum samples size of the History is reached.
 
 This parameter affects cases of "late-joining" Subscribers: Subscribers that come online after data transfers on a topic have started.
@@ -44,7 +44,7 @@ This parameter affects cases of "late-joining" Subscribers: Subscribers that com
     Keys allow to have multiple data endpoints within a topic as opposed to all data published in a topic going into the same "inbox".
 
     + On a topic without keys, all pieces of data go into a single endpoint.
-    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima FastRTPS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
+    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima Fast DDS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
 
     It is important to note that even if you configure a Topic and your History to be able to hold items from multiple keys, this configuration does not take effect unless you explicitly enable Keys.
 
@@ -91,11 +91,13 @@ makes decisions based on the temperature distribution. We would group all sensor
 - Event-based transmission
 
 In some cases, you may want to transmit information only under certain circumstances that happen in your system, for example a photo from a surveillance camera when it detects movement.
-In these cases and due to the low  it is important that all datagrams reach their destination
+In these cases it is important that all datagrams reach their destination
 		
 	Reliability: Reliable. All samples must reach their destination.
-	Durability: Volatile. Since corrective actions are taken as events come, past triggers provide have no use.
+	Durability: Volatile. Since corrective actions are taken as events come, past triggers have no use.
 	History: Keep-Last. No past alarm information is necessary for present-time transmissions.
 	Additional Settings: Reduce heartbeat period, which dictates system response velocity when a sample is lost. A lower heartbeat period equals fast response on data delivery.
 
-
+6. Run example
+----------------------
+To launch this test execute: './DDSSampleConfigEvents' (or DDSSampleConfigEvents.exe on windows).

--- a/examples/C++/DDS/SampleConfig_Multimedia/CMakeLists.txt
+++ b/examples/C++/DDS/SampleConfig_Multimedia/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/SampleConfig_Multimedia/README.txt
+++ b/examples/C++/DDS/SampleConfig_Multimedia/README.txt
@@ -1,22 +1,22 @@
 ------------------------------------------------
-- Use Case Sample Configuration: Controller for eProsima Fast RTPS -
+- Use Case Sample Configuration: Controller for eProsima Fast DDS -
 ------------------------------------------------
 
 1 - Application description
 ---------------------------
 
-eProsima Fast RTPS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
+eProsima Fast DDS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
 
 This example is a supplement to the UseCaseLauncher example, consisting on an application which illustrates the effect the different kinds of Subscriber Histories have on sample storage.
 
 2 - Configuration options
 --------------------------
 
-These are the main parameters that affect the behaviour of eProsima Fast RTPS and that are used in the Use Case set of example:
+These are the main parameters that affect the behaviour of eProsima Fast DDS and that are used in the Use Case set of example:
 
 - Reliability Kind 
     
-    Defines how eProsima Fast RTPS deals upon possible packet loss during data exchanges.    
+    Defines how eProsima Fast DDS deals upon possible packet loss during data exchanges.    
 
     + Best Effort: No arrival confirmation. It is fast but lost samples are not re-sent.
     + Reliable: With arrival confirmation. It is slower but provides guarantee that all lost samples are re-sent and eventually received by the subscriber.
@@ -34,7 +34,7 @@ Since this application runs the Publisher and Subscriber on the same machine, da
 
     Defines the storage policy for past samples.
 
-    + Keep Last: The History will save and give access to the alst "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
+    + Keep Last: The History will save and give access to the last "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
     + Keep All: The History will save and give access to all received samples until the maximum samples size of the History is reached.
 
 This parameter affects cases of "late-joining" Subscribers: Subscribers that come online after data transfers on a topic have started.
@@ -44,7 +44,7 @@ This parameter affects cases of "late-joining" Subscribers: Subscribers that com
     Keys allow to have multiple data endpoints within a topic as opposed to all data published in a topic going into the same "inbox".
 
     + On a topic without keys, all pieces of data go into a single endpoint.
-    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima FastRTPS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
+    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima Fast DDS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
 
     It is important to note that even if you configure a Topic and your History to be able to hold items from multiple keys, this configuration does not take effect unless you explicitly enable Keys.
 
@@ -91,11 +91,14 @@ makes decisions based on the temperature distribution. We would group all sensor
 - Event-based transmission
 
 In some cases, you may want to transmit information only under certain circumstances that happen in your system, for example a photo from a surveillance camera when it detects movement.
-In these cases and due to the low  it is important that all datagrams reach their destination
+In these cases it is important that all datagrams reach their destination
 		
 	Reliability: Reliable. All samples must reach their destination.
-	Durability: Volatile. Since corrective actions are taken as events come, past triggers provide have no use.
+	Durability: Volatile. Since corrective actions are taken as events come, past triggers have no use.
 	History: Keep-Last. No past alarm information is necessary for present-time transmissions.
 	Additional Settings: Reduce heartbeat period, which dictates system response velocity when a sample is lost. A lower heartbeat period equals fast response on data delivery.
 
+6. Run example
+----------------------
+To launch this test execute: './DDSSampleConfigMultimedia' (or DDSSampleConfigMultimedia.exe on windows).
 

--- a/examples/C++/DDS/SecureHelloWorldExample/CMakeLists.txt
+++ b/examples/C++/DDS/SecureHelloWorldExample/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/SecureHelloWorldExample/README.txt
+++ b/examples/C++/DDS/SecureHelloWorldExample/README.txt
@@ -6,6 +6,5 @@ example.
 To launch this test open two different consoles:
 
 In the first one launch: ./DDSSecureHelloWorldExample publisher (or DDSSecureHelloWorldExample.exe publisher on windows).
-In the second one: ./DDSSecureHelloWorldExample subscriber.
-
+In the second one: ./DDSSecureHelloWorldExample subscriber (or DDSSecureHelloWorldExample.exe subscriber on windows).
 

--- a/examples/C++/DDS/SecureHelloWorldExample/README.txt
+++ b/examples/C++/DDS/SecureHelloWorldExample/README.txt
@@ -5,7 +5,7 @@ example.
 
 To launch this test open two different consoles:
 
-In the first one launch: HelloWorldExample publisher (or HelloWorldExample.exe publisher on windows).
-In the second one: HelloWorldExample subscriber.
+In the first one launch: ./DDSSecureHelloWorldExample publisher (or DDSSecureHelloWorldExample.exe publisher on windows).
+In the second one: ./DDSSecureHelloWorldExample subscriber.
 
 

--- a/examples/C++/DDS/StaticHelloWorldExample/CMakeLists.txt
+++ b/examples/C++/DDS/StaticHelloWorldExample/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/StaticHelloWorldExample/README.txt
+++ b/examples/C++/DDS/StaticHelloWorldExample/README.txt
@@ -1,6 +1,6 @@
 To launch this test open two different consoles:
 
 In the first one launch: ./DDSStaticHelloWorldExample publisher (or DDSStaticHelloWorldExample.exe publisher on windows).
-In the second one: ./DDSStaticHelloWorldExample subscriber.
+In the second one: ./DDSStaticHelloWorldExample subscriber (or DDSStaticHelloWorldExample.exe subscriber on windows).
 
 Note: This example needs the xml file stored in the sources directory. You need to copy this folder where you will execute the example executable. The CMakeList.txt file also copies this file to the folder used to build the example.

--- a/examples/C++/DDS/StaticHelloWorldExample/README.txt
+++ b/examples/C++/DDS/StaticHelloWorldExample/README.txt
@@ -1,6 +1,6 @@
 To launch this test open two different consoles:
 
-In the first one launch: HelloWorldExample publisher (or HelloWorldExample.exe publisher on windows).
-In the second one: HelloWorldExample subscriber.
+In the first one launch: ./DDSStaticHelloWorldExample publisher (or DDSStaticHelloWorldExample.exe publisher on windows).
+In the second one: ./DDSStaticHelloWorldExample subscriber.
 
 Note: This example needs the xml file stored in the sources directory. You need to copy this folder where you will execute the example executable. The CMakeList.txt file also copies this file to the folder used to build the example.

--- a/examples/C++/DDS/TypeLookupService/CMakeLists.txt
+++ b/examples/C++/DDS/TypeLookupService/CMakeLists.txt
@@ -29,14 +29,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DDS/TypeLookupService/README.txt
+++ b/examples/C++/DDS/TypeLookupService/README.txt
@@ -2,7 +2,8 @@ To launch this test open two different consoles:
 
 In the first one launch: ./TypeLookupExample publisher
 (or TypeLookupExample.exe publisher on windows).
-In the second one: ./TypeLookupExample subscriber.
+In the second one: ./TypeLookupExample subscriber
+(or TypeLookupExample.exe subscriber on windows).
 
 In this example, the publisher loads a type from the XML file "example_type.xml".
 The publisher shares the TypeInformation so other participants can discover it.

--- a/examples/C++/DDS/TypeLookupService/README.txt
+++ b/examples/C++/DDS/TypeLookupService/README.txt
@@ -1,8 +1,8 @@
 To launch this test open two different consoles:
 
-In the first one launch: TypeLookupExample publisher
+In the first one launch: ./TypeLookupExample publisher
 (or TypeLookupExample.exe publisher on windows).
-In the second one: TypeLookupExample subscriber.
+In the second one: ./TypeLookupExample subscriber.
 
 In this example, the publisher loads a type from the XML file "example_type.xml".
 The publisher shares the TypeInformation so other participants can discover it.

--- a/examples/C++/DeadlineQoSExample/CMakeLists.txt
+++ b/examples/C++/DeadlineQoSExample/CMakeLists.txt
@@ -48,14 +48,12 @@ if(NOT Asio_FOUND)
     endif()
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DeadlineQoSExample/README.md
+++ b/examples/C++/DeadlineQoSExample/README.md
@@ -2,7 +2,7 @@
 
 ## Application description
 
-This example illustrates the Deadline QoS feature on a FastRTPS Application.
+This example illustrates the Deadline QoS feature on a Fast DDS Application.
 
 To launch this example open two different consoles:
 

--- a/examples/C++/DisablePositiveACKs/CMakeLists.txt
+++ b/examples/C++/DisablePositiveACKs/CMakeLists.txt
@@ -29,14 +29,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DisablePositiveACKs/README.md
+++ b/examples/C++/DisablePositiveACKs/README.md
@@ -1,6 +1,6 @@
 # Disable Positive ACKs QoS example
 
-This example illustrates how to use the Disable Positive ACKs QoS extension in a Fast-RTPS application. When using this QoS, Acknack messages are only sent by the reader if it is missing any samples. In this way, strict reliability is no longer maintained but the writer keeps samples in its history for a sufficient duration (or keep duration) so that readers can negatively acknowledge it. After this duration, the sample is considered to be acknowledged by all readers and is removed from the writer history.
+This example illustrates how to use the Disable Positive ACKs QoS extension in a Fast DDS application. When using this QoS, Acknack messages are only sent by the reader if it is missing any samples. In this way, strict reliability is no longer maintained but the writer keeps samples in its history for a sufficient duration (or keep duration) so that readers can negatively acknowledge it. After this duration, the sample is considered to be acknowledged by all readers and is removed from the writer history.
 
 To launch this test open two different consoles:
 

--- a/examples/C++/DynamicHelloWorldExample/CMakeLists.txt
+++ b/examples/C++/DynamicHelloWorldExample/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/DynamicHelloWorldExample/README.txt
+++ b/examples/C++/DynamicHelloWorldExample/README.txt
@@ -1,6 +1,5 @@
 To launch this test open two different consoles:
 
 In the first one launch: ./DynamicHelloWorldExample publisher (or DynamicHelloWorldExample.exe publisher on windows).
-In the second one: ./DynamicHelloWorldExample subscriber.
-
+In the second one: ./DynamicHelloWorldExample subscriber (or DynamicHelloWorldExample.exe subscriber on windows).
 

--- a/examples/C++/DynamicHelloWorldExample/README.txt
+++ b/examples/C++/DynamicHelloWorldExample/README.txt
@@ -1,6 +1,6 @@
 To launch this test open two different consoles:
 
-In the first one launch: HelloWorldExample publisher (or HelloWorldExample.exe publisher on windows).
-In the second one: HelloWorldExample subscriber.
+In the first one launch: ./DynamicHelloWorldExample publisher (or DynamicHelloWorldExample.exe publisher on windows).
+In the second one: ./DynamicHelloWorldExample subscriber.
 
 

--- a/examples/C++/Filtering/CMakeLists.txt
+++ b/examples/C++/Filtering/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/Filtering/README.txt
+++ b/examples/C++/Filtering/README.txt
@@ -7,31 +7,31 @@ A typical use case on a Pub/Sub middleware is subscribing to a subset of the pub
 
 - Time Based Filter: The subscriber requests just one sample in a given period. Imagine a Topic with a high frequency of updates, and a subscriber in charge of representing these updates in a GUI. This subscriber does not need all the updates, but just a reasonable rate of updates for the human eye.
 
-A straightforward solution is to just discard not required samples in the subscriber side, but that is not always a good solution. If your subscriber is using a wireless low bandwidth link, or is a low power device, you don’t want to spend valuable bandwidth or CPU time. In that case, you need publisher filtering.
+A straightforward solution is to just discard not required samples in the subscriber side, but that is not always a good solution. If your subscriber is using a wireless low bandwidth link, or is a low power device, you don't want to spend valuable bandwidth or CPU time. In that case, you need publisher filtering.
 
 Publisher filtering:
 --------------------
 
-To enable publisher filtering you should make use of the partition Qos (Quality of Service) of the publisher and subscriber. This QoS parameter allows you to “partition” your topic. The publisher and subscriber will match only if they have a common partition, and the partition QoS allows you to specify a list of partitions giving you full flexibility.
+To enable publisher filtering you should make use of the partition Qos (Quality of Service) of the publisher and subscriber. This QoS parameter allows you to "partition" your topic. The publisher and subscriber will match only if they have a common partition, and the partition QoS allows you to specify a list of partitions giving you full flexibility.
 
 The example:
 ------------
 
 In the example we will filter by time. We create two publishers on the same topic:
 
-- Fast Publisher: publishing on the partition “Fast_Partition”, a sample per second.
-- Slow Publisher: publishing on the partition “Slow_Partition”, a sample every 5 seconds.
+- Fast Publisher: publishing on the partition "Fast_Partition", a sample per second.
+- Slow Publisher: publishing on the partition "Slow_Partition", a sample every 5 seconds.
 
 And in the subscriber side, we create a subscriber on one of these partitions.
 
 To run the example, execute an instance of the publishers:
 
-	FilteringExamplePubliserSubscriber publisher
+	./FilteringExample publisher
 
 And two instances of the subscriber, on the two different partitions:
 
-	FilteringExamplePubliserSubscriber subscriber slow
-	FilteringExamplePubliserSubscriber subscriber fast
+	./FilteringExample subscriber slow
+	./FilteringExample subscriber fast
 
-You will see the slow partition subscriber getting just one sample every 5 seconds, and the fast partition subscriber every second. You can now use wireshark to see that the filtering is happening in the publishing side, because the partitions mechanism.
+You will see the slow partition subscriber getting just one sample every 5 seconds, and the fast partition subscriber every second. You can now use wireshark to see that the filtering is happening in the publishing side, due to the partitions mechanism.
 

--- a/examples/C++/FlowControlExample/CMakeLists.txt
+++ b/examples/C++/FlowControlExample/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/FlowControlExample/README.txt
+++ b/examples/C++/FlowControlExample/README.txt
@@ -1,8 +1,8 @@
 To launch this example open two consoles:
 
- 1) "$ FlowControlExample subscriber" (or "FlowControlExample.exe subscriber" in Windows). 
+ 1) "$ ./FlowControlExample subscriber" (or "FlowControlExample.exe subscriber" in Windows). 
 
- 2..*) "$ FlowControlExample publisher" (or "FlowControlExample.exe publisher XX" in Windows).
+ 2) "$ ./FlowControlExample publisher" (or "FlowControlExample.exe publisher" in Windows).
 
 This example illustrates the flow control feature. 
 
@@ -10,7 +10,7 @@ This example illustrates the flow control feature.
                               = Flow Control =
                               ================
 
-In FastRTPS, Flow Control is implemented through objects called Flow Controllers. In 
+In Fast DDS, Flow Control is implemented through objects called Flow Controllers. In 
 particular, we will be looking at the simplest kind, the Throughput Controller.
 
 A throughput controller is univocally defined by a Throughput Controller Descriptor,

--- a/examples/C++/HelloWorldExample/CMakeLists.txt
+++ b/examples/C++/HelloWorldExample/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/HelloWorldExample/README.txt
+++ b/examples/C++/HelloWorldExample/README.txt
@@ -1,6 +1,5 @@
 To launch this test open two different consoles:
 
 In the first one launch: ./HelloWorldExample publisher (or HelloWorldExample.exe publisher on windows).
-In the second one: ./HelloWorldExample subscriber.
-
+In the second one: ./HelloWorldExample subscriber (or HelloWorldExample.exe subscriber on windows).
 

--- a/examples/C++/HelloWorldExample/README.txt
+++ b/examples/C++/HelloWorldExample/README.txt
@@ -1,6 +1,6 @@
 To launch this test open two different consoles:
 
-In the first one launch: HelloWorldExample publisher (or HelloWorldExample.exe publisher on windows).
-In the second one: HelloWorldExample subscriber.
+In the first one launch: ./HelloWorldExample publisher (or HelloWorldExample.exe publisher on windows).
+In the second one: ./HelloWorldExample subscriber.
 
 

--- a/examples/C++/HelloWorldExampleSharedMem/CMakeLists.txt
+++ b/examples/C++/HelloWorldExampleSharedMem/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/HelloWorldExampleSharedMem/README.txt
+++ b/examples/C++/HelloWorldExampleSharedMem/README.txt
@@ -1,6 +1,5 @@
 To launch this test open two different consoles:
 
 In the first one launch: ./HelloWorldExampleSharedMem publisher (or HelloWorldExampleSharedMem.exe publisher on windows).
-In the second one: ./HelloWorldExampleSharedMem subscriber.
-
+In the second one: ./HelloWorldExampleSharedMem subscriber (or HelloWorldExampleSharedMem.exe subscriber on windows).
 

--- a/examples/C++/HelloWorldExampleSharedMem/README.txt
+++ b/examples/C++/HelloWorldExampleSharedMem/README.txt
@@ -1,6 +1,6 @@
 To launch this test open two different consoles:
 
-In the first one launch: HelloWorldExample publisher (or HelloWorldExample.exe publisher on windows).
-In the second one: HelloWorldExample subscriber.
+In the first one launch: ./HelloWorldExampleSharedMem publisher (or HelloWorldExampleSharedMem.exe publisher on windows).
+In the second one: ./HelloWorldExampleSharedMem subscriber.
 
 

--- a/examples/C++/HelloWorldExampleTCP/CMakeLists.txt
+++ b/examples/C++/HelloWorldExampleTCP/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/HelloWorldExampleTCP/README.txt
+++ b/examples/C++/HelloWorldExampleTCP/README.txt
@@ -1,7 +1,7 @@
 To launch this test open two different consoles:
 
 In the first one launch: ./HelloWorldExampleTCP publisher (or HelloWorldExampleTCP.exe publisher on windows).
-In the second one: ./HelloWorldExampleTCP subscriber.
+In the second one: ./HelloWorldExampleTCP subscriber (or HelloWorldExampleTCP.exe subscriber on windows).
 
 
 This example includes additional options to show the capabilities of the TCP Transport on Fast DDS,

--- a/examples/C++/HelloWorldExampleTCP/README.txt
+++ b/examples/C++/HelloWorldExampleTCP/README.txt
@@ -1,10 +1,10 @@
 To launch this test open two different consoles:
 
-In the first one launch: HelloWorldExampleTCP publisher (or HelloWorldExampleTCP.exe publisher on windows).
-In the second one: HelloWorldExampleTCP subscriber.
+In the first one launch: ./HelloWorldExampleTCP publisher (or HelloWorldExampleTCP.exe publisher on windows).
+In the second one: ./HelloWorldExampleTCP subscriber.
 
 
-This example includes additional options to show the capabilities of the TCP Transport on Fast-RPTS,
+This example includes additional options to show the capabilities of the TCP Transport on Fast DDS,
 such as WAN and TLS. In this example the publisher will work as a TCP server and the subscriber as a
 TCP client.
 

--- a/examples/C++/HistoryKind/CMakeLists.txt
+++ b/examples/C++/HistoryKind/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/HistoryKind/README.txt
+++ b/examples/C++/HistoryKind/README.txt
@@ -1,22 +1,22 @@
 ------------------------------------------------
-- Use Case Example: History Kind for eProsima Fast RTPS -
+- Use Case Example: History Kind for eProsima Fast DDS -
 ------------------------------------------------
 
 1 - Application description
 ---------------------------
 
-eProsima Fast RTPS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
+eProsima Fast DDS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
 
 This example is a supplement to the UseCaseLauncher example, consisting on an application which illustrates the effect the different kinds of Subscriber Histories have on sample storage.
 
 2 - Configuration options
 --------------------------
 
-These are the main parameters that affect the behaviour of eProsima Fast RTPS and that are used in the Use Case set of example:
+These are the main parameters that affect the behaviour of eProsima Fast DDS and that are used in the Use Case set of example:
 
 - Reliability Kind 
     
-    Defines how eProsima Fast RTPS deals upon possible packet loss during data exchanges.    
+    Defines how eProsima Fast DDS deals upon possible packet loss during data exchanges.    
 
     + Best Effort: No arrival confirmation. It is fast but lost samples are not re-sent.
     + Reliable: With arrival confirmation. It is slower but provides guarantee that all lost samples are re-sent and eventually received by the subscriber.
@@ -34,7 +34,7 @@ Since this application runs the Publisher and Subscriber on the same machine, da
 
     Defines the storage policy for past samples.
 
-    + Keep Last: The History will save and give access to the alst "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
+    + Keep Last: The History will save and give access to the last "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
     + Keep All: The History will save and give access to all received samples until the maximum samples size of the History is reached.
 
 This parameter affects cases of "late-joining" Subscribers: Subscribers that come online after data transfers on a topic have started.
@@ -44,7 +44,7 @@ This parameter affects cases of "late-joining" Subscribers: Subscribers that com
     Keys allow to have multiple data endpoints within a topic as opposed to all data published in a topic going into the same "inbox".
 
     + On a topic without keys, all pieces of data go into a single endpoint.
-    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima FastRTPS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
+    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima Fast DDS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
 
     It is important to note that even if you configure a Topic and your History to be able to hold items from multiple keys, this configuration does not take effect unless you explicitly enable Keys.
 
@@ -81,3 +81,6 @@ Other than this application, he Use Case set of examples contains the following 
 * Keys: Provides a working example of how data can be split into multiple endpoints based of keys.
 * SampleConfig: Provides a basic Publish-Subscribe example for the three sample configurations specified in section 5.
 
+5. Run example
+-----------------
+To launch this test execute: './historykind' (or historykind.exe on windows).

--- a/examples/C++/Keys/CMakeLists.txt
+++ b/examples/C++/Keys/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/Keys/README.txt
+++ b/examples/C++/Keys/README.txt
@@ -1,22 +1,22 @@
 -------------------------------------------------
-- Use Case Example: Keys for eProsima Fast RTPS -
+- Use Case Example: Keys for eProsima Fast DDS -
 -------------------------------------------------
 
 1 - Application description
 ---------------------------
 
-eProsima Fast RTPS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
+eProsima Fast DDS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
 
 This example is a supplement to the UseCaseLauncher example, consisting on an application which illustrates how keys work.
 
 2 - Configuration options
 --------------------------
 
-These are the main parameters that affect the behaviour of eProsima Fast RTPS and that are used in the Use Case set of example:
+These are the main parameters that affect the behaviour of eProsima Fast DDS and that are used in the Use Case set of example:
 
 - Reliability Kind 
     
-    Defines how eProsima Fast RTPS deals upon possible packet loss during data exchanges.    
+    Defines how eProsima Fast DDS deals upon possible packet loss during data exchanges.    
 
     + Best Effort: No arrival confirmation. It is fast but lost samples are not re-sent.
     + Reliable: With arrival confirmation. It is slower but provides guarantee that all lost samples are re-sent and eventually received by the subscriber.
@@ -34,7 +34,7 @@ Since this application runs the Publisher and Subscriber on the same machine, da
 
     Defines the storage policy for past samples.
 
-    + Keep Last: The History will save and give access to the alst "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
+    + Keep Last: The History will save and give access to the last "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
     + Keep All: The History will save and give access to all received samples until the maximum samples size of the History is reached.
 
 This parameter affects cases of "late-joining" Subscribers: Subscribers that come online after data transfers on a topic have started.
@@ -44,7 +44,7 @@ This parameter affects cases of "late-joining" Subscribers: Subscribers that com
     Keys allow to have multiple data endpoints within a topic as opposed to all data published in a topic going into the same "inbox".
 
     + On a topic without keys, all pieces of data go into a single endpoint.
-    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima FastRTPS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
+    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima Fast DDS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
 
     It is important to note that even if you configure a Topic and your History to be able to hold items from multiple keys, this configuration does not take effect unless you explicitly enable Keys.
 
@@ -78,3 +78,6 @@ Other than this application, he Use Case set of examples contains the following 
 * Latejoiners: Shows how a Transient-Local Subscriber receives past samples while Volatile starts receiving from the moment of its creation.
 * SampleConfig: Provides a basic Publish-Subscribe example for the three sample configurations specified in section 5.
 
+5. Run example
+-----------------
+To launch this test execute './keys' (or keys.exe on windows).

--- a/examples/C++/LateJoiners/CMakeLists.txt
+++ b/examples/C++/LateJoiners/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/LateJoiners/README.txt
+++ b/examples/C++/LateJoiners/README.txt
@@ -1,22 +1,22 @@
 ---------------------------------------------------------
-- Use Case Example: Late Joiners for eProsima Fast RTPS -
+- Use Case Example: Late Joiners for eProsima Fast DDS -
 ---------------------------------------------------------
 
 1 - Application description
 ---------------------------
 
-eProsima Fast RTPS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
+eProsima Fast DDS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
 
 This example is a supplement to the UseCaseLauncher example, consisting on an application which illustrates the effect the different kinds of Subscriber Durability have on sample storage.
 
 2 - Configuration options
 --------------------------
 
-These are the main parameters that affect the behaviour of eProsima Fast RTPS and that are used in the Use Case set of example:
+These are the main parameters that affect the behaviour of eProsima Fast DDS and that are used in the Use Case set of example:
 
 - Reliability Kind
 
-    Defines how eProsima Fast RTPS deals upon possible packet loss during data exchanges.
+    Defines how eProsima Fast DDS deals upon possible packet loss during data exchanges.
 
     + Best Effort: No arrival confirmation. It is fast but lost samples are not re-sent.
     + Reliable: With arrival confirmation. It is slower but provides guarantee that all lost samples are re-sent and eventually received by the subscriber.
@@ -34,7 +34,7 @@ Since this application runs the Publisher and Subscriber on the same machine, da
 
     Defines the storage policy for past samples.
 
-    + Keep Last: The History will save and give access to the alst "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
+    + Keep Last: The History will save and give access to the last "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
     + Keep All: The History will save and give access to all received samples until the maximum samples size of the History is reached.
 
 This parameter affects cases of "late-joining" Subscribers: Subscribers that come online after data transfers on a topic have started.
@@ -44,7 +44,7 @@ This parameter affects cases of "late-joining" Subscribers: Subscribers that com
     Keys allow to have multiple data endpoints within a topic as opposed to all data published in a topic going into the same "inbox".
 
     + On a topic without keys, all pieces of data go into a single endpoint.
-    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima FastRTPS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
+    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima Fast DDS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
 
     It is important to note that even if you configure a Topic and your History to be able to hold items from multiple keys, this configuration does not take effect unless you explicitly enable Keys.
 
@@ -81,3 +81,6 @@ The use case launcher contains the following built-in examples:
 * Keys: Provides a working example of how data can be split into multiple endpoints based of keys.
 * SampleConfig: Provides a basic Publish-Subscribe example for the three sample configurations specified in section 5.
 
+5. Run example
+-----------------
+To launch this test execute './latejoiners' (or latejoiners.exe on windows).

--- a/examples/C++/LifespanQoSExample/CMakeLists.txt
+++ b/examples/C++/LifespanQoSExample/CMakeLists.txt
@@ -29,14 +29,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/LifespanQoSExample/README.md
+++ b/examples/C++/LifespanQoSExample/README.md
@@ -1,6 +1,6 @@
 # Lifespan QoS example
 
-This example illustrates how to use the Lifespan QoS in a Fast-RTPS application.
+This example illustrates how to use the Lifespan QoS in a Fast DDS application.
 
 To launch this test open two different consoles:
 

--- a/examples/C++/LivelinessQoS/CMakeLists.txt
+++ b/examples/C++/LivelinessQoS/CMakeLists.txt
@@ -29,14 +29,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/LivelinessQoS/README.md
+++ b/examples/C++/LivelinessQoS/README.md
@@ -1,6 +1,6 @@
 ## Liveliness QoS example
 
-This example illustrates the Liveliness QoS feature on a Fast-RTPS application.
+This example illustrates the Liveliness QoS feature on a Fast DDS application.
 
 To launch this example open two different consoles:
 

--- a/examples/C++/OwnershipStrengthQoSExample/CMakeLists.txt
+++ b/examples/C++/OwnershipStrengthQoSExample/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/OwnershipStrengthQoSExample/README.txt
+++ b/examples/C++/OwnershipStrengthQoSExample/README.txt
@@ -1,9 +1,9 @@
 To launch this test open two or more consoles:
 
-1) "$OwnershipStrengthQosExample subscriber" 
+1) "$./OwnershipStrengthQosExample subscriber" 
     (or "OwnershipStrengthQosExample.exe subscriber" on Windows). 
 
-2..*) "$OwnershipStrengthQosExample publisher XX" 
+2) "$./OwnershipStrengthQosExample publisher XX" 
       (or "OwnershipStrengthQosExample.exe publisher XX" on Windows).
 
 For the publishers, XX represents an Ownership Strength QoS number. 

--- a/examples/C++/RTPSTest_as_socket/CMakeLists.txt
+++ b/examples/C++/RTPSTest_as_socket/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/RTPSTest_as_socket/README.txt
+++ b/examples/C++/RTPSTest_as_socket/README.txt
@@ -1,0 +1,4 @@
+To launch this test open two different consoles:
+
+In the first one launch: ./RTPSTest_as_socket reader (or RTPSTest_as_socket.exe writer on windows).
+In the second one: ./RTPSTest_as_socket writer.

--- a/examples/C++/RTPSTest_as_socket/README.txt
+++ b/examples/C++/RTPSTest_as_socket/README.txt
@@ -1,4 +1,4 @@
 To launch this test open two different consoles:
 
-In the first one launch: ./RTPSTest_as_socket reader (or RTPSTest_as_socket.exe writer on windows).
-In the second one: ./RTPSTest_as_socket writer.
+In the first one launch: ./RTPSTest_as_socket reader (or RTPSTest_as_socket.exe reader on windows).
+In the second one: ./RTPSTest_as_socket writer (or RTPSTest_as_socket.exe writer on windows).

--- a/examples/C++/RTPSTest_persistent/CMakeLists.txt
+++ b/examples/C++/RTPSTest_persistent/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/RTPSTest_persistent/README.txt
+++ b/examples/C++/RTPSTest_persistent/README.txt
@@ -1,4 +1,4 @@
 To launch this test open two different consoles:
 
 In the first one launch: ./RTPSTest_persistent writer (or RTPSTest_persistent.exe writer on windows).
-In the second one: ./RTPSTest_persistent reader.
+In the second one: ./RTPSTest_persistent reader (or RTPSTest_persistent.exe reader on windows).

--- a/examples/C++/RTPSTest_persistent/README.txt
+++ b/examples/C++/RTPSTest_persistent/README.txt
@@ -1,0 +1,4 @@
+To launch this test open two different consoles:
+
+In the first one launch: ./RTPSTest_persistent writer (or RTPSTest_persistent.exe writer on windows).
+In the second one: ./RTPSTest_persistent reader.

--- a/examples/C++/RTPSTest_registered/CMakeLists.txt
+++ b/examples/C++/RTPSTest_registered/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/RTPSTest_registered/README.txt
+++ b/examples/C++/RTPSTest_registered/README.txt
@@ -1,0 +1,4 @@
+To launch this test open two different consoles:
+
+In the first one launch: ./RTPSTest_registered writer (or RTPSTest_registered.exe writer on windows).
+In the second one: ./RTPSTest_registered reader.

--- a/examples/C++/RTPSTest_registered/README.txt
+++ b/examples/C++/RTPSTest_registered/README.txt
@@ -1,4 +1,4 @@
 To launch this test open two different consoles:
 
 In the first one launch: ./RTPSTest_registered writer (or RTPSTest_registered.exe writer on windows).
-In the second one: ./RTPSTest_registered reader.
+In the second one: ./RTPSTest_registered reader (or RTPSTest_registered.exe reader on windows).

--- a/examples/C++/SampleConfig_Controller/CMakeLists.txt
+++ b/examples/C++/SampleConfig_Controller/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/SampleConfig_Controller/README.txt
+++ b/examples/C++/SampleConfig_Controller/README.txt
@@ -1,22 +1,22 @@
 ------------------------------------------------
-- Use Case Sample Configuration: Controller for eProsima Fast RTPS -
+- Use Case Sample Configuration: Controller for eProsima Fast DDS -
 ------------------------------------------------
 
 1 - Application description
 ---------------------------
 
-eProsima Fast RTPS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
+eProsima Fast DDS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
 
 This example is a supplement to the UseCaseLauncher example, consisting on a sample Publisher-Subscriber application with a configuration optimized to perform secure data transmission where not only the samples but the historic tendency matters. 
 
 2 - Configuration options
 --------------------------
 
-These are the main parameters that affect the behaviour of eProsima Fast RTPS and that are used in the Use Case set of example:
+These are the main parameters that affect the behaviour of eProsima Fast DDS and that are used in the Use Case set of example:
 
 - Reliability Kind 
     
-    Defines how eProsima Fast RTPS deals upon possible packet loss during data exchanges.    
+    Defines how eProsima Fast DDS deals upon possible packet loss during data exchanges.    
 
     + Best Effort: No arrival confirmation. It is fast but lost samples are not re-sent.
     + Reliable: With arrival confirmation. It is slower but provides guarantee that all lost samples are re-sent and eventually received by the subscriber.
@@ -34,7 +34,7 @@ Since this application runs the Publisher and Subscriber on the same machine, da
 
     Defines the storage policy for past samples.
 
-    + Keep Last: The History will save and give access to the alst "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
+    + Keep Last: The History will save and give access to the last "k" received samples. This "k" number is called the History Depth and can be manually set too by the user.
     + Keep All: The History will save and give access to all received samples until the maximum samples size of the History is reached.
 
 This parameter affects cases of "late-joining" Subscribers: Subscribers that come online after data transfers on a topic have started.
@@ -44,7 +44,7 @@ This parameter affects cases of "late-joining" Subscribers: Subscribers that com
     Keys allow to have multiple data endpoints within a topic as opposed to all data published in a topic going into the same "inbox".
 
     + On a topic without keys, all pieces of data go into a single endpoint.
-    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima FastRTPS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
+    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima Fast DDS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
 
     It is important to note that even if you configure a Topic and your History to be able to hold items from multiple keys, this configuration does not take effect unless you explicitly enable Keys.
 
@@ -80,7 +80,7 @@ Audio and Video transmission have a common characteristic: Having a stable, high
 
 - Distributed measurement: Controllers
 
-Lets say we have a factory with a network of distributed temperature sensors and we want to use eProsima Fast RTPS to send data from said sensors to an automation computer which
+Lets say we have a factory with a network of distributed temperature sensors and we want to use eProsima Fast DDS to send data from said sensors to an automation computer which
 makes decisions based on the temperature distribution. We would group all sensors within one single topic, 
 
 	Reliability: Reliable. We want to make sure samples are not lost. Furthermore, since reliable more ensures data delivery, it allows us to detect hardware problems when a sensor becomes silent
@@ -91,11 +91,13 @@ makes decisions based on the temperature distribution. We would group all sensor
 - Event-based transmission
 
 In some cases, you may want to transmit information only under certain circumstances that happen in your system, for example a photo from a surveillance camera when it detects movement.
-In these cases and due to the low  it is important that all datagrams reach their destination
+In these cases it is important that all datagrams reach their destination
 		
 	Reliability: Reliable. All samples must reach their destination.
-	Durability: Volatile. Since corrective actions are taken as events come, past triggers provide have no use.
+	Durability: Volatile. Since corrective actions are taken as events come, past triggers have no use.
 	History: Keep-Last. No past alarm information is necessary for present-time transmissions.
 	Additional Settings: Reduce heartbeat period, which dictates system response velocity when a sample is lost. A lower heartbeat period equals fast response on data delivery.
 
-
+6. Run example
+----------------------
+To launch this test execute: './sampleconfig_controller' (or sampleconfig_controller.exe on windows).

--- a/examples/C++/SampleConfig_Events/CMakeLists.txt
+++ b/examples/C++/SampleConfig_Events/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/SampleConfig_Events/README.txt
+++ b/examples/C++/SampleConfig_Events/README.txt
@@ -100,5 +100,4 @@ In these cases it is important that all datagrams reach their destination
 
 6. Run example
 ----------------------
-To launch this test execute: './sampleconfig_events' (or DDSSampleConfigEvents.exe on windows).
-
+To launch this test execute: './sampleconfig_events' (or sampleconfig_events.exe on windows).

--- a/examples/C++/SampleConfig_Events/README.txt
+++ b/examples/C++/SampleConfig_Events/README.txt
@@ -1,22 +1,22 @@
 ----------------------------------------------------------------
-- Use Case Sample Configuration: Events for eProsima Fast RTPS -
+- Use Case Sample Configuration: Events for eProsima Fast DDS -
 ----------------------------------------------------------------
 
 1 - Application description
 ---------------------------
 
-eProsima Fast RTPS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
+eProsima Fast DDS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
 
 This example is a supplement to the UseCaseLauncher example, consisting on a sample Publisher-Subscriber application with a configuration optimized to perform secure event-based transmissions.
 
 2 - Configuration options
 --------------------------
 
-These are the main parameters that affect the behaviour of eProsima Fast RTPS and that are used in the Use Case set of example:
+These are the main parameters that affect the behaviour of eProsima Fast DDS and that are used in the Use Case set of example:
 
 - Reliability Kind
 
-    Defines how eProsima Fast RTPS deals upon possible packet loss during data exchanges.
+    Defines how eProsima Fast DDS deals upon possible packet loss during data exchanges.
 
     + Best Effort: No arrival confirmation. It is fast but lost samples are not re-sent.
     + Reliable: With arrival confirmation. It is slower but provides guarantee that all lost samples are re-sent and eventually received by the subscriber.
@@ -44,7 +44,7 @@ This parameter affects cases of "late-joining" Subscribers: Subscribers that com
     Keys allow to have multiple data endpoints within a topic as opposed to all data published in a topic going into the same "inbox".
 
     + On a topic without keys, all pieces of data go into a single endpoint.
-    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima FastRTPS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
+    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima Fast DDS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
 
     It is important to note that even if you configure a Topic and your History to be able to hold items from multiple keys, this configuration does not take effect unless you explicitly enable Keys.
 
@@ -91,11 +91,14 @@ makes decisions based on the temperature distribution. We would group all sensor
 - Event-based transmission
 
 In some cases, you may want to transmit information only under certain circumstances that happen in your system, for example a photo from a surveillance camera when it detects movement.
-In these cases and due to the low  it is important that all datagrams reach their destination
+In these cases it is important that all datagrams reach their destination
 
 	Reliability: Reliable. All samples must reach their destination.
-	Durability: Volatile. Since corrective actions are taken as events come, past triggers provide have no use.
+	Durability: Volatile. Since corrective actions are taken as events come, past triggers have no use.
 	History: Keep-Last. No past alarm information is necessary for present-time transmissions.
 	Additional Settings: Reduce heartbeat period, which dictates system response velocity when a sample is lost. A lower heartbeat period equals fast response on data delivery.
 
+6. Run example
+----------------------
+To launch this test execute: './sampleconfig_events' (or DDSSampleConfigEvents.exe on windows).
 

--- a/examples/C++/SampleConfig_Multimedia/CMakeLists.txt
+++ b/examples/C++/SampleConfig_Multimedia/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/SampleConfig_Multimedia/README.txt
+++ b/examples/C++/SampleConfig_Multimedia/README.txt
@@ -100,5 +100,4 @@ In these cases it is important that all datagrams reach their destination
 
 6. Run example
 ----------------------
-To launch this test execute: './sampleconfig_multimedia' (or DDSSampleConfigMultimedia.exe on windows).
-
+To launch this test execute: './sampleconfig_multimedia' (or sampleconfig_multimedia.exe on windows).

--- a/examples/C++/SampleConfig_Multimedia/README.txt
+++ b/examples/C++/SampleConfig_Multimedia/README.txt
@@ -1,22 +1,22 @@
 ------------------------------------------------
-- Use Case Sample Configuration: Controller for eProsima Fast RTPS -
+- Use Case Sample Configuration: Controller for eProsima Fast DDS -
 ------------------------------------------------
 
 1 - Application description
 ---------------------------
 
-eProsima Fast RTPS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
+eProsima Fast DDS provides users with a wide range of configuration options. This example has the objective of providing a testing ground where you can experiment and see the influence different combinations of parameters can have on the behaviours on the Publisher/Subscriber scheme.
 
 This example is a supplement to the UseCaseLauncher example, consisting on an application which illustrates the effect the different kinds of Subscriber Histories have on sample storage.
 
 2 - Configuration options
 --------------------------
 
-These are the main parameters that affect the behaviour of eProsima Fast RTPS and that are used in the Use Case set of example:
+These are the main parameters that affect the behaviour of eProsima Fast DDS and that are used in the Use Case set of example:
 
 - Reliability Kind 
     
-    Defines how eProsima Fast RTPS deals upon possible packet loss during data exchanges.    
+    Defines how eProsima Fast DDS deals upon possible packet loss during data exchanges.    
 
     + Best Effort: No arrival confirmation. It is fast but lost samples are not re-sent.
     + Reliable: With arrival confirmation. It is slower but provides guarantee that all lost samples are re-sent and eventually received by the subscriber.
@@ -44,7 +44,7 @@ This parameter affects cases of "late-joining" Subscribers: Subscribers that com
     Keys allow to have multiple data endpoints within a topic as opposed to all data published in a topic going into the same "inbox".
 
     + On a topic without keys, all pieces of data go into a single endpoint.
-    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima FastRTPS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
+    + On a topic without keys, the key field is used to determine which of the multiple endpoints the data goes into. If, for example, a history is set to transient local with depth=3 (the last three samples are stores) then eProsima Fast DDS will ensure that 3 samples per data endpoint are stored. This means that three samples are stored for each unique key instead of three samples total.
 
     It is important to note that even if you configure a Topic and your History to be able to hold items from multiple keys, this configuration does not take effect unless you explicitly enable Keys.
 
@@ -91,11 +91,14 @@ makes decisions based on the temperature distribution. We would group all sensor
 - Event-based transmission
 
 In some cases, you may want to transmit information only under certain circumstances that happen in your system, for example a photo from a surveillance camera when it detects movement.
-In these cases and due to the low  it is important that all datagrams reach their destination
+In these cases it is important that all datagrams reach their destination
 		
 	Reliability: Reliable. All samples must reach their destination.
-	Durability: Volatile. Since corrective actions are taken as events come, past triggers provide have no use.
+	Durability: Volatile. Since corrective actions are taken as events come, past triggers have no use.
 	History: Keep-Last. No past alarm information is necessary for present-time transmissions.
 	Additional Settings: Reduce heartbeat period, which dictates system response velocity when a sample is lost. A lower heartbeat period equals fast response on data delivery.
 
+6. Run example
+----------------------
+To launch this test execute: './sampleconfig_multimedia' (or DDSSampleConfigMultimedia.exe on windows).
 

--- a/examples/C++/SecureHelloWorldExample/CMakeLists.txt
+++ b/examples/C++/SecureHelloWorldExample/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/SecureHelloWorldExample/README.txt
+++ b/examples/C++/SecureHelloWorldExample/README.txt
@@ -6,6 +6,5 @@ example.
 To launch this test open two different consoles:
 
 In the first one launch: ./SecureHelloWorldExample publisher (or SecureHelloWorldExample.exe publisher on windows).
-In the second one: ./SecureHelloWorldExample subscriber.
-
+In the second one: ./SecureHelloWorldExample subscriber (or SecureHelloWorldExample.exe subscriber on windows).
 

--- a/examples/C++/SecureHelloWorldExample/README.txt
+++ b/examples/C++/SecureHelloWorldExample/README.txt
@@ -5,7 +5,7 @@ example.
 
 To launch this test open two different consoles:
 
-In the first one launch: HelloWorldExample publisher (or HelloWorldExample.exe publisher on windows).
-In the second one: HelloWorldExample subscriber.
+In the first one launch: ./SecureHelloWorldExample publisher (or SecureHelloWorldExample.exe publisher on windows).
+In the second one: ./SecureHelloWorldExample subscriber.
 
 

--- a/examples/C++/StaticHelloWorldExample/CMakeLists.txt
+++ b/examples/C++/StaticHelloWorldExample/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/StaticHelloWorldExample/README.txt
+++ b/examples/C++/StaticHelloWorldExample/README.txt
@@ -1,6 +1,6 @@
 To launch this test open two different consoles:
 
-In the first one launch: HelloWorldExample publisher (or HelloWorldExample.exe publisher on windows).
-In the second one: HelloWorldExample subscriber.
+In the first one launch: ./StaticHelloWorldExample publisher (or StaticHelloWorldExample.exe publisher on windows).
+In the second one: ./StaticHelloWorldExample subscriber.
 
 Note: This example needs the xml file stored in the sources directory. You need to copy this folder where you will execute the example executable. The CMakeList.txt file also copies this file to the folder used to build the example.

--- a/examples/C++/StaticHelloWorldExample/README.txt
+++ b/examples/C++/StaticHelloWorldExample/README.txt
@@ -1,6 +1,6 @@
 To launch this test open two different consoles:
 
 In the first one launch: ./StaticHelloWorldExample publisher (or StaticHelloWorldExample.exe publisher on windows).
-In the second one: ./StaticHelloWorldExample subscriber.
+In the second one: ./StaticHelloWorldExample subscriber (or StaticHelloWorldExample.exe subscriber on windows).
 
 Note: This example needs the xml file stored in the sources directory. You need to copy this folder where you will execute the example executable. The CMakeList.txt file also copies this file to the folder used to build the example.

--- a/examples/C++/UserDefinedTransportExample/CMakeLists.txt
+++ b/examples/C++/UserDefinedTransportExample/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/examples/C++/UserDefinedTransportExample/README.txt
+++ b/examples/C++/UserDefinedTransportExample/README.txt
@@ -1,0 +1,4 @@
+To launch this test open two different consoles:
+
+In the first one launch: ./UserDefinedTransportExample Writer (or UserDefinedTransportExample.exe Writer on windows).
+In the second one: ./UserDefinedTransportExample Reader.

--- a/examples/C++/UserDefinedTransportExample/README.txt
+++ b/examples/C++/UserDefinedTransportExample/README.txt
@@ -1,4 +1,4 @@
 To launch this test open two different consoles:
 
 In the first one launch: ./UserDefinedTransportExample Writer (or UserDefinedTransportExample.exe Writer on windows).
-In the second one: ./UserDefinedTransportExample Reader.
+In the second one: ./UserDefinedTransportExample Reader (or UserDefinedTransportExample.exe Reader on windows).

--- a/examples/C++/XMLProfiles/CMakeLists.txt
+++ b/examples/C++/XMLProfiles/CMakeLists.txt
@@ -33,14 +33,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+#Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()

--- a/tools/fds/CMakeLists.txt
+++ b/tools/fds/CMakeLists.txt
@@ -25,14 +25,12 @@ if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
 
-# Set C++11
+# Check C++11
 include(CheckCXXCompilerFlag)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
+    if(NOT SUPPORTS_CXX11)
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()
 endif()


### PR DESCRIPTION
Update CMakeLists.txt not setting C++11 compiler flag.
Update Examples README.txt

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>