### PR TITLE
Improvements on StatefulWriter

### DIFF
--- a/examples/C++/DDS/Configurability/UseCasePublisher.cpp
+++ b/examples/C++/DDS/Configurability/UseCasePublisher.cpp
@@ -22,9 +22,18 @@ using namespace eprosima::fastdds::dds;
 using namespace eprosima::fastrtps::rtps;
 
 //Enums and configuration structuredepth
-enum Reliability_type { Best_Effort, Reliable };
-enum Durability_type { Transient_Local, Volatile };
-enum HistoryKind_type { Keep_Last, Keep_All };
+enum Reliability_type
+{
+    Best_Effort, Reliable
+};
+enum Durability_type
+{
+    Transient_Local, Volatile
+};
+enum HistoryKind_type
+{
+    Keep_Last, Keep_All
+};
 
 struct example_configuration
 {
@@ -58,9 +67,12 @@ int main()
     {
         std::cin >> userchoice;
         int choice;
-        try{
+        try
+        {
             choice = std::stoi(userchoice);
-        }catch (std::invalid_argument&){
+        }
+        catch (std::invalid_argument&)
+        {
             std::cout << "Please input a valid argument" << std::endl;
             continue;
         }
@@ -91,9 +103,12 @@ int main()
     {
         std::cin >> userchoice;
         int choice;
-        try{
+        try
+        {
             choice = std::stoi(userchoice);
-        }catch (std::invalid_argument&){
+        }
+        catch (std::invalid_argument&)
+        {
             std::cout << "Please input a valid argument" << std::endl;
             continue;
         }
@@ -124,9 +139,12 @@ int main()
     {
         std::cin >> userchoice;
         int choice;
-        try{
+        try
+        {
             choice = std::stoi(userchoice);
-        }catch (std::invalid_argument&){
+        }
+        catch (std::invalid_argument&)
+        {
             std::cout << "Please input a valid argument" << std::endl;
             continue;
         }
@@ -157,9 +175,12 @@ int main()
         {
             std::cin >> userchoice;
             int choice;
-            try{
+            try
+            {
                 choice = std::stoi(userchoice);
-            }catch (std::invalid_argument&){
+            }
+            catch (std::invalid_argument&)
+            {
                 std::cout << "Please input a valid argument" << std::endl;
                 continue;
             }
@@ -177,9 +198,12 @@ int main()
     {
         std::cin >> userchoice;
         int choice;
-        try{
+        try
+        {
             choice = std::stoi(userchoice);
-        }catch (std::invalid_argument&){
+        }
+        catch (std::invalid_argument&)
+        {
             std::cout << "Please input a valid argument" << std::endl;
             continue;
         }
@@ -207,9 +231,12 @@ int main()
         {
             std::cin >> userchoice;
             int choice;
-            try{
+            try
+            {
                 choice = std::stoi(userchoice);
-            }catch (std::invalid_argument&){
+            }
+            catch (std::invalid_argument&)
+            {
                 std::cout << "Please input a valid argument" << std::endl;
                 continue;
             }
@@ -227,9 +254,12 @@ int main()
     {
         std::cin >> userchoice;
         int choice;
-        try{
+        try
+        {
             choice = std::stoi(userchoice);
-        }catch (std::invalid_argument&){
+        }
+        catch (std::invalid_argument&)
+        {
             std::cout << "Please input a valid argument" << std::endl;
             continue;
         }
@@ -305,7 +335,7 @@ int main()
     wqos.resource_limits().max_samples = user_configuration.history_size;
     wqos.resource_limits().max_instances = user_configuration.no_keys;
     wqos.resource_limits().max_samples_per_instance = user_configuration.no_keys > 1 ?
-        user_configuration.max_samples_per_key : user_configuration.history_size;
+            user_configuration.max_samples_per_key : user_configuration.history_size;
 
     DataWriter* myWriter = myPub->create_datawriter(PubTopic, wqos);
 
@@ -331,9 +361,12 @@ int main()
         }
         else
         {
-            try{
+            try
+            {
                 no = std::stoi(c);
-            }catch (std::invalid_argument&){
+            }
+            catch (std::invalid_argument&)
+            {
                 std::cout << "Please input a valid argument" << std::endl;
                 continue;
             }

--- a/examples/C++/DDS/Configurability/UseCasePublisher.cpp
+++ b/examples/C++/DDS/Configurability/UseCasePublisher.cpp
@@ -26,7 +26,7 @@ enum Reliability_type { Best_Effort, Reliable };
 enum Durability_type { Transient_Local, Volatile };
 enum HistoryKind_type { Keep_Last, Keep_All };
 
-typedef struct
+struct example_configuration
 {
     Reliability_type reliability;
     Durability_type durability;
@@ -35,7 +35,7 @@ typedef struct
     uint8_t depth = 1;
     uint8_t no_keys = 1;
     uint16_t max_samples_per_key = 1;
-} example_configuration;
+};
 
 int main()
 {

--- a/examples/C++/DDS/Configurability/UseCaseSubscriber.cpp
+++ b/examples/C++/DDS/Configurability/UseCaseSubscriber.cpp
@@ -24,9 +24,18 @@ using namespace eprosima::fastdds::dds;
 using namespace eprosima::fastrtps::rtps;
 
 //Enums and configuration structure
-enum Reliability_type { Best_Effort, Reliable };
-enum Durability_type { Transient_Local, Volatile };
-enum HistoryKind_type { Keep_Last, Keep_All };
+enum Reliability_type
+{
+    Best_Effort, Reliable
+};
+enum Durability_type
+{
+    Transient_Local, Volatile
+};
+enum HistoryKind_type
+{
+    Keep_Last, Keep_All
+};
 
 struct example_configuration
 {
@@ -62,9 +71,12 @@ int main()
     {
         std::cin >> userchoice;
         int choice;
-        try{
+        try
+        {
             choice = std::stoi(userchoice);
-        }catch (std::invalid_argument&){
+        }
+        catch (std::invalid_argument&)
+        {
             std::cout << "Please input a valid argument" << std::endl;
             continue;
         }
@@ -95,9 +107,12 @@ int main()
     {
         std::cin >> userchoice;
         int choice;
-        try{
+        try
+        {
             choice = std::stoi(userchoice);
-        }catch (std::invalid_argument&){
+        }
+        catch (std::invalid_argument&)
+        {
             std::cout << "Please input a valid argument" << std::endl;
             continue;
         }
@@ -128,9 +143,12 @@ int main()
     {
         std::cin >> userchoice;
         int choice;
-        try{
+        try
+        {
             choice = std::stoi(userchoice);
-        }catch (std::invalid_argument&){
+        }
+        catch (std::invalid_argument&)
+        {
             std::cout << "Please input a valid argument" << std::endl;
             continue;
         }
@@ -161,9 +179,12 @@ int main()
         {
             std::cin >> userchoice;
             int choice;
-            try{
+            try
+            {
                 choice = std::stoi(userchoice);
-            }catch (std::invalid_argument&){
+            }
+            catch (std::invalid_argument&)
+            {
                 std::cout << "Please input a valid argument" << std::endl;
                 continue;
             }
@@ -181,9 +202,12 @@ int main()
     {
         std::cin >> userchoice;
         int choice;
-        try{
+        try
+        {
             choice = std::stoi(userchoice);
-        }catch (std::invalid_argument&){
+        }
+        catch (std::invalid_argument&)
+        {
             std::cout << "Please input a valid argument" << std::endl;
             continue;
         }
@@ -211,9 +235,12 @@ int main()
         {
             std::cin >> userchoice;
             int choice;
-            try{
+            try
+            {
                 choice = std::stoi(userchoice);
-            }catch (std::invalid_argument&){
+            }
+            catch (std::invalid_argument&)
+            {
                 std::cout << "Please input a valid argument" << std::endl;
                 continue;
             }
@@ -231,9 +258,12 @@ int main()
     {
         std::cin >> userchoice;
         int choice;
-        try{
+        try
+        {
             choice = std::stoi(userchoice);
-        }catch (std::invalid_argument&){
+        }
+        catch (std::invalid_argument&)
+        {
             std::cout << "Please input a valid argument" << std::endl;
             continue;
         }
@@ -309,7 +339,7 @@ int main()
     rqos.resource_limits().max_samples = user_configuration.history_size;
     rqos.resource_limits().max_instances = user_configuration.no_keys;
     rqos.resource_limits().max_samples_per_instance = user_configuration.no_keys > 1 ?
-        user_configuration.max_samples_per_key : user_configuration.history_size;
+            user_configuration.max_samples_per_key : user_configuration.history_size;
 
     DataReader* EarlyReader = EarlySubscriber->create_datareader(SubTopic, rqos);
     if (EarlyReader == nullptr)
@@ -327,11 +357,11 @@ int main()
     {
         std::cout << "Press 'r' to read Messages from the History or 'q' to quit" << std::endl;
         std::cin >> c;
-        if ( c == std::string("q") )
+        if ( c == std::string("q"))
         {
             condition = false;
         }
-        else if ( c == std::string("r") )
+        else if ( c == std::string("r"))
         {
             while (EarlyReader->read_next_sample(&my_sample, &sample_info) == ReturnCode_t::RETCODE_OK)
             {

--- a/examples/C++/DDS/Configurability/UseCaseSubscriber.cpp
+++ b/examples/C++/DDS/Configurability/UseCaseSubscriber.cpp
@@ -28,7 +28,7 @@ enum Reliability_type { Best_Effort, Reliable };
 enum Durability_type { Transient_Local, Volatile };
 enum HistoryKind_type { Keep_Last, Keep_All };
 
-typedef struct
+struct example_configuration
 {
     Reliability_type reliability;
     Durability_type durability;
@@ -37,7 +37,7 @@ typedef struct
     uint8_t depth = 1;
     uint8_t no_keys = 1;
     uint16_t max_samples_per_key = 1;
-} example_configuration;
+};
 
 
 

--- a/src/cpp/rtps/writer/ReaderLocator.cpp
+++ b/src/cpp/rtps/writer/ReaderLocator.cpp
@@ -129,7 +129,7 @@ bool ReaderLocator::send(
         CDRMessage_t* message,
         std::chrono::steady_clock::time_point& max_blocking_time_point) const
 {
-    if (locator_info_.remote_guid != c_Guid_Unknown)
+    if (locator_info_.remote_guid != c_Guid_Unknown && !is_local_reader_)
     {
         if (locator_info_.unicast.size() > 0)
         {

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1101,7 +1101,7 @@ bool StatefulWriter::send_hole_gaps_to_group(
     SequenceNumber_t last_sequence = mp_history->next_sequence_number();
     SequenceNumber_t min_history_seq = get_seq_num_min();
     uint32_t history_size = static_cast<uint32_t>(mp_history->getHistorySize());
-    if ( (min_readers_low_mark_ < max_removed) &&    // some holes pending acknowledgement
+    if ((min_readers_low_mark_ < max_removed) &&     // some holes pending acknowledgement
             (min_history_seq + history_size != last_sequence)) // There is a hole in the history
     {
         try
@@ -1583,7 +1583,7 @@ void StatefulWriter::check_acked_status()
         // min_low_mark will be zero, and no change will be notified as received by all
         if (next_all_acked_notify_sequence_ <= min_low_mark)
         {
-            if ( (mp_listener != nullptr) && (min_low_mark >= get_seq_num_min()))
+            if ((mp_listener != nullptr) && (min_low_mark >= get_seq_num_min()))
             {
                 // We will inform backwards about the changes received by all readers, starting
                 // on min_low_mark down until next_all_acked_notify_sequence_. This way we can

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1846,6 +1846,10 @@ void StatefulWriter::send_heartbeat_nts_(
         bool final,
         bool liveliness)
 {
+    if (!number_of_readers)
+    {
+        return;
+    }
 
     SequenceNumber_t firstSeq = get_seq_num_min();
     SequenceNumber_t lastSeq = get_seq_num_max();

--- a/test/unittest/transport/SharedMemTests.cpp
+++ b/test/unittest/transport/SharedMemTests.cpp
@@ -149,7 +149,7 @@ protected:
     };
 
     std::unique_ptr<MultiProducerConsumerRingBuffer<MyData>::Cell[]> cells_;
-    std::unique_ptr<MultiProducerConsumerRingBuffer<MyData> > ring_buffer_;
+    std::unique_ptr<MultiProducerConsumerRingBuffer<MyData>> ring_buffer_;
     uint32_t buffer_size_;
 
     SHMRingBuffer()
@@ -163,7 +163,7 @@ protected:
             new MultiProducerConsumerRingBuffer<MyData>::Cell[buffer_size_]);
 
         ring_buffer_ =
-                std::unique_ptr<MultiProducerConsumerRingBuffer<MyData> >(new MultiProducerConsumerRingBuffer<MyData>(
+                std::unique_ptr<MultiProducerConsumerRingBuffer<MyData>>(new MultiProducerConsumerRingBuffer<MyData>(
                             cells_.get(), buffer_size_));
     }
 
@@ -177,7 +177,7 @@ protected:
 
 class SHMRingBufferMultiThread
     :   public SHMRingBuffer,
-    public testing::WithParamInterface<std::tuple<uint32_t, uint32_t, uint32_t> >
+    public testing::WithParamInterface<std::tuple<uint32_t, uint32_t, uint32_t>>
 {
 
 };
@@ -261,14 +261,14 @@ TEST_F(SHMRingBuffer, one_listener_reads_all)
 
 TEST_F(SHMRingBuffer, copy)
 {
-    std::unique_ptr<MultiProducerConsumerRingBuffer<MyData> > ring_buffer;
+    std::unique_ptr<MultiProducerConsumerRingBuffer<MyData>> ring_buffer;
 
     std::unique_ptr<MultiProducerConsumerRingBuffer<MyData>::Cell[]> cells
         = std::unique_ptr<MultiProducerConsumerRingBuffer<MyData>::Cell[]>(
                 new MultiProducerConsumerRingBuffer<MyData>::Cell[2]);
 
     ring_buffer =
-            std::unique_ptr<MultiProducerConsumerRingBuffer<MyData> >(new MultiProducerConsumerRingBuffer<MyData>(
+            std::unique_ptr<MultiProducerConsumerRingBuffer<MyData>>(new MultiProducerConsumerRingBuffer<MyData>(
                         cells_.get(), 2));
 
     auto listener = ring_buffer->register_listener();
@@ -1177,7 +1177,7 @@ TEST_F(SHMTransportTests, memory_bounds)
         allocations = 1u;
     }
 
-    std::vector<std::shared_ptr<SharedMemManager::Segment> > segments;
+    std::vector<std::shared_ptr<SharedMemManager::Segment>> segments;
 
     auto zero_mem = [&]()
             {
@@ -1616,10 +1616,10 @@ TEST_F(SHMTransportTests, remote_segments_free)
     const std::string domain_name("SHMTests");
     uint32_t num_participants = 100;
 
-    std::vector<std::shared_ptr<SharedMemManager> > managers;
-    std::vector<std::shared_ptr<SharedMemManager::Port> > ports;
-    std::vector<std::shared_ptr<SharedMemManager::Segment> > segments;
-    std::vector<std::shared_ptr<SharedMemManager::Listener> > listeners;
+    std::vector<std::shared_ptr<SharedMemManager>> managers;
+    std::vector<std::shared_ptr<SharedMemManager::Port>> ports;
+    std::vector<std::shared_ptr<SharedMemManager::Segment>> segments;
+    std::vector<std::shared_ptr<SharedMemManager::Listener>> listeners;
 
     std::cout << "Creating " << num_participants << " SharedMemManagers & respective segments..." << std::endl;
 

--- a/test/unittest/transport/SharedMemTests.cpp
+++ b/test/unittest/transport/SharedMemTests.cpp
@@ -1023,7 +1023,7 @@ TEST_F(SHMTransportTests, robust_exclusive_lock)
     auto el1 = std::make_shared<RobustExclusiveLock>(lock_name);
 
     // A second lock fail
-    ASSERT_THROW(std::make_shared<RobustExclusiveLock>(lock_name), std::exception);
+    ASSERT_THROW(auto foo = std::make_shared<RobustExclusiveLock>(lock_name), std::exception);
     ASSERT_TRUE(RobustExclusiveLock::is_locked(lock_name));
 
     // Remove lock


### PR DESCRIPTION
Some improvements on StatefulWriter:

* Avoid trying to send a heartbeat if no reader is matched.
Although quite harmless, this may cause an ERROR log with security because the writer is unable to encrypt the message if there are no matched readers.
* Avoid sending traffic to newly matched intraprocess reader.