### PR TITLE
[Discovery Server] Fix Discovery-Server v2 bugs [9821]

### DIFF
--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -418,14 +418,14 @@ void DiscoveryDataBase::process_pdp_data_queue()
         {
             // Update participants map
             logInfo(DISCOVERY_DATABASE, "DATA(p) " << data_queue_info.change()->instanceHandle << " received from: "
-                    << data_queue_info.change()->writerGUID);
+                                                   << data_queue_info.change()->writerGUID);
             create_participant_from_change_(data_queue_info.change(), data_queue_info.participant_change_data());
         }
         // If the change is a DATA(Up)
         else
         {
             logInfo(DISCOVERY_DATABASE, "DATA(Up) " << data_queue_info.change()->instanceHandle << " received from: "
-                    << data_queue_info.change()->writerGUID);
+                                                    << data_queue_info.change()->writerGUID);
             process_dispose_participant_(data_queue_info.change());
         }
 
@@ -1046,7 +1046,7 @@ void DiscoveryDataBase::process_dispose_participant_(
         if (pit->second.change()->kind != fastrtps::rtps::ChangeKind_t::ALIVE)
         {
             logInfo(DISCOVERY_DATABASE, "Ignoring second DATA(Up)"
-                << participant_guid.guidPrefix);
+                    << participant_guid.guidPrefix);
             return;
         }
         // Only update DATA(p), leaving the change info untouched. This is because DATA(Up) does not have the
@@ -1214,7 +1214,9 @@ bool DiscoveryDataBase::process_dirty_topics()
                     if (parts_reader_it->second.is_matched(writer.guidPrefix))
                     {
                         // Check the status of the writer in `readers_[reader]::relevant_participants_builtin_ack_status`.
-                        if (readers_it != readers_.end() && readers_it->second.is_relevant_participant(writer.guidPrefix) && !readers_it->second.is_matched(writer.guidPrefix))
+                        if (readers_it != readers_.end() &&
+                                readers_it->second.is_relevant_participant(writer.guidPrefix) &&
+                                !readers_it->second.is_matched(writer.guidPrefix))
                         {
                             // If the status is 0, add DATA(r) to a `edp_publications_to_send_` (if it's not there).
                             if (add_edp_subscriptions_to_send_(readers_it->second.change()))
@@ -1244,7 +1246,9 @@ bool DiscoveryDataBase::process_dirty_topics()
                     if (parts_writer_it->second.is_matched(reader.guidPrefix))
                     {
                         // Check the status of the reader in `writers_[writer]::relevant_participants_builtin_ack_status`.
-                        if (writers_it != writers_.end() && writers_it->second.is_relevant_participant(reader.guidPrefix) && !writers_it->second.is_matched(reader.guidPrefix))
+                        if (writers_it != writers_.end() &&
+                                writers_it->second.is_relevant_participant(reader.guidPrefix) &&
+                                !writers_it->second.is_matched(reader.guidPrefix))
                         {
                             // If the status is 0, add DATA(w) to a `edp_subscriptions_to_send_` (if it's not there).
                             if (add_edp_publications_to_send_(writers_it->second.change()))
@@ -1540,7 +1544,8 @@ void DiscoveryDataBase::unmatch_participant_(
                 // This is not an error. Remote participants will try to unmatch with participants even
                 // when the match is not reciprocal
                 logInfo(DISCOVERY_DATABASE,
-                        "Participant " << relevant_participant << " matched with an unexisting participant: " << guid_prefix);
+                        "Participant " << relevant_participant << " matched with an unexisting participant: " <<
+                                        guid_prefix);
             }
             else
             {

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -1508,7 +1508,7 @@ void DiscoveryDataBase::AckedFunctor::operator () (
             // if the reader proxy is from a server that we are pinging, the data is set as acked
             for (auto it = db_->servers_.begin(); it < db_->servers_.end(); ++it)
             {
-                if (reader_proxy->guid().guidPrefix == *(it.base()))
+                if (reader_proxy->guid().guidPrefix == *it)
                 {
                     return;
                 }
@@ -1722,7 +1722,7 @@ void DiscoveryDataBase::remove_writer_from_topic_(
         const eprosima::fastrtps::rtps::GUID_t& writer_guid,
         const std::string& topic_name)
 {
-    if (topic_name.compare(virtual_topic_) == 0)
+    if (topic_name == virtual_topic_)
     {
         std::map<std::string, std::vector<eprosima::fastrtps::rtps::GUID_t>>::iterator topic_it;
         for (topic_it = writers_by_topic_.begin(); topic_it != writers_by_topic_.end(); topic_it++)
@@ -1770,7 +1770,7 @@ void DiscoveryDataBase::remove_reader_from_topic_(
 {
     logInfo(DISCOVERY_DATABASE, "removing: " << reader_guid << " from topic " << topic_name);
 
-    if (topic_name.compare(virtual_topic_) == 0)
+    if (topic_name == virtual_topic_)
     {
         std::map<std::string, std::vector<eprosima::fastrtps::rtps::GUID_t>>::iterator topic_it;
         for (topic_it = readers_by_topic_.begin(); topic_it != readers_by_topic_.end(); topic_it++)

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -1544,7 +1544,7 @@ void DiscoveryDataBase::unmatch_participant_(
                 // when the match is not reciprocal
                 logInfo(DISCOVERY_DATABASE,
                         "Participant " << relevant_participant << " matched with an unexisting participant: " <<
-                                        guid_prefix);
+                        guid_prefix);
             }
             else
             {

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -18,7 +18,6 @@
  */
 
 #include <mutex>
-#include <shared_mutex>
 
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/rtps/common/EntityId_t.hpp>

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer2.hpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer2.hpp
@@ -28,9 +28,6 @@
 #include <fastdds/rtps/builtin/discovery/endpoint/EDPSimple.h>
 #include "../participant/PDPServer2.hpp"
 
-// To be eventually removed together with eprosima::fastrtps
-namespace aux = ::eprosima::fastrtps::rtps;
-
 namespace eprosima {
 namespace fastdds {
 namespace rtps {
@@ -43,7 +40,7 @@ class EDPServerSUBListener2;
  * Inherits from EDPSimple class.
  *@ingroup DISCOVERY_MODULE
  */
-class EDPServer2 : public aux::EDPSimple
+class EDPServer2 : public fastrtps::rtps::EDPSimple
 {
     friend class EDPServerPUBListener2;
     friend class EDPServerSUBListener2;
@@ -56,8 +53,8 @@ public:
      * @param part Pointer to the RTPSParticipantImpl
      */
     EDPServer2(
-            aux::PDP* p,
-            aux::RTPSParticipantImpl* part)
+            fastrtps::rtps::PDP* p,
+            fastrtps::rtps::RTPSParticipantImpl* part)
         : EDPSimple(p, part)
     {
     }
@@ -79,8 +76,8 @@ public:
      * @return true if correct.
      */
     bool processLocalReaderProxyData(
-            aux::RTPSReader* reader,
-            aux::ReaderProxyData* rdata) override;
+            fastrtps::rtps::RTPSReader* reader,
+            fastrtps::rtps::ReaderProxyData* rdata) override;
     /**
      * This method generates the corresponding change in the publciations writer and send it to all known remote endpoints.
      * @param writer Pointer to the Writer object.
@@ -88,22 +85,22 @@ public:
      * @return true if correct.
      */
     bool processLocalWriterProxyData(
-            aux::RTPSWriter* writer,
-            aux::WriterProxyData* wdata) override;
+            fastrtps::rtps::RTPSWriter* writer,
+            fastrtps::rtps::WriterProxyData* wdata) override;
     /**
      * This methods generates the change disposing of the local Reader and calls the unpairing and removal methods of the base class.
      * @param R Pointer to the RTPSReader object.
      * @return True if correct.
      */
     bool removeLocalReader(
-            aux::RTPSReader* R) override;
+            fastrtps::rtps::RTPSReader* R) override;
     /**
      * This methods generates the change disposing of the local Writer and calls the unpairing and removal methods of the base class.
      * @param W Pointer to the RTPSWriter object.
      * @return True if correct.
      */
     bool removeLocalWriter(
-            aux::RTPSWriter* W) override;
+            fastrtps::rtps::RTPSWriter* W) override;
 
 private:
 

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners2.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners2.cpp
@@ -55,7 +55,8 @@ void EDPServerPUBListener2::onNewCacheChangeAdded(
 {
     logInfo(RTPS_EDP_LISTENER, "");
     logInfo(RTPS_EDP_LISTENER, "------------------ EDP PUB SERVER LISTENER START ------------------");
-    logInfo(RTPS_EDP_LISTENER, "-------------------- " << sedp_->mp_RTPSParticipant->getGuid() << " --------------------");
+    logInfo(RTPS_EDP_LISTENER,
+            "-------------------- " << sedp_->mp_RTPSParticipant->getGuid() << " --------------------");
 
     // Create a new change from the one received
     CacheChange_t* change = (CacheChange_t*)change_in;
@@ -121,7 +122,8 @@ void EDPServerPUBListener2::onNewCacheChangeAdded(
         // If the database doesn't take the ownership, then return the CacheChante_t to the pool.
         reader->releaseCache(change);
     }
-    logInfo(RTPS_EDP_LISTENER, "-------------------- " << sedp_->mp_RTPSParticipant->getGuid() << " --------------------");
+    logInfo(RTPS_EDP_LISTENER,
+            "-------------------- " << sedp_->mp_RTPSParticipant->getGuid() << " --------------------");
     logInfo(RTPS_EDP_LISTENER, "------------------ EDP PUB SERVER LISTENER END ------------------");
     logInfo(RTPS_EDP_LISTENER, "");
 }
@@ -145,7 +147,8 @@ void EDPServerSUBListener2::onNewCacheChangeAdded(
 {
     logInfo(RTPS_EDP_LISTENER, "");
     logInfo(RTPS_EDP_LISTENER, "------------------ EDP SUB SERVER LISTENER START ------------------");
-    logInfo(RTPS_EDP_LISTENER, "-------------------- " << sedp_->mp_RTPSParticipant->getGuid() << " --------------------");
+    logInfo(RTPS_EDP_LISTENER,
+            "-------------------- " << sedp_->mp_RTPSParticipant->getGuid() << " --------------------");
 
     // Create a new change from the one received
     CacheChange_t* change = (CacheChange_t*)change_in;
@@ -213,7 +216,8 @@ void EDPServerSUBListener2::onNewCacheChangeAdded(
         reader->releaseCache(change);
     }
 
-    logInfo(RTPS_EDP_LISTENER, "-------------------- " << sedp_->mp_RTPSParticipant->getGuid() << " --------------------");
+    logInfo(RTPS_EDP_LISTENER,
+            "-------------------- " << sedp_->mp_RTPSParticipant->getGuid() << " --------------------");
     logInfo(RTPS_EDP_LISTENER, "------------------ EDP SUB SERVER LISTENER END ------------------");
     logInfo(RTPS_EDP_LISTENER, "");
 }

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners2.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners2.cpp
@@ -53,8 +53,10 @@ void EDPServerPUBListener2::onNewCacheChangeAdded(
         RTPSReader* reader,
         const CacheChange_t* const change_in)
 {
-    logInfo(RTPS_PDP_LISTENER, "");
-    logInfo(RTPS_PDP_LISTENER, "------------------ EDP PUB SERVER LISTENER START ------------------");
+    logInfo(RTPS_EDP_LISTENER, "");
+    logInfo(RTPS_EDP_LISTENER, "------------------ EDP PUB SERVER LISTENER START ------------------");
+    logInfo(RTPS_EDP_LISTENER, "-------------------- " << sedp_->mp_RTPSParticipant->getGuid() << " --------------------");
+
     // Create a new change from the one received
     CacheChange_t* change = (CacheChange_t*)change_in;
     logInfo(RTPS_EDP_LISTENER, "EDP Server PUB Message received: " << change_in->instanceHandle);
@@ -119,8 +121,9 @@ void EDPServerPUBListener2::onNewCacheChangeAdded(
         // If the database doesn't take the ownership, then return the CacheChante_t to the pool.
         reader->releaseCache(change);
     }
-    logInfo(RTPS_PDP_LISTENER, "------------------ EDP PUB SERVER LISTENER END ------------------");
-    logInfo(RTPS_PDP_LISTENER, "");
+    logInfo(RTPS_EDP_LISTENER, "-------------------- " << sedp_->mp_RTPSParticipant->getGuid() << " --------------------");
+    logInfo(RTPS_EDP_LISTENER, "------------------ EDP PUB SERVER LISTENER END ------------------");
+    logInfo(RTPS_EDP_LISTENER, "");
 }
 
 PDPServer2* EDPServerSUBListener2::get_pdp()
@@ -140,8 +143,10 @@ void EDPServerSUBListener2::onNewCacheChangeAdded(
         RTPSReader* reader,
         const CacheChange_t* const change_in)
 {
-    logInfo(RTPS_PDP_LISTENER, "");
-    logInfo(RTPS_PDP_LISTENER, "------------------ EDP SUB SERVER LISTENER START ------------------");
+    logInfo(RTPS_EDP_LISTENER, "");
+    logInfo(RTPS_EDP_LISTENER, "------------------ EDP SUB SERVER LISTENER START ------------------");
+    logInfo(RTPS_EDP_LISTENER, "-------------------- " << sedp_->mp_RTPSParticipant->getGuid() << " --------------------");
+
     // Create a new change from the one received
     CacheChange_t* change = (CacheChange_t*)change_in;
     logInfo(RTPS_EDP_LISTENER, "EDP Server SUB Message received: " << change_in->instanceHandle);
@@ -207,8 +212,10 @@ void EDPServerSUBListener2::onNewCacheChangeAdded(
         // If the database doesn't take the ownership, then return the CacheChante_t to the pool.
         reader->releaseCache(change);
     }
-    logInfo(RTPS_PDP_LISTENER, "------------------ EDP SUB SERVER LISTENER END ------------------");
-    logInfo(RTPS_PDP_LISTENER, "");
+
+    logInfo(RTPS_EDP_LISTENER, "-------------------- " << sedp_->mp_RTPSParticipant->getGuid() << " --------------------");
+    logInfo(RTPS_EDP_LISTENER, "------------------ EDP SUB SERVER LISTENER END ------------------");
+    logInfo(RTPS_EDP_LISTENER, "");
 }
 
 } /* namespace rtps */

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners2.hpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners2.hpp
@@ -34,9 +34,6 @@ struct CacheChange_t;
 } // namespace fastdds
 } // namespace eprosima
 
-// To be eventually removed together with eprosima::fastrtps
-namespace aux = ::eprosima::fastrtps::rtps;
-
 namespace eprosima {
 namespace fastdds {
 namespace rtps {
@@ -48,7 +45,7 @@ class EDPServer2;
  * Class EDPServerPUBListener2, used to define the behavior when a new WriterProxyData is received.
  * @ingroup DISCOVERY_MODULE
  */
-class EDPServerPUBListener2 : public aux::EDPBasePUBListener
+class EDPServerPUBListener2 : public fastrtps::rtps::EDPBasePUBListener
 {
 public:
 
@@ -72,8 +69,8 @@ public:
      * @param change
      */
     void onNewCacheChangeAdded(
-            aux::RTPSReader* reader,
-            const aux::CacheChange_t* const change) override;
+            fastrtps::rtps::RTPSReader* reader,
+            const fastrtps::rtps::CacheChange_t* const change) override;
 
 private:
 
@@ -85,7 +82,7 @@ private:
  * Class EDPServerSUBListener2, used to define the behavior when a new ReaderProxyData is received.
  * @ingroup DISCOVERY_MODULE
  */
-class EDPServerSUBListener2 : public aux::EDPBaseSUBListener
+class EDPServerSUBListener2 : public fastrtps::rtps::EDPBaseSUBListener
 {
 public:
 
@@ -106,8 +103,8 @@ public:
      * @param change
      */
     void onNewCacheChangeAdded(
-            aux::RTPSReader* reader,
-            const aux::CacheChange_t* const change) override;
+            fastrtps::rtps::RTPSReader* reader,
+            const fastrtps::rtps::CacheChange_t* const change) override;
 
 private:
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient2.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient2.hpp
@@ -46,7 +46,7 @@ namespace rtps {
  * Class PDPClient manages client side of the discovery server mechanism
  *@ingroup DISCOVERY_MODULE
  */
-class PDPClient2 : public aux::PDP
+class PDPClient2 : public fastrtps::rtps::PDP
 {
     friend class DSClientEvent2;
 
@@ -58,12 +58,12 @@ public:
      * @param allocation Participant allocation parameters.
      */
     PDPClient2(
-            aux::BuiltinProtocols* builtin,
-            const aux::RTPSParticipantAllocationAttributes& allocation);
+            fastrtps::rtps::BuiltinProtocols* builtin,
+            const fastrtps::rtps::RTPSParticipantAllocationAttributes& allocation);
     ~PDPClient2();
 
     void initializeParticipantProxyData(
-            aux::ParticipantProxyData* participant_data) override;
+            fastrtps::rtps::ParticipantProxyData* participant_data) override;
 
     /**
      * Initialize the PDP.
@@ -71,7 +71,7 @@ public:
      * @return True on success
      */
     bool init(
-            aux::RTPSParticipantImpl* part) override;
+            fastrtps::rtps::RTPSParticipantImpl* part) override;
 
     /**
      * Creates an initializes a new participant proxy from a DATA(p) raw info
@@ -79,9 +79,9 @@ public:
      * @param writer_guid GUID of originating writer
      * @return new ParticipantProxyData * or nullptr on failure
      */
-    aux::ParticipantProxyData* createParticipantProxyData(
-            const aux::ParticipantProxyData& p,
-            const aux::GUID_t& writer_guid) override;
+    fastrtps::rtps::ParticipantProxyData* createParticipantProxyData(
+            const fastrtps::rtps::ParticipantProxyData& p,
+            const fastrtps::rtps::GUID_t& writer_guid) override;
 
     /**
      * Create the SPDP Writer and Reader
@@ -99,14 +99,14 @@ public:
     void announceParticipantState(
             bool new_change,
             bool dispose = false,
-            aux::WriteParams& wparams = aux::WriteParams::WRITE_PARAM_DEFAULT) override;
+            fastrtps::rtps::WriteParams& wparams = fastrtps::rtps::WriteParams::WRITE_PARAM_DEFAULT) override;
 
     void assignRemoteEndpoints(
-            aux::ParticipantProxyData* pdata) override;
+            fastrtps::rtps::ParticipantProxyData* pdata) override;
     void removeRemoteEndpoints(
-            aux::ParticipantProxyData* pdata) override;
+            fastrtps::rtps::ParticipantProxyData* pdata) override;
     void notifyAboveRemoteEndpoints(
-            const aux::ParticipantProxyData& pdata) override;
+            const fastrtps::rtps::ParticipantProxyData& pdata) override;
 
 private:
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer2.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer2.cpp
@@ -1183,6 +1183,9 @@ bool PDPServer2::pending_ack()
             mp_PDPWriterHistory->getHistorySize() > 1 ||
             edp->publications_writer_.second->getHistorySize() > 0 ||
             edp->subscriptions_writer_.second->getHistorySize() > 0);
+    
+    logInfo(RTPS_PDP_SERVER, "PDP writer history length " << mp_PDPWriterHistory->getHistorySize());     
+    logInfo(RTPS_PDP_SERVER, "is server " << mp_PDPWriter->getGuid() << " acked by all? " << discovery_db_.server_acked_by_all());
     logInfo(RTPS_PDP_SERVER, "Are there pending changes? " << ret);
     return ret;
 }

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer2.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer2.cpp
@@ -744,7 +744,7 @@ bool PDPServer2::server_update_routine()
     }
     // If the data queue is not empty re-start the routine.
     // A non-empty queue means that the server has received a change while it is running the processing routine.
-    while (!discovery_db_.data_queue_empty());
+    while (!discovery_db_.data_queue_empty() && discovery_db_.is_enabled());
 
     // Must restart the routin after the period time
     return pending_work;

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer2.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer2.cpp
@@ -1193,7 +1193,7 @@ bool PDPServer2::pending_ack()
     logInfo(RTPS_PDP_SERVER, "PDP writer history length " << mp_PDPWriterHistory->getHistorySize());
     logInfo(RTPS_PDP_SERVER,
             "is server " << mp_PDPWriter->getGuid() << " acked by all? " <<
-                        discovery_db_.server_acked_by_all());
+            discovery_db_.server_acked_by_all());
     logInfo(RTPS_PDP_SERVER, "Are there pending changes? " << ret);
     return ret;
 }

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer2.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer2.cpp
@@ -1191,7 +1191,9 @@ bool PDPServer2::pending_ack()
             edp->subscriptions_writer_.second->getHistorySize() > 0);
 
     logInfo(RTPS_PDP_SERVER, "PDP writer history length " << mp_PDPWriterHistory->getHistorySize());
-    logInfo(RTPS_PDP_SERVER, "is server " << mp_PDPWriter->getGuid() << " acked by all? " << discovery_db_.server_acked_by_all());
+    logInfo(RTPS_PDP_SERVER,
+            "is server " << mp_PDPWriter->getGuid() << " acked by all? " <<
+                        discovery_db_.server_acked_by_all());
     logInfo(RTPS_PDP_SERVER, "Are there pending changes? " << ret);
     return ret;
 }

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer2.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer2.cpp
@@ -731,6 +731,7 @@ bool PDPServer2::server_update_routine()
     {
         logInfo(RTPS_PDP_SERVER, "");
         logInfo(RTPS_PDP_SERVER, "-------------------- Server routine start --------------------");
+        logInfo(RTPS_PDP_SERVER, "-------------------- " << mp_RTPSParticipant->getGuid() << " --------------------");
 
         process_writers_acknowledgements();     // server + ddb(functor_with_ddb)
         process_data_queues();                  // all ddb
@@ -740,6 +741,7 @@ bool PDPServer2::server_update_routine()
         process_to_send_lists();                // server + ddb(get_to_send, remove_to_send_this)
         pending_work = pending_ack();           // all server
 
+        logInfo(RTPS_PDP_SERVER, "-------------------- " << mp_RTPSParticipant->getGuid() << " --------------------");
         logInfo(RTPS_PDP_SERVER, "-------------------- Server routine end --------------------");
         logInfo(RTPS_PDP_SERVER, "");
 
@@ -868,6 +870,7 @@ bool PDPServer2::process_disposals()
     // Iterate over disposals
     for (auto change: disposals)
     {
+        logInfo(RTPS_PDP_SERVER, "Process disposal change from: " << change->instanceHandle);
         // No check is performed on whether the change is an actual disposal, leaving the responsability of correctly
         // populating the disposals list to discovery_db_.process_data_queue().
 
@@ -927,7 +930,7 @@ bool PDPServer2::process_disposals()
         }
         else
         {
-            logError(RTPS_PDP_SERVER, "Wrong DATA received from disposals" << change->instanceHandle);
+            logError(RTPS_PDP_SERVER, "Wrong DATA received from disposals " << change->instanceHandle);
         }
     }
     // Clear database disposals list

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer2.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer2.cpp
@@ -528,6 +528,9 @@ void PDPServer2::announceParticipantState(
                     metatraffic_locators.add_multicast_locator(locator);
                 }
 
+                // If the DATA is already in the writer's history, then remove it, but do not release the change.
+                remove_change_from_history_nts(mp_PDPWriterHistory, change, false);
+
                 // Add our change to PDPWriterHistory
                 mp_PDPWriterHistory->add_change(change, wp);
                 change->write_params = wp;

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer2.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer2.hpp
@@ -113,7 +113,8 @@ public:
     void send_announcement(
             fastrtps::rtps::CacheChange_t* change,
             std::vector<fastrtps::rtps::GUID_t> remote_readers,
-            fastrtps::rtps::LocatorList_t locators);
+            fastrtps::rtps::LocatorList_t locators,
+            bool dispose = false);
 
     /**
      * These methods wouldn't be needed under perfect server operation (no need of dynamic endpoint allocation)

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer2.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer2.hpp
@@ -29,9 +29,6 @@
 #include "../database/DiscoveryDataBase.hpp"
 #include "./DServerEvent2.hpp"
 
-// To be eventually removed together with eprosima::fastrtps
-namespace aux = ::eprosima::fastrtps::rtps;
-
 namespace eprosima {
 namespace fastdds {
 namespace rtps {
@@ -40,7 +37,7 @@ namespace rtps {
  * Class PDPServer2 manages server side of the discovery server mechanism
  *@ingroup DISCOVERY_MODULE
  */
-class PDPServer2 : public aux::PDP
+class PDPServer2 : public fastrtps::rtps::PDP
 {
     friend class DServerRoutineEvent2;
     friend class DServerPingEvent2;
@@ -56,12 +53,12 @@ public:
      * @param durability_kind the kind of persistence we want for the discovery data
      */
     PDPServer2(
-            aux::BuiltinProtocols* builtin,
-            const aux::RTPSParticipantAllocationAttributes& allocation);
+            fastrtps::rtps::BuiltinProtocols* builtin,
+            const fastrtps::rtps::RTPSParticipantAllocationAttributes& allocation);
     ~PDPServer2();
 
     void initializeParticipantProxyData(
-            aux::ParticipantProxyData* participant_data) override;
+            fastrtps::rtps::ParticipantProxyData* participant_data) override;
 
     /**
      * Initialize the PDP.
@@ -69,7 +66,7 @@ public:
      * @return True on success
      */
     bool init(
-            aux::RTPSParticipantImpl* part) override;
+            fastrtps::rtps::RTPSParticipantImpl* part) override;
 
     /**
      * Creates an initializes a new participant proxy from a DATA(p) raw info
@@ -77,9 +74,9 @@ public:
      * @param writer_guid GUID of originating writer
      * @return new ParticipantProxyData * or nullptr on failure
      */
-    aux::ParticipantProxyData* createParticipantProxyData(
-            const aux::ParticipantProxyData& p,
-            const aux::GUID_t& writer_guid) override;
+    fastrtps::rtps::ParticipantProxyData* createParticipantProxyData(
+            const fastrtps::rtps::ParticipantProxyData& p,
+            const fastrtps::rtps::GUID_t& writer_guid) override;
 
     /**
      * Create the SPDP Writer and Reader
@@ -94,8 +91,8 @@ public:
      * @return true if correct.
      */
     bool remove_remote_participant(
-            const aux::GUID_t& participant_guid,
-            aux::ParticipantDiscoveryInfo::DISCOVERY_STATUS reason) override;
+            const fastrtps::rtps::GUID_t& participant_guid,
+            fastrtps::rtps::ParticipantDiscoveryInfo::DISCOVERY_STATUS reason) override;
 
     /**
      * Force the sending of our local PDP to all servers
@@ -106,7 +103,7 @@ public:
     void announceParticipantState(
             bool new_change,
             bool dispose = false,
-            aux::WriteParams& wparams = aux::WriteParams::WRITE_PARAM_DEFAULT) override;
+            fastrtps::rtps::WriteParams& wparams = fastrtps::rtps::WriteParams::WRITE_PARAM_DEFAULT) override;
 
     // Force the sending of our DATA(p) to those servers that has not acked yet
     void ping_remote_servers();
@@ -114,7 +111,7 @@ public:
     // send a specific Data to specific locators
     void send_announcement(
             fastrtps::rtps::CacheChange_t* change,
-            std::vector<aux::GUID_t> remote_readers,
+            std::vector<fastrtps::rtps::GUID_t> remote_readers,
             fastrtps::rtps::LocatorList_t locators);
 
     /**
@@ -123,11 +120,11 @@ public:
      * @param pdata Pointer to the RTPSParticipantProxyData object.
      */
     void assignRemoteEndpoints(
-            aux::ParticipantProxyData* pdata) override;
+            fastrtps::rtps::ParticipantProxyData* pdata) override;
     void removeRemoteEndpoints(
-            aux::ParticipantProxyData* pdata) override;
+            fastrtps::rtps::ParticipantProxyData* pdata) override;
     void notifyAboveRemoteEndpoints(
-            const aux::ParticipantProxyData& pdata) override;
+            const fastrtps::rtps::ParticipantProxyData& pdata) override;
 
 #if HAVE_SQLITE3
     //! Get filename for persistence database file

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer2.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer2.hpp
@@ -43,6 +43,7 @@ class PDPServer2 : public fastrtps::rtps::PDP
     friend class DServerPingEvent2;
     friend class EDPServer2;
     friend class PDPServerListener2;
+    friend class EDPServerListener2;
 
 public:
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener2.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener2.cpp
@@ -53,7 +53,9 @@ void PDPServerListener2::onNewCacheChangeAdded(
 {
     logInfo(RTPS_PDP_LISTENER, "");
     logInfo(RTPS_PDP_LISTENER, "------------------ PDP SERVER LISTENER START ------------------");
-    logInfo(RTPS_PDP_LISTENER, "-------------------- " << pdp_server()->mp_RTPSParticipant->getGuid() << " --------------------");
+    logInfo(RTPS_PDP_LISTENER,
+            "-------------------- " << pdp_server()->mp_RTPSParticipant->getGuid() <<
+                        " --------------------");
     logInfo(RTPS_PDP_LISTENER, "PDP Server Message received: " << change_in->instanceHandle);
 
     // Get PDP reader history
@@ -361,7 +363,9 @@ void PDPServerListener2::onNewCacheChangeAdded(
     // unique pointer destruction grants it. If the ownership has been taken away from the unique pointer, then nothing
     // happens at this point
 
-    logInfo(RTPS_PDP_LISTENER, "-------------------- " << pdp_server()->mp_RTPSParticipant->getGuid() << " --------------------");
+    logInfo(RTPS_PDP_LISTENER,
+            "-------------------- " << pdp_server()->mp_RTPSParticipant->getGuid() <<
+                        " --------------------");
     logInfo(RTPS_PDP_LISTENER, "------------------ PDP SERVER LISTENER END ------------------");
     logInfo(RTPS_PDP_LISTENER, "");
 }

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener2.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener2.cpp
@@ -278,9 +278,9 @@ void PDPServerListener2::onNewCacheChangeAdded(
                 // Realease PDP mutex
                 lock.unlock();
 
-                // All builtins are connected, the database will avoid any EDP DATA to be send before having PDP DATA
-                // acknowledgement
-                if (pdata)
+                // All local builtins are connected, the database will avoid any EDP DATA to be send before having PDP
+                // DATA acknowledgement
+                if (pdata && is_local)
                 {
                     pdp_server()->assignRemoteEndpoints(pdata);
                 }
@@ -296,7 +296,7 @@ void PDPServerListener2::onNewCacheChangeAdded(
 
                 // TODO: pending client liveliness management here
                 // Included form symmetry with PDPListener to profit from a future updateInfoMatchesEDP override
-                if (pdp_server()->updateInfoMatchesEDP())
+                if (pdp_server()->updateInfoMatchesEDP() && is_local)
                 {
                     pdp_server()->mp_EDP->assignRemoteEndpoints(*pdata);
                 }

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener2.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener2.cpp
@@ -100,7 +100,9 @@ void PDPServerListener2::onNewCacheChangeAdded(
     // Related_sample_identity could be lost in message delivered, so we set as sample_identity
     // An empty related_sample_identity could lead into an empty sample_identity when resending this msg
     if (change->write_params.related_sample_identity() == SampleIdentity::unknown())
-    {:
+    {
+        change->write_params.related_sample_identity(change->write_params.sample_identity());
+    }
 
 
     // DATA(p) case

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener2.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener2.cpp
@@ -55,7 +55,7 @@ void PDPServerListener2::onNewCacheChangeAdded(
     logInfo(RTPS_PDP_LISTENER, "------------------ PDP SERVER LISTENER START ------------------");
     logInfo(RTPS_PDP_LISTENER,
             "-------------------- " << pdp_server()->mp_RTPSParticipant->getGuid() <<
-                        " --------------------");
+            " --------------------");
     logInfo(RTPS_PDP_LISTENER, "PDP Server Message received: " << change_in->instanceHandle);
 
     // Get PDP reader history
@@ -100,9 +100,7 @@ void PDPServerListener2::onNewCacheChangeAdded(
     // Related_sample_identity could be lost in message delivered, so we set as sample_identity
     // An empty related_sample_identity could lead into an empty sample_identity when resending this msg
     if (change->write_params.related_sample_identity() == SampleIdentity::unknown())
-    {
-        change->write_params.related_sample_identity(change->write_params.sample_identity());
-    }
+    {:
 
 
     // DATA(p) case
@@ -365,7 +363,7 @@ void PDPServerListener2::onNewCacheChangeAdded(
 
     logInfo(RTPS_PDP_LISTENER,
             "-------------------- " << pdp_server()->mp_RTPSParticipant->getGuid() <<
-                        " --------------------");
+            " --------------------");
     logInfo(RTPS_PDP_LISTENER, "------------------ PDP SERVER LISTENER END ------------------");
     logInfo(RTPS_PDP_LISTENER, "");
 }

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener2.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener2.cpp
@@ -53,6 +53,7 @@ void PDPServerListener2::onNewCacheChangeAdded(
 {
     logInfo(RTPS_PDP_LISTENER, "");
     logInfo(RTPS_PDP_LISTENER, "------------------ PDP SERVER LISTENER START ------------------");
+    logInfo(RTPS_PDP_LISTENER, "-------------------- " << pdp_server()->mp_RTPSParticipant->getGuid() << " --------------------");
     logInfo(RTPS_PDP_LISTENER, "PDP Server Message received: " << change_in->instanceHandle);
 
     // Get PDP reader history
@@ -108,7 +109,8 @@ void PDPServerListener2::onNewCacheChangeAdded(
         // Ignore announcement from own RTPSParticipant
         if (guid == pdp_server()->getRTPSParticipant()->getGuid())
         {
-            logInfo(RTPS_PDP_LISTENER, "Message from own RTPSParticipant, ignoring");
+            // Observation: It never reaches this point
+            logWarning(RTPS_PDP_LISTENER, "Message from own RTPSParticipant, ignoring");
             logInfo(RTPS_PDP_LISTENER, "------------------ PDP SERVER LISTENER END ------------------");
             logInfo(RTPS_PDP_LISTENER, "");
             return;
@@ -359,6 +361,7 @@ void PDPServerListener2::onNewCacheChangeAdded(
     // unique pointer destruction grants it. If the ownership has been taken away from the unique pointer, then nothing
     // happens at this point
 
+    logInfo(RTPS_PDP_LISTENER, "-------------------- " << pdp_server()->mp_RTPSParticipant->getGuid() << " --------------------");
     logInfo(RTPS_PDP_LISTENER, "------------------ PDP SERVER LISTENER END ------------------");
     logInfo(RTPS_PDP_LISTENER, "");
 }

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener2.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener2.hpp
@@ -23,9 +23,6 @@
 
 #include <fastdds/rtps/builtin/discovery/participant/PDPListener.h>
 
-// To be eventually removed together with eprosima::fastrtps
-namespace aux = ::eprosima::fastrtps::rtps;
-
 namespace eprosima {
 namespace fastdds {
 namespace rtps {
@@ -37,7 +34,7 @@ class PDPServer2;
  * This class is implemented in order to use the same structure than with any other RTPSReader.
  *@ingroup DISCOVERY_MODULE
  */
-class PDPServerListener2 : public aux::PDPListener
+class PDPServerListener2 : public fastrtps::rtps::PDPListener
 {
 public:
 
@@ -58,8 +55,8 @@ public:
      * @param change
      */
     void onNewCacheChangeAdded(
-            aux::RTPSReader* reader,
-            const aux::CacheChange_t* const change) override;
+            fastrtps::rtps::RTPSReader* reader,
+            const fastrtps::rtps::CacheChange_t* const change) override;
 };
 
 


### PR DESCRIPTION
This PR fix the following errors in Discovery-Server v2:
* Remove virtual readers and writers from all topics.
* Fix find in map without verification
* Only assign remote endpoints to local participants.
* Replace `aux` namespace by the full namespace.
* Remove own DATA(p) from servers history.
* Do not send virtual changes.
* Fix double disposal error and change log priority
* Fixed client servers dispose by adding a final heartbeat to the packet with the server DATA(Up).

Merge after #1323 