### PR TITLE
Add SYSTEM_TESTS cmake option [9210]

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,11 +17,13 @@ check_gtest()
 check_gmock()
 
 option(PERFORMANCE_TESTS "Activate the building and execution of performance tests" OFF)
+option(SYSTEM_TESTS "Activate the building and execution of system tests" OFF)
 option(PROFILING_TESTS "Activate the building and execution of profiling tests" OFF)
 option(EPROSIMA_BUILD_TESTS "Activate the building and execution unit tests and integral tests" OFF)
 
 if(EPROSIMA_BUILD AND NOT EPROSIMA_INSTALLER AND NOT EPROSIMA_INSTALLER_MINION)
     set(EPROSIMA_BUILD_TESTS ON)
+    set(SYSTEM_TESTS ON)
 endif()
 
 file(TO_CMAKE_PATH "${PROJECT_SOURCE_DIR}/valgrind.supp" MEMORYCHECK_SUPPRESSIONS_FILE_TMP)
@@ -62,6 +64,6 @@ endif()
 ###############################################################################
 # System tests
 ###############################################################################
-if(PERFORMANCE_TESTS)
+if(SYSTEM_TESTS)
     add_subdirectory(system/tools/fastdds)
 endif()


### PR DESCRIPTION
During the review of #1326, which is a backport of #1252, it was detected that the tests for the new CLI tool were dependant on `PERFORMANCE_TESTS` option, and a new `SYSTEM_TESTS` option was added.

This PR is a port of that part to master.

Signed-off-by: Miguel Company <MiguelCompany@eprosima.com>