### PR TITLE
Resolve unused variable warning

### DIFF
--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -2322,7 +2322,7 @@ bool DiscoveryDataBase::from_json(
             }
 
             // Add Participant
-            auto wit = writers_.insert(std::make_pair(guid_aux, dei));
+            writers_.insert(std::make_pair(guid_aux, dei));
 
             // Extra configurations for writers
             // Add writer to writers_by_topic. This will create the topic if necessary

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -2322,7 +2322,9 @@ bool DiscoveryDataBase::from_json(
             }
 
             // Add Participant
-            writers_.insert(std::make_pair(guid_aux, dei));
+            auto wit = writers_.insert(std::make_pair(guid_aux, dei));
+            // wit is only used in log message below, so it's potentially unused. 
+            static_cast<void>(wit);
 
             // Extra configurations for writers
             // Add writer to writers_by_topic. This will create the topic if necessary


### PR DESCRIPTION
#1555 introduced this unused variable. It doesn' look like the code needs to refer to the pair itself, so I thought it best to just remove the iterator variable.

Signed-off-by: Stephen Brawner <brawner@gmail.com>