### PR TITLE
Fixed TopicPayloadPoolRegistryTests [9801]

### DIFF
--- a/src/cpp/rtps/history/TopicPayloadPoolRegistry.cpp
+++ b/src/cpp/rtps/history/TopicPayloadPoolRegistry.cpp
@@ -20,9 +20,9 @@
 
 #include <rtps/history/TopicPayloadPool.hpp>
 
-#include "./TopicPayloadPoolRegistry_impl/TopicPayloadPoolProxy.hpp"
-#include "./TopicPayloadPoolRegistry_impl/TopicPayloadPoolRegistryEntry.hpp"
-#include "./TopicPayloadPoolRegistry_impl/TopicPayloadPoolRegistry.hpp"
+#include <rtps/history/TopicPayloadPoolRegistry_impl/TopicPayloadPoolProxy.hpp>
+#include <rtps/history/TopicPayloadPoolRegistry_impl/TopicPayloadPoolRegistryEntry.hpp>
+#include <rtps/history/TopicPayloadPoolRegistry_impl/TopicPayloadPoolRegistry.hpp>
 
 namespace eprosima {
 namespace fastrtps {

--- a/test/mock/rtps/TopicPayloadPoolProxy/rtps/history/TopicPayloadPoolRegistry_impl/TopicPayloadPoolProxy.hpp
+++ b/test/mock/rtps/TopicPayloadPoolProxy/rtps/history/TopicPayloadPoolRegistry_impl/TopicPayloadPoolProxy.hpp
@@ -74,7 +74,7 @@ public:
     {
         DestructorHelper::instance().increment();
     }
-        
+
     const std::string& topic_name() const
     {
         return topic_name_;

--- a/test/mock/rtps/TopicPayloadPoolProxy/rtps/history/TopicPayloadPoolRegistry_impl/TopicPayloadPoolProxy.hpp
+++ b/test/mock/rtps/TopicPayloadPoolProxy/rtps/history/TopicPayloadPoolRegistry_impl/TopicPayloadPoolProxy.hpp
@@ -1,0 +1,146 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file TopicPayloadPoolProxy.hpp
+ */
+
+#ifndef RTPS_HISTORY_TOPICPAYLOADPOOLREGISTRY_IMPL_TOPICPAYLOADPOOLPROXY_HPP
+#define RTPS_HISTORY_TOPICPAYLOADPOOLREGISTRY_IMPL_TOPICPAYLOADPOOLPROXY_HPP
+
+#include <rtps/history/TopicPayloadPool.hpp>
+
+#include <memory>
+#include <string>
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+namespace detail {
+
+/**
+ * Proxy class that adds the topic name to a ITopicPayloadPool, so we can look-up
+ * the corresponding entry in the registry when releasing the pool.
+ */
+class TopicPayloadPoolProxy : public ITopicPayloadPool
+{
+
+public:
+
+    struct DestructorHelper
+    {
+        static DestructorHelper& instance()
+        {
+            static DestructorHelper singleton;
+            return singleton;
+        }
+
+        void increment()
+        {
+            ++num_objects_destroyed;
+        }
+
+        size_t get()
+        {
+            return num_objects_destroyed;
+        }
+
+    private:
+
+        size_t num_objects_destroyed = 0u;
+    };
+
+    TopicPayloadPoolProxy(
+            const std::string& topic_name,
+            const BasicPoolConfig& config)
+        : topic_name_(topic_name)
+        , policy_(config.memory_policy)
+        , inner_pool_(TopicPayloadPool::get(config))
+    {
+    }
+
+    ~TopicPayloadPoolProxy()
+    {
+        DestructorHelper::instance().increment();
+    }
+        
+    const std::string& topic_name() const
+    {
+        return topic_name_;
+    }
+
+    MemoryManagementPolicy_t memory_policy() const
+    {
+        return policy_;
+    }
+
+    bool get_payload(
+            uint32_t size,
+            CacheChange_t& cache_change) override
+    {
+        return inner_pool_->get_payload(size, cache_change);
+    }
+
+    bool get_payload(
+            SerializedPayload_t& data,
+            IPayloadPool*& data_owner,
+            CacheChange_t& cache_change) override
+    {
+        return inner_pool_->get_payload(data, data_owner, cache_change);
+    }
+
+    bool release_payload(
+            CacheChange_t& cache_change) override
+    {
+        return inner_pool_->release_payload(cache_change);
+    }
+
+    bool reserve_history(
+            const PoolConfig& config,
+            bool is_reader) override
+    {
+        return inner_pool_->reserve_history(config, is_reader);
+    }
+
+    bool release_history(
+            const PoolConfig& config,
+            bool is_reader) override
+    {
+        return inner_pool_->release_history(config, is_reader);
+    }
+
+    size_t payload_pool_allocated_size() const override
+    {
+        return inner_pool_->payload_pool_allocated_size();
+    }
+
+    size_t payload_pool_available_size() const override
+    {
+        return inner_pool_->payload_pool_available_size();
+    }
+
+private:
+
+    std::string topic_name_;
+    MemoryManagementPolicy_t policy_;
+    std::unique_ptr<ITopicPayloadPool> inner_pool_;
+
+};
+
+}  // namespace detail
+}  // namespace rtps
+}  // namespace fastrtps
+}  // namespace eprosima
+
+#endif  // RTPS_HISTORY_TOPICPAYLOADPOOLREGISTRY_IMPL_TOPICPAYLOADPOOLPROXY_HPP

--- a/test/unittest/rtps/history/CMakeLists.txt
+++ b/test/unittest/rtps/history/CMakeLists.txt
@@ -100,6 +100,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         target_compile_definitions(TopicPayloadPoolTests PRIVATE FASTRTPS_NO_LIB)
         target_include_directories(TopicPayloadPoolTests PRIVATE
             ${GTEST_INCLUDE_DIRS}
+            ${PROJECT_SOURCE_DIR}/test/mock/rtps/TopicPayloadPoolProxy
             ${PROJECT_SOURCE_DIR}/src/cpp
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
         target_link_libraries(TopicPayloadPoolTests

--- a/test/unittest/rtps/history/TopicPayloadPoolRegistryTests.cpp
+++ b/test/unittest/rtps/history/TopicPayloadPoolRegistryTests.cpp
@@ -75,12 +75,12 @@ TEST(TopicPayloadPoolRegistryTests, basic_checks)
     EXPECT_FALSE(pool_b2);
 
     // Repeat allocations and check a different pointer is returned
+    cfg.memory_policy = DYNAMIC_RESERVE_MEMORY_MODE;
+    pool_a3 = TopicPayloadPoolRegistry::get("topic_a", cfg);
+    EXPECT_NE(pool_a3.get(), pool_backup_a3);
     cfg.memory_policy = PREALLOCATED_MEMORY_MODE;
     pool_a1 = TopicPayloadPoolRegistry::get("topic_a", cfg);
     EXPECT_NE(pool_a1.get(), pool_backup_a1);
     pool_b1 = TopicPayloadPoolRegistry::get("topic_b", cfg);
     EXPECT_NE(pool_b1.get(), pool_backup_b1);
-    cfg.memory_policy = DYNAMIC_RESERVE_MEMORY_MODE;
-    pool_a3 = TopicPayloadPoolRegistry::get("topic_a", cfg);
-    EXPECT_NE(pool_a3.get(), pool_backup_a3);
 }

--- a/test/unittest/rtps/history/TopicPayloadPoolRegistryTests.cpp
+++ b/test/unittest/rtps/history/TopicPayloadPoolRegistryTests.cpp
@@ -16,6 +16,8 @@
 
 #include <rtps/history/TopicPayloadPoolRegistry.hpp>
 
+#include <rtps/history/TopicPayloadPoolRegistry_impl/TopicPayloadPoolProxy.hpp>
+
 using namespace eprosima::fastrtps::rtps;
 using namespace ::testing;
 using namespace std;
@@ -45,11 +47,6 @@ TEST(TopicPayloadPoolRegistryTests, basic_checks)
     // And be different from the other topic.
     EXPECT_NE(pool_b1, pool_a3);
 
-    // Backups to check reference counts
-    auto pool_backup_a1 = pool_a1.get();
-    auto pool_backup_a3 = pool_a3.get();
-    auto pool_backup_b1 = pool_b1.get();
-
     // Releasing pointers should reset them
     TopicPayloadPoolRegistry::release(pool_a1);
     EXPECT_FALSE(pool_a1);
@@ -74,13 +71,6 @@ TEST(TopicPayloadPoolRegistryTests, basic_checks)
     EXPECT_NO_THROW(TopicPayloadPoolRegistry::release(pool_b2));
     EXPECT_FALSE(pool_b2);
 
-    // Repeat allocations and check a different pointer is returned
-    cfg.memory_policy = DYNAMIC_RESERVE_MEMORY_MODE;
-    pool_a3 = TopicPayloadPoolRegistry::get("topic_a", cfg);
-    EXPECT_NE(pool_a3.get(), pool_backup_a3);
-    cfg.memory_policy = PREALLOCATED_MEMORY_MODE;
-    pool_a1 = TopicPayloadPoolRegistry::get("topic_a", cfg);
-    EXPECT_NE(pool_a1.get(), pool_backup_a1);
-    pool_b1 = TopicPayloadPoolRegistry::get("topic_b", cfg);
-    EXPECT_NE(pool_b1.get(), pool_backup_b1);
+    // Destructor should have been called a certain number of times
+    EXPECT_EQ(detail::TopicPayloadPoolProxy::DestructorHelper::instance().get(), 3u);
 }


### PR DESCRIPTION
TopicPayloadPoolRegistryTests were incorrectly checking that allocating new pools after releasing was giving different pointers. This PR changes the order of the second creation, to force the system allocators giving different pointers.

Signed-off-by: Miguel Company <MiguelCompany@eprosima.com>