### PR TITLE
Add support for XML environmental variables parsing [10697]

### DIFF
--- a/src/cpp/rtps/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLElementParser.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+#include <cstdlib>
 #include <cstring>
 #include <regex>
 #include <tinyxml2.h>
@@ -3341,7 +3342,16 @@ XMLP_ret XMLParser::getXMLString(
         logError(XMLPARSER, "<" << elem->Value() << "> getXMLString XML_ERROR!");
         return XMLP_ret::XML_ERROR;
     }
-    *s = text;
+    else if (const char* env_var_value = std::getenv(text))
+    {
+        // If 'text' is an environmental variable, get its value
+        *s = env_var_value;
+    }
+    else
+    {
+        *s = text;
+    }
+
     return XMLP_ret::XML_OK;
 }
 


### PR DESCRIPTION
This commit would allow to use OS environmental variables in XML profiles. For example:
```
# In bash terminal
export ROBOT_IP_ADDRESS=192.168.0.1

# In XML profile
<?xml version="1.0" encoding="UTF-8" ?>
<profiles xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles">
    <participant profile_name="env_var_parsing_example">
        <rtps>
            <builtin>
                <initialPeersList>
                    <locator>
                        <udpv4>
                            <address>ROBOT_IP_ADDRESS</address>
                        </udpv4>
                    </locator>
                </initialPeersList>
            </builtin>
        </rtps>
    </participant>
</profiles>
```