### PR TITLE
Fix interval of WLP timer when remove_local_writer called.

### DIFF
--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -748,7 +748,7 @@ bool WLP::remove_local_writer(
                 min_automatic_ms_ = announcement_period;
             }
         }
-        automatic_liveliness_assertion_->update_interval(min_automatic_ms_);
+        automatic_liveliness_assertion_->update_interval_millisec(min_automatic_ms_);
     }
     else if (W->get_liveliness_kind() == MANUAL_BY_PARTICIPANT_LIVELINESS_QOS)
     {
@@ -790,7 +790,7 @@ bool WLP::remove_local_writer(
                 min_manual_by_participant_ms_ = announcement_period;
             }
         }
-        manual_liveliness_assertion_->update_interval(min_manual_by_participant_ms_);
+        manual_liveliness_assertion_->update_interval_millisec(min_manual_by_participant_ms_);
         return true;
     }
     else if (W->get_liveliness_kind() == MANUAL_BY_TOPIC_LIVELINESS_QOS)


### PR DESCRIPTION
The interval of WLP timer should be updated when remove_local_writer is called.
But the parameter min_automatic_ms_ and min_manual_by_participant_ms_ are in MILLI-second, we should call update_interval_millisec instead of update_interval.