### PR TITLE
Fix broken Windows build: Use bare ${TINYXML2_LIBRARY}

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -398,7 +398,7 @@ elseif(NOT EPROSIMA_INSTALLER)
     # Link library to external libraries.
     target_link_libraries(${PROJECT_NAME} ${PRIVACY} fastcdr foonathan_memory
         ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS}
-        $<$<BOOL:${TINYXML2_LIBRARY}>:${TINYXML2_LIBRARY}>
+        ${TINYXML2_LIBRARY}
         $<$<BOOL:${LINK_SSL}>:OpenSSL::SSL$<SEMICOLON>OpenSSL::Crypto>
         $<$<BOOL:${WIN32}>:iphlpapi$<SEMICOLON>Shlwapi>
         ${THIRDPARTY_BOOST_LINK_LIBS}


### PR DESCRIPTION
Fixes https://github.com/eProsima/Fast-DDS/issues/1385 caused by #1267

CI Windows building and testing only fastrtps [![Build Status](https://ci.ros2.org/job/ci_windows/12170/badge/icon)](https://ci.ros2.org/job/ci_windows/12170/)