### PR TITLE
Servers receive all clients info [9500]

### DIFF
--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -160,14 +160,33 @@ void DiscoveryDataBase::add_ack_(
 }
 
 bool DiscoveryDataBase::update(
+            eprosima::fastrtps::rtps::CacheChange_t* change,
+            DiscoveryParticipantChangeData participant_change_data)
+{
+    if (!is_participant(change))
+    {
+        logError(DISCOVERY_DATABASE, "Change is not a DATA(p|Up): " << change->instanceHandle);
+        return false;
+    }
+    logInfo(DISCOVERY_DATABASE, "Adding DATA(p|Up) to the queue: " << change->instanceHandle);
+    //  Add the DATA(p|Up) to the PDP queue to process
+    pdp_data_queue_.Push(eprosima::fastdds::rtps::ddb::DiscoveryPDPDataQueueInfo(change, participant_change_data));
+    return true;
+}
+
+bool DiscoveryDataBase::update(
         eprosima::fastrtps::rtps::CacheChange_t* change,
         std::string topic_name)
 {
-    logInfo(DISCOVERY_DATABASE, "Adding change to the queue: " << change->instanceHandle);
-    //  add the data to the queue to process
-    data_queue_.Push(eprosima::fastdds::rtps::ddb::DiscoveryDataQueueInfo(change, topic_name));
+    if (!is_writer(change) && !is_reader(change))
+    {
+        logError(DISCOVERY_DATABASE, "Change is not a DATA(w|Uw|r|Ur): " << change->instanceHandle);
+        return false;
+    }
 
-    // not way to check if is an error
+    logInfo(DISCOVERY_DATABASE, "Adding DATA(w|Uw|r|Ur) to the queue: " << change->instanceHandle);
+    //  add the DATA(w|Uw|r|Ur) to the EDP queue to process
+    edp_data_queue_.Push(eprosima::fastdds::rtps::ddb::DiscoveryEDPDataQueueInfo(change, topic_name));
     return true;
 }
 
@@ -244,8 +263,40 @@ void DiscoveryDataBase::clear_changes_to_release()
 }
 
 ////////////
-// Functions to process_data_queue()
-bool DiscoveryDataBase::process_data_queue()
+// Functions to process PDP and EDP data queues
+void DiscoveryDataBase::process_pdp_data_queue()
+{
+    // Lock(exclusive mode) mutex locally
+    std::unique_lock<share_mutex_t> lock(sh_mtx_);
+
+    // Swap DATA queues
+    pdp_data_queue_.Swap();
+
+    // Process all messages in the queque
+    while (!pdp_data_queue_.Empty())
+    {
+        // Process each message with Front()
+        DiscoveryPDPDataQueueInfo data_queue_info = pdp_data_queue_.Front();
+
+        // If the change is a DATA(p)
+        if (data_queue_info.change()->kind == eprosima::fastrtps::rtps::ALIVE)
+        {
+            // Update participants map
+            logInfo(DISCOVERY_DATABASE, "DATA(p) received from: " << data_queue_info.change()->instanceHandle);
+            create_participant_from_change(data_queue_info.change(), data_queue_info.participant_change_data());
+        }
+        // If the change is a DATA(Up)
+        else
+        {
+            process_dispose_participant(data_queue_info.change());
+        }
+
+        // Pop the message from the queue
+        pdp_data_queue_.Pop();
+    }
+}
+
+bool DiscoveryDataBase::process_edp_data_queue()
 {
     bool is_dirty_topic = false;
 
@@ -253,32 +304,25 @@ bool DiscoveryDataBase::process_data_queue()
     std::unique_lock<share_mutex_t> lock(sh_mtx_);
 
     // Swap DATA queues
-    data_queue_.Swap();
+    edp_data_queue_.Swap();
 
     eprosima::fastrtps::rtps::CacheChange_t* change;
     std::string topic_name;
 
     // Process all messages in the queque
-    while (!data_queue_.Empty())
+    while (!edp_data_queue_.Empty())
     {
         // Process each message with Front()
-        DiscoveryDataQueueInfo data_queue_info = data_queue_.Front();
+        DiscoveryEDPDataQueueInfo data_queue_info = edp_data_queue_.Front();
         change = data_queue_info.change();
         topic_name = data_queue_info.topic();
 
-        // If the change is a DATA(p|w|r)
+        // If the change is a DATA(w|r)
         if (change->kind == eprosima::fastrtps::rtps::ALIVE)
         {
             logInfo(DISCOVERY_DATABASE, "ALIVE change received from: " << change->instanceHandle);
-            // DATA(p) case
-            if (is_participant(change))
-            {
-                // Update participants map
-                logInfo(DISCOVERY_DATABASE, "DATA(p) received from: " << change->instanceHandle);
-                create_participant_from_change(change);
-            }
             // DATA(w) case
-            else if (is_writer(change))
+            if (is_writer(change))
             {
                 logInfo(DISCOVERY_DATABASE, "DATA(w) in topic " << topic_name << " received from: "
                                                                 << change->instanceHandle);
@@ -293,9 +337,9 @@ bool DiscoveryDataBase::process_data_queue()
             }
 
             // Update set of dirty_topics
-            // In case of Data(p), topic name is empty, so no topic should be added to dirty_topics_
-            if ((topic_name != "") &&
-                    std::find(dirty_topics_.begin(), dirty_topics_.end(),
+            if (std::find(
+                    dirty_topics_.begin(),
+                    dirty_topics_.end(),
                     topic_name) == dirty_topics_.end())
             {
                 logInfo(DISCOVERY_DATABASE, "Setting topic " << topic_name << " as dirty");
@@ -303,16 +347,11 @@ bool DiscoveryDataBase::process_data_queue()
                 is_dirty_topic = true;
             }
         }
-        // If the change is a DATA(Up|Uw|Ur)
+        // If the change is a DATA(Uw|Ur)
         else
         {
-            // DATA(Up) case
-            if (is_participant(change))
-            {
-                process_dispose_participant(change);
-            }
             // DATA(Uw) case
-            else if (is_writer(change))
+            if (is_writer(change))
             {
                 process_dispose_writer(change, topic_name);
             }
@@ -324,16 +363,17 @@ bool DiscoveryDataBase::process_data_queue()
         }
 
         // Pop the message from the queue
-        data_queue_.Pop();
+        edp_data_queue_.Pop();
     }
 
     return is_dirty_topic;
 }
 
 void DiscoveryDataBase::create_participant_from_change(
-        eprosima::fastrtps::rtps::CacheChange_t* ch)
+        eprosima::fastrtps::rtps::CacheChange_t* ch,
+        const DiscoveryParticipantChangeData& change_data)
 {
-    DiscoveryParticipantInfo part(ch);
+    DiscoveryParticipantInfo part(ch, change_data);
     std::pair<std::map<eprosima::fastrtps::rtps::GuidPrefix_t, DiscoveryParticipantInfo>::iterator, bool> ret =
             participants_.insert(std::make_pair(guid_from_change(ch).guidPrefix, part));
 
@@ -343,7 +383,7 @@ void DiscoveryDataBase::create_participant_from_change(
     {
         // Add old change to changes_to_release_
         logInfo(DISCOVERY_DATABASE, "Participant updating. Marking old change to release");
-        changes_to_release_.push_back(ret.first->second.set_change_and_unmatch(ch));
+        changes_to_release_.push_back(ret.first->second.update_and_unmatch(ch, change_data));
     }
     else
     {
@@ -461,7 +501,7 @@ void DiscoveryDataBase::create_writers_from_change(
     // If writer exists, update the change and set all participant ack status to false
     else
     {
-        changes_to_release_.push_back(ret.first->second.set_change_and_unmatch(ch));
+        changes_to_release_.push_back(ret.first->second.update_and_unmatch(ch));
     }
 
 }
@@ -560,7 +600,7 @@ void DiscoveryDataBase::create_readers_from_change(
     // If reader exists, update the change and set all participant ack status to false
     else
     {
-        changes_to_release_.push_back(ret.first->second.set_change_and_unmatch(ch));
+        changes_to_release_.push_back(ret.first->second.update_and_unmatch(ch));
     }
 }
 
@@ -574,7 +614,9 @@ void DiscoveryDataBase::process_dispose_participant(
             participants_.find(participant_guid.guidPrefix);
     if (pit != participants_.end())
     {
-        changes_to_release_.push_back(pit->second.set_change_and_unmatch(ch));
+        // Only update DATA(p), leaving the change info untouched. This is because DATA(Up) does not have the
+        // participant's meta-information, but we don't want to loose it here.
+        changes_to_release_.push_back(pit->second.update_and_unmatch(ch));
     }
 
     // Delete entries from writers_ belonging to the participant
@@ -678,7 +720,7 @@ void DiscoveryDataBase::process_dispose_writer(
     std::map<eprosima::fastrtps::rtps::GUID_t, DiscoveryEndpointInfo>::iterator wit = writers_.find(writer_guid);
     if (wit != writers_.end())
     {
-        changes_to_release_.push_back(wit->second.set_change_and_unmatch(ch));
+        changes_to_release_.push_back(wit->second.update_and_unmatch(ch));
     }
 
     // Update own entry participants_::writers
@@ -729,7 +771,7 @@ void DiscoveryDataBase::process_dispose_reader(
     std::map<eprosima::fastrtps::rtps::GUID_t, DiscoveryEndpointInfo>::iterator rit = readers_.find(reader_guid);
     if (rit != readers_.end())
     {
-        changes_to_release_.push_back(rit->second.set_change_and_unmatch(ch));
+        changes_to_release_.push_back(rit->second.update_and_unmatch(ch));
     }
 
     // Update own entry participants_::readers

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
@@ -126,8 +126,11 @@ public:
      */
     bool update(
             eprosima::fastrtps::rtps::CacheChange_t* change,
-            std::string topic_name = "");
+            std::string topic_name);
 
+    bool update(
+            eprosima::fastrtps::rtps::CacheChange_t* change,
+            DiscoveryParticipantChangeData participant_change_data);
 
     ////////////
     // Functions to is_relevant
@@ -155,11 +158,14 @@ public:
 
 
     ////////////
-    // Functions to process_data_queue()
-    bool process_data_queue();
+    // Functions to process PDP and EDP data queues
+    void process_pdp_data_queue();
+
+    bool process_edp_data_queue();
 
     void create_participant_from_change(
-            eprosima::fastrtps::rtps::CacheChange_t* ch);
+            eprosima::fastrtps::rtps::CacheChange_t* ch,
+            const DiscoveryParticipantChangeData& change_data);
 
     void create_writers_from_change(
             eprosima::fastrtps::rtps::CacheChange_t* ch,
@@ -259,8 +265,14 @@ protected:
         //sh_mtx_.unlock();
     }
 
+<<<<<<< HEAD
     //! Incoming discovery traffic populated by the listeners, PDP database is already updated on notify
     fastrtps::DBQueue<eprosima::fastdds::rtps::ddb::DiscoveryDataQueueInfo> data_queue_;
+=======
+    fastrtps::DBQueue<eprosima::fastdds::rtps::ddb::DiscoveryPDPDataQueueInfo> pdp_data_queue_;
+
+    fastrtps::DBQueue<eprosima::fastdds::rtps::ddb::DiscoveryEDPDataQueueInfo> edp_data_queue_;
+>>>>>>> 261857512... Refs #9449: Add locators + whether a participant is a client + whether a participant is my client to DDB
 
     //! Covenient per-topic mapping of readers and writers to speed-up queries
     std::map<std::string, std::vector<eprosima::fastrtps::rtps::GUID_t>> readers_by_topic_;

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
@@ -231,7 +231,10 @@ public:
 
     fastrtps::rtps::CacheChange_t* cache_change_own_participant();
 
-    const std::vector<fastrtps::rtps::GuidPrefix_t> remote_participants();
+    const std::vector<fastrtps::rtps::GuidPrefix_t> direct_clients_and_servers();
+
+    fastrtps::rtps::LocatorList_t participant_metatraffic_locators(
+            fastrtps::rtps::GuidPrefix_t participant_guid_prefix);
 
 protected:
 
@@ -265,14 +268,9 @@ protected:
         //sh_mtx_.unlock();
     }
 
-<<<<<<< HEAD
-    //! Incoming discovery traffic populated by the listeners, PDP database is already updated on notify
-    fastrtps::DBQueue<eprosima::fastdds::rtps::ddb::DiscoveryDataQueueInfo> data_queue_;
-=======
     fastrtps::DBQueue<eprosima::fastdds::rtps::ddb::DiscoveryPDPDataQueueInfo> pdp_data_queue_;
 
     fastrtps::DBQueue<eprosima::fastdds::rtps::ddb::DiscoveryEDPDataQueueInfo> edp_data_queue_;
->>>>>>> 261857512... Refs #9449: Add locators + whether a participant is a client + whether a participant is my client to DDB
 
     //! Covenient per-topic mapping of readers and writers to speed-up queries
     std::map<std::string, std::vector<eprosima::fastrtps::rtps::GUID_t>> readers_by_topic_;

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
@@ -268,6 +268,12 @@ protected:
         //sh_mtx_.unlock();
     }
 
+    // Get a vector of entities that are in the topic name, + plus those that are in the virtual_topic_.
+    // If topic_name == virtual_topic_, then return all entities in the map.
+    std::vector<eprosima::fastrtps::rtps::GUID_t> find_by_topic_(
+            const std::map<std::string, std::vector<eprosima::fastrtps::rtps::GUID_t>>& map_by_topic,
+            const std::string& topic_name);
+
     fastrtps::DBQueue<eprosima::fastdds::rtps::ddb::DiscoveryPDPDataQueueInfo> pdp_data_queue_;
 
     fastrtps::DBQueue<eprosima::fastdds::rtps::ddb::DiscoveryEDPDataQueueInfo> edp_data_queue_;
@@ -307,6 +313,16 @@ protected:
     mutable share_mutex_t sh_mtx_;
 
     fastrtps::rtps::GuidPrefix_t server_guid_prefix_;
+
+    eprosima::fastrtps::rtps::GUID_t virtual_guid_;
+
+    eprosima::fastrtps::rtps::SampleIdentity sample_id_;
+
+    std::unique_ptr<eprosima::fastrtps::rtps::CacheChange_t> virtual_change_;
+
+    const std::string virtual_topic_ = "eprosima_server_virtual_topic";
+
+    uint16_t local_servers_count_ = 0;
 
 };
 

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataQueueInfo.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataQueueInfo.hpp
@@ -21,6 +21,8 @@
 #include <fastrtps/utils/fixed_size_string.hpp>
 #include <fastdds/rtps/common/Guid.h>
 
+#include "./DiscoveryParticipantChangeData.hpp"
+
 
 namespace eprosima {
 namespace fastdds {
@@ -32,10 +34,8 @@ class DiscoveryDataQueueInfo
 public:
 
     DiscoveryDataQueueInfo(
-            eprosima::fastrtps::rtps::CacheChange_t* change,
-            eprosima::fastrtps::string_255 topic)
+            eprosima::fastrtps::rtps::CacheChange_t* change)
         : change_(change)
-        , topic_(topic)
     {
     }
 
@@ -48,6 +48,55 @@ public:
         return change_;
     }
 
+protected:
+
+    eprosima::fastrtps::rtps::CacheChange_t* change_;
+
+};
+
+class DiscoveryPDPDataQueueInfo: public DiscoveryDataQueueInfo
+{
+public:
+
+    DiscoveryPDPDataQueueInfo(
+            eprosima::fastrtps::rtps::CacheChange_t* change,
+            DiscoveryParticipantChangeData participant_change_data)
+        : DiscoveryDataQueueInfo(change)
+        , participant_change_data_(participant_change_data)
+    {
+    }
+
+    ~DiscoveryPDPDataQueueInfo()
+    {
+    }
+
+    DiscoveryParticipantChangeData participant_change_data()
+    {
+        return participant_change_data_;
+    }
+
+private:
+
+    DiscoveryParticipantChangeData participant_change_data_;
+
+};
+
+class DiscoveryEDPDataQueueInfo: public DiscoveryDataQueueInfo
+{
+public:
+
+    DiscoveryEDPDataQueueInfo(
+            eprosima::fastrtps::rtps::CacheChange_t* change,
+            eprosima::fastrtps::string_255 topic)
+        : DiscoveryDataQueueInfo(change)
+        , topic_(topic)
+    {
+    }
+
+    ~DiscoveryEDPDataQueueInfo()
+    {
+    }
+
     eprosima::fastrtps::string_255 topic()
     {
         return topic_;
@@ -55,11 +104,9 @@ public:
 
 private:
 
-    eprosima::fastrtps::rtps::CacheChange_t* change_;
-
     eprosima::fastrtps::string_255 topic_;
-};
 
+};
 
 } /* namespace ddb */
 } /* namespace dds */

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryEndpointInfo.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryEndpointInfo.hpp
@@ -52,6 +52,11 @@ public:
     {
     }
 
+    const eprosima::fastrtps::string_255& topic()
+    {
+        return topic_;
+    }
+
 private:
 
     eprosima::fastrtps::string_255 topic_;

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryParticipantChangeData.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryParticipantChangeData.hpp
@@ -42,10 +42,12 @@ struct DiscoveryParticipantChangeData
     DiscoveryParticipantChangeData(
             fastrtps::rtps::RemoteLocatorList metatraffic_locators_,
             bool is_client_,
-            bool is_my_client_)
+            bool is_my_client_,
+            bool is_my_server_)
         : metatraffic_locators(metatraffic_locators_)
         , is_client(is_client_)
         , is_my_client(is_my_client_)
+        , is_my_server(is_my_server_)
     {
     }
 
@@ -55,6 +57,8 @@ struct DiscoveryParticipantChangeData
     bool is_client = true;
     // Whether this participant (CLIENT OR SERVER) is a client of this server
     bool is_my_client = true;
+    // Whether this participant is my server (necessary to sort out the relayed servers)
+    bool is_my_server = false;
 };
 
 } /* namespace ddb */

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryParticipantChangeData.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryParticipantChangeData.hpp
@@ -1,0 +1,65 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file DiscoveryParticipantChangeData.hpp
+ *
+ */
+
+#ifndef _FASTDDS_RTPS_DISCOVERY_PARTICIPANT_CHANGE_DATA_H_
+#define _FASTDDS_RTPS_DISCOVERY_PARTICIPANT_CHANGE_DATA_H_
+
+#include <fastdds/rtps/common/RemoteLocators.hpp>
+#include <fastdds/dds/core/policy/ParameterTypes.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+namespace ddb {
+
+/**
+ * Class to join the main info required from a Participant in the Discovery Data Base
+ *@ingroup DISCOVERY_MODULE
+ */
+struct DiscoveryParticipantChangeData
+{
+    DiscoveryParticipantChangeData()
+        : metatraffic_locators(fastrtps::rtps::RemoteLocatorList(0, 0))
+    {
+    }
+
+    DiscoveryParticipantChangeData(
+            fastrtps::rtps::RemoteLocatorList metatraffic_locators_,
+            bool is_client_,
+            bool is_my_client_)
+        : metatraffic_locators(metatraffic_locators_)
+        , is_client(is_client_)
+        , is_my_client(is_my_client_)
+    {
+    }
+
+    // The metatraffic locators of from the serialized payload
+    fastrtps::rtps::RemoteLocatorList metatraffic_locators;
+    // Whether this participant is a CLIENT or a SERVER
+    bool is_client = true;
+    // Whether this participant (CLIENT OR SERVER) is a client of this server
+    bool is_my_client = true;
+};
+
+} /* namespace ddb */
+} /* namespace rtps */
+} /* namespace fastdds */
+} /* namespace eprosima */
+
+#endif /* _FASTDDS_RTPS_PARTICIPANT_INFO_H_ */

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryParticipantInfo.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryParticipantInfo.cpp
@@ -29,6 +29,24 @@ namespace fastdds {
 namespace rtps {
 namespace ddb {
 
+eprosima::fastrtps::rtps::CacheChange_t* DiscoveryParticipantInfo::update(
+    eprosima::fastrtps::rtps::CacheChange_t* change,
+    DiscoveryParticipantChangeData participant_change_data)
+{
+    eprosima::fastrtps::rtps::CacheChange_t* old_change = change_;
+    change_ = change;
+    participant_change_data_ = participant_change_data;
+    return old_change;
+}
+
+eprosima::fastrtps::rtps::CacheChange_t* DiscoveryParticipantInfo::update_and_unmatch(
+        eprosima::fastrtps::rtps::CacheChange_t* change,
+        DiscoveryParticipantChangeData participant_change_data)
+{
+    relevant_participants_builtin_ack_status_.unmatch_all();
+    return update(change, participant_change_data);
+}
+
 void DiscoveryParticipantInfo::add_reader(
         const eprosima::fastrtps::rtps::GUID_t& guid)
 {

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryParticipantInfo.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryParticipantInfo.hpp
@@ -97,6 +97,11 @@ public:
         return participant_change_data_.is_my_client;
     }
 
+    bool is_my_server()
+    {
+        return participant_change_data_.is_my_server;
+    }
+
     fastrtps::rtps::RemoteLocatorList metatraffic_locators()
     {
         return participant_change_data_.metatraffic_locators;

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryParticipantInfo.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryParticipantInfo.hpp
@@ -26,6 +26,7 @@
 #include <fastdds/rtps/common/GuidPrefix_t.hpp>
 
 #include "./DiscoverySharedInfo.hpp"
+#include "./DiscoveryParticipantChangeData.hpp"
 
 namespace eprosima {
 namespace fastdds {
@@ -42,13 +43,35 @@ class DiscoveryParticipantInfo : public DiscoverySharedInfo
 public:
 
     DiscoveryParticipantInfo(
-            eprosima::fastrtps::rtps::CacheChange_t* change_)
-        : DiscoverySharedInfo(change_)
+            eprosima::fastrtps::rtps::CacheChange_t* change,
+            DiscoveryParticipantChangeData participant_change_data)
+        : DiscoverySharedInfo(change)
+        , participant_change_data_(participant_change_data)
     {
     }
 
     ~DiscoveryParticipantInfo()
     {
+    }
+
+    eprosima::fastrtps::rtps::CacheChange_t* update(
+            eprosima::fastrtps::rtps::CacheChange_t* change,
+            DiscoveryParticipantChangeData participant_change_data);
+
+    eprosima::fastrtps::rtps::CacheChange_t* update(
+            eprosima::fastrtps::rtps::CacheChange_t* change)
+    {
+        return DiscoverySharedInfo::update(change);
+    }
+
+    eprosima::fastrtps::rtps::CacheChange_t* update_and_unmatch(
+            eprosima::fastrtps::rtps::CacheChange_t* change,
+            DiscoveryParticipantChangeData participant_change_data);
+
+    eprosima::fastrtps::rtps::CacheChange_t* update_and_unmatch(
+            eprosima::fastrtps::rtps::CacheChange_t* change)
+    {
+        return DiscoverySharedInfo::update_and_unmatch(change);
     }
 
     // populate functions
@@ -64,11 +87,28 @@ public:
     void remove_writer(
             const eprosima::fastrtps::rtps::GUID_t& guid);
 
+    bool is_client()
+    {
+        return participant_change_data_.is_client;
+    }
+
+    bool is_my_client()
+    {
+        return participant_change_data_.is_my_client;
+    }
+
+    fastrtps::rtps::RemoteLocatorList metatraffic_locators()
+    {
+        return participant_change_data_.metatraffic_locators;
+    }
+
 private:
 
     std::vector<eprosima::fastrtps::rtps::GUID_t> readers;
 
     std::vector<eprosima::fastrtps::rtps::GUID_t> writers;
+
+    DiscoveryParticipantChangeData participant_change_data_;
 
 };
 

--- a/src/cpp/rtps/builtin/discovery/database/DiscoverySharedInfo.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoverySharedInfo.cpp
@@ -28,22 +28,20 @@ namespace rtps {
 namespace ddb {
 
 
-eprosima::fastrtps::rtps::CacheChange_t* DiscoverySharedInfo::set_change_and_unmatch(
+eprosima::fastrtps::rtps::CacheChange_t* DiscoverySharedInfo::update_and_unmatch(
         eprosima::fastrtps::rtps::CacheChange_t* change)
 {
     relevant_participants_builtin_ack_status_.unmatch_all();
-    return change_info(change);
+    return update(change);
 }
 
-eprosima::fastrtps::rtps::CacheChange_t* DiscoverySharedInfo::change_info(
+eprosima::fastrtps::rtps::CacheChange_t* DiscoverySharedInfo::update(
         eprosima::fastrtps::rtps::CacheChange_t* change)
 {
     eprosima::fastrtps::rtps::CacheChange_t* old_change = change_;
     change_ = change;
     return old_change;
 }
-
-eprosima::fastrtps::rtps::CacheChange_t* change();
 
 } /* namespace ddb */
 } /* namespace rtps */

--- a/src/cpp/rtps/builtin/discovery/database/DiscoverySharedInfo.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoverySharedInfo.hpp
@@ -50,6 +50,12 @@ public:
     {
     }
 
+    virtual eprosima::fastrtps::rtps::CacheChange_t* update_and_unmatch(
+            eprosima::fastrtps::rtps::CacheChange_t* change);
+
+    virtual eprosima::fastrtps::rtps::CacheChange_t* update(
+            eprosima::fastrtps::rtps::CacheChange_t* change);
+
     void add_or_update_ack_participant(
             const eprosima::fastrtps::rtps::GuidPrefix_t& guid_p,
             bool status = false)
@@ -64,12 +70,6 @@ public:
     {
         relevant_participants_builtin_ack_status_.remove_participant(guid_p);
     }
-
-    eprosima::fastrtps::rtps::CacheChange_t* set_change_and_unmatch(
-            eprosima::fastrtps::rtps::CacheChange_t* change);
-
-    eprosima::fastrtps::rtps::CacheChange_t* change_info(
-            eprosima::fastrtps::rtps::CacheChange_t* change);
 
     bool is_matched(
             const eprosima::fastrtps::rtps::GuidPrefix_t& guid_p) const
@@ -88,7 +88,7 @@ public:
         return change_;
     }
 
-private:
+protected:
 
     eprosima::fastrtps::rtps::CacheChange_t* change_;
 

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners2.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners2.cpp
@@ -69,7 +69,7 @@ void EDPServerPUBListener2::onNewCacheChangeAdded(
     ReaderHistory* reader_history = sedp_->publications_reader_.second;
 
     // String to store the topic of the writer
-    std::string topic_name;
+    std::string topic_name = "";
 
     // DATA(w) case: new writer or updated information about an existing writer
     if (change->kind == ALIVE)
@@ -156,7 +156,7 @@ void EDPServerSUBListener2::onNewCacheChangeAdded(
     ReaderHistory* reader_history = sedp_->subscriptions_reader_.second;
 
     // String to store the topic of the reader
-    std::string topic_name;
+    std::string topic_name = "";
 
     // DATA(r) case: new reader or updated information about an existing reader
     if (change->kind == ALIVE)

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer2.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer2.hpp
@@ -202,9 +202,6 @@ private:
     //! Discovery database
     fastdds::rtps::ddb::DiscoveryDataBase discovery_db_;
 
-    //! Temporary locator list to solve new Writer API issue
-    // TODO: remove when the Writer API issue is resolved
-    std::map<fastrtps::rtps::GUID_t, fastrtps::rtps::ReaderProxyData> clients_;
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer2.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer2.hpp
@@ -137,6 +137,8 @@ public:
 
     fastdds::rtps::ddb::DiscoveryDataBase& discovery_db();
 
+    const RemoteServerList_t& servers();
+
 protected:
 
     // Check the messages in histories. Check which ones modify the database to unlock further messages
@@ -152,7 +154,7 @@ protected:
             fastrtps::rtps::StatefulWriter* writer,
             fastrtps::rtps::WriterHistory* writer_history);
 
-    bool process_data_queue();
+    bool process_data_queues();
 
     bool process_disposals();
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener2.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener2.cpp
@@ -139,9 +139,10 @@ void PDPServerListener2::onNewCacheChangeAdded(
             // Check whether the participant is a client of this server, or it has been discovered through another
             // server
             bool is_my_client = true;
+            bool is_my_server = false;
             // If the instance handle is different from the writer GUID, then the change has been relayed. That means,
             // that the participants is somebody else's client
-            if (change->instanceHandle != change->writerGUID)
+            if (iHandle2GUID(change->instanceHandle).guidPrefix != change->writerGUID.guidPrefix)
             {
                 is_my_client = false;
             }
@@ -159,6 +160,7 @@ void PDPServerListener2::onNewCacheChangeAdded(
                     if (iHandle2GUID(change->instanceHandle).guidPrefix == server.guidPrefix)
                     {
                         is_my_client = false;
+                        is_my_server = true;
                         break;
                     }
                 }
@@ -170,7 +172,8 @@ void PDPServerListener2::onNewCacheChangeAdded(
                 ddb::DiscoveryParticipantChangeData(
                     temp_participant_data_.metatraffic_locators,
                     is_client,
-                    is_my_client)))
+                    is_my_client,
+                    is_my_server)))
             {
                 // Remove change from PDP reader history, but do not return it to the pool. From here on, the discovery
                 // database takes ownership of the CacheChange_t. Henceforth there are no references to the change.


### PR DESCRIPTION
This PR adds for each server a virtual reader and writer in a virtual topic so that the virtual entities match with all topics. Furthermore, info about the virtual entities is not sent to the clients.

Merge after #1442 