### PR TITLE
Handle missing PID_PARTICIPANT_GUID for readers and writers [9296]

### DIFF
--- a/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
@@ -788,13 +788,6 @@ bool ReaderProxyData::readFromCDRMessage(
                         m_guid = p.guid;
                         memcpy(m_key.value, p.guid.guidPrefix.value, 12);
                         memcpy(m_key.value + 12, p.guid.entityId.value, 4);
-
-                        if (!m_RTPSParticipantKey.isDefined())
-                        {
-                            p.guid.entityId = c_EntityId_RTPSParticipant;
-                            memcpy(m_RTPSParticipantKey.value, p.guid.guidPrefix.value, 12);
-                            memcpy(m_RTPSParticipantKey.value + 12, p.guid.entityId.value, 4);
-                        }
                         break;
                     }
                     case fastdds::dds::PID_UNICAST_LOCATOR:
@@ -969,6 +962,18 @@ bool ReaderProxyData::readFromCDRMessage(
             else if (m_guid.entityId.value[3] == 0x07)
             {
                 m_topicKind = WITH_KEY;
+            }
+
+            /* Some vendors (i.e. CycloneDDS) do not follow DDSI-RTPS and omit PID_PARTICIPANT_GUID
+             * In that case we use a default value relying on the prefix from m_guid and the default
+             * participant entity id
+             */
+            if (!m_RTPSParticipantKey.isDefined())
+            {
+                GUID_t tmp_guid = m_guid;
+                tmp_guid.entityId = c_EntityId_RTPSParticipant;
+                memcpy(m_RTPSParticipantKey.value, tmp_guid.guidPrefix.value, 12);
+                memcpy(m_RTPSParticipantKey.value + 12, tmp_guid.entityId.value, 4);
             }
 
             return true;

--- a/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
@@ -936,6 +936,7 @@ bool ReaderProxyData::readFromCDRMessage(
                         break;
                     }
 #endif // if HAVE_SECURITY
+
                     case fastdds::dds::PID_PROPERTY_LIST:
                     {
                         if (!fastdds::dds::ParameterSerializer<ParameterPropertyList_t>::read_from_cdr_message(

--- a/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
@@ -763,19 +763,6 @@ bool ReaderProxyData::readFromCDRMessage(
                         m_typeName = p.getName();
                         break;
                     }
-                    case fastdds::dds::PID_PARTICIPANT_GUID:
-                    {
-                        ParameterGuid_t p(pid, plength);
-                        if (!fastdds::dds::ParameterSerializer<ParameterGuid_t>::read_from_cdr_message(p, msg,
-                                plength))
-                        {
-                            return false;
-                        }
-
-                        memcpy(m_RTPSParticipantKey.value, p.guid.guidPrefix.value, 12);
-                        memcpy(m_RTPSParticipantKey.value + 12, p.guid.entityId.value, 4);
-                        break;
-                    }
                     case fastdds::dds::PID_ENDPOINT_GUID:
                     {
                         ParameterGuid_t p(pid, plength);
@@ -788,6 +775,10 @@ bool ReaderProxyData::readFromCDRMessage(
                         m_guid = p.guid;
                         memcpy(m_key.value, p.guid.guidPrefix.value, 12);
                         memcpy(m_key.value + 12, p.guid.entityId.value, 4);
+
+                        p.guid.entityId = c_EntityId_RTPSParticipant;
+                        memcpy(m_RTPSParticipantKey.value, p.guid.guidPrefix.value, 12);
+                        memcpy(m_RTPSParticipantKey.value + 12, p.guid.entityId.value, 4);
                         break;
                     }
                     case fastdds::dds::PID_UNICAST_LOCATOR:

--- a/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
@@ -763,6 +763,19 @@ bool ReaderProxyData::readFromCDRMessage(
                         m_typeName = p.getName();
                         break;
                     }
+                    case fastdds::dds::PID_PARTICIPANT_GUID:
+                    {
+                        ParameterGuid_t p(pid, plength);
+                        if (!fastdds::dds::ParameterSerializer<ParameterGuid_t>::read_from_cdr_message(p, msg,
+                                plength))
+                        {
+                            return false;
+                        }
+
+                        memcpy(m_RTPSParticipantKey.value, p.guid.guidPrefix.value, 12);
+                        memcpy(m_RTPSParticipantKey.value + 12, p.guid.entityId.value, 4);
+                        break;
+                    }
                     case fastdds::dds::PID_ENDPOINT_GUID:
                     {
                         ParameterGuid_t p(pid, plength);
@@ -776,9 +789,12 @@ bool ReaderProxyData::readFromCDRMessage(
                         memcpy(m_key.value, p.guid.guidPrefix.value, 12);
                         memcpy(m_key.value + 12, p.guid.entityId.value, 4);
 
-                        p.guid.entityId = c_EntityId_RTPSParticipant;
-                        memcpy(m_RTPSParticipantKey.value, p.guid.guidPrefix.value, 12);
-                        memcpy(m_RTPSParticipantKey.value + 12, p.guid.entityId.value, 4);
+                        if (!m_RTPSParticipantKey.isDefined())
+                        {
+                            p.guid.entityId = c_EntityId_RTPSParticipant;
+                            memcpy(m_RTPSParticipantKey.value, p.guid.guidPrefix.value, 12);
+                            memcpy(m_RTPSParticipantKey.value + 12, p.guid.entityId.value, 4);
+                        }
                         break;
                     }
                     case fastdds::dds::PID_UNICAST_LOCATOR:

--- a/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.cpp
@@ -781,18 +781,6 @@ bool WriterProxyData::readFromCDRMessage(
                         m_typeName = p.getName();
                         break;
                     }
-                    case fastdds::dds::PID_PARTICIPANT_GUID:
-                    {
-                        ParameterGuid_t p(pid, plength);
-                        if (!fastdds::dds::ParameterSerializer<ParameterGuid_t>::read_from_cdr_message(p, msg, plength))
-                        {
-                            return false;
-                        }
-
-                        memcpy(m_RTPSParticipantKey.value, p.guid.guidPrefix.value, 12);
-                        memcpy(m_RTPSParticipantKey.value + 12, p.guid.entityId.value, 4);
-                        break;
-                    }
                     case fastdds::dds::PID_ENDPOINT_GUID:
                     {
                         ParameterGuid_t p(pid, plength);
@@ -804,6 +792,10 @@ bool WriterProxyData::readFromCDRMessage(
                         m_guid = p.guid;
                         memcpy(m_key.value, p.guid.guidPrefix.value, 12);
                         memcpy(m_key.value + 12, p.guid.entityId.value, 4);
+
+                        p.guid.entityId = c_EntityId_RTPSParticipant;
+                        memcpy(m_RTPSParticipantKey.value, p.guid.guidPrefix.value, 12);
+                        memcpy(m_RTPSParticipantKey.value + 12, p.guid.entityId.value, 4);
                         break;
                     }
                     case fastdds::dds::PID_PERSISTENCE_GUID:

--- a/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.cpp
@@ -781,6 +781,18 @@ bool WriterProxyData::readFromCDRMessage(
                         m_typeName = p.getName();
                         break;
                     }
+                    case fastdds::dds::PID_PARTICIPANT_GUID:
+                    {
+                        ParameterGuid_t p(pid, plength);
+                        if (!fastdds::dds::ParameterSerializer<ParameterGuid_t>::read_from_cdr_message(p, msg, plength))
+                        {
+                            return false;
+                        }
+
+                        memcpy(m_RTPSParticipantKey.value, p.guid.guidPrefix.value, 12);
+                        memcpy(m_RTPSParticipantKey.value + 12, p.guid.entityId.value, 4);
+                        break;
+                    }
                     case fastdds::dds::PID_ENDPOINT_GUID:
                     {
                         ParameterGuid_t p(pid, plength);
@@ -793,9 +805,12 @@ bool WriterProxyData::readFromCDRMessage(
                         memcpy(m_key.value, p.guid.guidPrefix.value, 12);
                         memcpy(m_key.value + 12, p.guid.entityId.value, 4);
 
-                        p.guid.entityId = c_EntityId_RTPSParticipant;
-                        memcpy(m_RTPSParticipantKey.value, p.guid.guidPrefix.value, 12);
-                        memcpy(m_RTPSParticipantKey.value + 12, p.guid.entityId.value, 4);
+                        if (!m_RTPSParticipantKey.isDefined())
+                        {
+                            p.guid.entityId = c_EntityId_RTPSParticipant;
+                            memcpy(m_RTPSParticipantKey.value, p.guid.guidPrefix.value, 12);
+                            memcpy(m_RTPSParticipantKey.value + 12, p.guid.entityId.value, 4);
+                        }
                         break;
                     }
                     case fastdds::dds::PID_PERSISTENCE_GUID:

--- a/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.cpp
@@ -804,13 +804,6 @@ bool WriterProxyData::readFromCDRMessage(
                         m_guid = p.guid;
                         memcpy(m_key.value, p.guid.guidPrefix.value, 12);
                         memcpy(m_key.value + 12, p.guid.entityId.value, 4);
-
-                        if (!m_RTPSParticipantKey.isDefined())
-                        {
-                            p.guid.entityId = c_EntityId_RTPSParticipant;
-                            memcpy(m_RTPSParticipantKey.value, p.guid.guidPrefix.value, 12);
-                            memcpy(m_RTPSParticipantKey.value + 12, p.guid.entityId.value, 4);
-                        }
                         break;
                     }
                     case fastdds::dds::PID_PERSISTENCE_GUID:
@@ -980,6 +973,19 @@ bool WriterProxyData::readFromCDRMessage(
             {
                 m_topicKind = WITH_KEY;
             }
+
+            /* Some vendors (i.e. CycloneDDS) do not follow DDSI-RTPS and omit PID_PARTICIPANT_GUID
+             * In that case we use a default value relying on the prefix from m_guid and the default
+             * participant entity id
+             */
+            if (!m_RTPSParticipantKey.isDefined())
+            {
+                GUID_t tmp_guid = m_guid;
+                tmp_guid.entityId = c_EntityId_RTPSParticipant;
+                memcpy(m_RTPSParticipantKey.value, tmp_guid.guidPrefix.value, 12);
+                memcpy(m_RTPSParticipantKey.value + 12, tmp_guid.entityId.value, 4);
+            }
+
             return true;
         }
     }


### PR DESCRIPTION
When receiving EDP information of writers and readers, their participant key can be directly obtained from PID_ENDPOINT_GUID.

This PR ignores PID_PARTICIPANT_GUID on them.

Related to #1380 

Signed-off-by: Miguel Company <MiguelCompany@eprosima.com>