### PR TITLE
Correct fast-discovery-server.bat issue

### DIFF
--- a/tools/fds/fast-discovery-server.bat.in
+++ b/tools/fds/fast-discovery-server.bat.in
@@ -7,7 +7,7 @@ rem Bypass "Terminate Batch Job" prompt.
 if "%~1"=="-FIXED_CTRL_C" (
    REM Remove the -FIXED_CTRL_C parameter
    SHIFT
-   %~dp0\@FAST_SERVER_BINARY_NAME@ %*
+   "%~dp0@FAST_SERVER_BINARY_NAME@" %*
 ) ELSE (
    REM Run the batch with <NUL and -FIXED_CTRL_C
    CALL <NUL %0 -FIXED_CTRL_C %*


### PR DESCRIPTION
Make the **fast-discovery-server.bat** batch handle whitespaces on installation path.