### PR TITLE
Include Shared Memory in the default transports. <2.0.x> [9726]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,11 +259,8 @@ option(SQLITE3_SUPPORT "Activate SQLITE3 support" ON)
 ###############################################################################
 # SHM as Default transport
 ###############################################################################
-option(SHM_TRANSPORT_DEFAULT "Adds SHM transport to the default transports" OFF)
+option(SHM_TRANSPORT_DEFAULT "Adds SHM transport to the default transports" ON)
 
-if(EPROSIMA_BUILD)
-    set(SHM_TRANSPORT_DEFAULT ON)
-endif()
 
 ###############################################################################
 # Tools default setup 


### PR DESCRIPTION
There have been several improvements and fixes on the Shared Memory transport, like #1329 and #1330, that made it more robust.

This PR adds this transport to the default ones.

Signed-off-by: Miguel Company <MiguelCompany@eprosima.com>