### PR TITLE
Fixes #1395. Removed ASIO_STANDALONE compile definition from CMakeList

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -357,8 +357,6 @@ elseif(NOT EPROSIMA_INSTALLER)
 
     target_compile_definitions(${PROJECT_NAME} PRIVATE
         ${PROJECT_NAME_UPPER}_SOURCE
-        BOOST_ASIO_STANDALONE
-        ASIO_STANDALONE
         SQLITE_WIN32_GETVERSIONEX=0
         $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
         $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.


### PR DESCRIPTION
Fixes #1395. Removes ASIO_STANDALONE compile definition from CMakeLists to enable ASIO together with Boost with the define ASIO_ENABLE_BOOST as enabled by design. ASIO_STANDALONE is still the default option if no define is given.