### PR TITLE
Increased writer depth on flaky test [9188]

### DIFF
--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -1473,6 +1473,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_payload_ok_same_participan
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     wreader.sub_history_depth(10).sub_reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS);
+    wreader.pub_history_depth(10).pub_reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS);
     wreader.sub_durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS);
     wreader.pub_durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS);
     wreader.property_policy(property_policy).


### PR DESCRIPTION
Test BuiltinAuthenticationAndCryptoPlugin_payload_ok_same_participant_300kb was failing form time to time due to a sample not being received.

The writer was created with default history QoS (keep_last, 1), and sometimes the sample was overwritten before being completely sent. 

This PR fixes this by increasing the writer's history depth.

Signed-off-by: Miguel Company <MiguelCompany@eprosima.com>