### PR TITLE
Fix mismatching tag in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,7 @@
   <buildtool_depend>cmake</buildtool_depend>
 
   <depend>fastcdr</depend>
-  <depend>libssl-dev</dev>
+  <depend>libssl-dev</depend>
   <depend>libtinyxml2-dev</depend>
 
   <build_depend>foonathan_memory_vendor</build_depend>


### PR DESCRIPTION
Building this package with ROS fails.

Error message:
```
Error(s) in package '/ros2_foxy/src/eProsima/Fast-DDS/package.xml':
The manifest contains invalid XML:
mismatched tag: line 20, column 22
```

This pull request fixes this error by changing `dev` to `depend` in `package.xml`.

This fixes the master branch, but this is also fixed in the 2.0.x branch with #1554