### PR TITLE
Fix warning: change unsigned for signed comparison

### DIFF
--- a/test/unittest/logging/LogTests.cpp
+++ b/test/unittest/logging/LogTests.cpp
@@ -405,11 +405,11 @@ TEST_F(LogTests, stdout_consumer_stream)
     // Else, there should only be 2 messagea in the out buffer, corresponding to logError and logWarning.
 #if (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG)) && (defined(_DEBUG) || defined(__DEBUG)) && \
     (!defined(LOG_NO_INFO))
-    ASSERT_EQ(3u, lines_out);
+    ASSERT_EQ(3, lines_out);
 #else
-    ASSERT_EQ(2u, lines_out);
+    ASSERT_EQ(2, lines_out);
 #endif // if (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG)) && (defined(_DEBUG) || defined(__DEBUG)) && (!defined(LOG_NO_INFO))
-    ASSERT_EQ(0u, lines_err);
+    ASSERT_EQ(0, lines_err);
     std::cout << "Number of messages in the out buffer is correct: " << lines_out << std::endl;
     std::cout << "No messages in the err buffer: " << lines_err << std::endl;
 
@@ -490,7 +490,7 @@ TEST_F(LogTests, stdouterr_consumer_stream)
     lines_out = std::count(out_string_out.begin(), out_string_out.end(), '\n');
 
     // Only the logError message should be in the error buffer, since stderr_threshold was set to Log::Kind::Error.
-    ASSERT_EQ(1u, lines_err);
+    ASSERT_EQ(1, lines_err);
     std::cout << "Number of messages in the error buffer is correct: " << lines_err << std::endl;
 
     // If CMAKE_BUILD_TYPE is Debug, the INTERNAL_DEBUG flag was set, and the logInfo messages were not deactivated,
@@ -498,9 +498,9 @@ TEST_F(LogTests, stdouterr_consumer_stream)
     // Else, there should only be 1 message in the out buffer, corresponding to the logWarning.
 #if (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG)) && (defined(_DEBUG) || defined(__DEBUG)) && \
     (!defined(LOG_NO_INFO))
-    ASSERT_EQ(2u, lines_out);
+    ASSERT_EQ(2, lines_out);
 #else
-    ASSERT_EQ(1u, lines_out);
+    ASSERT_EQ(1, lines_out);
 #endif // if (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG)) && (defined(_DEBUG) || defined(__DEBUG)) && (!defined(LOG_NO_INFO))
     std::cout << "Number of messages in the out buffer is correct: " << lines_out << std::endl;
     // Reset the log module to the test default


### PR DESCRIPTION
`std::string::difference_type` is of type `std::ptrdiff_t` which is the signed integer type of the result of subtracting two pointers.