### PR TITLE
Keep PDP lock when calling EDP::assignRemoteEndpoints

### DIFF
--- a/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
@@ -151,7 +151,6 @@ void PDPListener::onNewCacheChangeAdded(
                 pdata->updateData(temp_participant_data_);
                 pdata->isAlive = true;
                 reader->getMutex().unlock();
-                lock.unlock();
 
                 logInfo(RTPS_PDP_DISCOVERY, "Update participant " << pdata->m_guid << " at " << "MTTLoc: "
                         << pdata->metatraffic_locators << " DefLoc:" << pdata->default_locators);
@@ -160,6 +159,8 @@ void PDPListener::onNewCacheChangeAdded(
                 {
                     parent_pdp_->mp_EDP->assignRemoteEndpoints(*pdata);
                 }
+
+                lock.unlock();
             }
 
             if (pdata != nullptr)

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -401,6 +401,8 @@ void PDPSimple::removeRemoteEndpoints(
 void PDPSimple::notifyAboveRemoteEndpoints(
         const ParticipantProxyData& pdata)
 {
+    std::unique_lock<std::recursive_mutex> lock(*getMutex());
+
     //Inform EDP of new RTPSParticipant data:
     if (mp_EDP != nullptr)
     {


### PR DESCRIPTION
This should fix #1506 