### PR TITLE
Improve dependencies on package.xml [9887]

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,12 +14,17 @@
   <url type="bugtracker">https://github.com/eProsima/Fast-DDS/issues</url>
   <url type="repository">https://github.com/eProsima/Fast-DDS</url>
 
-  <buildtool_depend>cmake</buildtool_depend>
+  <build_depend>asio</build_depend>
+
+  <build_export_depend>libssl-dev</build_export_depend>
+
+  <exec_depend>libssl-dev</exec_depend>
 
   <depend>fastcdr</depend>
-  <depend>libssl-dev</depend>
+  <depend>foonathan_memory_vendor</depend>
+  <depend>tinyxml2</depend>
 
-  <build_depend>foonathan_memory_vendor</build_depend>
+  <buildtool_depend>cmake</buildtool_depend>
 
   <doc_depend>doxygen</doc_depend>
 


### PR DESCRIPTION
This PR mimicks the package dependencies from [ros2-gbp/fastrtps-release](https://github.com/ros2-gbp/fastrtps-release/blob/fcfe2fe9a9fb488f1ecc8c7a101b60775f205885/foxy/package.xml#L10-L20)