### PR TITLE
Discovery Data Filter

### DIFF
--- a/include/fastdds/rtps/builtin/discovery/DiscoveryDataBase.hpp
+++ b/include/fastdds/rtps/builtin/discovery/DiscoveryDataBase.hpp
@@ -1,0 +1,68 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file DiscoveryDataBase.hpp
+ *
+ */
+
+#ifndef _FASTDDS_RTPS_DISCOVERY_DATABASE_H_
+#define _FASTDDS_RTPS_DISCOVERY_DATABASE_H_
+
+#include <fastdds/rtps/builtin/discovery/DiscoveryDataFilter.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+
+/**
+ * Class to manage the discovery data base
+ *@ingroup DISCOVERY_MODULE
+ */
+class DiscoveryDataBase
+    : public PDPDataFilter<DiscoveryDataBase>
+    , public EDPDataFilter<DiscoveryDataBase>
+    , public EDPDataFilter<DiscoveryDataBase, false>
+{
+public:
+    bool pdp_is_relevant(const fastrtps::rtps::CacheChange_t& change,
+            const fastrtps::rtps::GUID_t& reader_guid) const
+    {
+        (void)change;
+        (void)reader_guid;
+        return true;
+    }
+
+    bool edp_publications_is_relevant(const fastrtps::rtps::CacheChange_t& change,
+            const fastrtps::rtps::GUID_t& reader_guid) const
+    {
+        (void)change;
+        (void)reader_guid;
+        return true;
+    }
+
+    bool edp_subscriptions_is_relevant(const fastrtps::rtps::CacheChange_t& change,
+            const fastrtps::rtps::GUID_t& reader_guid) const
+    {
+        (void)change;
+        (void)reader_guid;
+        return true;
+    }
+};
+
+} /* namespace rtps */
+} /* namespace fastdds */
+} /* namespace eprosima */
+
+#endif /* _FASTDDS_RTPS_DISCOVERY_DATABASE_H_ */

--- a/include/fastdds/rtps/builtin/discovery/DiscoveryDataBase.hpp
+++ b/include/fastdds/rtps/builtin/discovery/DiscoveryDataBase.hpp
@@ -36,7 +36,9 @@ class DiscoveryDataBase
     , public EDPDataFilter<DiscoveryDataBase, false>
 {
 public:
-    bool pdp_is_relevant(const fastrtps::rtps::CacheChange_t& change,
+
+    bool pdp_is_relevant(
+            const fastrtps::rtps::CacheChange_t& change,
             const fastrtps::rtps::GUID_t& reader_guid) const
     {
         (void)change;
@@ -44,7 +46,8 @@ public:
         return true;
     }
 
-    bool edp_publications_is_relevant(const fastrtps::rtps::CacheChange_t& change,
+    bool edp_publications_is_relevant(
+            const fastrtps::rtps::CacheChange_t& change,
             const fastrtps::rtps::GUID_t& reader_guid) const
     {
         (void)change;
@@ -52,13 +55,15 @@ public:
         return true;
     }
 
-    bool edp_subscriptions_is_relevant(const fastrtps::rtps::CacheChange_t& change,
+    bool edp_subscriptions_is_relevant(
+            const fastrtps::rtps::CacheChange_t& change,
             const fastrtps::rtps::GUID_t& reader_guid) const
     {
         (void)change;
         (void)reader_guid;
         return true;
     }
+
 };
 
 } /* namespace rtps */

--- a/include/fastdds/rtps/builtin/discovery/DiscoveryDataFilter.hpp
+++ b/include/fastdds/rtps/builtin/discovery/DiscoveryDataFilter.hpp
@@ -36,11 +36,14 @@ class PDPDataFilter
     : public IReaderDataFilter
 {
 public:
-    bool is_relevant(const fastrtps::rtps::CacheChange_t& change,
+
+    bool is_relevant(
+            const fastrtps::rtps::CacheChange_t& change,
             const fastrtps::rtps::GUID_t& reader_guid) const override
     {
         return static_cast<const DiscoveryDataBase*>(this)->pdp_is_relevant(change, reader_guid);
     }
+
 };
 
 /**
@@ -55,11 +58,14 @@ class EDPDataFilter
     : public IReaderDataFilter
 {
 public:
-    bool is_relevant(const fastrtps::rtps::CacheChange_t& change,
+
+    bool is_relevant(
+            const fastrtps::rtps::CacheChange_t& change,
             const fastrtps::rtps::GUID_t& reader_guid) const override
     {
         return static_cast<const DiscoveryDataBase*>(this)->edp_publications_is_relevant(change, reader_guid);
     }
+
 };
 
 /**
@@ -71,11 +77,14 @@ class EDPDataFilter<DiscoveryDataBase, false>
     : public IReaderDataFilter
 {
 public:
-    bool is_relevant(const fastrtps::rtps::CacheChange_t& change,
+
+    bool is_relevant(
+            const fastrtps::rtps::CacheChange_t& change,
             const fastrtps::rtps::GUID_t& reader_guid) const override
     {
         return static_cast<const DiscoveryDataBase*>(this)->edp_subscriptions_is_relevant(change, reader_guid);
     }
+
 };
 
 } /* namespace rtps */

--- a/include/fastdds/rtps/builtin/discovery/DiscoveryDataFilter.hpp
+++ b/include/fastdds/rtps/builtin/discovery/DiscoveryDataFilter.hpp
@@ -1,0 +1,85 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file DiscoveryDataFilter.hpp
+ *
+ */
+
+#ifndef _FASTDDS_RTPS_DISCOVERY_DATA_FILTER_H_
+#define _FASTDDS_RTPS_DISCOVERY_DATA_FILTER_H_
+
+#include <fastdds/rtps/writer/IReaderDataFilter.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+
+/**
+ * Class to filter PDP data depending on the destination reader.
+ *    1. Template parameter <DiscoveryDataBase> represents the DiscoveryDataBase
+ *@ingroup DISCOVERY_MODULE
+ */
+template<class DiscoveryDataBase>
+class PDPDataFilter
+    : public IReaderDataFilter
+{
+public:
+    bool is_relevant(const fastrtps::rtps::CacheChange_t& change,
+            const fastrtps::rtps::GUID_t& reader_guid) const override
+    {
+        return static_cast<const DiscoveryDataBase*>(this)->pdp_is_relevant(change, reader_guid);
+    }
+};
+
+/**
+ * Class to filter EDP data depending on the destination reader.
+ *    1. Template parameter <DiscoveryDataBase> represents the DiscoveryDataBase
+ *    2. Template parameter <publications> represents whether the class is specialized for publications or
+ *       subscriptions data [Default to publications].
+ *@ingroup DISCOVERY_MODULE
+ */
+template<class DiscoveryDataBase, bool publications = true>
+class EDPDataFilter
+    : public IReaderDataFilter
+{
+public:
+    bool is_relevant(const fastrtps::rtps::CacheChange_t& change,
+            const fastrtps::rtps::GUID_t& reader_guid) const override
+    {
+        return static_cast<const DiscoveryDataBase*>(this)->edp_publications_is_relevant(change, reader_guid);
+    }
+};
+
+/**
+ * Class to filter EDP subscriptions data depending on the destination reader.
+ *@ingroup DISCOVERY_MODULE
+ */
+template<class DiscoveryDataBase>
+class EDPDataFilter<DiscoveryDataBase, false>
+    : public IReaderDataFilter
+{
+public:
+    bool is_relevant(const fastrtps::rtps::CacheChange_t& change,
+            const fastrtps::rtps::GUID_t& reader_guid) const override
+    {
+        return static_cast<const DiscoveryDataBase*>(this)->edp_subscriptions_is_relevant(change, reader_guid);
+    }
+};
+
+} /* namespace rtps */
+} /* namespace fastdds */
+} /* namespace eprosima */
+
+#endif /* _FASTDDS_RTPS_DISCOVERY_DATA_FILTER_H_ */

--- a/include/fastdds/rtps/writer/IReaderDataFilter.hpp
+++ b/include/fastdds/rtps/writer/IReaderDataFilter.hpp
@@ -41,13 +41,15 @@ public:
      * @param change The CacheChange_t to be evaluated
      * @return true if relevant, false otherwise.
      */
-    virtual bool is_relevant(const fastrtps::rtps::CacheChange_t& change,
+    virtual bool is_relevant(
+            const fastrtps::rtps::CacheChange_t& change,
             const fastrtps::rtps::GUID_t& reader_guid) const
     {
         (void)change;
         (void)reader_guid;
         return true;
     }
+
 };
 
 } /* namespace rtps */

--- a/include/fastdds/rtps/writer/IReaderDataFilter.hpp
+++ b/include/fastdds/rtps/writer/IReaderDataFilter.hpp
@@ -1,0 +1,57 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file IReaderDataFilter.hpp
+ *
+ */
+
+#ifndef _FASTDDS_RTPS_IREADERDATA_FILTER_H_
+#define _FASTDDS_RTPS_IREADERDATA_FILTER_H_
+
+#include <fastdds/rtps/common/CacheChange.h>
+#include <fastdds/rtps/common/Guid.h>
+
+
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+
+/**
+ * Abstract class IReaderDataFilter that acts as virtual interface for data filters in ReaderProxy.
+ *@ingroup WRITER_MODULE
+ */
+class IReaderDataFilter
+{
+public:
+
+    /**
+     * This method checks whether a CacheChange_t is relevant for the Reader
+     * @param change The CacheChange_t to be evaluated
+     * @return true if relevant, false otherwise.
+     */
+    virtual bool is_relevant(const fastrtps::rtps::CacheChange_t& change,
+            const fastrtps::rtps::GUID_t& reader_guid) const
+    {
+        (void)change;
+        (void)reader_guid;
+        return true;
+    }
+};
+
+} /* namespace rtps */
+} /* namespace fastdds */
+} /* namespace eprosima */
+
+#endif /* _FASTDDS_RTPS_IREADERDATA_FILTER_H_ */

--- a/include/fastdds/rtps/writer/ReaderProxy.h
+++ b/include/fastdds/rtps/writer/ReaderProxy.h
@@ -345,15 +345,11 @@ public:
             const FragmentNumberSet_t& fragments_state);
 
     /**
-     * Filter a CacheChange_t, in this version always returns true.
+     * Filter a CacheChange_t using the StatefulWriter's IReaderDataFilter.
      * @param change
      * @return true if the change is relevant, false otherwise.
      */
-    inline bool rtps_is_relevant(
-            CacheChange_t* change)
-    {
-        (void)change; return true;
-    }
+    bool rtps_is_relevant(CacheChange_t* change);
 
     /**
      * Get the highest fully acknowledged sequence number.

--- a/include/fastdds/rtps/writer/ReaderProxy.h
+++ b/include/fastdds/rtps/writer/ReaderProxy.h
@@ -349,7 +349,8 @@ public:
      * @param change
      * @return true if the change is relevant, false otherwise.
      */
-    bool rtps_is_relevant(CacheChange_t* change);
+    bool rtps_is_relevant(
+            CacheChange_t* change);
 
     /**
      * Get the highest fully acknowledged sequence number.

--- a/include/fastdds/rtps/writer/StatefulWriter.h
+++ b/include/fastdds/rtps/writer/StatefulWriter.h
@@ -22,6 +22,7 @@
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 #include <fastdds/rtps/writer/RTPSWriter.h>
+#include <fastdds/rtps/writer/IReaderDataFilter.hpp>
 #include <fastrtps/utils/collections/ResourceLimitedVector.hpp>
 #include <condition_variable>
 #include <mutex>
@@ -304,6 +305,17 @@ public:
             const FragmentNumberSet_t fragments_state,
             bool& result) override;
 
+    /**
+     * @brief Set a reader data filter to filter data in ReaderProxies
+     * @param reader_data_filter The reader data filter
+     */
+    void reader_data_filter(fastdds::rtps::IReaderDataFilter* reader_data_filter);
+
+    /**
+     * @brief Get the reader data filter used to filter data in ReaderProxies
+     */
+    const fastdds::rtps::IReaderDataFilter* reader_data_filter() const;
+
 private:
 
     void update_reader_info(
@@ -374,6 +386,9 @@ private:
 
     StatefulWriter& operator =(
             const StatefulWriter&) = delete;
+
+    //! The filter for the reader
+    fastdds::rtps::IReaderDataFilter* reader_data_filter_ = nullptr;
 };
 
 } /* namespace rtps */

--- a/include/fastdds/rtps/writer/StatefulWriter.h
+++ b/include/fastdds/rtps/writer/StatefulWriter.h
@@ -309,7 +309,8 @@ public:
      * @brief Set a reader data filter to filter data in ReaderProxies
      * @param reader_data_filter The reader data filter
      */
-    void reader_data_filter(fastdds::rtps::IReaderDataFilter* reader_data_filter);
+    void reader_data_filter(
+            fastdds::rtps::IReaderDataFilter* reader_data_filter);
 
     /**
      * @brief Get the reader data filter used to filter data in ReaderProxies

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -77,6 +77,16 @@ ReaderProxy::ReaderProxy(
     stop();
 }
 
+bool ReaderProxy::rtps_is_relevant(
+        CacheChange_t* change)
+{
+    if (nullptr != writer_->reader_data_filter())
+    {
+        return writer_->reader_data_filter()->is_relevant(*change, guid());
+    }
+    return true;
+}
+
 ReaderProxy::~ReaderProxy()
 {
     if (nack_supression_event_)

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -605,7 +605,8 @@ void StatefulWriter::send_changes_separatedly(
             auto unsent_change_process =
                     [&](const SequenceNumber_t& seqNum, const ChangeForReader_t* unsentChange)
                     {
-                        if (unsentChange != nullptr && remoteReader->rtps_is_relevant(unsentChange->getChange()) && unsentChange->isValid())
+                        if (unsentChange != nullptr && remoteReader->rtps_is_relevant(unsentChange->getChange()) &&
+                                unsentChange->isValid())
                         {
                             if (intraprocess_delivery(unsentChange->getChange(), remoteReader))
                             {
@@ -659,7 +660,8 @@ void StatefulWriter::send_changes_separatedly(
                 auto unsent_change_process =
                         [&](const SequenceNumber_t& seqNum, const ChangeForReader_t* unsentChange)
                         {
-                            if (unsentChange != nullptr && remoteReader->rtps_is_relevant(unsentChange->getChange()) && unsentChange->isValid())
+                            if (unsentChange != nullptr && remoteReader->rtps_is_relevant(unsentChange->getChange()) &&
+                                    unsentChange->isValid())
                             {
                                 bool sent_ok = send_data_or_fragments(
                                     group,
@@ -689,7 +691,8 @@ void StatefulWriter::send_changes_separatedly(
                 auto unsent_change_process =
                         [&](const SequenceNumber_t& seqNum, const ChangeForReader_t* unsentChange)
                         {
-                            if (unsentChange != nullptr && remoteReader->rtps_is_relevant(unsentChange->getChange()) && unsentChange->isValid())
+                            if (unsentChange != nullptr && remoteReader->rtps_is_relevant(unsentChange->getChange()) &&
+                                    unsentChange->isValid())
                             {
                                 bool sent_ok = send_data_or_fragments(
                                     group,
@@ -727,7 +730,8 @@ void StatefulWriter::send_all_intraprocess_changes(
             SequenceNumber_t max_ack_seq = SequenceNumber_t::unknown();
             auto unsent_change_process = [&](const SequenceNumber_t& seq_num, const ChangeForReader_t* unsentChange)
                     {
-                        if (unsentChange != nullptr && remoteReader->rtps_is_relevant(unsentChange->getChange()) && unsentChange->isValid())
+                        if (unsentChange != nullptr && remoteReader->rtps_is_relevant(unsentChange->getChange()) &&
+                                unsentChange->isValid())
                         {
                             if (intraprocess_delivery(unsentChange->getChange(), remoteReader))
                             {
@@ -948,7 +952,8 @@ void StatefulWriter::send_unsent_changes_with_flow_control(
         RTPSGapBuilder gaps(group, remoteReader->guid());
         auto unsent_change_process = [&](const SequenceNumber_t& seq_num, const ChangeForReader_t* unsentChange)
                 {
-                    if (unsentChange != nullptr && remoteReader->rtps_is_relevant(unsentChange->getChange()) && unsentChange->isValid())
+                    if (unsentChange != nullptr && remoteReader->rtps_is_relevant(unsentChange->getChange()) &&
+                            unsentChange->isValid())
                     {
                         relevantChanges.add_change(
                             unsentChange->getChange(), remoteReader, unsentChange->getUnsentFragments());
@@ -2086,8 +2091,8 @@ bool StatefulWriter::ack_timer_expired()
     return true;
 }
 
-
-void StatefulWriter::reader_data_filter(fastdds::rtps::IReaderDataFilter* reader_data_filter)
+void StatefulWriter::reader_data_filter(
+        fastdds::rtps::IReaderDataFilter* reader_data_filter)
 {
     reader_data_filter_ = reader_data_filter;
 }
@@ -2096,7 +2101,6 @@ const fastdds::rtps::IReaderDataFilter* StatefulWriter::reader_data_filter() con
 {
     return reader_data_filter_;
 }
-
 
 }  // namespace rtps
 }  // namespace fastrtps

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -19,6 +19,7 @@
 
 #include <fastdds/rtps/writer/StatefulWriter.h>
 #include <fastdds/rtps/writer/WriterListener.h>
+#include <fastdds/rtps/writer/IReaderDataFilter.hpp>
 #include <fastdds/rtps/writer/ReaderProxy.h>
 #include <fastdds/rtps/resources/AsyncWriterThread.h>
 
@@ -604,7 +605,7 @@ void StatefulWriter::send_changes_separatedly(
             auto unsent_change_process =
                     [&](const SequenceNumber_t& seqNum, const ChangeForReader_t* unsentChange)
                     {
-                        if (unsentChange != nullptr && unsentChange->isRelevant() && unsentChange->isValid())
+                        if (unsentChange != nullptr && remoteReader->rtps_is_relevant(unsentChange->getChange()) && unsentChange->isValid())
                         {
                             if (intraprocess_delivery(unsentChange->getChange(), remoteReader))
                             {
@@ -658,7 +659,7 @@ void StatefulWriter::send_changes_separatedly(
                 auto unsent_change_process =
                         [&](const SequenceNumber_t& seqNum, const ChangeForReader_t* unsentChange)
                         {
-                            if (unsentChange != nullptr && unsentChange->isRelevant() && unsentChange->isValid())
+                            if (unsentChange != nullptr && remoteReader->rtps_is_relevant(unsentChange->getChange()) && unsentChange->isValid())
                             {
                                 bool sent_ok = send_data_or_fragments(
                                     group,
@@ -688,7 +689,7 @@ void StatefulWriter::send_changes_separatedly(
                 auto unsent_change_process =
                         [&](const SequenceNumber_t& seqNum, const ChangeForReader_t* unsentChange)
                         {
-                            if (unsentChange != nullptr && unsentChange->isRelevant() && unsentChange->isValid())
+                            if (unsentChange != nullptr && remoteReader->rtps_is_relevant(unsentChange->getChange()) && unsentChange->isValid())
                             {
                                 bool sent_ok = send_data_or_fragments(
                                     group,
@@ -726,7 +727,7 @@ void StatefulWriter::send_all_intraprocess_changes(
             SequenceNumber_t max_ack_seq = SequenceNumber_t::unknown();
             auto unsent_change_process = [&](const SequenceNumber_t& seq_num, const ChangeForReader_t* unsentChange)
                     {
-                        if (unsentChange != nullptr && unsentChange->isRelevant() && unsentChange->isValid())
+                        if (unsentChange != nullptr && remoteReader->rtps_is_relevant(unsentChange->getChange()) && unsentChange->isValid())
                         {
                             if (intraprocess_delivery(unsentChange->getChange(), remoteReader))
                             {
@@ -947,7 +948,7 @@ void StatefulWriter::send_unsent_changes_with_flow_control(
         RTPSGapBuilder gaps(group, remoteReader->guid());
         auto unsent_change_process = [&](const SequenceNumber_t& seq_num, const ChangeForReader_t* unsentChange)
                 {
-                    if (unsentChange != nullptr && unsentChange->isRelevant() && unsentChange->isValid())
+                    if (unsentChange != nullptr && remoteReader->rtps_is_relevant(unsentChange->getChange()) && unsentChange->isValid())
                     {
                         relevantChanges.add_change(
                             unsentChange->getChange(), remoteReader, unsentChange->getUnsentFragments());
@@ -2084,6 +2085,18 @@ bool StatefulWriter::ack_timer_expired()
     ack_event_->update_interval_millisec((double)duration_cast<milliseconds>(interval).count());
     return true;
 }
+
+
+void StatefulWriter::reader_data_filter(fastdds::rtps::IReaderDataFilter* reader_data_filter)
+{
+    reader_data_filter_ = reader_data_filter;
+}
+
+const fastdds::rtps::IReaderDataFilter* StatefulWriter::reader_data_filter() const
+{
+    return reader_data_filter_;
+}
+
 
 }  // namespace rtps
 }  // namespace fastrtps

--- a/test/mock/rtps/StatefulWriter/fastdds/rtps/writer/StatefulWriter.h
+++ b/test/mock/rtps/StatefulWriter/fastdds/rtps/writer/StatefulWriter.h
@@ -93,7 +93,8 @@ public:
         return mp_history->next_sequence_number();
     }
 
-    void reader_data_filter(fastdds::rtps::IReaderDataFilter* reader_data_filter)
+    void reader_data_filter(
+            fastdds::rtps::IReaderDataFilter* reader_data_filter)
     {
         reader_data_filter_ = reader_data_filter;
     }

--- a/test/mock/rtps/StatefulWriter/fastdds/rtps/writer/StatefulWriter.h
+++ b/test/mock/rtps/StatefulWriter/fastdds/rtps/writer/StatefulWriter.h
@@ -20,6 +20,7 @@
 #define _FASTDDS_RTPS_STATEFULWRITER_H_
 
 #include <fastrtps/rtps/writer/RTPSWriter.h>
+#include <fastdds/rtps/writer/IReaderDataFilter.hpp>
 #include <fastrtps/rtps/history/WriterHistory.h>
 
 namespace eprosima {
@@ -92,6 +93,16 @@ public:
         return mp_history->next_sequence_number();
     }
 
+    void reader_data_filter(fastdds::rtps::IReaderDataFilter* reader_data_filter)
+    {
+        reader_data_filter_ = reader_data_filter;
+    }
+
+    const fastdds::rtps::IReaderDataFilter* reader_data_filter() const
+    {
+        return reader_data_filter_;
+    }
+
 private:
 
     friend class ReaderProxy;
@@ -99,6 +110,9 @@ private:
     RTPSParticipantImpl* participant_;
 
     WriterHistory* mp_history;
+
+    fastdds::rtps::IReaderDataFilter* reader_data_filter_;
+
 };
 
 } // namespace rtps


### PR DESCRIPTION
This PR:
1. Adds `IReaderDataFilter` virtual class for Reader proxies to query whether a change is relevant for them.
1. Adds a member `reader_data_filter_` to `StatefulWriter`. This also includes a setter and a getter.
1. Adds discovery data filter interfaces for PDP, EDP publications, and EDP subscriptions.
1. Adds a `DiscoveryDataBase` which implements the interfaces for PDP, EDP publications, and EDP subscriptions.

This way, each discovery writer query the discovery database for a specific change using its specialized filter. The Database will tell the filter whether a change is relevant for a given reader. This way the writer can avoid sending irrelevant messages to certain readers.

Signed-off-by: EduPonz <eduardoponz@eprosima.com>