### PR TITLE
Forwardport of #1469 into master [9574]

### DIFF
--- a/include/fastrtps/utils/collections/foonathan_memory_helpers.hpp
+++ b/include/fastrtps/utils/collections/foonathan_memory_helpers.hpp
@@ -29,7 +29,7 @@ namespace eprosima {
 namespace fastrtps {
 
 /**
- * A helper to calculate the block size of a memory pool given the side of the node and
+ * A helper to calculate the block size of a memory pool given the size of the node and
  * a resource limits configuration.
  *
  * @tparam MemoryPool memory_pool specialization
@@ -44,6 +44,11 @@ std::size_t memory_pool_block_size(
         std::size_t node_size,
         const ResourceLimitedContainerConfig& limits)
 {
+#ifdef FOONATHAN_MEMORY_MEMORY_POOL_HAS_MIN_BLOCK_SIZE
+
+    return MemoryPool::min_block_size(node_size, limits.initial ? limits.initial : 1);
+
+#else
     size_t num_elems = limits.increment > 0 ? limits.initial : limits.maximum;
     if (num_elems < 1u)
     {
@@ -54,6 +59,7 @@ std::size_t memory_pool_block_size(
            * ((node_size > MemoryPool::min_node_size ? node_size : MemoryPool::min_node_size) // Room for elements
            * (foonathan::memory::detail::debug_fence_size ? 3 : 1))                           // Room for debug info
            + foonathan::memory::detail::memory_block_stack::implementation_offset;            // Room for padding
+#endif  // FOONATHAN_MEMORY_MEMORY_POOL_HAS_MIN_BLOCK_SIZE
 }
 
 }  // namespace fastrtps


### PR DESCRIPTION
An unused part of the public API was missing the modifications to be compatible with the new [foonathan_memory](https://github.com/foonathan/memory) API.

Signed-off-by: imontesino <monte.igna@gmail.com>