### PR TITLE
Fix communications with localhost only <2.0.x> [9744]

### DIFF
--- a/include/fastdds/rtps/transport/UDPTransportInterface.h
+++ b/include/fastdds/rtps/transport/UDPTransportInterface.h
@@ -168,6 +168,7 @@ protected:
     virtual asio::ip::udp::endpoint generate_local_endpoint(const fastrtps::rtps::Locator_t& loc, uint16_t port) = 0;
     virtual asio::ip::udp generate_protocol() const = 0;
     virtual void get_ips(std::vector<fastrtps::rtps::IPFinder::info_IP>& locNames, bool return_loopback = false) = 0;
+    virtual const std::string& localhost_name() = 0;
 
     //! Checks if the interfaces white list is empty.
     virtual bool is_interface_whitelist_empty() const = 0;

--- a/include/fastdds/rtps/transport/UDPTransportInterface.h
+++ b/include/fastdds/rtps/transport/UDPTransportInterface.h
@@ -28,48 +28,55 @@
 #include <map>
 #include <mutex>
 
-namespace eprosima{
-namespace fastdds{
-namespace rtps{
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
 
 class UDPTransportInterface : public TransportInterface
 {
 public:
 
-   virtual ~UDPTransportInterface() override;
+    virtual ~UDPTransportInterface() override;
 
-   void clean();
+    void clean();
 
-   //! Removes the listening socket for the specified port.
-   virtual bool CloseInputChannel(const fastrtps::rtps::Locator_t&) override;
+    //! Removes the listening socket for the specified port.
+    virtual bool CloseInputChannel(
+            const fastrtps::rtps::Locator_t&) override;
 
-   //! Removes all outbound sockets on the given port.
-   void CloseOutputChannel(eProsimaUDPSocket& socket);
+    //! Removes all outbound sockets on the given port.
+    void CloseOutputChannel(
+            eProsimaUDPSocket& socket);
 
-   //! Reports whether Locators correspond to the same port.
-   virtual bool DoInputLocatorsMatch(const fastrtps::rtps::Locator_t&, const fastrtps::rtps::Locator_t&) const override;
+    //! Reports whether Locators correspond to the same port.
+    virtual bool DoInputLocatorsMatch(
+            const fastrtps::rtps::Locator_t&,
+            const fastrtps::rtps::Locator_t&) const override;
 
-   virtual const UDPTransportDescriptor* configuration() const = 0;
+    virtual const UDPTransportDescriptor* configuration() const = 0;
 
-   bool init() override;
+    bool init() override;
 
-   //! Checks whether there are open and bound sockets for the given port.
-   virtual bool IsInputChannelOpen(const fastrtps::rtps::Locator_t&) const override;
+    //! Checks whether there are open and bound sockets for the given port.
+    virtual bool IsInputChannelOpen(
+            const fastrtps::rtps::Locator_t&) const override;
 
-   //! Checks for TCP kinds.
-   virtual bool IsLocatorSupported(const fastrtps::rtps::Locator_t&) const override;
+    //! Checks for TCP kinds.
+    virtual bool IsLocatorSupported(
+            const fastrtps::rtps::Locator_t&) const override;
 
-   //! Opens a socket on the given address and port (as long as they are white listed).
-   virtual bool OpenOutputChannel(
-           SendResourceList& sender_resource_list,
-           const fastrtps::rtps::Locator_t&) override;
+    //! Opens a socket on the given address and port (as long as they are white listed).
+    virtual bool OpenOutputChannel(
+            SendResourceList& sender_resource_list,
+            const fastrtps::rtps::Locator_t&) override;
 
-   /**
-   * Converts a given remote locator (that is, a locator referring to a remote
-   * destination) to the main local locator whose channel can write to that
-   * destination. In this case it will return a 0.0.0.0 address on that port.
-   */
-   virtual fastrtps::rtps::Locator_t RemoteToMainLocal(const fastrtps::rtps::Locator_t&) const override;
+    /**
+     * Converts a given remote locator (that is, a locator referring to a remote
+     * destination) to the main local locator whose channel can write to that
+     * destination. In this case it will return a 0.0.0.0 address on that port.
+     */
+    virtual fastrtps::rtps::Locator_t RemoteToMainLocal(
+            const fastrtps::rtps::Locator_t&) const override;
 
     /**
      * Transforms a remote locator into a locator optimized for local communications.
@@ -86,28 +93,28 @@ public:
             const fastrtps::rtps::Locator_t& remote_locator,
             fastrtps::rtps::Locator_t& result_locator) const override;
 
-   /**
-   * Blocking Send through the specified channel. In both modes, using a localLocator of 0.0.0.0 will
-   * send through all whitelisted interfaces provided the channel is open.
-   * @param send_buffer Slice into the raw data to send.
-   * @param send_buffer_size Size of the raw data. It will be used as a bounds check for the previous argument.
-   * It must not exceed the send_buffer_size fed to this class during construction.
-   * @param socket channel we're sending from.
-   * @param destination_locators_begin pointer to destination locators iterator begin, the iterator can be advanced inside this fuction
-   * so should not be reuse.
-   * @param destination_locators_end pointer to destination locators iterator end, the iterator can be advanced inside this fuction
-   * so should not be reuse.
-   * @param only_multicast_purpose
-   * @param max_blocking_time_point maximum blocking time.
-   */
-   virtual bool send(
-           const fastrtps::rtps::octet* send_buffer,
-           uint32_t send_buffer_size,
-           eProsimaUDPSocket& socket,
-           fastrtps::rtps::LocatorsIterator* destination_locators_begin,
-           fastrtps::rtps::LocatorsIterator* destination_locators_end,
-           bool only_multicast_purpose,
-           const std::chrono::steady_clock::time_point& max_blocking_time_point);
+    /**
+     * Blocking Send through the specified channel. In both modes, using a localLocator of 0.0.0.0 will
+     * send through all whitelisted interfaces provided the channel is open.
+     * @param send_buffer Slice into the raw data to send.
+     * @param send_buffer_size Size of the raw data. It will be used as a bounds check for the previous argument.
+     * It must not exceed the send_buffer_size fed to this class during construction.
+     * @param socket channel we're sending from.
+     * @param destination_locators_begin pointer to destination locators iterator begin, the iterator can be advanced inside this fuction
+     * so should not be reuse.
+     * @param destination_locators_end pointer to destination locators iterator end, the iterator can be advanced inside this fuction
+     * so should not be reuse.
+     * @param only_multicast_purpose
+     * @param max_blocking_time_point maximum blocking time.
+     */
+    virtual bool send(
+            const fastrtps::rtps::octet* send_buffer,
+            uint32_t send_buffer_size,
+            eProsimaUDPSocket& socket,
+            fastrtps::rtps::LocatorsIterator* destination_locators_begin,
+            fastrtps::rtps::LocatorsIterator* destination_locators_end,
+            bool only_multicast_purpose,
+            const std::chrono::steady_clock::time_point& max_blocking_time_point);
 
     /**
      * Performs the locator selection algorithm for this transport.
@@ -122,17 +129,26 @@ public:
      *
      * @param [in, out] selector Locator selector.
      */
-    virtual void select_locators(fastrtps::rtps::LocatorSelector& selector) const override;
+    virtual void select_locators(
+            fastrtps::rtps::LocatorSelector& selector) const override;
 
-    virtual bool fillMetatrafficMulticastLocator(fastrtps::rtps::Locator_t &locator,
-        uint32_t metatraffic_multicast_port) const override;
+    virtual bool fillMetatrafficMulticastLocator(
+            fastrtps::rtps::Locator_t& locator,
+            uint32_t metatraffic_multicast_port) const override;
 
-    virtual bool fillMetatrafficUnicastLocator(fastrtps::rtps::Locator_t &locator, uint32_t metatraffic_unicast_port) const override;
+    virtual bool fillMetatrafficUnicastLocator(
+            fastrtps::rtps::Locator_t& locator,
+            uint32_t metatraffic_unicast_port) const override;
 
-    virtual bool configureInitialPeerLocator(fastrtps::rtps::Locator_t &locator, const fastrtps::rtps::PortParameters &port_params, uint32_t domainId,
-        fastrtps::rtps::LocatorList_t& list) const override;
+    virtual bool configureInitialPeerLocator(
+            fastrtps::rtps::Locator_t& locator,
+            const fastrtps::rtps::PortParameters& port_params,
+            uint32_t domainId,
+            fastrtps::rtps::LocatorList_t& list) const override;
 
-    virtual bool fillUnicastLocator(fastrtps::rtps::Locator_t &locator, uint32_t well_known_port) const override;
+    virtual bool fillUnicastLocator(
+            fastrtps::rtps::Locator_t& locator,
+            uint32_t well_known_port) const override;
 
     virtual uint32_t max_recv_buffer_size() const override
     {
@@ -153,56 +169,91 @@ protected:
     uint32_t mSendBufferSize;
     uint32_t mReceiveBufferSize;
 
-    UDPTransportInterface(int32_t transport_kind);
+    UDPTransportInterface(
+            int32_t transport_kind);
 
-    virtual bool compare_locator_ip(const fastrtps::rtps::Locator_t& lh, const fastrtps::rtps::Locator_t& rh) const = 0;
-    virtual bool compare_locator_ip_and_port(const fastrtps::rtps::Locator_t& lh, const fastrtps::rtps::Locator_t& rh) const = 0;
+    virtual bool compare_locator_ip(
+            const fastrtps::rtps::Locator_t& lh,
+            const fastrtps::rtps::Locator_t& rh) const = 0;
+    virtual bool compare_locator_ip_and_port(
+            const fastrtps::rtps::Locator_t& lh,
+            const fastrtps::rtps::Locator_t& rh) const = 0;
 
-    virtual void endpoint_to_locator(asio::ip::udp::endpoint& endpoint, fastrtps::rtps::Locator_t& locator) = 0;
-    virtual void fill_local_ip(fastrtps::rtps::Locator_t& loc) const = 0;
+    virtual void endpoint_to_locator(
+            asio::ip::udp::endpoint& endpoint,
+            fastrtps::rtps::Locator_t& locator) = 0;
+    virtual void fill_local_ip(
+            fastrtps::rtps::Locator_t& loc) const = 0;
 
-    virtual asio::ip::udp::endpoint GenerateAnyAddressEndpoint(uint16_t port) = 0;
-    virtual asio::ip::udp::endpoint generate_endpoint(uint16_t port) = 0;
-    virtual asio::ip::udp::endpoint generate_endpoint(const std::string& sIp, uint16_t port) = 0;
-    virtual asio::ip::udp::endpoint generate_endpoint(const fastrtps::rtps::Locator_t& loc, uint16_t port) = 0;
-    virtual asio::ip::udp::endpoint generate_local_endpoint(const fastrtps::rtps::Locator_t& loc, uint16_t port) = 0;
+    virtual asio::ip::udp::endpoint GenerateAnyAddressEndpoint(
+            uint16_t port) = 0;
+    virtual asio::ip::udp::endpoint generate_endpoint(
+            uint16_t port) = 0;
+    virtual asio::ip::udp::endpoint generate_endpoint(
+            const std::string& sIp,
+            uint16_t port) = 0;
+    virtual asio::ip::udp::endpoint generate_endpoint(
+            const fastrtps::rtps::Locator_t& loc,
+            uint16_t port) = 0;
+    virtual asio::ip::udp::endpoint generate_local_endpoint(
+            const fastrtps::rtps::Locator_t& loc,
+            uint16_t port) = 0;
     virtual asio::ip::udp generate_protocol() const = 0;
-    virtual void get_ips(std::vector<fastrtps::rtps::IPFinder::info_IP>& locNames, bool return_loopback = false) = 0;
+    virtual void get_ips(
+            std::vector<fastrtps::rtps::IPFinder::info_IP>& locNames,
+            bool return_loopback = false) = 0;
     virtual const std::string& localhost_name() = 0;
 
     //! Checks if the interfaces white list is empty.
     virtual bool is_interface_whitelist_empty() const = 0;
 
     //! Checks if the given interface is allowed by the white list.
-    virtual bool is_interface_allowed(const std::string& interface) const = 0;
+    virtual bool is_interface_allowed(
+            const std::string& interface) const = 0;
 
     /**
-    * Method to get a list of interfaces to bind the socket associated to the given locator.
-    * @return Vector of interfaces in string format.
-    */
+     * Method to get a list of interfaces to bind the socket associated to the given locator.
+     * @return Vector of interfaces in string format.
+     */
     virtual std::vector<std::string> get_binding_interfaces_list() = 0;
 
-    bool OpenAndBindInputSockets(const fastrtps::rtps::Locator_t& locator, TransportReceiverInterface* receiver, bool is_multicast,
-        uint32_t maxMsgSize);
-    UDPChannelResource* CreateInputChannelResource(const std::string& sInterface, const fastrtps::rtps::Locator_t& locator,
-        bool is_multicast, uint32_t maxMsgSize, TransportReceiverInterface* receiver);
-    virtual eProsimaUDPSocket OpenAndBindInputSocket(const std::string& sIp, uint16_t port, bool is_multicast) = 0;
-    eProsimaUDPSocket OpenAndBindUnicastOutputSocket(const asio::ip::udp::endpoint& endpoint, uint16_t& port);
+    bool OpenAndBindInputSockets(
+            const fastrtps::rtps::Locator_t& locator,
+            TransportReceiverInterface* receiver,
+            bool is_multicast,
+            uint32_t maxMsgSize);
+    UDPChannelResource* CreateInputChannelResource(
+            const std::string& sInterface,
+            const fastrtps::rtps::Locator_t& locator,
+            bool is_multicast,
+            uint32_t maxMsgSize,
+            TransportReceiverInterface* receiver);
+    virtual eProsimaUDPSocket OpenAndBindInputSocket(
+            const std::string& sIp,
+            uint16_t port,
+            bool is_multicast) = 0;
+    eProsimaUDPSocket OpenAndBindUnicastOutputSocket(
+            const asio::ip::udp::endpoint& endpoint,
+            uint16_t& port);
 
-    virtual void set_receive_buffer_size(uint32_t size) = 0;
-    virtual void set_send_buffer_size(uint32_t size) = 0;
-    virtual void SetSocketOutboundInterface(eProsimaUDPSocket&, const std::string&) = 0;
+    virtual void set_receive_buffer_size(
+            uint32_t size) = 0;
+    virtual void set_send_buffer_size(
+            uint32_t size) = 0;
+    virtual void SetSocketOutboundInterface(
+            eProsimaUDPSocket&,
+            const std::string&) = 0;
 
     /**
      * Send a buffer to a destination
      */
     bool send(
-        const fastrtps::rtps::octet* send_buffer,
-        uint32_t send_buffer_size,
-        eProsimaUDPSocket& socket,
-        const fastrtps::rtps::Locator_t& remote_locator,
-        bool only_multicast_purpose,
-        const std::chrono::microseconds& timeout);
+            const fastrtps::rtps::octet* send_buffer,
+            uint32_t send_buffer_size,
+            eProsimaUDPSocket& socket,
+            const fastrtps::rtps::Locator_t& remote_locator,
+            bool only_multicast_purpose,
+            const std::chrono::microseconds& timeout);
 };
 
 } // namespace rtps

--- a/include/fastdds/rtps/transport/UDPv4Transport.h
+++ b/include/fastdds/rtps/transport/UDPv4Transport.h
@@ -18,9 +18,9 @@
 #include <fastdds/rtps/transport/UDPTransportInterface.h>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
 
-namespace eprosima{
-namespace fastdds{
-namespace rtps{
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
 
 /**
  * This is a default UDPv4 implementation.
@@ -43,33 +43,47 @@ class UDPv4Transport : public UDPTransportInterface
 {
 public:
 
-    RTPS_DllAPI UDPv4Transport(const UDPv4TransportDescriptor&);
+    RTPS_DllAPI UDPv4Transport(
+            const UDPv4TransportDescriptor&);
 
     virtual ~UDPv4Transport() override;
 
     virtual const UDPTransportDescriptor* configuration() const override;
 
     /**
-        * Starts listening on the specified port, and if the specified address is in the
-        * multicast range, it joins the specified multicast group,
-        */
-    virtual bool OpenInputChannel(const fastrtps::rtps::Locator_t&, TransportReceiverInterface*, uint32_t) override;
+     * Starts listening on the specified port, and if the specified address is in the
+     * multicast range, it joins the specified multicast group,
+     */
+    virtual bool OpenInputChannel(
+            const fastrtps::rtps::Locator_t&,
+            TransportReceiverInterface*,
+            uint32_t) override;
 
-    virtual fastrtps::rtps::LocatorList_t NormalizeLocator(const fastrtps::rtps::Locator_t& locator) override;
+    virtual fastrtps::rtps::LocatorList_t NormalizeLocator(
+            const fastrtps::rtps::Locator_t& locator) override;
 
-    virtual bool is_local_locator(const fastrtps::rtps::Locator_t& locator) const override;
+    virtual bool is_local_locator(
+            const fastrtps::rtps::Locator_t& locator) const override;
 
-    TransportDescriptorInterface* get_configuration() override { return &configuration_; }
+    TransportDescriptorInterface* get_configuration() override
+    {
+        return &configuration_;
+    }
 
-    virtual void AddDefaultOutputLocator(fastrtps::rtps::LocatorList_t &defaultList) override;
+    virtual void AddDefaultOutputLocator(
+            fastrtps::rtps::LocatorList_t& defaultList) override;
 
-    virtual bool getDefaultMetatrafficMulticastLocators(fastrtps::rtps::LocatorList_t &locators,
-        uint32_t metatraffic_multicast_port) const override;
+    virtual bool getDefaultMetatrafficMulticastLocators(
+            fastrtps::rtps::LocatorList_t& locators,
+            uint32_t metatraffic_multicast_port) const override;
 
-    virtual bool getDefaultMetatrafficUnicastLocators(fastrtps::rtps::LocatorList_t &locators,
-        uint32_t metatraffic_unicast_port) const override;
+    virtual bool getDefaultMetatrafficUnicastLocators(
+            fastrtps::rtps::LocatorList_t& locators,
+            uint32_t metatraffic_unicast_port) const override;
 
-    bool getDefaultUnicastLocators(fastrtps::rtps::LocatorList_t &locators, uint32_t unicast_port) const override;
+    bool getDefaultUnicastLocators(
+            fastrtps::rtps::LocatorList_t& locators,
+            uint32_t unicast_port) const override;
 
 protected:
 
@@ -77,44 +91,71 @@ protected:
     UDPv4Transport();
     UDPv4TransportDescriptor configuration_;
 
-    virtual bool compare_locator_ip(const fastrtps::rtps::Locator_t& lh, const fastrtps::rtps::Locator_t& rh) const override;
-    virtual bool compare_locator_ip_and_port(const fastrtps::rtps::Locator_t& lh, const fastrtps::rtps::Locator_t& rh) const override;
+    virtual bool compare_locator_ip(
+            const fastrtps::rtps::Locator_t& lh,
+            const fastrtps::rtps::Locator_t& rh) const override;
+    virtual bool compare_locator_ip_and_port(
+            const fastrtps::rtps::Locator_t& lh,
+            const fastrtps::rtps::Locator_t& rh) const override;
 
-    virtual void endpoint_to_locator(asio::ip::udp::endpoint& endpoint, fastrtps::rtps::Locator_t& locator) override;
-    virtual void fill_local_ip(fastrtps::rtps::Locator_t& loc) const override;
+    virtual void endpoint_to_locator(
+            asio::ip::udp::endpoint& endpoint,
+            fastrtps::rtps::Locator_t& locator) override;
+    virtual void fill_local_ip(
+            fastrtps::rtps::Locator_t& loc) const override;
 
-    virtual asio::ip::udp::endpoint GenerateAnyAddressEndpoint(uint16_t port) override;
-    virtual asio::ip::udp::endpoint generate_endpoint(uint16_t port) override;
-    virtual asio::ip::udp::endpoint generate_endpoint(const std::string& sIp, uint16_t port) override;
-    virtual asio::ip::udp::endpoint generate_endpoint(const fastrtps::rtps::Locator_t& loc, uint16_t port) override;
-    virtual asio::ip::udp::endpoint generate_local_endpoint(const fastrtps::rtps::Locator_t& loc, uint16_t port) override;
+    virtual asio::ip::udp::endpoint GenerateAnyAddressEndpoint(
+            uint16_t port) override;
+    virtual asio::ip::udp::endpoint generate_endpoint(
+            uint16_t port) override;
+    virtual asio::ip::udp::endpoint generate_endpoint(
+            const std::string& sIp,
+            uint16_t port) override;
+    virtual asio::ip::udp::endpoint generate_endpoint(
+            const fastrtps::rtps::Locator_t& loc,
+            uint16_t port) override;
+    virtual asio::ip::udp::endpoint generate_local_endpoint(
+            const fastrtps::rtps::Locator_t& loc,
+            uint16_t port) override;
     virtual asio::ip::udp generate_protocol() const override;
-    virtual void get_ips(std::vector<fastrtps::rtps::IPFinder::info_IP>& locNames, bool return_loopback = false) override;
+    virtual void get_ips(
+            std::vector<fastrtps::rtps::IPFinder::info_IP>& locNames,
+            bool return_loopback = false) override;
     virtual const std::string& localhost_name() override;
-    eProsimaUDPSocket OpenAndBindInputSocket(const std::string& sIp, uint16_t port, bool is_multicast) override;
+    eProsimaUDPSocket OpenAndBindInputSocket(
+            const std::string& sIp,
+            uint16_t port,
+            bool is_multicast) override;
 
     //! Checks if the given interface is allowed by the white list.
-    virtual bool is_interface_allowed(const std::string& interface) const override;
+    virtual bool is_interface_allowed(
+            const std::string& interface) const override;
 
     /**
-    * Method to get a list of interfaces to bind the socket associated to the given locator.
-    * @return Vector of interfaces in string format.
-    */
+     * Method to get a list of interfaces to bind the socket associated to the given locator.
+     * @return Vector of interfaces in string format.
+     */
     virtual std::vector<std::string> get_binding_interfaces_list() override;
 
     //! Checks for whether locator is allowed.
-    virtual bool is_locator_allowed(const fastrtps::rtps::Locator_t&) const override;
+    virtual bool is_locator_allowed(
+            const fastrtps::rtps::Locator_t&) const override;
 
     //! Checks if the given interface is allowed by the white list.
-    bool is_interface_allowed(const asio::ip::address_v4& ip) const;
+    bool is_interface_allowed(
+            const asio::ip::address_v4& ip) const;
 
     //! Checks if the interfaces white list is empty.
     virtual bool is_interface_whitelist_empty() const override;
     std::vector<asio::ip::address_v4> interface_whitelist_;
 
-    virtual void set_receive_buffer_size(uint32_t size) override;
-    virtual void set_send_buffer_size(uint32_t size) override;
-    virtual void SetSocketOutboundInterface(eProsimaUDPSocket&, const std::string&) override;
+    virtual void set_receive_buffer_size(
+            uint32_t size) override;
+    virtual void set_send_buffer_size(
+            uint32_t size) override;
+    virtual void SetSocketOutboundInterface(
+            eProsimaUDPSocket&,
+            const std::string&) override;
 };
 
 } // namespace rtps

--- a/include/fastdds/rtps/transport/UDPv4Transport.h
+++ b/include/fastdds/rtps/transport/UDPv4Transport.h
@@ -90,6 +90,7 @@ protected:
     virtual asio::ip::udp::endpoint generate_local_endpoint(const fastrtps::rtps::Locator_t& loc, uint16_t port) override;
     virtual asio::ip::udp generate_protocol() const override;
     virtual void get_ips(std::vector<fastrtps::rtps::IPFinder::info_IP>& locNames, bool return_loopback = false) override;
+    virtual const std::string& localhost_name() override;
     eProsimaUDPSocket OpenAndBindInputSocket(const std::string& sIp, uint16_t port, bool is_multicast) override;
 
     //! Checks if the given interface is allowed by the white list.

--- a/include/fastdds/rtps/transport/UDPv6Transport.h
+++ b/include/fastdds/rtps/transport/UDPv6Transport.h
@@ -90,6 +90,7 @@ protected:
     virtual asio::ip::udp::endpoint generate_local_endpoint(const fastrtps::rtps::Locator_t& loc, uint16_t port) override;
     virtual asio::ip::udp generate_protocol() const override;
     virtual void get_ips(std::vector<fastrtps::rtps::IPFinder::info_IP>& locNames, bool return_loopback = false) override;
+    virtual const std::string& localhost_name() override;
     eProsimaUDPSocket OpenAndBindInputSocket(const std::string& sIp, uint16_t port, bool is_multicast) override;
 
     //! Checks for whether locator is allowed.

--- a/include/fastdds/rtps/transport/UDPv6Transport.h
+++ b/include/fastdds/rtps/transport/UDPv6Transport.h
@@ -18,9 +18,9 @@
 #include <fastdds/rtps/transport/UDPTransportInterface.h>
 #include <fastdds/rtps/transport/UDPv6TransportDescriptor.h>
 
-namespace eprosima{
-namespace fastdds{
-namespace rtps{
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
 
 /**
  * This is a default UDPv6 implementation.
@@ -43,33 +43,47 @@ class UDPv6Transport : public UDPTransportInterface
 {
 public:
 
-    RTPS_DllAPI UDPv6Transport(const UDPv6TransportDescriptor&);
+    RTPS_DllAPI UDPv6Transport(
+            const UDPv6TransportDescriptor&);
 
     virtual ~UDPv6Transport() override;
 
     virtual const UDPTransportDescriptor* configuration() const override;
 
     /**
-        * Starts listening on the specified port, and if the specified address is in the
-        * multicast range, it joins the specified multicast group,
-        */
-    virtual bool OpenInputChannel(const fastrtps::rtps::Locator_t&, TransportReceiverInterface*, uint32_t) override;
+     * Starts listening on the specified port, and if the specified address is in the
+     * multicast range, it joins the specified multicast group,
+     */
+    virtual bool OpenInputChannel(
+            const fastrtps::rtps::Locator_t&,
+            TransportReceiverInterface*,
+            uint32_t) override;
 
-    virtual fastrtps::rtps::LocatorList_t NormalizeLocator(const fastrtps::rtps::Locator_t& locator) override;
+    virtual fastrtps::rtps::LocatorList_t NormalizeLocator(
+            const fastrtps::rtps::Locator_t& locator) override;
 
-    virtual bool is_local_locator(const fastrtps::rtps::Locator_t& locator) const override;
+    virtual bool is_local_locator(
+            const fastrtps::rtps::Locator_t& locator) const override;
 
-    TransportDescriptorInterface* get_configuration() override { return &configuration_; }
+    TransportDescriptorInterface* get_configuration() override
+    {
+        return &configuration_;
+    }
 
-    virtual bool getDefaultMetatrafficMulticastLocators(fastrtps::rtps::LocatorList_t &locators,
-        uint32_t metatraffic_multicast_port) const override;
+    virtual bool getDefaultMetatrafficMulticastLocators(
+            fastrtps::rtps::LocatorList_t& locators,
+            uint32_t metatraffic_multicast_port) const override;
 
-    virtual bool getDefaultMetatrafficUnicastLocators(fastrtps::rtps::LocatorList_t &locators,
-        uint32_t metatraffic_unicast_port) const override;
+    virtual bool getDefaultMetatrafficUnicastLocators(
+            fastrtps::rtps::LocatorList_t& locators,
+            uint32_t metatraffic_unicast_port) const override;
 
-    bool getDefaultUnicastLocators(fastrtps::rtps::LocatorList_t &locators, uint32_t unicast_port) const override;
+    bool getDefaultUnicastLocators(
+            fastrtps::rtps::LocatorList_t& locators,
+            uint32_t unicast_port) const override;
 
-    virtual void AddDefaultOutputLocator(fastrtps::rtps::LocatorList_t &defaultList) override;
+    virtual void AddDefaultOutputLocator(
+            fastrtps::rtps::LocatorList_t& defaultList) override;
 
 protected:
 
@@ -77,44 +91,71 @@ protected:
     UDPv6Transport();
     UDPv6TransportDescriptor configuration_;
 
-    virtual bool compare_locator_ip(const fastrtps::rtps::Locator_t& lh, const fastrtps::rtps::Locator_t& rh) const override;
-    virtual bool compare_locator_ip_and_port(const fastrtps::rtps::Locator_t& lh, const fastrtps::rtps::Locator_t& rh) const override;
+    virtual bool compare_locator_ip(
+            const fastrtps::rtps::Locator_t& lh,
+            const fastrtps::rtps::Locator_t& rh) const override;
+    virtual bool compare_locator_ip_and_port(
+            const fastrtps::rtps::Locator_t& lh,
+            const fastrtps::rtps::Locator_t& rh) const override;
 
-    virtual void endpoint_to_locator(asio::ip::udp::endpoint& endpoint, fastrtps::rtps::Locator_t& locator) override;
-    virtual void fill_local_ip(fastrtps::rtps::Locator_t& loc) const override;
+    virtual void endpoint_to_locator(
+            asio::ip::udp::endpoint& endpoint,
+            fastrtps::rtps::Locator_t& locator) override;
+    virtual void fill_local_ip(
+            fastrtps::rtps::Locator_t& loc) const override;
 
-    virtual asio::ip::udp::endpoint GenerateAnyAddressEndpoint(uint16_t port) override;
-    virtual asio::ip::udp::endpoint generate_endpoint(uint16_t port) override;
-    virtual asio::ip::udp::endpoint generate_endpoint(const std::string& sIp, uint16_t port) override;
-    virtual asio::ip::udp::endpoint generate_endpoint(const fastrtps::rtps::Locator_t& loc, uint16_t port) override;
-    virtual asio::ip::udp::endpoint generate_local_endpoint(const fastrtps::rtps::Locator_t& loc, uint16_t port) override;
+    virtual asio::ip::udp::endpoint GenerateAnyAddressEndpoint(
+            uint16_t port) override;
+    virtual asio::ip::udp::endpoint generate_endpoint(
+            uint16_t port) override;
+    virtual asio::ip::udp::endpoint generate_endpoint(
+            const std::string& sIp,
+            uint16_t port) override;
+    virtual asio::ip::udp::endpoint generate_endpoint(
+            const fastrtps::rtps::Locator_t& loc,
+            uint16_t port) override;
+    virtual asio::ip::udp::endpoint generate_local_endpoint(
+            const fastrtps::rtps::Locator_t& loc,
+            uint16_t port) override;
     virtual asio::ip::udp generate_protocol() const override;
-    virtual void get_ips(std::vector<fastrtps::rtps::IPFinder::info_IP>& locNames, bool return_loopback = false) override;
+    virtual void get_ips(
+            std::vector<fastrtps::rtps::IPFinder::info_IP>& locNames,
+            bool return_loopback = false) override;
     virtual const std::string& localhost_name() override;
-    eProsimaUDPSocket OpenAndBindInputSocket(const std::string& sIp, uint16_t port, bool is_multicast) override;
+    eProsimaUDPSocket OpenAndBindInputSocket(
+            const std::string& sIp,
+            uint16_t port,
+            bool is_multicast) override;
 
     //! Checks for whether locator is allowed.
-    virtual bool is_locator_allowed(const fastrtps::rtps::Locator_t&) const override;
+    virtual bool is_locator_allowed(
+            const fastrtps::rtps::Locator_t&) const override;
 
     /**
-    * Method to get a list of interfaces to bind the socket associated to the given locator.
-    * @return Vector of interfaces in string format.
-    */
+     * Method to get a list of interfaces to bind the socket associated to the given locator.
+     * @return Vector of interfaces in string format.
+     */
     virtual std::vector<std::string> get_binding_interfaces_list() override;
 
     //! Checks if the given interface is allowed by the white list.
-    virtual bool is_interface_allowed(const std::string& interface) const override;
+    virtual bool is_interface_allowed(
+            const std::string& interface) const override;
 
     //! Checks if the given interface is allowed by the white list.
-    bool is_interface_allowed(const asio::ip::address_v6& ip) const;
+    bool is_interface_allowed(
+            const asio::ip::address_v6& ip) const;
 
     //! Checks if the interfaces white list is empty.
     virtual bool is_interface_whitelist_empty() const override;
     std::vector<asio::ip::address_v6> interface_whitelist_;
 
-    virtual void set_receive_buffer_size(uint32_t size) override;
-    virtual void set_send_buffer_size(uint32_t size) override;
-    virtual void SetSocketOutboundInterface(eProsimaUDPSocket&, const std::string&) override;
+    virtual void set_receive_buffer_size(
+            uint32_t size) override;
+    virtual void set_send_buffer_size(
+            uint32_t size) override;
+    virtual void SetSocketOutboundInterface(
+            eProsimaUDPSocket&,
+            const std::string&) override;
 };
 
 } // namespace rtps

--- a/include/fastdds/rtps/transport/test_UDPv4Transport.h
+++ b/include/fastdds/rtps/transport/test_UDPv4Transport.h
@@ -51,6 +51,13 @@ public:
     RTPS_DllAPI static std::vector<std::vector<fastrtps::rtps::octet> > test_UDPv4Transport_DropLog;
     RTPS_DllAPI static uint32_t test_UDPv4Transport_DropLogLength;
     RTPS_DllAPI static bool always_drop_participant_builtin_topic_data;
+    RTPS_DllAPI static bool simulate_no_interfaces;
+
+protected:
+
+    virtual void get_ips(
+        std::vector<fastrtps::rtps::IPFinder::info_IP>& locNames,
+        bool return_loopback = false) override;
 
 private:
 

--- a/include/fastdds/rtps/transport/test_UDPv4Transport.h
+++ b/include/fastdds/rtps/transport/test_UDPv4Transport.h
@@ -23,9 +23,9 @@
 
 #include <fastdds/rtps/transport/test_UDPv4TransportDescriptor.h>
 
-namespace eprosima{
-namespace fastdds{
-namespace rtps{
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
 
 /*
  * This transport acts as a shim over UDPv4, allowing
@@ -35,20 +35,22 @@ namespace rtps{
 class test_UDPv4Transport : public UDPv4Transport
 {
 public:
-    test_UDPv4Transport(const test_UDPv4TransportDescriptor& descriptor);
+
+    test_UDPv4Transport(
+            const test_UDPv4TransportDescriptor& descriptor);
 
     virtual bool send(
-           const fastrtps::rtps::octet* send_buffer,
-           uint32_t send_buffer_size,
-           eProsimaUDPSocket& socket,
-           fastrtps::rtps::LocatorsIterator* destination_locators_begin,
-           fastrtps::rtps::LocatorsIterator* destination_locators_end,
-           bool only_multicast_purpose,
-           const std::chrono::steady_clock::time_point& max_blocking_time_point) override;
+            const fastrtps::rtps::octet* send_buffer,
+            uint32_t send_buffer_size,
+            eProsimaUDPSocket& socket,
+            fastrtps::rtps::LocatorsIterator* destination_locators_begin,
+            fastrtps::rtps::LocatorsIterator* destination_locators_end,
+            bool only_multicast_purpose,
+            const std::chrono::steady_clock::time_point& max_blocking_time_point) override;
 
     RTPS_DllAPI static bool test_UDPv4Transport_ShutdownAllNetwork;
     // Handle to a persistent log of dropped packets. Defaults to length 0 (no logging) to prevent wasted resources.
-    RTPS_DllAPI static std::vector<std::vector<fastrtps::rtps::octet> > test_UDPv4Transport_DropLog;
+    RTPS_DllAPI static std::vector<std::vector<fastrtps::rtps::octet>> test_UDPv4Transport_DropLog;
     RTPS_DllAPI static uint32_t test_UDPv4Transport_DropLogLength;
     RTPS_DllAPI static bool always_drop_participant_builtin_topic_data;
     RTPS_DllAPI static bool simulate_no_interfaces;
@@ -56,14 +58,15 @@ public:
 protected:
 
     virtual void get_ips(
-        std::vector<fastrtps::rtps::IPFinder::info_IP>& locNames,
-        bool return_loopback = false) override;
+            std::vector<fastrtps::rtps::IPFinder::info_IP>& locNames,
+            bool return_loopback = false) override;
 
 private:
 
     struct PercentageData
     {
-        PercentageData(uint8_t percent)
+        PercentageData(
+                uint8_t percent)
             : percentage(percent)
             , accumulator(0)
         {
@@ -73,7 +76,7 @@ private:
         uint8_t accumulator;
     };
 
-    typedef std::function<bool(fastrtps::rtps::CDRMessage_t& msg)> filter;
+    typedef std::function<bool (fastrtps::rtps::CDRMessage_t& msg)> filter;
 
     PercentageData drop_data_messages_percentage_;
     test_UDPv4TransportDescriptor::filter drop_data_messages_filter_;
@@ -93,18 +96,23 @@ private:
     std::vector<fastrtps::rtps::SequenceNumber_t> sequence_number_data_messages_to_drop_;
 
 
-    bool log_drop(const fastrtps::rtps::octet* buffer, uint32_t size);
-    bool packet_should_drop(const fastrtps::rtps::octet* send_buffer, uint32_t send_buffer_size);
+    bool log_drop(
+            const fastrtps::rtps::octet* buffer,
+            uint32_t size);
+    bool packet_should_drop(
+            const fastrtps::rtps::octet* send_buffer,
+            uint32_t send_buffer_size);
     bool random_chance_drop();
-    bool should_be_dropped(PercentageData* percentage);
+    bool should_be_dropped(
+            PercentageData* percentage);
 
     bool send(
-           const fastrtps::rtps::octet* send_buffer,
-           uint32_t send_buffer_size,
-           eProsimaUDPSocket& socket,
-           const fastrtps::rtps::Locator_t& remote_locator,
-           bool only_multicast_purpose,
-           const std::chrono::microseconds& timeout);
+            const fastrtps::rtps::octet* send_buffer,
+            uint32_t send_buffer_size,
+            eProsimaUDPSocket& socket,
+            const fastrtps::rtps::Locator_t& remote_locator,
+            bool only_multicast_purpose,
+            const std::chrono::microseconds& timeout);
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -168,13 +168,6 @@ RTPSParticipant* RTPSDomain::createParticipant(
     LocatorList_t loc;
     IPFinder::getIP4Address(&loc);
 
-    if (loc.empty() && PParam.builtin.initialPeersList.empty())
-    {
-        Locator_t local;
-        IPLocator::setIPv4(local, 127, 0, 0, 1);
-        PParam.builtin.initialPeersList.push_back(local);
-    }
-
     // Generate a new GuidPrefix_t
     GuidPrefix_t guidP;
     guid_prefix_create(ID, guidP);

--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -291,6 +291,10 @@ bool UDPTransportInterface::OpenOutputChannel(
             {
                 SetSocketOutboundInterface(unicastSocket, (*locNames.begin()).name);
             }
+            else
+            {
+                SetSocketOutboundInterface(unicastSocket, localhost_name());
+            }
 
             // If more than one interface, then create sockets for outbounding multicast.
             if (locNames.size() > 1)

--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -28,8 +28,8 @@
 using namespace std;
 using namespace asio;
 
-namespace eprosima{
-namespace fastdds{
+namespace eprosima {
+namespace fastdds {
 namespace rtps {
 
 using Locator_t = fastrtps::rtps::Locator_t;
@@ -45,7 +45,9 @@ using Log = fastdds::dds::Log;
 
 struct MultiUniLocatorsLinkage
 {
-    MultiUniLocatorsLinkage(LocatorList_t&& m, LocatorList_t&& u)
+    MultiUniLocatorsLinkage(
+            LocatorList_t&& m,
+            LocatorList_t&& u)
         : multicast(std::move(m))
         , unicast(std::move(u))
     {
@@ -61,13 +63,15 @@ UDPTransportDescriptor::UDPTransportDescriptor()
 {
 }
 
-UDPTransportDescriptor::UDPTransportDescriptor(const UDPTransportDescriptor& t)
+UDPTransportDescriptor::UDPTransportDescriptor(
+        const UDPTransportDescriptor& t)
     : SocketTransportDescriptor(t)
     , m_output_udp_socket(t.m_output_udp_socket)
 {
 }
 
-UDPTransportInterface::UDPTransportInterface(int32_t transport_kind)
+UDPTransportInterface::UDPTransportInterface(
+        int32_t transport_kind)
     : TransportInterface(transport_kind)
     , mSendBufferSize(0)
     , mReceiveBufferSize(0)
@@ -83,13 +87,16 @@ void UDPTransportInterface::clean()
     assert(mInputSockets.size() == 0);
 }
 
-bool UDPTransportInterface::CloseInputChannel(const Locator_t& locator)
+bool UDPTransportInterface::CloseInputChannel(
+        const Locator_t& locator)
 {
     std::vector<UDPChannelResource*> channel_resources;
     {
         std::unique_lock<std::recursive_mutex> scopedLock(mInputMapMutex);
         if (!IsInputChannelOpen(locator))
+        {
             return false;
+        }
 
         channel_resources = std::move(mInputSockets.at(IPLocator::getPhysicalPort(locator)));
         mInputSockets.erase(IPLocator::getPhysicalPort(locator));
@@ -108,13 +115,16 @@ bool UDPTransportInterface::CloseInputChannel(const Locator_t& locator)
     return true;
 }
 
-void UDPTransportInterface::CloseOutputChannel(eProsimaUDPSocket& socket)
+void UDPTransportInterface::CloseOutputChannel(
+        eProsimaUDPSocket& socket)
 {
     socket.cancel();
     socket.close();
 }
 
-bool UDPTransportInterface::DoInputLocatorsMatch(const Locator_t& left, const Locator_t& right) const
+bool UDPTransportInterface::DoInputLocatorsMatch(
+        const Locator_t& left,
+        const Locator_t& right) const
 {
     return IPLocator::getPhysicalPort(left) == IPLocator::getPhysicalPort(right);
 }
@@ -178,19 +188,25 @@ bool UDPTransportInterface::init()
     return true;
 }
 
-bool UDPTransportInterface::IsInputChannelOpen(const Locator_t& locator) const
+bool UDPTransportInterface::IsInputChannelOpen(
+        const Locator_t& locator) const
 {
     std::unique_lock<std::recursive_mutex> scopedLock(mInputMapMutex);
-    return IsLocatorSupported(locator) && (mInputSockets.find(IPLocator::getPhysicalPort(locator)) != mInputSockets.end());
+    return IsLocatorSupported(locator) && (mInputSockets.find(IPLocator::getPhysicalPort(
+               locator)) != mInputSockets.end());
 }
 
-bool UDPTransportInterface::IsLocatorSupported(const Locator_t& locator) const
+bool UDPTransportInterface::IsLocatorSupported(
+        const Locator_t& locator) const
 {
     return locator.kind == transport_kind_;
 }
 
-bool UDPTransportInterface::OpenAndBindInputSockets(const Locator_t& locator, TransportReceiverInterface* receiver,
-    bool is_multicast, uint32_t maxMsgSize)
+bool UDPTransportInterface::OpenAndBindInputSockets(
+        const Locator_t& locator,
+        TransportReceiverInterface* receiver,
+        bool is_multicast,
+        uint32_t maxMsgSize)
 {
     std::unique_lock<std::recursive_mutex> scopedLock(mInputMapMutex);
 
@@ -208,7 +224,7 @@ bool UDPTransportInterface::OpenAndBindInputSockets(const Locator_t& locator, Tr
     {
         (void)e;
         logInfo(RTPS_MSG_OUT, "UDPTransport Error binding at port: (" << IPLocator::getPhysicalPort(locator) << ")"
-            << " with msg: " << e.what());
+                                                                      << " with msg: " << e.what());
         mInputSockets.erase(IPLocator::getPhysicalPort(locator));
         return false;
     }
@@ -224,9 +240,9 @@ UDPChannelResource* UDPTransportInterface::CreateInputChannelResource(
         TransportReceiverInterface* receiver)
 {
     eProsimaUDPSocket unicastSocket = OpenAndBindInputSocket(sInterface,
-                                                             IPLocator::getPhysicalPort(locator), is_multicast);
+                    IPLocator::getPhysicalPort(locator), is_multicast);
     UDPChannelResource* p_channel_resource = new UDPChannelResource(this, unicastSocket, maxMsgSize, locator,
-                                                                    sInterface, receiver);
+                    sInterface, receiver);
     return p_channel_resource;
 }
 
@@ -264,11 +280,11 @@ bool UDPTransportInterface::OpenOutputChannel(
     // We try to find a SenderResource that can be reuse to this locator.
     // Note: This is done in this level because if we do in NetworkFactory level, we have to mantain what transport
     // already reuses a SenderResource.
-    for(auto& sender_resource : sender_resource_list)
+    for (auto& sender_resource : sender_resource_list)
     {
         UDPSenderResource* udp_sender_resource = UDPSenderResource::cast(*this, sender_resource.get());
 
-        if(udp_sender_resource)
+        if (udp_sender_resource)
         {
             return true;
         }
@@ -287,7 +303,7 @@ bool UDPTransportInterface::OpenOutputChannel(
             getSocketPtr(unicastSocket)->set_option(ip::multicast::enable_loopback(true));
 
             // Outbounding first interface with already created socket.
-            if(!locNames.empty())
+            if (!locNames.empty())
             {
                 SetSocketOutboundInterface(unicastSocket, (*locNames.begin()).name);
             }
@@ -301,7 +317,7 @@ bool UDPTransportInterface::OpenOutputChannel(
             {
                 auto locIt = locNames.begin();
                 sender_resource_list.emplace_back(
-                        static_cast<SenderResource*>(new UDPSenderResource(*this, unicastSocket)));
+                    static_cast<SenderResource*>(new UDPSenderResource(*this, unicastSocket)));
 
                 // Create other socket for outbounding rest of interfaces.
                 for (++locIt; locIt != locNames.end(); ++locIt)
@@ -310,17 +326,17 @@ bool UDPTransportInterface::OpenOutputChannel(
                     try
                     {
                         eProsimaUDPSocket multicastSocket =
-                            OpenAndBindUnicastOutputSocket(generate_endpoint((*locIt).name, new_port), new_port);
+                                OpenAndBindUnicastOutputSocket(generate_endpoint((*locIt).name, new_port), new_port);
                         SetSocketOutboundInterface(multicastSocket, (*locIt).name);
 
                         sender_resource_list.emplace_back(
-                                static_cast<SenderResource*>(new UDPSenderResource(*this, multicastSocket, true)));
+                            static_cast<SenderResource*>(new UDPSenderResource(*this, multicastSocket, true)));
                     }
-                    catch(asio::system_error const& e)
+                    catch (asio::system_error const& e)
                     {
                         (void)e;
                         logWarning(RTPS_MSG_OUT, "UDPTransport Error binding interface "
-                            << (*locIt).name << " (skipping) with msg: " << e.what());
+                                << (*locIt).name << " (skipping) with msg: " << e.what());
                     }
                 }
             }
@@ -328,7 +344,7 @@ bool UDPTransportInterface::OpenOutputChannel(
             {
                 // Multicast data will be sent for the only one interface.
                 sender_resource_list.emplace_back(
-                        static_cast<SenderResource*>(new UDPSenderResource(*this, unicastSocket)));
+                    static_cast<SenderResource*>(new UDPSenderResource(*this, unicastSocket)));
             }
 
             if (!locNames.empty())
@@ -340,7 +356,7 @@ bool UDPTransportInterface::OpenOutputChannel(
                 try
                 {
                     eProsimaUDPSocket multicastSocket =
-                        OpenAndBindUnicastOutputSocket(generate_endpoint(localhost, new_port), new_port);
+                            OpenAndBindUnicastOutputSocket(generate_endpoint(localhost, new_port), new_port);
                     SetSocketOutboundInterface(multicastSocket, localhost);
 
                     sender_resource_list.emplace_back(
@@ -349,8 +365,8 @@ bool UDPTransportInterface::OpenOutputChannel(
                 catch (asio::system_error const& e)
                 {
                     (void)e;
-                    logWarning(RTPS_MSG_OUT, "UDPTransport Error binding interface " << localhost
-                        << " (skipping) with msg: " << e.what());
+                    logWarning(RTPS_MSG_OUT, "UDPTransport Error binding interface "
+                            << localhost << " (skipping) with msg: " << e.what());
                 }
             }
         }
@@ -365,7 +381,7 @@ bool UDPTransportInterface::OpenOutputChannel(
                 if (is_interface_allowed(infoIP.name))
                 {
                     eProsimaUDPSocket unicastSocket =
-                        OpenAndBindUnicastOutputSocket(generate_endpoint(infoIP.name, port), port);
+                            OpenAndBindUnicastOutputSocket(generate_endpoint(infoIP.name, port), port);
                     SetSocketOutboundInterface(unicastSocket, infoIP.name);
                     if (!firstInterface)
                     {
@@ -373,7 +389,7 @@ bool UDPTransportInterface::OpenOutputChannel(
                         firstInterface = true;
                     }
                     sender_resource_list.emplace_back(
-                            static_cast<SenderResource*>(new UDPSenderResource(*this, unicastSocket)));
+                        static_cast<SenderResource*>(new UDPSenderResource(*this, unicastSocket)));
                 }
             }
         }
@@ -382,21 +398,22 @@ bool UDPTransportInterface::OpenOutputChannel(
     {
         (void)e;
         /* TODO Que hacer?
-        logError(RTPS_MSG_OUT, "UDPTransport Error binding at port: (" << IPLocator::getPhysicalPort(locator) << ")"
+           logError(RTPS_MSG_OUT, "UDPTransport Error binding at port: (" << IPLocator::getPhysicalPort(locator) << ")"
             << " with msg: " << e.what());
-        for (auto& socket : mOutputSockets)
-        {
+           for (auto& socket : mOutputSockets)
+           {
             delete socket;
-        }
-        mOutputSockets.clear();
-        */
+           }
+           mOutputSockets.clear();
+         */
         return false;
     }
 
     return true;
 }
 
-Locator_t UDPTransportInterface::RemoteToMainLocal(const Locator_t& remote) const
+Locator_t UDPTransportInterface::RemoteToMainLocal(
+        const Locator_t& remote) const
 {
     if (!IsLocatorSupported(remote))
     {
@@ -463,12 +480,12 @@ bool UDPTransportInterface::send(
     {
         if (IsLocatorSupported(*it))
         {
-            ret &= send(send_buffer, 
-                send_buffer_size, 
-                socket,
-                *it, 
-                only_multicast_purpose, 
-                time_out);
+            ret &= send(send_buffer,
+                            send_buffer_size,
+                            socket,
+                            *it,
+                            only_multicast_purpose,
+                            time_out);
         }
 
         ++it;
@@ -508,14 +525,15 @@ bool UDPTransportInterface::send(
             timeStruct.tv_usec = timeout.count() > 0 ? timeout.count() : 0;
             setsockopt(getSocketPtr(socket)->native_handle(), SOL_SOCKET, SO_SNDTIMEO,
                     reinterpret_cast<const char*>(&timeStruct), sizeof(timeStruct));
-#endif
+#endif // ifndef _WIN32
 
             asio::error_code ec;
-            bytesSent = getSocketPtr(socket)->send_to(asio::buffer(send_buffer, send_buffer_size), destinationEndpoint, 0, ec);
-            if(!!ec)
+            bytesSent = getSocketPtr(socket)->send_to(asio::buffer(send_buffer,
+                            send_buffer_size), destinationEndpoint, 0, ec);
+            if (!!ec)
             {
                 if ((ec.value() == asio::error::would_block) ||
-                    (ec.value() == asio::error::try_again))
+                        (ec.value() == asio::error::try_again))
                 {
                     logWarning(RTPS_MSG_OUT, "UDP send would have blocked. Packet is dropped.");
                     return true;
@@ -533,7 +551,7 @@ bool UDPTransportInterface::send(
 
         (void)bytesSent;
         logInfo(RTPS_MSG_OUT, "UDPTransport: " << bytesSent << " bytes TO endpoint: " << destinationEndpoint
-            << " FROM " << getSocketPtr(socket)->local_endpoint());
+                                               << " FROM " << getSocketPtr(socket)->local_endpoint());
         success = true;
     }
 
@@ -581,7 +599,8 @@ static bool check_and_invalidate(
     return ret_val;
 }
 
-void UDPTransportInterface::select_locators(LocatorSelector& selector) const
+void UDPTransportInterface::select_locators(
+        LocatorSelector& selector) const
 {
     fastrtps::ResourceLimitedVector<LocatorSelectorEntry*>& entries = selector.transport_starts();
 
@@ -632,7 +651,8 @@ void UDPTransportInterface::select_locators(LocatorSelector& selector) const
     }
 }
 
-bool UDPTransportInterface::fillMetatrafficMulticastLocator(Locator_t &locator,
+bool UDPTransportInterface::fillMetatrafficMulticastLocator(
+        Locator_t& locator,
         uint32_t metatraffic_multicast_port) const
 {
     if (locator.port == 0)
@@ -642,7 +662,8 @@ bool UDPTransportInterface::fillMetatrafficMulticastLocator(Locator_t &locator,
     return true;
 }
 
-bool UDPTransportInterface::fillMetatrafficUnicastLocator(Locator_t &locator,
+bool UDPTransportInterface::fillMetatrafficUnicastLocator(
+        Locator_t& locator,
         uint32_t metatraffic_unicast_port) const
 {
     if (locator.port == 0)
@@ -652,12 +673,15 @@ bool UDPTransportInterface::fillMetatrafficUnicastLocator(Locator_t &locator,
     return true;
 }
 
-bool UDPTransportInterface::configureInitialPeerLocator(Locator_t &locator, const PortParameters &port_params,
-        uint32_t domainId, LocatorList_t& list) const
+bool UDPTransportInterface::configureInitialPeerLocator(
+        Locator_t& locator,
+        const PortParameters& port_params,
+        uint32_t domainId,
+        LocatorList_t& list) const
 {
-    if(locator.port == 0)
+    if (locator.port == 0)
     {
-        for(uint32_t i = 0; i < configuration()->maxInitialPeersRange; ++i)
+        for (uint32_t i = 0; i < configuration()->maxInitialPeersRange; ++i)
         {
             Locator_t auxloc(locator);
             auxloc.port = port_params.getUnicastPort(domainId, i);
@@ -666,12 +690,16 @@ bool UDPTransportInterface::configureInitialPeerLocator(Locator_t &locator, cons
         }
     }
     else
+    {
         list.push_back(locator);
+    }
 
     return true;
 }
 
-bool UDPTransportInterface::fillUnicastLocator(Locator_t &locator, uint32_t well_known_port) const
+bool UDPTransportInterface::fillUnicastLocator(
+        Locator_t& locator,
+        uint32_t well_known_port) const
 {
     if (locator.port == 0)
     {

--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -335,12 +335,13 @@ bool UDPTransportInterface::OpenOutputChannel(
             {
                 // We add localhost output for multicast, so in case the network cable is unplugged, local
                 // participants keep receiving DATA(p) announcements
+                const std::string& localhost = localhost_name();
                 uint16_t new_port = 0;
                 try
                 {
                     eProsimaUDPSocket multicastSocket =
-                        OpenAndBindUnicastOutputSocket(generate_endpoint("127.0.0.1", new_port), new_port);
-                    SetSocketOutboundInterface(multicastSocket, "127.0.0.1");
+                        OpenAndBindUnicastOutputSocket(generate_endpoint(localhost, new_port), new_port);
+                    SetSocketOutboundInterface(multicastSocket, localhost);
 
                     sender_resource_list.emplace_back(
                         static_cast<SenderResource*>(new UDPSenderResource(*this, multicastSocket, true)));
@@ -348,7 +349,7 @@ bool UDPTransportInterface::OpenOutputChannel(
                 catch (asio::system_error const& e)
                 {
                     (void)e;
-                    logWarning(RTPS_MSG_OUT, "UDPTransport Error binding interface 127.0.0.1"
+                    logWarning(RTPS_MSG_OUT, "UDPTransport Error binding interface " << localhost
                         << " (skipping) with msg: " << e.what());
                 }
             }

--- a/src/cpp/rtps/transport/UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/UDPv4Transport.cpp
@@ -262,6 +262,12 @@ void UDPv4Transport::get_ips(
     get_ipv4s(locNames, return_loopback);
 }
 
+const std::string& UDPv4Transport::localhost_name()
+{
+    static const std::string ip4_localhost = "127.0.0.1";
+    return ip4_localhost;
+}
+
 eProsimaUDPSocket UDPv4Transport::OpenAndBindInputSocket(
         const std::string& sIp,
         uint16_t port,

--- a/src/cpp/rtps/transport/UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/UDPv4Transport.cpp
@@ -28,9 +28,9 @@
 using namespace std;
 using namespace asio;
 
-namespace eprosima{
-namespace fastdds{
-namespace rtps{
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
 
 using IPFinder = fastrtps::rtps::IPFinder;
 using IPLocator = fastrtps::rtps::IPLocator;
@@ -44,13 +44,16 @@ static void get_ipv4s(
 {
     IPFinder::getIPs(&locNames, return_loopback);
     auto new_end = remove_if(locNames.begin(),
-            locNames.end(),
-            [](IPFinder::info_IP ip){return ip.type != IPFinder::IP4 && ip.type != IPFinder::IP4_LOCAL;});
+                    locNames.end(),
+                    [](IPFinder::info_IP ip)
+                    {
+                        return ip.type != IPFinder::IP4 && ip.type != IPFinder::IP4_LOCAL;
+                    });
     locNames.erase(new_end, locNames.end());
     std::for_each(locNames.begin(), locNames.end(), [](IPFinder::info_IP& loc)
-    {
-        loc.locator.kind = LOCATOR_KIND_UDPv4;
-    });
+            {
+                loc.locator.kind = LOCATOR_KIND_UDPv4;
+            });
 }
 
 static void get_ipv4s_unique_interfaces(
@@ -59,13 +62,20 @@ static void get_ipv4s_unique_interfaces(
 {
     get_ipv4s(locNames, return_loopback);
     std::sort(locNames.begin(), locNames.end(),
-            [](const IPFinder::info_IP&  a, const IPFinder::info_IP& b) -> bool {return a.dev < b.dev;});
+            [](const IPFinder::info_IP&  a, const IPFinder::info_IP& b) -> bool
+            {
+                return a.dev < b.dev;
+            });
     auto new_end = std::unique(locNames.begin(), locNames.end(),
-            [](const IPFinder::info_IP&  a, const IPFinder::info_IP& b) -> bool {return a.type != IPFinder::IP4_LOCAL && b.type != IPFinder::IP4_LOCAL && a.dev == b.dev;});
+                    [](const IPFinder::info_IP&  a, const IPFinder::info_IP& b) -> bool
+                    {
+                        return a.type != IPFinder::IP4_LOCAL && b.type != IPFinder::IP4_LOCAL && a.dev == b.dev;
+                    });
     locNames.erase(new_end, locNames.end());
 }
 
-static asio::ip::address_v4::bytes_type locator_to_native(const Locator_t& locator)
+static asio::ip::address_v4::bytes_type locator_to_native(
+        const Locator_t& locator)
 {
     if (IPLocator::hasWan(locator))
     {
@@ -83,7 +93,8 @@ static asio::ip::address_v4::bytes_type locator_to_native(const Locator_t& locat
     }
 }
 
-UDPv4Transport::UDPv4Transport(const UDPv4TransportDescriptor& descriptor)
+UDPv4Transport::UDPv4Transport(
+        const UDPv4TransportDescriptor& descriptor)
     : UDPTransportInterface(LOCATOR_KIND_UDPv4)
     , configuration_(descriptor)
 {
@@ -98,7 +109,7 @@ UDPv4Transport::UDPv4Transport(const UDPv4TransportDescriptor& descriptor)
         get_ipv4s(local_interfaces, true);
         for (const IPFinder::info_IP& infoIP : local_interfaces)
         {
-            if(std::find(white_begin, white_end, infoIP.name) != white_end)
+            if (std::find(white_begin, white_end, infoIP.name) != white_end)
             {
                 interface_whitelist_.emplace_back(ip::address_v4::from_string(infoIP.name));
             }
@@ -122,13 +133,13 @@ UDPv4Transport::~UDPv4Transport()
     clean();
 }
 
-
 UDPv4TransportDescriptor::UDPv4TransportDescriptor()
     : UDPTransportDescriptor()
 {
 }
 
-UDPv4TransportDescriptor::UDPv4TransportDescriptor(const UDPv4TransportDescriptor& t)
+UDPv4TransportDescriptor::UDPv4TransportDescriptor(
+        const UDPv4TransportDescriptor& t)
     : UDPTransportDescriptor(t)
 {
 }
@@ -139,7 +150,7 @@ TransportInterface* UDPv4TransportDescriptor::create_transport() const
 }
 
 bool UDPv4Transport::getDefaultMetatrafficMulticastLocators(
-        LocatorList_t &locators,
+        LocatorList_t& locators,
         uint32_t metatraffic_multicast_port) const
 {
     Locator_t locator;
@@ -151,7 +162,7 @@ bool UDPv4Transport::getDefaultMetatrafficMulticastLocators(
 }
 
 bool UDPv4Transport::getDefaultMetatrafficUnicastLocators(
-        LocatorList_t &locators,
+        LocatorList_t& locators,
         uint32_t metatraffic_unicast_port) const
 {
     Locator_t locator;
@@ -164,7 +175,7 @@ bool UDPv4Transport::getDefaultMetatrafficUnicastLocators(
 }
 
 bool UDPv4Transport::getDefaultUnicastLocators(
-        LocatorList_t &locators,
+        LocatorList_t& locators,
         uint32_t unicast_port) const
 {
     Locator_t locator;
@@ -176,7 +187,8 @@ bool UDPv4Transport::getDefaultUnicastLocators(
     return true;
 }
 
-void UDPv4Transport::AddDefaultOutputLocator(LocatorList_t &defaultList)
+void UDPv4Transport::AddDefaultOutputLocator(
+        LocatorList_t& defaultList)
 {
     Locator_t locator;
     IPLocator::createLocator(LOCATOR_KIND_UDPv4, "239.255.0.1", configuration_.m_output_udp_socket, locator);
@@ -206,7 +218,8 @@ void UDPv4Transport::endpoint_to_locator(
     IPLocator::setIPv4(locator, ipBytes.data());
 }
 
-void UDPv4Transport::fill_local_ip(Locator_t& loc) const
+void UDPv4Transport::fill_local_ip(
+        Locator_t& loc) const
 {
     IPLocator::setIPv4(loc, "127.0.0.1");
     loc.kind = LOCATOR_KIND_UDPv4;
@@ -217,7 +230,8 @@ const UDPTransportDescriptor* UDPv4Transport::configuration() const
     return &configuration_;
 }
 
-asio::ip::udp::endpoint UDPv4Transport::GenerateAnyAddressEndpoint(uint16_t port)
+asio::ip::udp::endpoint UDPv4Transport::GenerateAnyAddressEndpoint(
+        uint16_t port)
 {
     return ip::udp::endpoint(ip::address_v4::any(), port);
 }
@@ -238,7 +252,8 @@ ip::udp::endpoint UDPv4Transport::generate_endpoint(
     return asio::ip::udp::endpoint(ip::address_v4::from_string(sIp), port);
 }
 
-ip::udp::endpoint UDPv4Transport::generate_endpoint(uint16_t port)
+ip::udp::endpoint UDPv4Transport::generate_endpoint(
+        uint16_t port)
 {
     return asio::ip::udp::endpoint(asio::ip::udp::v4(), port);
 }
@@ -285,8 +300,8 @@ eProsimaUDPSocket UDPv4Transport::OpenAndBindInputSocket(
         getSocketPtr(socket)->set_option(ip::udp::socket::reuse_address(true));
 #if defined(__QNX__)
         getSocketPtr(socket)->set_option(asio::detail::socket_option::boolean<
-            ASIO_OS_DEF(SOL_SOCKET), SO_REUSEPORT>(true));
-#endif
+                    ASIO_OS_DEF(SOL_SOCKET), SO_REUSEPORT>(true));
+#endif // if defined(__QNX__)
     }
 
     getSocketPtr(socket)->bind(generate_endpoint(sIp, port));
@@ -300,12 +315,16 @@ bool UDPv4Transport::OpenInputChannel(
 {
     std::unique_lock<std::recursive_mutex> scopedLock(mInputMapMutex);
     if (!is_locator_allowed(locator))
+    {
         return false;
+    }
 
     bool success = false;
 
     if (!IsInputChannelOpen(locator))
+    {
         success = OpenAndBindInputSockets(locator, receiver, IPLocator::isMulticast(locator), maxMsgSize);
+    }
 
     if (IPLocator::isMulticast(locator) && IsInputChannelOpen(locator))
     {
@@ -336,7 +355,8 @@ bool UDPv4Transport::OpenInputChannel(
                 {
                     // Bind to multicast address
                     UDPChannelResource* p_channel_resource;
-                    p_channel_resource = CreateInputChannelResource(locatorAddressStr, locator, true, maxMsgSize, receiver);
+                    p_channel_resource = CreateInputChannelResource(locatorAddressStr, locator, true, maxMsgSize,
+                                    receiver);
                     mInputSockets[IPLocator::getPhysicalPort(locator)].push_back(p_channel_resource);
 
                     // Join group on all whitelisted interfaces
@@ -348,13 +368,14 @@ bool UDPv4Transport::OpenInputChannel(
                 catch (asio::system_error const& e)
                 {
                     (void)e;
-                    logWarning(RTPS_MSG_OUT, "UDPTransport Error binding " << locatorAddressStr << " at port: (" << IPLocator::getPhysicalPort(locator) << ")"
-                        << " with msg: " << e.what());
+                    logWarning(RTPS_MSG_OUT, "UDPTransport Error binding " << locatorAddressStr << " at port: (" << IPLocator::getPhysicalPort(
+                                locator) << ")"
+                                                                           << " with msg: " << e.what());
                 }
             }
         }
         else
-#endif
+#endif // ifndef _WIN32
         {
             // The multicast group will be joined silently, because we do not
             // want to return another resource.
@@ -417,18 +438,24 @@ std::vector<std::string> UDPv4Transport::get_binding_interfaces_list()
     return vOutputInterfaces;
 }
 
-bool UDPv4Transport::is_interface_allowed(const std::string& interface) const
+bool UDPv4Transport::is_interface_allowed(
+        const std::string& interface) const
 {
     return is_interface_allowed(asio::ip::address_v4::from_string(interface));
 }
 
-bool UDPv4Transport::is_interface_allowed(const ip::address_v4& ip) const
+bool UDPv4Transport::is_interface_allowed(
+        const ip::address_v4& ip) const
 {
     if (interface_whitelist_.empty())
+    {
         return true;
+    }
 
     if (ip == ip::address_v4::any())
+    {
         return true;
+    }
 
     return find(interface_whitelist_.begin(), interface_whitelist_.end(), ip) != interface_whitelist_.end();
 }
@@ -438,7 +465,8 @@ bool UDPv4Transport::is_interface_whitelist_empty() const
     return interface_whitelist_.empty();
 }
 
-bool UDPv4Transport::is_locator_allowed(const Locator_t& locator) const
+bool UDPv4Transport::is_locator_allowed(
+        const Locator_t& locator) const
 {
     if (!IsLocatorSupported(locator))
     {
@@ -451,7 +479,8 @@ bool UDPv4Transport::is_locator_allowed(const Locator_t& locator) const
     return is_interface_allowed(IPLocator::toIPv4string(locator));
 }
 
-LocatorList_t UDPv4Transport::NormalizeLocator(const Locator_t& locator)
+LocatorList_t UDPv4Transport::NormalizeLocator(
+        const Locator_t& locator)
 {
     LocatorList_t list;
 
@@ -484,7 +513,8 @@ LocatorList_t UDPv4Transport::NormalizeLocator(const Locator_t& locator)
     return list;
 }
 
-bool UDPv4Transport::is_local_locator(const Locator_t& locator) const
+bool UDPv4Transport::is_local_locator(
+        const Locator_t& locator) const
 {
     assert(locator.kind == LOCATOR_KIND_UDPv4);
 
@@ -504,12 +534,14 @@ bool UDPv4Transport::is_local_locator(const Locator_t& locator) const
     return false;
 }
 
-void UDPv4Transport::set_receive_buffer_size(uint32_t size)
+void UDPv4Transport::set_receive_buffer_size(
+        uint32_t size)
 {
     configuration_.receiveBufferSize = size;
 }
 
-void UDPv4Transport::set_send_buffer_size(uint32_t size)
+void UDPv4Transport::set_send_buffer_size(
+        uint32_t size)
 {
     configuration_.sendBufferSize = size;
 }

--- a/src/cpp/rtps/transport/UDPv6Transport.cpp
+++ b/src/cpp/rtps/transport/UDPv6Transport.cpp
@@ -272,6 +272,12 @@ void UDPv6Transport::get_ips(
     get_ipv6s(locNames, return_loopback);
 }
 
+const std::string& UDPv6Transport::localhost_name()
+{
+    static const std::string ip6_localhost = "::1";
+    return ip6_localhost;
+}
+
 eProsimaUDPSocket UDPv6Transport::OpenAndBindInputSocket(
         const std::string& sIp,
         uint16_t port,

--- a/src/cpp/rtps/transport/UDPv6Transport.cpp
+++ b/src/cpp/rtps/transport/UDPv6Transport.cpp
@@ -26,9 +26,9 @@
 using namespace std;
 using namespace asio;
 
-namespace eprosima{
-namespace fastdds{
-namespace rtps{
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
 
 using Locator_t = fastrtps::rtps::Locator_t;
 using IPFinder = fastrtps::rtps::IPFinder;
@@ -44,13 +44,16 @@ static void get_ipv6s(
     IPFinder::getIPs(&locNames, return_loopback);
     // Controller out IP4
     auto new_end = remove_if(locNames.begin(),
-            locNames.end(),
-            [](IPFinder::info_IP ip){return ip.type != IPFinder::IP6 && ip.type != IPFinder::IP6_LOCAL;});
+                    locNames.end(),
+                    [](IPFinder::info_IP ip)
+                    {
+                        return ip.type != IPFinder::IP6 && ip.type != IPFinder::IP6_LOCAL;
+                    });
     locNames.erase(new_end, locNames.end());
     std::for_each(locNames.begin(), locNames.end(), [](IPFinder::info_IP& loc)
-    {
-        loc.locator.kind = LOCATOR_KIND_UDPv6;
-    });
+            {
+                loc.locator.kind = LOCATOR_KIND_UDPv6;
+            });
 }
 
 static void get_ipv6s_unique_interfaces(
@@ -59,13 +62,20 @@ static void get_ipv6s_unique_interfaces(
 {
     get_ipv6s(locNames, return_loopback);
     std::sort(locNames.begin(), locNames.end(),
-            [](const IPFinder::info_IP&  a, const IPFinder::info_IP& b) -> bool {return a.dev < b.dev;});
+            [](const IPFinder::info_IP&  a, const IPFinder::info_IP& b) -> bool
+            {
+                return a.dev < b.dev;
+            });
     auto new_end = std::unique(locNames.begin(), locNames.end(),
-            [](const IPFinder::info_IP&  a, const IPFinder::info_IP& b) -> bool {return a.dev == b.dev;});
+                    [](const IPFinder::info_IP&  a, const IPFinder::info_IP& b) -> bool
+                    {
+                        return a.dev == b.dev;
+                    });
     locNames.erase(new_end, locNames.end());
 }
 
-static asio::ip::address_v6::bytes_type locator_to_native(const Locator_t& locator)
+static asio::ip::address_v6::bytes_type locator_to_native(
+        const Locator_t& locator)
 {
     return { { IPLocator::getIPv6(locator)[0],
         IPLocator::getIPv6(locator)[1],
@@ -85,14 +95,17 @@ static asio::ip::address_v6::bytes_type locator_to_native(const Locator_t& locat
         IPLocator::getIPv6(locator)[15] } };
 }
 
-UDPv6Transport::UDPv6Transport(const UDPv6TransportDescriptor& descriptor)
+UDPv6Transport::UDPv6Transport(
+        const UDPv6TransportDescriptor& descriptor)
     : UDPTransportInterface(LOCATOR_KIND_UDPv6)
     , configuration_(descriptor)
 {
     mSendBufferSize = descriptor.sendBufferSize;
     mReceiveBufferSize = descriptor.receiveBufferSize;
     for (const auto& interface : descriptor.interfaceWhiteList)
+    {
         interface_whitelist_.emplace_back(ip::address_v6::from_string(interface));
+    }
 }
 
 UDPv6Transport::UDPv6Transport()
@@ -105,13 +118,13 @@ UDPv6Transport::~UDPv6Transport()
     clean();
 }
 
-
 UDPv6TransportDescriptor::UDPv6TransportDescriptor()
     : UDPTransportDescriptor()
 {
 }
 
-UDPv6TransportDescriptor::UDPv6TransportDescriptor(const UDPv6TransportDescriptor& t)
+UDPv6TransportDescriptor::UDPv6TransportDescriptor(
+        const UDPv6TransportDescriptor& t)
     : UDPTransportDescriptor(t)
 {
 }
@@ -122,7 +135,7 @@ TransportInterface* UDPv6TransportDescriptor::create_transport() const
 }
 
 bool UDPv6Transport::getDefaultMetatrafficMulticastLocators(
-        LocatorList_t &locators,
+        LocatorList_t& locators,
         uint32_t metatraffic_multicast_port) const
 {
     Locator_t locator;
@@ -134,7 +147,7 @@ bool UDPv6Transport::getDefaultMetatrafficMulticastLocators(
 }
 
 bool UDPv6Transport::getDefaultMetatrafficUnicastLocators(
-        LocatorList_t &locators,
+        LocatorList_t& locators,
         uint32_t metatraffic_unicast_port) const
 {
     if (interface_whitelist_.empty())
@@ -160,7 +173,7 @@ bool UDPv6Transport::getDefaultMetatrafficUnicastLocators(
 }
 
 bool UDPv6Transport::getDefaultUnicastLocators(
-        LocatorList_t &locators,
+        LocatorList_t& locators,
         uint32_t unicast_port) const
 {
     if (interface_whitelist_.empty())
@@ -185,7 +198,8 @@ bool UDPv6Transport::getDefaultUnicastLocators(
     return true;
 }
 
-void UDPv6Transport::AddDefaultOutputLocator(LocatorList_t &defaultList)
+void UDPv6Transport::AddDefaultOutputLocator(
+        LocatorList_t& defaultList)
 {
     // TODO What is the default IPv6 address?
     Locator_t temp;
@@ -216,7 +230,8 @@ void UDPv6Transport::endpoint_to_locator(
     IPLocator::setIPv6(locator, ipBytes.data());
 }
 
-void UDPv6Transport::fill_local_ip(Locator_t& loc) const
+void UDPv6Transport::fill_local_ip(
+        Locator_t& loc) const
 {
     IPLocator::setIPv6(loc, "::1");
     loc.kind = LOCATOR_KIND_UDPv6;
@@ -236,7 +251,8 @@ ip::udp::endpoint UDPv6Transport::generate_endpoint(
     return ip::udp::endpoint(asio::ip::address_v6(remoteAddress), port);
 }
 
-asio::ip::udp::endpoint UDPv6Transport::GenerateAnyAddressEndpoint(uint16_t port)
+asio::ip::udp::endpoint UDPv6Transport::GenerateAnyAddressEndpoint(
+        uint16_t port)
 {
     return ip::udp::endpoint(ip::address_v6::any(), port);
 }
@@ -248,7 +264,8 @@ ip::udp::endpoint UDPv6Transport::generate_endpoint(
     return asio::ip::udp::endpoint(ip::address_v6::from_string(sIp), port);
 }
 
-ip::udp::endpoint UDPv6Transport::generate_endpoint(uint16_t port)
+ip::udp::endpoint UDPv6Transport::generate_endpoint(
+        uint16_t port)
 {
     return asio::ip::udp::endpoint(asio::ip::udp::v6(), port);
 }
@@ -295,8 +312,8 @@ eProsimaUDPSocket UDPv6Transport::OpenAndBindInputSocket(
         getSocketPtr(socket)->set_option(ip::udp::socket::reuse_address(true));
 #if defined(__QNX__)
         getSocketPtr(socket)->set_option(asio::detail::socket_option::boolean<
-            ASIO_OS_DEF(SOL_SOCKET), SO_REUSEPORT>(true));
-#endif
+                    ASIO_OS_DEF(SOL_SOCKET), SO_REUSEPORT>(true));
+#endif // if defined(__QNX__)
     }
 
     getSocketPtr(socket)->bind(generate_endpoint(sIp, port));
@@ -311,12 +328,16 @@ bool UDPv6Transport::OpenInputChannel(
 {
     std::unique_lock<std::recursive_mutex> scopedLock(mInputMapMutex);
     if (!is_locator_allowed(locator))
+    {
         return false;
+    }
 
     bool success = false;
 
     if (!IsInputChannelOpen(locator))
+    {
         success = OpenAndBindInputSockets(locator, receiver, IPLocator::isMulticast(locator), maxMsgSize);
+    }
 
     if (IPLocator::isMulticast(locator) && IsInputChannelOpen(locator))
     {
@@ -335,7 +356,7 @@ bool UDPv6Transport::OpenInputChannel(
                     try
                     {
                         channelResource->socket()->set_option(ip::multicast::join_group(
-                            ip::address_v6::from_string(IPLocator::toIPv6string(locator)), ip.scope_id()));
+                                    ip::address_v6::from_string(IPLocator::toIPv6string(locator)), ip.scope_id()));
                     }
                     catch (std::system_error& ex)
                     {
@@ -350,7 +371,7 @@ bool UDPv6Transport::OpenInputChannel(
                 try
                 {
                     channelResource->socket()->set_option(ip::multicast::join_group(
-                        ip::address_v6::from_string(IPLocator::toIPv6string(locator)), ip.scope_id()));
+                                ip::address_v6::from_string(IPLocator::toIPv6string(locator)), ip.scope_id()));
                 }
                 catch (std::system_error& ex)
                 {
@@ -382,20 +403,26 @@ std::vector<std::string> UDPv6Transport::get_binding_interfaces_list()
     return vOutputInterfaces;
 }
 
-bool UDPv6Transport::is_interface_allowed(const std::string& interface) const
+bool UDPv6Transport::is_interface_allowed(
+        const std::string& interface) const
 {
     return is_interface_allowed(asio::ip::address_v6::from_string(interface));
 }
 
-bool UDPv6Transport::is_interface_allowed(const ip::address_v6& ip) const
+bool UDPv6Transport::is_interface_allowed(
+        const ip::address_v6& ip) const
 {
     if (interface_whitelist_.empty())
+    {
         return true;
+    }
 
     if (ip == ip::address_v6::any())
+    {
         return true;
+    }
 
-    return  find(interface_whitelist_.begin(), interface_whitelist_.end(), ip) != interface_whitelist_.end();
+    return find(interface_whitelist_.begin(), interface_whitelist_.end(), ip) != interface_whitelist_.end();
 }
 
 bool UDPv6Transport::is_interface_whitelist_empty() const
@@ -403,20 +430,22 @@ bool UDPv6Transport::is_interface_whitelist_empty() const
     return interface_whitelist_.empty();
 }
 
-bool UDPv6Transport::is_locator_allowed(const Locator_t& locator) const
+bool UDPv6Transport::is_locator_allowed(
+        const Locator_t& locator) const
 {
     if (!IsLocatorSupported(locator))
     {
         return false;
     }
-    if (interface_whitelist_.empty() ||IPLocator::isMulticast(locator))
+    if (interface_whitelist_.empty() || IPLocator::isMulticast(locator))
     {
         return true;
     }
     return is_interface_allowed(IPLocator::toIPv6string(locator));
 }
 
-LocatorList_t UDPv6Transport::NormalizeLocator(const Locator_t& locator)
+LocatorList_t UDPv6Transport::NormalizeLocator(
+        const Locator_t& locator)
 {
     LocatorList_t list;
     if (IPLocator::isAny(locator))
@@ -449,7 +478,8 @@ LocatorList_t UDPv6Transport::NormalizeLocator(const Locator_t& locator)
     return list;
 }
 
-bool UDPv6Transport::is_local_locator(const Locator_t& locator) const
+bool UDPv6Transport::is_local_locator(
+        const Locator_t& locator) const
 {
     assert(locator.kind == LOCATOR_KIND_UDPv4);
 
@@ -460,7 +490,7 @@ bool UDPv6Transport::is_local_locator(const Locator_t& locator) const
 
     for (const IPFinder::info_IP& localInterface : currentInterfaces)
     {
-        if(IPLocator::compareAddress(localInterface.locator, locator))
+        if (IPLocator::compareAddress(localInterface.locator, locator))
         {
             return true;
         }
@@ -469,12 +499,14 @@ bool UDPv6Transport::is_local_locator(const Locator_t& locator) const
     return false;
 }
 
-void UDPv6Transport::set_receive_buffer_size(uint32_t size)
+void UDPv6Transport::set_receive_buffer_size(
+        uint32_t size)
 {
     configuration_.receiveBufferSize = size;
 }
 
-void UDPv6Transport::set_send_buffer_size(uint32_t size)
+void UDPv6Transport::set_send_buffer_size(
+        uint32_t size)
 {
     configuration_.sendBufferSize = size;
 }
@@ -484,7 +516,7 @@ void UDPv6Transport::SetSocketOutboundInterface(
         const std::string& sIp)
 {
     getSocketPtr(socket)->set_option(ip::multicast::outbound_interface(
-        asio::ip::address_v6::from_string(sIp).scope_id()));
+                asio::ip::address_v6::from_string(sIp).scope_id()));
 }
 
 } // namespace rtps

--- a/src/cpp/rtps/transport/test_UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.cpp
@@ -19,9 +19,9 @@
 
 using namespace std;
 
-namespace eprosima{
-namespace fastdds{
-namespace rtps{
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
 
 using octet = fastrtps::rtps::octet;
 using Locator_t = fastrtps::rtps::Locator_t;
@@ -30,63 +30,82 @@ using SubmessageHeader_t = fastrtps::rtps::SubmessageHeader_t;
 using SequenceNumber_t = fastrtps::rtps::SequenceNumber_t;
 using EntityId_t = fastrtps::rtps::EntityId_t;
 
-std::vector<std::vector<octet> > test_UDPv4Transport::test_UDPv4Transport_DropLog;
+std::vector<std::vector<octet>> test_UDPv4Transport::test_UDPv4Transport_DropLog;
 uint32_t test_UDPv4Transport::test_UDPv4Transport_DropLogLength = 0;
 bool test_UDPv4Transport::test_UDPv4Transport_ShutdownAllNetwork = false;
 bool test_UDPv4Transport::always_drop_participant_builtin_topic_data = false;
 bool test_UDPv4Transport::simulate_no_interfaces = false;
 
-test_UDPv4Transport::test_UDPv4Transport(const test_UDPv4TransportDescriptor& descriptor):
-    drop_data_messages_percentage_(descriptor.dropDataMessagesPercentage),
-    drop_data_messages_filter_(descriptor.drop_data_messages_filter_),
-    drop_participant_builtin_topic_data_(descriptor.dropParticipantBuiltinTopicData),
-    drop_publication_builtin_topic_data_(descriptor.dropPublicationBuiltinTopicData),
-    drop_subscription_builtin_topic_data_(descriptor.dropSubscriptionBuiltinTopicData),
-    drop_data_frag_messages_percentage_(descriptor.dropDataFragMessagesPercentage),
-    drop_data_frag_messages_filter_(descriptor.drop_data_frag_messages_filter_),
-    drop_heartbeat_messages_percentage_(descriptor.dropHeartbeatMessagesPercentage),
-    drop_heartbeat_messages_filter_(descriptor.drop_heartbeat_messages_filter_),
-    drop_ack_nack_messages_percentage_(descriptor.dropAckNackMessagesPercentage),
-    drop_ack_nack_messages_filter_(descriptor.drop_ack_nack_messages_filter_),
-    drop_gap_messages_percentage_(descriptor.dropGapMessagesPercentage),
-    drop_gap_messages_filter_(descriptor.drop_gap_messages_filter_),
-    percentage_of_messages_to_drop_(descriptor.percentageOfMessagesToDrop),
-    messages_filter_(descriptor.messages_filter_),
-    sequence_number_data_messages_to_drop_(descriptor.sequenceNumberDataMessagesToDrop)
+test_UDPv4Transport::test_UDPv4Transport(
+        const test_UDPv4TransportDescriptor& descriptor)
+    : drop_data_messages_percentage_(descriptor.dropDataMessagesPercentage)
+    , drop_data_messages_filter_(descriptor.drop_data_messages_filter_)
+    , drop_participant_builtin_topic_data_(descriptor.dropParticipantBuiltinTopicData)
+    , drop_publication_builtin_topic_data_(descriptor.dropPublicationBuiltinTopicData)
+    , drop_subscription_builtin_topic_data_(descriptor.dropSubscriptionBuiltinTopicData)
+    , drop_data_frag_messages_percentage_(descriptor.dropDataFragMessagesPercentage)
+    , drop_data_frag_messages_filter_(descriptor.drop_data_frag_messages_filter_)
+    , drop_heartbeat_messages_percentage_(descriptor.dropHeartbeatMessagesPercentage)
+    , drop_heartbeat_messages_filter_(descriptor.drop_heartbeat_messages_filter_)
+    , drop_ack_nack_messages_percentage_(descriptor.dropAckNackMessagesPercentage)
+    , drop_ack_nack_messages_filter_(descriptor.drop_ack_nack_messages_filter_)
+    , drop_gap_messages_percentage_(descriptor.dropGapMessagesPercentage)
+    , drop_gap_messages_filter_(descriptor.drop_gap_messages_filter_)
+    , percentage_of_messages_to_drop_(descriptor.percentageOfMessagesToDrop)
+    , messages_filter_(descriptor.messages_filter_)
+    , sequence_number_data_messages_to_drop_(descriptor.sequenceNumberDataMessagesToDrop)
+{
+    test_UDPv4Transport_DropLogLength = 0;
+    test_UDPv4Transport_ShutdownAllNetwork = false;
+    UDPv4Transport::mSendBufferSize = descriptor.sendBufferSize;
+    UDPv4Transport::mReceiveBufferSize = descriptor.receiveBufferSize;
+    for (auto interf : descriptor.interfaceWhiteList)
     {
-        test_UDPv4Transport_DropLogLength = 0;
-        test_UDPv4Transport_ShutdownAllNetwork = false;
-        UDPv4Transport::mSendBufferSize = descriptor.sendBufferSize;
-        UDPv4Transport::mReceiveBufferSize = descriptor.receiveBufferSize;
-        for (auto interf : descriptor.interfaceWhiteList)
-        {
-            UDPv4Transport::interface_whitelist_.emplace_back(asio::ip::address_v4::from_string(interf));
-        }
-        test_UDPv4Transport_DropLog.clear();
-        test_UDPv4Transport_DropLogLength = descriptor.dropLogLength;
+        UDPv4Transport::interface_whitelist_.emplace_back(asio::ip::address_v4::from_string(interf));
     }
+    test_UDPv4Transport_DropLog.clear();
+    test_UDPv4Transport_DropLogLength = descriptor.dropLogLength;
+}
 
-test_UDPv4TransportDescriptor::test_UDPv4TransportDescriptor():
-    SocketTransportDescriptor(s_maximumMessageSize, s_maximumInitialPeersRange),
-    dropDataMessagesPercentage(0),
-    drop_data_messages_filter_([](CDRMessage_t&){return false;}),
+test_UDPv4TransportDescriptor::test_UDPv4TransportDescriptor()
+    : SocketTransportDescriptor(s_maximumMessageSize, s_maximumInitialPeersRange)
+    , dropDataMessagesPercentage(0)
+    , drop_data_messages_filter_([](CDRMessage_t&)
+            {
+                return false;
+            }),
     dropParticipantBuiltinTopicData(false),
     dropPublicationBuiltinTopicData(false),
     dropSubscriptionBuiltinTopicData(false),
     dropDataFragMessagesPercentage(0),
-    drop_data_frag_messages_filter_([](CDRMessage_t&){return false;}),
+    drop_data_frag_messages_filter_([](CDRMessage_t&)
+            {
+                return false;
+            }),
     dropHeartbeatMessagesPercentage(0),
-    drop_heartbeat_messages_filter_([](CDRMessage_t&){return false;}),
+    drop_heartbeat_messages_filter_([](CDRMessage_t&)
+            {
+                return false;
+            }),
     dropAckNackMessagesPercentage(0),
-    drop_ack_nack_messages_filter_([](CDRMessage_t&){return false;}),
+    drop_ack_nack_messages_filter_([](CDRMessage_t&)
+            {
+                return false;
+            }),
     dropGapMessagesPercentage(0),
-    drop_gap_messages_filter_([](CDRMessage_t&){return false;}),
+    drop_gap_messages_filter_([](CDRMessage_t&)
+            {
+                return false;
+            }),
     percentageOfMessagesToDrop(0),
-    messages_filter_([](CDRMessage_t&){return false;}),
+    messages_filter_([](CDRMessage_t&)
+            {
+                return false;
+            }),
     sequenceNumberDataMessagesToDrop(),
     dropLogLength(0)
-    {
-    }
+{
+}
 
 TransportInterface* test_UDPv4TransportDescriptor::create_transport() const
 {
@@ -128,19 +147,19 @@ bool test_UDPv4Transport::send(
     fastrtps::rtps::LocatorsIterator& it = *destination_locators_begin;
 
     bool ret = true;
-    
+
     while (it != *destination_locators_end)
     {
         auto now = std::chrono::steady_clock::now();
 
-        if(now < max_blocking_time_point)
+        if (now < max_blocking_time_point)
         {
-            ret &= send(send_buffer, 
-                send_buffer_size, 
-                socket,
-                *it, 
-                only_multicast_purpose, 
-                std::chrono::duration_cast<std::chrono::microseconds>(now - max_blocking_time_point));
+            ret &= send(send_buffer,
+                            send_buffer_size,
+                            socket,
+                            *it,
+                            only_multicast_purpose,
+                            std::chrono::duration_cast<std::chrono::microseconds>(now - max_blocking_time_point));
 
             ++it;
         }
@@ -169,14 +188,19 @@ bool test_UDPv4Transport::send(
     }
     else
     {
-        return UDPv4Transport::send(send_buffer, send_buffer_size, socket, remote_locator, only_multicast_purpose, timeout);
+        return UDPv4Transport::send(send_buffer, send_buffer_size, socket, remote_locator, only_multicast_purpose,
+                       timeout);
     }
 }
 
-static bool ReadSubmessageHeader(CDRMessage_t& msg, SubmessageHeader_t& smh)
+static bool ReadSubmessageHeader(
+        CDRMessage_t& msg,
+        SubmessageHeader_t& smh)
 {
     if (msg.length - msg.pos < 4)
+    {
         return false;
+    }
 
     smh.submessageId = msg.buffer[msg.pos]; msg.pos++;
     smh.flags = msg.buffer[msg.pos]; msg.pos++;
@@ -189,7 +213,7 @@ static bool ReadSubmessageHeader(CDRMessage_t& msg, SubmessageHeader_t& smh)
         return false;
     }
 
-    if ( (length == 0) && (smh.submessageId != fastrtps::rtps::INFO_TS) && (smh.submessageId != fastrtps::rtps::PAD) )
+    if ((length == 0) && (smh.submessageId != fastrtps::rtps::INFO_TS) && (smh.submessageId != fastrtps::rtps::PAD))
     {
         // THIS IS THE LAST SUBMESSAGE
         smh.submessageLength = msg.length - msg.pos;
@@ -203,25 +227,31 @@ static bool ReadSubmessageHeader(CDRMessage_t& msg, SubmessageHeader_t& smh)
     return true;
 }
 
-bool test_UDPv4Transport::packet_should_drop(const octet* send_buffer, uint32_t send_buffer_size)
+bool test_UDPv4Transport::packet_should_drop(
+        const octet* send_buffer,
+        uint32_t send_buffer_size)
 {
-    if(test_UDPv4Transport_ShutdownAllNetwork)
+    if (test_UDPv4Transport_ShutdownAllNetwork)
     {
         return true;
     }
 
-    CDRMessage_t cdrMessage(send_buffer_size);;
+    CDRMessage_t cdrMessage(send_buffer_size);
     memcpy(cdrMessage.buffer, send_buffer, send_buffer_size);
     cdrMessage.length = send_buffer_size;
 
-    if(cdrMessage.length < RTPSMESSAGE_HEADER_SIZE)
+    if (cdrMessage.length < RTPSMESSAGE_HEADER_SIZE)
+    {
         return false;
+    }
 
-    if(cdrMessage.buffer[cdrMessage.pos++] != 'R' ||
+    if (cdrMessage.buffer[cdrMessage.pos++] != 'R' ||
             cdrMessage.buffer[cdrMessage.pos++] != 'T' ||
             cdrMessage.buffer[cdrMessage.pos++] != 'P' ||
             cdrMessage.buffer[cdrMessage.pos++] != 'S')
+    {
         return false;
+    }
 
     cdrMessage.pos += 4 + 12; // RTPS version + GUID
 
@@ -230,13 +260,15 @@ bool test_UDPv4Transport::packet_should_drop(const octet* send_buffer, uint32_t 
     {
         ReadSubmessageHeader(cdrMessage, cdrSubMessageHeader);
         if (cdrMessage.pos + cdrSubMessageHeader.submessageLength > cdrMessage.length)
+        {
             return false;
+        }
 
         SequenceNumber_t sequence_number{SequenceNumber_t::unknown()};
         EntityId_t writer_id;
         auto old_pos = cdrMessage.pos;
 
-        switch(cdrSubMessageHeader.submessageId)
+        switch (cdrSubMessageHeader.submessageId)
         {
             case fastrtps::rtps::DATA:
                 // Get WriterID.
@@ -246,35 +278,45 @@ bool test_UDPv4Transport::packet_should_drop(const octet* send_buffer, uint32_t 
                 fastrtps::rtps::CDRMessage::readUInt32(&cdrMessage, &sequence_number.low);
                 cdrMessage.pos = old_pos;
 
-                if(writer_id == fastrtps::rtps::c_EntityId_SPDPWriter)
+                if (writer_id == fastrtps::rtps::c_EntityId_SPDPWriter)
                 {
                     if (always_drop_participant_builtin_topic_data)
                     {
                         return true;
                     }
-                    else if(!drop_participant_builtin_topic_data_)
+                    else if (!drop_participant_builtin_topic_data_)
                     {
                         return false;
                     }
                 }
-                else if((!drop_publication_builtin_topic_data_ && writer_id == fastrtps::rtps::c_EntityId_SEDPPubWriter) ||
-                        (!drop_subscription_builtin_topic_data_ && writer_id == fastrtps::rtps::c_EntityId_SEDPSubWriter))
+                else if ((!drop_publication_builtin_topic_data_ &&
+                        writer_id == fastrtps::rtps::c_EntityId_SEDPPubWriter) ||
+                        (!drop_subscription_builtin_topic_data_ &&
+                        writer_id == fastrtps::rtps::c_EntityId_SEDPSubWriter))
                 {
                     return false;
                 }
 
-                if(should_be_dropped(&drop_data_messages_percentage_))
+                if (should_be_dropped(&drop_data_messages_percentage_))
+                {
                     return true;
-                if(drop_data_messages_filter_(cdrMessage))
+                }
+                if (drop_data_messages_filter_(cdrMessage))
+                {
                     return true;
+                }
 
                 break;
 
             case fastrtps::rtps::ACKNACK:
-                if(should_be_dropped(&drop_ack_nack_messages_percentage_))
+                if (should_be_dropped(&drop_ack_nack_messages_percentage_))
+                {
                     return true;
-                if(drop_ack_nack_messages_filter_(cdrMessage))
+                }
+                if (drop_ack_nack_messages_filter_(cdrMessage))
+                {
                     return true;
+                }
 
                 break;
 
@@ -283,18 +325,26 @@ bool test_UDPv4Transport::packet_should_drop(const octet* send_buffer, uint32_t 
                 fastrtps::rtps::CDRMessage::readInt32(&cdrMessage, &sequence_number.high);
                 fastrtps::rtps::CDRMessage::readUInt32(&cdrMessage, &sequence_number.low);
                 cdrMessage.pos = old_pos;
-                if(should_be_dropped(&drop_heartbeat_messages_percentage_))
+                if (should_be_dropped(&drop_heartbeat_messages_percentage_))
+                {
                     return true;
-                if(drop_heartbeat_messages_filter_(cdrMessage))
+                }
+                if (drop_heartbeat_messages_filter_(cdrMessage))
+                {
                     return true;
+                }
 
                 break;
 
             case fastrtps::rtps::DATA_FRAG:
-                if(should_be_dropped(&drop_data_frag_messages_percentage_))
+                if (should_be_dropped(&drop_data_frag_messages_percentage_))
+                {
                     return true;
-                if(drop_data_frag_messages_filter_(cdrMessage))
+                }
+                if (drop_data_frag_messages_filter_(cdrMessage))
+                {
                     return true;
+                }
 
                 break;
 
@@ -303,32 +353,44 @@ bool test_UDPv4Transport::packet_should_drop(const octet* send_buffer, uint32_t 
                 fastrtps::rtps::CDRMessage::readInt32(&cdrMessage, &sequence_number.high);
                 fastrtps::rtps::CDRMessage::readUInt32(&cdrMessage, &sequence_number.low);
                 cdrMessage.pos = old_pos;
-                if(should_be_dropped(&drop_gap_messages_percentage_))
+                if (should_be_dropped(&drop_gap_messages_percentage_))
+                {
                     return true;
-                if(drop_gap_messages_filter_(cdrMessage))
+                }
+                if (drop_gap_messages_filter_(cdrMessage))
+                {
                     return true;
+                }
 
                 break;
         }
 
-        if(sequence_number != SequenceNumber_t::unknown() &&
+        if (sequence_number != SequenceNumber_t::unknown() &&
                 find(sequence_number_data_messages_to_drop_.begin(),
-                    sequence_number_data_messages_to_drop_.end(),
-                    sequence_number) != sequence_number_data_messages_to_drop_.end())
+                sequence_number_data_messages_to_drop_.end(),
+                sequence_number) != sequence_number_data_messages_to_drop_.end())
+        {
             return true;
+        }
 
         cdrMessage.pos += cdrSubMessageHeader.submessageLength;
     }
 
-    if(should_be_dropped(&percentage_of_messages_to_drop_))
+    if (should_be_dropped(&percentage_of_messages_to_drop_))
+    {
         return true;
-    if(messages_filter_(cdrMessage))
+    }
+    if (messages_filter_(cdrMessage))
+    {
         return true;
+    }
 
     return false;
 }
 
-bool test_UDPv4Transport::log_drop(const octet* buffer, uint32_t size)
+bool test_UDPv4Transport::log_drop(
+        const octet* buffer,
+        uint32_t size)
 {
     if (test_UDPv4Transport_DropLog.size() < test_UDPv4Transport_DropLogLength)
     {
@@ -341,7 +403,8 @@ bool test_UDPv4Transport::log_drop(const octet* buffer, uint32_t size)
     return false;
 }
 
-bool test_UDPv4Transport::should_be_dropped(PercentageData* percent)
+bool test_UDPv4Transport::should_be_dropped(
+        PercentageData* percent)
 {
     percent->accumulator += percent->percentage;
     if (percent->accumulator >= 100u)

--- a/src/cpp/rtps/transport/test_UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.cpp
@@ -34,6 +34,7 @@ std::vector<std::vector<octet> > test_UDPv4Transport::test_UDPv4Transport_DropLo
 uint32_t test_UDPv4Transport::test_UDPv4Transport_DropLogLength = 0;
 bool test_UDPv4Transport::test_UDPv4Transport_ShutdownAllNetwork = false;
 bool test_UDPv4Transport::always_drop_participant_builtin_topic_data = false;
+bool test_UDPv4Transport::simulate_no_interfaces = false;
 
 test_UDPv4Transport::test_UDPv4Transport(const test_UDPv4TransportDescriptor& descriptor):
     drop_data_messages_percentage_(descriptor.dropDataMessagesPercentage),
@@ -90,6 +91,29 @@ test_UDPv4TransportDescriptor::test_UDPv4TransportDescriptor():
 TransportInterface* test_UDPv4TransportDescriptor::create_transport() const
 {
     return new test_UDPv4Transport(*this);
+}
+
+void test_UDPv4Transport::get_ips(
+        std::vector<fastrtps::rtps::IPFinder::info_IP>& locNames,
+        bool return_loopback)
+{
+
+    if (!simulate_no_interfaces)
+    {
+        UDPv4Transport::get_ips(locNames, return_loopback);
+        return;
+    }
+
+    if (return_loopback)
+    {
+        fastrtps::rtps::IPFinder::info_IP local;
+        local.type = fastrtps::rtps::IPFinder::IPTYPE::IP4_LOCAL;
+        local.dev = "lo";
+        local.name = "127.0.0.1";
+        local.locator.kind = LOCATOR_KIND_UDPv4;
+        fill_local_ip(local.locator);
+        locNames.emplace_back(local);
+    }
 }
 
 bool test_UDPv4Transport::send(

--- a/test/blackbox/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/BlackboxTestsDiscovery.cpp
@@ -576,11 +576,13 @@ TEST_P(Discovery, PubSubAsReliableHelloworldUserData)
 }
 
 //! Auxiliar method for discovering participants tests
+template <typename ParticipantConfigurator>
 static void discoverParticipantsTest(
         bool avoid_multicast,
         size_t n_participants,
         uint32_t wait_ms,
-        const std::string& topic_name)
+        const std::string& topic_name,
+        ParticipantConfigurator participant_configurator)
 {
     std::vector<std::shared_ptr<PubSubWriterReader<HelloWorldType> > > pubsub;
     pubsub.reserve(n_participants);
@@ -596,6 +598,7 @@ static void discoverParticipantsTest(
     for (auto& ps : pubsub)
     {
         std::cout << "\rParticipant " << idx++ << " of " << n_participants << std::flush;
+        participant_configurator(ps);
         ps->init(avoid_multicast);
         ASSERT_EQ(ps->isInitialized(), true);
     }
@@ -632,6 +635,16 @@ static void discoverParticipantsTest(
     {
         ps->destroy();
     }
+}
+
+static void discoverParticipantsTest(
+        bool avoid_multicast,
+        size_t n_participants,
+        uint32_t wait_ms,
+        const std::string& topic_name)
+{
+    auto no_op = [](const std::shared_ptr<PubSubWriterReader<HelloWorldType> >&) {};
+    discoverParticipantsTest(avoid_multicast, n_participants, wait_ms, topic_name, no_op);
 }
 
 //! Tests discovery of 20 participants, having one publisher and one subscriber each, using multicast

--- a/test/blackbox/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/BlackboxTestsDiscovery.cpp
@@ -151,10 +151,11 @@ TEST(Discovery, StaticDiscovery)
     WriterMulticastLocators.push_back(LocatorBuffer);
 
     writer.history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
-    durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS);
+            durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS);
     writer.static_discovery("PubSubWriter.xml").reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-    unicastLocatorList(WriterUnicastLocators).multicastLocatorList(WriterMulticastLocators).
-    setPublisherIDs(1, 2).setManualTopicName(std::string("BlackBox_StaticDiscovery_") + TOPIC_RANDOM_NUMBER).init();
+            unicastLocatorList(WriterUnicastLocators).multicastLocatorList(WriterMulticastLocators).
+            setPublisherIDs(1,
+            2).setManualTopicName(std::string("BlackBox_StaticDiscovery_") + TOPIC_RANDOM_NUMBER).init();
 
 
     ASSERT_TRUE(writer.isInitialized());
@@ -173,11 +174,12 @@ TEST(Discovery, StaticDiscovery)
 
 
     reader.reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-    history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
-    durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS);
+            history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
+            durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS);
     reader.static_discovery("PubSubReader.xml").
-    unicastLocatorList(ReaderUnicastLocators).multicastLocatorList(ReaderMulticastLocators).
-    setSubscriberIDs(3, 4).setManualTopicName(std::string("BlackBox_StaticDiscovery_") + TOPIC_RANDOM_NUMBER).init();
+            unicastLocatorList(ReaderUnicastLocators).multicastLocatorList(ReaderMulticastLocators).
+            setSubscriberIDs(3,
+            4).setManualTopicName(std::string("BlackBox_StaticDiscovery_") + TOPIC_RANDOM_NUMBER).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -319,12 +321,13 @@ TEST(Discovery, ParticipantLivelinessAssertion)
     auto test_transport = std::make_shared<test_UDPv4TransportDescriptor>();
 
     reader.disable_builtin_transport().add_user_transport_to_pparams(test_transport).
-    lease_duration({ 0, 800000000 }, { 0, 500000000 }).reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
+            lease_duration({ 0, 800000000 },
+            { 0, 500000000 }).reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
     writer.disable_builtin_transport().add_user_transport_to_pparams(test_transport).
-    lease_duration({ 0, 800000000 }, { 0, 500000000 }).init();
+            lease_duration({ 0, 800000000 }, { 0, 500000000 }).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -404,8 +407,8 @@ TEST(Discovery, LocalInitialPeers)
     reader_default_unicast_locator.push_back(loc_default_unicast);
 
     reader.metatraffic_unicast_locator_list(reader_default_unicast_locator).
-    initial_peers(reader_initial_peers).
-    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
+            initial_peers(reader_initial_peers).
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -417,7 +420,7 @@ TEST(Discovery, LocalInitialPeers)
     writer_default_unicast_locator.push_back(loc_default_unicast);
 
     writer.metatraffic_unicast_locator_list(writer_default_unicast_locator).
-    initial_peers(writer_initial_peers).init();
+            initial_peers(writer_initial_peers).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -445,13 +448,13 @@ TEST_P(Discovery, PubSubAsReliableHelloworldPartitions)
     PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
 
     reader.history_depth(10).
-    partition("PartitionTests").
-    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
+            partition("PartitionTests").
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
     writer.history_depth(10).
-    partition("PartitionTe*").init();
+            partition("PartitionTe*").init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -524,7 +527,7 @@ TEST_P(Discovery, PubSubAsReliableHelloworldParticipantDiscovery)
             });
 
     reader.history_depth(100).
-    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -544,7 +547,7 @@ TEST_P(Discovery, PubSubAsReliableHelloworldUserData)
     PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
 
     writer.history_depth(100).
-    userData({'a', 'b', 'c', 'd'}).init();
+            userData({'a', 'b', 'c', 'd'}).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -564,7 +567,7 @@ TEST_P(Discovery, PubSubAsReliableHelloworldUserData)
             });
 
     reader.history_depth(100).
-    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -584,12 +587,12 @@ static void discoverParticipantsTest(
         const std::string& topic_name,
         ParticipantConfigurator participant_configurator)
 {
-    std::vector<std::shared_ptr<PubSubWriterReader<HelloWorldType> > > pubsub;
+    std::vector<std::shared_ptr<PubSubWriterReader<HelloWorldType>>> pubsub;
     pubsub.reserve(n_participants);
 
     for (size_t i = 0; i < n_participants; ++i)
     {
-        pubsub.emplace_back(std::make_shared<PubSubWriterReader<HelloWorldType> >(topic_name));
+        pubsub.emplace_back(std::make_shared<PubSubWriterReader<HelloWorldType>>(topic_name));
     }
 
     // Initialization of all the participants
@@ -643,7 +646,9 @@ static void discoverParticipantsTest(
         uint32_t wait_ms,
         const std::string& topic_name)
 {
-    auto no_op = [](const std::shared_ptr<PubSubWriterReader<HelloWorldType> >&) {};
+    auto no_op = [](const std::shared_ptr<PubSubWriterReader<HelloWorldType>>&)
+            {
+            };
     discoverParticipantsTest(avoid_multicast, n_participants, wait_ms, topic_name, no_op);
 }
 
@@ -657,10 +662,10 @@ TEST(Discovery, TwentyParticipantsMulticast)
 TEST(Discovery, TwentyParticipantsMulticastLocalhostOnly)
 {
     auto test_transport = std::make_shared<test_UDPv4TransportDescriptor>();
-    auto participant_config = [&test_transport](const std::shared_ptr<PubSubWriterReader<HelloWorldType> >& part)
-    {
-        part->disable_builtin_transport().add_user_transport_to_pparams(test_transport);
-    };
+    auto participant_config = [&test_transport](const std::shared_ptr<PubSubWriterReader<HelloWorldType>>& part)
+            {
+                part->disable_builtin_transport().add_user_transport_to_pparams(test_transport);
+            };
 
     test_UDPv4Transport::simulate_no_interfaces = true;
     discoverParticipantsTest(false, 20, 20, TEST_TOPIC_NAME, participant_config);
@@ -683,12 +688,12 @@ static void discoverParticipantsSeveralEndpointsTest(
     // Total number of discovered endpoints
     size_t n_total_endpoints = n_participants * n_topics;
 
-    std::vector<std::shared_ptr<PubSubWriterReader<HelloWorldType> > > pubsub;
+    std::vector<std::shared_ptr<PubSubWriterReader<HelloWorldType>>> pubsub;
     pubsub.reserve(n_participants);
 
     for (unsigned int i = 0; i < n_participants; i++)
     {
-        pubsub.emplace_back(std::make_shared<PubSubWriterReader<HelloWorldType> >(topic_name));
+        pubsub.emplace_back(std::make_shared<PubSubWriterReader<HelloWorldType>>(topic_name));
     }
 
     // Initialization of all the participants
@@ -756,18 +761,18 @@ TEST_P(Discovery, RepeatPubGuid)
     PubSubWriter<HelloWorldType> writer2(TEST_TOPIC_NAME);
 
     reader
-    .history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS)
-    .history_depth(10)
-    .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
-    .participant_id(2)
-    .init();
+            .history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS)
+            .history_depth(10)
+            .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+            .participant_id(2)
+            .init();
 
     writer
-    .history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS)
-    .history_depth(10)
-    .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
-    .participant_id(1)
-    .init();
+            .history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS)
+            .history_depth(10)
+            .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+            .participant_id(1)
+            .init();
 
     ASSERT_TRUE(reader.isInitialized());
     ASSERT_TRUE(writer.isInitialized());
@@ -791,11 +796,11 @@ TEST_P(Discovery, RepeatPubGuid)
     reader.wait_participant_undiscovery();
 
     writer2
-    .history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS)
-    .history_depth(10)
-    .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
-    .participant_id(1)
-    .init();
+            .history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS)
+            .history_depth(10)
+            .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+            .participant_id(1)
+            .init();
 
     ASSERT_TRUE(writer2.isInitialized());
 

--- a/test/blackbox/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/BlackboxTestsDiscovery.cpp
@@ -653,6 +653,19 @@ TEST(Discovery, TwentyParticipantsMulticast)
     discoverParticipantsTest(false, 20, 20, TEST_TOPIC_NAME);
 }
 
+//! Regresion test for ros2/ros2#1052
+TEST(Discovery, TwentyParticipantsMulticastLocalhostOnly)
+{
+    auto test_transport = std::make_shared<test_UDPv4TransportDescriptor>();
+    auto participant_config = [&test_transport](const std::shared_ptr<PubSubWriterReader<HelloWorldType> >& part)
+    {
+        part->disable_builtin_transport().add_user_transport_to_pparams(test_transport);
+    };
+
+    test_UDPv4Transport::simulate_no_interfaces = true;
+    discoverParticipantsTest(false, 20, 20, TEST_TOPIC_NAME, participant_config);
+}
+
 //! Tests discovery of 20 participants, having one publisher and one subscriber each, using unicast
 TEST_P(Discovery, TwentyParticipantsUnicast)
 {

--- a/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
@@ -34,6 +34,7 @@
 #include <fastdds/dds/subscriber/DataReaderListener.hpp>
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 #include <fastdds/dds/subscriber/SampleInfo.hpp>
+#include <fastrtps/transport/TransportDescriptorInterface.h>
 
 #include <string>
 #include <list>
@@ -620,6 +621,19 @@ public:
     }
 
 #endif
+
+    PubSubWriterReader& disable_builtin_transport()
+    {
+        participant_qos_.transport().use_builtin_transports = false;
+        return *this;
+    }
+
+    PubSubWriterReader& add_user_transport_to_pparams(
+            std::shared_ptr<eprosima::fastrtps::rtps::TransportDescriptorInterface> userTransportDescriptor)
+    {
+        participant_qos_.transport().user_transports.push_back(userTransportDescriptor);
+        return *this;
+    }
 
     PubSubWriterReader& property_policy(
             const eprosima::fastrtps::rtps::PropertyPolicy property_policy)

--- a/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
@@ -52,7 +52,7 @@ class PubSubWriterReader
 {
     class ParticipantListener : public eprosima::fastdds::dds::DomainParticipantListener
     {
-public:
+    public:
 
         ParticipantListener(
                 PubSubWriterReader& wreader)
@@ -79,7 +79,7 @@ public:
             }
         }
 
-#endif
+#endif // if HAVE_SECURITY
         void on_participant_discovery(
                 eprosima::fastdds::dds::DomainParticipant* participant,
                 eprosima::fastrtps::rtps::ParticipantDiscoveryInfo&& info) override
@@ -166,7 +166,7 @@ public:
             return discovered_subscribers_.size();
         }
 
-private:
+    private:
 
         //! Mutex guarding all info collections
         mutable std::mutex info_mutex_;
@@ -199,11 +199,12 @@ private:
         //! Pointer to the pub sub writer reader
         PubSubWriterReader& wreader_;
 
-    } participant_listener_;
+    }
+    participant_listener_;
 
     class PubListener : public eprosima::fastdds::dds::DataWriterListener
     {
-public:
+    public:
 
         PubListener(
                 PubSubWriterReader& wreader)
@@ -229,18 +230,19 @@ public:
             }
         }
 
-private:
+    private:
 
         PubListener& operator =(
                 const PubListener&) = delete;
 
         PubSubWriterReader& wreader_;
 
-    } pub_listener_;
+    }
+    pub_listener_;
 
     class SubListener : public eprosima::fastdds::dds::DataReaderListener
     {
-public:
+    public:
 
         SubListener(
                 PubSubWriterReader& wreader)
@@ -281,13 +283,14 @@ public:
             }
         }
 
-private:
+    private:
 
         SubListener& operator =(
                 const SubListener&) = delete;
 
         PubSubWriterReader& wreader_;
-    } sub_listener_;
+    }
+    sub_listener_;
 
     friend class PubListener;
     friend class SubListener;
@@ -315,7 +318,7 @@ public:
 #if HAVE_SECURITY
         , authorized_(0)
         , unauthorized_(0)
-#endif
+#endif // if HAVE_SECURITY
     {
         // Generate topic name
         std::ostringstream t;
@@ -545,9 +548,10 @@ public:
 
     void block_for_all()
     {
-        block([this]() -> bool {
-            return number_samples_expected_ == current_received_count_;
-        });
+        block([this]() -> bool
+                {
+                    return number_samples_expected_ == current_received_count_;
+                });
     }
 
     void block(
@@ -620,7 +624,7 @@ public:
         std::cout << "WReader unauthorization finished..." << std::endl;
     }
 
-#endif
+#endif // if HAVE_SECURITY
 
     PubSubWriterReader& disable_builtin_transport()
     {
@@ -764,7 +768,7 @@ private:
         cvAuthentication_.notify_all();
     }
 
-#endif
+#endif // if HAVE_SECURITY
 
     PubSubWriterReader& operator =(
             const PubSubWriterReader&) = delete;
@@ -783,7 +787,7 @@ private:
                 eprosima::fastdds::dds::Topic*,
                 eprosima::fastdds::dds::DataWriter*,
                 eprosima::fastdds::dds::DataReader*
-                > > entities_extra_;
+                >> entities_extra_;
 
     std::string topic_name_;
     bool initialized_;
@@ -804,7 +808,7 @@ private:
     std::condition_variable cvAuthentication_;
     unsigned int authorized_;
     unsigned int unauthorized_;
-#endif
+#endif // if HAVE_SECURITY
 };
 
 #endif // _TEST_BLACKBOX_PUBSUBWRITER_HPP_

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriterReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriterReader.hpp
@@ -46,7 +46,7 @@ class PubSubWriterReader
 {
     class ParticipantListener : public eprosima::fastrtps::ParticipantListener
     {
-public:
+    public:
 
         ParticipantListener(
                 PubSubWriterReader& wreader)
@@ -73,7 +73,7 @@ public:
             }
         }
 
-#endif
+#endif // if HAVE_SECURITY
         void onParticipantDiscovery(
                 eprosima::fastrtps::Participant* participant,
                 eprosima::fastrtps::rtps::ParticipantDiscoveryInfo&& info) override
@@ -160,7 +160,7 @@ public:
             return discovered_subscribers_.size();
         }
 
-private:
+    private:
 
         //! Mutex guarding all info collections
         mutable std::mutex info_mutex_;
@@ -193,11 +193,12 @@ private:
         //! Pointer to the pub sub writer reader
         PubSubWriterReader& wreader_;
 
-    } participant_listener_;
+    }
+    participant_listener_;
 
     class PubListener : public eprosima::fastrtps::PublisherListener
     {
-public:
+    public:
 
         PubListener(
                 PubSubWriterReader& wreader)
@@ -223,18 +224,19 @@ public:
             }
         }
 
-private:
+    private:
 
         PubListener& operator =(
                 const PubListener&) = delete;
 
         PubSubWriterReader& wreader_;
 
-    } pub_listener_;
+    }
+    pub_listener_;
 
     class SubListener : public eprosima::fastrtps::SubscriberListener
     {
-public:
+    public:
 
         SubListener(
                 PubSubWriterReader& wreader)
@@ -275,13 +277,14 @@ public:
             }
         }
 
-private:
+    private:
 
         SubListener& operator =(
                 const SubListener&) = delete;
 
         PubSubWriterReader& wreader_;
-    } sub_listener_;
+    }
+    sub_listener_;
 
     friend class PubListener;
     friend class SubListener;
@@ -306,7 +309,7 @@ public:
 #if HAVE_SECURITY
         , authorized_(0)
         , unauthorized_(0)
-#endif
+#endif // if HAVE_SECURITY
     {
         publisher_attr_.topic.topicDataType = type_.getName();
         subscriber_attr_.topic.topicDataType = type_.getName();
@@ -482,9 +485,10 @@ public:
 
     void block_for_all()
     {
-        block([this]() -> bool {
-            return number_samples_expected_ == current_received_count_;
-        });
+        block([this]() -> bool
+                {
+                    return number_samples_expected_ == current_received_count_;
+                });
     }
 
     void block(
@@ -557,7 +561,7 @@ public:
         std::cout << "WReader unauthorization finished..." << std::endl;
     }
 
-#endif
+#endif // if HAVE_SECURITY
 
     PubSubWriterReader& disable_builtin_transport()
     {
@@ -701,7 +705,7 @@ private:
         cvAuthentication_.notify_all();
     }
 
-#endif
+#endif // if HAVE_SECURITY
 
     PubSubWriterReader& operator =(
             const PubSubWriterReader&) = delete;
@@ -734,7 +738,7 @@ private:
     std::condition_variable cvAuthentication_;
     unsigned int authorized_;
     unsigned int unauthorized_;
-#endif
+#endif // if HAVE_SECURITY
 };
 
 #endif // _TEST_BLACKBOX_PUBSUBWRITER_HPP_

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriterReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriterReader.hpp
@@ -32,6 +32,7 @@
 #include <fastrtps/subscriber/SubscriberListener.h>
 #include <fastrtps/attributes/SubscriberAttributes.h>
 #include <fastrtps/subscriber/SampleInfo.h>
+#include <fastrtps/transport/TransportDescriptorInterface.h>
 
 #include <string>
 #include <list>
@@ -557,6 +558,19 @@ public:
     }
 
 #endif
+
+    PubSubWriterReader& disable_builtin_transport()
+    {
+        participant_attr_.rtps.useBuiltinTransports = false;
+        return *this;
+    }
+
+    PubSubWriterReader& add_user_transport_to_pparams(
+            std::shared_ptr<eprosima::fastrtps::rtps::TransportDescriptorInterface> userTransportDescriptor)
+    {
+        participant_attr_.rtps.userTransports.push_back(userTransportDescriptor);
+        return *this;
+    }
 
     PubSubWriterReader& property_policy(
             const eprosima::fastrtps::rtps::PropertyPolicy property_policy)


### PR DESCRIPTION
This should fix the issue reported on ros2/ros2#1052

Multicast was not correctly being sent through localhost interface when no network interface was detected. This PR changes the mechanism from adding a localhost initial peer to binding the outbound socket to the local interface.