### PR TITLE
Do not relay on first reader only to decode encrypted message [9502]

### DIFF
--- a/include/fastdds/rtps/messages/MessageReceiver.h
+++ b/include/fastdds/rtps/messages/MessageReceiver.h
@@ -202,9 +202,11 @@ private:
      * @param[in] change    The CacheChange with the received data to process
      */
     ///@{
+ #if HAVE_SECURITY
     void process_data_message_with_security(
             const EntityId_t& reader_id,
             CacheChange_t& change);
+#endif // HAVE_SECURITY
 
     void process_data_message_without_security(
             const EntityId_t& reader_id,
@@ -222,12 +224,14 @@ private:
      * @param[in] fragments_in_submessage The number of fragments in the message
      */
     ///@{
+ #if HAVE_SECURITY
     void process_data_fragment_message_with_security(
             const EntityId_t& reader_id,
             CacheChange_t& change,
             uint32_t sample_size,
             uint32_t fragment_starting_num,
             uint32_t fragments_in_submessage);
+#endif // HAVE_SECURITY
 
     void process_data_fragment_message_without_security(
             const EntityId_t& reader_id,

--- a/include/fastdds/rtps/messages/MessageReceiver.h
+++ b/include/fastdds/rtps/messages/MessageReceiver.h
@@ -104,7 +104,7 @@ private:
                 CacheChange_t&,
                 uint32_t,
                 uint32_t,
-                uint32_t)> process_data_fragment_message_function_;
+                uint16_t)> process_data_fragment_message_function_;
 
 
     //!Reset the MessageReceiver to process a new message.
@@ -230,7 +230,7 @@ private:
             CacheChange_t& change,
             uint32_t sample_size,
             uint32_t fragment_starting_num,
-            uint32_t fragments_in_submessage);
+            uint16_t fragments_in_submessage);
 #endif // HAVE_SECURITY
 
     void process_data_fragment_message_without_security(
@@ -238,7 +238,7 @@ private:
             CacheChange_t& change,
             uint32_t sample_size,
             uint32_t fragment_starting_num,
-            uint32_t fragments_in_submessage);
+            uint16_t fragments_in_submessage);
     ///@}
 };
 

--- a/include/fastdds/rtps/messages/MessageReceiver.h
+++ b/include/fastdds/rtps/messages/MessageReceiver.h
@@ -73,7 +73,7 @@ private:
 
     std::mutex mtx_;
     std::vector<RTPSWriter*> associated_writers_;
-    std::unordered_map<EntityId_t, std::vector<RTPSReader*> > associated_readers_;
+    std::unordered_map<EntityId_t, std::vector<RTPSReader*>> associated_readers_;
 
     RTPSParticipantImpl* participant_;
     //!Protocol version of the message
@@ -96,15 +96,15 @@ private:
 
     //! Function used to process a received message
     std::function<void(
-            const EntityId_t&,
-            CacheChange_t&)> process_data_message_function_;
+                const EntityId_t&,
+                CacheChange_t&)> process_data_message_function_;
     //! Function used to process a received fragment message
     std::function<void(
-            const EntityId_t&,
-            CacheChange_t&,
-            uint32_t,
-            uint32_t,
-            uint32_t)> process_data_fragment_message_function_;
+                const EntityId_t&,
+                CacheChange_t&,
+                uint32_t,
+                uint32_t,
+                uint32_t)> process_data_fragment_message_function_;
 
 
     //!Reset the MessageReceiver to process a new message.
@@ -197,7 +197,7 @@ private:
 
     /**
      * @name Variants of received data message processing functions.
-     * 
+     *
      * @param[in] reader_id The ID of the reader to which the changes is addressed
      * @param[in] change    The CacheChange with the received data to process
      */
@@ -213,10 +213,10 @@ private:
 
     /**
      * @name Variants of received data fragment message processing functions.
-     * 
+     *
      * @param[in] reader_id The ID of the reader to which the changes is addressed
      * @param[in] change    The CacheChange with the received data to process
-     * 
+     *
      * @param[in] sample_size             The size of the message
      * @param[in] fragment_starting_num   The index of the first fragment in the message
      * @param[in] fragments_in_submessage The number of fragments in the message

--- a/include/fastdds/rtps/messages/MessageReceiver.h
+++ b/include/fastdds/rtps/messages/MessageReceiver.h
@@ -24,6 +24,7 @@
 
 #include <unordered_map>
 #include <mutex>
+#include <functional>
 
 namespace eprosima {
 namespace fastrtps {
@@ -92,6 +93,19 @@ private:
     CDRMessage_t crypto_msg_;
     SerializedPayload_t crypto_payload_;
 #endif // if HAVE_SECURITY
+
+    //! Function used to process a received message
+    std::function<void(
+            const EntityId_t&,
+            CacheChange_t&)> process_data_message_function_;
+    //! Function used to process a received fragment message
+    std::function<void(
+            const EntityId_t&,
+            CacheChange_t&,
+            uint32_t,
+            uint32_t,
+            uint32_t)> process_data_fragment_message_function_;
+
 
     //!Reset the MessageReceiver to process a new message.
     void reset();
@@ -178,6 +192,49 @@ private:
     bool proc_Submsg_HeartbeatFrag(
             CDRMessage_t* msg,
             SubmessageHeader_t* smh);
+    ///@}
+
+
+    /**
+     * @name Variants of received data message processing functions.
+     * 
+     * @param[in] reader_id The ID of the reader to which the changes is addressed
+     * @param[in] change    The CacheChange with the received data to process
+     */
+    ///@{
+    void process_data_message_with_security(
+            const EntityId_t& reader_id,
+            CacheChange_t& change);
+
+    void process_data_message_without_security(
+            const EntityId_t& reader_id,
+            CacheChange_t& change);
+    ///@}
+
+    /**
+     * @name Variants of received data fragment message processing functions.
+     * 
+     * @param[in] reader_id The ID of the reader to which the changes is addressed
+     * @param[in] change    The CacheChange with the received data to process
+     * 
+     * @param[in] sample_size             The size of the message
+     * @param[in] fragment_starting_num   The index of the first fragment in the message
+     * @param[in] fragments_in_submessage The number of fragments in the message
+     */
+    ///@{
+    void process_data_fragment_message_with_security(
+            const EntityId_t& reader_id,
+            CacheChange_t& change,
+            uint32_t sample_size,
+            uint32_t fragment_starting_num,
+            uint32_t fragments_in_submessage);
+
+    void process_data_fragment_message_without_security(
+            const EntityId_t& reader_id,
+            CacheChange_t& change,
+            uint32_t sample_size,
+            uint32_t fragment_starting_num,
+            uint32_t fragments_in_submessage);
     ///@}
 };
 

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -63,39 +63,40 @@ MessageReceiver::MessageReceiver(
     if (participant->is_secure())
     {
         process_data_message_function_ = std::bind(
-                &MessageReceiver::process_data_message_with_security,
-                this,
-                std::placeholders::_1,
-                std::placeholders::_2);
+            &MessageReceiver::process_data_message_with_security,
+            this,
+            std::placeholders::_1,
+            std::placeholders::_2);
 
         process_data_fragment_message_function_ = std::bind(
-                &MessageReceiver::process_data_fragment_message_with_security,
-                this,
-                std::placeholders::_1,
-                std::placeholders::_2,
-                std::placeholders::_3,
-                std::placeholders::_4,
-                std::placeholders::_5);
+            &MessageReceiver::process_data_fragment_message_with_security,
+            this,
+            std::placeholders::_1,
+            std::placeholders::_2,
+            std::placeholders::_3,
+            std::placeholders::_4,
+            std::placeholders::_5);
     }
     else
     {
 #endif // if HAVE SECURITY
-        process_data_message_function_ = std::bind(
-                &MessageReceiver::process_data_message_without_security,
-                this,
-                std::placeholders::_1,
-                std::placeholders::_2);
+    process_data_message_function_ = std::bind(
+        &MessageReceiver::process_data_message_without_security,
+        this,
+        std::placeholders::_1,
+        std::placeholders::_2);
 
-        process_data_fragment_message_function_ = std::bind(
-                &MessageReceiver::process_data_fragment_message_without_security,
-                this,
-                std::placeholders::_1,
-                std::placeholders::_2,
-                std::placeholders::_3,
-                std::placeholders::_4,
-                std::placeholders::_5);
+    process_data_fragment_message_function_ = std::bind(
+        &MessageReceiver::process_data_fragment_message_without_security,
+        this,
+        std::placeholders::_1,
+        std::placeholders::_2,
+        std::placeholders::_3,
+        std::placeholders::_4,
+        std::placeholders::_5);
 #if HAVE_SECURITY
-    }
+}
+
 #endif // if HAVE SECURITY
 }
 
@@ -152,13 +153,14 @@ void MessageReceiver::process_data_message_without_security(
 }
 
 void MessageReceiver::process_data_fragment_message_with_security(
-            const EntityId_t& reader_id,
-            CacheChange_t& change,
-            uint32_t sample_size,
-            uint32_t fragment_starting_num,
-            uint32_t fragments_in_submessage)
+        const EntityId_t& reader_id,
+        CacheChange_t& change,
+        uint32_t sample_size,
+        uint32_t fragment_starting_num,
+        uint32_t fragments_in_submessage)
 {
-    auto process_message = [&change, sample_size, fragment_starting_num, fragments_in_submessage, this](RTPSReader* reader)
+    auto process_message =
+            [&change, sample_size, fragment_starting_num, fragments_in_submessage, this](RTPSReader* reader)
             {
                 if (!reader->getAttributes().security_attributes().is_payload_protected)
                 {
@@ -188,11 +190,11 @@ void MessageReceiver::process_data_fragment_message_with_security(
 }
 
 void MessageReceiver::process_data_fragment_message_without_security(
-            const EntityId_t& reader_id,
-            CacheChange_t& change,
-            uint32_t sample_size,
-            uint32_t fragment_starting_num,
-            uint32_t fragments_in_submessage)
+        const EntityId_t& reader_id,
+        CacheChange_t& change,
+        uint32_t sample_size,
+        uint32_t fragment_starting_num,
+        uint32_t fragments_in_submessage)
 {
     auto process_message = [&change, sample_size, fragment_starting_num, fragments_in_submessage](RTPSReader* reader)
             {

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -107,6 +107,7 @@ MessageReceiver::~MessageReceiver()
     assert(associated_readers_.empty());
 }
 
+ #if HAVE_SECURITY
 void MessageReceiver::process_data_message_with_security(
         const EntityId_t& reader_id,
         CacheChange_t& change)
@@ -135,18 +136,6 @@ void MessageReceiver::process_data_message_with_security(
                 reader->processDataMsg(&change);
                 std::swap(change.serializedPayload.data, crypto_payload_.data);
                 std::swap(change.serializedPayload.length, crypto_payload_.length);
-            };
-
-    findAllReaders(reader_id, process_message);
-}
-
-void MessageReceiver::process_data_message_without_security(
-        const EntityId_t& reader_id,
-        CacheChange_t& change)
-{
-    auto process_message = [&change](RTPSReader* reader)
-            {
-                reader->processDataMsg(&change);
             };
 
     findAllReaders(reader_id, process_message);
@@ -184,6 +173,20 @@ void MessageReceiver::process_data_fragment_message_with_security(
                 reader->processDataFragMsg(&change, sample_size, fragment_starting_num, fragments_in_submessage);
                 std::swap(change.serializedPayload.data, crypto_payload_.data);
                 std::swap(change.serializedPayload.length, crypto_payload_.length);
+            };
+
+    findAllReaders(reader_id, process_message);
+}
+
+#endif // if HAVE SECURITY
+
+void MessageReceiver::process_data_message_without_security(
+        const EntityId_t& reader_id,
+        CacheChange_t& change)
+{
+    auto process_message = [&change](RTPSReader* reader)
+            {
+                reader->processDataMsg(&change);
             };
 
     findAllReaders(reader_id, process_message);

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -679,33 +679,22 @@ bool MessageReceiver::proc_Submsg_Data(
                     return;
                 }
 
-                bool is_decoded = false;
-                if (participant_->security_manager().decode_serialized_payload(ch.serializedPayload,
+                if (!participant_->security_manager().decode_serialized_payload(ch.serializedPayload,
                         crypto_payload_, reader->getGuid(), ch.writerGUID))
-                {
-                    std::swap(ch.serializedPayload.data, crypto_payload_.data);
-                    std::swap(ch.serializedPayload.length, crypto_payload_.length);
-                    is_decoded = true;
-                }
-                else
                 {
                     return;
                 }
-                reader->processDataMsg(&ch);
 
-                if (is_decoded)
-                {
-                    std::swap(ch.serializedPayload.data, crypto_payload_.data);
-                    std::swap(ch.serializedPayload.length, crypto_payload_.length);
-                }
+                std::swap(ch.serializedPayload.data, crypto_payload_.data);
+                std::swap(ch.serializedPayload.length, crypto_payload_.length);
+                reader->processDataMsg(&ch);
+                std::swap(ch.serializedPayload.data, crypto_payload_.data);
+                std::swap(ch.serializedPayload.length, crypto_payload_.length);
             };
 #else
     auto process_message = [&ch](RTPSReader* reader)
             {
-                if (reader->matched_writer_is_matched(ch.writerGUID))
-                {
-                    reader->processDataMsg(&ch);
-                }
+                reader->processDataMsg(&ch);
             };
 #endif  // HAVE_SECURITY
 
@@ -895,33 +884,22 @@ bool MessageReceiver::proc_Submsg_DataFrag(
                     return;
                 }
 
-                bool is_decoded = false;
-                if (participant_->security_manager().decode_serialized_payload(ch.serializedPayload,
+                if (!participant_->security_manager().decode_serialized_payload(ch.serializedPayload,
                         crypto_payload_, reader->getGuid(), ch.writerGUID))
-                {
-                    std::swap(ch.serializedPayload.data, crypto_payload_.data);
-                    std::swap(ch.serializedPayload.length, crypto_payload_.length);
-                    is_decoded = true;
-                }
-                else
                 {
                     return;
                 }
-                reader->processDataMsg(&ch, sampleSize, fragmentStartingNum, fragmentsInSubmessage);
 
-                if (is_decoded)
-                {
-                    std::swap(ch.serializedPayload.data, crypto_payload_.data);
-                    std::swap(ch.serializedPayload.length, crypto_payload_.length);
-                }
+                std::swap(ch.serializedPayload.data, crypto_payload_.data);
+                std::swap(ch.serializedPayload.length, crypto_payload_.length);
+                reader->processDataFragMsg(&ch, sampleSize, fragmentStartingNum, fragmentsInSubmessage);
+                std::swap(ch.serializedPayload.data, crypto_payload_.data);
+                std::swap(ch.serializedPayload.length, crypto_payload_.length);
             };
 #else
     auto process_message = [&ch, sampleSize, fragmentStartingNum, fragmentsInSubmessage](RTPSReader* reader)
             {
-                if (reader->matched_writer_is_matched(ch.writerGUID))
-                {
-                    reader->processDataFragMsg(&ch, sampleSize, fragmentStartingNum, fragmentsInSubmessage);
-                }
+                reader->processDataFragMsg(&ch, sampleSize, fragmentStartingNum, fragmentsInSubmessage);
             };
 #endif  // HAVE_SECURITY
 

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -427,7 +427,7 @@ bool MessageReceiver::readSubmessageHeader(
         return false;
     }
 
-    if ( (length == 0) && (smh->submessageId != INFO_TS) && (smh->submessageId != PAD) )
+    if ((length == 0) && (smh->submessageId != INFO_TS) && (smh->submessageId != PAD))
     {
         // THIS IS THE LAST SUBMESSAGE
         smh->submessageLength = msg->length - msg->pos;
@@ -605,7 +605,7 @@ bool MessageReceiver::proc_Submsg_Data(
 
     if (inlineQosFlag)
     {
-        if (!ParameterList::updateCacheChangeFromInlineQos(ch, msg, inlineQosSize) )
+        if (!ParameterList::updateCacheChangeFromInlineQos(ch, msg, inlineQosSize))
         {
             logInfo(RTPS_MSG_IN, IDSTRING "SubMessage Data ERROR, Inline Qos ParameterList error");
             return false;
@@ -677,8 +677,8 @@ bool MessageReceiver::proc_Submsg_Data(
                             reader->getAttributes().security_attributes().is_payload_protected &&
                             reader->matched_writer_is_matched(ch.writerGUID))
                     {
-                        if (participant_->security_manager().decode_serialized_payload(ch.serializedPayload, crypto_payload_,
-                                reader->getGuid(), ch.writerGUID))
+                        if (participant_->security_manager().decode_serialized_payload(ch.serializedPayload,
+                                crypto_payload_, reader->getGuid(), ch.writerGUID))
                         {
                             ch.serializedPayload.data = crypto_payload_.data;
                             ch.serializedPayload.length = crypto_payload_.length;
@@ -873,8 +873,8 @@ bool MessageReceiver::proc_Submsg_DataFrag(
                             reader->getAttributes().security_attributes().is_payload_protected &&
                             reader->matched_writer_is_matched(ch.writerGUID))
                     {
-                        if (participant_->security_manager().decode_serialized_payload(ch.serializedPayload, crypto_payload_,
-                                reader->getGuid(), ch.writerGUID))
+                        if (participant_->security_manager().decode_serialized_payload(ch.serializedPayload,
+                                crypto_payload_, reader->getGuid(), ch.writerGUID))
                         {
                             ch.serializedPayload.data = crypto_payload_.data;
                             ch.serializedPayload.length = crypto_payload_.length;

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -146,7 +146,7 @@ void MessageReceiver::process_data_fragment_message_with_security(
         CacheChange_t& change,
         uint32_t sample_size,
         uint32_t fragment_starting_num,
-        uint32_t fragments_in_submessage)
+        uint16_t fragments_in_submessage)
 {
     auto process_message =
             [&change, sample_size, fragment_starting_num, fragments_in_submessage, this](RTPSReader* reader)
@@ -197,7 +197,7 @@ void MessageReceiver::process_data_fragment_message_without_security(
         CacheChange_t& change,
         uint32_t sample_size,
         uint32_t fragment_starting_num,
-        uint32_t fragments_in_submessage)
+        uint16_t fragments_in_submessage)
 {
     auto process_message = [&change, sample_size, fragment_starting_num, fragments_in_submessage](RTPSReader* reader)
             {


### PR DESCRIPTION
This corrects a bug added on PR #1312 , where the first reader of the participant was always used to decode the encrypted message, even though that reader may not be matched to the sending writer, and thus, would not be able to decrypt it.
