### PR TITLE
Add module and option to detect and enable linking with -latomic in environments that need it (#1495)

### DIFF
--- a/cmake/modules/CheckLibatomic.cmake
+++ b/cmake/modules/CheckLibatomic.cmake
@@ -1,0 +1,54 @@
+# LINK_LIBATOMIC
+
+# Check if platform needs to explicitly specify linking with libatomic
+
+set(LINK_LIBATOMIC 0)
+
+set(ATOMIC_TEST_CODE
+	"#include <atomic>
+	int main()
+	{
+		volatile std::atomic_ullong i(0xcafebabedeadbeeful);
+		i += 0xfeedbadc0de8f00dul;
+		return 0;
+	}"
+)
+
+include(CheckLibraryExists)
+include(CheckCXXSourceCompiles)
+
+set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+set(CMAKE_REQUIRED_FLAGS "-std=c++11 ${CMAKE_REQUIRED_FLAGS}")
+
+# Test linking without atomic
+check_cxx_source_compiles(
+	"${ATOMIC_TEST_CODE}"
+	ATOMIC_WITHOUT_LIB
+)
+
+# Test linking with atomic
+check_library_exists(atomic __atomic_load_8 "" HAVE_LIBATOMIC)
+if (HAVE_LIBATOMIC)
+	set(OLD_CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
+	set(CMAKE_REQUIRED_LIBRARIES atomic ${CMAKE_REQUIRED_LIBRARIES})
+	check_cxx_source_compiles(
+		"${ATOMIC_TEST_CODE}"
+		ATOMIC_WITH_LIB
+	)
+
+	set(CMAKE_REQUIRED_LIBRARIES ${OLD_CMAKE_REQUIRED_LIBRARIES})
+else()
+	set(ATOMIC_WITH_LIB 0)
+endif()
+
+set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
+
+
+# Set LINK_LIBATOMIC to true only if linking with atomic is required
+if (NOT ATOMIC_WITHOUT_LIB)
+	if (ATOMIC_WITH_LIB)
+		set(LINK_LIBATOMIC 1)
+	else()
+		message(FATAL_ERROR "Unable to create binaries with atomic dependencies")
+	endif()
+endif()

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 include(${PROJECT_SOURCE_DIR}/cmake/dev/set_sources.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/dev/generate_msvc_libraries.cmake)
+include(CheckLibatomic)
 
 # Set source files
 
@@ -403,6 +404,7 @@ elseif(NOT EPROSIMA_INSTALLER)
         $<$<BOOL:${LINK_SSL}>:OpenSSL::SSL$<SEMICOLON>OpenSSL::Crypto>
         $<$<BOOL:${WIN32}>:iphlpapi$<SEMICOLON>Shlwapi>
         ${THIRDPARTY_BOOST_LINK_LIBS}
+        $<$<BOOL:${LINK_LIBATOMIC}>:atomic>
         )
 
     if(MSVC OR MSVC_IDE)


### PR DESCRIPTION
Similar to the implementation of CheckAtomic.cmake from LLVM.

Signed-off-by: Pablo Bleyer <pablo@bleyer.org>