### PR TITLE
Bugfix: preprocess_secure_submsg should look both local and remote endpoints [9465]

### DIFF
--- a/src/cpp/security/cryptography/AESGCMGMAC_Transform.cpp
+++ b/src/cpp/security/cryptography/AESGCMGMAC_Transform.cpp
@@ -2245,7 +2245,7 @@ bool AESGCMGMAC_Transform::lookup_reader(
         DatareaderCryptoHandle** datareader_crypto,
         CryptoTransformKeyId key_id)
 {
-    for (auto readerHandle : participant->Readers)
+    for (DatareaderCryptoHandle* readerHandle : participant->Readers)
     {
         AESGCMGMAC_ReaderCryptoHandle& reader = AESGCMGMAC_ReaderCryptoHandle::narrow(*readerHandle);
 
@@ -2255,7 +2255,7 @@ bool AESGCMGMAC_Transform::lookup_reader(
             continue;
         }
 
-        for (auto elem : reader->Remote2EntityKeyMaterial)
+        for (const KeyMaterial_AES_GCM_GMAC& elem : reader->Remote2EntityKeyMaterial)
         {
             if (elem.sender_key_id == key_id)
             {
@@ -2273,7 +2273,7 @@ bool AESGCMGMAC_Transform::lookup_writer(
         DatawriterCryptoHandle** datawriter_crypto,
         CryptoTransformKeyId key_id)
 {
-    for (auto writerHandle : participant->Writers)
+    for (DatawriterCryptoHandle* writerHandle : participant->Writers)
     {
         AESGCMGMAC_WriterCryptoHandle& writer = AESGCMGMAC_WriterCryptoHandle::narrow(*writerHandle);
 
@@ -2283,7 +2283,7 @@ bool AESGCMGMAC_Transform::lookup_writer(
             continue;
         }
 
-        for (auto elem : writer->Remote2EntityKeyMaterial)
+        for (const KeyMaterial_AES_GCM_GMAC& elem : writer->Remote2EntityKeyMaterial)
         {
             if (elem.sender_key_id == key_id)
             {

--- a/src/cpp/security/cryptography/AESGCMGMAC_Transform.cpp
+++ b/src/cpp/security/cryptography/AESGCMGMAC_Transform.cpp
@@ -1453,7 +1453,7 @@ bool AESGCMGMAC_Transform::decode_serialized_payload(
 
 bool AESGCMGMAC_Transform::lookup_reader(
         AESGCMGMAC_ParticipantCryptoHandle& participant,
-        DatareaderCryptoHandle **datareader_crypto,
+        DatareaderCryptoHandle** datareader_crypto,
         CryptoTransformKeyId key_id)
 {
     for (auto readerHandle : participant->Readers)
@@ -1481,7 +1481,7 @@ bool AESGCMGMAC_Transform::lookup_reader(
 
 bool AESGCMGMAC_Transform::lookup_writer(
         AESGCMGMAC_ParticipantCryptoHandle& participant,
-        DatawriterCryptoHandle **datawriter_crypto,
+        DatawriterCryptoHandle** datawriter_crypto,
         CryptoTransformKeyId key_id)
 {
     for (auto writerHandle : participant->Writers)

--- a/src/cpp/security/cryptography/AESGCMGMAC_Transform.cpp
+++ b/src/cpp/security/cryptography/AESGCMGMAC_Transform.cpp
@@ -904,51 +904,21 @@ bool AESGCMGMAC_Transform::preprocess_secure_submsg(
             *datawriter_crypto = *it;
 
             //We have the remote writer, now lets look for the local datareader
-            for (std::vector<DatareaderCryptoHandle*>::iterator itt = local_participant->Readers.begin();
-                    itt != local_participant->Readers.end(); ++itt)
-            {
-                AESGCMGMAC_ReaderCryptoHandle& reader = AESGCMGMAC_ReaderCryptoHandle::narrow(**itt);
+            bool found = lookup_reader(local_participant, datareader_crypto, key_id);
 
-                if (reader->Remote2EntityKeyMaterial.size() == 0)
+            if (found)
+            {
+                return true;
+            }
+            // Datareader not found locally. Look remotelly (Discovery case)
+            else if (is_key_id_zero)
+            {
+                found = lookup_reader(remote_participant, datareader_crypto, key_id);
+                if (found)
                 {
-                    logWarning(SECURITY_CRYPTO, "No key material yet");
-                    continue;
+                    return true;
                 }
-
-                for (size_t i = 0; i < reader->Remote2EntityKeyMaterial.size(); ++i)
-                {
-                    if (reader->Remote2EntityKeyMaterial.at(i).sender_key_id == key_id)
-                    {
-                        *datareader_crypto = *itt;
-                        return true;
-                    }
-                }   //For each Reader2WriterKeyMaterial in the local datareader
-            } //For each datareader present in the local participant
-
-            // Discovery: local datareader not found, look for remote datareader only when is_key_id_zero is true
-            if (is_key_id_zero)
-            {
-                for (std::vector<DatareaderCryptoHandle*>::iterator itt = remote_participant->Readers.begin();
-                        itt != remote_participant->Readers.end(); ++itt)
-                {
-                    AESGCMGMAC_ReaderCryptoHandle& reader = AESGCMGMAC_ReaderCryptoHandle::narrow(**itt);
-
-                    if (reader->Remote2EntityKeyMaterial.size() == 0)
-                    {
-                        logWarning(SECURITY_CRYPTO, "No key material yet");
-                        continue;
-                    }
-
-                    for (size_t i = 0; i < reader->Remote2EntityKeyMaterial.size(); ++i)
-                    {
-                        if (reader->Remote2EntityKeyMaterial.at(i).sender_key_id == key_id)
-                        {
-                            *datareader_crypto = *itt;
-                            return true;
-                        }
-                    }   //For each Reader2WriterKeyMaterial in the remote datareader
-                } //For each datareader present in the remote participant
-            } // key_id is zero
+            }
         } //Remote writer key found
     } //For each datawriter present in the remote participant
 
@@ -972,51 +942,21 @@ bool AESGCMGMAC_Transform::preprocess_secure_submsg(
             *datareader_crypto = *it;
 
             //We have the remote reader, now lets look for the local datawriter
-            for (std::vector<DatawriterCryptoHandle*>::iterator itt = local_participant->Writers.begin();
-                    itt != local_participant->Writers.end(); ++itt)
-            {
-                AESGCMGMAC_WriterCryptoHandle& writer = AESGCMGMAC_ReaderCryptoHandle::narrow(**itt);
+            bool found = lookup_writer(local_participant, datawriter_crypto, key_id);
 
-                if (writer->Remote2EntityKeyMaterial.size() == 0)
+            if (found)
+            {
+                return true;
+            }
+            // Datawriter not found locally. Look remotelly (Discovery case)
+            else if (is_key_id_zero)
+            {
+                found = lookup_writer(remote_participant, datawriter_crypto, key_id);
+                if (found)
                 {
-                    logWarning(SECURITY_CRYPTO, "No key material yet");
-                    continue;
+                    return true;
                 }
-
-                for (size_t i = 0; i < writer->Remote2EntityKeyMaterial.size(); ++i)
-                {
-                    if (writer->Remote2EntityKeyMaterial.at(i).sender_key_id == key_id)
-                    {
-                        *datawriter_crypto = *itt;
-                        return true;
-                    }
-                }   //For each Writer2ReaderKeyMaterial in the local datawriter
-            } //For each datawriter present in the local participant
-
-            // Discovery: local datawriter not found, look for remote datawriter only when is_key_id_zero is true
-            if (is_key_id_zero)
-            {
-                for (std::vector<DatawriterCryptoHandle*>::iterator itt = remote_participant->Writers.begin();
-                        itt != remote_participant->Writers.end(); ++itt)
-                {
-                    AESGCMGMAC_WriterCryptoHandle& writer = AESGCMGMAC_ReaderCryptoHandle::narrow(**itt);
-
-                    if (writer->Remote2EntityKeyMaterial.size() == 0)
-                    {
-                        logWarning(SECURITY_CRYPTO, "No key material yet");
-                        continue;
-                    }
-
-                    for (size_t i = 0; i < writer->Remote2EntityKeyMaterial.size(); ++i)
-                    {
-                        if (writer->Remote2EntityKeyMaterial.at(i).sender_key_id == key_id)
-                        {
-                            *datawriter_crypto = *itt;
-                            return true;
-                        }
-                    }   //For each Writer2ReaderKeyMaterial in the remote datawriter
-                } //For each datawriter present in the remote participant
-            } // key_id is zero
+            }
         } //Remote reader key found
     } //For each datareader present in the remote participant
 
@@ -1509,6 +1449,62 @@ bool AESGCMGMAC_Transform::decode_serialized_payload(
     plain_payload.encapsulation = encoded_payload.encapsulation;
 
     return true;
+}
+
+bool AESGCMGMAC_Transform::lookup_reader(
+        AESGCMGMAC_ParticipantCryptoHandle& participant,
+        DatareaderCryptoHandle **datareader_crypto,
+        CryptoTransformKeyId key_id)
+{
+    for (auto readerHandle : participant->Readers)
+    {
+        AESGCMGMAC_ReaderCryptoHandle& reader = AESGCMGMAC_ReaderCryptoHandle::narrow(*readerHandle);
+
+        if (reader->Remote2EntityKeyMaterial.size() == 0)
+        {
+            logWarning(SECURITY_CRYPTO, "No key material yet");
+            continue;
+        }
+
+        for (size_t i = 0; i < reader->Remote2EntityKeyMaterial.size(); ++i)
+        {
+            if (reader->Remote2EntityKeyMaterial.at(i).sender_key_id == key_id)
+            {
+                *datareader_crypto = readerHandle;
+                return true;
+            }
+        }   //For each Reader2WriterKeyMaterial in the datareader
+    } //For each datareader present in the participant
+
+    return false;
+}
+
+bool AESGCMGMAC_Transform::lookup_writer(
+        AESGCMGMAC_ParticipantCryptoHandle& participant,
+        DatawriterCryptoHandle **datawriter_crypto,
+        CryptoTransformKeyId key_id)
+{
+    for (auto writerHandle : participant->Writers)
+    {
+        AESGCMGMAC_WriterCryptoHandle& writer = AESGCMGMAC_WriterCryptoHandle::narrow(*writerHandle);
+
+        if (writer->Remote2EntityKeyMaterial.size() == 0)
+        {
+            logWarning(SECURITY_CRYPTO, "No key material yet");
+            continue;
+        }
+
+        for (size_t i = 0; i < writer->Remote2EntityKeyMaterial.size(); ++i)
+        {
+            if (writer->Remote2EntityKeyMaterial.at(i).sender_key_id == key_id)
+            {
+                *datawriter_crypto = writerHandle;
+                return true;
+            }
+        }   //For each Writer2ReaderKeyMaterial in the datawriter
+    } //For each datawriter present in the participant
+
+    return false;
 }
 
 void AESGCMGMAC_Transform::compute_sessionkey(

--- a/src/cpp/security/cryptography/AESGCMGMAC_Transform.h
+++ b/src/cpp/security/cryptography/AESGCMGMAC_Transform.h
@@ -33,7 +33,7 @@ namespace security {
 
 class AESGCMGMAC_Transform : public CryptoTransform
 {
-    public:
+public:
 
     AESGCMGMAC_Transform();
     ~AESGCMGMAC_Transform();
@@ -62,39 +62,39 @@ class AESGCMGMAC_Transform : public CryptoTransform
     bool encode_rtps_message(
             CDRMessage_t& encoded_rtps_message,
             const CDRMessage_t& plain_rtps_message,
-            ParticipantCryptoHandle &sending_crypto,
-            std::vector<ParticipantCryptoHandle*> &receiving_crypto_list,
-            SecurityException &exception) override;
+            ParticipantCryptoHandle& sending_crypto,
+            std::vector<ParticipantCryptoHandle*>& receiving_crypto_list,
+            SecurityException& exception) override;
 
     bool decode_rtps_message(
             CDRMessage_t& plain_buffer,
             const CDRMessage_t& encoded_buffer,
-            const ParticipantCryptoHandle &receiving_crypto,
-            const ParticipantCryptoHandle &sending_crypto,
-            SecurityException &exception) override;
+            const ParticipantCryptoHandle& receiving_crypto,
+            const ParticipantCryptoHandle& sending_crypto,
+            SecurityException& exception) override;
 
     bool preprocess_secure_submsg(
-            DatawriterCryptoHandle **datawriter_crypto,
-            DatareaderCryptoHandle **datareader_crypto,
-            SecureSubmessageCategory_t &secure_submessage_category,
+            DatawriterCryptoHandle** datawriter_crypto,
+            DatareaderCryptoHandle** datareader_crypto,
+            SecureSubmessageCategory_t& secure_submessage_category,
             const CDRMessage_t& encoded_rtps_submessage,
-            ParticipantCryptoHandle &receiving_crypto,
-            ParticipantCryptoHandle &sending_crypto,
-            SecurityException &exception) override;
+            ParticipantCryptoHandle& receiving_crypto,
+            ParticipantCryptoHandle& sending_crypto,
+            SecurityException& exception) override;
 
     bool decode_datawriter_submessage(
             CDRMessage_t& plain_rtps_submessage,
             CDRMessage_t& encoded_rtps_submessage,
-            DatareaderCryptoHandle &receiving_datareader_crypto,
-            DatawriterCryptoHandle &sending_datawriter_cryupto,
-            SecurityException &exception) override;
+            DatareaderCryptoHandle& receiving_datareader_crypto,
+            DatawriterCryptoHandle& sending_datawriter_cryupto,
+            SecurityException& exception) override;
 
     bool decode_datareader_submessage(
             CDRMessage_t& plain_rtps_submessage,
             CDRMessage_t& encoded_rtps_submessage,
-            DatawriterCryptoHandle &receiving_datawriter_crypto,
-            DatareaderCryptoHandle &sending_datareader_crypto,
-            SecurityException &exception) override;
+            DatawriterCryptoHandle& receiving_datawriter_crypto,
+            DatareaderCryptoHandle& sending_datareader_crypto,
+            SecurityException& exception) override;
 
     bool decode_serialized_payload(
             SerializedPayload_t& plain_payload,
@@ -106,42 +106,57 @@ class AESGCMGMAC_Transform : public CryptoTransform
 
     //Aux functions to compute session key from the master material
     void compute_sessionkey(
-        std::array<uint8_t, 32>& session_key, 
-        bool receiver_specific,
-        const std::array<uint8_t, 32>& master_key, 
-        const std::array<uint8_t, 32>& master_salt, 
-        const uint32_t session_id, 
-        int key_len);
+            std::array<uint8_t, 32>& session_key,
+            bool receiver_specific,
+            const std::array<uint8_t, 32>& master_key,
+            const std::array<uint8_t, 32>& master_salt,
+            const uint32_t session_id,
+            int key_len);
 
     void compute_sessionkey(
-        std::array<uint8_t, 32>& session_key, 
-        const KeyMaterial_AES_GCM_GMAC& key, 
-        const uint32_t session_id);
+            std::array<uint8_t, 32>& session_key,
+            const KeyMaterial_AES_GCM_GMAC& key,
+            const uint32_t session_id);
 
     //Serialization and deserialization of message components
-    void serialize_SecureDataHeader(eprosima::fastcdr::Cdr& serializer,
-            const CryptoTransformKind& transformation_kind, const CryptoTransformKeyId& transformation_key_id,
-            const std::array<uint8_t, 4>& session_id, const std::array<uint8_t, 8>& initialization_vector_suffix);
+    void serialize_SecureDataHeader(
+            eprosima::fastcdr::Cdr& serializer,
+            const CryptoTransformKind& transformation_kind,
+            const CryptoTransformKeyId& transformation_key_id,
+            const std::array<uint8_t, 4>& session_id,
+            const std::array<uint8_t, 8>& initialization_vector_suffix);
 
-    bool serialize_SecureDataBody(eprosima::fastcdr::Cdr& serializer,
-            const std::array<uint8_t, 4>& transformation_kind, const std::array<uint8_t,32>& session_key,
+    bool serialize_SecureDataBody(
+            eprosima::fastcdr::Cdr& serializer,
+            const std::array<uint8_t, 4>& transformation_kind,
+            const std::array<uint8_t, 32>& session_key,
             const std::array<uint8_t, 12>& initialization_vector,
-            eprosima::fastcdr::FastBuffer& output_buffer, octet* plain_buffer, uint32_t plain_buffer_len,
-            SecureDataTag& tag, bool submessage);
+            eprosima::fastcdr::FastBuffer& output_buffer,
+            octet* plain_buffer,
+            uint32_t plain_buffer_len,
+            SecureDataTag& tag,
+            bool submessage);
 
-    bool serialize_SecureDataTag(eprosima::fastcdr::Cdr& serializer,
-            const std::array<uint8_t, 4>& transformation_kind, const uint32_t session_id,
+    bool serialize_SecureDataTag(
+            eprosima::fastcdr::Cdr& serializer,
+            const std::array<uint8_t, 4>& transformation_kind,
+            const uint32_t session_id,
             const std::array<uint8_t, 12>& initialization_vector,
-            std::vector<EntityCryptoHandle*>& receiving_datareader_crypto_list, bool update_specific_keys,
-            SecureDataTag& tag, size_t sessionIndex);
+            std::vector<EntityCryptoHandle*>& receiving_datareader_crypto_list,
+            bool update_specific_keys,
+            SecureDataTag& tag,
+            size_t sessionIndex);
 
-    bool serialize_SecureDataTag(eprosima::fastcdr::Cdr& serializer,
+    bool serialize_SecureDataTag(
+            eprosima::fastcdr::Cdr& serializer,
             const AESGCMGMAC_ParticipantCryptoHandle& local_participant,
             const std::array<uint8_t, 12>& initialization_vector,
-            std::vector<ParticipantCryptoHandle*>& receiving_crypto_list, bool update_specific_keys,
+            std::vector<ParticipantCryptoHandle*>& receiving_crypto_list,
+            bool update_specific_keys,
             SecureDataTag& tag);
 
-    SecureDataHeader deserialize_SecureDataHeader(eprosima::fastcdr::Cdr& decoder);
+    SecureDataHeader deserialize_SecureDataHeader(
+            eprosima::fastcdr::Cdr& decoder);
 
     /**
      * Get information on the data between a Header and a Tag submessage.
@@ -150,37 +165,53 @@ class AESGCMGMAC_Transform : public CryptoTransform
      * @param body_align Outputs number of alignment bytes after protected data
      * @return true when protected data is encrypted (i.e. it is a SEC_BODY submessage)
      */
-    bool predeserialize_SecureDataBody(eprosima::fastcdr::Cdr& decoder, uint32_t& body_length, uint32_t& body_align);
+    bool predeserialize_SecureDataBody(
+            eprosima::fastcdr::Cdr& decoder,
+            uint32_t& body_length,
+            uint32_t& body_align);
 
-    bool deserialize_SecureDataBody(eprosima::fastcdr::Cdr& decoder,
-            eprosima::fastcdr::Cdr::state& body_state, SecureDataTag& tag, uint32_t body_length,
+    bool deserialize_SecureDataBody(
+            eprosima::fastcdr::Cdr& decoder,
+            eprosima::fastcdr::Cdr::state& body_state,
+            SecureDataTag& tag,
+            uint32_t body_length,
             const std::array<uint8_t, 4>& transformation_kind,
-            const std::array<uint8_t,32>& session_key, const std::array<uint8_t, 12>& initialization_vector,
-            octet* plain_buffer, uint32_t& plain_buffer_len);
+            const std::array<uint8_t, 32>& session_key,
+            const std::array<uint8_t, 12>& initialization_vector,
+            octet* plain_buffer,
+            uint32_t& plain_buffer_len);
 
-    bool deserialize_SecureDataTag(eprosima::fastcdr::Cdr& decoder, SecureDataTag& tag,
+    bool deserialize_SecureDataTag(
+            eprosima::fastcdr::Cdr& decoder,
+            SecureDataTag& tag,
             const CryptoTransformKind& transformation_kind,
-            const CryptoTransformKeyId& receiver_specific_key_id, const std::array<uint8_t, 32>& receiver_specific_key,
-            const std::array<uint8_t,32>& master_salt, const std::array<uint8_t,12>& initialization_vector,
-            uint32_t session_id, SecurityException& exception);
+            const CryptoTransformKeyId& receiver_specific_key_id,
+            const std::array<uint8_t, 32>& receiver_specific_key,
+            const std::array<uint8_t, 32>& master_salt,
+            const std::array<uint8_t, 12>& initialization_vector,
+            uint32_t session_id,
+            SecurityException& exception);
 
-    uint32_t calculate_extra_size_for_rtps_message(uint32_t number_discovered_participants) const override;
+    uint32_t calculate_extra_size_for_rtps_message(
+            uint32_t number_discovered_participants) const override;
 
-    uint32_t calculate_extra_size_for_rtps_submessage(uint32_t number_discovered_readers) const override;
+    uint32_t calculate_extra_size_for_rtps_submessage(
+            uint32_t number_discovered_readers) const override;
 
-    uint32_t calculate_extra_size_for_encoded_payload(uint32_t number_discovered_readers) const override;
+    uint32_t calculate_extra_size_for_encoded_payload(
+            uint32_t number_discovered_readers) const override;
 
 private:
 
-        //Aux function to lookup endpoints
+    //Aux function to lookup endpoints
     bool lookup_reader(
             AESGCMGMAC_ParticipantCryptoHandle& participant,
-            DatareaderCryptoHandle **datareader_crypto,
+            DatareaderCryptoHandle** datareader_crypto,
             CryptoTransformKeyId key_id);
 
     bool lookup_writer(
             AESGCMGMAC_ParticipantCryptoHandle& participant,
-            DatawriterCryptoHandle **datawriter_crypto,
+            DatawriterCryptoHandle** datawriter_crypto,
             CryptoTransformKeyId key_id);
 
 };

--- a/src/cpp/security/cryptography/AESGCMGMAC_Transform.h
+++ b/src/cpp/security/cryptography/AESGCMGMAC_Transform.h
@@ -169,6 +169,20 @@ class AESGCMGMAC_Transform : public CryptoTransform
     uint32_t calculate_extra_size_for_rtps_submessage(uint32_t number_discovered_readers) const override;
 
     uint32_t calculate_extra_size_for_encoded_payload(uint32_t number_discovered_readers) const override;
+
+private:
+
+        //Aux function to lookup endpoints
+    bool lookup_reader(
+            AESGCMGMAC_ParticipantCryptoHandle& participant,
+            DatareaderCryptoHandle **datareader_crypto,
+            CryptoTransformKeyId key_id);
+
+    bool lookup_writer(
+            AESGCMGMAC_ParticipantCryptoHandle& participant,
+            DatawriterCryptoHandle **datawriter_crypto,
+            CryptoTransformKeyId key_id);
+
 };
 
 


### PR DESCRIPTION
Previous implementation made CryptographyPluginTest.transform_preprocess_secure_submessage to have flaky behavior when key_id is zero. In this particular case, the method AESGCMGMAC_Transform::preprocess_secure_submessage instead of looking for a match through the local endpoints, the method looked only through the remote endpoints. This particular case is needed only during discovery.

The method has been updated to first look through the local endpoints (in case it is an user message) and, if there is no matching endpoint found, look in the remote endpoints for a match if the key_id is zero (in case it is a discovery message). 

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>