### PR TITLE
Fixed RTPSWithRegistrationReader

### DIFF
--- a/test/blackbox/common/RTPSWithRegistrationReader.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationReader.hpp
@@ -419,7 +419,10 @@ private:
             {
                 total_msgs_.erase(it);
                 ++current_received_count_;
-                if (check_seq) { default_receive_print<type>(data); }
+                if (check_seq)
+                {
+                    default_receive_print<type>(data);
+                }
                 cv_.notify_one();
             }
 


### PR DESCRIPTION
Test `BlackboxTests_RTPS.RTPS.RTPSAsReliableWithRegistrationAndHolesInHistory.Intraprocess` was failing sporadically with an infinite loop. This PR solves a possible race when using late joiners on RTPS blackbox tests.