### PR TITLE
[Discovery Server] Remove change in History comparing instance handle

### DIFF
--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -32,7 +32,7 @@ namespace ddb {
 DiscoveryDataBase::DiscoveryDataBase(
         fastrtps::rtps::GuidPrefix_t server_guid_prefix)
     : server_guid_prefix_(server_guid_prefix)
-    , server_acked_by_all_(true)
+    , server_acked_by_all_(false)
 {
 }
 
@@ -411,13 +411,13 @@ void DiscoveryDataBase::create_participant_from_change_(
         const DiscoveryParticipantChangeData& change_data)
 {
     DiscoveryParticipantInfo part(ch, server_guid_prefix_, change_data);
-    // must be acked also by the entity that has sent the data (in local entities, itself)
+    // The change must be acked also by the entity that has sent the data (in local entities, itself)
     part.add_or_update_ack_participant(ch->writerGUID.guidPrefix, true);
     std::pair<std::map<eprosima::fastrtps::rtps::GuidPrefix_t, DiscoveryParticipantInfo>::iterator, bool> ret =
             participants_.insert(std::make_pair(guid_from_change(ch).guidPrefix, part));
 
 
-    // If insert resturn false, means that the participant already existed (DATA(p) is an update). In that case
+    // If insert returns false, means that the participant already existed (DATA(p) is an update). In that case
     // we need to update the change related to the participant and return the old change to the pool
     if (!ret.second)
     {

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -32,7 +32,7 @@ namespace ddb {
 DiscoveryDataBase::DiscoveryDataBase(
         fastrtps::rtps::GuidPrefix_t server_guid_prefix)
     : server_guid_prefix_(server_guid_prefix)
-    , server_acked_by_all_(false)
+    , server_acked_by_all_(true)
 {
 }
 
@@ -131,6 +131,15 @@ bool DiscoveryDataBase::edp_subscriptions_is_relevant(
     }
     // not relevant
     return false;
+}
+
+void DiscoveryDataBase::update_change_and_unmatch_(
+        fastrtps::rtps::CacheChange_t* new_change,
+        ddb::DiscoverySharedInfo& entity)
+{
+    changes_to_release_.push_back(entity.update_and_unmatch(new_change));
+    entity.add_or_update_ack_participant(server_guid_prefix_, true);
+    entity.add_or_update_ack_participant(new_change->writerGUID.guidPrefix, true);
 }
 
 void DiscoveryDataBase::add_ack_(
@@ -402,8 +411,11 @@ void DiscoveryDataBase::create_participant_from_change_(
         const DiscoveryParticipantChangeData& change_data)
 {
     DiscoveryParticipantInfo part(ch, server_guid_prefix_, change_data);
+    // must be acked also by the entity that has sent the data (in local entities, itself)
+    part.add_or_update_ack_participant(ch->writerGUID.guidPrefix, true);
     std::pair<std::map<eprosima::fastrtps::rtps::GuidPrefix_t, DiscoveryParticipantInfo>::iterator, bool> ret =
             participants_.insert(std::make_pair(guid_from_change(ch).guidPrefix, part));
+
 
     // If insert resturn false, means that the participant already existed (DATA(p) is an update). In that case
     // we need to update the change related to the participant and return the old change to the pool
@@ -602,7 +614,7 @@ void DiscoveryDataBase::process_dispose_participant_(
     {
         // Only update DATA(p), leaving the change info untouched. This is because DATA(Up) does not have the
         // participant's meta-information, but we don't want to loose it here.
-        changes_to_release_.push_back(pit->second.update_and_unmatch(ch));
+        update_change_and_unmatch_(ch, pit->second);
     }
     else
     {

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -416,7 +416,6 @@ void DiscoveryDataBase::create_participant_from_change_(
     std::pair<std::map<eprosima::fastrtps::rtps::GuidPrefix_t, DiscoveryParticipantInfo>::iterator, bool> ret =
             participants_.insert(std::make_pair(guid_from_change(ch).guidPrefix, part));
 
-
     // If insert returns false, means that the participant already existed (DATA(p) is an update). In that case
     // we need to update the change related to the participant and return the old change to the pool
     if (!ret.second)

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
@@ -64,7 +64,7 @@ public:
 
     class AckedFunctor
     {
-        using argument_type = eprosima::fastrtps::rtps::ReaderProxy*;
+        using argument_type = eprosima::fastrtps::rtps::ReaderProxy *;
         using result_type = void;
 
         // friend class DiscoveryDataBase;
@@ -242,10 +242,7 @@ protected:
     // change a cacheChange by update or new disposal
     void update_change_and_unmatch_(
             fastrtps::rtps::CacheChange_t* new_change,
-            ddb::DiscoverySharedInfo& entity)
-    {
-        changes_to_release_.push_back(entity.update_and_unmatch(new_change));
-    }
+            ddb::DiscoverySharedInfo& entity);
 
     // update the acks
     void add_ack_(

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
@@ -64,7 +64,7 @@ public:
 
     class AckedFunctor
     {
-        using argument_type = eprosima::fastrtps::rtps::ReaderProxy *;
+        using argument_type = eprosima::fastrtps::rtps::ReaderProxy*;
         using result_type = void;
 
         // friend class DiscoveryDataBase;

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer2.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer2.cpp
@@ -671,12 +671,9 @@ bool PDPServer2::server_update_routine()
         process_writers_acknowledgements();     // server + ddb(functor_with_ddb)
         process_data_queues();                  // all ddb
         process_dirty_topics();                 // all ddb
-
         process_changes_release();              // server + ddb(changes_to_release(), clear_changes_to_release())
-
         process_disposals();                    // server + ddb(changes_to_dispose(), clear_changes_to_disposes())
         process_to_send_lists();                // server + ddb(get_to_send, remove_to_send_this)
-
         pending_work = pending_ack();           // all server
 
         logInfo(RTPS_PDP_SERVER, "-------------------- Server routine end --------------------");

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer2.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer2.cpp
@@ -667,13 +667,18 @@ bool PDPServer2::server_update_routine()
     {
         logInfo(RTPS_PDP_SERVER, "");
         logInfo(RTPS_PDP_SERVER, "-------------------- Server routine start --------------------");
+
         process_writers_acknowledgements();     // server + ddb(functor_with_ddb)
         process_data_queues();                  // all ddb
-        process_disposals();                    // server + ddb(changes_to_dispose(), clear_changes_to_disposes())
         process_dirty_topics();                 // all ddb
-        process_to_send_lists();                // server + ddb(get_to_send, remove_to_send_this)
+
         process_changes_release();              // server + ddb(changes_to_release(), clear_changes_to_release())
+
+        process_disposals();                    // server + ddb(changes_to_dispose(), clear_changes_to_disposes())
+        process_to_send_lists();                // server + ddb(get_to_send, remove_to_send_this)
+
         pending_work = pending_ack();           // all server
+
         logInfo(RTPS_PDP_SERVER, "-------------------- Server routine end --------------------");
         logInfo(RTPS_PDP_SERVER, "");
     }
@@ -1079,7 +1084,8 @@ bool PDPServer2::remove_change_from_history_nts(
 {
     for (auto chit = history->changesRbegin(); chit != history->changesRend(); chit++)
     {
-        if (change->instanceHandle == (*chit)->instanceHandle)
+        if (change->instanceHandle == (*chit)->instanceHandle &&
+                change->write_params.sample_identity() == (*chit)->write_params.sample_identity())
         {
             if (release_change)
             {


### PR DESCRIPTION
The removing of Data in a History was compared by the guid, but not by the instance Handle.
Different minor fixes.