### PR TITLE
Backport Quality Declaration to <2.0.x> [9723]

### DIFF
--- a/PLATFORM_SUPPORT.md
+++ b/PLATFORM_SUPPORT.md
@@ -1,0 +1,42 @@
+# Platform Support
+
+This document reflects the level of support offered by *eprosima Fast DDS* on different platforms as per the following
+definitions:
+
+## Tier 1
+
+Tier 1 platforms are subjected to our unit test suite and other testing tools on a frequent basis including continuous
+integration jobs, nightly jobs, packaging jobs, and performance testing.
+Errors or bugs discovered in these platforms are prioritized for correction by the development team.
+Significant errors discovered in Tier 1 platforms can impact release dates and we strive to resolve all known high
+priority errors in Tier 1 platforms prior to new version releases.
+
+## Tier 2
+
+Tier 2 platforms are subject to periodic CI testing which runs both builds and tests with publicly accessible results.
+The CI is expected to be run at least within a week of relevant changes for the current release of *Fast DDS*.
+Installation instructions should be available and up-to-date in order for a platform to be listed in this category.
+Package-level binary packages may not be provided but providing a downloadable archive of the built workspace is
+encouraged.
+Errors may be present in released product versions for Tier 2 platforms.
+Known errors in Tier 2 platforms will be addressed subject to resource availability on a best effort basis and may or
+may not be corrected prior to new version releases.
+One or more entities should be committed to continuing support of the platform.
+
+## Tier 3
+
+Tier 3 platforms are those for which community reports indicate that the release is functional.
+The development team does not run the unit test suite or perform any other tests on platforms in Tier 3.
+Community members may provide assistance with these platforms.
+
+## Platforms
+
+|Architecture|Ubuntu Focal (20.04)|MacOS Mojave (10.14)|Windows 10 (VS2019)|Debian Buster (10)|
+|------------|--------------------|--------------------|-------------------|------------------|
+|amd64       |Tier 1 [a][s]       |Tier 1 [s]          |Tier 1 [a][s]      |Tier 3 [s]        |
+|amd32       |                    |                    |Tier 1 [a][s]      |                  |
+|arm64       |Tier 1 [a][s]       |                    |                   |Tier 3 [s]        |
+|arm32       |Tier 3 [s]          |                    |                   |Tier 3 [s]        |
+
+" [a] " Binary releases are provided as a single archive per platform.\
+" [s] " Compilation from source.

--- a/Public_API_foonathan_memory.md
+++ b/Public_API_foonathan_memory.md
@@ -1,0 +1,41 @@
+# **External Dependency Public API** `foonathan_memory`
+
+This document lists the `foonathan_memory` API that *eprosima Fast DDS* uses.
+This document will be updated if new features are included and used in *eprosima Fast DDS*.
+
+## Allocators
+
+1. Typedef [foonathan::memory::default_allocator](https://foonathan.net/memory/group__allocator.html#ga10acce2d854fc42fea7306e511d9cd10)
+1. Typedef [foonathan::memory::heap_allocator](https://foonathan.net/memory/group__allocator.html#ga22bca7a15392be2aa9be773d838ec4f4)
+1. Typedef [foonathan::memory::new_allocator](https://foonathan.net/memory/group__allocator.html#ga0203ba3d8ef46a65c504a6c98e3f7bb5)
+
+## Allocator implementations
+
+1. Class [foonathan::memory::memory_pool](https://foonathan.net/memory/classfoonathan_1_1memory_1_1memory__pool.html)
+1. Struct [foonathan::memory::node_pool](https://foonathan.net/memory/structfoonathan_1_1memory_1_1node__pool.html)
+
+## Adapters and Wrappers
+
+1. Class [foonathan::memory::binary_segregator](https://foonathan.net/memory/classfoonathan_1_1memory_1_1binary__segregator.html)
+
+
+## Alias Templates
+
+1. Class [foonathan::memory::unordered_map](https://foonathan.net/memory/classfoonathan_1_1memory_1_1unordered__map.html)
+1. Class [foonathan::memory::map](https://foonathan.net/memory/classfoonathan_1_1memory_1_1map.html)
+1. Class [foonathan::memory::set](https://foonathan.net/memory/classfoonathan_1_1memory_1_1set.html)
+
+## Node sizes
+
+1. Struct [foonathan::memory::map_node_size](https://foonathan.net/memory/structfoonathan_1_1memory_1_1map__node__size.html)
+1. Struct [foonathan::memory::set_node_size](https://foonathan.net/memory/structfoonathan_1_1memory_1_1set__node__size.html)
+1. Struct [foonathan::memory::unordered_map_node_size](https://foonathan.net/memory/structfoonathan_1_1memory_1_1unordered__map__node__size.html)
+
+## Internal methods
+
+When the library allocates memory blocks, some of this memory is reserved by `foonathan_memory` for internal uses and, consequently, is not available to the user.
+The following methods provide information about the internal needs of `foonathan_memory`. 
+
+1. foonathan::memory::detail::debug_fence_size
+1. foonathan::memory::detail::max_alignment
+1. foonathan::memory::detail::memory_block_stack::implementation_offset

--- a/QUALITY.md
+++ b/QUALITY.md
@@ -1,0 +1,220 @@
+This document is a declaration of software quality for *eprosima Fast DDS* inspired on the guidelines provided in the [ROS 2 REP-2004 document](https://www.ros.org/reps/rep-2004.html).
+
+Quality Declaration
+=============================
+
+*eprosima Fast DDS* (formerly Fast RTPS) is a C++ implementation of the DDS (Data Distribution Service) standard of the OMG (Object Management Group).
+eProsima Fast DDS implements the RTPS (Real Time Publish Subscribe) protocol, which provides publisher-subscriber communications over unreliable transports such as UDP,
+as defined and maintained by the Object Management Group (OMG) consortium.
+
+*eprosima Fast DDS* claims to be in the **Quality Level 2** category.
+
+Below are the rationales, notes and caveats for this claim, organized by the requirements listed in the [Package Requirements for Quality Level 1 in REP-2004](https://www.ros.org/reps/rep-2004.html#package-requirements).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+The **Versioning Policy Declaration** for *eprosima Fast DDS* can be found [here](VERSIONING.md) and it adheres to [`semver`](https://semver.org/).
+
+### Version Stability [1.ii]
+
+*eprosima Fast DDS* is at a stable version, i.e. `>=1.0.0`.
+The latest version can be found [here](https://github.com/eProsima/Fast-DDS/releases) and its change history can be found [here](versions.md).
+
+### Public API Declaration [1.iii]
+
+*eprosima Fast DDS* documentation is hosted on [Read the Docs](https://fast-dds.docs.eprosima.com). The documentation includes the [API Reference](https://fast-dds.docs.eprosima.com/en/latest/fastdds/api_reference/api_reference.html).
+
+### API Stability Policy [1.iv]
+
+*eprosima Fast DDS* will only break public API between major releases.
+
+### ABI Stability Policy [1.v]
+
+Any ABI break in *eprosima Fast DDS* will be done between minor versions and it should be clearly stated on the release notes.
+
+## Change Control Process [2]
+
+The stability of *eprosima Fast DDS* is ensured through review, CI and tests.
+The change control process can be found in [CONTRIBUTING](https://github.com/eProsima/policies/blob/main/CONTRIBUTING.md).
+
+All changes to *eprosima Fast DDS* occur through pull requests that are required to pass all CI tests.
+In case of failure, only maintainers can merge the pull request, and only when there is enough evidence that the failure is unrelated to the change.
+Additionally, all pull requests must have a positive review from one other contributor that did not author the pull request.
+
+### Change Requests [2.i]
+
+All changes will occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+*eprosima Fast DDS* uses the [Developer Certificate of Origin (DCO)](https://developercertificate.org/) as its confirmation of contributor origin policy.
+More information can be found in [CONTRIBUTING](https://github.com/eProsima/policies/blob/main/CONTRIBUTING.md)
+
+### Peer Review Policy [2.iii]
+
+All pull requests will be peer-reviewed by at least one other contributor who did not author the pull request. Approval is required before merging.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI to be considered for merging, unless maintainers consider that there is enough evidence that the failure is unrelated to the changes.
+CI testing is automatically triggered by incoming pull requests.
+Current nightly results can be seen here for all supported platforms:
+
+* Linux [![Linux amd64 ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_linux/badge/icon?subject=%20%20%20Linux%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_linux)
+* Linux-aarch64 [![Linux arm64 ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_linux_aarch64/badge/icon?subject=%20%20%20Linux-aarch64%20CI%20)](http://jenkins.eprosima.com:8080/view/Nightly/job/nightly_fastdds_sec_master_linux_aarch64/)
+* Windows [![Windows ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_windows/label=windows-secure,platform=x64,toolset=v141/badge/icon?subject=%20%20%20%20Windows%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_windows/label=windows-secure,platform=x64,toolset=v141)
+* Mac [![Mac ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_mac/badge/icon?subject=%20%20%20%20%20%20%20Mac%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_mac)
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging as stated in [CONTRIBUTING](https://github.com/eProsima/policies/blob/main/CONTRIBUTING.md).
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+*eprosima Fast DDS* has a documented feature list hosted in [Read the Docs](https://fast-dds.docs.eprosima.com/en/latest/fastdds/dds_layer/dds_layer.html#dds-layer).
+
+### Public API Documentation [3.ii]
+
+*eprosima Fast DDS* includes a complete API Reference which is hosted in [Read the Docs](https://fast-dds.docs.eprosima.com/en/latest/fastdds/api_reference/api_reference.html).
+
+### License [3.iii]
+
+The license for *eprosima Fast DDS* is Apache 2.0, and a summary can be found in each source file.
+A full copy of the license can be found [here](LICENSE).
+
+There is some third-party content included with *eprosima Fast DDS* which is distributed under the [Boost Software License version 1.0](http://www.boost.org/LICENSE_1_0.txt) and [Zlib license](https://github.com/leethomason/tinyxml2/blob/8c8293ba8969a46947606a93ff0cb5a083aab47a/readme.md#license).
+
+### Copyright Statements [3.iv]
+
+*eprosima Fast DDS* copyright holder provide a statement of copyright in each source file.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+Each feature in *eprosima Fast DDS* has corresponding tests which simulate typical usage, and they are located in the [`test` directory](test).
+New features are required to have tests before being added as stated in [CONTRIBUTING](https://github.com/eProsima/policies/blob/main/CONTRIBUTING.md).
+Current nightly results can be found here:
+
+* Linux [![Linux ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_linux/badge/icon?subject=%20%20%20Linux%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_linux)
+* Linux-aarch64 [![Linux arm64 ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_linux_aarch64/badge/icon?subject=%20%20%20Linux-aarch64%20CI%20)](http://jenkins.eprosima.com:8080/view/Nightly/job/nightly_fastdds_sec_master_linux_aarch64/)
+* Windows [![Windows ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_windows/label=windows-secure,platform=x64,toolset=v141/badge/icon?subject=%20%20%20%20Windows%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_windows/label=windows-secure,platform=x64,toolset=v141)
+* Mac [![Mac ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_mac/badge/icon?subject=%20%20%20%20%20%20%20Mac%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_mac)
+
+### Public API Testing [4.ii]
+
+Each part of the public API has tests, and new additions or changes to the public API require tests before being added.
+The tests aim to cover typical usage. Currently, efforts are being made to improve our code coverage statistics in order to test corner cases.
+
+### Coverage [4.iii]
+
+*eprosima Fast DDS* coverage reports can be accessed from the CI nightly results. These reports provide statistics of line and conditional coverage.
+
+* [Linux Coverage Report](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_linux/cobertura)
+* [Mac Coverage Report](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_mac/cobertura)
+
+Changes are required to make a best effort to keep or increase coverage before being accepted, but decreases are allowed if properly justified and accepted by maintainers.
+
+### Performance [4.iv]
+
+*eprosima Fast DDS* provides a test directory specifically dedicated to performance that can be found [here](test/performance).
+Performace tests are automatically run after merging to the master branch of the project.
+If there has been any performance regression a notification is issued to maintainers that will study and decide how to proceed.
+
+Latest latency performance test results can be accesed [here](http://jenkins.eprosima.com:8080/job/FastRTPS_latency_performance/lastBuild/) and latest throughput performance test results can be seen [here](http://jenkins.eprosima.com:8080/job/fastrtps_throughput_performance/lastBuild/).
+
+Furthermore, [*eprosima benchmarking* project](https://github.com/eProsima/benchmarking) provides tools to run performance tests and a methodology to analyze and present the results:
+
+* [Latency Performance Test Specification](https://github.com/eProsima/benchmarking/blob/master/fastrtps_automated_benchmark/latency/README.md)
+* [Throughput Performance Test Specification](https://github.com/eProsima/benchmarking/blob/master/fastrtps_automated_benchmark/throughput/README.md)
+
+### Linters and Static Analysis [4.v]
+
+*eprosima Fast DDS* has a [code style](https://github.com/eProsima/cpp-style) that is enforced using [*uncrustify*](https://github.com/uncrustify/uncrustify).
+Among the CI tests there are tests that ensures that every pull request is compliant with the code style.
+The latest pull request results can be seen [here](http://jenkins.eprosima.com:8080/job/fastdds_github_uncrustify/lastBuild).
+The tests only check files where changes have been made.
+Therefore, the code style is only enforced in some files.
+However, the tendency will be to homogenize the older source files to the code style.
+
+*eprosima Fast DDS* uses Synopsis Coverity static code analysis and the latest results can be found [here](https://scan.coverity.com/projects/eprosima-fast-dds).
+
+## Dependencies [5]
+
+### Direct Runtime Dependencies [5.iii]
+
+*eprosima Fast DDS* depends on the following packages:
+
+- `libasio-dev`
+- `libtinyxml2-dev`
+- `fast-cdr`
+- `foonathan_memory`
+
+The first two dependencies are suggested to be installed for Linux using apt package manager, which would pull them from the Debian upstream.
+Therefore, these dependencies can be considered Quality Level 1 following the [advantages of being packaged for Debian](https://wiki.debian.org/AdvantagesForUpstream).
+
+**eProsima Fast CDR** Quality Declaration can be found [here](https://github.com/eProsima/Fast-CDR/blob/master/QUALITY_DECLARATION.md). Currently, **eProsima Fast CDR** claims to be in the **Quality Level 2** category.
+
+`foonathan_memory` Quality Declaration can be found [here](Quality_Declaration_foonathan_memory.md).
+This declaration claims that, even though `foonathan_memory` does not meet several quality requirements, it is considered to fulfill the **Quality Level 2** requirements for its use within *eprosima Fast DDS* with the caveats explained in the declaration.
+
+Therefore, *eprosima Fast DDS* currently could claim to be **Quality Level 2** at most.
+
+## Platform Support [6]
+
+*eprosima Fast DDS* supports the following platforms and tests each change against all of them as can be seen in the current nightly results:
+
+* Linux [![Linux ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_linux/badge/icon?subject=%20%20%20Linux%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_linux)
+* Linux-aarch64 [![Linux arm64 ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_linux_aarch64/badge/icon?subject=%20%20%20Linux-aarch64%20CI%20)](http://jenkins.eprosima.com:8080/view/Nightly/job/nightly_fastdds_sec_master_linux_aarch64/)
+* Windows [![Windows ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_windows/label=windows-secure,platform=x64,toolset=v141/badge/icon?subject=%20%20%20%20Windows%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_windows/label=windows-secure,platform=x64,toolset=v141)
+* Mac [![Mac ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_mac/badge/icon?subject=%20%20%20%20%20%20%20Mac%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_mac)
+
+More information about the supported platforms can be found in [PLATFORM_SUPPORT](PLATFORM_SUPPORT.md)
+
+## Vulnerability Disclosure Policy [7.i]
+
+*eprosima Fast DDS* vulnerability Disclosure Policy can be found [here](https://github.com/eProsima/policies/blob/main/VULNERABILITY.md)
+
+# Current Status Summary
+
+The chart below compares the requirements in the [REP-2004](https://www.ros.org/reps/rep-2004.html#quality-level-comparison-chart) with the current state of *eprosima Fast DDS*
+|Number| Requirement| Current State |
+|--|--|--|
+|1| **Version policy** |---|
+|1.i|Version Policy available |✓|
+|1.ii|Stable version |✓|
+|1.iii|Declared public API|✓|
+|1.iv|API stability policy|✓|
+|1.v|ABI stability policy|✓|
+|2| **Change control process** |---|
+|2.i| All changes occur on change request |✓|
+|2.ii| Contributor origin (DCO, CLA, etc) |✓|
+|2.iii| Peer review policy |✓|
+|2.iv| CI policy for change requests |✓|
+|2.v| Documentation policy for change requests |✓|
+|3| **Documentation** | --- |
+|3.i| Per feature documentation |✓|
+|3.ii| Per public API item documentation |✓|
+|3.iii| Declared License(s) |✓|
+|3.iv| Copyright in source files|✓|
+|3.v.a| Quality declaration linked to README |✓|
+|3.v.b| Centralized declaration available for peer review |✓|
+|4| **Testing** | --- |
+|4.i| Feature items tests |✓|
+|4.ii| Public API tests |✓|
+|4.iii.a| Using coverage |✓|
+|4.iii.b| Coverage policy ||
+|4.iv.a| Performance tests (if applicable) |✓|
+|4.iv.b| Performance tests policy|✓|
+|4.v.a| Code style enforcement (linters)|✓|
+|4.v.b| Use of static analysis tools |✓|
+|5| **Dependencies** | --- |
+|5.iii| Justifies quality use of dependencies |✓|
+|6| **Platform support** | --- |
+|6.i| Support targets Tier1 ROS platforms|✓|
+|7| **Security** | --- |
+|7.i| Vulnerability Disclosure Policy |✓|

--- a/QUALITY.md
+++ b/QUALITY.md
@@ -157,7 +157,7 @@ However, the tendency will be to homogenize the older source files to the code s
 The first two dependencies are suggested to be installed for Linux using apt package manager, which would pull them from the Debian upstream.
 Therefore, these dependencies can be considered Quality Level 1 following the [advantages of being packaged for Debian](https://wiki.debian.org/AdvantagesForUpstream).
 
-**eProsima Fast CDR** Quality Declaration can be found [here](https://github.com/eProsima/Fast-CDR/blob/master/QUALITY_DECLARATION.md). Currently, **eProsima Fast CDR** claims to be in the **Quality Level 2** category.
+**eProsima Fast CDR** Quality Declaration can be found [here](https://github.com/eProsima/Fast-CDR/blob/master/QUALITY.md). Currently, **eProsima Fast CDR** claims to be in the **Quality Level 2** category.
 
 `foonathan_memory` Quality Declaration can be found [here](Quality_Declaration_foonathan_memory.md).
 This declaration claims that, even though `foonathan_memory` does not meet several quality requirements, it is considered to fulfill the **Quality Level 2** requirements for its use within *eprosima Fast DDS* with the caveats explained in the declaration.

--- a/Quality_Declaration_foonathan_memory.md
+++ b/Quality_Declaration_foonathan_memory.md
@@ -1,0 +1,205 @@
+# **External Dependency Quality Declaration** `foonathan_memory`
+
+This document is a declaration of software quality for the `foonathan_memory` external dependency, inspired on the
+guidelines provided in the [ROS2 REP-2004 document](https://ros.org/reps/rep-2004.html).
+
+Foonathan's [`memory`](https://github.com/foonathan/memory) is a C++ library to manage memory allocations that improves upon the STL.
+*eprosima Fast DDS* started using this library following the advice of ROS's and eProsima's partner, Apex.AI.
+
+Even though several requirements established in REP-2004 are not met and, consequently, `foonathan_memory` cannot claim a high Quality Level, this document assesses the quality risks that can be introduced by the use of this library in *eprosima Fast DDS*.
+This Quality Declaration claims that the external dependency `foonathan_memory` qualifies to Quality Level 2 category for its use within *eprosima Fast DDS*.
+
+Below are the rationales, notes and caveats for this claim, organized by the requirements listed in the [Package Requirements for Quality Level 1 in REP-2004](https://www.ros.org/reps/rep-2004.html#package-requirements).
+
+##  Version Policy [1]
+
+### Version Scheme [1.i]
+
+`foonathan_memory` does not have a declared versioning scheme.
+
+The latest release can be found [here](https://github.com/foonathan/memory/releases) and the release notes can be found in the [CHANGELOG](https://github.com/foonathan/memory/blob/master/CHANGELOG.MD).
+Even though the current version is `< 1.0.0`, `foonathan_memory` is in [maintenance mode](https://www.jonathanmueller.dev/project/).
+
+*eprosima Fast DDS* ensures `foonathan_memory` version stability by pinning to a specific [commit](https://github.com/foonathan/memory/commits/c619113a616c5771ee693c7abdcef284e02f7d61).
+Both *eprosima* `foonathan_memory_vendor` utility and *eprosima Fast DDS* CI tests use this specific commit.
+This commit (signed December 16th 2019) is more recent than the current v0.6-2 released October 2nd 2019.
+
+*eprosima Fast DDS* maintainers will keep a continuous watch over new releases in order to assess the impact they could have over *eprosima Fast DDS*.
+Any `bugfix` or security vulnerability corrected that affects the API used by *eprosima Fast DDS* will be analyzed by the maintainers.
+Decision about updating the used commit rests in *eprosima Fast DDS* maintainers.
+
+### Version Stability [1.ii]
+
+`foonathan_memory` is stable and in [maintenance mode](https://www.jonathanmueller.dev/project/).
+
+### Public API Declaration [1.iii]
+
+`foonathan_memory` public API is defined in its [documentation](https://foonathan.net/memory/index.html).
+Additionally, *eprosima Fast DDS* has clearly stated the API used by the project [here](Public_API_foonathan_memory.md).
+
+### API and ABI Stability Policy [1.iv]/[1.v]
+
+`foonathan_memory` does not provide any versioning policy.
+However, by pinning *eprosima Fast DDS* CI tests and `foonathan_memory_vendor` utility to a particular commit ensures API and ABI stability within *eprosima Fast DDS* project.
+
+## Change Control Process [2]
+
+`foonathan_memory` does not have a stated change control process.
+Nevertheless, only when the pinned commit is updated is *eprosima Fast DDS* affected.
+The change control process for the  update of the `foonathan_memory_vendor` utility follows [eProsima Contributing guidelines](https://github.com/eProsima/policies/blob/main/CONTRIBUTING.md). 
+
+### Change Requests [2.i]
+
+`foonathan_memory` does not require that changes occur through a pull request.
+Many changes are committed directly by its maintainer.
+
+`foonathan_memory_vendor` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`foonathan_memory` does not have a confirmation of contributor origin policy.
+
+`foonathan_memory_vendor` uses DCO as its confirmation of contributor origin policy. More information can be found [here](https://github.com/eProsima/policies/blob/main/CONTRIBUTING.md).
+
+### Peer Review Policy [2.iii]
+
+`foonathan_memory` does not state its peer review policy, but each pull request is at least reviewed by the maintainer.
+
+All `foonathan_memory_vendor` pull requests will be peer reviewed and need at least one approved review to be merged.
+
+### Continuous Integration [2.iv]
+
+`foonathan_memory` changes run CI tests and the latest results can be seen here:
+
+* [Ubuntu and MacOS](https://travis-ci.org/github/foonathan/memory)
+* [Windows](https://ci.appveyor.com/project/foonathan/memory/branch/master)
+
+Additionally, eProsima CI runs `foonathan_memory` tests nightly in all *eprosima Fast DDS* [Tier 1 platforms](PLATFORM_SUPPORT.md).
+Latest results can be found here:
+
+* Linux [![Linux ci](http://jenkins.eprosima.com:8080/job/nightly_foonathan_memory_master_linux/badge/icon?subject=%20%20%20Linux%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_foonathan_memory_master_linux)
+* Linux-aarch64 [![Linux arm64 ci](http://jenkins.eprosima.com:8080/job/nightly_foonathan_memory_master_linux_aarch64/badge/icon?subject=%20%20%20Linux-aarch64%20CI%20)](http://jenkins.eprosima.com:8080/view/Nightly/job/nightly_foonathan_memory_master_linux_aarch64/)
+* Windows [![Windows ci](http://jenkins.eprosima.com:8080/job/nightly_foonathan_memory_master_windows/label=windows-secure,platform=x64,toolset=v141/badge/icon?subject=%20%20%20%20Windows%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_foonathan_memory_master_windows/label=windows-secure,platform=x64,toolset=v141)
+* Mac [![Mac ci](http://jenkins.eprosima.com:8080/job/nightly_foonathan_memory_master_mac/badge/icon?subject=%20%20%20%20%20%20%20Mac%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_foonathan_memory_master_mac)
+
+`foonathan_memory_vendor` does not provide CI tests being only an utility providing CMake files that configure `foonathan_memory`.
+If ROS 2 dependencies are found, `foonathan_memory_vendor` could run ROS 2 linters and copyright tests as can be seen in the [nightly CI results](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/testReport/foonathan_memory_vendor/).
+
+### Documentation Policy [2.v]
+
+`foonathan_memory` does not have a stated documentation policy.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`foonathan_memory` provides a [feature list](https://foonathan.net/memory/index.html) with descriptions of its main features.
+
+### Public API Documentation [3.ii]
+
+`foonathan_memory` has embedded API documentation that is generated using [Doxygen](https://www.doxygen.nl/index.html) and is [hosted](https://foonathan.net/memory/namespacefoonathan_1_1memory.html) alongside the feature documentation.
+
+Additionally, *eprosima Fast DDS* provides a [document](Public_API_foonathan_memory.md) stating the API used within the project.
+
+### License [3.iii]
+
+The license for `foonathan_memory` is Zlib.
+A summary statement is provided in each source file and a full copy can be found in the [LICENSE](https://raw.githubusercontent.com/foonathan/memory/master/LICENSE) file.
+
+### Copyright Statements [3.iv]
+
+The copyright holders each provide a statement of copyright in each source file in `foonathan_memory`.
+
+## Testing [4]
+
+### Feature and Public API Testing [4.i]/[4.ii]
+
+`foonathan_memory` provides tests which simulate typical usage located in the [`test`](https://github.com/foonathan/memory/tree/master/test) directory.
+
+Specifically, the API used by *eprosima Fast DDS* is tested in the following tests:
+
+* Allocators: [test/default_allocator.cpp](https://github.com/foonathan/memory/blob/c619113a616c5771ee693c7abdcef284e02f7d61/test/default_allocator.cpp)
+* Allocator implementations: [test/memory_pool.cpp](https://github.com/foonathan/memory/blob/c619113a616c5771ee693c7abdcef284e02f7d61/test/memory_pool.cpp)
+* Adapters and Wrappers: [test/segregator.cpp](https://github.com/foonathan/memory/blob/c619113a616c5771ee693c7abdcef284e02f7d61/test/segregator.cpp)
+* Alias templates: `foonathan_memory` does not provide any tests to check this functionality.
+Regardless, *eprosima Fast DDS* tests these features in the [PersistenceTests](https://github.com/eProsima/Fast-DDS/tree/master/test/unittest/rtps/persistence) and the [WriterProxyTests](https://github.com/eProsima/Fast-DDS/tree/master/test/unittest/rtps/reader).
+
+### Coverage [4.iii]
+
+`foonathan_memory` does not track testing coverage.
+Anyway, *eprosima Fast DDS* ensures that every feature and API used within the library has been tested.
+
+### Performance [4.iv]
+
+`foonathan_memory` does not conduct performance tests.
+
+*eprosima Fast DDS* will run its [performance tests](test/performance) and analyze their results before deciding to change the pinned commit to prevent performance regression.
+Being pinned to a specific commit, any performance regression in *eprosima Fast DDS* could not be blamed on `foonathan_memory`.
+
+### Linters and Static Analysis [4.v]
+
+`foonathan_memory` does not conduct tests with linters or any static analysis tool.
+As `foonathan_memory` is not maintained by eProsima, these requirements should be waved.
+
+## Dependencies [5]
+
+`foonathan_memory` does not have any dependencies outside of the C++ standard library.
+
+## Platform Support [6.i]
+
+*eprosima Fast DDS* ensures `foonathan_memory` support for the same platforms defined in [PLATFORM_SUPPORT](PLATFORM_SUPPORT.md).
+Current nightly results can be found here:
+
+* Linux [![Linux ci](http://jenkins.eprosima.com:8080/job/nightly_foonathan_memory_master_linux/badge/icon?subject=%20%20%20Linux%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_foonathan_memory_master_linux)
+* Linux-aarch64 [![Linux arm64 ci](http://jenkins.eprosima.com:8080/job/nightly_foonathan_memory_master_linux_aarch64/badge/icon?subject=%20%20%20Linux-aarch64%20CI%20)](http://jenkins.eprosima.com:8080/view/Nightly/job/nightly_foonathan_memory_master_linux_aarch64/)
+* Windows [![Windows ci](http://jenkins.eprosima.com:8080/job/nightly_foonathan_memory_master_windows/label=windows-secure,platform=x64,toolset=v141/badge/icon?subject=%20%20%20%20Windows%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_foonathan_memory_master_windows/label=windows-secure,platform=x64,toolset=v141)
+* Mac [![Mac ci](http://jenkins.eprosima.com:8080/job/nightly_foonathan_memory_master_mac/badge/icon?subject=%20%20%20%20%20%20%20Mac%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_foonathan_memory_master_mac)
+
+## Vulnerability Disclosure Policy [7.i]
+
+Even though `foonathan_memory` does not provide a Vulnerability Disclosure Policy, eProsima will apply its [Vulnerability Disclosure Policy](https://github.com/eProsima/policies/blob/main/VULNERABILITY.md) for any security issue within the scope of *eprosima Fast DDS* project.
+
+# Current Status Summary
+
+The chart below compares the requirements in the [REP-2004](https://www.ros.org/reps/rep-2004.html#quality-level-comparison-chart) with the current state of `foonathan_memory` with the specifics dealt in this document to guarantee its quality level.
+
+■ = requirement not properly fulfilled but dealt with.
+
+● = requirement waved
+
+|Number| Requirement| Current State |
+|--|--|--|
+|1| **Version policy** |---|
+|1.i|Version Policy available |■|
+|1.ii|Stable version |✓|
+|1.iii|Declared public API|✓|
+|1.iv|API stability policy|■|
+|1.v|ABI stability policy|■|
+|2| **Change control process** |---|
+|2.i| All changes occur on change request |■|
+|2.ii| Contributor origin (DCO, CLA, etc) |■|
+|2.iii| Peer review policy |■|
+|2.iv| CI policy for change requests |■|
+|2.v| Documentation policy for change requests |■|
+|3| **Documentation** | --- |
+|3.i| Per feature documentation |✓|
+|3.ii| Per public API item documentation |✓|
+|3.iii| Declared License(s) |✓|
+|3.iv| Copyright in source files|✓|
+|3.v.a| Quality declaration linked to README |✓|
+|3.v.b| Centralized declaration available for peer review |✓|
+|4| **Testing** | --- |
+|4.i| Feature items tests |✓|
+|4.ii| Public API tests |✓|
+|4.iii.a| Using coverage |■|
+|4.iii.b| Coverage policy ||
+|4.iv.a| Performance tests (if applicable) |■|
+|4.iv.b| Performance tests policy||
+|4.v.a| Code style enforcement (linters)|●|
+|4.v.b| Use of static analysis tools |●|
+|5| **Dependencies** | --- |
+|5.iii| Justifies quality use of dependencies |✓|
+|6| **Platform support** | --- |
+|6.i| Support targets Tier1 ROS platforms|✓|
+|7| **Security** | --- |
+|7.i| Vulnerability Disclosure Policy |✓|

--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@
 <br/>
 [![Documentation badge](https://img.shields.io/readthedocs/eprosima-fast-rtps.svg)](https://eprosima-fast-rtps.readthedocs.io)
 ![Status](https://nexus.lab.fiware.org/static/badges/statuses/incubating.svg)
-
+[![Linux ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_linux/badge/icon?subject=%20%20%20Linux%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_linux)
+[![Linux arm64 ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_linux_aarch64/badge/icon?subject=%20%20%20Linux-aarch64%20CI%20)](http://jenkins.eprosima.com:8080/view/Nightly/job/nightly_fastdds_sec_master_linux_aarch64/)
+[![Windows ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_windows/label=windows-secure,platform=x64,toolset=v141/badge/icon?subject=%20%20%20%20Windows%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_windows/label=windows-secure,platform=x64,toolset=v141)
+[![Mac ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_mac/badge/icon?subject=%20%20%20%20%20%20%20Mac%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_mac)
 
 <a href="http://www.eprosima.com"><img src="https://encrypted-tbn3.gstatic.com/images?q=tbn:ANd9GcSd0PDlVz1U_7MgdTe0FRIWD0Jc9_YH-gGi0ZpLkr-qgCI6ZEoJZ5GBqQ" align="left" hspace="8" vspace="2" width="100" height="100" ></a>
 
@@ -48,9 +51,10 @@ We are curious to get to know your use case!**
 
 ## Supported platforms
 
-* Linux [![Linux Build Status](http://jenkins.eprosima.com:8080/job/FastRTPS%20Nightly%20Master%20Security%20Linux/badge/icon)](http://jenkins.eprosima.com:8080/job/FastRTPS%20Nightly%20Master%20Security%20Linux)
-* Windows [![Windows Build Status](http://jenkins.eprosima.com:8080/job/FastRTPS%20Nightly%20Master%20Security%20Windows/badge/icon)](http://jenkins.eprosima.com:8080/job/FastRTPS%20Nightly%20Master%20Security%20Windows)
-* Mac [![Mac Build Status](http://jenkins.eprosima.com:8080/job/FastRTPS%20Nightly%20Master%20Security%20Mac/badge/icon)](http://jenkins.eprosima.com:8080/job/FastRTPS%20Nightly%20Master%20Security%20Mac)
+* Linux [![Linux ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_linux/badge/icon?subject=%20%20%20Linux%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_linux)
+* Linux-aarch64 [![Linux arm64 ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_linux_aarch64/badge/icon?subject=%20%20%20Linux-aarch64%20CI%20)](http://jenkins.eprosima.com:8080/view/Nightly/job/nightly_fastdds_sec_master_linux_aarch64/)
+* Windows [![Windows ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_windows/label=windows-secure,platform=x64,toolset=v141/badge/icon?subject=%20%20%20%20Windows%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_windows/label=windows-secure,platform=x64,toolset=v141)
+* Mac [![Mac ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_mac/badge/icon?subject=%20%20%20%20%20%20%20Mac%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_mac)
 
 ## Installation Guide
 You can get either a binary distribution of *eprosima Fast RTPS* or compile the library yourself from source.

--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ You can access the documentation online, which is hosted on [Read the Docs](http
 * [FastRTPSGen manual](http://eprosima-fast-rtps.readthedocs.io/en/latest/geninfo.html)
 * [Release notes](http://eprosima-fast-rtps.readthedocs.io/en/latest/notes.html)
 
+## Quality Declaration
+
+*eprosima Fast DDS* claims to be in the **Quality Level 2** category based on the guidelines provided by [ROS 2](https://ros.org/reps/rep-2004.html). See the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md) for more details.
+
 ## Quick Demo
 
 For those who want to try a quick demonstration of Fast-RTPS libraries on Ubuntu, here is a way to launch an example application.


### PR DESCRIPTION
This backports all pull requests related to the Quality Declaration to <2.0.x>:

* Platform support #1397 
* Foonathan's API #1403 
* Update CI badges in README #1405 
* Foonathan memory Quality Declaration #1404 
* Fast DDS Quality Declaration #1400 
* Fixed broken link to Fast CDR Quality Declaration #1443 