### PR TITLE
Fix wrong calculation of user multicast port [9599]

### DIFF
--- a/include/fastdds/rtps/network/NetworkFactory.h
+++ b/include/fastdds/rtps/network/NetworkFactory.h
@@ -83,7 +83,7 @@ public:
      */
     bool BuildReceiverResources(
             Locator_t& local,
-            std::vector<std::shared_ptr<ReceiverResource> >& returned_resources_list,
+            std::vector<std::shared_ptr<ReceiverResource>>& returned_resources_list,
             uint32_t receiver_max_message_size);
 
     void NormalizeLocators(
@@ -195,10 +195,11 @@ public:
     /**
      * Fills the locator with the default unicast configuration.
      * */
-    bool fillDefaultUnicastLocator(
+    bool fill_default_locator_port(
             uint32_t domain_id,
             Locator_t& locator,
-            const RTPSParticipantAttributes& m_att) const;
+            const RTPSParticipantAttributes& m_att,
+            bool is_multicast) const;
 
     /**
      * Shutdown method to close the connections of the transports.
@@ -207,7 +208,7 @@ public:
 
 private:
 
-    std::vector<std::unique_ptr<fastdds::rtps::TransportInterface> > mRegisteredTransports;
+    std::vector<std::unique_ptr<fastdds::rtps::TransportInterface>> mRegisteredTransports;
 
     uint32_t maxMessageSizeBetweenTransports_;
 
@@ -216,9 +217,10 @@ private:
     /**
      * Calculates well-known ports.
      */
-    uint16_t calculateWellKnownPort(
+    uint16_t calculate_well_known_port(
             uint32_t domain_id,
-            const RTPSParticipantAttributes& att) const;
+            const RTPSParticipantAttributes& att,
+            bool is_multicast) const;
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -286,7 +286,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         std::for_each(m_att.defaultUnicastLocatorList.begin(), m_att.defaultUnicastLocatorList.end(),
                 [&](Locator_t& loc)
                 {
-                    m_network_Factory.fillDefaultUnicastLocator(domain_id_, loc, m_att);
+                    m_network_Factory.fill_default_locator_port(domain_id_, loc, m_att, false);
                 });
 
     }
@@ -1221,11 +1221,11 @@ void RTPSParticipantImpl::normalize_endpoint_locators(
     // Locators with port 0, calculate port.
     for (Locator_t& loc : endpoint_att.unicastLocatorList)
     {
-        m_network_Factory.fillDefaultUnicastLocator(domain_id_, loc, m_att);
+        m_network_Factory.fill_default_locator_port(domain_id_, loc, m_att, false);
     }
     for (Locator_t& loc : endpoint_att.multicastLocatorList)
     {
-        m_network_Factory.fillDefaultUnicastLocator(domain_id_, loc, m_att);
+        m_network_Factory.fill_default_locator_port(domain_id_, loc, m_att, true);
     }
 
     // Normalize unicast locators


### PR DESCRIPTION
When the user sets a multicast address to a DataReader, without specifying the port, the user multicast port is calculated wrongly.
This PR fixes this.