### PR TITLE
Update entityId on big endian system

### DIFF
--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -492,16 +492,9 @@ bool RTPSParticipantImpl::preprocess_endpoint_attributes(
             idnum = IdCounter;
         }
 
-        octet* c = reinterpret_cast<octet*>(&idnum);
-#if __BIG_ENDIAN__
-        entId.value[2] = c[1];
-        entId.value[1] = c[2];
-        entId.value[0] = c[3];
-#else
-        entId.value[2] = c[0];
-        entId.value[1] = c[1];
-        entId.value[0] = c[2];
-#endif // if __BIG_ENDIAN__
+        entId.value[2] = octet(idnum);
+        entId.value[1] = octet(idnum >> 8);
+        entId.value[0] = octet(idnum >> 16);
         if (this->existsEntityId(entId, kind))
         {
             logError(RTPS_PARTICIPANT,

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -493,9 +493,15 @@ bool RTPSParticipantImpl::preprocess_endpoint_attributes(
         }
 
         octet* c = reinterpret_cast<octet*>(&idnum);
+#if __BIG_ENDIAN__
+        entId.value[2] = c[1];
+        entId.value[1] = c[2];
+        entId.value[0] = c[3];
+#else
         entId.value[2] = c[0];
         entId.value[1] = c[1];
         entId.value[0] = c[2];
+#endif // if __BIG_ENDIAN__
         if (this->existsEntityId(entId, kind))
         {
             logError(RTPS_PARTICIPANT,


### PR DESCRIPTION
The byte c[3] will always be dropped when creating entityId, but it could be the only byte that contains information in the variable idnum on big endian system, especially when idnum is created by calling setEntityID(uint8_t id).