### PR TITLE
Fix enable separate sending in subscriptions writer [9477]

### DIFF
--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer2.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer2.cpp
@@ -153,7 +153,7 @@ bool EDPServer2::createSEDPEndpoints()
                             false>*>(&dynamic_cast<PDPServer2*>(mp_PDP)->discovery_db());
             subscriptions_writer_.first->reader_data_filter(edp_subscriptions_filter);
             // 1.2. Enable separate sending so the filter can be called for each change and reader proxy
-            publications_writer_.first->set_separate_sending(true);
+            subscriptions_writer_.first->set_separate_sending(true);
             logInfo(RTPS_EDP, "SEDP Subscriptions Writer created");
 
         }


### PR DESCRIPTION
The subcriptions writer must have separate sending enable for the DS 2.0 to work properly.

Signed-off-by: EduPonz <eduardoponz@eprosima.com>