### PR TITLE
governance rules order <master> [9583]

### DIFF
--- a/src/cpp/security/accesscontrol/AccessPermissionsHandle.h
+++ b/src/cpp/security/accesscontrol/AccessPermissionsHandle.h
@@ -35,30 +35,34 @@ namespace security {
 
 class AccessPermissions
 {
-    public:
+public:
 
-        AccessPermissions() : store_(nullptr), there_are_crls_(false)  {}
+    AccessPermissions()
+        : store_(nullptr)
+        , there_are_crls_(false)
+    {
+    }
 
-        ~AccessPermissions()
+    ~AccessPermissions()
+    {
+        if (store_ != nullptr)
         {
-            if(store_ != nullptr)
-            {
-                X509_STORE_free(store_);
-            }
+            X509_STORE_free(store_);
         }
+    }
 
-        static const char* const class_id_;
+    static const char* const class_id_;
 
-        X509_STORE* store_;
-        std::string sn;
-        std::string algo;
-        bool there_are_crls_;
-        PermissionsToken permissions_token_;
-        PermissionsCredentialToken permissions_credential_token_;
-        ParticipantSecurityAttributes governance_rule_;
-        std::vector<std::pair<std::string, EndpointSecurityAttributes>> governance_reader_topic_rules_;
-        std::vector<std::pair<std::string, EndpointSecurityAttributes>> governance_writer_topic_rules_;
-        Grant grant;
+    X509_STORE* store_;
+    std::string sn;
+    std::string algo;
+    bool there_are_crls_;
+    PermissionsToken permissions_token_;
+    PermissionsCredentialToken permissions_credential_token_;
+    ParticipantSecurityAttributes governance_rule_;
+    std::vector<std::pair<std::string, EndpointSecurityAttributes>> governance_reader_topic_rules_;
+    std::vector<std::pair<std::string, EndpointSecurityAttributes>> governance_writer_topic_rules_;
+    Grant grant;
 };
 
 typedef HandleImpl<AccessPermissions> AccessPermissionsHandle;

--- a/src/cpp/security/accesscontrol/AccessPermissionsHandle.h
+++ b/src/cpp/security/accesscontrol/AccessPermissionsHandle.h
@@ -60,8 +60,7 @@ public:
     PermissionsToken permissions_token_;
     PermissionsCredentialToken permissions_credential_token_;
     ParticipantSecurityAttributes governance_rule_;
-    std::vector<std::pair<std::string, EndpointSecurityAttributes>> governance_reader_topic_rules_;
-    std::vector<std::pair<std::string, EndpointSecurityAttributes>> governance_writer_topic_rules_;
+    std::vector<std::pair<std::string, EndpointSecurityAttributes>> governance_topic_rules_;
     Grant grant;
 };
 

--- a/src/cpp/security/accesscontrol/AccessPermissionsHandle.h
+++ b/src/cpp/security/accesscontrol/AccessPermissionsHandle.h
@@ -56,8 +56,8 @@ class AccessPermissions
         PermissionsToken permissions_token_;
         PermissionsCredentialToken permissions_credential_token_;
         ParticipantSecurityAttributes governance_rule_;
-        std::map<std::string, EndpointSecurityAttributes> governance_reader_topic_rules_;
-        std::map<std::string, EndpointSecurityAttributes> governance_writer_topic_rules_;
+        std::vector<std::pair<std::string, EndpointSecurityAttributes>> governance_reader_topic_rules_;
+        std::vector<std::pair<std::string, EndpointSecurityAttributes>> governance_writer_topic_rules_;
         Grant grant;
 };
 

--- a/src/cpp/security/accesscontrol/Permissions.cpp
+++ b/src/cpp/security/accesscontrol/Permissions.cpp
@@ -84,7 +84,7 @@ static bool is_domain_in_set(const uint32_t domain_id, const Domains& domains)
 }
 
 static const EndpointSecurityAttributes* is_topic_in_sec_attributes(const char* topic_name,
-        const std::map<std::string, EndpointSecurityAttributes>& attributes)
+        const std::vector<std::pair<std::string, EndpointSecurityAttributes>>& attributes)
 {
     const EndpointSecurityAttributes* returned_value = nullptr;
 
@@ -672,9 +672,9 @@ static bool check_subject_name(const IdentityHandle& ih, AccessPermissionsHandle
                         reader_attributes.plugin_endpoint_attributes = plugin_attributes.mask();
                         writer_attributes.plugin_endpoint_attributes = plugin_attributes.mask();
 
-                        ah->governance_reader_topic_rules_.insert(std::pair<std::string, EndpointSecurityAttributes>(
+                        ah->governance_reader_topic_rules_.push_back(std::pair<std::string, EndpointSecurityAttributes>(
                                     topic_expression, std::move(reader_attributes)));
-                        ah->governance_writer_topic_rules_.insert(std::pair<std::string, EndpointSecurityAttributes>(
+                        ah->governance_writer_topic_rules_.push_back(std::pair<std::string, EndpointSecurityAttributes>(
                                     std::move(topic_expression), std::move(writer_attributes)));
                     }
 

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -332,14 +332,14 @@ public:
         if (datareader_ == nullptr)
         {
             datareader_ = subscriber_->create_datareader(topic_, datareader_qos_, &listener_, status_mask_);
-            ASSERT_NE(datareader_, nullptr);
-            ASSERT_TRUE(datareader_->is_enabled());
         }
 
-        std::cout << "Created datareader " << datareader_->guid() << " for topic " <<
-            topic_name_ << std::endl;
-
-        initialized_ = true;
+        if (datareader_ != nullptr)
+        {
+            std::cout << "Created datareader " << datareader_->guid() << " for topic " <<
+                topic_name_ << std::endl;
+            initialized_ = true;
+        }
     }
 
     bool isInitialized() const

--- a/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
@@ -285,12 +285,14 @@ public:
 
         //Create subscribe r
         subscriber_ = eprosima::fastrtps::Domain::createSubscriber(participant_, subscriber_attr, &listener_);
-        ASSERT_NE(subscriber_, nullptr);
+        
+        if (subscriber_ != nullptr)
+        {
+            std::cout << "Created subscriber " << subscriber_->getGuid() << " for topic " <<
+                subscriber_attr_.topic.topicName << std::endl;
 
-        std::cout << "Created subscriber " << subscriber_->getGuid() << " for topic " <<
-            subscriber_attr_.topic.topicName << std::endl;
-
-        initialized_ = true;
+            initialized_ = true;
+        }
     }
 
     bool isInitialized() const

--- a/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
@@ -285,7 +285,7 @@ public:
 
         //Create subscribe r
         subscriber_ = eprosima::fastrtps::Domain::createSubscriber(participant_, subscriber_attr, &listener_);
-        
+
         if (subscriber_ != nullptr)
         {
             std::cout << "Created subscriber " << subscriber_->getGuid() << " for topic " <<

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -74,8 +74,8 @@ TEST_P(Security, BuiltinAuthenticationPlugin_PKIDH_validation_ok)
             "file://" + std::string(certs_path) + "/mainsubkey.pem"));
 
     reader.history_depth(10).
-    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-    property_policy(sub_property_policy).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -89,7 +89,7 @@ TEST_P(Security, BuiltinAuthenticationPlugin_PKIDH_validation_ok)
             "file://" + std::string(certs_path) + "/mainpubkey.pem"));
 
     writer.history_depth(10).
-    property_policy(pub_property_policy).init();
+            property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -158,7 +158,7 @@ TEST_P(Security, BuiltinAuthenticationPlugin_PKIDH_validation_fail)
         PropertyPolicy pub_property_policy;
 
         reader.history_depth(10).
-        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
+                reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
 
         ASSERT_TRUE(reader.isInitialized());
 
@@ -172,7 +172,7 @@ TEST_P(Security, BuiltinAuthenticationPlugin_PKIDH_validation_fail)
                 "file://" + std::string(certs_path) + "/mainpubkey.pem"));
 
         writer.history_depth(10).
-        property_policy(pub_property_policy).init();
+                property_policy(pub_property_policy).init();
 
         ASSERT_TRUE(writer.isInitialized());
 
@@ -195,8 +195,8 @@ TEST_P(Security, BuiltinAuthenticationPlugin_PKIDH_validation_fail)
                 "file://" + std::string(certs_path) + "/mainsubkey.pem"));
 
         reader.history_depth(10).
-        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-        property_policy(sub_property_policy).init();
+                reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+                property_policy(sub_property_policy).init();
 
         ASSERT_TRUE(reader.isInitialized());
 
@@ -226,8 +226,8 @@ TEST_P(Security, BuiltinAuthenticationPlugin_PKIDH_lossy_conditions)
             "file://" + std::string(certs_path) + "/mainsubkey.pem"));
 
     reader.history_depth(10).
-    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-    property_policy(sub_property_policy).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            property_policy(sub_property_policy).init();
 
     // To simulate lossy conditions, we are going to remove the default
     // bultin transport, and instead use a lossy shim layer variant.
@@ -250,7 +250,7 @@ TEST_P(Security, BuiltinAuthenticationPlugin_PKIDH_lossy_conditions)
             "file://" + std::string(certs_path) + "/mainpubkey.pem"));
 
     writer.history_depth(10).
-    property_policy(pub_property_policy).init();
+            property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -283,7 +283,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_rtps_ok)
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
-    property_policy(sub_property_policy).init();
+            property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -300,8 +300,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_rtps_ok)
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
-    reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
-    property_policy(pub_property_policy).init();
+            reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
+            property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -355,7 +355,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_shm_transport_ok)
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
-    property_policy(sub_property_policy).init();
+            property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -372,8 +372,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_shm_transport_ok)
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
-    reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
-    property_policy(pub_property_policy).init();
+            reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
+            property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -429,7 +429,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_shm_udp_transport_ok)
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
-    property_policy(sub_property_policy).init();
+            property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -446,8 +446,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_shm_udp_transport_ok)
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
-    reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
-    property_policy(pub_property_policy).init();
+            reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
+            property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -491,8 +491,8 @@ TEST(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_rtps_ok)
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
-    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-    property_policy(sub_property_policy).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -509,7 +509,7 @@ TEST(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_rtps_ok)
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
-    property_policy(pub_property_policy).init();
+            property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -592,7 +592,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_large_string)
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
-    property_policy(sub_property_policy).init();
+            property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -609,8 +609,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_large_string)
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
-    reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
-    property_policy(pub_property_policy).init();
+            reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
+            property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -654,8 +654,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_rtps_large_string
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
-    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-    property_policy(sub_property_policy).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -672,7 +672,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_rtps_large_string
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
-    property_policy(pub_property_policy).init();
+            property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -716,7 +716,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_rtps_data300kb)
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     reader.history_depth(5).
-    property_policy(sub_property_policy).init();
+            property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -738,10 +738,10 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_rtps_data300kb)
     uint32_t periodInMs = 500;
 
     writer.history_depth(5).
-    reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
-    asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).
-    add_throughput_controller_descriptor_to_pparams(bytesPerPeriod, periodInMs).
-    property_policy(pub_property_policy).init();
+            reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
+            asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).
+            add_throughput_controller_descriptor_to_pparams(bytesPerPeriod, periodInMs).
+            property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -785,8 +785,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_rtps_data300kb)
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     reader.history_depth(5).
-    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-    property_policy(sub_property_policy).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -808,9 +808,9 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_rtps_data300kb)
     uint32_t periodInMs = 50;
 
     writer.history_depth(5).
-    asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).
-    add_throughput_controller_descriptor_to_pparams(bytesPerPeriod, periodInMs).
-    property_policy(pub_property_policy).init();
+            asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).
+            add_throughput_controller_descriptor_to_pparams(bytesPerPeriod, periodInMs).
+            property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -855,8 +855,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_ok)
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
-    property_policy(sub_part_property_policy).
-    entity_property_policy(sub_property_policy).init();
+            property_policy(sub_part_property_policy).
+            entity_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -873,9 +873,9 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_ok)
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
-    reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
-    property_policy(pub_part_property_policy).
-    entity_property_policy(pub_property_policy).init();
+            reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
+            property_policy(pub_part_property_policy).
+            entity_property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -920,9 +920,9 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_ok)
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
-    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-    property_policy(sub_part_property_policy).
-    entity_property_policy(sub_property_policy).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            property_policy(sub_part_property_policy).
+            entity_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -939,8 +939,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_ok)
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
-    property_policy(pub_part_property_policy).
-    entity_property_policy(pub_property_policy).init();
+            property_policy(pub_part_property_policy).
+            entity_property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -987,8 +987,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_submessage_ok_same_partici
 
     wreader.sub_history_depth(10).sub_reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS);
     wreader.property_policy(property_policy).
-    pub_property_policy(pub_property_policy).
-    sub_property_policy(sub_property_policy).init();
+            pub_property_policy(pub_property_policy).
+            sub_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(wreader.isInitialized());
 
@@ -1028,8 +1028,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_larg
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
-    property_policy(sub_part_property_policy).
-    entity_property_policy(sub_property_policy).init();
+            property_policy(sub_part_property_policy).
+            entity_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -1046,9 +1046,9 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_larg
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
-    reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
-    property_policy(pub_part_property_policy).
-    entity_property_policy(pub_property_policy).init();
+            reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
+            property_policy(pub_part_property_policy).
+            entity_property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -1093,9 +1093,9 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_large_
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
-    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-    property_policy(sub_part_property_policy).
-    entity_property_policy(sub_property_policy).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            property_policy(sub_part_property_policy).
+            entity_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -1112,8 +1112,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_large_
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
-    property_policy(pub_part_property_policy).
-    entity_property_policy(pub_property_policy).init();
+            property_policy(pub_part_property_policy).
+            entity_property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -1158,8 +1158,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_data
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
     reader.history_depth(5).
-    property_policy(sub_part_property_policy).
-    entity_property_policy(sub_property_policy).init();
+            property_policy(sub_part_property_policy).
+            entity_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -1181,11 +1181,11 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_data
     uint32_t periodInMs = 500;
 
     writer.history_depth(5).
-    reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
-    asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).
-    add_throughput_controller_descriptor_to_pparams(bytesPerPeriod, periodInMs).
-    property_policy(pub_part_property_policy).
-    entity_property_policy(pub_property_policy).init();
+            reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
+            asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).
+            add_throughput_controller_descriptor_to_pparams(bytesPerPeriod, periodInMs).
+            property_policy(pub_part_property_policy).
+            entity_property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -1230,9 +1230,9 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_data30
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
     reader.history_depth(5).
-    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-    property_policy(sub_part_property_policy).
-    entity_property_policy(sub_property_policy).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            property_policy(sub_part_property_policy).
+            entity_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -1254,10 +1254,10 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_data30
     uint32_t periodInMs = 50;
 
     writer.history_depth(5).
-    asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).
-    add_throughput_controller_descriptor_to_pparams(bytesPerPeriod, periodInMs).
-    property_policy(pub_part_property_policy).
-    entity_property_policy(pub_property_policy).init();
+            asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).
+            add_throughput_controller_descriptor_to_pparams(bytesPerPeriod, periodInMs).
+            property_policy(pub_part_property_policy).
+            entity_property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -1302,8 +1302,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_ok)
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
-    property_policy(sub_part_property_policy).
-    entity_property_policy(sub_property_policy).init();
+            property_policy(sub_part_property_policy).
+            entity_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -1320,9 +1320,9 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_ok)
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
-    reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
-    property_policy(pub_part_property_policy).
-    entity_property_policy(pub_property_policy).init();
+            reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
+            property_policy(pub_part_property_policy).
+            entity_property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -1367,9 +1367,9 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_ok)
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
-    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-    property_policy(sub_part_property_policy).
-    entity_property_policy(sub_property_policy).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            property_policy(sub_part_property_policy).
+            entity_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -1386,8 +1386,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_ok)
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
-    property_policy(pub_part_property_policy).
-    entity_property_policy(pub_property_policy).init();
+            property_policy(pub_part_property_policy).
+            entity_property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -1434,8 +1434,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_payload_ok_same_participan
 
     wreader.sub_history_depth(10).sub_reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS);
     wreader.property_policy(property_policy).
-    pub_property_policy(pub_property_policy).
-    sub_property_policy(sub_property_policy).init();
+            pub_property_policy(pub_property_policy).
+            sub_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(wreader.isInitialized());
 
@@ -1477,8 +1477,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_payload_ok_same_participan
     wreader.sub_durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS);
     wreader.pub_durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS);
     wreader.property_policy(property_policy).
-    pub_property_policy(pub_property_policy).
-    sub_property_policy(sub_property_policy).init();
+            pub_property_policy(pub_property_policy).
+            sub_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(wreader.isInitialized());
 
@@ -1518,8 +1518,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_large_s
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
-    property_policy(sub_part_property_policy).
-    entity_property_policy(sub_property_policy).init();
+            property_policy(sub_part_property_policy).
+            entity_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -1536,9 +1536,9 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_large_s
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
-    reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
-    property_policy(pub_part_property_policy).
-    entity_property_policy(pub_property_policy).init();
+            reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
+            property_policy(pub_part_property_policy).
+            entity_property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -1583,9 +1583,9 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_large_str
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
-    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-    property_policy(sub_part_property_policy).
-    entity_property_policy(sub_property_policy).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            property_policy(sub_part_property_policy).
+            entity_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -1602,8 +1602,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_large_str
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
-    property_policy(pub_part_property_policy).
-    entity_property_policy(pub_property_policy).init();
+            property_policy(pub_part_property_policy).
+            entity_property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -1648,8 +1648,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_data300
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     reader.history_depth(5).
-    property_policy(sub_part_property_policy).
-    entity_property_policy(sub_property_policy).init();
+            property_policy(sub_part_property_policy).
+            entity_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -1671,11 +1671,11 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_data300
     uint32_t periodInMs = 500;
 
     writer.history_depth(5).
-    reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
-    asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).
-    add_throughput_controller_descriptor_to_pparams(bytesPerPeriod, periodInMs).
-    property_policy(pub_part_property_policy).
-    entity_property_policy(pub_property_policy).init();
+            reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
+            asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).
+            add_throughput_controller_descriptor_to_pparams(bytesPerPeriod, periodInMs).
+            property_policy(pub_part_property_policy).
+            entity_property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -1720,9 +1720,9 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_data300kb
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     reader.history_depth(5).
-    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-    property_policy(sub_part_property_policy).
-    entity_property_policy(sub_property_policy).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            property_policy(sub_part_property_policy).
+            entity_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -1744,10 +1744,10 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_data300kb
     uint32_t periodInMs = 50;
 
     writer.history_depth(5).
-    asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).
-    add_throughput_controller_descriptor_to_pparams(bytesPerPeriod, periodInMs).
-    property_policy(pub_part_property_policy).
-    entity_property_policy(pub_property_policy).init();
+            asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).
+            add_throughput_controller_descriptor_to_pparams(bytesPerPeriod, periodInMs).
+            property_policy(pub_part_property_policy).
+            entity_property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -1794,8 +1794,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_ok)
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
-    property_policy(sub_part_property_policy).
-    entity_property_policy(sub_property_policy).init();
+            property_policy(sub_part_property_policy).
+            entity_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -1814,9 +1814,9 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_ok)
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
-    reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
-    property_policy(pub_part_property_policy).
-    entity_property_policy(pub_property_policy).init();
+            reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
+            property_policy(pub_part_property_policy).
+            entity_property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -1863,9 +1863,9 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_ok)
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
-    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-    property_policy(sub_part_property_policy).
-    entity_property_policy(sub_property_policy).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            property_policy(sub_part_property_policy).
+            entity_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -1884,8 +1884,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_ok)
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
-    property_policy(pub_part_property_policy).
-    entity_property_policy(pub_property_policy).init();
+            property_policy(pub_part_property_policy).
+            entity_property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -1932,8 +1932,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_large_strin
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
-    property_policy(sub_part_property_policy).
-    entity_property_policy(sub_property_policy).init();
+            property_policy(sub_part_property_policy).
+            entity_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -1952,9 +1952,9 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_large_strin
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
-    reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
-    property_policy(pub_part_property_policy).
-    entity_property_policy(pub_property_policy).init();
+            reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
+            property_policy(pub_part_property_policy).
+            entity_property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -2001,9 +2001,9 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_large_string)
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
-    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-    property_policy(sub_part_property_policy).
-    entity_property_policy(sub_property_policy).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            property_policy(sub_part_property_policy).
+            entity_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -2022,8 +2022,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_large_string)
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
-    property_policy(pub_part_property_policy).
-    entity_property_policy(pub_property_policy).init();
+            property_policy(pub_part_property_policy).
+            entity_property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -2070,8 +2070,8 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_data300kb)
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     reader.history_depth(5).
-    property_policy(sub_part_property_policy).
-    entity_property_policy(sub_property_policy).init();
+            property_policy(sub_part_property_policy).
+            entity_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -2095,11 +2095,11 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_data300kb)
     uint32_t periodInMs = 1000;
 
     writer.history_depth(5).
-    reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
-    asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).
-    add_throughput_controller_descriptor_to_pparams(bytesPerPeriod, periodInMs).
-    property_policy(pub_part_property_policy).
-    entity_property_policy(pub_property_policy).init();
+            reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
+            asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).
+            add_throughput_controller_descriptor_to_pparams(bytesPerPeriod, periodInMs).
+            property_policy(pub_part_property_policy).
+            entity_property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -2146,9 +2146,9 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_data300kb)
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     reader.history_depth(5).
-    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-    property_policy(sub_part_property_policy).
-    entity_property_policy(sub_property_policy).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            property_policy(sub_part_property_policy).
+            entity_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -2172,10 +2172,10 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_data300kb)
     uint32_t periodInMs = 50;
 
     writer.history_depth(5).
-    asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).
-    add_throughput_controller_descriptor_to_pparams(bytesPerPeriod, periodInMs).
-    property_policy(pub_part_property_policy).
-    entity_property_policy(pub_property_policy).init();
+            asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).
+            add_throughput_controller_descriptor_to_pparams(bytesPerPeriod, periodInMs).
+            property_policy(pub_part_property_policy).
+            entity_property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -2223,9 +2223,9 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_data300kb_mix
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     reader.history_depth(5).
-    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-    property_policy(sub_part_property_policy).
-    entity_property_policy(sub_property_policy).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            property_policy(sub_part_property_policy).
+            entity_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -2244,9 +2244,9 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_data300kb_mix
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     writer.history_depth(2).resource_limits_max_samples(2).resource_limits_allocated_samples(2).
-    asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).
-    property_policy(pub_part_property_policy).
-    entity_property_policy(pub_property_policy).init();
+            asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).
+            property_policy(pub_part_property_policy).
+            entity_property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -2300,9 +2300,9 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_user_data)
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     writer.history_depth(100).
-    userData({ 'a', 'b', 'c', 'd', 'e' }).
-    property_policy(pub_part_property_policy).
-    entity_property_policy(pub_property_policy).init();
+            userData({ 'a', 'b', 'c', 'd', 'e' }).
+            property_policy(pub_part_property_policy).
+            entity_property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -2336,9 +2336,9 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_user_data)
             });
 
     reader.history_depth(100).
-    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-    property_policy(sub_part_property_policy).
-    entity_property_policy(sub_property_policy).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            property_policy(sub_part_property_policy).
+            entity_property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -2377,8 +2377,9 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_governance_rule_o
                 "builtin.AES-GCM-GMAC"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        sub_property_policy.properties().emplace_back(Property(
+                    "dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                    "file://" + std::string(certs_path) + "/maincacert.pem"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
                 "file://" + std::string(certs_path) + "/" + governance_file));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
@@ -2402,8 +2403,9 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_governance_rule_o
                 "builtin.AES-GCM-GMAC"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        pub_property_policy.properties().emplace_back(Property(
+                    "dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                    "file://" + std::string(certs_path) + "/maincacert.pem"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
                 "file://" + std::string(certs_path) + "/" + governance_file));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
@@ -2457,8 +2459,9 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_governance_rule_o
                 "builtin.AES-GCM-GMAC"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        sub_property_policy.properties().emplace_back(Property(
+                    "dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                    "file://" + std::string(certs_path) + "/maincacert.pem"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
                 "file://" + std::string(certs_path) + "/" + governance_file));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
@@ -2480,8 +2483,9 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_governance_rule_o
                 "builtin.AES-GCM-GMAC"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        pub_property_policy.properties().emplace_back(Property(
+                    "dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                    "file://" + std::string(certs_path) + "/maincacert.pem"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
                 "file://" + std::string(certs_path) + "/" + governance_file));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
@@ -2520,8 +2524,8 @@ static void BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_validation
             "file://" + std::string(certs_path) + "/permissions.smime"));
 
     reader.history_depth(10).
-    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-    property_policy(sub_property_policy).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            property_policy(sub_property_policy).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -2545,7 +2549,7 @@ static void BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_validation
             "file://" + std::string(certs_path) + "/permissions.smime"));
 
     writer.history_depth(10).
-    property_policy(pub_property_policy).init();
+            property_policy(pub_property_policy).init();
 
     ASSERT_TRUE(writer.isInitialized());
 

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -2352,6 +2352,147 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_user_data)
     reader.wait_discovery_result();
 }
 
+TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_governance_rule_order)
+{
+    {
+        // Governance rule for topic *HelloWorldTopic* with enable_read/write_access_contrl set to false
+        // Governance rule for topic * with enable_read/write_access_contrl set to true
+        // Permission denied for topic HelloWorldTopic
+        // Creation of reader and writer is allowed
+        PubSubReader<HelloWorldType> reader("HelloWorldTopic");
+        PubSubWriter<HelloWorldType> writer("HelloWorldTopic");
+        std::string governance_file("governance_rule_order_test.smime");
+
+        PropertyPolicy pub_property_policy, sub_property_policy;
+
+        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
+                "builtin.PKI-DH"));
+        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
+                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
+                "file://" + std::string(certs_path) + "/mainsubcert.pem"));
+        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
+                "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+        sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
+                "builtin.AES-GCM-GMAC"));
+        sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
+                "builtin.Access-Permissions"));
+        sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
+                "file://" + std::string(certs_path) + "/" + governance_file));
+        sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
+                "file://" + std::string(certs_path) + "/permissions.smime"));
+
+        reader.history_depth(10).
+                reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+                property_policy(sub_property_policy).init();
+
+        ASSERT_TRUE(reader.isInitialized());
+
+        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
+                "builtin.PKI-DH"));
+        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
+                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
+                "file://" + std::string(certs_path) + "/mainpubcert.pem"));
+        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
+                "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+        pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
+                "builtin.AES-GCM-GMAC"));
+        pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
+                "builtin.Access-Permissions"));
+        pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
+                "file://" + std::string(certs_path) + "/" + governance_file));
+        pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
+                "file://" + std::string(certs_path) + "/permissions.smime"));
+
+        writer.history_depth(10).
+                property_policy(pub_property_policy).init();
+
+        ASSERT_TRUE(writer.isInitialized());
+
+        // Wait for authorization
+        reader.waitAuthorized();
+        writer.waitAuthorized();
+
+        // Wait for discovery.
+        writer.wait_discovery();
+        reader.wait_discovery();
+
+        auto data = default_helloworld_data_generator();
+
+        reader.startReception(data);
+
+        // Send data
+        writer.send(data);
+        // In this test all data should be sent.
+        ASSERT_TRUE(data.empty());
+        // Block reader until reception finished or timeout.
+        reader.block_for_all();
+    }
+
+    {
+        // Governance rule for topic * with enable_read/write_access_contrl set to true
+        // Governance rule for topic *HelloWorldTopic* with enable_read/write_access_contrl set to false
+        // Permission denied for topic HelloWorldTopic
+        // Creation of reader and writer is denied
+        PubSubReader<HelloWorldType> reader("HelloWorldTopic");
+        PubSubWriter<HelloWorldType> writer("HelloWorldTopic");
+        std::string governance_file("governance_rule_order_test_inverse.smime");
+
+        PropertyPolicy pub_property_policy, sub_property_policy;
+
+        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
+                "builtin.PKI-DH"));
+        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
+                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
+                "file://" + std::string(certs_path) + "/mainsubcert.pem"));
+        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
+                "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+        sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
+                "builtin.AES-GCM-GMAC"));
+        sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
+                "builtin.Access-Permissions"));
+        sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
+                "file://" + std::string(certs_path) + "/" + governance_file));
+        sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
+                "file://" + std::string(certs_path) + "/permissions.smime"));
+
+        reader.property_policy(sub_property_policy).init();
+
+        ASSERT_FALSE(reader.isInitialized());
+
+        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
+                "builtin.PKI-DH"));
+        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
+                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
+                "file://" + std::string(certs_path) + "/mainpubcert.pem"));
+        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
+                "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+        pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
+                "builtin.AES-GCM-GMAC"));
+        pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
+                "builtin.Access-Permissions"));
+        pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
+                "file://" + std::string(certs_path) + "/" + governance_file));
+        pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
+                "file://" + std::string(certs_path) + "/permissions.smime"));
+
+        writer.property_policy(pub_property_policy).init();
+
+        ASSERT_FALSE(writer.isInitialized());
+    }
+}
+
 static void BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_validation_ok_common(
         PubSubReader<HelloWorldType>& reader,
         PubSubWriter<HelloWorldType>& writer,

--- a/test/certs/governance_rule_order_test.smime
+++ b/test/certs/governance_rule_order_test.smime
@@ -1,0 +1,81 @@
+MIME-Version: 1.0
+Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----F6D0687973D5A407B1CEB3E2B58A5CC9"
+
+This is an S/MIME signed message
+
+------F6D0687973D5A407B1CEB3E2B58A5CC9
+Content-Type: text/plain
+
+<?xml version="1.0" encoding="utf-8"?>
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="omg_shared_ca_domain_governance.xsd">
+    <domain_access_rules>
+        <domain_rule>
+            <domains>
+                <id_range>
+                    <min>0</min>
+                    <max>230</max>
+                </id_range>
+            </domains>
+            <allow_unauthenticated_participants>false</allow_unauthenticated_participants>
+            <enable_join_access_control>true</enable_join_access_control>
+            <discovery_protection_kind>ENCRYPT</discovery_protection_kind>
+            <liveliness_protection_kind>ENCRYPT</liveliness_protection_kind>
+            <rtps_protection_kind>ENCRYPT</rtps_protection_kind>
+            <topic_access_rules>
+                <topic_rule>
+                    <topic_expression>HelloWorldTopic_*</topic_expression>
+                    <enable_discovery_protection>true</enable_discovery_protection>
+                    <enable_liveliness_protection>true</enable_liveliness_protection>
+                    <enable_read_access_control>false</enable_read_access_control>
+                    <enable_write_access_control>false</enable_write_access_control>
+                    <metadata_protection_kind>ENCRYPT</metadata_protection_kind>
+                    <data_protection_kind>ENCRYPT</data_protection_kind>
+                </topic_rule>
+                <topic_rule>
+                    <topic_expression>*</topic_expression>
+                    <enable_discovery_protection>true</enable_discovery_protection>
+                    <enable_liveliness_protection>true</enable_liveliness_protection>
+                    <enable_read_access_control>true</enable_read_access_control>
+                    <enable_write_access_control>true</enable_write_access_control>
+                    <metadata_protection_kind>ENCRYPT</metadata_protection_kind>
+                    <data_protection_kind>ENCRYPT</data_protection_kind>
+                </topic_rule>
+            </topic_access_rules>
+        </domain_rule>
+    </domain_access_rules>
+</dds>
+
+
+------F6D0687973D5A407B1CEB3E2B58A5CC9
+Content-Type: application/x-pkcs7-signature; name="smime.p7s"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="smime.p7s"
+
+MIIEeAYJKoZIhvcNAQcCoIIEaTCCBGUCAQExDzANBglghkgBZQMEAgEFADALBgkq
+hkiG9w0BBwGgggJAMIICPDCCAeOgAwIBAgIJALZwpgo2sxthMAoGCCqGSM49BAMC
+MIGaMQswCQYDVQQGEwJFUzELMAkGA1UECAwCTUExFDASBgNVBAcMC1RyZXMgQ2Fu
+dG9zMREwDwYDVQQKDAhlUHJvc2ltYTERMA8GA1UECwwIZVByb3NpbWExHjAcBgNV
+BAMMFWVQcm9zaW1hIE1haW4gVGVzdCBDQTEiMCAGCSqGSIb3DQEJARYTbWFpbmNh
+QGVwcm9zaW1hLmNvbTAeFw0xNzA5MDYwOTAzMDNaFw0yNzA5MDQwOTAzMDNaMIGa
+MQswCQYDVQQGEwJFUzELMAkGA1UECAwCTUExFDASBgNVBAcMC1RyZXMgQ2FudG9z
+MREwDwYDVQQKDAhlUHJvc2ltYTERMA8GA1UECwwIZVByb3NpbWExHjAcBgNVBAMM
+FWVQcm9zaW1hIE1haW4gVGVzdCBDQTEiMCAGCSqGSIb3DQEJARYTbWFpbmNhQGVw
+cm9zaW1hLmNvbTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABGLlhB3WQ8l1fpUE
+3DfOoulA/de38Zfj7hmpKtOnxiH2q6RJbwhxvJeA7R7mkmAKaJKmzx695BjyiXVS
+7bE7vgejEDAOMAwGA1UdEwQFMAMBAf8wCgYIKoZIzj0EAwIDRwAwRAIgVTY1BEvT
+4pw3GyBMzaUqmp69wi0kBkyOgq04OhyJ13UCICR125vvt0fUhXsXaxOAx28E4Ac9
+SVxpI+3UYs2kV5n0MYIB/DCCAfgCAQEwgagwgZoxCzAJBgNVBAYTAkVTMQswCQYD
+VQQIDAJNQTEUMBIGA1UEBwwLVHJlcyBDYW50b3MxETAPBgNVBAoMCGVQcm9zaW1h
+MREwDwYDVQQLDAhlUHJvc2ltYTEeMBwGA1UEAwwVZVByb3NpbWEgTWFpbiBUZXN0
+IENBMSIwIAYJKoZIhvcNAQkBFhNtYWluY2FAZXByb3NpbWEuY29tAgkAtnCmCjaz
+G2EwDQYJYIZIAWUDBAIBBQCggeQwGAYJKoZIhvcNAQkDMQsGCSqGSIb3DQEHATAc
+BgkqhkiG9w0BCQUxDxcNMjAxMDA5MDgyNTAyWjAvBgkqhkiG9w0BCQQxIgQggYay
+Tcucukf7oWEdxuCkFHtd2QaneCXM16AHXupNhbQweQYJKoZIhvcNAQkPMWwwajAL
+BglghkgBZQMEASowCwYJYIZIAWUDBAEWMAsGCWCGSAFlAwQBAjAKBggqhkiG9w0D
+BzAOBggqhkiG9w0DAgICAIAwDQYIKoZIhvcNAwICAUAwBwYFKw4DAgcwDQYIKoZI
+hvcNAwICASgwCgYIKoZIzj0EAwIERjBEAiAcJ+aB2yxHTRbUeZqmaxR9PXpuerdf
+eKLOi1NGpcVnCgIgX54vwkKMTDbEJMep9m47mI05bIjt0jDni6Bfu8UIXuo=
+
+------F6D0687973D5A407B1CEB3E2B58A5CC9--
+

--- a/test/certs/governance_rule_order_test.xml
+++ b/test/certs/governance_rule_order_test.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="omg_shared_ca_domain_governance.xsd">
+    <domain_access_rules>
+        <domain_rule>
+            <domains>
+                <id_range>
+                    <min>0</min>
+                    <max>230</max>
+                </id_range>
+            </domains>
+            <allow_unauthenticated_participants>false</allow_unauthenticated_participants>
+            <enable_join_access_control>true</enable_join_access_control>
+            <discovery_protection_kind>ENCRYPT</discovery_protection_kind>
+            <liveliness_protection_kind>ENCRYPT</liveliness_protection_kind>
+            <rtps_protection_kind>ENCRYPT</rtps_protection_kind>
+            <topic_access_rules>
+                <topic_rule>
+                    <topic_expression>HelloWorldTopic_*</topic_expression>
+                    <enable_discovery_protection>true</enable_discovery_protection>
+                    <enable_liveliness_protection>true</enable_liveliness_protection>
+                    <enable_read_access_control>false</enable_read_access_control>
+                    <enable_write_access_control>false</enable_write_access_control>
+                    <metadata_protection_kind>ENCRYPT</metadata_protection_kind>
+                    <data_protection_kind>ENCRYPT</data_protection_kind>
+                </topic_rule>
+                <topic_rule>
+                    <topic_expression>*</topic_expression>
+                    <enable_discovery_protection>true</enable_discovery_protection>
+                    <enable_liveliness_protection>true</enable_liveliness_protection>
+                    <enable_read_access_control>true</enable_read_access_control>
+                    <enable_write_access_control>true</enable_write_access_control>
+                    <metadata_protection_kind>ENCRYPT</metadata_protection_kind>
+                    <data_protection_kind>ENCRYPT</data_protection_kind>
+                </topic_rule>
+            </topic_access_rules>
+        </domain_rule>
+    </domain_access_rules>
+</dds>
+

--- a/test/certs/governance_rule_order_test_inverse.smime
+++ b/test/certs/governance_rule_order_test_inverse.smime
@@ -1,0 +1,81 @@
+MIME-Version: 1.0
+Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----B7765AE3472A645801725428F69BB2B2"
+
+This is an S/MIME signed message
+
+------B7765AE3472A645801725428F69BB2B2
+Content-Type: text/plain
+
+<?xml version="1.0" encoding="utf-8"?>
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="omg_shared_ca_domain_governance.xsd">
+    <domain_access_rules>
+        <domain_rule>
+            <domains>
+                <id_range>
+                    <min>0</min>
+                    <max>230</max>
+                </id_range>
+            </domains>
+            <allow_unauthenticated_participants>false</allow_unauthenticated_participants>
+            <enable_join_access_control>true</enable_join_access_control>
+            <discovery_protection_kind>ENCRYPT</discovery_protection_kind>
+            <liveliness_protection_kind>ENCRYPT</liveliness_protection_kind>
+            <rtps_protection_kind>ENCRYPT</rtps_protection_kind>
+            <topic_access_rules>
+                <topic_rule>
+                    <topic_expression>*</topic_expression>
+                    <enable_discovery_protection>true</enable_discovery_protection>
+                    <enable_liveliness_protection>true</enable_liveliness_protection>
+                    <enable_read_access_control>true</enable_read_access_control>
+                    <enable_write_access_control>true</enable_write_access_control>
+                    <metadata_protection_kind>ENCRYPT</metadata_protection_kind>
+                    <data_protection_kind>ENCRYPT</data_protection_kind>
+                </topic_rule>
+                <topic_rule>
+                    <topic_expression>HelloWorldTopic_*</topic_expression>
+                    <enable_discovery_protection>true</enable_discovery_protection>
+                    <enable_liveliness_protection>true</enable_liveliness_protection>
+                    <enable_read_access_control>false</enable_read_access_control>
+                    <enable_write_access_control>false</enable_write_access_control>
+                    <metadata_protection_kind>ENCRYPT</metadata_protection_kind>
+                    <data_protection_kind>ENCRYPT</data_protection_kind>
+                </topic_rule>
+            </topic_access_rules>
+        </domain_rule>
+    </domain_access_rules>
+</dds>
+
+
+------B7765AE3472A645801725428F69BB2B2
+Content-Type: application/x-pkcs7-signature; name="smime.p7s"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="smime.p7s"
+
+MIIEeAYJKoZIhvcNAQcCoIIEaTCCBGUCAQExDzANBglghkgBZQMEAgEFADALBgkq
+hkiG9w0BBwGgggJAMIICPDCCAeOgAwIBAgIJALZwpgo2sxthMAoGCCqGSM49BAMC
+MIGaMQswCQYDVQQGEwJFUzELMAkGA1UECAwCTUExFDASBgNVBAcMC1RyZXMgQ2Fu
+dG9zMREwDwYDVQQKDAhlUHJvc2ltYTERMA8GA1UECwwIZVByb3NpbWExHjAcBgNV
+BAMMFWVQcm9zaW1hIE1haW4gVGVzdCBDQTEiMCAGCSqGSIb3DQEJARYTbWFpbmNh
+QGVwcm9zaW1hLmNvbTAeFw0xNzA5MDYwOTAzMDNaFw0yNzA5MDQwOTAzMDNaMIGa
+MQswCQYDVQQGEwJFUzELMAkGA1UECAwCTUExFDASBgNVBAcMC1RyZXMgQ2FudG9z
+MREwDwYDVQQKDAhlUHJvc2ltYTERMA8GA1UECwwIZVByb3NpbWExHjAcBgNVBAMM
+FWVQcm9zaW1hIE1haW4gVGVzdCBDQTEiMCAGCSqGSIb3DQEJARYTbWFpbmNhQGVw
+cm9zaW1hLmNvbTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABGLlhB3WQ8l1fpUE
+3DfOoulA/de38Zfj7hmpKtOnxiH2q6RJbwhxvJeA7R7mkmAKaJKmzx695BjyiXVS
+7bE7vgejEDAOMAwGA1UdEwQFMAMBAf8wCgYIKoZIzj0EAwIDRwAwRAIgVTY1BEvT
+4pw3GyBMzaUqmp69wi0kBkyOgq04OhyJ13UCICR125vvt0fUhXsXaxOAx28E4Ac9
+SVxpI+3UYs2kV5n0MYIB/DCCAfgCAQEwgagwgZoxCzAJBgNVBAYTAkVTMQswCQYD
+VQQIDAJNQTEUMBIGA1UEBwwLVHJlcyBDYW50b3MxETAPBgNVBAoMCGVQcm9zaW1h
+MREwDwYDVQQLDAhlUHJvc2ltYTEeMBwGA1UEAwwVZVByb3NpbWEgTWFpbiBUZXN0
+IENBMSIwIAYJKoZIhvcNAQkBFhNtYWluY2FAZXByb3NpbWEuY29tAgkAtnCmCjaz
+G2EwDQYJYIZIAWUDBAIBBQCggeQwGAYJKoZIhvcNAQkDMQsGCSqGSIb3DQEHATAc
+BgkqhkiG9w0BCQUxDxcNMjAxMDA5MDgyNTQ4WjAvBgkqhkiG9w0BCQQxIgQg5j45
+TiMKofbmtFJN25Px0awre9uAEmFNUUJuGNqeNwkweQYJKoZIhvcNAQkPMWwwajAL
+BglghkgBZQMEASowCwYJYIZIAWUDBAEWMAsGCWCGSAFlAwQBAjAKBggqhkiG9w0D
+BzAOBggqhkiG9w0DAgICAIAwDQYIKoZIhvcNAwICAUAwBwYFKw4DAgcwDQYIKoZI
+hvcNAwICASgwCgYIKoZIzj0EAwIERjBEAiBnHXnTccvwSpBTuY6mw/tyWSwSkNv+
+To/8tA/y5Zr4iwIgYNQPKTdD+CpNv02+aEBctnDfNzAsuUacIKJEqocSgxs=
+
+------B7765AE3472A645801725428F69BB2B2--
+

--- a/test/certs/governance_rule_order_test_inverse.xml
+++ b/test/certs/governance_rule_order_test_inverse.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="omg_shared_ca_domain_governance.xsd">
+    <domain_access_rules>
+        <domain_rule>
+            <domains>
+                <id_range>
+                    <min>0</min>
+                    <max>230</max>
+                </id_range>
+            </domains>
+            <allow_unauthenticated_participants>false</allow_unauthenticated_participants>
+            <enable_join_access_control>true</enable_join_access_control>
+            <discovery_protection_kind>ENCRYPT</discovery_protection_kind>
+            <liveliness_protection_kind>ENCRYPT</liveliness_protection_kind>
+            <rtps_protection_kind>ENCRYPT</rtps_protection_kind>
+            <topic_access_rules>
+                <topic_rule>
+                    <topic_expression>*</topic_expression>
+                    <enable_discovery_protection>true</enable_discovery_protection>
+                    <enable_liveliness_protection>true</enable_liveliness_protection>
+                    <enable_read_access_control>true</enable_read_access_control>
+                    <enable_write_access_control>true</enable_write_access_control>
+                    <metadata_protection_kind>ENCRYPT</metadata_protection_kind>
+                    <data_protection_kind>ENCRYPT</data_protection_kind>
+                </topic_rule>
+                <topic_rule>
+                    <topic_expression>HelloWorldTopic_*</topic_expression>
+                    <enable_discovery_protection>true</enable_discovery_protection>
+                    <enable_liveliness_protection>true</enable_liveliness_protection>
+                    <enable_read_access_control>false</enable_read_access_control>
+                    <enable_write_access_control>false</enable_write_access_control>
+                    <metadata_protection_kind>ENCRYPT</metadata_protection_kind>
+                    <data_protection_kind>ENCRYPT</data_protection_kind>
+                </topic_rule>
+            </topic_access_rules>
+        </domain_rule>
+    </domain_access_rules>
+</dds>
+


### PR DESCRIPTION
According to the standard, governance rules must be evaluated in order, and the first matching rule is applied.
We are using a map to store the rules before applying them, therefore, losing the original order.
Besides, the map object is never searched by key.
Changed the map for a vector.