### PR TITLE
Fix mismatching tag in package.xml <2.0.x>

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,7 @@
   <buildtool_depend>cmake</buildtool_depend>
 
   <depend>fastcdr</depend>
-  <depend>libssl-dev</dev>
+  <depend>libssl-dev</depend>
   <depend>libtinyxml2-dev</depend>
 
   <build_depend>foonathan_memory_vendor</build_depend>


### PR DESCRIPTION
Currently, the 2.0.x branch is being used in ROS Foxy [[1](https://github.com/ros2/ros2/blob/master/ros2.repos#L41)] [[2](https://github.com/ros/rosdistro/blob/master/foxy/distribution.yaml#L911)]. Because the package.xml in this branch is malformed since 669a400b704b6e70752e559d4a5719d4a36a6296, all builds that build ROS 2 from source fail.

Error message:
```
Error(s) in package '/ros2_foxy/src/eProsima/Fast-DDS/package.xml':
The manifest contains invalid XML:
mismatched tag: line 20, column 22
```

This pull request fixes this error by changing `dev` to `depend` in `package.xml`.

This fixes the 2.0.x branch, but https://github.com/eProsima/Fast-DDS/pull/1553 fixes this for the master branch.