### PR TITLE
Force size greater than 0 when getting payloads [9799]

### DIFF
--- a/include/fastdds/rtps/history/IPayloadPool.h
+++ b/include/fastdds/rtps/history/IPayloadPool.h
@@ -48,7 +48,8 @@ public:
      *
      * In both cases, the received @c size will be for the whole serialized payload.
      *
-     * @param [in]     size          Number of bytes required for the serialized payload
+     * @param [in]     size          Number of bytes required for the serialized payload.
+     *                               Should be greater than 0.
      * @param [in,out] cache_change  Cache change to assign the payload to
      *
      * @returns whether the operation succeeded or not

--- a/src/cpp/rtps/history/BasicPayloadPool.hpp
+++ b/src/cpp/rtps/history/BasicPayloadPool.hpp
@@ -79,6 +79,11 @@ private:
     static std::shared_ptr<IPayloadPool> get(
             const BasicPoolConfig& config)
     {
+        if (config.payload_initial_size == 0)
+        {
+            return nullptr;
+        }
+
         switch (config.memory_policy)
         {
             case PREALLOCATED_MEMORY_MODE:

--- a/src/cpp/rtps/history/BasicPayloadPool_impl/Preallocated.hpp
+++ b/src/cpp/rtps/history/BasicPayloadPool_impl/Preallocated.hpp
@@ -25,6 +25,7 @@ public:
             uint32_t payload_size)
         : payload_size_(payload_size)
     {
+        assert(payload_size_ > 0);
     }
 
     bool get_payload(

--- a/src/cpp/rtps/history/BasicPayloadPool_impl/PreallocatedWithRealloc.hpp
+++ b/src/cpp/rtps/history/BasicPayloadPool_impl/PreallocatedWithRealloc.hpp
@@ -25,6 +25,7 @@ public:
             uint32_t payload_size)
         : min_payload_size_(payload_size)
     {
+        assert(min_payload_size_ > 0);
     }
 
     bool get_payload(

--- a/src/cpp/rtps/history/TopicPayloadPool.cpp
+++ b/src/cpp/rtps/history/TopicPayloadPool.cpp
@@ -280,6 +280,11 @@ bool TopicPayloadPool::shrink (
 std::unique_ptr<ITopicPayloadPool> TopicPayloadPool::get(
         const BasicPoolConfig& config)
 {
+    if (config.payload_initial_size == 0u)
+    {
+        return nullptr;
+    }
+
     ITopicPayloadPool* ret_val = nullptr;
 
     switch (config.memory_policy)

--- a/src/cpp/rtps/history/TopicPayloadPool.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPool.hpp
@@ -139,6 +139,8 @@ protected:
         explicit PayloadNode(
                 uint32_t size)
         {
+            assert(size > 0);
+
             buffer = (octet*)calloc(size + offsetof(NodeInfo, data), sizeof(octet));
             if (buffer == nullptr)
             {

--- a/src/cpp/rtps/history/TopicPayloadPool_impl/Dynamic.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPool_impl/Dynamic.hpp
@@ -29,7 +29,14 @@ class DynamicTopicPayloadPool : public TopicPayloadPool
 {
 public:
 
-    virtual bool release_payload(
+    bool get_payload(
+            uint32_t size,
+            CacheChange_t& cache_change) override
+    {
+        return (size > 0u) && do_get_payload(size, cache_change, true);
+    }
+
+    bool release_payload(
             CacheChange_t& cache_change) override
     {
         assert(cache_change.payload_owner() == this);

--- a/src/cpp/rtps/history/TopicPayloadPool_impl/DynamicReusable.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPool_impl/DynamicReusable.hpp
@@ -31,7 +31,7 @@ class DynamicReusableTopicPayloadPool : public TopicPayloadPool
             uint32_t size,
             CacheChange_t& cache_change) override
     {
-        return do_get_payload(size, cache_change, true);
+        return (size > 0u) && do_get_payload(size, cache_change, true);
     }
 
 protected:

--- a/src/cpp/rtps/history/TopicPayloadPool_impl/Preallocated.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPool_impl/Preallocated.hpp
@@ -34,6 +34,7 @@ public:
         : payload_size_(payload_size)
         , minimum_pool_size_(0)
     {
+        assert(payload_size_ > 0);
     }
 
     bool get_payload(

--- a/src/cpp/rtps/history/TopicPayloadPool_impl/PreallocatedWithRealloc.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPool_impl/PreallocatedWithRealloc.hpp
@@ -34,6 +34,7 @@ public:
         : min_payload_size_(payload_size)
         , minimum_pool_size_(0)
     {
+        assert(min_payload_size_ > 0);
     }
 
     bool get_payload(

--- a/test/unittest/rtps/history/TopicPayloadPoolTests.cpp
+++ b/test/unittest/rtps/history/TopicPayloadPoolTests.cpp
@@ -150,7 +150,7 @@ protected:
         //Reserve to the expected maximum
         for (uint32_t i = 0; i < num_reserves; i++)
         {
-            uint32_t data_size = i * 16;
+            uint32_t data_size = i * 16 + 1u;
             CacheChange_t* ch = new CacheChange_t();
             cache_changes.push_back(ch);
 


### PR DESCRIPTION
Valgrind detected [errors](http://jenkins.eprosima.com:8080/view/Nightly%20Fast%20DDS/job/nightly_fastdds_sec_master_linux/483/valgrindResult/pid=38327,0x0/) on the unit tests for TopicPayloadPool.

It was found that the constructor of `PayloadNode` was accessing the `data[1]` field. In the case where a payload of size 0 is requested, that part of the memory has not been allocated