### PR TITLE
Endianness macro [9189]

### DIFF
--- a/cmake/common/check_configuration.cmake
+++ b/cmake/common/check_configuration.cmake
@@ -83,7 +83,7 @@ macro(check_endianness)
     # Test endianness
     include(TestBigEndian)
     test_big_endian(BIG_ENDIAN)
-    set(__BIG_ENDIAN__ ${BIG_ENDIAN})
+    set(FASTDDS_IS_BIG_ENDIAN_TARGET ${BIG_ENDIAN})
 endmacro()
 
 macro(check_msvc_arch)

--- a/configure.ac
+++ b/configure.ac
@@ -51,8 +51,8 @@ AS_IF([test $HAVE_CXX11 = 1],
 
 # Check endianess
 AC_C_BIGENDIAN(
-  AC_DEFINE(__BIG_ENDIAN__, 1, [machine is bigendian]),
-  AC_DEFINE(__BIG_ENDIAN__, 0, [machine is littleendian]),
+  AC_DEFINE(FASTDDS_IS_BIG_ENDIAN_TARGET, 1, [machine is bigendian]),
+  AC_DEFINE(FASTDDS_IS_BIG_ENDIAN_TARGET, 0, [machine is littleendian]),
   AC_MSG_ERROR(unknown endianess),
   AC_MSG_ERROR(universial endianess not supported)
 )

--- a/include/fastdds/rtps/common/CDRMessage_t.h
+++ b/include/fastdds/rtps/common/CDRMessage_t.h
@@ -85,12 +85,7 @@ struct RTPS_DllAPI CDRMessage_t final
 
         max_size = size;
         reserved_size = size;
-
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-        msg_endian = BIGEND;
-#else
-        msg_endian = LITTLEEND;
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+        msg_endian = DEFAULT_ENDIAN;
     }
 
     /**
@@ -144,11 +139,7 @@ struct RTPS_DllAPI CDRMessage_t final
         reserved_size = message.reserved_size;
         message.reserved_size = 0;
         msg_endian = message.msg_endian;
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-        message.msg_endian = BIGEND;
-#else
-        message.msg_endian = LITTLEEND;
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+        message.msg_endian = DEFAULT_ENDIAN;
         buffer = message.buffer;
         message.buffer = nullptr;
     }
@@ -167,11 +158,7 @@ struct RTPS_DllAPI CDRMessage_t final
         reserved_size = message.reserved_size;
         message.reserved_size = 0;
         msg_endian = message.msg_endian;
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-        message.msg_endian = BIGEND;
-#else
-        message.msg_endian = LITTLEEND;
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+        message.msg_endian = DEFAULT_ENDIAN;
         buffer = message.buffer;
         message.buffer = nullptr;
 
@@ -189,12 +176,7 @@ struct RTPS_DllAPI CDRMessage_t final
         buffer = buffer_ptr;
         max_size = size;
         reserved_size = size;
-
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-        msg_endian = BIGEND;
-#else
-        msg_endian = LITTLEEND;
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+        msg_endian = DEFAULT_ENDIAN;
     }
 
     void reserve(

--- a/include/fastdds/rtps/common/CDRMessage_t.h
+++ b/include/fastdds/rtps/common/CDRMessage_t.h
@@ -90,7 +90,7 @@ struct RTPS_DllAPI CDRMessage_t final
         msg_endian = BIGEND;
 #else
         msg_endian = LITTLEEND;
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     }
 
     /**
@@ -148,7 +148,7 @@ struct RTPS_DllAPI CDRMessage_t final
         message.msg_endian = BIGEND;
 #else
         message.msg_endian = LITTLEEND;
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
         buffer = message.buffer;
         message.buffer = nullptr;
     }
@@ -171,7 +171,7 @@ struct RTPS_DllAPI CDRMessage_t final
         message.msg_endian = BIGEND;
 #else
         message.msg_endian = LITTLEEND;
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
         buffer = message.buffer;
         message.buffer = nullptr;
 
@@ -194,7 +194,7 @@ struct RTPS_DllAPI CDRMessage_t final
         msg_endian = BIGEND;
 #else
         msg_endian = LITTLEEND;
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     }
 
     void reserve(

--- a/include/fastdds/rtps/common/CDRMessage_t.h
+++ b/include/fastdds/rtps/common/CDRMessage_t.h
@@ -86,7 +86,7 @@ struct RTPS_DllAPI CDRMessage_t final
         max_size = size;
         reserved_size = size;
 
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
         msg_endian = BIGEND;
 #else
         msg_endian = LITTLEEND;
@@ -144,7 +144,7 @@ struct RTPS_DllAPI CDRMessage_t final
         reserved_size = message.reserved_size;
         message.reserved_size = 0;
         msg_endian = message.msg_endian;
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
         message.msg_endian = BIGEND;
 #else
         message.msg_endian = LITTLEEND;
@@ -167,7 +167,7 @@ struct RTPS_DllAPI CDRMessage_t final
         reserved_size = message.reserved_size;
         message.reserved_size = 0;
         msg_endian = message.msg_endian;
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
         message.msg_endian = BIGEND;
 #else
         message.msg_endian = LITTLEEND;
@@ -190,7 +190,7 @@ struct RTPS_DllAPI CDRMessage_t final
         max_size = size;
         reserved_size = size;
 
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
         msg_endian = BIGEND;
 #else
         msg_endian = LITTLEEND;

--- a/include/fastdds/rtps/common/EntityId_t.hpp
+++ b/include/fastdds/rtps/common/EntityId_t.hpp
@@ -62,7 +62,7 @@ namespace rtps {
 #define ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_READER  0xff0202C4
 #define ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER 0xff0101c2
 #define ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER 0xff0101c7
-#endif
+#endif // if HAVE_SECURITY
 
 //!@brief Structure EntityId_t, entity id part of GUID_t.
 //!@ingroup COMMON_MODULE
@@ -71,9 +71,11 @@ struct RTPS_DllAPI EntityId_t
     static constexpr unsigned int size = 4;
     octet value[size];
     //! Default constructor. Uknown entity.
-    EntityId_t(){
+    EntityId_t()
+    {
         *this = ENTITYID_UNKNOWN;
     }
+
     /**
      * Main constructor.
      * @param id Entity id
@@ -84,7 +86,7 @@ struct RTPS_DllAPI EntityId_t
         memcpy(value, &id, size);
 #if !FASTDDS_IS_BIG_ENDIAN_TARGET
         reverse();
-#endif
+#endif // if !FASTDDS_IS_BIG_ENDIAN_TARGET
     }
 
     /*!
@@ -129,13 +131,15 @@ struct RTPS_DllAPI EntityId_t
         memcpy(value, &id, size);
 #if !FASTDDS_IS_BIG_ENDIAN_TARGET
         reverse();
-#endif
+#endif // if !FASTDDS_IS_BIG_ENDIAN_TARGET
         return *this;
         //return id;
     }
+
 #if !FASTDDS_IS_BIG_ENDIAN_TARGET
     //!
-    void reverse(){
+    void reverse()
+    {
         octet oaux;
         oaux = value[3];
         value[3] = value[0];
@@ -144,12 +148,14 @@ struct RTPS_DllAPI EntityId_t
         value[2] = value[1];
         value[1] = oaux;
     }
-#endif
+
+#endif // if !FASTDDS_IS_BIG_ENDIAN_TARGET
 
     static EntityId_t unknown()
     {
         return EntityId_t();
     }
+
 };
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
@@ -166,13 +172,14 @@ inline bool operator ==(
 {
 #if !FASTDDS_IS_BIG_ENDIAN_TARGET
     id1.reverse();
-#endif
+#endif // if !FASTDDS_IS_BIG_ENDIAN_TARGET
     const bool result = 0 == memcmp(id1.value, &id2, sizeof(id2));
 #if !FASTDDS_IS_BIG_ENDIAN_TARGET
     id1.reverse();
-#endif
+#endif // if !FASTDDS_IS_BIG_ENDIAN_TARGET
     return result;
 }
+
 /**
  * Guid prefix comparison operator
  * @param id1 First EntityId to compare
@@ -213,7 +220,7 @@ inline bool operator !=(
     return false;
 }
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 inline std::ostream& operator <<(
         std::ostream& output,
@@ -303,7 +310,7 @@ const EntityId_t participant_volatile_message_secure_reader_entity_id =
 
 const EntityId_t c_EntityId_WriterLivelinessSecure = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER;
 const EntityId_t c_EntityId_ReaderLivelinessSecure = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER;
-#endif
+#endif // if HAVE_SECURITY
 
 } // namespace rtps
 } // namespace fastrtps
@@ -313,7 +320,7 @@ namespace std {
 template <>
 struct hash<eprosima::fastrtps::rtps::EntityId_t>
 {
-    std::size_t operator()(
+    std::size_t operator ()(
             const eprosima::fastrtps::rtps::EntityId_t& k) const
     {
         // recover the participant entity counter
@@ -329,9 +336,10 @@ struct hash<eprosima::fastrtps::rtps::EntityId_t>
         value[2] = k.value[0];
         value[1] = k.value[1];
         value[0] = k.value[2];
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
         return static_cast<std::size_t>(*reinterpret_cast<const uint32_t*>(&value));
     }
+
 };
 
 } // namespace std

--- a/include/fastdds/rtps/common/EntityId_t.hpp
+++ b/include/fastdds/rtps/common/EntityId_t.hpp
@@ -82,7 +82,7 @@ struct RTPS_DllAPI EntityId_t
             uint32_t id)
     {
         memcpy(value, &id, size);
-#if !__BIG_ENDIAN__
+#if !FASTDDS_IS_BIG_ENDIAN_TARGET
         reverse();
 #endif
     }
@@ -127,13 +127,13 @@ struct RTPS_DllAPI EntityId_t
             uint32_t id)
     {
         memcpy(value, &id, size);
-#if !__BIG_ENDIAN__
+#if !FASTDDS_IS_BIG_ENDIAN_TARGET
         reverse();
 #endif
         return *this;
         //return id;
     }
-#if !__BIG_ENDIAN__
+#if !FASTDDS_IS_BIG_ENDIAN_TARGET
     //!
     void reverse(){
         octet oaux;
@@ -164,11 +164,11 @@ inline bool operator ==(
         EntityId_t& id1,
         const uint32_t id2)
 {
-#if !__BIG_ENDIAN__
+#if !FASTDDS_IS_BIG_ENDIAN_TARGET
     id1.reverse();
 #endif
     const bool result = 0 == memcmp(id1.value, &id2, sizeof(id2));
-#if !__BIG_ENDIAN__
+#if !FASTDDS_IS_BIG_ENDIAN_TARGET
     id1.reverse();
 #endif
     return result;
@@ -319,7 +319,7 @@ struct hash<eprosima::fastrtps::rtps::EntityId_t>
         // recover the participant entity counter
         eprosima::fastrtps::rtps::octet value[4];
 
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
         value[3] = k.value[2];
         value[2] = k.value[1];
         value[1] = k.value[0];

--- a/include/fastdds/rtps/common/SerializedPayload.h
+++ b/include/fastdds/rtps/common/SerializedPayload.h
@@ -41,6 +41,13 @@ namespace rtps {
 #define PL_CDR_BE 0x0002
 #define PL_CDR_LE 0x0003
 
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
+#define DEFAULT_ENCAPSULATION CDR_LE
+#define PL_DEFAULT_ENCAPSULATION PL_CDR_BE
+#else
+#define DEFAULT_ENCAPSULATION CDR_LE
+#define PL_DEFAULT_ENCAPSULATION PL_CDR_LE
+#endif  // FASTDDS_IS_BIG_ENDIAN_TARGET
 
 //!@brief Structure SerializedPayload_t.
 //!@ingroup COMMON_MODULE

--- a/include/fastdds/rtps/common/Types.h
+++ b/include/fastdds/rtps/common/Types.h
@@ -76,9 +76,9 @@ typedef enum TopicKind_t
 }TopicKind_t;
 
 #if FASTDDS_IS_BIG_ENDIAN_TARGET
-const Endianness_t DEFAULT_ENDIAN = BIGEND;
+constexpr Endianness_t DEFAULT_ENDIAN = BIGEND;
 #else
-const Endianness_t DEFAULT_ENDIAN = LITTLEEND;
+constexpr Endianness_t DEFAULT_ENDIAN = LITTLEEND;
 #endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 
 using octet = unsigned char;

--- a/include/fastdds/rtps/common/Types.h
+++ b/include/fastdds/rtps/common/Types.h
@@ -74,7 +74,7 @@ typedef enum TopicKind_t
     WITH_KEY
 }TopicKind_t;
 
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
 const Endianness_t DEFAULT_ENDIAN = BIGEND;
 #else
 const Endianness_t DEFAULT_ENDIAN = LITTLEEND;

--- a/include/fastdds/rtps/common/Types.h
+++ b/include/fastdds/rtps/common/Types.h
@@ -26,15 +26,16 @@
 
 #include <fastrtps/fastrtps_dll.h>
 
-namespace eprosima{
-namespace fastrtps{
-namespace rtps{
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
 
 /*!
  * @brief This enumeration represents endianness types.
  * @ingroup COMMON_MODULE
  */
-enum Endianness_t{
+enum Endianness_t
+{
     //! @brief Big endianness.
     BIGEND = 0x1,
     //! @brief Little endianness.
@@ -78,7 +79,7 @@ typedef enum TopicKind_t
 const Endianness_t DEFAULT_ENDIAN = BIGEND;
 #else
 const Endianness_t DEFAULT_ENDIAN = LITTLEEND;
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 
 using octet = unsigned char;
 //typedef unsigned int uint;
@@ -105,31 +106,36 @@ struct RTPS_DllAPI ProtocolVersion_t
     octet m_minor;
     ProtocolVersion_t():
 #if HAVE_SECURITY
-        // As imposed by DDSSEC11-93
-        ProtocolVersion_t(2,3)
+    // As imposed by DDSSEC11-93
+    ProtocolVersion_t(2, 3)
 #else
-        ProtocolVersion_t(2,2)
-#endif
+        ProtocolVersion_t(2, 2)
+#endif // if HAVE_SECURITY
     {
 
-    };
+    }
 
-    ProtocolVersion_t(octet maj,octet min)
+    ProtocolVersion_t(
+            octet maj,
+            octet min)
         : m_major(maj)
         , m_minor(min)
     {
 
     }
 
-    bool operator==(const ProtocolVersion_t &v) const
+    bool operator ==(
+            const ProtocolVersion_t& v) const
     {
         return m_major == v.m_major && m_minor == v.m_minor;
     }
 
-    bool operator!=(const ProtocolVersion_t &v) const
+    bool operator !=(
+            const ProtocolVersion_t& v) const
     {
         return m_major != v.m_major || m_minor != v.m_minor;
     }
+
 };
 
 /**
@@ -138,14 +144,17 @@ struct RTPS_DllAPI ProtocolVersion_t
  * @param pv ProtocolVersion
  * @return OStream.
  */
-inline std::ostream& operator<<(std::ostream& output, const ProtocolVersion_t& pv){
+inline std::ostream& operator <<(
+        std::ostream& output,
+        const ProtocolVersion_t& pv)
+{
     return output << static_cast<int>(pv.m_major) << "." << static_cast<int>(pv.m_minor);
 }
 
-const ProtocolVersion_t c_ProtocolVersion_2_0(2,0);
-const ProtocolVersion_t c_ProtocolVersion_2_1(2,1);
-const ProtocolVersion_t c_ProtocolVersion_2_2(2,2);
-const ProtocolVersion_t c_ProtocolVersion_2_3(2,3);
+const ProtocolVersion_t c_ProtocolVersion_2_0(2, 0);
+const ProtocolVersion_t c_ProtocolVersion_2_1(2, 1);
+const ProtocolVersion_t c_ProtocolVersion_2_2(2, 2);
+const ProtocolVersion_t c_ProtocolVersion_2_3(2, 3);
 
 const ProtocolVersion_t c_ProtocolVersion;
 
@@ -153,51 +162,61 @@ const ProtocolVersion_t c_ProtocolVersion;
 class VendorId_t
 {
 public:
-    VendorId_t(const VendorId_t &v)// : m_vendor{v[0], v[1]}
+
+    VendorId_t(
+            const VendorId_t& v)   // : m_vendor{v[0], v[1]}
     {
         // There isn't a explicit constructor because VS2013 doesn't support it.
         m_vendor[0] = v[0];
         m_vendor[1] = v[1];
     }
 
-    VendorId_t(const octet id0, const octet id1)// : m_vendor{id0, id1}
+    VendorId_t(
+            const octet id0,
+            const octet id1)                    // : m_vendor{id0, id1}
     {
         // There isn't a explicit constructor because VS2013 doesn't support it.
         m_vendor[0] = id0;
         m_vendor[1] = id1;
     }
 
-    VendorId_t& operator=(const VendorId_t &v)
+    VendorId_t& operator =(
+            const VendorId_t& v)
     {
         m_vendor[0] = v[0];
         m_vendor[1] = v[1];
         return *this;
     }
 
-    octet& operator[](const int index)
+    octet& operator [](
+            const int index)
     {
         return m_vendor[index];
     }
 
-    octet operator[](const int index) const
+    octet operator [](
+            const int index) const
     {
         return m_vendor[index];
     }
 
-    bool operator==(const VendorId_t &v) const
+    bool operator ==(
+            const VendorId_t& v) const
     {
         return m_vendor[0] == v[0] && m_vendor[1] == v[1];
     }
+
 private:
+
     octet m_vendor[2];
 };
 //typedef octet VendorId_t[2];
 
-const VendorId_t c_VendorId_Unknown = {0x00,0x00};
-const VendorId_t c_VendorId_eProsima = {0x01,0x0F};
+const VendorId_t c_VendorId_Unknown = {0x00, 0x00};
+const VendorId_t c_VendorId_eProsima = {0x01, 0x0F};
 
-}
-}
-}
+} // namespace rtps
+} // namespace fastrtps
+} // namespace eprosima
 
 #endif /* _FASTDDS_RTPS_COMMON_TYPES_H_ */

--- a/include/fastdds/rtps/messages/CDRMessage.hpp
+++ b/include/fastdds/rtps/messages/CDRMessage.hpp
@@ -41,11 +41,7 @@ inline bool CDRMessage::initCDRMsg(
     }
     msg->pos = 0;
     msg->length = 0;
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-    msg->msg_endian = BIGEND;
-#else
-    msg->msg_endian = LITTLEEND;
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+    msg->msg_endian = DEFAULT_ENDIAN;
     return true;
 }
 
@@ -62,11 +58,7 @@ inline bool CDRMessage::wrapVector(
     msg->buffer = vectorToWrap.data();
     msg->length = (uint32_t)vectorToWrap.size();
     msg->max_size = (uint32_t)vectorToWrap.capacity();
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-    msg->msg_endian = BIGEND;
-#else
-    msg->msg_endian = LITTLEEND;
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+    msg->msg_endian = DEFAULT_ENDIAN;
     return true;
 }
 
@@ -1221,7 +1213,7 @@ inline bool CDRMessage::readParticipantGenericMessage(
 }
 
 } // namespace rtps
-} /* namespace rtps */
-} /* namespace eprosima */
+} // namespace fastrtps
+} // namespace eprosima
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */

--- a/include/fastdds/rtps/messages/CDRMessage.hpp
+++ b/include/fastdds/rtps/messages/CDRMessage.hpp
@@ -45,7 +45,7 @@ inline bool CDRMessage::initCDRMsg(
     msg->msg_endian = BIGEND;
 #else
     msg->msg_endian = LITTLEEND;
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     return true;
 }
 
@@ -66,7 +66,7 @@ inline bool CDRMessage::wrapVector(
     msg->msg_endian = BIGEND;
 #else
     msg->msg_endian = LITTLEEND;
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     return true;
 }
 
@@ -1220,7 +1220,7 @@ inline bool CDRMessage::readParticipantGenericMessage(
     return true;
 }
 
-}
+} // namespace rtps
 } /* namespace rtps */
 } /* namespace eprosima */
 

--- a/include/fastdds/rtps/messages/CDRMessage.hpp
+++ b/include/fastdds/rtps/messages/CDRMessage.hpp
@@ -41,7 +41,7 @@ inline bool CDRMessage::initCDRMsg(
     }
     msg->pos = 0;
     msg->length = 0;
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     msg->msg_endian = BIGEND;
 #else
     msg->msg_endian = LITTLEEND;
@@ -62,7 +62,7 @@ inline bool CDRMessage::wrapVector(
     msg->buffer = vectorToWrap.data();
     msg->length = (uint32_t)vectorToWrap.size();
     msg->max_size = (uint32_t)vectorToWrap.capacity();
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     msg->msg_endian = BIGEND;
 #else
     msg->msg_endian = LITTLEEND;

--- a/include/fastrtps/config.h.in
+++ b/include/fastrtps/config.h.in
@@ -54,8 +54,8 @@
 #endif
 
 // Endianness defines
-#ifndef __BIG_ENDIAN__
-#define __BIG_ENDIAN__ @__BIG_ENDIAN__@
+#ifndef FASTDDS_IS_BIG_ENDIAN_TARGET
+#define FASTDDS_IS_BIG_ENDIAN_TARGET @FASTDDS_IS_BIG_ENDIAN_TARGET@
 #endif
 
 // Security

--- a/src/cpp/fastdds/builtin/typelookup/TypeLookupManager.cpp
+++ b/src/cpp/fastdds/builtin/typelookup/TypeLookupManager.cpp
@@ -549,15 +549,9 @@ bool TypeLookupManager::send_request(
         CDRMessage_t msg(change->serializedPayload);
 
         bool valid = CDRMessage::addOctet(&msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-        change->serializedPayload.encapsulation = static_cast<uint16_t>(PL_CDR_BE);
-        msg.msg_endian = BIGEND;
-        valid &= CDRMessage::addOctet(&msg, PL_CDR_BE);
-#else
-        change->serializedPayload.encapsulation = static_cast<uint16_t>(PL_CDR_LE);
-        msg.msg_endian = LITTLEEND;
-        valid &= CDRMessage::addOctet(&msg, PL_CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+        change->serializedPayload.encapsulation = static_cast<uint16_t>(PL_DEFAULT_ENCAPSULATION);
+        msg.msg_endian = DEFAULT_ENDIAN;
+        valid &= CDRMessage::addOctet(&msg, PL_DEFAULT_ENCAPSULATION);
         valid &= CDRMessage::addUInt16(&msg, 0);
 
         change->serializedPayload.pos = msg.pos;
@@ -596,15 +590,9 @@ bool TypeLookupManager::send_reply(
         CDRMessage_t msg(change->serializedPayload);
 
         bool valid = CDRMessage::addOctet(&msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-        change->serializedPayload.encapsulation = static_cast<uint16_t>(PL_CDR_BE);
-        msg.msg_endian = BIGEND;
-        valid &= CDRMessage::addOctet(&msg, PL_CDR_BE);
-#else
-        change->serializedPayload.encapsulation = static_cast<uint16_t>(PL_CDR_LE);
-        msg.msg_endian = LITTLEEND;
-        valid &= CDRMessage::addOctet(&msg, PL_CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+        change->serializedPayload.encapsulation = static_cast<uint16_t>(PL_DEFAULT_ENCAPSULATION);
+        msg.msg_endian = DEFAULT_ENDIAN;
+        valid &= CDRMessage::addOctet(&msg, PL_DEFAULT_ENCAPSULATION);
         valid &= CDRMessage::addUInt16(&msg, 0);
 
         change->serializedPayload.pos = msg.pos;

--- a/src/cpp/fastdds/builtin/typelookup/TypeLookupManager.cpp
+++ b/src/cpp/fastdds/builtin/typelookup/TypeLookupManager.cpp
@@ -69,40 +69,40 @@ TypeLookupManager::TypeLookupManager(
     , request_listener_(nullptr)
     , reply_listener_(nullptr)
     , temp_reader_proxy_data_(
-          prot->mp_participantImpl->getRTPSParticipantAttributes().allocation.locators.max_unicast_locators,
-          prot->mp_participantImpl->getRTPSParticipantAttributes().allocation.locators.max_multicast_locators)
+        prot->mp_participantImpl->getRTPSParticipantAttributes().allocation.locators.max_unicast_locators,
+        prot->mp_participantImpl->getRTPSParticipantAttributes().allocation.locators.max_multicast_locators)
     , temp_writer_proxy_data_(
-          prot->mp_participantImpl->getRTPSParticipantAttributes().allocation.locators.max_unicast_locators,
-          prot->mp_participantImpl->getRTPSParticipantAttributes().allocation.locators.max_multicast_locators)
-/* TODO Uncomment if security is implemented
-#if HAVE_SECURITY
-    , builtin_request_writer_secure_(nullptr)
-    , builtin_reply_writer_secure_(nullptr)
-    , builtin_request_reader_secure_(nullptr)
-    , builtin_reply_reader_secure_(nullptr)
-    , builtin_request_writer_secure_history_(nullptr)
-    , builtin_reply_writer_secure_history_(nullptr)
-    , builtin_request_reader_secure_history_(nullptr)
-    , builtin_reply_reader_secure_history_(nullptr)
-#endif
-*/
+        prot->mp_participantImpl->getRTPSParticipantAttributes().allocation.locators.max_unicast_locators,
+        prot->mp_participantImpl->getRTPSParticipantAttributes().allocation.locators.max_multicast_locators)
+    /* TODO Uncomment if security is implemented
+     #if HAVE_SECURITY
+        , builtin_request_writer_secure_(nullptr)
+        , builtin_reply_writer_secure_(nullptr)
+        , builtin_request_reader_secure_(nullptr)
+        , builtin_reply_reader_secure_(nullptr)
+        , builtin_request_writer_secure_history_(nullptr)
+        , builtin_reply_writer_secure_history_(nullptr)
+        , builtin_request_reader_secure_history_(nullptr)
+        , builtin_reply_reader_secure_history_(nullptr)
+     #endif
+     */
 {
 }
 
 TypeLookupManager::~TypeLookupManager()
 {
-/* TODO Uncomment if security is implemented
-#if HAVE_SECURITY
-    participant_->deleteUserEndpoint(builtin_request_writer_secure_);
-    participant_->deleteUserEndpoint(builtin_reply_writer_secure_);
-    participant_->deleteUserEndpoint(builtin_request_reader_secure_);
-    participant_->deleteUserEndpoint(builtin_reply_reader_secure_);
-    delete builtin_request_writer_secure_history_;
-    delete builtin_reply_writer_secure_history_;
-    delete builtin_request_reader_secure_history_;
-    delete builtin_reply_reader_secure_history_;
-#endif
-*/
+    /* TODO Uncomment if security is implemented
+     #if HAVE_SECURITY
+        participant_->deleteUserEndpoint(builtin_request_writer_secure_);
+        participant_->deleteUserEndpoint(builtin_reply_writer_secure_);
+        participant_->deleteUserEndpoint(builtin_request_reader_secure_);
+        participant_->deleteUserEndpoint(builtin_reply_reader_secure_);
+        delete builtin_request_writer_secure_history_;
+        delete builtin_reply_writer_secure_history_;
+        delete builtin_request_reader_secure_history_;
+        delete builtin_reply_reader_secure_history_;
+     #endif
+     */
     if (nullptr != builtin_reply_reader_)
     {
         participant_->deleteUserEndpoint(builtin_reply_reader_);
@@ -134,15 +134,15 @@ bool TypeLookupManager::init_typelookup_service(
     logInfo(TYPELOOKUP_SERVICE, "Initializing TypeLookup Service");
     participant_ = participant;
     bool retVal = create_endpoints();
-/*
-#if HAVE_SECURITY
-    if (retVal)
-    {
-        retVal = create_secure_endpoints();
-    }
-#endif
-*/
-    return  retVal;
+    /*
+     #if HAVE_SECURITY
+        if (retVal)
+        {
+            retVal = create_secure_endpoints();
+        }
+     #endif
+     */
+    return retVal;
 }
 
 bool TypeLookupManager::assign_remote_endpoints(
@@ -175,7 +175,7 @@ bool TypeLookupManager::assign_remote_endpoints(
     partdet &= DISC_BUILTIN_ENDPOINT_PARTICIPANT_DETECTOR; //Habria que quitar esta linea que comprueba si tiene PDP.
     auxendp &= BUILTIN_ENDPOINT_TYPELOOKUP_SERVICE_REQUEST_DATA_WRITER;
 
-    if ((auxendp!=0 || partdet!=0) && builtin_request_reader_ != nullptr)
+    if ((auxendp != 0 || partdet != 0) && builtin_request_reader_ != nullptr)
     {
         logInfo(TYPELOOKUP_SERVICE, "Adding remote writer to the local Builtin Request Reader");
         temp_writer_proxy_data_.guid().entityId = fastrtps::rtps::c_EntityId_TypeLookup_request_writer;
@@ -186,7 +186,7 @@ bool TypeLookupManager::assign_remote_endpoints(
     auxendp = endp;
     auxendp &= BUILTIN_ENDPOINT_TYPELOOKUP_SERVICE_REPLY_DATA_WRITER;
 
-    if ((auxendp!=0 || partdet!=0) && builtin_reply_reader_ != nullptr)
+    if ((auxendp != 0 || partdet != 0) && builtin_reply_reader_ != nullptr)
     {
         logInfo(TYPELOOKUP_SERVICE, "Adding remote writer to the local Builtin Reply Reader");
         temp_writer_proxy_data_.guid().entityId = fastrtps::rtps::c_EntityId_TypeLookup_reply_writer;
@@ -197,7 +197,7 @@ bool TypeLookupManager::assign_remote_endpoints(
     auxendp = endp;
     auxendp &= BUILTIN_ENDPOINT_TYPELOOKUP_SERVICE_REQUEST_DATA_READER;
 
-    if ((auxendp!=0 || partdet!=0) && builtin_request_writer_ != nullptr)
+    if ((auxendp != 0 || partdet != 0) && builtin_request_writer_ != nullptr)
     {
         logInfo(TYPELOOKUP_SERVICE, "Adding remote reader to the local Builtin Request Writer");
         temp_reader_proxy_data_.guid().entityId = fastrtps::rtps::c_EntityId_TypeLookup_request_reader;
@@ -207,7 +207,7 @@ bool TypeLookupManager::assign_remote_endpoints(
     auxendp = endp;
     auxendp &= BUILTIN_ENDPOINT_TYPELOOKUP_SERVICE_REPLY_DATA_READER;
 
-    if ((auxendp!=0 || partdet!=0) && builtin_reply_writer_ != nullptr)
+    if ((auxendp != 0 || partdet != 0) && builtin_reply_writer_ != nullptr)
     {
         logInfo(TYPELOOKUP_SERVICE, "Adding remote reader to the local Builtin Reply Writer");
         temp_reader_proxy_data_.guid().entityId = fastrtps::rtps::c_EntityId_TypeLookup_reply_reader;
@@ -230,7 +230,7 @@ void TypeLookupManager::remove_remote_endpoints(
     partdet &= DISC_BUILTIN_ENDPOINT_PARTICIPANT_DETECTOR; //Habria que quitar esta linea que comprueba si tiene PDP.
     auxendp &= BUILTIN_ENDPOINT_TYPELOOKUP_SERVICE_REQUEST_DATA_WRITER;
 
-    if ((auxendp!=0 || partdet!=0) && builtin_request_reader_ != nullptr)
+    if ((auxendp != 0 || partdet != 0) && builtin_request_reader_ != nullptr)
     {
         logInfo(TYPELOOKUP_SERVICE, "Removing remote writer from the local Builtin Request Reader");
         tmp_guid.entityId = fastrtps::rtps::c_EntityId_TypeLookup_request_writer;
@@ -240,7 +240,7 @@ void TypeLookupManager::remove_remote_endpoints(
     auxendp = endp;
     auxendp &= BUILTIN_ENDPOINT_TYPELOOKUP_SERVICE_REPLY_DATA_WRITER;
 
-    if ((auxendp!=0 || partdet!=0) && builtin_reply_reader_ != nullptr)
+    if ((auxendp != 0 || partdet != 0) && builtin_reply_reader_ != nullptr)
     {
         logInfo(TYPELOOKUP_SERVICE, "Removing remote writer from the local Builtin Reply Reader");
         tmp_guid.entityId = fastrtps::rtps::c_EntityId_TypeLookup_reply_writer;
@@ -250,7 +250,7 @@ void TypeLookupManager::remove_remote_endpoints(
     auxendp = endp;
     auxendp &= BUILTIN_ENDPOINT_TYPELOOKUP_SERVICE_REQUEST_DATA_READER;
 
-    if ((auxendp!=0 || partdet!=0) && builtin_request_writer_ != nullptr)
+    if ((auxendp != 0 || partdet != 0) && builtin_request_writer_ != nullptr)
     {
         logInfo(TYPELOOKUP_SERVICE, "Removing remote reader from the local Builtin Request Writer");
         tmp_guid.entityId = fastrtps::rtps::c_EntityId_TypeLookup_request_reader;
@@ -260,7 +260,7 @@ void TypeLookupManager::remove_remote_endpoints(
     auxendp = endp;
     auxendp &= BUILTIN_ENDPOINT_TYPELOOKUP_SERVICE_REPLY_DATA_READER;
 
-    if ((auxendp!=0 || partdet!=0) && builtin_reply_writer_ != nullptr)
+    if ((auxendp != 0 || partdet != 0) && builtin_reply_writer_ != nullptr)
     {
         logInfo(TYPELOOKUP_SERVICE, "Removing remote reader from the local Builtin Reply Writer");
         tmp_guid.entityId = fastrtps::rtps::c_EntityId_TypeLookup_reply_reader;
@@ -307,23 +307,24 @@ ReaderHistory* TypeLookupManager::get_builtin_reply_reader_history()
 {
     return builtin_reply_reader_history_;
 }
+
 /* TODO Implement if security is needed.
-#if HAVE_SECURITY
-bool TypeLookupManager::pairing_remote_reader_with_local_writer_after_security(
+ #if HAVE_SECURITY
+   bool TypeLookupManager::pairing_remote_reader_with_local_writer_after_security(
         const GUID_t& local_writer,
         const ReaderProxyData& remote_reader_data)
-{
+   {
 
-}
+   }
 
-bool TypeLookupManager::pairing_remote_writer_with_local_reader_after_security(
+   bool TypeLookupManager::pairing_remote_writer_with_local_reader_after_security(
         const GUID_t& local_reader,
         const WriterProxyData& remote_writer_data)
-{
+   {
 
-}
-#endif
-*/
+   }
+ #endif
+ */
 bool TypeLookupManager::create_endpoints()
 {
     // Built-in history attributes.
@@ -348,12 +349,12 @@ bool TypeLookupManager::create_endpoints()
 
         RTPSWriter* req_writer;
         if (participant_->createWriter(
-                &req_writer,
-                watt,
-                builtin_request_writer_history_,
-                nullptr,
-                fastrtps::rtps::c_EntityId_TypeLookup_request_writer,
-                true))
+                    &req_writer,
+                    watt,
+                    builtin_request_writer_history_,
+                    nullptr,
+                    fastrtps::rtps::c_EntityId_TypeLookup_request_writer,
+                    true))
         {
             builtin_request_writer_ = dynamic_cast<StatefulWriter*>(req_writer);
             logInfo(TYPELOOKUP_SERVICE, "Builtin Typelookup request writer created.");
@@ -374,12 +375,12 @@ bool TypeLookupManager::create_endpoints()
 
         RTPSWriter* rep_writer;
         if (participant_->createWriter(
-                &rep_writer,
-                watt,
-                builtin_reply_writer_history_,
-                nullptr,
-                fastrtps::rtps::c_EntityId_TypeLookup_reply_writer,
-                true))
+                    &rep_writer,
+                    watt,
+                    builtin_reply_writer_history_,
+                    nullptr,
+                    fastrtps::rtps::c_EntityId_TypeLookup_reply_writer,
+                    true))
         {
             builtin_reply_writer_ = dynamic_cast<StatefulWriter*>(rep_writer);
             logInfo(TYPELOOKUP_SERVICE, "Builtin Typelookup reply writer created.");
@@ -411,12 +412,12 @@ bool TypeLookupManager::create_endpoints()
 
         RTPSReader* req_reader;
         if (participant_->createReader(
-                &req_reader,
-                ratt,
-                builtin_request_reader_history_,
-                request_listener_,
-                fastrtps::rtps::c_EntityId_TypeLookup_request_reader,
-                true))
+                    &req_reader,
+                    ratt,
+                    builtin_request_reader_history_,
+                    request_listener_,
+                    fastrtps::rtps::c_EntityId_TypeLookup_request_reader,
+                    true))
         {
             builtin_request_reader_ = dynamic_cast<StatefulReader*>(req_reader);
             logInfo(TYPELOOKUP_SERVICE, "Builtin Typelookup request reader created.");
@@ -440,12 +441,12 @@ bool TypeLookupManager::create_endpoints()
 
         RTPSReader* rep_reader;
         if (participant_->createReader(
-                &rep_reader,
-                ratt,
-                builtin_reply_reader_history_,
-                reply_listener_,
-                fastrtps::rtps::c_EntityId_TypeLookup_reply_reader,
-                true))
+                    &rep_reader,
+                    ratt,
+                    builtin_reply_reader_history_,
+                    reply_listener_,
+                    fastrtps::rtps::c_EntityId_TypeLookup_reply_reader,
+                    true))
         {
             builtin_reply_reader_ = dynamic_cast<StatefulReader*>(rep_reader);
             logInfo(TYPELOOKUP_SERVICE, "Builtin Typelookup reply reader created.");
@@ -463,13 +464,14 @@ bool TypeLookupManager::create_endpoints()
 
     return true;
 }
+
 /* TODO Implement if security is needed.
-#if HAVE_SECURITY
-bool TypeLookupManager::create_secure_endpoints()
-{
-}
-#endif
-*/
+ #if HAVE_SECURITY
+   bool TypeLookupManager::create_secure_endpoints()
+   {
+   }
+ #endif
+ */
 
 SampleIdentity TypeLookupManager::get_type_dependencies(
         const fastrtps::types::TypeIdentifierSeq& id_seq) const
@@ -519,10 +521,10 @@ std::string TypeLookupManager::get_instanceName() const
     ss << participant_->getGuid();
     std::string str = ss.str();
     std::transform(str.begin(), str.end(), str.begin(),
-       [](unsigned char c)
-       {
-           return static_cast<unsigned char>(std::tolower(c));
-       });
+            [](unsigned char c)
+            {
+                return static_cast<unsigned char>(std::tolower(c));
+            });
     str.erase(std::remove(str.begin(), str.end(), '.'), str.end());
     return "dds.builtin.TOS." + str;
 }
@@ -555,7 +557,7 @@ bool TypeLookupManager::send_request(
         change->serializedPayload.encapsulation = static_cast<uint16_t>(PL_CDR_LE);
         msg.msg_endian = LITTLEEND;
         valid &= CDRMessage::addOctet(&msg, PL_CDR_LE);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
         valid &= CDRMessage::addUInt16(&msg, 0);
 
         change->serializedPayload.pos = msg.pos;
@@ -602,7 +604,7 @@ bool TypeLookupManager::send_reply(
         change->serializedPayload.encapsulation = static_cast<uint16_t>(PL_CDR_LE);
         msg.msg_endian = LITTLEEND;
         valid &= CDRMessage::addOctet(&msg, PL_CDR_LE);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
         valid &= CDRMessage::addUInt16(&msg, 0);
 
         change->serializedPayload.pos = msg.pos;

--- a/src/cpp/fastdds/builtin/typelookup/TypeLookupManager.cpp
+++ b/src/cpp/fastdds/builtin/typelookup/TypeLookupManager.cpp
@@ -547,7 +547,7 @@ bool TypeLookupManager::send_request(
         CDRMessage_t msg(change->serializedPayload);
 
         bool valid = CDRMessage::addOctet(&msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
         change->serializedPayload.encapsulation = static_cast<uint16_t>(PL_CDR_BE);
         msg.msg_endian = BIGEND;
         valid &= CDRMessage::addOctet(&msg, PL_CDR_BE);
@@ -594,7 +594,7 @@ bool TypeLookupManager::send_reply(
         CDRMessage_t msg(change->serializedPayload);
 
         bool valid = CDRMessage::addOctet(&msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
         change->serializedPayload.encapsulation = static_cast<uint16_t>(PL_CDR_BE);
         msg.msg_endian = BIGEND;
         valid &= CDRMessage::addOctet(&msg, PL_CDR_BE);

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -593,13 +593,8 @@ bool EDPSimple::serialize_proxy_data(
         {
             CDRMessage_t aux_msg(change->serializedPayload);
 
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-            change->serializedPayload.encapsulation = (uint16_t)PL_CDR_BE;
-            aux_msg.msg_endian = BIGEND;
-#else
-            change->serializedPayload.encapsulation = (uint16_t)PL_CDR_LE;
-            aux_msg.msg_endian = LITTLEEND;
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+            change->serializedPayload.encapsulation = (uint16_t)PL_DEFAULT_ENCAPSULATION;
+            aux_msg.msg_endian = DEFAULT_ENDIAN;
 
             data.writeToCDRMessage(&aux_msg, true);
             change->serializedPayload.length = (uint16_t)aux_msg.length;

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -172,7 +172,7 @@ void EDPSimple::processPersistentData(t_p_StatefulReader & reader, t_p_StatefulW
 
         if (!change_to_add->copy(change))
         {
-            logWarning(RTPS_EDP,"Problem copying CacheChange, received data is: " 
+            logWarning(RTPS_EDP,"Problem copying CacheChange, received data is: "
                 << change->serializedPayload.length << " bytes and max size in EDPServer reader"
                 << " is " << change_to_add->serializedPayload.max_size);
 
@@ -591,7 +591,7 @@ bool EDPSimple::serialize_proxy_data(
         {
             CDRMessage_t aux_msg(change->serializedPayload);
 
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
             change->serializedPayload.encapsulation = (uint16_t)PL_CDR_BE;
             aux_msg.msg_endian = BIGEND;
 #else

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -95,7 +95,7 @@ EDPSimple::~EDPSimple()
         this->mp_RTPSParticipant->deleteUserEndpoint(subscriptions_secure_reader_.first);
         delete(subscriptions_secure_reader_.second);
     }
-#endif
+#endif // if HAVE_SECURITY
 
     if (this->publications_reader_.first != nullptr)
     {
@@ -147,48 +147,50 @@ bool EDPSimple::initEDP(
         logError(RTPS_EDP, "Problem creation SimpleEDP endpoints");
         return false;
     }
-#endif
+#endif // if HAVE_SECURITY
 
     return true;
 }
 
 //! Process the info recorded in the persistence database
-void EDPSimple::processPersistentData(t_p_StatefulReader & reader, t_p_StatefulWriter & writer)
+void EDPSimple::processPersistentData(
+        t_p_StatefulReader& reader,
+        t_p_StatefulWriter& writer)
 {
     std::lock_guard<RecursiveTimedMutex> guardR(reader.first->getMutex());
     std::lock_guard<RecursiveTimedMutex> guardW(writer.first->getMutex());
 
     std::for_each(writer.second->changesBegin(),
-        writer.second->changesEnd(),
-        [&reader](CacheChange_t* change)
-    {
-        CacheChange_t* change_to_add = nullptr;
+            writer.second->changesEnd(),
+            [&reader](CacheChange_t* change)
+            {
+                CacheChange_t* change_to_add = nullptr;
 
-        if (!reader.first->reserveCache(&change_to_add, change->serializedPayload.length)) //Reserve a new cache from the corresponding cache pool
-        {
-            logError(RTPS_EDP, "Problem reserving CacheChange in EDPServer reader");
-            return;
-        }
+                if (!reader.first->reserveCache(&change_to_add, change->serializedPayload.length)) //Reserve a new cache from the corresponding cache pool
+                {
+                    logError(RTPS_EDP, "Problem reserving CacheChange in EDPServer reader");
+                    return;
+                }
 
-        if (!change_to_add->copy(change))
-        {
-            logWarning(RTPS_EDP,"Problem copying CacheChange, received data is: "
-                << change->serializedPayload.length << " bytes and max size in EDPServer reader"
-                << " is " << change_to_add->serializedPayload.max_size);
+                if (!change_to_add->copy(change))
+                {
+                    logWarning(RTPS_EDP, "Problem copying CacheChange, received data is: "
+                        << change->serializedPayload.length << " bytes and max size in EDPServer reader"
+                        << " is " << change_to_add->serializedPayload.max_size);
 
-            reader.first->releaseCache(change_to_add);
-            return ;
-        }
+                    reader.first->releaseCache(change_to_add);
+                    return;
+                }
 
-        if (!reader.first->change_received(change_to_add, nullptr))
-        {
-            logInfo(RTPS_EDP, "EDPServer couldn't process database data not add change "
-                << change_to_add->sequenceNumber);
-            reader.first->releaseCache(change_to_add);
-        }
+                if (!reader.first->change_received(change_to_add, nullptr))
+                {
+                    logInfo(RTPS_EDP, "EDPServer couldn't process database data not add change "
+                        << change_to_add->sequenceNumber);
+                    reader.first->releaseCache(change_to_add);
+                }
 
-        // change_to_add would be released within change_received
-    });
+                // change_to_add would be released within change_received
+            });
 }
 
 void EDPSimple::set_builtin_reader_history_attributes(
@@ -499,7 +501,7 @@ bool EDPSimple::create_sedp_secure_endpoints()
     return created;
 }
 
-#endif
+#endif // if HAVE_SECURITY
 
 bool EDPSimple::processLocalReaderProxyData(
         RTPSReader* local_reader,
@@ -515,7 +517,7 @@ bool EDPSimple::processLocalReaderProxyData(
     {
         writer = &subscriptions_secure_writer_;
     }
-#endif
+#endif // if HAVE_SECURITY
     CacheChange_t* change = nullptr;
     bool ret_val = serialize_reader_proxy_data(*rdata, *writer, true, &change);
     if (change != nullptr)
@@ -539,7 +541,7 @@ bool EDPSimple::processLocalWriterProxyData(
     {
         writer = &publications_secure_writer_;
     }
-#endif
+#endif // if HAVE_SECURITY
 
     CacheChange_t* change = nullptr;
     bool ret_val = serialize_writer_proxy_data(*wdata, *writer, true, &change);
@@ -597,12 +599,12 @@ bool EDPSimple::serialize_proxy_data(
 #else
             change->serializedPayload.encapsulation = (uint16_t)PL_CDR_LE;
             aux_msg.msg_endian = LITTLEEND;
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 
             data.writeToCDRMessage(&aux_msg, true);
             change->serializedPayload.length = (uint16_t)aux_msg.length;
 
-            if(remove_same_instance)
+            if (remove_same_instance)
             {
                 std::unique_lock<RecursiveTimedMutex> lock(*writer.second->getMutex());
                 for (auto ch = writer.second->changesBegin(); ch != writer.second->changesEnd(); ++ch)
@@ -634,7 +636,7 @@ bool EDPSimple::removeLocalWriter(
     {
         writer = &publications_secure_writer_;
     }
-#endif
+#endif // if HAVE_SECURITY
 
     if (writer->first != nullptr)
     {
@@ -679,7 +681,7 @@ bool EDPSimple::removeLocalReader(
     {
         writer = &subscriptions_secure_writer_;
     }
-#endif
+#endif // if HAVE_SECURITY
 
     if (writer->first != nullptr)
     {
@@ -848,7 +850,7 @@ void EDPSimple::assignRemoteEndpoints(
                     subscriptions_secure_writer_.first->getGuid());
         }
     }
-#endif
+#endif // if HAVE_SECURITY
 }
 
 void EDPSimple::removeRemoteEndpoints(
@@ -956,7 +958,7 @@ void EDPSimple::removeRemoteEndpoints(
                 subscriptions_secure_writer_.first->getGuid(), pdata->m_guid, tmp_guid);
         }
     }
-#endif
+#endif // if HAVE_SECURITY
 }
 
 bool EDPSimple::areRemoteEndpointsMatched(
@@ -1064,7 +1066,7 @@ bool EDPSimple::pairing_remote_reader_with_local_builtin_writer_after_security(
     return returned_value;
 }
 
-#endif
+#endif // if HAVE_SECURITY
 
 } /* namespace rtps */
 } /* namespace fastrtps */

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -410,13 +410,8 @@ void PDP::announceParticipantState(
             {
                 CDRMessage_t aux_msg(change->serializedPayload);
 
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-                change->serializedPayload.encapsulation = (uint16_t)PL_CDR_BE;
-                aux_msg.msg_endian = BIGEND;
-#else
-                change->serializedPayload.encapsulation = (uint16_t)PL_CDR_LE;
-                aux_msg.msg_endian =  LITTLEEND;
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+                change->serializedPayload.encapsulation = (uint16_t)PL_DEFAULT_ENCAPSULATION;
+                aux_msg.msg_endian = DEFAULT_ENDIAN;
 
                 if (proxy_data_copy.writeToCDRMessage(&aux_msg, true))
                 {
@@ -453,13 +448,8 @@ void PDP::announceParticipantState(
         {
             CDRMessage_t aux_msg(change->serializedPayload);
 
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-            change->serializedPayload.encapsulation = (uint16_t)PL_CDR_BE;
-            aux_msg.msg_endian = BIGEND;
-#else
-            change->serializedPayload.encapsulation = (uint16_t)PL_CDR_LE;
-            aux_msg.msg_endian =  LITTLEEND;
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+            change->serializedPayload.encapsulation = (uint16_t)PL_DEFAULT_ENCAPSULATION;
+            aux_msg.msg_endian = DEFAULT_ENDIAN;
 
             if (proxy_data_copy.writeToCDRMessage(&aux_msg, true))
             {

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -175,11 +175,11 @@ ParticipantProxyData* PDP::add_participant_proxy_data(
             if (participant_guid != mp_RTPSParticipant->getGuid())
             {
                 ret_val->lease_duration_event = new TimedEvent(mp_RTPSParticipant->getEventResource(),
-                        [this, ret_val]() -> bool
-                        {
-                            check_remote_participant_liveliness(ret_val);
-                            return false;
-                        }, 0.0);
+                                [this, ret_val]() -> bool
+                                {
+                                    check_remote_participant_liveliness(ret_val);
+                                    return false;
+                                }, 0.0);
             }
         }
         else
@@ -217,7 +217,7 @@ void PDP::initializeParticipantProxyData(
 #if HAVE_SECURITY
     participant_data->m_availableBuiltinEndpoints |= DISC_BUILTIN_ENDPOINT_PARTICIPANT_SECURE_ANNOUNCER;
     participant_data->m_availableBuiltinEndpoints |= DISC_BUILTIN_ENDPOINT_PARTICIPANT_SECURE_DETECTOR;
-#endif
+#endif // if HAVE_SECURITY
 
     if (mp_RTPSParticipant->getAttributes().builtin.use_WriterLivelinessProtocol)
     {
@@ -227,7 +227,7 @@ void PDP::initializeParticipantProxyData(
 #if HAVE_SECURITY
         participant_data->m_availableBuiltinEndpoints |= BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_SECURE_DATA_WRITER;
         participant_data->m_availableBuiltinEndpoints |= BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_SECURE_DATA_READER;
-#endif
+#endif // if HAVE_SECURITY
     }
 
     if (mp_RTPSParticipant->getAttributes().builtin.typelookup_config.use_server)
@@ -244,7 +244,7 @@ void PDP::initializeParticipantProxyData(
 
 #if HAVE_SECURITY
     participant_data->m_availableBuiltinEndpoints |= mp_RTPSParticipant->security_manager().builtin_endpoints();
-#endif
+#endif // if HAVE_SECURITY
 
     for (const Locator_t& loc : mp_RTPSParticipant->getAttributes().defaultUnicastLocatorList)
     {
@@ -318,7 +318,7 @@ void PDP::initializeParticipantProxyData(
         participant_data->security_attributes_ = 0UL;
         participant_data->plugin_security_attributes_ = 0UL;
     }
-#endif
+#endif // if HAVE_SECURITY
 }
 
 bool PDP::initPDP(
@@ -350,21 +350,21 @@ bool PDP::initPDP(
     for (ParticipantProxyData* pool_item : participant_proxies_pool_)
     {
         pool_item->lease_duration_event = new TimedEvent(mp_RTPSParticipant->getEventResource(),
-                [this, pool_item]() -> bool
-                {
-                    check_remote_participant_liveliness(pool_item);
-                    return false;
-                }, 0.0);
+                        [this, pool_item]() -> bool
+                        {
+                            check_remote_participant_liveliness(pool_item);
+                            return false;
+                        }, 0.0);
     }
 
     resend_participant_info_event_ = new TimedEvent(mp_RTPSParticipant->getEventResource(),
-            [&]() -> bool
-            {
-                announceParticipantState(false);
-                set_next_announcement_interval();
-                return true;
-            },
-            0);
+                    [&]() -> bool
+                    {
+                        announceParticipantState(false);
+                        set_next_announcement_interval();
+                        return true;
+                    },
+                    0);
 
     set_initial_announcement_interval();
 
@@ -416,7 +416,7 @@ void PDP::announceParticipantState(
 #else
                 change->serializedPayload.encapsulation = (uint16_t)PL_CDR_LE;
                 aux_msg.msg_endian =  LITTLEEND;
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 
                 if (proxy_data_copy.writeToCDRMessage(&aux_msg, true))
                 {
@@ -444,10 +444,10 @@ void PDP::announceParticipantState(
         }
         uint32_t cdr_size = proxy_data_copy.get_serialized_size(true);
         change = mp_PDPWriter->new_change([cdr_size]() -> uint32_t
-            {
-                return cdr_size;
-            },
-            NOT_ALIVE_DISPOSED_UNREGISTERED, getLocalParticipantProxyData()->m_key);
+                        {
+                            return cdr_size;
+                        },
+                        NOT_ALIVE_DISPOSED_UNREGISTERED, getLocalParticipantProxyData()->m_key);
 
         if (change != nullptr)
         {
@@ -459,7 +459,7 @@ void PDP::announceParticipantState(
 #else
             change->serializedPayload.encapsulation = (uint16_t)PL_CDR_LE;
             aux_msg.msg_endian =  LITTLEEND;
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 
             if (proxy_data_copy.writeToCDRMessage(&aux_msg, true))
             {
@@ -852,7 +852,8 @@ bool PDP::remove_remote_participant(
         ParticipantDiscoveryInfo::DISCOVERY_STATUS reason)
 {
     if (partGUID == getLocalParticipantProxyData()->m_guid)
-    {   // avoid removing our own data
+    {
+        // avoid removing our own data
         return false;
     }
 
@@ -928,7 +929,7 @@ bool PDP::remove_remote_participant(
 
 #if HAVE_SECURITY
         mp_builtin->mp_participantImpl->security_manager().remove_participant(*pdata);
-#endif
+#endif // if HAVE_SECURITY
 
         this->mp_PDPReaderHistory->getMutex()->lock();
         for (std::vector<CacheChange_t*>::iterator it = this->mp_PDPReaderHistory->changesBegin();

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -410,7 +410,7 @@ void PDP::announceParticipantState(
             {
                 CDRMessage_t aux_msg(change->serializedPayload);
 
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
                 change->serializedPayload.encapsulation = (uint16_t)PL_CDR_BE;
                 aux_msg.msg_endian = BIGEND;
 #else
@@ -453,7 +453,7 @@ void PDP::announceParticipantState(
         {
             CDRMessage_t aux_msg(change->serializedPayload);
 
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
             change->serializedPayload.encapsulation = (uint16_t)PL_CDR_BE;
             aux_msg.msg_endian = BIGEND;
 #else

--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -849,14 +849,9 @@ bool WLP::send_liveliness_message(
 
     if (change != nullptr)
     {
+        change->serializedPayload.encapsulation = (uint16_t)PL_DEFAULT_ENCAPSULATION;
         change->serializedPayload.data[0] = 0;
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-        change->serializedPayload.encapsulation = (uint16_t)PL_CDR_BE;
-        change->serializedPayload.data[1] = PL_CDR_BE;
-#else
-        change->serializedPayload.encapsulation = (uint16_t)PL_CDR_LE;
-        change->serializedPayload.data[1] = PL_CDR_LE;
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+        change->serializedPayload.data[1] = PL_DEFAULT_ENCAPSULATION;
         change->serializedPayload.data[2] = 0;
         change->serializedPayload.data[3] = 0;
 

--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -56,7 +56,7 @@ static void set_builtin_reader_history_attributes(
     hatt.payloadMaxSize = is_secure ? 128 : 28;
 
     if ( (allocation.maximum < c_upper_limit) &&
-         (allocation.initial < c_upper_limit) )
+            (allocation.initial < c_upper_limit) )
     {
         hatt.initialReservedCaches = static_cast<uint32_t>(allocation.initial) * 2;
         hatt.maximumReservedCaches = static_cast<uint32_t>(allocation.maximum) * 2;
@@ -102,7 +102,7 @@ WLP::WLP(
     , mp_builtinReaderSecure(nullptr)
     , mp_builtinWriterSecureHistory(nullptr)
     , mp_builtinReaderSecureHistory(nullptr)
-#endif
+#endif // if HAVE_SECURITY
     , temp_reader_proxy_data_(
         p->mp_participantImpl->getRTPSParticipantAttributes().allocation.locators.max_unicast_locators,
         p->mp_participantImpl->getRTPSParticipantAttributes().allocation.locators.max_multicast_locators,
@@ -141,7 +141,7 @@ WLP::~WLP()
         delete this->mp_builtinReaderSecureHistory;
         delete this->mp_builtinWriterSecureHistory;
     }
-#endif
+#endif // if HAVE_SECURITY
     mp_participant->deleteUserEndpoint(mp_builtinReader);
     mp_participant->deleteUserEndpoint(mp_builtinWriter);
     delete this->mp_builtinReaderHistory;
@@ -161,10 +161,10 @@ bool WLP::initWL(
 
     pub_liveliness_manager_ = new LivelinessManager(
         [&](const GUID_t& guid,
-            const LivelinessQosPolicyKind& kind,
-            const Duration_t& lease_duration,
-            int alive_count,
-            int not_alive_count) -> void
+        const LivelinessQosPolicyKind& kind,
+        const Duration_t& lease_duration,
+        int alive_count,
+        int not_alive_count) -> void
         {
             pub_liveliness_changed(
                 guid,
@@ -178,10 +178,10 @@ bool WLP::initWL(
 
     sub_liveliness_manager_ = new LivelinessManager(
         [&](const GUID_t& guid,
-            const LivelinessQosPolicyKind& kind,
-            const Duration_t& lease_duration,
-            int alive_count,
-            int not_alive_count) -> void
+        const LivelinessQosPolicyKind& kind,
+        const Duration_t& lease_duration,
+        int alive_count,
+        int not_alive_count) -> void
         {
             sub_liveliness_changed(
                 guid,
@@ -198,14 +198,14 @@ bool WLP::initWL(
     {
         retVal = createSecureEndpoints();
     }
-#endif
+#endif // if HAVE_SECURITY
     return retVal;
 }
 
 bool WLP::createEndpoints()
 {
     const ResourceLimitedContainerConfig& participants_allocation =
-        mp_participant->getRTPSParticipantAttributes().allocation.participants;
+            mp_participant->getRTPSParticipantAttributes().allocation.participants;
 
     // Built-in writer history
     HistoryAttributes hatt;
@@ -296,7 +296,7 @@ bool WLP::createEndpoints()
 bool WLP::createSecureEndpoints()
 {
     const ResourceLimitedContainerConfig& participants_allocation =
-        mp_participant->getRTPSParticipantAttributes().allocation.participants;
+            mp_participant->getRTPSParticipantAttributes().allocation.participants;
 
     //CREATE WRITER
     HistoryAttributes hatt;
@@ -429,7 +429,7 @@ bool WLP::pairing_remote_writer_with_local_reader_after_security(
     return false;
 }
 
-#endif
+#endif // if HAVE_SECURITY
 
 bool WLP::assignRemoteEndpoints(
         const ParticipantProxyData& pdata)
@@ -508,7 +508,7 @@ bool WLP::assignRemoteEndpoints(
                     mp_builtinWriterSecure->getGuid());
         }
     }
-#endif
+#endif // if HAVE_SECURITY
 
     return true;
 }
@@ -566,7 +566,7 @@ void WLP::removeRemoteEndpoints(
                 mp_builtinWriterSecure->getGuid(), pdata->m_guid, tmp_guid);
         }
     }
-#endif
+#endif // if HAVE_SECURITY
 }
 
 bool WLP::add_local_writer(
@@ -583,12 +583,12 @@ bool WLP::add_local_writer(
         if (automatic_liveliness_assertion_ == nullptr)
         {
             automatic_liveliness_assertion_ = new TimedEvent(mp_participant->getEventResource(),
-                    [&]() -> bool
-                    {
-                        automatic_liveliness_assertion();
-                        return true;
-                    },
-                    wAnnouncementPeriodMilliSec);
+                            [&]() -> bool
+                            {
+                                automatic_liveliness_assertion();
+                                return true;
+                            },
+                            wAnnouncementPeriodMilliSec);
             automatic_liveliness_assertion_->restart_timer();
             min_automatic_ms_ = wAnnouncementPeriodMilliSec;
         }
@@ -610,12 +610,12 @@ bool WLP::add_local_writer(
         if (manual_liveliness_assertion_ == nullptr)
         {
             manual_liveliness_assertion_ = new TimedEvent(mp_participant->getEventResource(),
-                    [&]() -> bool
-                    {
-                        participant_liveliness_assertion();
-                        return true;
-                    },
-                    wAnnouncementPeriodMilliSec);
+                            [&]() -> bool
+                            {
+                                participant_liveliness_assertion();
+                                return true;
+                            },
+                            wAnnouncementPeriodMilliSec);
             manual_liveliness_assertion_->restart_timer();
             min_manual_by_participant_ms_ = wAnnouncementPeriodMilliSec;
         }
@@ -856,7 +856,7 @@ bool WLP::send_liveliness_message(
 #else
         change->serializedPayload.encapsulation = (uint16_t)PL_CDR_LE;
         change->serializedPayload.data[1] = PL_CDR_LE;
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
         change->serializedPayload.data[2] = 0;
         change->serializedPayload.data[3] = 0;
 
@@ -894,7 +894,7 @@ StatefulWriter* WLP::builtin_writer()
     {
         ret_val = mp_builtinWriterSecure;
     }
-#endif
+#endif // if HAVE_SECURITY
 
     return ret_val;
 }
@@ -908,7 +908,7 @@ WriterHistory* WLP::builtin_writer_history()
     {
         ret_val = mp_builtinWriterSecureHistory;
     }
-#endif
+#endif // if HAVE_SECURITY
 
     return ret_val;
 }

--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -850,7 +850,7 @@ bool WLP::send_liveliness_message(
     if (change != nullptr)
     {
         change->serializedPayload.data[0] = 0;
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
         change->serializedPayload.encapsulation = (uint16_t)PL_CDR_BE;
         change->serializedPayload.data[1] = PL_CDR_BE;
 #else

--- a/src/cpp/rtps/messages/RTPSMessageCreator.cpp
+++ b/src/cpp/rtps/messages/RTPSMessageCreator.cpp
@@ -85,7 +85,7 @@ bool RTPSMessageCreator::addSubmessageInfoTS(
 {
     octet flags = 0x0;
     uint16_t size = 8;
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     msg->msg_endian = BIGEND;
 #else
     flags = flags | BIT(0);
@@ -115,7 +115,7 @@ bool RTPSMessageCreator::addSubmessageInfoSRC(CDRMessage_t* msg, const ProtocolV
 {
     octet flags = 0x0;
     uint16_t size = 20;
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     msg->msg_endian = BIGEND;
 #else
     flags = flags | BIT(0);
@@ -141,7 +141,7 @@ bool RTPSMessageCreator::addSubmessageInfoDST(CDRMessage_t* msg, const GuidPrefi
 {
     octet flags = 0x0;
     uint16_t size = 12;
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     msg->msg_endian = BIGEND;
 #else
     flags = flags | BIT(0);

--- a/src/cpp/rtps/messages/RTPSMessageCreator.cpp
+++ b/src/cpp/rtps/messages/RTPSMessageCreator.cpp
@@ -31,32 +31,40 @@ namespace eprosima {
 namespace fastrtps {
 namespace rtps {
 
-bool RTPSMessageCreator::addHeader(CDRMessage_t*msg, const GuidPrefix_t& guidPrefix,
-        const ProtocolVersion_t& version,const VendorId_t& vendorId)
+bool RTPSMessageCreator::addHeader(
+        CDRMessage_t* msg,
+        const GuidPrefix_t& guidPrefix,
+        const ProtocolVersion_t& version,
+        const VendorId_t& vendorId)
 {
-    CDRMessage::addOctet(msg,'R');
-    CDRMessage::addOctet(msg,'T');
-    CDRMessage::addOctet(msg,'P');
-    CDRMessage::addOctet(msg,'S');
+    CDRMessage::addOctet(msg, 'R');
+    CDRMessage::addOctet(msg, 'T');
+    CDRMessage::addOctet(msg, 'P');
+    CDRMessage::addOctet(msg, 'S');
 
-    CDRMessage::addOctet(msg,version.m_major);
-    CDRMessage::addOctet(msg,version.m_minor);
+    CDRMessage::addOctet(msg, version.m_major);
+    CDRMessage::addOctet(msg, version.m_minor);
 
-    CDRMessage::addOctet(msg,vendorId[0]);
-    CDRMessage::addOctet(msg,vendorId[1]);
+    CDRMessage::addOctet(msg, vendorId[0]);
+    CDRMessage::addOctet(msg, vendorId[1]);
 
-    CDRMessage::addData(msg,guidPrefix.value, 12);
+    CDRMessage::addData(msg, guidPrefix.value, 12);
     msg->length = msg->pos;
 
     return true;
 }
 
-bool RTPSMessageCreator::addHeader(CDRMessage_t*msg, const GuidPrefix_t& guidPrefix)
+bool RTPSMessageCreator::addHeader(
+        CDRMessage_t* msg,
+        const GuidPrefix_t& guidPrefix)
 {
-    return RTPSMessageCreator::addHeader(msg,guidPrefix, c_ProtocolVersion,c_VendorId_eProsima);
+    return RTPSMessageCreator::addHeader(msg, guidPrefix, c_ProtocolVersion, c_VendorId_eProsima);
 }
 
-bool RTPSMessageCreator::addCustomContent(CDRMessage_t*msg, const octet* content, const size_t contentSize)
+bool RTPSMessageCreator::addCustomContent(
+        CDRMessage_t* msg,
+        const octet* content,
+        const size_t contentSize)
 {
     CDRMessage::addData(msg, content, static_cast<uint32_t>(contentSize));
     msg->length = msg->pos;
@@ -70,8 +78,8 @@ bool RTPSMessageCreator::addSubmessageHeader(
         octet flags,
         uint16_t size)
 {
-    CDRMessage::addOctet(msg,id);
-    CDRMessage::addOctet(msg,flags);
+    CDRMessage::addOctet(msg, id);
+    CDRMessage::addOctet(msg, flags);
     CDRMessage::addUInt16(msg, size);
     msg->length = msg->pos;
 
@@ -80,7 +88,7 @@ bool RTPSMessageCreator::addSubmessageHeader(
 
 bool RTPSMessageCreator::addSubmessageInfoTS(
         CDRMessage_t* msg,
-        const Time_t &time,
+        const Time_t& time,
         bool invalidateFlag)
 {
     octet flags = 0x0;
@@ -90,18 +98,18 @@ bool RTPSMessageCreator::addSubmessageInfoTS(
 #else
     flags = flags | BIT(0);
     msg->msg_endian  = LITTLEEND;
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 
-    if(invalidateFlag)
+    if (invalidateFlag)
     {
         flags = flags | BIT(1);
         size = 0;
     }
 
-    CDRMessage::addOctet(msg,INFO_TS);
-    CDRMessage::addOctet(msg,flags);
+    CDRMessage::addOctet(msg, INFO_TS);
+    CDRMessage::addOctet(msg, flags);
     CDRMessage::addUInt16(msg, size);
-    if(!invalidateFlag)
+    if (!invalidateFlag)
     {
         CDRMessage::addInt32(msg, time.seconds());
         CDRMessage::addUInt32(msg, time.fraction());
@@ -110,8 +118,11 @@ bool RTPSMessageCreator::addSubmessageInfoTS(
     return true;
 }
 
-bool RTPSMessageCreator::addSubmessageInfoSRC(CDRMessage_t* msg, const ProtocolVersion_t& version,
-    const VendorId_t& vendorId, const GuidPrefix_t& guidPrefix)
+bool RTPSMessageCreator::addSubmessageInfoSRC(
+        CDRMessage_t* msg,
+        const ProtocolVersion_t& version,
+        const VendorId_t& vendorId,
+        const GuidPrefix_t& guidPrefix)
 {
     octet flags = 0x0;
     uint16_t size = 20;
@@ -120,7 +131,7 @@ bool RTPSMessageCreator::addSubmessageInfoSRC(CDRMessage_t* msg, const ProtocolV
 #else
     flags = flags | BIT(0);
     msg->msg_endian = LITTLEEND;
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 
     CDRMessage::addOctet(msg, INFO_SRC);
     CDRMessage::addOctet(msg, flags);
@@ -137,7 +148,9 @@ bool RTPSMessageCreator::addSubmessageInfoSRC(CDRMessage_t* msg, const ProtocolV
     return true;
 }
 
-bool RTPSMessageCreator::addSubmessageInfoDST(CDRMessage_t* msg, const GuidPrefix_t& guidP)
+bool RTPSMessageCreator::addSubmessageInfoDST(
+        CDRMessage_t* msg,
+        const GuidPrefix_t& guidP)
 {
     octet flags = 0x0;
     uint16_t size = 12;
@@ -146,25 +159,26 @@ bool RTPSMessageCreator::addSubmessageInfoDST(CDRMessage_t* msg, const GuidPrefi
 #else
     flags = flags | BIT(0);
     msg->msg_endian  = LITTLEEND;
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 
-    CDRMessage::addOctet(msg,INFO_DST);
-    CDRMessage::addOctet(msg,flags);
+    CDRMessage::addOctet(msg, INFO_DST);
+    CDRMessage::addOctet(msg, flags);
     CDRMessage::addUInt16(msg, size);
-    CDRMessage::addData(msg,guidP.value,12);
+    CDRMessage::addData(msg, guidP.value, 12);
 
     return true;
 }
 
-
-
-bool RTPSMessageCreator::addSubmessageInfoTS_Now(CDRMessage_t* msg,bool invalidateFlag)
+bool RTPSMessageCreator::addSubmessageInfoTS_Now(
+        CDRMessage_t* msg,
+        bool invalidateFlag)
 {
     Time_t time_now;
     Time_t::now(time_now);
-    return RTPSMessageCreator::addSubmessageInfoTS(msg,time_now,invalidateFlag);
+    return RTPSMessageCreator::addSubmessageInfoTS(msg, time_now, invalidateFlag);
 }
-}
+
+} // namespace rtps
 } /* namespace rtps */
 } /* namespace eprosima */
 

--- a/src/cpp/rtps/messages/submessages/AckNackMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/AckNackMsg.hpp
@@ -17,9 +17,9 @@
  *
  */
 
-namespace eprosima{
-namespace fastrtps{
-namespace rtps{
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
 
 bool RTPSMessageCreator::addMessageAcknack(
         CDRMessage_t* msg,
@@ -31,9 +31,9 @@ bool RTPSMessageCreator::addMessageAcknack(
         int32_t count,
         bool finalFlag)
 {
-    RTPSMessageCreator::addHeader(msg,guidprefix);
+    RTPSMessageCreator::addHeader(msg, guidprefix);
     RTPSMessageCreator::addSubmessageInfoDST(msg, remoteGuidPrefix);
-    RTPSMessageCreator::addSubmessageAcknack(msg,readerId, writerId,SNSet,count,finalFlag);
+    RTPSMessageCreator::addSubmessageAcknack(msg, readerId, writerId, SNSet, count, finalFlag);
     msg->length = msg->pos;
     return true;
 }
@@ -53,9 +53,9 @@ bool RTPSMessageCreator::addSubmessageAcknack(
 #else
     flags = flags | BIT(0);
     msg->msg_endian  = LITTLEEND;
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 
-    if(finalFlag)
+    if (finalFlag)
     {
         flags = flags | BIT(1);
     }
@@ -76,16 +76,16 @@ bool RTPSMessageCreator::addSubmessageAcknack(
 
     //TODO(Ricardo) Improve.
     submessage_size = uint16_t(msg->pos - position_size_count_size);
-    octet* o= (octet*)&submessage_size;
-    if(msg->msg_endian == DEFAULT_ENDIAN)
+    octet* o = (octet*)&submessage_size;
+    if (msg->msg_endian == DEFAULT_ENDIAN)
     {
         msg->buffer[submessage_size_pos] = *(o);
-        msg->buffer[submessage_size_pos+1] = *(o+1);
+        msg->buffer[submessage_size_pos + 1] = *(o + 1);
     }
     else
     {
-        msg->buffer[submessage_size_pos] = *(o+1);
-        msg->buffer[submessage_size_pos+1] = *(o);
+        msg->buffer[submessage_size_pos] = *(o + 1);
+        msg->buffer[submessage_size_pos + 1] = *(o);
     }
 
     msg->msg_endian = old_endianess;
@@ -125,7 +125,7 @@ bool RTPSMessageCreator::addSubmessageNackFrag(
 #else
     flags = flags | BIT(0);
     msg->msg_endian = LITTLEEND;
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 
     // Submessage header.
     CDRMessage::addOctet(msg, NACK_FRAG);
@@ -145,16 +145,16 @@ bool RTPSMessageCreator::addSubmessageNackFrag(
 
     //TODO(Ricardo) Improve.
     submessage_size = uint16_t(msg->pos - position_size_count_size);
-    octet* o= (octet*)&submessage_size;
-    if(msg->msg_endian == DEFAULT_ENDIAN)
+    octet* o = (octet*)&submessage_size;
+    if (msg->msg_endian == DEFAULT_ENDIAN)
     {
         msg->buffer[submessage_size_pos] = *(o);
-        msg->buffer[submessage_size_pos+1] = *(o+1);
+        msg->buffer[submessage_size_pos + 1] = *(o + 1);
     }
     else
     {
-        msg->buffer[submessage_size_pos] = *(o+1);
-        msg->buffer[submessage_size_pos+1] = *(o);
+        msg->buffer[submessage_size_pos] = *(o + 1);
+        msg->buffer[submessage_size_pos + 1] = *(o);
     }
 
     msg->msg_endian = old_endianess;
@@ -162,6 +162,6 @@ bool RTPSMessageCreator::addSubmessageNackFrag(
     return true;
 }
 
-}
-}
-}
+} // namespace rtps
+} // namespace fastrtps
+} // namespace eprosima

--- a/src/cpp/rtps/messages/submessages/AckNackMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/AckNackMsg.hpp
@@ -48,7 +48,7 @@ bool RTPSMessageCreator::addSubmessageAcknack(
 {
     octet flags = 0x0;
     Endianness_t old_endianess = msg->msg_endian;
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     msg->msg_endian = BIGEND;
 #else
     flags = flags | BIT(0);
@@ -120,7 +120,7 @@ bool RTPSMessageCreator::addSubmessageNackFrag(
 {
     octet flags = 0x0;
     Endianness_t old_endianess = msg->msg_endian;
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     msg->msg_endian = BIGEND;
 #else
     flags = flags | BIT(0);

--- a/src/cpp/rtps/messages/submessages/DataMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/DataMsg.hpp
@@ -70,7 +70,7 @@ bool RTPSMessageCreator::addSubmessageData(
 #else
     flags = flags | BIT(0);
     msg->msg_endian = LITTLEEND;
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 
     if (change->kind == ALIVE && change->serializedPayload.length > 0 && change->serializedPayload.data != NULL)
     {
@@ -302,7 +302,7 @@ bool RTPSMessageCreator::addSubmessageDataFrag(
 #else
     flags = flags | BIT(0);
     msg->msg_endian = LITTLEEND;
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 
     if (change->kind == ALIVE && change->serializedPayload.length > 0 && change->serializedPayload.data != NULL)
     {
@@ -426,7 +426,8 @@ bool RTPSMessageCreator::addSubmessageDataFrag(
                         change->serializedPayload.length);
     }
     else
-    {   // keyflag = 1 means that the serializedPayload SubmessageElement contains the serialized Key
+    {
+        // keyflag = 1 means that the serializedPayload SubmessageElement contains the serialized Key
         /*
             added_no_error &= CDRMessage::addOctet(&submsgElem, 0); //ENCAPSULATION
             if (submsgElem.msg_endian == BIGEND)
@@ -469,6 +470,6 @@ bool RTPSMessageCreator::addSubmessageDataFrag(
     return added_no_error;
 }
 
-}
-}
-}
+} // namespace rtps
+} // namespace fastrtps
+} // namespace eprosima

--- a/src/cpp/rtps/messages/submessages/DataMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/DataMsg.hpp
@@ -65,7 +65,7 @@ bool RTPSMessageCreator::addSubmessageData(
     bool inlineQosFlag = false;
 
     Endianness_t old_endianess = msg->msg_endian;
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     msg->msg_endian = BIGEND;
 #else
     flags = flags | BIT(0);
@@ -297,7 +297,7 @@ bool RTPSMessageCreator::addSubmessageDataFrag(
     bool inlineQosFlag = false;
 
     Endianness_t old_endianess = msg->msg_endian;
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     msg->msg_endian = BIGEND;
 #else
     flags = flags | BIT(0);

--- a/src/cpp/rtps/messages/submessages/GapMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/GapMsg.hpp
@@ -38,7 +38,7 @@ bool RTPSMessageCreator::addMessageGap(
 }
 
 bool RTPSMessageCreator::addSubmessageGap(
-        CDRMessage_t* msg, 
+        CDRMessage_t* msg,
         const SequenceNumber_t& seqNumFirst,
         const SequenceNumberSet_t& seqNumList,
         const EntityId_t& readerId,
@@ -46,7 +46,7 @@ bool RTPSMessageCreator::addSubmessageGap(
 {
     octet flags = 0x0;
     Endianness_t old_endianess = msg->msg_endian;
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     msg->msg_endian = BIGEND;
 #else
     flags = flags | BIT(0);

--- a/src/cpp/rtps/messages/submessages/GapMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/GapMsg.hpp
@@ -17,9 +17,9 @@
  *
  */
 
-namespace eprosima{
-namespace fastrtps{
-namespace rtps{
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
 
 bool RTPSMessageCreator::addMessageGap(
         CDRMessage_t* msg,
@@ -32,8 +32,8 @@ bool RTPSMessageCreator::addMessageGap(
 {
     RTPSMessageCreator::addHeader(msg, guidprefix);
     RTPSMessageCreator::addSubmessageInfoDST(msg, remoteGuidPrefix);
-    RTPSMessageCreator::addSubmessageInfoTS_Now(msg,false);
-    RTPSMessageCreator::addSubmessageGap(msg,seqNumFirst,seqNumList,readerId, writerId);
+    RTPSMessageCreator::addSubmessageInfoTS_Now(msg, false);
+    RTPSMessageCreator::addSubmessageGap(msg, seqNumFirst, seqNumList, readerId, writerId);
     return true;
 }
 
@@ -51,7 +51,7 @@ bool RTPSMessageCreator::addSubmessageGap(
 #else
     flags = flags | BIT(0);
     msg->msg_endian   = LITTLEEND;
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 
     // Submessage header.
     CDRMessage::addOctet(msg, GAP);
@@ -69,16 +69,16 @@ bool RTPSMessageCreator::addSubmessageGap(
 
     //TODO(Ricardo) Improve.
     submessage_size = uint16_t(msg->pos - position_size_count_size);
-    octet* o= reinterpret_cast<octet*>(&submessage_size);
-    if(msg->msg_endian == DEFAULT_ENDIAN)
+    octet* o = reinterpret_cast<octet*>(&submessage_size);
+    if (msg->msg_endian == DEFAULT_ENDIAN)
     {
         msg->buffer[submessage_size_pos] = *(o);
-        msg->buffer[submessage_size_pos+1] = *(o+1);
+        msg->buffer[submessage_size_pos + 1] = *(o + 1);
     }
     else
     {
-        msg->buffer[submessage_size_pos] = *(o+1);
-        msg->buffer[submessage_size_pos+1] = *(o);
+        msg->buffer[submessage_size_pos] = *(o + 1);
+        msg->buffer[submessage_size_pos + 1] = *(o);
     }
 
     msg->msg_endian = old_endianess;
@@ -86,6 +86,6 @@ bool RTPSMessageCreator::addSubmessageGap(
     return true;
 }
 
-}
-}
-}
+} // namespace rtps
+} // namespace fastrtps
+} // namespace eprosima

--- a/src/cpp/rtps/messages/submessages/HeartbeatMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/HeartbeatMsg.hpp
@@ -32,8 +32,9 @@ bool RTPSMessageCreator::addMessageHeartbeat(
         bool isFinal,
         bool livelinessFlag)
 {
-    RTPSMessageCreator::addHeader(msg,guidprefix);
-    RTPSMessageCreator::addSubmessageHeartbeat(msg,readerId, writerId,firstSN,lastSN,count,isFinal,livelinessFlag);
+    RTPSMessageCreator::addHeader(msg, guidprefix);
+    RTPSMessageCreator::addSubmessageHeartbeat(msg, readerId, writerId, firstSN, lastSN, count, isFinal,
+            livelinessFlag);
     msg->length = msg->pos;
     return true;
 }
@@ -50,9 +51,10 @@ bool RTPSMessageCreator::addMessageHeartbeat(
         bool isFinal,
         bool livelinessFlag)
 {
-    RTPSMessageCreator::addHeader(msg,guidprefix);
+    RTPSMessageCreator::addHeader(msg, guidprefix);
     RTPSMessageCreator::addSubmessageInfoDST(msg, remoteGuidprefix);
-    RTPSMessageCreator::addSubmessageHeartbeat(msg,readerId, writerId,firstSN,lastSN,count,isFinal,livelinessFlag);
+    RTPSMessageCreator::addSubmessageHeartbeat(msg, readerId, writerId, firstSN, lastSN, count, isFinal,
+            livelinessFlag);
     msg->length = msg->pos;
     return true;
 }
@@ -75,12 +77,16 @@ bool RTPSMessageCreator::addSubmessageHeartbeat(
 #else
     flags = flags | BIT(0);
     msg->msg_endian = LITTLEEND;
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 
-    if(isFinal)
+    if (isFinal)
+    {
         flags = flags | BIT(1);
-    if(livelinessFlag)
+    }
+    if (livelinessFlag)
+    {
         flags = flags | BIT(2);
+    }
 
     // Submessage header.
     CDRMessage::addOctet(msg, HEARTBEAT);
@@ -95,20 +101,20 @@ bool RTPSMessageCreator::addSubmessageHeartbeat(
     //Add Sequence Number
     CDRMessage::addSequenceNumber(msg, &firstSN);
     CDRMessage::addSequenceNumber(msg, &lastSN);
-    CDRMessage::addInt32(msg,(int32_t)count);
+    CDRMessage::addInt32(msg, (int32_t)count);
 
     //TODO(Ricardo) Improve.
     submessage_size = uint16_t(msg->pos - position_size_count_size);
-    octet* o= reinterpret_cast<octet*>(&submessage_size);
-    if(msg->msg_endian == DEFAULT_ENDIAN)
+    octet* o = reinterpret_cast<octet*>(&submessage_size);
+    if (msg->msg_endian == DEFAULT_ENDIAN)
     {
         msg->buffer[submessage_size_pos] = *(o);
-        msg->buffer[submessage_size_pos+1] = *(o+1);
+        msg->buffer[submessage_size_pos + 1] = *(o + 1);
     }
     else
     {
-        msg->buffer[submessage_size_pos] = *(o+1);
-        msg->buffer[submessage_size_pos+1] = *(o);
+        msg->buffer[submessage_size_pos] = *(o + 1);
+        msg->buffer[submessage_size_pos + 1] = *(o);
     }
 
     msg->msg_endian = old_endianess;
@@ -146,7 +152,7 @@ bool RTPSMessageCreator::addSubmessageHeartbeatFrag(
 #else
     flags = flags | BIT(0);
     msg->msg_endian = LITTLEEND;
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 
     // Submessage header.
     CDRMessage::addOctet(msg, HEARTBEAT_FRAG);
@@ -165,16 +171,16 @@ bool RTPSMessageCreator::addSubmessageHeartbeatFrag(
 
     //TODO(Ricardo) Improve.
     submessage_size = uint16_t(msg->pos - position_size_count_size);
-    octet* o= reinterpret_cast<octet*>(&submessage_size);
-    if(msg->msg_endian == DEFAULT_ENDIAN)
+    octet* o = reinterpret_cast<octet*>(&submessage_size);
+    if (msg->msg_endian == DEFAULT_ENDIAN)
     {
         msg->buffer[submessage_size_pos] = *(o);
-        msg->buffer[submessage_size_pos+1] = *(o+1);
+        msg->buffer[submessage_size_pos + 1] = *(o + 1);
     }
     else
     {
-        msg->buffer[submessage_size_pos] = *(o+1);
-        msg->buffer[submessage_size_pos+1] = *(o);
+        msg->buffer[submessage_size_pos] = *(o + 1);
+        msg->buffer[submessage_size_pos + 1] = *(o);
     }
 
     msg->msg_endian = old_endianess;
@@ -182,6 +188,6 @@ bool RTPSMessageCreator::addSubmessageHeartbeatFrag(
     return true;
 }
 
-}
-}
-}
+} // namespace rtps
+} // namespace fastrtps
+} // namespace eprosima

--- a/src/cpp/rtps/messages/submessages/HeartbeatMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/HeartbeatMsg.hpp
@@ -22,7 +22,7 @@ namespace fastrtps {
 namespace rtps {
 
 bool RTPSMessageCreator::addMessageHeartbeat(
-        CDRMessage_t* msg, 
+        CDRMessage_t* msg,
         const GuidPrefix_t& guidprefix,
         const EntityId_t& readerId,
         const EntityId_t& writerId,
@@ -47,7 +47,7 @@ bool RTPSMessageCreator::addMessageHeartbeat(
         const SequenceNumber_t& firstSN,
         const SequenceNumber_t& lastSN,
         Count_t count,
-        bool isFinal, 
+        bool isFinal,
         bool livelinessFlag)
 {
     RTPSMessageCreator::addHeader(msg,guidprefix);
@@ -70,7 +70,7 @@ bool RTPSMessageCreator::addSubmessageHeartbeat(
     octet flags = 0x0;
 
     Endianness_t old_endianess = msg->msg_endian;
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     msg->msg_endian = BIGEND;
 #else
     flags = flags | BIT(0);
@@ -141,7 +141,7 @@ bool RTPSMessageCreator::addSubmessageHeartbeatFrag(
 {
     octet flags = 0x0;
     Endianness_t old_endianess = msg->msg_endian;
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     msg->msg_endian = BIGEND;
 #else
     flags = flags | BIT(0);

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -858,15 +858,9 @@ bool SecurityManager::on_process_handshake(
 
             // Serialize encapsulation
             CDRMessage::addOctet(&aux_msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-            aux_msg.msg_endian = BIGEND;
-            change->serializedPayload.encapsulation = PL_CDR_BE;
-            CDRMessage::addOctet(&aux_msg, CDR_BE);
-#else
-            aux_msg.msg_endian = LITTLEEND;
-            change->serializedPayload.encapsulation = PL_CDR_LE;
-            CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+            aux_msg.msg_endian = DEFAULT_ENDIAN;
+            change->serializedPayload.encapsulation = PL_DEFAULT_ENCAPSULATION;
+            CDRMessage::addOctet(&aux_msg, DEFAULT_ENCAPSULATION);
             CDRMessage::addUInt16(&aux_msg, 0);
 
             if (CDRMessage::addParticipantGenericMessage(&aux_msg, message))
@@ -2032,15 +2026,9 @@ void SecurityManager::exchange_participant_crypto(
 
             // Serialize encapsulation
             CDRMessage::addOctet(&aux_msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-            aux_msg.msg_endian = BIGEND;
-            change->serializedPayload.encapsulation = PL_CDR_BE;
-            CDRMessage::addOctet(&aux_msg, CDR_BE);
-#else
-            aux_msg.msg_endian = LITTLEEND;
-            change->serializedPayload.encapsulation = PL_CDR_LE;
-            CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+            aux_msg.msg_endian = DEFAULT_ENDIAN;
+            change->serializedPayload.encapsulation = PL_DEFAULT_ENCAPSULATION;
+            CDRMessage::addOctet(&aux_msg, DEFAULT_ENCAPSULATION);
             CDRMessage::addUInt16(&aux_msg, 0);
 
             if (CDRMessage::addParticipantGenericMessage(&aux_msg, message))
@@ -2800,15 +2788,9 @@ bool SecurityManager::discovered_reader(
 
                                     // Serialize encapsulation
                                     CDRMessage::addOctet(&aux_msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-                                    aux_msg.msg_endian = BIGEND;
-                                    change->serializedPayload.encapsulation = PL_CDR_BE;
-                                    CDRMessage::addOctet(&aux_msg, CDR_BE);
-#else
-                                    aux_msg.msg_endian = LITTLEEND;
-                                    change->serializedPayload.encapsulation = PL_CDR_LE;
-                                    CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+                                    aux_msg.msg_endian = DEFAULT_ENDIAN;
+                                    change->serializedPayload.encapsulation = PL_DEFAULT_ENCAPSULATION;
+                                    CDRMessage::addOctet(&aux_msg, DEFAULT_ENCAPSULATION);
                                     CDRMessage::addUInt16(&aux_msg, 0);
 
                                     if (CDRMessage::addParticipantGenericMessage(&aux_msg, message))
@@ -3137,15 +3119,9 @@ bool SecurityManager::discovered_writer(
 
                                     // Serialize encapsulation
                                     CDRMessage::addOctet(&aux_msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-                                    aux_msg.msg_endian = BIGEND;
-                                    change->serializedPayload.encapsulation = PL_CDR_BE;
-                                    CDRMessage::addOctet(&aux_msg, CDR_BE);
-#else
-                                    aux_msg.msg_endian = LITTLEEND;
-                                    change->serializedPayload.encapsulation = PL_CDR_LE;
-                                    CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+                                    aux_msg.msg_endian = DEFAULT_ENDIAN;
+                                    change->serializedPayload.encapsulation = PL_DEFAULT_ENCAPSULATION;
+                                    CDRMessage::addOctet(&aux_msg, DEFAULT_ENCAPSULATION);
                                     CDRMessage::addUInt16(&aux_msg, 0);
 
                                     if (CDRMessage::addParticipantGenericMessage(&aux_msg, message))

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -858,7 +858,7 @@ bool SecurityManager::on_process_handshake(
 
             // Serialize encapsulation
             CDRMessage::addOctet(&aux_msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
             aux_msg.msg_endian = BIGEND;
             change->serializedPayload.encapsulation = PL_CDR_BE;
             CDRMessage::addOctet(&aux_msg, CDR_BE);
@@ -866,7 +866,7 @@ bool SecurityManager::on_process_handshake(
             aux_msg.msg_endian = LITTLEEND;
             change->serializedPayload.encapsulation = PL_CDR_LE;
             CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if __BIG_ENDIAN__
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
             CDRMessage::addUInt16(&aux_msg, 0);
 
             if (CDRMessage::addParticipantGenericMessage(&aux_msg, message))
@@ -2032,7 +2032,7 @@ void SecurityManager::exchange_participant_crypto(
 
             // Serialize encapsulation
             CDRMessage::addOctet(&aux_msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
             aux_msg.msg_endian = BIGEND;
             change->serializedPayload.encapsulation = PL_CDR_BE;
             CDRMessage::addOctet(&aux_msg, CDR_BE);
@@ -2040,7 +2040,7 @@ void SecurityManager::exchange_participant_crypto(
             aux_msg.msg_endian = LITTLEEND;
             change->serializedPayload.encapsulation = PL_CDR_LE;
             CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if __BIG_ENDIAN__
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
             CDRMessage::addUInt16(&aux_msg, 0);
 
             if (CDRMessage::addParticipantGenericMessage(&aux_msg, message))
@@ -2800,7 +2800,7 @@ bool SecurityManager::discovered_reader(
 
                                     // Serialize encapsulation
                                     CDRMessage::addOctet(&aux_msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
                                     aux_msg.msg_endian = BIGEND;
                                     change->serializedPayload.encapsulation = PL_CDR_BE;
                                     CDRMessage::addOctet(&aux_msg, CDR_BE);
@@ -2808,7 +2808,7 @@ bool SecurityManager::discovered_reader(
                                     aux_msg.msg_endian = LITTLEEND;
                                     change->serializedPayload.encapsulation = PL_CDR_LE;
                                     CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if __BIG_ENDIAN__
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
                                     CDRMessage::addUInt16(&aux_msg, 0);
 
                                     if (CDRMessage::addParticipantGenericMessage(&aux_msg, message))
@@ -3137,7 +3137,7 @@ bool SecurityManager::discovered_writer(
 
                                     // Serialize encapsulation
                                     CDRMessage::addOctet(&aux_msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
                                     aux_msg.msg_endian = BIGEND;
                                     change->serializedPayload.encapsulation = PL_CDR_BE;
                                     CDRMessage::addOctet(&aux_msg, CDR_BE);
@@ -3145,7 +3145,7 @@ bool SecurityManager::discovered_writer(
                                     aux_msg.msg_endian = LITTLEEND;
                                     change->serializedPayload.encapsulation = PL_CDR_LE;
                                     CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if __BIG_ENDIAN__
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
                                     CDRMessage::addUInt16(&aux_msg, 0);
 
                                     if (CDRMessage::addParticipantGenericMessage(&aux_msg, message))

--- a/src/cpp/security/cryptography/AESGCMGMAC_Transform.cpp
+++ b/src/cpp/security/cryptography/AESGCMGMAC_Transform.cpp
@@ -227,7 +227,7 @@ bool AESGCMGMAC_Transform::encode_datawriter_submessage(
     std::array<uint8_t, 4> session_id;
     memcpy(session_id.data(), &(session->session_id), 4);
 
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     octet flags = 0x0;
     serializer.changeEndianness(eprosima::fastcdr::Cdr::Endianness::BIG_ENDIANNESS);
 #else
@@ -367,7 +367,7 @@ bool AESGCMGMAC_Transform::encode_datareader_submessage(
     std::array<uint8_t, 4> session_id;
     memcpy(session_id.data(), &(session->session_id), 4);
 
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     octet flags = 0x0;
     serializer.changeEndianness(eprosima::fastcdr::Cdr::Endianness::BIG_ENDIANNESS);
 #else
@@ -508,7 +508,7 @@ bool AESGCMGMAC_Transform::encode_rtps_message(
     std::array<uint8_t, 4> session_id;
     memcpy(session_id.data(), &(local_participant->session_id), 4);
 
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     octet flags = 0x0;
     serializer.changeEndianness(eprosima::fastcdr::Cdr::Endianness::BIG_ENDIANNESS);
 #else
@@ -1614,7 +1614,7 @@ bool AESGCMGMAC_Transform::serialize_SecureDataBody(
     }
     else
     {
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
         octet flags = 0x0;
         serializer.changeEndianness(eprosima::fastcdr::Cdr::Endianness::BIG_ENDIANNESS);
 #else

--- a/src/cpp/security/cryptography/AESGCMGMAC_Transform.cpp
+++ b/src/cpp/security/cryptography/AESGCMGMAC_Transform.cpp
@@ -30,12 +30,12 @@
 #define IS_OPENSSL_1_1 1
 #else
 #define IS_OPENSSL_1_1 0
-#endif
+#endif // if OPENSSL_VERSION_NUMBER >= 0x10100000L
 
 // Solve error with Win32 macro
 #ifdef WIN32
 #undef max
-#endif
+#endif // ifdef WIN32
 
 using namespace eprosima::fastrtps::rtps;
 using namespace eprosima::fastrtps::rtps::security;
@@ -233,7 +233,7 @@ bool AESGCMGMAC_Transform::encode_datawriter_submessage(
 #else
     octet flags = BIT(0);
     serializer.changeEndianness(eprosima::fastcdr::Cdr::Endianness::LITTLE_ENDIANNESS);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 
     //Header
     try
@@ -373,7 +373,7 @@ bool AESGCMGMAC_Transform::encode_datareader_submessage(
 #else
     octet flags = BIT(0);
     serializer.changeEndianness(eprosima::fastcdr::Cdr::Endianness::LITTLE_ENDIANNESS);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 
     //Header
     try
@@ -514,7 +514,7 @@ bool AESGCMGMAC_Transform::encode_rtps_message(
 #else
     octet flags = BIT(0);
     serializer.changeEndianness(eprosima::fastcdr::Cdr::Endianness::LITTLE_ENDIANNESS);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 
     //Header
     try
@@ -1512,7 +1512,7 @@ void AESGCMGMAC_Transform::compute_sessionkey(
             EVP_MD_CTX_new();
 #else
             (EVP_MD_CTX*)malloc(sizeof(EVP_MD_CTX));
-#endif
+#endif // if IS_OPENSSL_1_1
     EVP_MD_CTX_init(ctx);
     EVP_DigestSignInit(ctx, NULL, EVP_sha256(), NULL, key);
     EVP_DigestSignUpdate(ctx, source, sourceLen);
@@ -1527,7 +1527,7 @@ void AESGCMGMAC_Transform::compute_sessionkey(
 #else
     EVP_MD_CTX_cleanup(ctx);
     free(ctx);
-#endif
+#endif // if IS_OPENSSL_1_1
 }
 
 void AESGCMGMAC_Transform::serialize_SecureDataHeader(
@@ -1620,7 +1620,7 @@ bool AESGCMGMAC_Transform::serialize_SecureDataBody(
 #else
         octet flags = BIT(0);
         serializer.changeEndianness(eprosima::fastcdr::Cdr::Endianness::LITTLE_ENDIANNESS);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 
         if (submessage)
         {

--- a/src/cpp/utils/IPLocator.cpp
+++ b/src/cpp/utils/IPLocator.cpp
@@ -385,11 +385,11 @@ bool IPLocator::setLogicalPort(
         uint16_t port)
 {
     uint16_t* loc_logical = reinterpret_cast<uint16_t*>(&locator.port);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     loc_logical[0] = port; // Logical port is stored at 2nd and 3rd bytes of port
 #else
     loc_logical[1] = port; // Logical port is stored at 2nd and 3rd bytes of port
-#endif // if __BIG_ENDIAN__
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     return port != 0;
 }
 
@@ -397,11 +397,11 @@ uint16_t IPLocator::getLogicalPort(
         const Locator_t& locator)
 {
     const uint16_t* loc_logical = reinterpret_cast<const uint16_t*>(&locator.port);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     return loc_logical[0];
 #else
     return loc_logical[1];
-#endif // if __BIG_ENDIAN__
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 }
 
 bool IPLocator::setPhysicalPort(
@@ -409,11 +409,11 @@ bool IPLocator::setPhysicalPort(
         uint16_t port)
 {
     uint16_t* loc_physical = reinterpret_cast<uint16_t*>(&locator.port);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     loc_physical[1] = port; // Physical port is stored at 0 and 1st bytes of port
 #else
     loc_physical[0] = port; // Physical port is stored at 0 and 1st bytes of port
-#endif // if __BIG_ENDIAN__
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     return port != 0;
 }
 
@@ -421,11 +421,11 @@ uint16_t IPLocator::getPhysicalPort(
         const Locator_t& locator)
 {
     const uint16_t* loc_physical = reinterpret_cast<const uint16_t*>(&locator.port);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     return loc_physical[1];
 #else
     return loc_physical[0];
-#endif // if __BIG_ENDIAN__
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 }
 
 // TCPv4

--- a/test/profiling/main_MemoryTest.cpp
+++ b/test/profiling/main_MemoryTest.cpp
@@ -32,7 +32,7 @@
 #if defined(_MSC_VER)
 #pragma warning (push)
 #pragma warning (disable:4512)
-#endif
+#endif // if defined(_MSC_VER)
 
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
@@ -44,40 +44,57 @@ using std::endl;
 const Endianness_t DEFAULT_ENDIAN = BIGEND;
 #else
 const Endianness_t DEFAULT_ENDIAN = LITTLEEND;
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 
 #if defined(_WIN32)
 #define COPYSTR strcpy_s
 #else
 #define COPYSTR strcpy
-#endif
+#endif // if defined(_WIN32)
 
 
-struct Arg: public option::Arg
+struct Arg : public option::Arg
 {
-    static void printError(const char* msg1, const option::Option& opt, const char* msg2)
+    static void printError(
+            const char* msg1,
+            const option::Option& opt,
+            const char* msg2)
     {
         fprintf(stderr, "%s", msg1);
         fwrite(opt.name, opt.namelen, 1, stderr);
         fprintf(stderr, "%s", msg2);
     }
 
-    static option::ArgStatus Unknown(const option::Option& option, bool msg)
+    static option::ArgStatus Unknown(
+            const option::Option& option,
+            bool msg)
     {
-        if (msg) printError("Unknown option '", option, "'\n");
+        if (msg)
+        {
+            printError("Unknown option '", option, "'\n");
+        }
         return option::ARG_ILLEGAL;
     }
 
-    static option::ArgStatus Required(const option::Option& option, bool msg)
+    static option::ArgStatus Required(
+            const option::Option& option,
+            bool msg)
     {
         if (option.arg != 0 && option.arg[0] != 0)
-        return option::ARG_OK;
+        {
+            return option::ARG_OK;
+        }
 
-        if (msg) printError("Option '", option, "' requires an argument\n");
+        if (msg)
+        {
+            printError("Option '", option, "' requires an argument\n");
+        }
         return option::ARG_ILLEGAL;
     }
 
-    static option::ArgStatus Numeric(const option::Option& option, bool msg)
+    static option::ArgStatus Numeric(
+            const option::Option& option,
+            bool msg)
     {
         char* endptr = 0;
         if (option.arg != 0 && strtol(option.arg, &endptr, 10))
@@ -88,11 +105,16 @@ struct Arg: public option::Arg
             return option::ARG_OK;
         }
 
-        if (msg) printError("Option '", option, "' requires a numeric argument\n");
+        if (msg)
+        {
+            printError("Option '", option, "' requires a numeric argument\n");
+        }
         return option::ARG_ILLEGAL;
     }
 
-    static option::ArgStatus String(const option::Option& option, bool msg)
+    static option::ArgStatus String(
+            const option::Option& option,
+            bool msg)
     {
         if (option.arg != 0)
         {
@@ -104,9 +126,11 @@ struct Arg: public option::Arg
         }
         return option::ARG_ILLEGAL;
     }
+
 };
 
-enum  optionIndex {
+enum  optionIndex
+{
     UNKNOWN_OPT,
     HELP,
     RELIABILITY,
@@ -126,32 +150,44 @@ enum  optionIndex {
 };
 
 const option::Descriptor usage[] = {
-    { UNKNOWN_OPT, 0,"", "",                Arg::None,      "Usage: MemoryTest <publisher|subscriber>\n\nGeneral options:" },
-    { HELP,    0,"h", "help",               Arg::None,      "  -h \t--help  \tProduce help message." },
-    { RELIABILITY,0,"r","reliability",      Arg::Required,  "  -r <arg>, \t--reliability=<arg>  \tSet reliability (\"reliable\"/\"besteffort\")."},
-    { SAMPLES,0,"s","samples",              Arg::Numeric,   "  -s <num>, \t--samples=<num>  \tNumber of samples." },
-    { SEED,0,"","seed",                     Arg::Numeric,   "  \t--seed=<num>  \tNumber of subscribers." },
-    { TIME, 0,"t","time",                   Arg::Numeric,   "  -t <num>, \t--time=<num>  \tTime of the test in seconds." },
-    { UNKNOWN_OPT, 0,"", "",                Arg::None,      "\nPublisher options:"},
-    { SUBSCRIBERS,0,"n","subscribers",      Arg::Numeric,   "  -n <num>,   \t--subscribers=<arg>  \tSeed to calculate domain and topic, to isolate test." },
-    { UNKNOWN_OPT, 0,"", "",                Arg::None,      "\nSubscriber options:"},
-    { ECHO_OPT, 0,"e","echo",               Arg::Required,  "  -e <arg>, \t--echo=<arg>  \tEcho mode (\"true\"/\"false\")." },
-    { HOSTNAME,0,"","hostname",             Arg::None,      "" },
-    { EXPORT_CSV,0,"","export_csv",         Arg::None,      "" },
-    { EXPORT_PREFIX,0,"","export_prefix",   Arg::String,    "\t--export_prefix \tFile prefix for the CSV file." },
+    { UNKNOWN_OPT, 0, "", "",                Arg::None,
+      "Usage: MemoryTest <publisher|subscriber>\n\nGeneral options:" },
+    { HELP,    0, "h", "help",               Arg::None,      "  -h \t--help  \tProduce help message." },
+    { RELIABILITY, 0, "r", "reliability",      Arg::Required,
+      "  -r <arg>, \t--reliability=<arg>  \tSet reliability (\"reliable\"/\"besteffort\")."},
+    { SAMPLES, 0, "s", "samples",              Arg::Numeric,   "  -s <num>, \t--samples=<num>  \tNumber of samples." },
+    { SEED, 0, "", "seed",                     Arg::Numeric,   "  \t--seed=<num>  \tNumber of subscribers." },
+    { TIME, 0, "t", "time",                   Arg::Numeric,
+      "  -t <num>, \t--time=<num>  \tTime of the test in seconds." },
+    { UNKNOWN_OPT, 0, "", "",                Arg::None,      "\nPublisher options:"},
+    { SUBSCRIBERS, 0, "n", "subscribers",      Arg::Numeric,
+      "  -n <num>,   \t--subscribers=<arg>  \tSeed to calculate domain and topic, to isolate test." },
+    { UNKNOWN_OPT, 0, "", "",                Arg::None,      "\nSubscriber options:"},
+    { ECHO_OPT, 0, "e", "echo",               Arg::Required,
+      "  -e <arg>, \t--echo=<arg>  \tEcho mode (\"true\"/\"false\")." },
+    { HOSTNAME, 0, "", "hostname",             Arg::None,      "" },
+    { EXPORT_CSV, 0, "", "export_csv",         Arg::None,      "" },
+    { EXPORT_PREFIX, 0, "", "export_prefix",   Arg::String,    "\t--export_prefix \tFile prefix for the CSV file." },
 #if HAVE_SECURITY
-    { USE_SECURITY, 0, "", "security",      Arg::Required,      "  --security <arg>  \tEcho mode (\"true\"/\"false\")." },
+    {
+        USE_SECURITY, 0, "", "security",      Arg::Required,
+        "  --security <arg>  \tEcho mode (\"true\"/\"false\")."
+    },
     { CERTS_PATH, 0, "", "certs",           Arg::Required,      "  --certs <arg>  \tPath where located certificates." },
-#endif
-    { XML_FILE, 0, "", "xml",               Arg::String,    "\t--xml \tXML Configuration file." },
+#endif // if HAVE_SECURITY
+    {
+        XML_FILE, 0, "", "xml",               Arg::String,    "\t--xml \tXML Configuration file."
+    },
     { DATA_SIZE, 0, "", "size",             Arg::Numeric,   "\t--size\tData size." },
-    { DYNAMIC_TYPES, 0, "", "dynamic_types",Arg::None,      "\t--dynamic_types \tUse dynamic types." },
+    { DYNAMIC_TYPES, 0, "", "dynamic_types", Arg::None,      "\t--dynamic_types \tUse dynamic types." },
     { 0, 0, 0, 0, 0, 0 }
 };
 
 const int c_n_samples = 10000;
 
-int main(int argc, char** argv)
+int main(
+        int argc,
+        char** argv)
 {
     int columns;
 
@@ -169,7 +205,7 @@ int main(int argc, char** argv)
     }
 #else
     columns = getenv("COLUMNS") ? atoi(getenv("COLUMNS")) : 80;
-#endif
+#endif // if defined(_WIN32)
 
     bool pub_sub = false;
     int sub_number = 1;
@@ -177,7 +213,7 @@ int main(int argc, char** argv)
 #if HAVE_SECURITY
     bool use_security = false;
     std::string certs_path;
-#endif
+#endif // if HAVE_SECURITY
     bool echo = false;
     bool reliable = false;
     uint32_t seed = 80;
@@ -220,7 +256,9 @@ int main(int argc, char** argv)
     option::Parser parse(usage, argc, argv, &options[0], &buffer[0]);
 
     if (parse.error())
+    {
         return 1;
+    }
 
     if (options[HELP])
     {
@@ -345,7 +383,7 @@ int main(int argc, char** argv)
             case CERTS_PATH:
                 certs_path = opt.arg;
                 break;
-#endif
+#endif // if HAVE_SECURITY
 
             case UNKNOWN_OPT:
                 option::printUsage(fwrite, stdout, usage, columns);
@@ -355,7 +393,7 @@ int main(int argc, char** argv)
     }
 
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
-        pub_property_policy, sub_property_policy;
+            pub_property_policy, sub_property_policy;
 
 #if HAVE_SECURITY
     if (use_security)
@@ -367,34 +405,34 @@ int main(int argc, char** argv)
         }
 
         sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
+                "builtin.PKI-DH"));
         sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + certs_path + "/maincacert.pem"));
+                "file://" + certs_path + "/maincacert.pem"));
         sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + certs_path + "/mainsubcert.pem"));
+                "file://" + certs_path + "/mainsubcert.pem"));
         sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + certs_path + "/mainsubkey.pem"));
+                "file://" + certs_path + "/mainsubkey.pem"));
         sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+                "builtin.AES-GCM-GMAC"));
         sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
         sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
         sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
         pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
+                "builtin.PKI-DH"));
         pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + certs_path + "/maincacert.pem"));
+                "file://" + certs_path + "/maincacert.pem"));
         pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + certs_path + "/mainpubcert.pem"));
+                "file://" + certs_path + "/mainpubcert.pem"));
         pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + certs_path + "/mainpubkey.pem"));
+                "file://" + certs_path + "/mainpubkey.pem"));
         pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+                "builtin.AES-GCM-GMAC"));
         pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
         pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
         pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
     }
-#endif
+#endif // if HAVE_SECURITY
 
     // Load an XML file with predefined profiles for publisher and subscriber
     if (sXMLConfigFile.length() > 0)
@@ -407,14 +445,14 @@ int main(int argc, char** argv)
         cout << "Performing test with " << sub_number << " subscribers and " << n_samples << " samples" << endl;
         MemoryTestPublisher memoryPub;
         memoryPub.init(sub_number, n_samples, reliable, seed, hostname, export_csv, export_prefix,
-            pub_part_property_policy, pub_property_policy, sXMLConfigFile, data_size, dynamic_types);
+                pub_part_property_policy, pub_property_policy, sXMLConfigFile, data_size, dynamic_types);
         memoryPub.run(test_time_sec);
     }
     else
     {
         MemoryTestSubscriber memorySub;
         memorySub.init(echo, n_samples, reliable, seed, hostname, sub_part_property_policy, sub_property_policy,
-            sXMLConfigFile, data_size, dynamic_types);
+                sXMLConfigFile, data_size, dynamic_types);
         memorySub.run();
     }
 
@@ -427,4 +465,4 @@ int main(int argc, char** argv)
 
 #if defined(_MSC_VER)
 #pragma warning (pop)
-#endif
+#endif // if defined(_MSC_VER)

--- a/test/profiling/main_MemoryTest.cpp
+++ b/test/profiling/main_MemoryTest.cpp
@@ -40,10 +40,10 @@ using namespace eprosima::fastrtps::rtps;
 using std::cout;
 using std::endl;
 
-#if defined(__LITTLE_ENDIAN__)
-const Endianness_t DEFAULT_ENDIAN = LITTLEEND;
-#elif defined (__BIG_ENDIAN__)
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
 const Endianness_t DEFAULT_ENDIAN = BIGEND;
+#else
+const Endianness_t DEFAULT_ENDIAN = LITTLEEND;
 #endif
 
 #if defined(_WIN32)

--- a/test/unittest/rtps/security/SecurityHandshakeProcessTests.cpp
+++ b/test/unittest/rtps/security/SecurityHandshakeProcessTests.cpp
@@ -83,15 +83,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_not_remote_participa
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-    aux_msg.msg_endian = BIGEND;
-    change->serializedPayload.encapsulation = PL_CDR_BE;
-    CDRMessage::addOctet(&aux_msg, CDR_BE);
-#else
-    aux_msg.msg_endian = LITTLEEND;
-    change->serializedPayload.encapsulation = PL_CDR_LE;
-    CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+    aux_msg.msg_endian = DEFAULT_ENDIAN;
+    change->serializedPayload.encapsulation = PL_DEFAULT_ENCAPSULATION;
+    CDRMessage::addOctet(&aux_msg, DEFAULT_ENCAPSULATION);
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -130,15 +124,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_bad_message_class_id
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-    aux_msg.msg_endian = BIGEND;
-    change->serializedPayload.encapsulation = PL_CDR_BE;
-    CDRMessage::addOctet(&aux_msg, CDR_BE);
-#else
-    aux_msg.msg_endian = LITTLEEND;
-    change->serializedPayload.encapsulation = PL_CDR_LE;
-    CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+    aux_msg.msg_endian = DEFAULT_ENDIAN;
+    change->serializedPayload.encapsulation = PL_DEFAULT_ENCAPSULATION;
+    CDRMessage::addOctet(&aux_msg, DEFAULT_ENCAPSULATION);
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -191,15 +179,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_not_expecting_reques
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-    aux_msg.msg_endian = BIGEND;
-    change->serializedPayload.encapsulation = PL_CDR_BE;
-    CDRMessage::addOctet(&aux_msg, CDR_BE);
-#else
-    aux_msg.msg_endian = LITTLEEND;
-    change->serializedPayload.encapsulation = PL_CDR_LE;
-    CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+    aux_msg.msg_endian = DEFAULT_ENDIAN;
+    change->serializedPayload.encapsulation = PL_DEFAULT_ENCAPSULATION;
+    CDRMessage::addOctet(&aux_msg, DEFAULT_ENCAPSULATION);
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -245,15 +227,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_fail_begin_handshake
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-    aux_msg.msg_endian = BIGEND;
-    change->serializedPayload.encapsulation = PL_CDR_BE;
-    CDRMessage::addOctet(&aux_msg, CDR_BE);
-#else
-    aux_msg.msg_endian = LITTLEEND;
-    change->serializedPayload.encapsulation = PL_CDR_LE;
-    CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+    aux_msg.msg_endian = DEFAULT_ENDIAN;
+    change->serializedPayload.encapsulation = PL_DEFAULT_ENCAPSULATION;
+    CDRMessage::addOctet(&aux_msg, DEFAULT_ENCAPSULATION);
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -308,15 +284,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_begin_handshake_r
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-    aux_msg.msg_endian = BIGEND;
-    change->serializedPayload.encapsulation = PL_CDR_BE;
-    CDRMessage::addOctet(&aux_msg, CDR_BE);
-#else
-    aux_msg.msg_endian = LITTLEEND;
-    change->serializedPayload.encapsulation = PL_CDR_LE;
-    CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+    aux_msg.msg_endian = DEFAULT_ENDIAN;
+    change->serializedPayload.encapsulation = PL_DEFAULT_ENCAPSULATION;
+    CDRMessage::addOctet(&aux_msg, DEFAULT_ENCAPSULATION);
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -393,15 +363,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_new_change_fail)
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-    aux_msg.msg_endian = BIGEND;
-    change->serializedPayload.encapsulation = PL_CDR_BE;
-    CDRMessage::addOctet(&aux_msg, CDR_BE);
-#else
-    aux_msg.msg_endian = LITTLEEND;
-    change->serializedPayload.encapsulation = PL_CDR_LE;
-    CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+    aux_msg.msg_endian = DEFAULT_ENDIAN;
+    change->serializedPayload.encapsulation = PL_DEFAULT_ENCAPSULATION;
+    CDRMessage::addOctet(&aux_msg, DEFAULT_ENCAPSULATION);
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -460,15 +424,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_add_change_fail)
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-    aux_msg.msg_endian = BIGEND;
-    change->serializedPayload.encapsulation = PL_CDR_BE;
-    CDRMessage::addOctet(&aux_msg, CDR_BE);
-#else
-    aux_msg.msg_endian = LITTLEEND;
-    change->serializedPayload.encapsulation = PL_CDR_LE;
-    CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+    aux_msg.msg_endian = DEFAULT_ENDIAN;
+    change->serializedPayload.encapsulation = PL_DEFAULT_ENCAPSULATION;
+    CDRMessage::addOctet(&aux_msg, DEFAULT_ENCAPSULATION);
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -569,15 +527,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_pending_handshake_re
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-    aux_msg.msg_endian = BIGEND;
-    change->serializedPayload.encapsulation = PL_CDR_BE;
-    CDRMessage::addOctet(&aux_msg, CDR_BE);
-#else
-    aux_msg.msg_endian = LITTLEEND;
-    change->serializedPayload.encapsulation = PL_CDR_LE;
-    CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+    aux_msg.msg_endian = DEFAULT_ENDIAN;
+    change->serializedPayload.encapsulation = PL_DEFAULT_ENCAPSULATION;
+    CDRMessage::addOctet(&aux_msg, DEFAULT_ENCAPSULATION);
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -658,15 +610,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_fail_process_handsha
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-    aux_msg.msg_endian = BIGEND;
-    change->serializedPayload.encapsulation = PL_CDR_BE;
-    CDRMessage::addOctet(&aux_msg, CDR_BE);
-#else
-    aux_msg.msg_endian = LITTLEEND;
-    change->serializedPayload.encapsulation = PL_CDR_LE;
-    CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+    aux_msg.msg_endian = DEFAULT_ENDIAN;
+    change->serializedPayload.encapsulation = PL_DEFAULT_ENCAPSULATION;
+    CDRMessage::addOctet(&aux_msg, DEFAULT_ENCAPSULATION);
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -717,15 +663,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_process_handshake
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-    aux_msg.msg_endian = BIGEND;
-    change->serializedPayload.encapsulation = PL_CDR_BE;
-    CDRMessage::addOctet(&aux_msg, CDR_BE);
-#else
-    aux_msg.msg_endian = LITTLEEND;
-    change->serializedPayload.encapsulation = PL_CDR_LE;
-    CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+    aux_msg.msg_endian = DEFAULT_ENDIAN;
+    change->serializedPayload.encapsulation = PL_DEFAULT_ENCAPSULATION;
+    CDRMessage::addOctet(&aux_msg, DEFAULT_ENCAPSULATION);
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -795,15 +735,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_re
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-    aux_msg.msg_endian = BIGEND;
-    change->serializedPayload.encapsulation = PL_CDR_BE;
-    CDRMessage::addOctet(&aux_msg, CDR_BE);
-#else
-    aux_msg.msg_endian = LITTLEEND;
-    change->serializedPayload.encapsulation = PL_CDR_LE;
-    CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+    aux_msg.msg_endian = DEFAULT_ENDIAN;
+    change->serializedPayload.encapsulation = PL_DEFAULT_ENCAPSULATION;
+    CDRMessage::addOctet(&aux_msg, DEFAULT_ENCAPSULATION);
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -855,15 +789,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_re
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-    aux_msg.msg_endian = BIGEND;
-    change->serializedPayload.encapsulation = PL_CDR_BE;
-    CDRMessage::addOctet(&aux_msg, CDR_BE);
-#else
-    aux_msg.msg_endian = LITTLEEND;
-    change->serializedPayload.encapsulation = PL_CDR_LE;
-    CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+    aux_msg.msg_endian = DEFAULT_ENDIAN;
+    change->serializedPayload.encapsulation = PL_DEFAULT_ENCAPSULATION;
+    CDRMessage::addOctet(&aux_msg, DEFAULT_ENCAPSULATION);
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -939,15 +867,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_re
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-    aux_msg.msg_endian = BIGEND;
-    change->serializedPayload.encapsulation = PL_CDR_BE;
-    CDRMessage::addOctet(&aux_msg, CDR_BE);
-#else
-    aux_msg.msg_endian = LITTLEEND;
-    change->serializedPayload.encapsulation = PL_CDR_LE;
-    CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+    aux_msg.msg_endian = DEFAULT_ENDIAN;
+    change->serializedPayload.encapsulation = PL_DEFAULT_ENCAPSULATION;
+    CDRMessage::addOctet(&aux_msg, DEFAULT_ENCAPSULATION);
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -992,15 +914,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_bad_related_guid)
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-    aux_msg.msg_endian = BIGEND;
-    change->serializedPayload.encapsulation = PL_CDR_BE;
-    CDRMessage::addOctet(&aux_msg, CDR_BE);
-#else
-    aux_msg.msg_endian = LITTLEEND;
-    change->serializedPayload.encapsulation = PL_CDR_LE;
-    CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+    aux_msg.msg_endian = DEFAULT_ENDIAN;
+    change->serializedPayload.encapsulation = PL_DEFAULT_ENCAPSULATION;
+    CDRMessage::addOctet(&aux_msg, DEFAULT_ENCAPSULATION);
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -1042,15 +958,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_bad_related_sequence
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-    aux_msg.msg_endian = BIGEND;
-    change->serializedPayload.encapsulation = PL_CDR_BE;
-    CDRMessage::addOctet(&aux_msg, CDR_BE);
-#else
-    aux_msg.msg_endian = LITTLEEND;
-    change->serializedPayload.encapsulation = PL_CDR_LE;
-    CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+    aux_msg.msg_endian = DEFAULT_ENDIAN;
+    change->serializedPayload.encapsulation = PL_DEFAULT_ENCAPSULATION;
+    CDRMessage::addOctet(&aux_msg, DEFAULT_ENCAPSULATION);
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -1092,15 +1002,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_fail_process_handsha
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-    aux_msg.msg_endian = BIGEND;
-    change->serializedPayload.encapsulation = PL_CDR_BE;
-    CDRMessage::addOctet(&aux_msg, CDR_BE);
-#else
-    aux_msg.msg_endian = LITTLEEND;
-    change->serializedPayload.encapsulation = PL_CDR_LE;
-    CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+    aux_msg.msg_endian = DEFAULT_ENDIAN;
+    change->serializedPayload.encapsulation = PL_DEFAULT_ENCAPSULATION;
+    CDRMessage::addOctet(&aux_msg, DEFAULT_ENCAPSULATION);
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -1151,15 +1055,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_process_handshake
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-    aux_msg.msg_endian = BIGEND;
-    change->serializedPayload.encapsulation = PL_CDR_BE;
-    CDRMessage::addOctet(&aux_msg, CDR_BE);
-#else
-    aux_msg.msg_endian = LITTLEEND;
-    change->serializedPayload.encapsulation = PL_CDR_LE;
-    CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+    aux_msg.msg_endian = DEFAULT_ENDIAN;
+    change->serializedPayload.encapsulation = PL_DEFAULT_ENCAPSULATION;
+    CDRMessage::addOctet(&aux_msg, DEFAULT_ENCAPSULATION);
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));

--- a/test/unittest/rtps/security/SecurityHandshakeProcessTests.cpp
+++ b/test/unittest/rtps/security/SecurityHandshakeProcessTests.cpp
@@ -24,11 +24,12 @@ TEST_F(SecurityTest, discovered_participant_begin_handshake_request_fail_and_the
     HandshakeMessageToken handshake_message;
     CacheChange_t* change = new CacheChange_t(200);
 
-    EXPECT_CALL(*auth_plugin_, validate_remote_identity_rvr(_, Ref(local_identity_handle_),_,_,_)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle), Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_REQUEST)));
-    EXPECT_CALL(*auth_plugin_, begin_handshake_request(_,_, Ref(local_identity_handle_),
-                Ref(remote_identity_handle),_,_)).Times(1).
-        WillOnce(Return(ValidationResult_t::VALIDATION_FAILED));
+    EXPECT_CALL(*auth_plugin_, validate_remote_identity_rvr(_, Ref(local_identity_handle_), _, _, _)).Times(1).
+    WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle),
+            Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_REQUEST)));
+    EXPECT_CALL(*auth_plugin_, begin_handshake_request(_, _, Ref(local_identity_handle_),
+            Ref(remote_identity_handle), _, _)).Times(1).
+    WillOnce(Return(ValidationResult_t::VALIDATION_FAILED));
 
     ParticipantProxyData participant_data;
     fill_participant_key(participant_data.m_guid);
@@ -41,21 +42,21 @@ TEST_F(SecurityTest, discovered_participant_begin_handshake_request_fail_and_the
 
     ASSERT_FALSE(manager_.discovered_participant(participant_data));
 
-    EXPECT_CALL(*auth_plugin_, validate_remote_identity_rvr(_, Ref(local_identity_handle_),_,_,_)).Times(0);
-    EXPECT_CALL(*auth_plugin_, begin_handshake_request(_,_, Ref(local_identity_handle_),
-                Ref(remote_identity_handle),_,_)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&handshake_handle),
-                    SetArgPointee<1>(&handshake_message), Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
-    EXPECT_CALL(*stateless_writer_, new_change(_,_,_)).Times(1).
-        WillOnce(Return(change));
+    EXPECT_CALL(*auth_plugin_, validate_remote_identity_rvr(_, Ref(local_identity_handle_), _, _, _)).Times(0);
+    EXPECT_CALL(*auth_plugin_, begin_handshake_request(_, _, Ref(local_identity_handle_),
+            Ref(remote_identity_handle), _, _)).Times(1).
+    WillOnce(DoAll(SetArgPointee<0>(&handshake_handle),
+            SetArgPointee<1>(&handshake_message), Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
+    EXPECT_CALL(*stateless_writer_, new_change(_, _, _)).Times(1).
+    WillOnce(Return(change));
     EXPECT_CALL(*stateless_writer_->history_, add_change_mock(change)).Times(1).
-        WillOnce(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle,_)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle, _)).Times(1).
+    WillOnce(Return(true));
     EXPECT_CALL(participant_, pdpsimple()).Times(1).WillOnce(Return(&pdpsimple_));
     EXPECT_CALL(pdpsimple_, get_participant_proxy_data_serialized(BIGEND)).Times(1);
 
@@ -72,8 +73,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_not_remote_participa
 
     ParticipantGenericMessage message;
     message.message_class_id("dds.sec.auth");
-    CacheChange_t* change = new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
-            + 4 /*encapsulation*/);
+    CacheChange_t* change =
+            new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
+                    + 4 /*encapsulation*/);
     CDRMessage_t aux_msg(0);
     aux_msg.wraps = true;
     aux_msg.buffer = change->serializedPayload.data;
@@ -89,16 +91,16 @@ TEST_F(SecurityTest, discovered_participant_process_message_not_remote_participa
     aux_msg.msg_endian = LITTLEEND;
     change->serializedPayload.encapsulation = PL_CDR_LE;
     CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
     change->serializedPayload.length = aux_msg.length;
 
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
     EXPECT_CALL(*stateless_reader_->history_, remove_change_mock(change)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
 
     stateless_reader_->listener_->onNewCacheChangeAdded(stateless_reader_, change);
 }
@@ -109,16 +111,18 @@ TEST_F(SecurityTest, discovered_participant_process_message_bad_message_class_id
 
     MockIdentityHandle remote_identity_handle;
 
-    EXPECT_CALL(*auth_plugin_, validate_remote_identity_rvr(_, Ref(local_identity_handle_),_,_,_)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle), Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
+    EXPECT_CALL(*auth_plugin_, validate_remote_identity_rvr(_, Ref(local_identity_handle_), _, _, _)).Times(1).
+    WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle),
+            Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
 
     ParticipantProxyData participant_data;
     fill_participant_key(participant_data.m_guid);
     ASSERT_TRUE(manager_.discovered_participant(participant_data));
 
     ParticipantGenericMessage message;
-    CacheChange_t* change = new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
-            + 4 /*encapsulation*/);
+    CacheChange_t* change =
+            new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
+                    + 4 /*encapsulation*/);
     CDRMessage_t aux_msg(0);
     aux_msg.wraps = true;
     aux_msg.buffer = change->serializedPayload.data;
@@ -134,18 +138,18 @@ TEST_F(SecurityTest, discovered_participant_process_message_bad_message_class_id
     aux_msg.msg_endian = LITTLEEND;
     change->serializedPayload.encapsulation = PL_CDR_LE;
     CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
     change->serializedPayload.length = aux_msg.length;
 
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle,_)).Times(1).
-        WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle, _)).Times(1).
+    WillRepeatedly(Return(true));
     EXPECT_CALL(*stateless_reader_->history_, remove_change_mock(change)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
 
     stateless_reader_->listener_->onNewCacheChangeAdded(stateless_reader_, change);
 }
@@ -156,8 +160,8 @@ TEST_F(SecurityTest, discovered_participant_process_message_not_expecting_reques
 
     MockIdentityHandle remote_identity_handle;
 
-    EXPECT_CALL(*auth_plugin_, validate_remote_identity_rvr(_, Ref(local_identity_handle_),_,_,_)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle), Return(ValidationResult_t::VALIDATION_OK)));
+    EXPECT_CALL(*auth_plugin_, validate_remote_identity_rvr(_, Ref(local_identity_handle_), _, _, _)).Times(1).
+    WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle), Return(ValidationResult_t::VALIDATION_OK)));
 
     ParticipantProxyData participant_data;
     fill_participant_key(participant_data.m_guid);
@@ -177,8 +181,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_not_expecting_reques
     message.message_class_id("dds.sec.auth");
     HandshakeMessageToken token;
     message.message_data().push_back(token);
-    CacheChange_t* change = new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
-            + 4 /*encapsulation*/);
+    CacheChange_t* change =
+            new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
+                    + 4 /*encapsulation*/);
     CDRMessage_t aux_msg(0);
     aux_msg.wraps = true;
     aux_msg.buffer = change->serializedPayload.data;
@@ -194,18 +199,18 @@ TEST_F(SecurityTest, discovered_participant_process_message_not_expecting_reques
     aux_msg.msg_endian = LITTLEEND;
     change->serializedPayload.encapsulation = PL_CDR_LE;
     CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
     change->serializedPayload.length = aux_msg.length;
 
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle,_)).Times(1).
-        WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle, _)).Times(1).
+    WillRepeatedly(Return(true));
     EXPECT_CALL(*stateless_reader_->history_, remove_change_mock(change)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
 
     stateless_reader_->listener_->onNewCacheChangeAdded(stateless_reader_, change);
 }
@@ -216,8 +221,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_fail_begin_handshake
 
     MockIdentityHandle remote_identity_handle;
 
-    EXPECT_CALL(*auth_plugin_, validate_remote_identity_rvr(_, Ref(local_identity_handle_),_,_,_)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle), Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
+    EXPECT_CALL(*auth_plugin_, validate_remote_identity_rvr(_, Ref(local_identity_handle_), _, _, _)).Times(1).
+    WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle),
+            Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
 
     ParticipantProxyData participant_data;
     fill_participant_key(participant_data.m_guid);
@@ -229,8 +235,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_fail_begin_handshake
     message.message_class_id("dds.sec.auth");
     HandshakeMessageToken token;
     message.message_data().push_back(token);
-    CacheChange_t* change = new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
-            + 4 /*encapsulation*/);
+    CacheChange_t* change =
+            new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
+                    + 4 /*encapsulation*/);
     CDRMessage_t aux_msg(0);
     aux_msg.wraps = true;
     aux_msg.buffer = change->serializedPayload.data;
@@ -246,21 +253,21 @@ TEST_F(SecurityTest, discovered_participant_process_message_fail_begin_handshake
     aux_msg.msg_endian = LITTLEEND;
     change->serializedPayload.encapsulation = PL_CDR_LE;
     CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
     change->serializedPayload.length = aux_msg.length;
 
-    EXPECT_CALL(*auth_plugin_, begin_handshake_reply_rvr(_,_,_, Ref(remote_identity_handle),
-                Ref(local_identity_handle_),_,_)).Times(1).
-        WillOnce(Return(ValidationResult_t::VALIDATION_FAILED));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle,_)).Times(1).
-        WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, begin_handshake_reply_rvr(_, _, _, Ref(remote_identity_handle),
+            Ref(local_identity_handle_), _, _)).Times(1).
+    WillOnce(Return(ValidationResult_t::VALIDATION_FAILED));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle, _)).Times(1).
+    WillRepeatedly(Return(true));
     EXPECT_CALL(*stateless_reader_->history_, remove_change_mock(change)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
     ParticipantAuthenticationInfo info;
     info.status = ParticipantAuthenticationInfo::UNAUTHORIZED_PARTICIPANT;
     info.guid = participant_data.m_guid;
@@ -277,8 +284,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_begin_handshake_r
 
     MockIdentityHandle remote_identity_handle;
 
-    EXPECT_CALL(*auth_plugin_, validate_remote_identity_rvr(_, Ref(local_identity_handle_),_,_,_)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle), Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
+    EXPECT_CALL(*auth_plugin_, validate_remote_identity_rvr(_, Ref(local_identity_handle_), _, _, _)).Times(1).
+    WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle),
+            Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
 
     ParticipantProxyData participant_data;
     fill_participant_key(participant_data.m_guid);
@@ -290,8 +298,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_begin_handshake_r
     message.message_class_id("dds.sec.auth");
     HandshakeMessageToken token;
     message.message_data().push_back(token);
-    CacheChange_t* change = new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
-            + 4 /*encapsulation*/);
+    CacheChange_t* change =
+            new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
+                    + 4 /*encapsulation*/);
     CDRMessage_t aux_msg(0);
     aux_msg.wraps = true;
     aux_msg.buffer = change->serializedPayload.data;
@@ -307,7 +316,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_begin_handshake_r
     aux_msg.msg_endian = LITTLEEND;
     change->serializedPayload.encapsulation = PL_CDR_LE;
     CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -317,33 +326,34 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_begin_handshake_r
     MockSharedSecretHandle shared_secret_handle;
     MockParticipantCryptoHandle participant_crypto_handle;
 
-    EXPECT_CALL(*auth_plugin_, begin_handshake_reply_rvr(_,_,_, Ref(remote_identity_handle),
-                Ref(local_identity_handle_),_,_)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&handshake_handle),
-                    Return(ValidationResult_t::VALIDATION_OK)));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle,_)).Times(1).
-        WillOnce(Return(true));
+    EXPECT_CALL(*auth_plugin_, begin_handshake_reply_rvr(_, _, _, Ref(remote_identity_handle),
+            Ref(local_identity_handle_), _, _)).Times(1).
+    WillOnce(DoAll(SetArgPointee<0>(&handshake_handle),
+            Return(ValidationResult_t::VALIDATION_OK)));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle, _)).Times(1).
+    WillOnce(Return(true));
     EXPECT_CALL(*stateless_reader_->history_, remove_change_mock(change)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
     EXPECT_CALL(participant_, pdpsimple()).Times(2).WillRepeatedly(Return(&pdpsimple_));
     EXPECT_CALL(pdpsimple_, notifyAboveRemoteEndpoints(_)).Times(1);
     EXPECT_CALL(pdpsimple_, get_participant_proxy_data_serialized(BIGEND)).Times(1);
-    EXPECT_CALL(*auth_plugin_, get_shared_secret(Ref(handshake_handle),_)).Times(1).
-        WillOnce(Return(&shared_secret_handle));
-    EXPECT_CALL(*auth_plugin_, return_sharedsecret_handle(&shared_secret_handle,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, register_matched_remote_participant(Ref(local_participant_crypto_handle_),
-                Ref(remote_identity_handle),_,Ref(shared_secret_handle),_)).Times(1).
-        WillOnce(Return(&participant_crypto_handle));
+    EXPECT_CALL(*auth_plugin_, get_shared_secret(Ref(handshake_handle), _)).Times(1).
+    WillOnce(Return(&shared_secret_handle));
+    EXPECT_CALL(*auth_plugin_, return_sharedsecret_handle(&shared_secret_handle, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
+            register_matched_remote_participant(Ref(local_participant_crypto_handle_),
+            Ref(remote_identity_handle), _, Ref(shared_secret_handle), _)).Times(1).
+    WillOnce(Return(&participant_crypto_handle));
     EXPECT_CALL(crypto_plugin_->cryptokeyexchange_, create_local_participant_crypto_tokens(_,
-                Ref(local_participant_crypto_handle_), Ref(participant_crypto_handle),_)).Times(1).
-           WillOnce(Return(true));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, unregister_participant(&participant_crypto_handle,_)).Times(1).
-        WillOnce(Return(true));
+            Ref(local_participant_crypto_handle_), Ref(participant_crypto_handle), _)).Times(1).
+    WillOnce(Return(true));
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, unregister_participant(&participant_crypto_handle, _)).Times(1).
+    WillOnce(Return(true));
 
     ParticipantAuthenticationInfo info;
     info.status = ParticipantAuthenticationInfo::AUTHORIZED_PARTICIPANT;
@@ -359,8 +369,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_new_change_fail)
 
     MockIdentityHandle remote_identity_handle;
 
-    EXPECT_CALL(*auth_plugin_, validate_remote_identity_rvr(_, Ref(local_identity_handle_),_,_,_)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle), Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
+    EXPECT_CALL(*auth_plugin_, validate_remote_identity_rvr(_, Ref(local_identity_handle_), _, _, _)).Times(1).
+    WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle),
+            Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
 
     ParticipantProxyData participant_data;
     fill_participant_key(participant_data.m_guid);
@@ -372,8 +383,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_new_change_fail)
     message.message_class_id("dds.sec.auth");
     HandshakeMessageToken token;
     message.message_data().push_back(token);
-    CacheChange_t* change = new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
-            + 4 /*encapsulation*/);
+    CacheChange_t* change =
+            new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
+                    + 4 /*encapsulation*/);
     CDRMessage_t aux_msg(0);
     aux_msg.wraps = true;
     aux_msg.buffer = change->serializedPayload.data;
@@ -389,7 +401,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_new_change_fail)
     aux_msg.msg_endian = LITTLEEND;
     change->serializedPayload.encapsulation = PL_CDR_LE;
     CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -398,20 +410,20 @@ TEST_F(SecurityTest, discovered_participant_process_message_new_change_fail)
     MockHandshakeHandle handshake_handle;
     HandshakeMessageToken handshake_message;
 
-    EXPECT_CALL(*auth_plugin_, begin_handshake_reply_rvr(_,_,_, Ref(remote_identity_handle),
-                Ref(local_identity_handle_),_,_)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&handshake_handle),
-                    SetArgPointee<1>(&handshake_message), Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*stateless_writer_, new_change(_,_,_)).Times(1).
-        WillOnce(Return(nullptr));
-    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle,_)).Times(1).
-        WillOnce(Return(true));
+    EXPECT_CALL(*auth_plugin_, begin_handshake_reply_rvr(_, _, _, Ref(remote_identity_handle),
+            Ref(local_identity_handle_), _, _)).Times(1).
+    WillOnce(DoAll(SetArgPointee<0>(&handshake_handle),
+            SetArgPointee<1>(&handshake_message), Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*stateless_writer_, new_change(_, _, _)).Times(1).
+    WillOnce(Return(nullptr));
+    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle, _)).Times(1).
+    WillOnce(Return(true));
     EXPECT_CALL(*stateless_reader_->history_, remove_change_mock(change)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
     EXPECT_CALL(participant_, pdpsimple()).Times(1).WillOnce(Return(&pdpsimple_));
     EXPECT_CALL(pdpsimple_, get_participant_proxy_data_serialized(BIGEND)).Times(1);
 
@@ -424,8 +436,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_add_change_fail)
 
     MockIdentityHandle remote_identity_handle;
 
-    EXPECT_CALL(*auth_plugin_, validate_remote_identity_rvr(_, Ref(local_identity_handle_),_,_,_)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle), Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
+    EXPECT_CALL(*auth_plugin_, validate_remote_identity_rvr(_, Ref(local_identity_handle_), _, _, _)).Times(1).
+    WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle),
+            Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
 
     ParticipantProxyData participant_data;
     fill_participant_key(participant_data.m_guid);
@@ -437,8 +450,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_add_change_fail)
     message.message_class_id("dds.sec.auth");
     HandshakeMessageToken token;
     message.message_data().push_back(token);
-    CacheChange_t* change = new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
-            + 4 /*encapsulation*/);
+    CacheChange_t* change =
+            new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
+                    + 4 /*encapsulation*/);
     CDRMessage_t aux_msg(0);
     aux_msg.wraps = true;
     aux_msg.buffer = change->serializedPayload.data;
@@ -454,7 +468,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_add_change_fail)
     aux_msg.msg_endian = LITTLEEND;
     change->serializedPayload.encapsulation = PL_CDR_LE;
     CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -464,22 +478,22 @@ TEST_F(SecurityTest, discovered_participant_process_message_add_change_fail)
     HandshakeMessageToken handshake_message;
     CacheChange_t* change2 = new CacheChange_t(200);
 
-    EXPECT_CALL(*auth_plugin_, begin_handshake_reply_rvr(_,_,_, Ref(remote_identity_handle),
-                Ref(local_identity_handle_),_,_)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&handshake_handle),
-                    SetArgPointee<1>(&handshake_message), Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*stateless_writer_, new_change(_,_,_)).Times(1).
-        WillOnce(Return(change2));
+    EXPECT_CALL(*auth_plugin_, begin_handshake_reply_rvr(_, _, _, Ref(remote_identity_handle),
+            Ref(local_identity_handle_), _, _)).Times(1).
+    WillOnce(DoAll(SetArgPointee<0>(&handshake_handle),
+            SetArgPointee<1>(&handshake_message), Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*stateless_writer_, new_change(_, _, _)).Times(1).
+    WillOnce(Return(change2));
     EXPECT_CALL(*stateless_writer_->history_, add_change_mock(change2)).Times(1).
-        WillOnce(Return(false));
-    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle,_)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(false));
+    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle, _)).Times(1).
+    WillOnce(Return(true));
     EXPECT_CALL(*stateless_reader_->history_, remove_change_mock(change)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
     EXPECT_CALL(participant_, pdpsimple()).Times(1).WillOnce(Return(&pdpsimple_));
     EXPECT_CALL(pdpsimple_, get_participant_proxy_data_serialized(BIGEND)).Times(1);
 
@@ -492,32 +506,32 @@ TEST_F(SecurityTest, discovered_participant_process_message_add_change_fail)
 
 TEST_F(SecurityTest, discovered_participant_process_message_pending_handshake_reply_pending_message)
 {
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_,_)).Times(1).
-        WillOnce(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_, _)).Times(1).
+    WillOnce(Return(true));
 
     reply_process_ok();
 }
 
 TEST_F(SecurityTest, discovered_participant_process_message_pending_handshake_reply_pending_message_resent)
 {
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_,_)).Times(1).
-        WillOnce(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_, _)).Times(1).
+    WillOnce(Return(true));
 
     CacheChange_t* reply_message_change = nullptr;
     reply_process_ok(&reply_message_change);
 
     EXPECT_CALL(*stateless_writer_->history_, remove_change_and_reuse(reply_message_change->sequenceNumber)).Times(1).
-        WillOnce(Return(reply_message_change));
+    WillOnce(Return(reply_message_change));
     EXPECT_CALL(*stateless_writer_->history_, add_change_mock(reply_message_change)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
     stateless_writer_->history_->wait_for_more_samples_than(1);
 
     manager_.destroy();
@@ -531,8 +545,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_pending_handshake_re
 
     MockIdentityHandle remote_identity_handle;
 
-    EXPECT_CALL(*auth_plugin_, validate_remote_identity_rvr(_, Ref(local_identity_handle_),_,_,_)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle), Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
+    EXPECT_CALL(*auth_plugin_, validate_remote_identity_rvr(_, Ref(local_identity_handle_), _, _, _)).Times(1).
+    WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle),
+            Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
 
     ParticipantProxyData participant_data;
     fill_participant_key(participant_data.m_guid);
@@ -544,8 +559,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_pending_handshake_re
     message.message_class_id("dds.sec.auth");
     HandshakeMessageToken token;
     message.message_data().push_back(token);
-    CacheChange_t* change = new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
-            + 4 /*encapsulation*/);
+    CacheChange_t* change =
+            new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
+                    + 4 /*encapsulation*/);
     CDRMessage_t aux_msg(0);
     aux_msg.wraps = true;
     aux_msg.buffer = change->serializedPayload.data;
@@ -561,7 +577,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_pending_handshake_re
     aux_msg.msg_endian = LITTLEEND;
     change->serializedPayload.encapsulation = PL_CDR_LE;
     CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -573,37 +589,38 @@ TEST_F(SecurityTest, discovered_participant_process_message_pending_handshake_re
     MockSharedSecretHandle shared_secret_handle;
     MockParticipantCryptoHandle participant_crypto_handle;
 
-    EXPECT_CALL(*auth_plugin_, begin_handshake_reply_rvr(_,_,_, Ref(remote_identity_handle),
-                Ref(local_identity_handle_),_,_)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&handshake_handle),
-                    SetArgPointee<1>(&handshake_message), Return(ValidationResult_t::VALIDATION_OK_WITH_FINAL_MESSAGE)));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*stateless_writer_, new_change(_,_,_)).Times(1).
-        WillOnce(Return(change2));
+    EXPECT_CALL(*auth_plugin_, begin_handshake_reply_rvr(_, _, _, Ref(remote_identity_handle),
+            Ref(local_identity_handle_), _, _)).Times(1).
+    WillOnce(DoAll(SetArgPointee<0>(&handshake_handle),
+            SetArgPointee<1>(&handshake_message), Return(ValidationResult_t::VALIDATION_OK_WITH_FINAL_MESSAGE)));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*stateless_writer_, new_change(_, _, _)).Times(1).
+    WillOnce(Return(change2));
     EXPECT_CALL(*stateless_writer_->history_, add_change_mock(change2)).Times(1).
-        WillOnce(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle,_)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle, _)).Times(1).
+    WillOnce(Return(true));
     EXPECT_CALL(*stateless_reader_->history_, remove_change_mock(change)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
     EXPECT_CALL(participant_, pdpsimple()).Times(2).WillRepeatedly(Return(&pdpsimple_));
     EXPECT_CALL(pdpsimple_, notifyAboveRemoteEndpoints(_)).Times(1);
     EXPECT_CALL(pdpsimple_, get_participant_proxy_data_serialized(BIGEND)).Times(1);
-    EXPECT_CALL(*auth_plugin_, get_shared_secret(Ref(handshake_handle),_)).Times(1).
-        WillOnce(Return(&shared_secret_handle));
-    EXPECT_CALL(*auth_plugin_, return_sharedsecret_handle(&shared_secret_handle,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, register_matched_remote_participant(Ref(local_participant_crypto_handle_),
-                Ref(remote_identity_handle),_,Ref(shared_secret_handle),_)).Times(1).
-        WillOnce(Return(&participant_crypto_handle));
+    EXPECT_CALL(*auth_plugin_, get_shared_secret(Ref(handshake_handle), _)).Times(1).
+    WillOnce(Return(&shared_secret_handle));
+    EXPECT_CALL(*auth_plugin_, return_sharedsecret_handle(&shared_secret_handle, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
+            register_matched_remote_participant(Ref(local_participant_crypto_handle_),
+            Ref(remote_identity_handle), _, Ref(shared_secret_handle), _)).Times(1).
+    WillOnce(Return(&participant_crypto_handle));
     EXPECT_CALL(crypto_plugin_->cryptokeyexchange_, create_local_participant_crypto_tokens(_,
-                Ref(local_participant_crypto_handle_), Ref(participant_crypto_handle),_)).Times(1).
-           WillOnce(Return(true));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, unregister_participant(&participant_crypto_handle,_)).Times(1).
-        WillOnce(Return(true));
+            Ref(local_participant_crypto_handle_), Ref(participant_crypto_handle), _)).Times(1).
+    WillOnce(Return(true));
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, unregister_participant(&participant_crypto_handle, _)).Times(1).
+    WillOnce(Return(true));
 
     ParticipantAuthenticationInfo info;
     info.status = ParticipantAuthenticationInfo::AUTHORIZED_PARTICIPANT;
@@ -631,8 +648,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_fail_process_handsha
     message.message_class_id("dds.sec.auth");
     HandshakeMessageToken token;
     message.message_data().push_back(token);
-    CacheChange_t* change = new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
-            + 4 /*encapsulation*/);
+    CacheChange_t* change =
+            new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
+                    + 4 /*encapsulation*/);
     CDRMessage_t aux_msg(0);
     aux_msg.wraps = true;
     aux_msg.buffer = change->serializedPayload.data;
@@ -648,22 +666,22 @@ TEST_F(SecurityTest, discovered_participant_process_message_fail_process_handsha
     aux_msg.msg_endian = LITTLEEND;
     change->serializedPayload.encapsulation = PL_CDR_LE;
     CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
     change->serializedPayload.length = aux_msg.length;
 
-    EXPECT_CALL(*auth_plugin_, process_handshake_rvr(_,_, Ref(handshake_handle_),_)).Times(1).
-        WillOnce(Return(ValidationResult_t::VALIDATION_FAILED));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_,_)).Times(1).
-        WillOnce(Return(true));
+    EXPECT_CALL(*auth_plugin_, process_handshake_rvr(_, _, Ref(handshake_handle_), _)).Times(1).
+    WillOnce(Return(ValidationResult_t::VALIDATION_FAILED));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_, _)).Times(1).
+    WillOnce(Return(true));
     EXPECT_CALL(*stateless_reader_->history_, remove_change_mock(change)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
     ParticipantAuthenticationInfo info;
     info.status = ParticipantAuthenticationInfo::UNAUTHORIZED_PARTICIPANT;
     info.guid = remote_participant_key;
@@ -676,8 +694,8 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_process_handshake
 {
     request_process_ok();
 
-    EXPECT_CALL(*stateless_writer_->history_, remove_change(SequenceNumber_t{0,1})).Times(1).
-        WillOnce(Return(true));
+    EXPECT_CALL(*stateless_writer_->history_, remove_change(SequenceNumber_t{0, 1})).Times(1).
+    WillOnce(Return(true));
 
     GUID_t remote_participant_key(participant_data_.m_guid);
 
@@ -689,8 +707,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_process_handshake
     message.message_class_id("dds.sec.auth");
     HandshakeMessageToken token;
     message.message_data().push_back(token);
-    CacheChange_t* change = new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
-            + 4 /*encapsulation*/);
+    CacheChange_t* change =
+            new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
+                    + 4 /*encapsulation*/);
     CDRMessage_t aux_msg(0);
     aux_msg.wraps = true;
     aux_msg.buffer = change->serializedPayload.data;
@@ -706,7 +725,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_process_handshake
     aux_msg.msg_endian = LITTLEEND;
     change->serializedPayload.encapsulation = PL_CDR_LE;
     CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -715,30 +734,31 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_process_handshake
     MockSharedSecretHandle shared_secret_handle;
     MockParticipantCryptoHandle participant_crypto_handle;
 
-    EXPECT_CALL(*auth_plugin_, process_handshake_rvr(_,_, Ref(handshake_handle_),_)).Times(1).
-        WillOnce(Return(ValidationResult_t::VALIDATION_OK));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_,_)).Times(1).
-        WillOnce(Return(true));
+    EXPECT_CALL(*auth_plugin_, process_handshake_rvr(_, _, Ref(handshake_handle_), _)).Times(1).
+    WillOnce(Return(ValidationResult_t::VALIDATION_OK));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_, _)).Times(1).
+    WillOnce(Return(true));
     EXPECT_CALL(*stateless_reader_->history_, remove_change_mock(change)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
     EXPECT_CALL(participant_, pdpsimple()).Times(1).WillOnce(Return(&pdpsimple_));
     EXPECT_CALL(pdpsimple_, notifyAboveRemoteEndpoints(_)).Times(1);
-    EXPECT_CALL(*auth_plugin_, get_shared_secret(Ref(handshake_handle_),_)).Times(1).
-        WillOnce(Return(&shared_secret_handle));
-    EXPECT_CALL(*auth_plugin_, return_sharedsecret_handle(&shared_secret_handle,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, register_matched_remote_participant(Ref(local_participant_crypto_handle_),
-                Ref(remote_identity_handle_),_,Ref(shared_secret_handle),_)).Times(1).
-        WillOnce(Return(&participant_crypto_handle));
+    EXPECT_CALL(*auth_plugin_, get_shared_secret(Ref(handshake_handle_), _)).Times(1).
+    WillOnce(Return(&shared_secret_handle));
+    EXPECT_CALL(*auth_plugin_, return_sharedsecret_handle(&shared_secret_handle, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
+            register_matched_remote_participant(Ref(local_participant_crypto_handle_),
+            Ref(remote_identity_handle_), _, Ref(shared_secret_handle), _)).Times(1).
+    WillOnce(Return(&participant_crypto_handle));
     EXPECT_CALL(crypto_plugin_->cryptokeyexchange_, create_local_participant_crypto_tokens(_,
-                Ref(local_participant_crypto_handle_), Ref(participant_crypto_handle),_)).Times(1).
-           WillOnce(Return(true));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, unregister_participant(&participant_crypto_handle,_)).Times(1).
-        WillOnce(Return(true));
+            Ref(local_participant_crypto_handle_), Ref(participant_crypto_handle), _)).Times(1).
+    WillOnce(Return(true));
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, unregister_participant(&participant_crypto_handle, _)).Times(1).
+    WillOnce(Return(true));
 
     ParticipantAuthenticationInfo info;
     info.status = ParticipantAuthenticationInfo::AUTHORIZED_PARTICIPANT;
@@ -752,8 +772,8 @@ TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_re
 {
     request_process_ok();
 
-    EXPECT_CALL(*stateless_writer_->history_, remove_change(SequenceNumber_t{0,1})).Times(1).
-        WillOnce(Return(true));
+    EXPECT_CALL(*stateless_writer_->history_, remove_change(SequenceNumber_t{0, 1})).Times(1).
+    WillOnce(Return(true));
 
     GUID_t remote_participant_key(participant_data_.m_guid);
 
@@ -765,8 +785,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_re
     message.message_class_id("dds.sec.auth");
     HandshakeMessageToken token;
     message.message_data().push_back(token);
-    CacheChange_t* change = new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
-            + 4 /*encapsulation*/);
+    CacheChange_t* change =
+            new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
+                    + 4 /*encapsulation*/);
     CDRMessage_t aux_msg(0);
     aux_msg.wraps = true;
     aux_msg.buffer = change->serializedPayload.data;
@@ -782,7 +803,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_re
     aux_msg.msg_endian = LITTLEEND;
     change->serializedPayload.encapsulation = PL_CDR_LE;
     CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -790,18 +811,19 @@ TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_re
 
     HandshakeMessageToken handshake_message;
 
-    EXPECT_CALL(*auth_plugin_, process_handshake_rvr(_,_, Ref(handshake_handle_),_)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&handshake_message), Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*stateless_writer_, new_change(_,_,_)).Times(1).
-        WillOnce(Return(nullptr));
-    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_,_)).Times(1).
-        WillOnce(Return(true));
+    EXPECT_CALL(*auth_plugin_, process_handshake_rvr(_, _, Ref(handshake_handle_), _)).Times(1).
+    WillOnce(DoAll(SetArgPointee<0>(&handshake_message),
+            Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*stateless_writer_, new_change(_, _, _)).Times(1).
+    WillOnce(Return(nullptr));
+    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_, _)).Times(1).
+    WillOnce(Return(true));
     EXPECT_CALL(*stateless_reader_->history_, remove_change_mock(change)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
 
     stateless_reader_->listener_->onNewCacheChangeAdded(stateless_reader_, change);
 }
@@ -810,8 +832,8 @@ TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_re
 {
     request_process_ok();
 
-    EXPECT_CALL(*stateless_writer_->history_, remove_change(SequenceNumber_t{0,1})).Times(1).
-        WillOnce(Return(true));
+    EXPECT_CALL(*stateless_writer_->history_, remove_change(SequenceNumber_t{0, 1})).Times(1).
+    WillOnce(Return(true));
 
     GUID_t remote_participant_key(participant_data_.m_guid);
 
@@ -823,8 +845,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_re
     message.message_class_id("dds.sec.auth");
     HandshakeMessageToken token;
     message.message_data().push_back(token);
-    CacheChange_t* change = new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
-            + 4 /*encapsulation*/);
+    CacheChange_t* change =
+            new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
+                    + 4 /*encapsulation*/);
     CDRMessage_t aux_msg(0);
     aux_msg.wraps = true;
     aux_msg.buffer = change->serializedPayload.data;
@@ -840,7 +863,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_re
     aux_msg.msg_endian = LITTLEEND;
     change->serializedPayload.encapsulation = PL_CDR_LE;
     CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -849,20 +872,21 @@ TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_re
     HandshakeMessageToken handshake_message;
     CacheChange_t* change2 = new CacheChange_t(200);
 
-    EXPECT_CALL(*auth_plugin_, process_handshake_rvr(_,_, Ref(handshake_handle_),_)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&handshake_message), Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*stateless_writer_, new_change(_,_,_)).Times(1).
-        WillOnce(Return(change2));
+    EXPECT_CALL(*auth_plugin_, process_handshake_rvr(_, _, Ref(handshake_handle_), _)).Times(1).
+    WillOnce(DoAll(SetArgPointee<0>(&handshake_message),
+            Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*stateless_writer_, new_change(_, _, _)).Times(1).
+    WillOnce(Return(change2));
     EXPECT_CALL(*stateless_writer_->history_, add_change_mock(change2)).Times(1).
-        WillOnce(Return(false));
-    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_,_)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(false));
+    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_, _)).Times(1).
+    WillOnce(Return(true));
     EXPECT_CALL(*stateless_reader_->history_, remove_change_mock(change)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
 
     stateless_reader_->listener_->onNewCacheChangeAdded(stateless_reader_, change);
 
@@ -873,24 +897,24 @@ TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_re
 
 TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_reply_ok_with_final_message)
 {
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_,_)).Times(1).
-        WillOnce(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_, _)).Times(1).
+    WillOnce(Return(true));
 
     final_message_process_ok();
 }
 
 TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_reply_ok_with_final_message_resent)
 {
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_,_)).Times(1).
-        WillOnce(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_, _)).Times(1).
+    WillOnce(Return(true));
 
     CacheChange_t* final_message_change = nullptr;
     final_message_process_ok(&final_message_change);
@@ -905,8 +929,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_re
     message.message_class_id("dds.sec.auth");
     HandshakeMessageToken token;
     message.message_data().push_back(token);
-    CacheChange_t* change = new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
-            + 4 /*encapsulation*/);
+    CacheChange_t* change =
+            new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
+                    + 4 /*encapsulation*/);
     CDRMessage_t aux_msg(0);
     aux_msg.wraps = true;
     aux_msg.buffer = change->serializedPayload.data;
@@ -922,18 +947,18 @@ TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_re
     aux_msg.msg_endian = LITTLEEND;
     change->serializedPayload.encapsulation = PL_CDR_LE;
     CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
     change->serializedPayload.length = aux_msg.length;
 
     EXPECT_CALL(*stateless_writer_->history_, remove_change_and_reuse(final_message_change->sequenceNumber)).Times(1).
-        WillOnce(Return(final_message_change));
+    WillOnce(Return(final_message_change));
     EXPECT_CALL(*stateless_writer_->history_, add_change_mock(final_message_change)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
     EXPECT_CALL(*stateless_reader_->history_, remove_change_mock(change)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
 
     stateless_reader_->listener_->onNewCacheChangeAdded(stateless_reader_, change);
 
@@ -957,8 +982,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_bad_related_guid)
     message.message_class_id("dds.sec.auth");
     HandshakeMessageToken token;
     message.message_data().push_back(token);
-    CacheChange_t* change = new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
-            + 4 /*encapsulation*/);
+    CacheChange_t* change =
+            new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
+                    + 4 /*encapsulation*/);
     CDRMessage_t aux_msg(0);
     aux_msg.wraps = true;
     aux_msg.buffer = change->serializedPayload.data;
@@ -974,20 +1000,20 @@ TEST_F(SecurityTest, discovered_participant_process_message_bad_related_guid)
     aux_msg.msg_endian = LITTLEEND;
     change->serializedPayload.encapsulation = PL_CDR_LE;
     CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
     change->serializedPayload.length = aux_msg.length;
 
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_,_)).Times(1).
-        WillOnce(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_, _)).Times(1).
+    WillOnce(Return(true));
     EXPECT_CALL(*stateless_reader_->history_, remove_change_mock(change)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
 
     stateless_reader_->listener_->onNewCacheChangeAdded(stateless_reader_, change);
 }
@@ -1006,8 +1032,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_bad_related_sequence
     message.message_class_id("dds.sec.auth");
     HandshakeMessageToken token;
     message.message_data().push_back(token);
-    CacheChange_t* change = new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
-            + 4 /*encapsulation*/);
+    CacheChange_t* change =
+            new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
+                    + 4 /*encapsulation*/);
     CDRMessage_t aux_msg(0);
     aux_msg.wraps = true;
     aux_msg.buffer = change->serializedPayload.data;
@@ -1023,20 +1050,20 @@ TEST_F(SecurityTest, discovered_participant_process_message_bad_related_sequence
     aux_msg.msg_endian = LITTLEEND;
     change->serializedPayload.encapsulation = PL_CDR_LE;
     CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
     change->serializedPayload.length = aux_msg.length;
 
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_,_)).Times(1).
-        WillOnce(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_, _)).Times(1).
+    WillOnce(Return(true));
     EXPECT_CALL(*stateless_reader_->history_, remove_change_mock(change)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
 
     stateless_reader_->listener_->onNewCacheChangeAdded(stateless_reader_, change);
 }
@@ -1055,8 +1082,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_fail_process_handsha
     message.message_class_id("dds.sec.auth");
     HandshakeMessageToken token;
     message.message_data().push_back(token);
-    CacheChange_t* change = new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
-            + 4 /*encapsulation*/);
+    CacheChange_t* change =
+            new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
+                    + 4 /*encapsulation*/);
     CDRMessage_t aux_msg(0);
     aux_msg.wraps = true;
     aux_msg.buffer = change->serializedPayload.data;
@@ -1072,22 +1100,22 @@ TEST_F(SecurityTest, discovered_participant_process_message_fail_process_handsha
     aux_msg.msg_endian = LITTLEEND;
     change->serializedPayload.encapsulation = PL_CDR_LE;
     CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
     change->serializedPayload.length = aux_msg.length;
 
-    EXPECT_CALL(*auth_plugin_, process_handshake_rvr(_,_, Ref(handshake_handle_),_)).Times(1).
-        WillOnce(Return(ValidationResult_t::VALIDATION_FAILED));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_,_)).Times(1).
-        WillOnce(Return(true));
+    EXPECT_CALL(*auth_plugin_, process_handshake_rvr(_, _, Ref(handshake_handle_), _)).Times(1).
+    WillOnce(Return(ValidationResult_t::VALIDATION_FAILED));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_, _)).Times(1).
+    WillOnce(Return(true));
     EXPECT_CALL(*stateless_reader_->history_, remove_change_mock(change)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
     ParticipantAuthenticationInfo info;
     info.status = ParticipantAuthenticationInfo::UNAUTHORIZED_PARTICIPANT;
     info.guid = remote_participant_key;
@@ -1100,8 +1128,8 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_process_handshake
 {
     reply_process_ok();
 
-    EXPECT_CALL(*stateless_writer_->history_, remove_change(SequenceNumber_t{0,1})).Times(1).
-        WillOnce(Return(true));
+    EXPECT_CALL(*stateless_writer_->history_, remove_change(SequenceNumber_t{0, 1})).Times(1).
+    WillOnce(Return(true));
 
     GUID_t remote_participant_key(participant_data_.m_guid);
 
@@ -1113,8 +1141,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_process_handshake
     message.message_class_id("dds.sec.auth");
     HandshakeMessageToken token;
     message.message_data().push_back(token);
-    CacheChange_t* change = new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
-            + 4 /*encapsulation*/);
+    CacheChange_t* change =
+            new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
+                    + 4 /*encapsulation*/);
     CDRMessage_t aux_msg(0);
     aux_msg.wraps = true;
     aux_msg.buffer = change->serializedPayload.data;
@@ -1130,7 +1159,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_process_handshake
     aux_msg.msg_endian = LITTLEEND;
     change->serializedPayload.encapsulation = PL_CDR_LE;
     CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -1139,30 +1168,31 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_process_handshake
     MockSharedSecretHandle shared_secret_handle;
     MockParticipantCryptoHandle participant_crypto_handle;
 
-    EXPECT_CALL(*auth_plugin_, process_handshake_rvr(_,_, Ref(handshake_handle_),_)).Times(1).
-        WillOnce(Return(ValidationResult_t::VALIDATION_OK));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_,_)).Times(1).
-        WillOnce(Return(true));
+    EXPECT_CALL(*auth_plugin_, process_handshake_rvr(_, _, Ref(handshake_handle_), _)).Times(1).
+    WillOnce(Return(ValidationResult_t::VALIDATION_OK));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&remote_identity_handle_, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_handshake_handle(&handshake_handle_, _)).Times(1).
+    WillOnce(Return(true));
     EXPECT_CALL(*stateless_reader_->history_, remove_change_mock(change)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
     EXPECT_CALL(participant_, pdpsimple()).Times(1).WillOnce(Return(&pdpsimple_));
     EXPECT_CALL(pdpsimple_, notifyAboveRemoteEndpoints(_)).Times(1);
-    EXPECT_CALL(*auth_plugin_, get_shared_secret(Ref(handshake_handle_),_)).Times(1).
-        WillOnce(Return(&shared_secret_handle));
-    EXPECT_CALL(*auth_plugin_, return_sharedsecret_handle(&shared_secret_handle,_)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, register_matched_remote_participant(Ref(local_participant_crypto_handle_),
-                Ref(remote_identity_handle_),_,Ref(shared_secret_handle),_)).Times(1).
-        WillOnce(Return(&participant_crypto_handle));
+    EXPECT_CALL(*auth_plugin_, get_shared_secret(Ref(handshake_handle_), _)).Times(1).
+    WillOnce(Return(&shared_secret_handle));
+    EXPECT_CALL(*auth_plugin_, return_sharedsecret_handle(&shared_secret_handle, _)).Times(1).
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
+            register_matched_remote_participant(Ref(local_participant_crypto_handle_),
+            Ref(remote_identity_handle_), _, Ref(shared_secret_handle), _)).Times(1).
+    WillOnce(Return(&participant_crypto_handle));
     EXPECT_CALL(crypto_plugin_->cryptokeyexchange_, create_local_participant_crypto_tokens(_,
-                Ref(local_participant_crypto_handle_), Ref(participant_crypto_handle),_)).Times(1).
-           WillOnce(Return(true));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, unregister_participant(&participant_crypto_handle,_)).Times(1).
-        WillOnce(Return(true));
+            Ref(local_participant_crypto_handle_), Ref(participant_crypto_handle), _)).Times(1).
+    WillOnce(Return(true));
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, unregister_participant(&participant_crypto_handle, _)).Times(1).
+    WillOnce(Return(true));
 
     ParticipantAuthenticationInfo info;
     info.status = ParticipantAuthenticationInfo::AUTHORIZED_PARTICIPANT;
@@ -1172,7 +1202,9 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_process_handshake
     stateless_reader_->listener_->onNewCacheChangeAdded(stateless_reader_, change);
 }
 
-int main(int argc, char **argv)
+int main(
+        int argc,
+        char** argv)
 {
     testing::InitGoogleMock(&argc, argv);
     return RUN_ALL_TESTS();

--- a/test/unittest/rtps/security/SecurityHandshakeProcessTests.cpp
+++ b/test/unittest/rtps/security/SecurityHandshakeProcessTests.cpp
@@ -81,7 +81,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_not_remote_participa
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     aux_msg.msg_endian = BIGEND;
     change->serializedPayload.encapsulation = PL_CDR_BE;
     CDRMessage::addOctet(&aux_msg, CDR_BE);
@@ -126,7 +126,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_bad_message_class_id
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     aux_msg.msg_endian = BIGEND;
     change->serializedPayload.encapsulation = PL_CDR_BE;
     CDRMessage::addOctet(&aux_msg, CDR_BE);
@@ -186,7 +186,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_not_expecting_reques
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     aux_msg.msg_endian = BIGEND;
     change->serializedPayload.encapsulation = PL_CDR_BE;
     CDRMessage::addOctet(&aux_msg, CDR_BE);
@@ -238,7 +238,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_fail_begin_handshake
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     aux_msg.msg_endian = BIGEND;
     change->serializedPayload.encapsulation = PL_CDR_BE;
     CDRMessage::addOctet(&aux_msg, CDR_BE);
@@ -299,7 +299,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_begin_handshake_r
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     aux_msg.msg_endian = BIGEND;
     change->serializedPayload.encapsulation = PL_CDR_BE;
     CDRMessage::addOctet(&aux_msg, CDR_BE);
@@ -381,7 +381,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_new_change_fail)
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     aux_msg.msg_endian = BIGEND;
     change->serializedPayload.encapsulation = PL_CDR_BE;
     CDRMessage::addOctet(&aux_msg, CDR_BE);
@@ -446,7 +446,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_add_change_fail)
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     aux_msg.msg_endian = BIGEND;
     change->serializedPayload.encapsulation = PL_CDR_BE;
     CDRMessage::addOctet(&aux_msg, CDR_BE);
@@ -553,7 +553,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_pending_handshake_re
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     aux_msg.msg_endian = BIGEND;
     change->serializedPayload.encapsulation = PL_CDR_BE;
     CDRMessage::addOctet(&aux_msg, CDR_BE);
@@ -640,7 +640,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_fail_process_handsha
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     aux_msg.msg_endian = BIGEND;
     change->serializedPayload.encapsulation = PL_CDR_BE;
     CDRMessage::addOctet(&aux_msg, CDR_BE);
@@ -698,7 +698,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_process_handshake
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     aux_msg.msg_endian = BIGEND;
     change->serializedPayload.encapsulation = PL_CDR_BE;
     CDRMessage::addOctet(&aux_msg, CDR_BE);
@@ -774,7 +774,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_re
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     aux_msg.msg_endian = BIGEND;
     change->serializedPayload.encapsulation = PL_CDR_BE;
     CDRMessage::addOctet(&aux_msg, CDR_BE);
@@ -832,7 +832,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_re
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     aux_msg.msg_endian = BIGEND;
     change->serializedPayload.encapsulation = PL_CDR_BE;
     CDRMessage::addOctet(&aux_msg, CDR_BE);
@@ -914,7 +914,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_re
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     aux_msg.msg_endian = BIGEND;
     change->serializedPayload.encapsulation = PL_CDR_BE;
     CDRMessage::addOctet(&aux_msg, CDR_BE);
@@ -966,7 +966,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_bad_related_guid)
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     aux_msg.msg_endian = BIGEND;
     change->serializedPayload.encapsulation = PL_CDR_BE;
     CDRMessage::addOctet(&aux_msg, CDR_BE);
@@ -1015,7 +1015,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_bad_related_sequence
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     aux_msg.msg_endian = BIGEND;
     change->serializedPayload.encapsulation = PL_CDR_BE;
     CDRMessage::addOctet(&aux_msg, CDR_BE);
@@ -1064,7 +1064,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_fail_process_handsha
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     aux_msg.msg_endian = BIGEND;
     change->serializedPayload.encapsulation = PL_CDR_BE;
     CDRMessage::addOctet(&aux_msg, CDR_BE);
@@ -1122,7 +1122,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_process_handshake
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     aux_msg.msg_endian = BIGEND;
     change->serializedPayload.encapsulation = PL_CDR_BE;
     CDRMessage::addOctet(&aux_msg, CDR_BE);

--- a/test/unittest/rtps/security/SecurityTests.cpp
+++ b/test/unittest/rtps/security/SecurityTests.cpp
@@ -25,17 +25,19 @@ void SecurityTest::initialization_ok()
     volatile_reader_ = new ::testing::NiceMock<StatefulReader>();
 
     EXPECT_CALL(*auth_plugin_, validate_local_identity(_, _, _, _, _, _)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&local_identity_handle_), Return(ValidationResult_t::VALIDATION_OK)));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, register_local_participant(Ref(local_identity_handle_), _, _, _, _)).Times(1).
-        WillOnce(Return(&local_participant_crypto_handle_));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, unregister_participant(&local_participant_crypto_handle_, _)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(DoAll(SetArgPointee<0>(&local_identity_handle_), Return(ValidationResult_t::VALIDATION_OK)));
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
+            register_local_participant(Ref(local_identity_handle_), _, _, _, _)).Times(1).
+    WillOnce(Return(&local_participant_crypto_handle_));
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
+            unregister_participant(&local_participant_crypto_handle_, _)).Times(1).
+    WillOnce(Return(true));
     EXPECT_CALL(participant_, createWriter_mock(_, _, _, _, _, _)).Times(2).
-        WillOnce(DoAll(SetArgPointee<0>(stateless_writer_), Return(true))).
-        WillOnce(DoAll(SetArgPointee<0>(volatile_writer_), Return(true)));
+    WillOnce(DoAll(SetArgPointee<0>(stateless_writer_), Return(true))).
+    WillOnce(DoAll(SetArgPointee<0>(volatile_writer_), Return(true)));
     EXPECT_CALL(participant_, createReader_mock(_, _, _, _, _, _, _)).Times(2).
-        WillOnce(DoAll(SetArgPointee<0>(stateless_reader_), Return(true))).
-        WillOnce(DoAll(SetArgPointee<0>(volatile_reader_), Return(true)));
+    WillOnce(DoAll(SetArgPointee<0>(stateless_reader_), Return(true))).
+    WillOnce(DoAll(SetArgPointee<0>(volatile_reader_), Return(true)));
 
     ASSERT_TRUE(manager_.init(security_attributes_, participant_properties_, security_activated_));
     ASSERT_TRUE(!security_activated_ || manager_.create_entities());
@@ -52,17 +54,18 @@ void SecurityTest::initialization_auth_ok()
     stateless_reader_ = new ::testing::NiceMock<StatelessReader>();
 
     EXPECT_CALL(*auth_plugin_, validate_local_identity(_, _, _, _, _, _)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&local_identity_handle_), Return(ValidationResult_t::VALIDATION_OK)));
+    WillOnce(DoAll(SetArgPointee<0>(&local_identity_handle_), Return(ValidationResult_t::VALIDATION_OK)));
     EXPECT_CALL(participant_, createWriter_mock(_, _, _, _, _, _)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(stateless_writer_), Return(true)));
+    WillOnce(DoAll(SetArgPointee<0>(stateless_writer_), Return(true)));
     EXPECT_CALL(participant_, createReader_mock(_, _, _, _, _, _, _)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(stateless_reader_), Return(true)));
+    WillOnce(DoAll(SetArgPointee<0>(stateless_reader_), Return(true)));
 
     ASSERT_TRUE(manager_.init(security_attributes_, participant_properties_, security_activated_));
     ASSERT_TRUE(!security_activated_ || manager_.create_entities());
 }
 
-void SecurityTest::request_process_ok(CacheChange_t** request_message_change)
+void SecurityTest::request_process_ok(
+        CacheChange_t** request_message_change)
 {
     initialization_ok();
 
@@ -70,15 +73,16 @@ void SecurityTest::request_process_ok(CacheChange_t** request_message_change)
     CacheChange_t* change = new CacheChange_t(200);
 
     EXPECT_CALL(*auth_plugin_, validate_remote_identity_rvr(_, Ref(local_identity_handle_), _, _, _)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle_), Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_REQUEST)));
+    WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle_),
+            Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_REQUEST)));
     EXPECT_CALL(*auth_plugin_, begin_handshake_request(_, _, Ref(local_identity_handle_),
-        Ref(remote_identity_handle_), _, _)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&handshake_handle_),
+            Ref(remote_identity_handle_), _, _)).Times(1).
+    WillOnce(DoAll(SetArgPointee<0>(&handshake_handle_),
             SetArgPointee<1>(&handshake_message), Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
     EXPECT_CALL(*stateless_writer_, new_change(_, _, _)).Times(1).
-        WillOnce(Return(change));
+    WillOnce(Return(change));
     EXPECT_CALL(*stateless_writer_->history_, add_change_mock(change)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
     EXPECT_CALL(participant_, pdpsimple()).Times(1).WillOnce(Return(&pdpsimple_));
     EXPECT_CALL(pdpsimple_, get_participant_proxy_data_serialized(BIGEND)).Times(1);
 
@@ -86,17 +90,23 @@ void SecurityTest::request_process_ok(CacheChange_t** request_message_change)
     ASSERT_TRUE(manager_.discovered_participant(participant_data_));
 
     if (request_message_change != nullptr)
+    {
         *request_message_change = change;
+    }
     else
+    {
         delete change;
+    }
 }
 
-void SecurityTest::reply_process_ok(CacheChange_t** reply_message_change)
+void SecurityTest::reply_process_ok(
+        CacheChange_t** reply_message_change)
 {
     initialization_ok();
 
     EXPECT_CALL(*auth_plugin_, validate_remote_identity_rvr(_, Ref(local_identity_handle_), _, _, _)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle_), Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
+    WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle_),
+            Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
 
     fill_participant_key(participant_data_.m_guid);
     ASSERT_TRUE(manager_.discovered_participant(participant_data_));
@@ -108,8 +118,8 @@ void SecurityTest::reply_process_ok(CacheChange_t** reply_message_change)
     HandshakeMessageToken token;
     message.message_data().push_back(token);
     CacheChange_t* change =
-        new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
-            + 4 /*encapsulation*/); //TODO(Ricardo) Think casting
+            new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
+                    + 4 /*encapsulation*/); //TODO(Ricardo) Think casting
     CDRMessage_t aux_msg(0);
     aux_msg.wraps = true;
     aux_msg.buffer = change->serializedPayload.data;
@@ -125,7 +135,7 @@ void SecurityTest::reply_process_ok(CacheChange_t** reply_message_change)
     aux_msg.msg_endian = LITTLEEND;
     change->serializedPayload.encapsulation = PL_CDR_LE;
     CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -135,32 +145,37 @@ void SecurityTest::reply_process_ok(CacheChange_t** reply_message_change)
     CacheChange_t* change2 = new CacheChange_t(200);
 
     EXPECT_CALL(*auth_plugin_, begin_handshake_reply_rvr(_, _, _, Ref(remote_identity_handle_),
-        Ref(local_identity_handle_), _, _)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&handshake_handle_),
+            Ref(local_identity_handle_), _, _)).Times(1).
+    WillOnce(DoAll(SetArgPointee<0>(&handshake_handle_),
             SetArgPointee<1>(&handshake_message), Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
     EXPECT_CALL(*stateless_writer_, new_change(_, _, _)).Times(1).
-        WillOnce(Return(change2));
+    WillOnce(Return(change2));
     EXPECT_CALL(*stateless_writer_->history_, add_change_mock(change2)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
     EXPECT_CALL(*stateless_reader_->history_, remove_change_mock(change)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
     EXPECT_CALL(participant_, pdpsimple()).Times(1).WillOnce(Return(&pdpsimple_));
     EXPECT_CALL(pdpsimple_, get_participant_proxy_data_serialized(BIGEND)).Times(1);
 
     stateless_reader_->listener_->onNewCacheChangeAdded(stateless_reader_, change);
 
     if (reply_message_change != nullptr)
+    {
         *reply_message_change = change2;
+    }
     else
+    {
         delete change2;
+    }
 }
 
-void SecurityTest::final_message_process_ok(CacheChange_t** final_message_change)
+void SecurityTest::final_message_process_ok(
+        CacheChange_t** final_message_change)
 {
     request_process_ok();
 
-    EXPECT_CALL(*stateless_writer_->history_, remove_change(SequenceNumber_t{ 0,1 })).Times(1).
-        WillOnce(Return(true));
+    EXPECT_CALL(*stateless_writer_->history_, remove_change(SequenceNumber_t{ 0, 1 })).Times(1).
+    WillOnce(Return(true));
 
     GUID_t remote_participant_key(participant_data_.m_guid);
 
@@ -173,8 +188,8 @@ void SecurityTest::final_message_process_ok(CacheChange_t** final_message_change
     HandshakeMessageToken token;
     message.message_data().push_back(token);
     CacheChange_t* change =
-        new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
-            + 4 /*encapsulation*/);
+            new CacheChange_t(static_cast<uint32_t>(ParticipantGenericMessageHelper::serialized_size(message))
+                    + 4 /*encapsulation*/);
     CDRMessage_t aux_msg(0);
     aux_msg.wraps = true;
     aux_msg.buffer = change->serializedPayload.data;
@@ -190,7 +205,7 @@ void SecurityTest::final_message_process_ok(CacheChange_t** final_message_change
     aux_msg.msg_endian = LITTLEEND;
     change->serializedPayload.encapsulation = PL_CDR_LE;
     CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif
+#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -202,28 +217,29 @@ void SecurityTest::final_message_process_ok(CacheChange_t** final_message_change
     MockParticipantCryptoHandle participant_crypto_handle;
 
     EXPECT_CALL(*auth_plugin_, process_handshake_rvr(_, _, Ref(handshake_handle_), _)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&handshake_message), Return(ValidationResult_t::VALIDATION_OK_WITH_FINAL_MESSAGE)));
+    WillOnce(DoAll(SetArgPointee<0>(&handshake_message), Return(ValidationResult_t::VALIDATION_OK_WITH_FINAL_MESSAGE)));
     EXPECT_CALL(*stateless_writer_, new_change(_, _, _)).Times(1).
-        WillOnce(Return(change2));
+    WillOnce(Return(change2));
     EXPECT_CALL(*stateless_writer_->history_, add_change_mock(change2)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
     EXPECT_CALL(*stateless_reader_->history_, remove_change_mock(change)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
     //TODO(Ricardo) Verify parameter passed to notifyAboveRemoteEndpoints
     EXPECT_CALL(participant_, pdpsimple()).Times(1).WillOnce(Return(&pdpsimple_));
     EXPECT_CALL(pdpsimple_, notifyAboveRemoteEndpoints(_)).Times(1);
     EXPECT_CALL(*auth_plugin_, get_shared_secret(Ref(handshake_handle_), _)).Times(1).
-        WillOnce(Return(&shared_secret_handle));
+    WillOnce(Return(&shared_secret_handle));
     EXPECT_CALL(*auth_plugin_, return_sharedsecret_handle(&shared_secret_handle, _)).Times(1).
-        WillRepeatedly(Return(true));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, register_matched_remote_participant(Ref(local_participant_crypto_handle_),
-        Ref(remote_identity_handle_), _, Ref(shared_secret_handle), _)).Times(1).
-        WillOnce(Return(&participant_crypto_handle));
+    WillRepeatedly(Return(true));
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
+            register_matched_remote_participant(Ref(local_participant_crypto_handle_),
+            Ref(remote_identity_handle_), _, Ref(shared_secret_handle), _)).Times(1).
+    WillOnce(Return(&participant_crypto_handle));
     EXPECT_CALL(crypto_plugin_->cryptokeyexchange_, create_local_participant_crypto_tokens(_,
-        Ref(local_participant_crypto_handle_), Ref(participant_crypto_handle), _)).Times(1).
-        WillOnce(Return(true));
+            Ref(local_participant_crypto_handle_), Ref(participant_crypto_handle), _)).Times(1).
+    WillOnce(Return(true));
     EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, unregister_participant(&participant_crypto_handle, _)).Times(1).
-        WillOnce(Return(true));
+    WillOnce(Return(true));
 
     ParticipantAuthenticationInfo info;
     info.status = ParticipantAuthenticationInfo::AUTHORIZED_PARTICIPANT;
@@ -233,7 +249,11 @@ void SecurityTest::final_message_process_ok(CacheChange_t** final_message_change
     stateless_reader_->listener_->onNewCacheChangeAdded(stateless_reader_, change);
 
     if (final_message_change == nullptr)
+    {
         delete change2;
+    }
     else
+    {
         *final_message_change = change2;
+    }
 }

--- a/test/unittest/rtps/security/SecurityTests.cpp
+++ b/test/unittest/rtps/security/SecurityTests.cpp
@@ -127,15 +127,9 @@ void SecurityTest::reply_process_ok(
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-    aux_msg.msg_endian = BIGEND;
-    change->serializedPayload.encapsulation = PL_CDR_BE;
-    CDRMessage::addOctet(&aux_msg, CDR_BE);
-#else
-    aux_msg.msg_endian = LITTLEEND;
-    change->serializedPayload.encapsulation = PL_CDR_LE;
-    CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+    aux_msg.msg_endian = DEFAULT_ENDIAN;
+    change->serializedPayload.encapsulation = PL_DEFAULT_ENCAPSULATION;
+    CDRMessage::addOctet(&aux_msg, DEFAULT_ENCAPSULATION);
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));
@@ -197,15 +191,9 @@ void SecurityTest::final_message_process_ok(
     //
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if FASTDDS_IS_BIG_ENDIAN_TARGET
-    aux_msg.msg_endian = BIGEND;
-    change->serializedPayload.encapsulation = PL_CDR_BE;
-    CDRMessage::addOctet(&aux_msg, CDR_BE);
-#else
-    aux_msg.msg_endian = LITTLEEND;
-    change->serializedPayload.encapsulation = PL_CDR_LE;
-    CDRMessage::addOctet(&aux_msg, CDR_LE);
-#endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
+    aux_msg.msg_endian = DEFAULT_ENDIAN;
+    change->serializedPayload.encapsulation = PL_DEFAULT_ENCAPSULATION;
+    CDRMessage::addOctet(&aux_msg, DEFAULT_ENCAPSULATION);
     CDRMessage::addUInt16(&aux_msg, 0);
 
     ASSERT_TRUE(CDRMessage::addParticipantGenericMessage(&aux_msg, message));

--- a/test/unittest/rtps/security/SecurityTests.cpp
+++ b/test/unittest/rtps/security/SecurityTests.cpp
@@ -117,7 +117,7 @@ void SecurityTest::reply_process_ok(CacheChange_t** reply_message_change)
 
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     aux_msg.msg_endian = BIGEND;
     change->serializedPayload.encapsulation = PL_CDR_BE;
     CDRMessage::addOctet(&aux_msg, CDR_BE);
@@ -179,10 +179,10 @@ void SecurityTest::final_message_process_ok(CacheChange_t** final_message_change
     aux_msg.wraps = true;
     aux_msg.buffer = change->serializedPayload.data;
     aux_msg.max_size = change->serializedPayload.max_size;
-    // 
+    //
     // Serialize encapsulation
     CDRMessage::addOctet(&aux_msg, 0);
-#if __BIG_ENDIAN__
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
     aux_msg.msg_endian = BIGEND;
     change->serializedPayload.encapsulation = PL_CDR_BE;
     CDRMessage::addOctet(&aux_msg, CDR_BE);


### PR DESCRIPTION
This PR substitutes the definition we were making of `__BIG_ENDIAN__` for `FASTDDS_IS_BIG_ENDIAN_TARGET`. This way, we avoid using compiler reserved notation, and also defining a macro that some other libraries like boost do not expect to have defined when the machine is little endian. Furthermore, it updates the Fast CDR submodule to the [v1.0.15 release](https://github.com/eProsima/Fast-CDR/releases/tag/v1.0.15).

This PR solves #1001 