### PR TITLE
Add option to support TRANSIENT_LOCAL in persistence [9617]

### DIFF
--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -32,7 +32,7 @@
 #include <process.h>
 #else
 #include <unistd.h>
-#endif
+#endif // if defined(_WIN32)
 
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
 #include <fastdds/rtps/common/Guid.h>
@@ -54,7 +54,7 @@
 #include <fastdds/rtps/Endpoint.h>
 #include <fastdds/rtps/security/accesscontrol/ParticipantSecurityAttributes.h>
 #include <rtps/security/SecurityManager.h>
-#endif
+#endif // if HAVE_SECURITY
 
 namespace eprosima {
 
@@ -136,7 +136,7 @@ class RTPSParticipantImpl
             }
         }
 
-private:
+    private:
 
         ReceiverControlBlock(
                 const ReceiverControlBlock&) = delete;
@@ -316,7 +316,7 @@ public:
         return mp_userParticipant;
     }
 
-    std::vector<std::unique_ptr<FlowController> >& getFlowControllers()
+    std::vector<std::unique_ptr<FlowController>>& getFlowControllers()
     {
         return m_controllers;
     }
@@ -367,7 +367,7 @@ public:
             const GUID_t& local_reader,
             const WriterProxyData& remote_writer_data);
 
-#endif
+#endif // if HAVE_SECURITY
 
     PDPSimple* pdpsimple();
 
@@ -442,8 +442,8 @@ public:
 
     //!Compare metatraffic locators list searching for mutations
     bool did_mutation_took_place_on_meta(
-        const LocatorList_t& MulticastLocatorList,
-        const LocatorList_t& UnicastLocatorList) const;
+            const LocatorList_t& MulticastLocatorList,
+            const LocatorList_t& UnicastLocatorList) const;
 
 private:
 
@@ -490,7 +490,7 @@ private:
     bool m_security_manager_initialized;
     // Security activation flag
     bool m_is_security_active;
-#endif
+#endif // if HAVE_SECURITY
 
     //! Encapsulates all associated resources on a Receiving element.
     std::list<ReceiverControlBlock> m_receiverResourcelist;
@@ -576,11 +576,11 @@ private:
     /*
      * Flow controllers for this participant.
      */
-    std::vector<std::unique_ptr<FlowController> > m_controllers;
+    std::vector<std::unique_ptr<FlowController>> m_controllers;
 
 #if HAVE_SECURITY
     security::ParticipantSecurityAttributes security_attributes_;
-#endif
+#endif // if HAVE_SECURITY
 
     //! Indicates whether the participant has shared-memory transport
     bool has_shm_transport_;
@@ -591,6 +591,12 @@ private:
      */
     IPersistenceService* get_persistence_service(
             const EndpointAttributes& param);
+
+    /**
+     * Returns the Durability kind from which a endpoint is able to use the persistence service.
+     */
+    DurabilityKind_t get_persistence_durability_red_line(
+            bool is_builtin_endpoint);
 
 public:
 
@@ -764,10 +770,10 @@ public:
         endpoint->supports_rtps_protection_ = support;
     }
 
-#endif
+#endif // if HAVE_SECURITY
 };
-}
+} // namespace rtps
 } /* namespace rtps */
 } /* namespace eprosima */
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif //_RTPS_PARTICIPANT_RTPSPARTICIPANTIMPL_H_

--- a/test/blackbox/common/DDSBlackboxTestsPersistenceGuid.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPersistenceGuid.cpp
@@ -268,6 +268,87 @@ TEST_P(PersistenceGuid, SetPersistenceForTransientLocal)
 
 }
 
+/*!
+ * @fn TEST(Persistence, NoSetPersistenceForTransientLocal)
+ * @brief This test checks if the persistence desn't work for TRANSIENT_LOCAL endpoints when it is not used the option
+ * 'dds.persistence.also-support-transient-local'.
+ *
+ * This test creates a DataReader and DataWriter configuring for each of them the persistence plugin to use SQLITE3,
+ * the database filename, a specific persistence guid, and the TRANSIENT_LOCAL durability and reliability QoS.
+ * Once both are discovered, it generates a new data message to send, since every time a new message is sent the middleware doesn't insert
+ * a new entry on the persistence database.
+ * In order to check if the persistence guid specified is not applied correctly, the test uses the python file 'check_guid.py'
+ * that returns the number of apparitions of a guid, on a specific database and table.
+ */
+TEST_P(PersistenceGuid, NoSetPersistenceForTransientLocal)
+{
+    // Configure Participant Properties
+    PropertyPolicy participant_policy;
+    participant_policy.properties().emplace_back("dds.persistence.plugin", "builtin.SQLITE3");
+    participant_policy.properties().emplace_back("dds.persistence.sqlite3.filename", "persistence.db");
+
+    // Configure Writer Properties
+    PropertyPolicy writer_policy;
+    writer_policy.properties().emplace_back("dds.persistence.guid", "77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64");
+
+    // Create DataWriter and configure the durability and reliability QoS
+    PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+    writer.property_policy(participant_policy);
+    writer.entity_property_policy(writer_policy);
+    writer.durability_kind(TRANSIENT_LOCAL_DURABILITY_QOS);
+    writer.reliability(RELIABLE_RELIABILITY_QOS);
+
+    writer.init();
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Configure Reader Properties
+    PropertyPolicy reader_policy;
+    reader_policy.properties().emplace_back("dds.persistence.guid", "77.65.61.64.65.72.5f.70.65.72.73.5f|68.76.70.65");
+
+    // Create DataReader and configure the durability and reliability QoS
+    PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
+    reader.property_policy(participant_policy);
+    reader.entity_property_policy(reader_policy);
+    reader.durability_kind(TRANSIENT_LOCAL_DURABILITY_QOS);
+    reader.reliability(RELIABLE_RELIABILITY_QOS);
+
+    reader.init();
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Wait until both of them are discovered
+    reader.wait_discovery();
+    writer.wait_discovery();
+
+    // Generate a new data message to send
+    auto data = default_helloworld_data_generator(1);
+    auto aux = data;
+    writer.send(data);
+    reader.startReception(aux);
+    reader.block_for_all();
+#ifdef WIN32
+    // Check if there is one entry in the writers database table with the stated persistence guid
+    int result1 = system(
+        "python check_guid.py \"persistence.db\" \"writers\" \"77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64\"");
+    ASSERT_EQ(result1, 1);
+
+    // Check if there is one entry in the readers database table with the stated persistence guid
+    int result2 = system(
+        "python check_guid.py \"persistence.db\" \"readers\" \"77.65.61.64.65.72.5f.70.65.72.73.5f|68.76.70.65\"");
+    ASSERT_EQ(result2, 1);
+#else
+    // Check if there is one entry in the writers database table with the stated persistence guid
+    int result1 = system(
+        "python3 check_guid.py 'persistence.db' 'writers' '77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64'");
+    ASSERT_EQ((result1 >> 8), 255);
+
+    // Check if there is one entry in the readers database table with the stated persistence guid
+    int result2 = system(
+        "python3 check_guid.py 'persistence.db' 'readers' '77.65.61.64.65.72.5f.70.65.72.73.5f|68.76.70.65'");
+    ASSERT_EQ((result2 >> 8), 255);
+#endif // WIN32
+
+}
+
 INSTANTIATE_TEST_CASE_P(PersistenceGuid,
         PersistenceGuid,
         testing::Values(false, true),

--- a/test/blackbox/common/DDSBlackboxTestsPersistenceGuid.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPersistenceGuid.cpp
@@ -326,22 +326,22 @@ TEST_P(PersistenceGuid, NoSetPersistenceForTransientLocal)
     reader.startReception(aux);
     reader.block_for_all();
 #ifdef WIN32
-    // Check if there is one entry in the writers database table with the stated persistence guid
+    // Check if there is no entry in the writers database table with the stated persistence guid
     int result1 = system(
         "python check_guid.py \"persistence.db\" \"writers\" \"77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64\"");
-    ASSERT_EQ(result1, 1);
+    ASSERT_EQ(result1, 255);
 
-    // Check if there is one entry in the readers database table with the stated persistence guid
+    // Check if there is no entry in the readers database table with the stated persistence guid
     int result2 = system(
         "python check_guid.py \"persistence.db\" \"readers\" \"77.65.61.64.65.72.5f.70.65.72.73.5f|68.76.70.65\"");
-    ASSERT_EQ(result2, 1);
+    ASSERT_EQ(result2, 255);
 #else
-    // Check if there is one entry in the writers database table with the stated persistence guid
+    // Check if there is no entry in the writers database table with the stated persistence guid
     int result1 = system(
         "python3 check_guid.py 'persistence.db' 'writers' '77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64'");
     ASSERT_EQ((result1 >> 8), 255);
 
-    // Check if there is one entry in the readers database table with the stated persistence guid
+    // Check if there is no entry in the readers database table with the stated persistence guid
     int result2 = system(
         "python3 check_guid.py 'persistence.db' 'readers' '77.65.61.64.65.72.5f.70.65.72.73.5f|68.76.70.65'");
     ASSERT_EQ((result2 >> 8), 255);

--- a/test/blackbox/common/DDSBlackboxTestsPersistenceGuid.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPersistenceGuid.cpp
@@ -186,6 +186,88 @@ TEST_P(PersistenceGuid, SetPersistenceGuidByXML)
 #endif // WIN32
 }
 
+/*!
+ * @fn TEST(Persistence, SetPersistenceForTransientLocal)
+ * @brief This test checks if the persistence works for TRANSIENT_LOCAL endpoints when it is used the option
+ * 'dds.persistence.also-support-transient-local'.
+ *
+ * This test creates a DataReader and DataWriter configuring for each of them the persistence plugin to use SQLITE3,
+ * the database filename, a specific persistence guid, and the TRANSIENT_LOCAL durability and reliability QoS.
+ * Once both are discovered, it generates a new data message to send, since every time a new message is sent the middleware inserts
+ * a new entry on the persistence database.
+ * In order to check if the persistence guid specified is applied correctly, the test uses the python file 'check_guid.py'
+ * that returns the number of apparitions of a guid, on a specific database and table.
+ */
+TEST_P(PersistenceGuid, SetPersistenceForTransientLocal)
+{
+    // Configure Participant Properties
+    PropertyPolicy participant_policy;
+    participant_policy.properties().emplace_back("dds.persistence.plugin", "builtin.SQLITE3");
+    participant_policy.properties().emplace_back("dds.persistence.sqlite3.filename", "persistence.db");
+    participant_policy.properties().emplace_back("dds.persistence.also-support-transient-local", "true");
+
+    // Configure Writer Properties
+    PropertyPolicy writer_policy;
+    writer_policy.properties().emplace_back("dds.persistence.guid", "77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64");
+
+    // Create DataWriter and configure the durability and reliability QoS
+    PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+    writer.property_policy(participant_policy);
+    writer.entity_property_policy(writer_policy);
+    writer.durability_kind(TRANSIENT_LOCAL_DURABILITY_QOS);
+    writer.reliability(RELIABLE_RELIABILITY_QOS);
+
+    writer.init();
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Configure Reader Properties
+    PropertyPolicy reader_policy;
+    reader_policy.properties().emplace_back("dds.persistence.guid", "77.65.61.64.65.72.5f.70.65.72.73.5f|68.76.70.65");
+
+    // Create DataReader and configure the durability and reliability QoS
+    PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
+    reader.property_policy(participant_policy);
+    reader.entity_property_policy(reader_policy);
+    reader.durability_kind(TRANSIENT_LOCAL_DURABILITY_QOS);
+    reader.reliability(RELIABLE_RELIABILITY_QOS);
+
+    reader.init();
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Wait until both of them are discovered
+    reader.wait_discovery();
+    writer.wait_discovery();
+
+    // Generate a new data message to send
+    auto data = default_helloworld_data_generator(1);
+    auto aux = data;
+    writer.send(data);
+    reader.startReception(aux);
+    reader.block_for_all();
+#ifdef WIN32
+    // Check if there is one entry in the writers database table with the stated persistence guid
+    int result1 = system(
+        "python check_guid.py \"persistence.db\" \"writers\" \"77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64\"");
+    ASSERT_EQ(result1, 1);
+
+    // Check if there is one entry in the readers database table with the stated persistence guid
+    int result2 = system(
+        "python check_guid.py \"persistence.db\" \"readers\" \"77.65.61.64.65.72.5f.70.65.72.73.5f|68.76.70.65\"");
+    ASSERT_EQ(result2, 1);
+#else
+    // Check if there is one entry in the writers database table with the stated persistence guid
+    int result1 = system(
+        "python3 check_guid.py 'persistence.db' 'writers' '77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64'");
+    ASSERT_EQ((result1 >> 8), 1);
+
+    // Check if there is one entry in the readers database table with the stated persistence guid
+    int result2 = system(
+        "python3 check_guid.py 'persistence.db' 'readers' '77.65.61.64.65.72.5f.70.65.72.73.5f|68.76.70.65'");
+    ASSERT_EQ((result2 >> 8), 1);
+#endif // WIN32
+
+}
+
 INSTANTIATE_TEST_CASE_P(PersistenceGuid,
         PersistenceGuid,
         testing::Values(false, true),


### PR DESCRIPTION
This PR adds a Participant's property `"dds.persistence.also-support-transient-local"`. When this property is set to `"true"`, TRANSIENT_LOCAL endpoints could use persistence database.