### PR TITLE
[9180] Solving VS2015 errors and warnings on sources

### DIFF
--- a/src/cpp/rtps/transport/shared_mem/SharedMemSegment.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemSegment.hpp
@@ -109,14 +109,8 @@ public:
 
     ~SharedMemSegment()
     {
-        try
-        {
-            segment_.reset();
-        }
-        catch (const std::exception& e)
-        {
-            logWarning(RTPS_TRANSPORT_SHM, e.what());
-        }
+        // no need of exception handling cause never throws
+        segment_.reset();
     }
 
     void* get_address_from_offset(

--- a/src/cpp/utils/collections/node_size_helpers.hpp
+++ b/src/cpp/utils/collections/node_size_helpers.hpp
@@ -26,6 +26,14 @@
 #include <set>
 #include <unordered_map>
 
+// constexpr support for functions on VS 14.0 is defective
+// this macros will disable those scenarios that cannot be properly handled
+#if defined(_WIN32) && (_MSC_VER <= 1900)
+    #define CONSTEXPR_FUNC const
+#else
+    #define CONSTEXPR_FUNC constexpr
+#endif
+
 namespace eprosima {
 namespace utilities {
 namespace collections {
@@ -59,7 +67,7 @@ struct pool_size_helper
      * This is the value to be used as first parameter on the memory_pool constructor.
      */
     template<typename Pool>
-    static constexpr size_t min_pool_size(
+    static CONSTEXPR_FUNC size_t min_pool_size(
             size_t num_nodes)
     {
         return
@@ -72,7 +80,7 @@ struct pool_size_helper
 private:
 
     template<typename Pool>
-    static constexpr size_t min_size_per_node()
+    static CONSTEXPR_FUNC size_t min_size_per_node()
     {
         // Node size with minimum, plus debug space
         return

--- a/src/cpp/utils/collections/node_size_helpers.hpp
+++ b/src/cpp/utils/collections/node_size_helpers.hpp
@@ -32,7 +32,7 @@
     #define CONSTEXPR_FUNC const
 #else
     #define CONSTEXPR_FUNC constexpr
-#endif
+#endif // if defined(_WIN32) && (_MSC_VER <= 1900)
 
 namespace eprosima {
 namespace utilities {


### PR DESCRIPTION
Solving warnings and errors related with VS2015 v140 toolset faulty support to C++ 11 constexpr functions.