### PR TITLE
Delete continue in MessageReceiver::willAReaderAcceptMsgDirectedTo [9213]

### DIFF
--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -466,11 +466,6 @@ bool MessageReceiver::willAReaderAcceptMsgDirectedTo(
     {
         for (const auto& readers : associated_readers_)
         {
-            if (readers.second.empty())
-            {
-                continue;
-            }
-
             for (const auto& it : readers.second)
             {
                 if (it->m_acceptMessagesToUnknownReaders)


### PR DESCRIPTION
Delete continue statement in `MessageReceiver::willAReaderAcceptMsgDirectedTo` method. The condition previous the `continue` statement will never return true because the `MessageReceiver::removeEndpoint` ensures that after removing the last element of the vector, it is removed from the map `associated_readers_`.

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>