### PR TITLE
Fixed unit tests with BUILD_SECURITY=OFF

### DIFF
--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -56,6 +56,7 @@ public:
     TopicDataTypeMock()
         : TopicDataType()
     {
+        m_typeSize = 4u;
         setName("footype");
     }
 

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -240,7 +240,7 @@ TEST(DataWriterTests, SetListener)
     ASSERT_NE(datawriter, nullptr);
     ASSERT_EQ(datawriter->get_status_mask(), StatusMask::all());
 
-    std::vector<std::tuple<DataWriter*, DataWriterListener*, StatusMask> > testing_cases{
+    std::vector<std::tuple<DataWriter*, DataWriterListener*, StatusMask>> testing_cases{
         //statuses, one by one
         { datawriter, &listener, StatusMask::liveliness_lost() },
         { datawriter, &listener, StatusMask::offered_deadline_missed() },

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -72,6 +72,7 @@ public:
     TopicDataTypeMock()
         : TopicDataType()
     {
+        m_typeSize = 4u;
         setName("footype");
     }
 

--- a/test/unittest/dds/publisher/PublisherTests.cpp
+++ b/test/unittest/dds/publisher/PublisherTests.cpp
@@ -48,6 +48,7 @@ public:
     TopicDataTypeMock()
         : TopicDataType()
     {
+        m_typeSize = 4u;
         setName("footype");
     }
 

--- a/test/unittest/dds/status/ListenerTests.cpp
+++ b/test/unittest/dds/status/ListenerTests.cpp
@@ -489,6 +489,7 @@ public:
     TopicDataTypeMock()
         : TopicDataType()
     {
+        m_typeSize = 4u;
         setName("footype");
     }
 

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -85,6 +85,7 @@ public:
     TopicDataTypeMock()
         : TopicDataType()
     {
+        m_typeSize = 4u;
         setName("footype");
     }
 

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -194,7 +194,7 @@ TEST(DataReaderTests, SetListener)
     ASSERT_NE(datareader, nullptr);
     ASSERT_EQ(datareader->get_status_mask(), StatusMask::all());
 
-    std::vector<std::tuple<DataReader*, DataReaderListener*, StatusMask> > testing_cases{
+    std::vector<std::tuple<DataReader*, DataReaderListener*, StatusMask>> testing_cases{
         //statuses, one by one
         { datareader, &listener, StatusMask::data_available() },
         { datareader, &listener, StatusMask::sample_rejected() },

--- a/test/unittest/dds/subscriber/SubscriberTests.cpp
+++ b/test/unittest/dds/subscriber/SubscriberTests.cpp
@@ -85,6 +85,7 @@ public:
     TopicDataTypeMock()
         : TopicDataType()
     {
+        m_typeSize = 4u;
         setName("footype");
     }
 

--- a/test/unittest/dds/topic/TopicTests.cpp
+++ b/test/unittest/dds/topic/TopicTests.cpp
@@ -201,7 +201,7 @@ TEST(TopicTests, SetListener)
     ASSERT_NE(topic, nullptr);
     ASSERT_EQ(topic->get_status_mask(), StatusMask::all());
 
-    std::vector<std::tuple<Topic*, TopicListener*, StatusMask> > testing_cases{
+    std::vector<std::tuple<Topic*, TopicListener*, StatusMask>> testing_cases{
         //statuses, one by one
         { topic, &listener, StatusMask::data_available() },
         //all except one

--- a/test/unittest/dds/topic/TopicTests.cpp
+++ b/test/unittest/dds/topic/TopicTests.cpp
@@ -79,6 +79,7 @@ public:
     TopicDataTypeMock()
         : TopicDataType()
     {
+        m_typeSize = 4u;
         setName("footype");
     }
 


### PR DESCRIPTION
The mock used for `TopicDataType` on some tests was not respecting the restriction on the type size