### PR TITLE
One way match of wildcards on permissions [9287]

### DIFF
--- a/include/fastrtps/utils/StringMatching.h
+++ b/include/fastrtps/utils/StringMatching.h
@@ -34,9 +34,14 @@ class StringMatching
         StringMatching();
         virtual ~StringMatching();
         /** Static method to match two strings.
+         * It checks if the input strings match. Any of the strings or both can be a pattern.
+         */
+        static bool matchString(const char* input1,const char* input2);
+
+        /** Static method to match a string to a pattern.
          * It checks the string specified by the input argument to see if it matches the pattern specified by the pattern argument.
          */
-        static bool matchString(const char* pattern,const char* input);
+        static bool matchPattern(const char* pattern,const char* input);
 };
 }
 } /* namespace rtps */

--- a/include/fastrtps/utils/StringMatching.h
+++ b/include/fastrtps/utils/StringMatching.h
@@ -21,30 +21,35 @@
 #define STRINGMATCHING_H_
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 /**
  * Class StringMatching used to match different strings against each other as defined by the POSIX fnmatch API (1003.2-1992
-section B.6).
- @ingroup UTILITIES_MODULE
+   section B.6).
+   @ingroup UTILITIES_MODULE
  */
 class StringMatching
 {
-    public:
-        StringMatching();
-        virtual ~StringMatching();
-        /** Static method to match two strings.
-         * It checks if the input strings match. Any of the strings or both can be a pattern.
-         */
-        static bool matchString(const char* input1,const char* input2);
+public:
 
-        /** Static method to match a string to a pattern.
-         * It checks the string specified by the input argument to see if it matches the pattern specified by the pattern argument.
-         */
-        static bool matchPattern(const char* pattern,const char* input);
+    StringMatching();
+    virtual ~StringMatching();
+    /** Static method to match two strings.
+     * It checks if the input strings match. Any of the strings or both can be a pattern.
+     */
+    static bool matchString(
+            const char* input1,
+            const char* input2);
+
+    /** Static method to match a string to a pattern.
+     * It checks the string specified by the input argument to see if it matches the pattern specified by the pattern argument.
+     */
+    static bool matchPattern(
+            const char* pattern,
+            const char* input);
 };
-}
+} // namespace rtps
 } /* namespace rtps */
 } /* namespace eprosima */
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif /* STRINGMATCHING_H_ */

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -120,9 +120,11 @@ ReturnCode_t DataWriterImpl::enable()
     {
         property.name("partitions");
         std::string partitions;
+        bool is_first_partition = true;
         for (auto partition : publisher_->get_qos().partition().names())
         {
-            partitions += partition + ";";
+            partitions += (is_first_partition ? "" : ";") + partition;
+            is_first_partition = false;
         }
         property.value(std::move(partitions));
         w_att.endpoint.properties.properties().push_back(std::move(property));

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -355,7 +355,7 @@ ReturnCode_t DataReaderImpl::set_qos(
         // Deadline
         if (qos_.deadline().period != c_TimeInfinite)
         {
-            deadline_duration_us_ = duration<double, std::ratio<1, 1000000> >(qos_.deadline().period.to_ns() * 1e-3);
+            deadline_duration_us_ = duration<double, std::ratio<1, 1000000>>(qos_.deadline().period.to_ns() * 1e-3);
             deadline_timer_->update_interval_millisec(qos_.deadline().period.to_ns() * 1e-6);
         }
         else
@@ -367,7 +367,7 @@ ReturnCode_t DataReaderImpl::set_qos(
         if (qos_.lifespan().duration != c_TimeInfinite)
         {
             lifespan_duration_us_ =
-                    std::chrono::duration<double, std::ratio<1, 1000000> >(qos_.lifespan().duration.to_ns() * 1e-3);
+                    std::chrono::duration<double, std::ratio<1, 1000000>>(qos_.lifespan().duration.to_ns() * 1e-3);
             lifespan_timer_->update_interval_millisec(qos_.lifespan().duration.to_ns() * 1e-6);
         }
         else

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -145,9 +145,11 @@ ReturnCode_t DataReaderImpl::enable()
     {
         property.name("partitions");
         std::string partitions;
+        bool is_first_partition = true;
         for (auto partition : subscriber_->get_qos().partition().names())
         {
-            partitions += partition + ";";
+            partitions += (is_first_partition ? "" : ";") + partition;
+            is_first_partition = false;
         }
         property.value(std::move(partitions));
         att.endpoint.properties.properties().push_back(std::move(property));

--- a/src/cpp/fastrtps_deprecated/participant/ParticipantImpl.cpp
+++ b/src/cpp/fastrtps_deprecated/participant/ParticipantImpl.cpp
@@ -211,9 +211,11 @@ Publisher* ParticipantImpl::createPublisher(
     {
         property.name("partitions");
         std::string partitions;
+        bool is_first_partition = true;
         for (auto partition : att.qos.m_partition.names())
         {
-            partitions += partition + ";";
+            partitions += (is_first_partition ? "" : ";") + partition;
+            is_first_partition = false;
         }
         property.value(std::move(partitions));
         watt.endpoint.properties.properties().push_back(std::move(property));
@@ -343,9 +345,11 @@ Subscriber* ParticipantImpl::createSubscriber(
     {
         property.name("partitions");
         std::string partitions;
+        bool is_first_partition = true;
         for (auto partition : att.qos.m_partition.names())
         {
-            partitions += partition + ";";
+            partitions += (is_first_partition ? "" : ";") + partition;
+            is_first_partition = false;
         }
         property.value(std::move(partitions));
         ratt.endpoint.properties.properties().push_back(std::move(property));

--- a/src/cpp/security/accesscontrol/Permissions.cpp
+++ b/src/cpp/security/accesscontrol/Permissions.cpp
@@ -114,7 +114,7 @@ static bool is_topic_in_criterias(
     {
         for (auto topic : (*criteria_it).topics)
         {
-            if (StringMatching::matchString(topic.c_str(), topic_name))
+            if (StringMatching::matchPattern(topic.c_str(), topic_name))
             {
                 returned_value = true;
                 break;
@@ -136,7 +136,7 @@ static bool is_partition_in_criterias(
     {
         for (auto part : (*criteria_it).partitions)
         {
-            if (StringMatching::matchString(partition.c_str(), part.c_str()))
+            if (StringMatching::matchPattern(part.c_str(), partition.c_str()))
             {
                 returned_value = true;
                 break;

--- a/src/cpp/security/accesscontrol/Permissions.cpp
+++ b/src/cpp/security/accesscontrol/Permissions.cpp
@@ -1313,7 +1313,8 @@ bool Permissions::check_remote_datawriter(
 
     const EndpointSecurityAttributes* attributes = nullptr;
 
-    if ((attributes = is_topic_in_sec_attributes(publication_data.topicName().c_str(), rah->governance_topic_rules_))
+    if ((attributes =
+            is_topic_in_sec_attributes(publication_data.topicName().c_str(), rah->governance_topic_rules_))
             != nullptr)
     {
         if (!attributes->is_write_protected)
@@ -1382,7 +1383,8 @@ bool Permissions::check_remote_datareader(
 
     const EndpointSecurityAttributes* attributes = nullptr;
 
-    if ((attributes = is_topic_in_sec_attributes(subscription_data.topicName().c_str(), rah->governance_topic_rules_))
+    if ((attributes =
+            is_topic_in_sec_attributes(subscription_data.topicName().c_str(), rah->governance_topic_rules_))
             != nullptr)
     {
         if (!attributes->is_read_protected)

--- a/src/cpp/utils/StringMatching.cpp
+++ b/src/cpp/utils/StringMatching.cpp
@@ -26,101 +26,130 @@
 #include "Shlwapi.h"
 #else
 #include <fnmatch.h>
-#endif
+#endif // if defined(__cplusplus_winrt)
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
-StringMatching::StringMatching() {
-	// TODO Auto-generated constructor stub
+StringMatching::StringMatching()
+{
+    // TODO Auto-generated constructor stub
 
 }
 
-StringMatching::~StringMatching() {
-	// TODO Auto-generated destructor stub
+StringMatching::~StringMatching()
+{
+    // TODO Auto-generated destructor stub
 }
 
 #if defined(__cplusplus_winrt)
-void replace_all(std::string & subject, const std::string & search, const std::string & replace) {
-	size_t pos = 0;
-	while ((pos = subject.find(search, pos)) != std::string::npos) {
-		subject.replace(pos, search.length(), replace);
-		pos += replace.length();
-	}
+void replace_all(
+        std::string& subject,
+        const std::string& search,
+        const std::string& replace)
+{
+    size_t pos = 0;
+    while ((pos = subject.find(search, pos)) != std::string::npos)
+    {
+        subject.replace(pos, search.length(), replace);
+        pos += replace.length();
+    }
 }
 
-bool StringMatching::matchPattern(const char* pattern, const char* str)
+bool StringMatching::matchPattern(
+        const char* pattern,
+        const char* str)
 {
-	std::string path(pattern);
-	std::string spec(str);
+    std::string path(pattern);
+    std::string spec(str);
 
-	replace_all(pattern, "*", ".*");
-	replace_all(pattern, "?", ".");
+    replace_all(pattern, "*", ".*");
+    replace_all(pattern, "?", ".");
 
-	std::regex path_regex(path);
-	std::smatch spec_match;
-	if (std::regex_match(spec, spec_match, path_regex))
-	{
-		return true;
-	}
+    std::regex path_regex(path);
+    std::smatch spec_match;
+    if (std::regex_match(spec, spec_match, path_regex))
+    {
+        return true;
+    }
 
-	return false;
+    return false;
 }
 
-bool StringMatching::matchString(const char* str1, const char* str2)
+bool StringMatching::matchString(
+        const char* str1,
+        const char* str2)
 {
-	if (StringMatching::matchPattern(str1, str2))
-	{
-		return true;
-	}
+    if (StringMatching::matchPattern(str1, str2))
+    {
+        return true;
+    }
 
-	if (StringMatching::matchPattern(str2, str1))
-	{
-		return true;
-	}
+    if (StringMatching::matchPattern(str2, str1))
+    {
+        return true;
+    }
 
-	return false;
+    return false;
 }
 
 #elif defined(_WIN32)
-bool StringMatching::matchPattern(const char* pattern, const char* str)
+bool StringMatching::matchPattern(
+        const char* pattern,
+        const char* str)
 {
-	 if(PathMatchSpec(str, pattern))
-		 return true;
-	 return false;
+    if (PathMatchSpec(str, pattern))
+    {
+        return true;
+    }
+    return false;
 }
 
-bool StringMatching::matchString(const char* str1, const char* str2)
+bool StringMatching::matchString(
+        const char* str1,
+        const char* str2)
 {
-	 if(PathMatchSpec(str1,str2))
-		 return true;
-	 if(PathMatchSpec(str2,str1))
-	 	 return true;
-	 return false;
+    if (PathMatchSpec(str1, str2))
+    {
+        return true;
+    }
+    if (PathMatchSpec(str2, str1))
+    {
+        return true;
+    }
+    return false;
 }
 
 #else
-bool StringMatching::matchPattern(const char* pattern, const char* str)
+bool StringMatching::matchPattern(
+        const char* pattern,
+        const char* str)
 {
-	if(fnmatch(pattern, str, FNM_NOESCAPE) == 0)
-	{
-		return true;
-	}
-	return false;
+    if (fnmatch(pattern, str, FNM_NOESCAPE) == 0)
+    {
+        return true;
+    }
+    return false;
 }
 
-bool StringMatching::matchString(const char* str1, const char* str2)
+bool StringMatching::matchString(
+        const char* str1,
+        const char* str2)
 {
-	if(fnmatch(str1,str2,FNM_NOESCAPE)==0)
-		return true;
-	if(fnmatch(str2,str1,FNM_NOESCAPE)==0)
-		return true;
-	return false;
+    if (fnmatch(str1, str2, FNM_NOESCAPE) == 0)
+    {
+        return true;
+    }
+    if (fnmatch(str2, str1, FNM_NOESCAPE) == 0)
+    {
+        return true;
+    }
+    return false;
 }
 
-#endif
+#endif // if defined(__cplusplus_winrt)
 
-}
+} // namespace rtps
 } /* namespace rtps */
 } /* namespace eprosima */

--- a/src/cpp/utils/StringMatching.cpp
+++ b/src/cpp/utils/StringMatching.cpp
@@ -50,31 +50,32 @@ void replace_all(std::string & subject, const std::string & search, const std::s
 	}
 }
 
-bool StringMatching::matchString(const char* str1, const char* str2)
+bool StringMatching::matchPattern(const char* pattern, const char* str)
 {
-	std::string path(str1);
-	std::string spec(str2);
+	std::string path(pattern);
+	std::string spec(str);
 
-	std::string base_path(path);
-	std::string base_spec(spec);
+	replace_all(pattern, "*", ".*");
+	replace_all(pattern, "?", ".");
 
-	replace_all(base_spec, "*", ".*");
-	replace_all(base_spec, "?", ".");
-
-	std::regex base_spec_regex(base_spec);
-	std::smatch base_spec_match;
-	if (std::regex_match(path, base_spec_match, base_spec_regex))
+	std::regex path_regex(path);
+	std::smatch spec_match;
+	if (std::regex_match(spec, spec_match, path_regex))
 	{
 		return true;
 	}
 
-	replace_all(base_path, "*", ".*");
-	replace_all(base_path, "?", ".");
+	return false;
+}
 
-	std::regex base_path_regex(base_path);
-	std::smatch base_path_match;
+bool StringMatching::matchString(const char* str1, const char* str2)
+{
+	if (StringMatching::matchPattern(str1, str2))
+	{
+		return true;
+	}
 
-	if (std::regex_match(spec, base_path_match, base_path_regex))
+	if (StringMatching::matchPattern(str2, str1))
 	{
 		return true;
 	}
@@ -83,6 +84,13 @@ bool StringMatching::matchString(const char* str1, const char* str2)
 }
 
 #elif defined(_WIN32)
+bool StringMatching::matchPattern(const char* pattern, const char* str)
+{
+	 if(PathMatchSpec(str, pattern))
+		 return true;
+	 return false;
+}
+
 bool StringMatching::matchString(const char* str1, const char* str2)
 {
 	 if(PathMatchSpec(str1,str2))
@@ -93,6 +101,15 @@ bool StringMatching::matchString(const char* str1, const char* str2)
 }
 
 #else
+bool StringMatching::matchPattern(const char* pattern, const char* str)
+{
+	if(fnmatch(pattern, str, FNM_NOESCAPE) == 0)
+	{
+		return true;
+	}
+	return false;
+}
+
 bool StringMatching::matchString(const char* str1, const char* str2)
 {
 	if(fnmatch(str1,str2,FNM_NOESCAPE)==0)

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -2610,7 +2610,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
                 "file://" + std::string(certs_path) + "/permissions_helloworld.smime"));
 
         reader.setManualTopicName("*").
-        property_policy(sub_property_policy).init();
+                property_policy(sub_property_policy).init();
         ASSERT_FALSE(reader.isInitialized());
 
         pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
@@ -2634,7 +2634,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
                 "file://" + std::string(certs_path) + "/permissions_helloworld.smime"));
 
         writer.setManualTopicName("*").
-        property_policy(pub_property_policy).init();
+                property_policy(pub_property_policy).init();
 
         ASSERT_FALSE(writer.isInitialized());
     }
@@ -2668,8 +2668,8 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
                 "file://" + std::string(certs_path) + "/permissions_helloworld.smime"));
 
         reader.history_depth(10).
-        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-        property_policy(sub_property_policy).init();
+                reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+                property_policy(sub_property_policy).init();
 
         ASSERT_TRUE(reader.isInitialized());
 
@@ -2694,7 +2694,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
                 "file://" + std::string(certs_path) + "/permissions_helloworld.smime"));
 
         writer.history_depth(10).
-        property_policy(pub_property_policy).init();
+                property_policy(pub_property_policy).init();
 
         ASSERT_TRUE(writer.isInitialized());
 
@@ -2751,7 +2751,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
                 "file://" + std::string(certs_path) + "/permissions_helloworld_partitions.smime"));
 
         reader.partition("*").
-        property_policy(sub_property_policy).init();
+                property_policy(sub_property_policy).init();
         ASSERT_FALSE(reader.isInitialized());
 
         pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
@@ -2775,7 +2775,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
                 "file://" + std::string(certs_path) + "/permissions_helloworld_partitions.smime"));
 
         writer.partition("*").
-        property_policy(pub_property_policy).init();
+                property_policy(pub_property_policy).init();
 
         ASSERT_FALSE(writer.isInitialized());
     }
@@ -2809,9 +2809,9 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
                 "file://" + std::string(certs_path) + "/permissions_helloworld_partitions.smime"));
 
         reader.history_depth(10).
-        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-        property_policy(sub_property_policy).
-        partition("Partition1").init();
+                reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+                property_policy(sub_property_policy).
+                partition("Partition1").init();
 
         ASSERT_TRUE(reader.isInitialized());
 
@@ -2836,8 +2836,8 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
                 "file://" + std::string(certs_path) + "/permissions_helloworld_partitions.smime"));
 
         writer.history_depth(10).
-        property_policy(pub_property_policy).
-        partition("Partition*").init();
+                property_policy(pub_property_policy).
+                partition("Partition*").init();
 
         ASSERT_TRUE(writer.isInitialized());
 

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -2601,15 +2601,16 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
                 "builtin.AES-GCM-GMAC"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        sub_property_policy.properties().emplace_back(Property(
+                    "dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                    "file://" + std::string(certs_path) + "/maincacert.pem"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
                 "file://" + std::string(certs_path) + "/" + governance_file));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
                 "file://" + std::string(certs_path) + "/permissions_helloworld.smime"));
 
         reader.setManualTopicName("*").
-                property_policy(sub_property_policy).init();
+        property_policy(sub_property_policy).init();
         ASSERT_FALSE(reader.isInitialized());
 
         pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
@@ -2624,15 +2625,16 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
                 "builtin.AES-GCM-GMAC"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        pub_property_policy.properties().emplace_back(Property(
+                    "dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                    "file://" + std::string(certs_path) + "/maincacert.pem"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
                 "file://" + std::string(certs_path) + "/" + governance_file));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
                 "file://" + std::string(certs_path) + "/permissions_helloworld.smime"));
 
         writer.setManualTopicName("*").
-                property_policy(pub_property_policy).init();
+        property_policy(pub_property_policy).init();
 
         ASSERT_FALSE(writer.isInitialized());
     }
@@ -2657,16 +2659,17 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
                 "builtin.AES-GCM-GMAC"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        sub_property_policy.properties().emplace_back(Property(
+                    "dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                    "file://" + std::string(certs_path) + "/maincacert.pem"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
                 "file://" + std::string(certs_path) + "/" + governance_file));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
                 "file://" + std::string(certs_path) + "/permissions_helloworld.smime"));
 
         reader.history_depth(10).
-                reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-                property_policy(sub_property_policy).init();
+        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+        property_policy(sub_property_policy).init();
 
         ASSERT_TRUE(reader.isInitialized());
 
@@ -2682,15 +2685,16 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
                 "builtin.AES-GCM-GMAC"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        pub_property_policy.properties().emplace_back(Property(
+                    "dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                    "file://" + std::string(certs_path) + "/maincacert.pem"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
                 "file://" + std::string(certs_path) + "/" + governance_file));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
                 "file://" + std::string(certs_path) + "/permissions_helloworld.smime"));
 
         writer.history_depth(10).
-                property_policy(pub_property_policy).init();
+        property_policy(pub_property_policy).init();
 
         ASSERT_TRUE(writer.isInitialized());
 
@@ -2738,15 +2742,16 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
                 "builtin.AES-GCM-GMAC"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        sub_property_policy.properties().emplace_back(Property(
+                    "dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                    "file://" + std::string(certs_path) + "/maincacert.pem"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
                 "file://" + std::string(certs_path) + "/" + governance_file));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
                 "file://" + std::string(certs_path) + "/permissions_helloworld_partitions.smime"));
 
         reader.partition("*").
-                property_policy(sub_property_policy).init();
+        property_policy(sub_property_policy).init();
         ASSERT_FALSE(reader.isInitialized());
 
         pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
@@ -2761,15 +2766,16 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
                 "builtin.AES-GCM-GMAC"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        pub_property_policy.properties().emplace_back(Property(
+                    "dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                    "file://" + std::string(certs_path) + "/maincacert.pem"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
                 "file://" + std::string(certs_path) + "/" + governance_file));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
                 "file://" + std::string(certs_path) + "/permissions_helloworld_partitions.smime"));
 
         writer.partition("*").
-                property_policy(pub_property_policy).init();
+        property_policy(pub_property_policy).init();
 
         ASSERT_FALSE(writer.isInitialized());
     }
@@ -2794,17 +2800,18 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
                 "builtin.AES-GCM-GMAC"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        sub_property_policy.properties().emplace_back(Property(
+                    "dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                    "file://" + std::string(certs_path) + "/maincacert.pem"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
                 "file://" + std::string(certs_path) + "/" + governance_file));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
                 "file://" + std::string(certs_path) + "/permissions_helloworld_partitions.smime"));
 
         reader.history_depth(10).
-                reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-                property_policy(sub_property_policy).
-                partition("Partition1").init();
+        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+        property_policy(sub_property_policy).
+        partition("Partition1").init();
 
         ASSERT_TRUE(reader.isInitialized());
 
@@ -2820,16 +2827,17 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
                 "builtin.AES-GCM-GMAC"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        pub_property_policy.properties().emplace_back(Property(
+                    "dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                    "file://" + std::string(certs_path) + "/maincacert.pem"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
                 "file://" + std::string(certs_path) + "/" + governance_file));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
                 "file://" + std::string(certs_path) + "/permissions_helloworld_partitions.smime"));
 
         writer.history_depth(10).
-                property_policy(pub_property_policy).
-                partition("Partition*").init();
+        property_policy(pub_property_policy).
+        partition("Partition*").init();
 
         ASSERT_TRUE(writer.isInitialized());
 

--- a/test/certs/permissions_helloworld_partitions.smime
+++ b/test/certs/permissions_helloworld_partitions.smime
@@ -1,0 +1,94 @@
+MIME-Version: 1.0
+Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----7B3FFFCFAAA62A781C7D925733570C84"
+
+This is an S/MIME signed message
+
+------7B3FFFCFAAA62A781C7D925733570C84
+Content-Type: text/plain
+
+<?xml version="1.0" encoding="utf-8"?>
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.omg.org/spec/DDS-Security/20170801/omg_shared_ca_permissions.xsd">
+    <permissions>
+        <grant name="PublisherPermissions">
+            <subject_name>emailAddress=mainpub@eprosima.com, CN=Main Publisher, OU=eProsima, O=eProsima, ST=MA, C=ES</subject_name>
+            <validity>
+                <not_before>2013-06-01T13:00:00</not_before>
+                <not_after>2038-06-01T13:00:00</not_after>
+            </validity>
+            <allow_rule>
+                <domains>
+                    <id_range>
+                        <min>0</min>
+                        <max>230</max>
+                    </id_range>
+                </domains>
+                <publish>
+                    <topics>
+                        <topic>HelloWorldTopic_*</topic>
+                    </topics>
+                    <partitions>
+                        <partition>Partition*</partition>
+                    </partitions>
+                </publish>
+            </allow_rule>
+            <default>DENY</default>
+        </grant>
+        <grant name="SubscriberPermissions">
+            <subject_name> emailAddress=mainsub@eprosima.com, CN=Main Subscriber, OU=eProsima, O=eProsima, ST=MA, C=ES</subject_name>
+            <validity>
+                <not_before>2013-06-01T13:00:00</not_before>
+                <not_after>2038-06-01T13:00:00</not_after>
+            </validity>
+            <allow_rule>
+                <domains>
+                    <id_range>
+                        <min>0</min>
+                        <max>230</max>
+                    </id_range>
+                </domains>
+                <subscribe>
+                    <topics>
+                        <topic>HelloWorldTopic_*</topic>
+                    </topics>
+                    <partitions>
+                        <partition>Partition*</partition>
+                    </partitions>
+                </subscribe>
+            </allow_rule>
+            <default>DENY</default>
+        </grant>
+    </permissions>
+</dds>
+
+------7B3FFFCFAAA62A781C7D925733570C84
+Content-Type: application/x-pkcs7-signature; name="smime.p7s"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="smime.p7s"
+
+MIIEegYJKoZIhvcNAQcCoIIEazCCBGcCAQExDzANBglghkgBZQMEAgEFADALBgkq
+hkiG9w0BBwGgggJAMIICPDCCAeOgAwIBAgIJALZwpgo2sxthMAoGCCqGSM49BAMC
+MIGaMQswCQYDVQQGEwJFUzELMAkGA1UECAwCTUExFDASBgNVBAcMC1RyZXMgQ2Fu
+dG9zMREwDwYDVQQKDAhlUHJvc2ltYTERMA8GA1UECwwIZVByb3NpbWExHjAcBgNV
+BAMMFWVQcm9zaW1hIE1haW4gVGVzdCBDQTEiMCAGCSqGSIb3DQEJARYTbWFpbmNh
+QGVwcm9zaW1hLmNvbTAeFw0xNzA5MDYwOTAzMDNaFw0yNzA5MDQwOTAzMDNaMIGa
+MQswCQYDVQQGEwJFUzELMAkGA1UECAwCTUExFDASBgNVBAcMC1RyZXMgQ2FudG9z
+MREwDwYDVQQKDAhlUHJvc2ltYTERMA8GA1UECwwIZVByb3NpbWExHjAcBgNVBAMM
+FWVQcm9zaW1hIE1haW4gVGVzdCBDQTEiMCAGCSqGSIb3DQEJARYTbWFpbmNhQGVw
+cm9zaW1hLmNvbTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABGLlhB3WQ8l1fpUE
+3DfOoulA/de38Zfj7hmpKtOnxiH2q6RJbwhxvJeA7R7mkmAKaJKmzx695BjyiXVS
+7bE7vgejEDAOMAwGA1UdEwQFMAMBAf8wCgYIKoZIzj0EAwIDRwAwRAIgVTY1BEvT
+4pw3GyBMzaUqmp69wi0kBkyOgq04OhyJ13UCICR125vvt0fUhXsXaxOAx28E4Ac9
+SVxpI+3UYs2kV5n0MYIB/jCCAfoCAQEwgagwgZoxCzAJBgNVBAYTAkVTMQswCQYD
+VQQIDAJNQTEUMBIGA1UEBwwLVHJlcyBDYW50b3MxETAPBgNVBAoMCGVQcm9zaW1h
+MREwDwYDVQQLDAhlUHJvc2ltYTEeMBwGA1UEAwwVZVByb3NpbWEgTWFpbiBUZXN0
+IENBMSIwIAYJKoZIhvcNAQkBFhNtYWluY2FAZXByb3NpbWEuY29tAgkAtnCmCjaz
+G2EwDQYJYIZIAWUDBAIBBQCggeQwGAYJKoZIhvcNAQkDMQsGCSqGSIb3DQEHATAc
+BgkqhkiG9w0BCQUxDxcNMjAwOTA5MDcyNjMxWjAvBgkqhkiG9w0BCQQxIgQg+YtI
+HXLV1D5CIG0+9WhefHrcERTDu1RvHPvxBpzhdXEweQYJKoZIhvcNAQkPMWwwajAL
+BglghkgBZQMEASowCwYJYIZIAWUDBAEWMAsGCWCGSAFlAwQBAjAKBggqhkiG9w0D
+BzAOBggqhkiG9w0DAgICAIAwDQYIKoZIhvcNAwICAUAwBwYFKw4DAgcwDQYIKoZI
+hvcNAwICASgwCgYIKoZIzj0EAwIESDBGAiEA/nffPxxEjdk1vr1fLJYxxn33api8
+jTjWX1isCtv6JBMCIQCuy2x9HC8UDK6OEoDFOHzFN0R1Xe4V2BeESy5jZtxFxg==
+
+------7B3FFFCFAAA62A781C7D925733570C84--
+

--- a/test/certs/permissions_helloworld_partitions.xml
+++ b/test/certs/permissions_helloworld_partitions.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.omg.org/spec/DDS-Security/20170801/omg_shared_ca_permissions.xsd">
+    <permissions>
+        <grant name="PublisherPermissions">
+            <subject_name>emailAddress=mainpub@eprosima.com, CN=Main Publisher, OU=eProsima, O=eProsima, ST=MA, C=ES</subject_name>
+            <validity>
+                <not_before>2013-06-01T13:00:00</not_before>
+                <not_after>2038-06-01T13:00:00</not_after>
+            </validity>
+            <allow_rule>
+                <domains>
+                    <id_range>
+                        <min>0</min>
+                        <max>230</max>
+                    </id_range>
+                </domains>
+                <publish>
+                    <topics>
+                        <topic>HelloWorldTopic_*</topic>
+                    </topics>
+                    <partitions>
+                        <partition>Partition*</partition>
+                    </partitions>
+                </publish>
+            </allow_rule>
+            <default>DENY</default>
+        </grant>
+        <grant name="SubscriberPermissions">
+            <subject_name> emailAddress=mainsub@eprosima.com, CN=Main Subscriber, OU=eProsima, O=eProsima, ST=MA, C=ES</subject_name>
+            <validity>
+                <not_before>2013-06-01T13:00:00</not_before>
+                <not_after>2038-06-01T13:00:00</not_after>
+            </validity>
+            <allow_rule>
+                <domains>
+                    <id_range>
+                        <min>0</min>
+                        <max>230</max>
+                    </id_range>
+                </domains>
+                <subscribe>
+                    <topics>
+                        <topic>HelloWorldTopic_*</topic>
+                    </topics>
+                    <partitions>
+                        <partition>Partition*</partition>
+                    </partitions>
+                </subscribe>
+            </allow_rule>
+            <default>DENY</default>
+        </grant>
+    </permissions>
+</dds>


### PR DESCRIPTION
`*` and `?` on topic and partition names should not be considered wildcards when checking against security permissions. Otherwise, topic and partition `*` would always match any permissions rule.

Solves #441 