### PR TITLE
Fixes profile section to allow multiple profiles in different order.

### DIFF
--- a/resources/xsd/fastRTPS_profiles.xsd
+++ b/resources/xsd/fastRTPS_profiles.xsd
@@ -855,13 +855,15 @@
 
     <xs:complexType name="profilesType">
         <xs:sequence>
-            <xs:element name="library_settings" type="LibrarySettingsType" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="transport_descriptors" type="TransportDescriptorListType" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="participant" type="participantProfileType" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="publisher" type="publisherProfileType" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="subscriber" type="subscriberProfileType" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="topic" type="topicAttributesType" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="types" type="topicAttributesType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:choice minOccurs="1" maxOccurs="unbounded">
+                <xs:element name="library_settings" type="LibrarySettingsType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="transport_descriptors" type="TransportDescriptorListType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="participant" type="participantProfileType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="publisher" type="publisherProfileType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="subscriber" type="subscriberProfileType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="topic" type="topicAttributesType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="types" type="topicAttributesType" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:choice>
         </xs:sequence>
     </xs:complexType>
 


### PR DESCRIPTION
This PR allows validating XML files following the schema:

```xml
<dds xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles" >
    <profiles>
        <participant profile_name="Participant">
        ...
        </participant>

        <publisher profile_name="Pub1">
        ...
        </publisher>

        <subscriber profile_name="Sub1">
        ...
        </subscriber>

        <publisher profile_name="Pub2">
        ...
        </publisher>

        <subscriber profile_name="Sub2">
        ...
        </subscriber>
    </profiles>
</dds>
```

Without the `<xs::choice>` the schema doesn't allow defining a `<publisher>` after a `<subscriber>`.