### PR TITLE
governance rules order <2.0.x> [9584]

### DIFF
--- a/src/cpp/security/accesscontrol/AccessPermissionsHandle.h
+++ b/src/cpp/security/accesscontrol/AccessPermissionsHandle.h
@@ -35,30 +35,34 @@ namespace security {
 
 class AccessPermissions
 {
-    public:
+public:
 
-        AccessPermissions() : store_(nullptr), there_are_crls_(false)  {}
+    AccessPermissions()
+        : store_(nullptr)
+        , there_are_crls_(false)
+    {
+    }
 
-        ~AccessPermissions()
+    ~AccessPermissions()
+    {
+        if (store_ != nullptr)
         {
-            if(store_ != nullptr)
-            {
-                X509_STORE_free(store_);
-            }
+            X509_STORE_free(store_);
         }
+    }
 
-        static const char* const class_id_;
+    static const char* const class_id_;
 
-        X509_STORE* store_;
-        std::string sn;
-        std::string algo;
-        bool there_are_crls_;
-        PermissionsToken permissions_token_;
-        PermissionsCredentialToken permissions_credential_token_;
-        ParticipantSecurityAttributes governance_rule_;
-        std::vector<std::pair<std::string, EndpointSecurityAttributes>> governance_reader_topic_rules_;
-        std::vector<std::pair<std::string, EndpointSecurityAttributes>> governance_writer_topic_rules_;
-        Grant grant;
+    X509_STORE* store_;
+    std::string sn;
+    std::string algo;
+    bool there_are_crls_;
+    PermissionsToken permissions_token_;
+    PermissionsCredentialToken permissions_credential_token_;
+    ParticipantSecurityAttributes governance_rule_;
+    std::vector<std::pair<std::string, EndpointSecurityAttributes>> governance_reader_topic_rules_;
+    std::vector<std::pair<std::string, EndpointSecurityAttributes>> governance_writer_topic_rules_;
+    Grant grant;
 };
 
 typedef HandleImpl<AccessPermissions> AccessPermissionsHandle;

--- a/src/cpp/security/accesscontrol/AccessPermissionsHandle.h
+++ b/src/cpp/security/accesscontrol/AccessPermissionsHandle.h
@@ -60,8 +60,7 @@ public:
     PermissionsToken permissions_token_;
     PermissionsCredentialToken permissions_credential_token_;
     ParticipantSecurityAttributes governance_rule_;
-    std::vector<std::pair<std::string, EndpointSecurityAttributes>> governance_reader_topic_rules_;
-    std::vector<std::pair<std::string, EndpointSecurityAttributes>> governance_writer_topic_rules_;
+    std::vector<std::pair<std::string, EndpointSecurityAttributes>> governance_topic_rules_;
     Grant grant;
 };
 

--- a/src/cpp/security/accesscontrol/AccessPermissionsHandle.h
+++ b/src/cpp/security/accesscontrol/AccessPermissionsHandle.h
@@ -56,8 +56,8 @@ class AccessPermissions
         PermissionsToken permissions_token_;
         PermissionsCredentialToken permissions_credential_token_;
         ParticipantSecurityAttributes governance_rule_;
-        std::map<std::string, EndpointSecurityAttributes> governance_reader_topic_rules_;
-        std::map<std::string, EndpointSecurityAttributes> governance_writer_topic_rules_;
+        std::vector<std::pair<std::string, EndpointSecurityAttributes>> governance_reader_topic_rules_;
+        std::vector<std::pair<std::string, EndpointSecurityAttributes>> governance_writer_topic_rules_;
         Grant grant;
 };
 

--- a/src/cpp/security/accesscontrol/Permissions.cpp
+++ b/src/cpp/security/accesscontrol/Permissions.cpp
@@ -84,7 +84,7 @@ static bool is_domain_in_set(const uint32_t domain_id, const Domains& domains)
 }
 
 static const EndpointSecurityAttributes* is_topic_in_sec_attributes(const char* topic_name,
-        const std::map<std::string, EndpointSecurityAttributes>& attributes)
+        const std::vector<std::pair<std::string, EndpointSecurityAttributes>>& attributes)
 {
     const EndpointSecurityAttributes* returned_value = nullptr;
 
@@ -672,9 +672,9 @@ static bool check_subject_name(const IdentityHandle& ih, AccessPermissionsHandle
                         reader_attributes.plugin_endpoint_attributes = plugin_attributes.mask();
                         writer_attributes.plugin_endpoint_attributes = plugin_attributes.mask();
 
-                        ah->governance_reader_topic_rules_.insert(std::pair<std::string, EndpointSecurityAttributes>(
+                        ah->governance_reader_topic_rules_.push_back(std::pair<std::string, EndpointSecurityAttributes>(
                                     topic_expression, std::move(reader_attributes)));
-                        ah->governance_writer_topic_rules_.insert(std::pair<std::string, EndpointSecurityAttributes>(
+                        ah->governance_writer_topic_rules_.push_back(std::pair<std::string, EndpointSecurityAttributes>(
                                     std::move(topic_expression), std::move(writer_attributes)));
                     }
 

--- a/test/blackbox/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/BlackboxTestsSecurity.cpp
@@ -2412,8 +2412,9 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_governance_rule_o
                 "builtin.AES-GCM-GMAC"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        sub_property_policy.properties().emplace_back(Property(
+                    "dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                    "file://" + std::string(certs_path) + "/maincacert.pem"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
                 "file://" + std::string(certs_path) + "/" + governance_file));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
@@ -2437,8 +2438,9 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_governance_rule_o
                 "builtin.AES-GCM-GMAC"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        pub_property_policy.properties().emplace_back(Property(
+                    "dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                    "file://" + std::string(certs_path) + "/maincacert.pem"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
                 "file://" + std::string(certs_path) + "/" + governance_file));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
@@ -2492,8 +2494,9 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_governance_rule_o
                 "builtin.AES-GCM-GMAC"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        sub_property_policy.properties().emplace_back(Property(
+                    "dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                    "file://" + std::string(certs_path) + "/maincacert.pem"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
                 "file://" + std::string(certs_path) + "/" + governance_file));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
@@ -2515,8 +2518,9 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_governance_rule_o
                 "builtin.AES-GCM-GMAC"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
+        pub_property_policy.properties().emplace_back(Property(
+                    "dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                    "file://" + std::string(certs_path) + "/maincacert.pem"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
                 "file://" + std::string(certs_path) + "/" + governance_file));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -290,13 +290,13 @@ public:
         ASSERT_TRUE(topic_->is_enabled());
 
         datareader_ = subscriber_->create_datareader(topic_, datareader_qos_, &listener_);
-        ASSERT_NE(datareader_, nullptr);
-        ASSERT_TRUE(datareader_->is_enabled());
 
-        std::cout << "Created datareader " << datareader_->guid() << " for topic " <<
-            topic_name_ << std::endl;
-
-        initialized_ = true;
+        if (datareader_ != nullptr)
+        {
+            std::cout << "Created datareader " << datareader_->guid() << " for topic " <<
+                topic_name_ << std::endl;
+            initialized_ = true;
+        }
     }
 
     bool isInitialized() const

--- a/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
@@ -285,12 +285,14 @@ public:
 
         //Create subscribe r
         subscriber_ = eprosima::fastrtps::Domain::createSubscriber(participant_, subscriber_attr, &listener_);
-        ASSERT_NE(subscriber_, nullptr);
+        
+        if (subscriber_ != nullptr)
+        {
+            std::cout << "Created subscriber " << subscriber_->getGuid() << " for topic " <<
+                subscriber_attr_.topic.topicName << std::endl;
 
-        std::cout << "Created subscriber " << subscriber_->getGuid() << " for topic " <<
-            subscriber_attr_.topic.topicName << std::endl;
-
-        initialized_ = true;
+            initialized_ = true;
+        }
     }
 
     bool isInitialized() const

--- a/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
@@ -285,7 +285,7 @@ public:
 
         //Create subscribe r
         subscriber_ = eprosima::fastrtps::Domain::createSubscriber(participant_, subscriber_attr, &listener_);
-        
+
         if (subscriber_ != nullptr)
         {
             std::cout << "Created subscriber " << subscriber_->getGuid() << " for topic " <<

--- a/test/certs/governance_rule_order_test.smime
+++ b/test/certs/governance_rule_order_test.smime
@@ -1,0 +1,81 @@
+MIME-Version: 1.0
+Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----F6D0687973D5A407B1CEB3E2B58A5CC9"
+
+This is an S/MIME signed message
+
+------F6D0687973D5A407B1CEB3E2B58A5CC9
+Content-Type: text/plain
+
+<?xml version="1.0" encoding="utf-8"?>
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="omg_shared_ca_domain_governance.xsd">
+    <domain_access_rules>
+        <domain_rule>
+            <domains>
+                <id_range>
+                    <min>0</min>
+                    <max>230</max>
+                </id_range>
+            </domains>
+            <allow_unauthenticated_participants>false</allow_unauthenticated_participants>
+            <enable_join_access_control>true</enable_join_access_control>
+            <discovery_protection_kind>ENCRYPT</discovery_protection_kind>
+            <liveliness_protection_kind>ENCRYPT</liveliness_protection_kind>
+            <rtps_protection_kind>ENCRYPT</rtps_protection_kind>
+            <topic_access_rules>
+                <topic_rule>
+                    <topic_expression>HelloWorldTopic_*</topic_expression>
+                    <enable_discovery_protection>true</enable_discovery_protection>
+                    <enable_liveliness_protection>true</enable_liveliness_protection>
+                    <enable_read_access_control>false</enable_read_access_control>
+                    <enable_write_access_control>false</enable_write_access_control>
+                    <metadata_protection_kind>ENCRYPT</metadata_protection_kind>
+                    <data_protection_kind>ENCRYPT</data_protection_kind>
+                </topic_rule>
+                <topic_rule>
+                    <topic_expression>*</topic_expression>
+                    <enable_discovery_protection>true</enable_discovery_protection>
+                    <enable_liveliness_protection>true</enable_liveliness_protection>
+                    <enable_read_access_control>true</enable_read_access_control>
+                    <enable_write_access_control>true</enable_write_access_control>
+                    <metadata_protection_kind>ENCRYPT</metadata_protection_kind>
+                    <data_protection_kind>ENCRYPT</data_protection_kind>
+                </topic_rule>
+            </topic_access_rules>
+        </domain_rule>
+    </domain_access_rules>
+</dds>
+
+
+------F6D0687973D5A407B1CEB3E2B58A5CC9
+Content-Type: application/x-pkcs7-signature; name="smime.p7s"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="smime.p7s"
+
+MIIEeAYJKoZIhvcNAQcCoIIEaTCCBGUCAQExDzANBglghkgBZQMEAgEFADALBgkq
+hkiG9w0BBwGgggJAMIICPDCCAeOgAwIBAgIJALZwpgo2sxthMAoGCCqGSM49BAMC
+MIGaMQswCQYDVQQGEwJFUzELMAkGA1UECAwCTUExFDASBgNVBAcMC1RyZXMgQ2Fu
+dG9zMREwDwYDVQQKDAhlUHJvc2ltYTERMA8GA1UECwwIZVByb3NpbWExHjAcBgNV
+BAMMFWVQcm9zaW1hIE1haW4gVGVzdCBDQTEiMCAGCSqGSIb3DQEJARYTbWFpbmNh
+QGVwcm9zaW1hLmNvbTAeFw0xNzA5MDYwOTAzMDNaFw0yNzA5MDQwOTAzMDNaMIGa
+MQswCQYDVQQGEwJFUzELMAkGA1UECAwCTUExFDASBgNVBAcMC1RyZXMgQ2FudG9z
+MREwDwYDVQQKDAhlUHJvc2ltYTERMA8GA1UECwwIZVByb3NpbWExHjAcBgNVBAMM
+FWVQcm9zaW1hIE1haW4gVGVzdCBDQTEiMCAGCSqGSIb3DQEJARYTbWFpbmNhQGVw
+cm9zaW1hLmNvbTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABGLlhB3WQ8l1fpUE
+3DfOoulA/de38Zfj7hmpKtOnxiH2q6RJbwhxvJeA7R7mkmAKaJKmzx695BjyiXVS
+7bE7vgejEDAOMAwGA1UdEwQFMAMBAf8wCgYIKoZIzj0EAwIDRwAwRAIgVTY1BEvT
+4pw3GyBMzaUqmp69wi0kBkyOgq04OhyJ13UCICR125vvt0fUhXsXaxOAx28E4Ac9
+SVxpI+3UYs2kV5n0MYIB/DCCAfgCAQEwgagwgZoxCzAJBgNVBAYTAkVTMQswCQYD
+VQQIDAJNQTEUMBIGA1UEBwwLVHJlcyBDYW50b3MxETAPBgNVBAoMCGVQcm9zaW1h
+MREwDwYDVQQLDAhlUHJvc2ltYTEeMBwGA1UEAwwVZVByb3NpbWEgTWFpbiBUZXN0
+IENBMSIwIAYJKoZIhvcNAQkBFhNtYWluY2FAZXByb3NpbWEuY29tAgkAtnCmCjaz
+G2EwDQYJYIZIAWUDBAIBBQCggeQwGAYJKoZIhvcNAQkDMQsGCSqGSIb3DQEHATAc
+BgkqhkiG9w0BCQUxDxcNMjAxMDA5MDgyNTAyWjAvBgkqhkiG9w0BCQQxIgQggYay
+Tcucukf7oWEdxuCkFHtd2QaneCXM16AHXupNhbQweQYJKoZIhvcNAQkPMWwwajAL
+BglghkgBZQMEASowCwYJYIZIAWUDBAEWMAsGCWCGSAFlAwQBAjAKBggqhkiG9w0D
+BzAOBggqhkiG9w0DAgICAIAwDQYIKoZIhvcNAwICAUAwBwYFKw4DAgcwDQYIKoZI
+hvcNAwICASgwCgYIKoZIzj0EAwIERjBEAiAcJ+aB2yxHTRbUeZqmaxR9PXpuerdf
+eKLOi1NGpcVnCgIgX54vwkKMTDbEJMep9m47mI05bIjt0jDni6Bfu8UIXuo=
+
+------F6D0687973D5A407B1CEB3E2B58A5CC9--
+

--- a/test/certs/governance_rule_order_test.xml
+++ b/test/certs/governance_rule_order_test.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="omg_shared_ca_domain_governance.xsd">
+    <domain_access_rules>
+        <domain_rule>
+            <domains>
+                <id_range>
+                    <min>0</min>
+                    <max>230</max>
+                </id_range>
+            </domains>
+            <allow_unauthenticated_participants>false</allow_unauthenticated_participants>
+            <enable_join_access_control>true</enable_join_access_control>
+            <discovery_protection_kind>ENCRYPT</discovery_protection_kind>
+            <liveliness_protection_kind>ENCRYPT</liveliness_protection_kind>
+            <rtps_protection_kind>ENCRYPT</rtps_protection_kind>
+            <topic_access_rules>
+                <topic_rule>
+                    <topic_expression>HelloWorldTopic_*</topic_expression>
+                    <enable_discovery_protection>true</enable_discovery_protection>
+                    <enable_liveliness_protection>true</enable_liveliness_protection>
+                    <enable_read_access_control>false</enable_read_access_control>
+                    <enable_write_access_control>false</enable_write_access_control>
+                    <metadata_protection_kind>ENCRYPT</metadata_protection_kind>
+                    <data_protection_kind>ENCRYPT</data_protection_kind>
+                </topic_rule>
+                <topic_rule>
+                    <topic_expression>*</topic_expression>
+                    <enable_discovery_protection>true</enable_discovery_protection>
+                    <enable_liveliness_protection>true</enable_liveliness_protection>
+                    <enable_read_access_control>true</enable_read_access_control>
+                    <enable_write_access_control>true</enable_write_access_control>
+                    <metadata_protection_kind>ENCRYPT</metadata_protection_kind>
+                    <data_protection_kind>ENCRYPT</data_protection_kind>
+                </topic_rule>
+            </topic_access_rules>
+        </domain_rule>
+    </domain_access_rules>
+</dds>
+

--- a/test/certs/governance_rule_order_test_inverse.smime
+++ b/test/certs/governance_rule_order_test_inverse.smime
@@ -1,0 +1,81 @@
+MIME-Version: 1.0
+Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----B7765AE3472A645801725428F69BB2B2"
+
+This is an S/MIME signed message
+
+------B7765AE3472A645801725428F69BB2B2
+Content-Type: text/plain
+
+<?xml version="1.0" encoding="utf-8"?>
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="omg_shared_ca_domain_governance.xsd">
+    <domain_access_rules>
+        <domain_rule>
+            <domains>
+                <id_range>
+                    <min>0</min>
+                    <max>230</max>
+                </id_range>
+            </domains>
+            <allow_unauthenticated_participants>false</allow_unauthenticated_participants>
+            <enable_join_access_control>true</enable_join_access_control>
+            <discovery_protection_kind>ENCRYPT</discovery_protection_kind>
+            <liveliness_protection_kind>ENCRYPT</liveliness_protection_kind>
+            <rtps_protection_kind>ENCRYPT</rtps_protection_kind>
+            <topic_access_rules>
+                <topic_rule>
+                    <topic_expression>*</topic_expression>
+                    <enable_discovery_protection>true</enable_discovery_protection>
+                    <enable_liveliness_protection>true</enable_liveliness_protection>
+                    <enable_read_access_control>true</enable_read_access_control>
+                    <enable_write_access_control>true</enable_write_access_control>
+                    <metadata_protection_kind>ENCRYPT</metadata_protection_kind>
+                    <data_protection_kind>ENCRYPT</data_protection_kind>
+                </topic_rule>
+                <topic_rule>
+                    <topic_expression>HelloWorldTopic_*</topic_expression>
+                    <enable_discovery_protection>true</enable_discovery_protection>
+                    <enable_liveliness_protection>true</enable_liveliness_protection>
+                    <enable_read_access_control>false</enable_read_access_control>
+                    <enable_write_access_control>false</enable_write_access_control>
+                    <metadata_protection_kind>ENCRYPT</metadata_protection_kind>
+                    <data_protection_kind>ENCRYPT</data_protection_kind>
+                </topic_rule>
+            </topic_access_rules>
+        </domain_rule>
+    </domain_access_rules>
+</dds>
+
+
+------B7765AE3472A645801725428F69BB2B2
+Content-Type: application/x-pkcs7-signature; name="smime.p7s"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="smime.p7s"
+
+MIIEeAYJKoZIhvcNAQcCoIIEaTCCBGUCAQExDzANBglghkgBZQMEAgEFADALBgkq
+hkiG9w0BBwGgggJAMIICPDCCAeOgAwIBAgIJALZwpgo2sxthMAoGCCqGSM49BAMC
+MIGaMQswCQYDVQQGEwJFUzELMAkGA1UECAwCTUExFDASBgNVBAcMC1RyZXMgQ2Fu
+dG9zMREwDwYDVQQKDAhlUHJvc2ltYTERMA8GA1UECwwIZVByb3NpbWExHjAcBgNV
+BAMMFWVQcm9zaW1hIE1haW4gVGVzdCBDQTEiMCAGCSqGSIb3DQEJARYTbWFpbmNh
+QGVwcm9zaW1hLmNvbTAeFw0xNzA5MDYwOTAzMDNaFw0yNzA5MDQwOTAzMDNaMIGa
+MQswCQYDVQQGEwJFUzELMAkGA1UECAwCTUExFDASBgNVBAcMC1RyZXMgQ2FudG9z
+MREwDwYDVQQKDAhlUHJvc2ltYTERMA8GA1UECwwIZVByb3NpbWExHjAcBgNVBAMM
+FWVQcm9zaW1hIE1haW4gVGVzdCBDQTEiMCAGCSqGSIb3DQEJARYTbWFpbmNhQGVw
+cm9zaW1hLmNvbTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABGLlhB3WQ8l1fpUE
+3DfOoulA/de38Zfj7hmpKtOnxiH2q6RJbwhxvJeA7R7mkmAKaJKmzx695BjyiXVS
+7bE7vgejEDAOMAwGA1UdEwQFMAMBAf8wCgYIKoZIzj0EAwIDRwAwRAIgVTY1BEvT
+4pw3GyBMzaUqmp69wi0kBkyOgq04OhyJ13UCICR125vvt0fUhXsXaxOAx28E4Ac9
+SVxpI+3UYs2kV5n0MYIB/DCCAfgCAQEwgagwgZoxCzAJBgNVBAYTAkVTMQswCQYD
+VQQIDAJNQTEUMBIGA1UEBwwLVHJlcyBDYW50b3MxETAPBgNVBAoMCGVQcm9zaW1h
+MREwDwYDVQQLDAhlUHJvc2ltYTEeMBwGA1UEAwwVZVByb3NpbWEgTWFpbiBUZXN0
+IENBMSIwIAYJKoZIhvcNAQkBFhNtYWluY2FAZXByb3NpbWEuY29tAgkAtnCmCjaz
+G2EwDQYJYIZIAWUDBAIBBQCggeQwGAYJKoZIhvcNAQkDMQsGCSqGSIb3DQEHATAc
+BgkqhkiG9w0BCQUxDxcNMjAxMDA5MDgyNTQ4WjAvBgkqhkiG9w0BCQQxIgQg5j45
+TiMKofbmtFJN25Px0awre9uAEmFNUUJuGNqeNwkweQYJKoZIhvcNAQkPMWwwajAL
+BglghkgBZQMEASowCwYJYIZIAWUDBAEWMAsGCWCGSAFlAwQBAjAKBggqhkiG9w0D
+BzAOBggqhkiG9w0DAgICAIAwDQYIKoZIhvcNAwICAUAwBwYFKw4DAgcwDQYIKoZI
+hvcNAwICASgwCgYIKoZIzj0EAwIERjBEAiBnHXnTccvwSpBTuY6mw/tyWSwSkNv+
+To/8tA/y5Zr4iwIgYNQPKTdD+CpNv02+aEBctnDfNzAsuUacIKJEqocSgxs=
+
+------B7765AE3472A645801725428F69BB2B2--
+

--- a/test/certs/governance_rule_order_test_inverse.xml
+++ b/test/certs/governance_rule_order_test_inverse.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="omg_shared_ca_domain_governance.xsd">
+    <domain_access_rules>
+        <domain_rule>
+            <domains>
+                <id_range>
+                    <min>0</min>
+                    <max>230</max>
+                </id_range>
+            </domains>
+            <allow_unauthenticated_participants>false</allow_unauthenticated_participants>
+            <enable_join_access_control>true</enable_join_access_control>
+            <discovery_protection_kind>ENCRYPT</discovery_protection_kind>
+            <liveliness_protection_kind>ENCRYPT</liveliness_protection_kind>
+            <rtps_protection_kind>ENCRYPT</rtps_protection_kind>
+            <topic_access_rules>
+                <topic_rule>
+                    <topic_expression>*</topic_expression>
+                    <enable_discovery_protection>true</enable_discovery_protection>
+                    <enable_liveliness_protection>true</enable_liveliness_protection>
+                    <enable_read_access_control>true</enable_read_access_control>
+                    <enable_write_access_control>true</enable_write_access_control>
+                    <metadata_protection_kind>ENCRYPT</metadata_protection_kind>
+                    <data_protection_kind>ENCRYPT</data_protection_kind>
+                </topic_rule>
+                <topic_rule>
+                    <topic_expression>HelloWorldTopic_*</topic_expression>
+                    <enable_discovery_protection>true</enable_discovery_protection>
+                    <enable_liveliness_protection>true</enable_liveliness_protection>
+                    <enable_read_access_control>false</enable_read_access_control>
+                    <enable_write_access_control>false</enable_write_access_control>
+                    <metadata_protection_kind>ENCRYPT</metadata_protection_kind>
+                    <data_protection_kind>ENCRYPT</data_protection_kind>
+                </topic_rule>
+            </topic_access_rules>
+        </domain_rule>
+    </domain_access_rules>
+</dds>
+


### PR DESCRIPTION
This is a port of #1474 to 2.0.x

According to the standard, governance rules must be evaluated in order, and the first matching rule is applied.
We are using a map to store the rules before applying them, therefore, losing the original order.
Besides, the map object is never searched by key.
Changed the map for a vector.