### PR TITLE
Do not add alignment padding to payload [9219]

### DIFF
--- a/src/cpp/rtps/messages/submessages/DataMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/DataMsg.hpp
@@ -204,19 +204,6 @@ bool RTPSMessageCreator::addSubmessageData(
         added_no_error &= fastdds::dds::ParameterSerializer<Parameter_t>::add_parameter_sentinel(msg);
     }
 
-    // Align submessage to rtps alignment (4).
-    uint32_t align = (4 - msg->pos % 4) & 3;
-    for (uint32_t count = 0; count < align; ++count)
-    {
-        added_no_error &= CDRMessage::addOctet(msg, 0);
-    }
-
-    //if(align > 0)
-    {
-        //submsgElem.pos += align;
-        //submsgElem.length += align;
-    }
-
     uint32_t size32 = msg->pos - position_size_count_size;
     if (size32 <= std::numeric_limits<uint16_t>::max())
     {

--- a/src/cpp/rtps/messages/submessages/DataMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/DataMsg.hpp
@@ -70,7 +70,7 @@ bool RTPSMessageCreator::addSubmessageData(
 #else
     flags = flags | BIT(0);
     msg->msg_endian = LITTLEEND;
-#endif
+#endif // if __BIG_ENDIAN__
 
     if (change->kind == ALIVE && change->serializedPayload.length > 0 && change->serializedPayload.data != NULL)
     {
@@ -289,7 +289,7 @@ bool RTPSMessageCreator::addSubmessageDataFrag(
 #else
     flags = flags | BIT(0);
     msg->msg_endian = LITTLEEND;
-#endif
+#endif // if __BIG_ENDIAN__
 
     if (change->kind == ALIVE && change->serializedPayload.length > 0 && change->serializedPayload.data != NULL)
     {
@@ -413,7 +413,8 @@ bool RTPSMessageCreator::addSubmessageDataFrag(
                         change->serializedPayload.length);
     }
     else
-    {   // keyflag = 1 means that the serializedPayload SubmessageElement contains the serialized Key
+    {
+        // keyflag = 1 means that the serializedPayload SubmessageElement contains the serialized Key
         /*
             added_no_error &= CDRMessage::addOctet(&submsgElem, 0); //ENCAPSULATION
             if (submsgElem.msg_endian == BIGEND)
@@ -456,6 +457,6 @@ bool RTPSMessageCreator::addSubmessageDataFrag(
     return added_no_error;
 }
 
-}
-}
-}
+} // namespace rtps
+} // namespace fastrtps
+} // namespace eprosima


### PR DESCRIPTION
Removes the 4 byte alignment padding added to the payload, at it is not required by the RTPS specification.