### PR TITLE
Return false if type not found unregistering type [9182]

### DIFF
--- a/src/cpp/fastrtps_deprecated/participant/ParticipantImpl.cpp
+++ b/src/cpp/fastrtps_deprecated/participant/ParticipantImpl.cpp
@@ -460,6 +460,11 @@ bool ParticipantImpl::unregisterType(
             retValue =  false;
         }
     }
+    else
+    {
+        retValue = false;
+    }
+    
 
     return retValue;
 }

--- a/src/cpp/fastrtps_deprecated/participant/ParticipantImpl.cpp
+++ b/src/cpp/fastrtps_deprecated/participant/ParticipantImpl.cpp
@@ -464,7 +464,7 @@ bool ParticipantImpl::unregisterType(
     {
         retValue = false;
     }
-    
+
 
     return retValue;
 }
@@ -492,7 +492,7 @@ void ParticipantImpl::MyRTPSParticipantListener::onParticipantAuthentication(
     }
 }
 
-#endif
+#endif // if HAVE_SECURITY
 
 void ParticipantImpl::MyRTPSParticipantListener::onReaderDiscovery(
         RTPSParticipant*,

--- a/src/cpp/fastrtps_deprecated/participant/ParticipantImpl.cpp
+++ b/src/cpp/fastrtps_deprecated/participant/ParticipantImpl.cpp
@@ -420,7 +420,7 @@ bool ParticipantImpl::registerType(
 bool ParticipantImpl::unregisterType(
         const char* typeName)
 {
-    bool retValue = true;
+    bool retValue = false;
     std::vector<TopicDataType*>::iterator typeit;
 
     for (typeit = m_types.begin(); typeit != m_types.end(); ++typeit)
@@ -454,17 +454,9 @@ bool ParticipantImpl::unregisterType(
         if (!inUse)
         {
             m_types.erase(typeit);
-        }
-        else
-        {
-            retValue =  false;
+            retValue = true;
         }
     }
-    else
-    {
-        retValue = false;
-    }
-
 
     return retValue;
 }


### PR DESCRIPTION
Return `false` if the type is not registered.
This is in line with the registration, that returns `false` if the type is already registered.