### PR TITLE
remove latomic to clang

### DIFF
--- a/cmake/modules/FindThirdpartyBoost.cmake
+++ b/cmake/modules/FindThirdpartyBoost.cmake
@@ -19,10 +19,6 @@ else() # Posix
     set(THIRDPARTY_BOOST_LINK_LIBS ${CMAKE_THREAD_LIBS_INIT} rt)
 endif()
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    list(APPEND THIRDPARTY_BOOST_LINK_LIBS atomic)
-endif()
-
 try_compile(IS_THIRDPARTY_BOOST_OK
         ${CMAKE_BINARY_DIR}
         ${PROJECT_SOURCE_DIR}/thirdparty/boost/test/ThirdpartyBoostCompile_test.cpp


### PR DESCRIPTION
Clang automatically links again atomic (if the gcc runtime toolchain is not used) and does not need to be added. I assume that most likely this passed the OSX CI given that the compiler id with a stock clang on OSX is actually rebranded to `AppleClang` and thus doesn't match the expression.

see https://bcain-llvm.readthedocs.io/projects/clang/en/latest/Toolchain/#atomics-library for more information.