### PR TITLE
Changed durability to transient local [9170]

### DIFF
--- a/examples/C++/DDS/HistoryKind/pastsamples.cpp
+++ b/examples/C++/DDS/HistoryKind/pastsamples.cpp
@@ -19,10 +19,22 @@ using namespace eprosima::fastdds::dds;
 using namespace eprosima::fastrtps::rtps;
 
 //Enums and configuration structure
-enum Reliability_type { Best_Effort, Reliable };
-enum Durability_type { Transient_Local, Volatile };
-enum HistoryKind_type { Keep_Last, Keep_All };
-enum Key_type { No_Key, With_Key};
+enum Reliability_type
+{
+    Best_Effort, Reliable
+};
+enum Durability_type
+{
+    Transient_Local, Volatile
+};
+enum HistoryKind_type
+{
+    Keep_Last, Keep_All
+};
+enum Key_type
+{
+    No_Key, With_Key
+};
 
 typedef struct
 {

--- a/examples/C++/DDS/HistoryKind/pastsamples.cpp
+++ b/examples/C++/DDS/HistoryKind/pastsamples.cpp
@@ -133,7 +133,7 @@ void pastsamples()
     DataReaderQos rqos1;
     rqos1.endpoint().history_memory_policy = DYNAMIC_RESERVE_MEMORY_MODE;
     rqos1.history().kind = KEEP_ALL_HISTORY_QOS;
-    rqos1.durability().kind = VOLATILE_DURABILITY_QOS;
+    rqos1.durability().kind = TRANSIENT_LOCAL_DURABILITY_QOS;
     rqos1.reliability().kind = RELIABLE_RELIABILITY_QOS;
     rqos1.history().depth =  50;
     rqos1.resource_limits().max_samples = 100;
@@ -155,7 +155,7 @@ void pastsamples()
     DataReaderQos rqos2;
     rqos2.endpoint().history_memory_policy = DYNAMIC_RESERVE_MEMORY_MODE;
     rqos2.history().kind = KEEP_LAST_HISTORY_QOS;
-    rqos2.durability().kind = VOLATILE_DURABILITY_QOS;
+    rqos2.durability().kind = TRANSIENT_LOCAL_DURABILITY_QOS;
     rqos2.reliability().kind = RELIABLE_RELIABILITY_QOS;
     rqos2.history().depth =  10;
     rqos2.resource_limits().max_samples = 100;
@@ -184,6 +184,7 @@ void pastsamples()
         std::cout << std::to_string(my_sample.index()) << " ";
     }
     std::cout << std::endl;
+
     std::cout << "The Keep Last (Depth 10) Subscriber holds: " << std::endl;
     while (myReader2->read_next_sample(&my_sample, &sample_info) == ReturnCode_t::RETCODE_OK)
     {


### PR DESCRIPTION
Changed reader's durability to transient local to prevent the time it took to match to the writer to influence the behavior of the example.

Signed-off-by: imontesino <monte.igna@gmail.com>