### PR TITLE
Reset the minimum time before canceling WLP timer

### DIFF
--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -731,6 +731,7 @@ bool WLP::remove_local_writer(
 
         automatic_writers_.erase(it);
 
+        min_automatic_ms_ = std::numeric_limits<double>::max();
         if (automatic_writers_.size() == 0)
         {
             automatic_liveliness_assertion_->cancel_timer();
@@ -738,8 +739,6 @@ bool WLP::remove_local_writer(
         }
 
         // There are still some writers. Calculate the new minimum announcement period
-
-        min_automatic_ms_ = std::numeric_limits<double>::max();
         for (const auto& w : automatic_writers_)
         {
             auto announcement_period = TimeConv::Duration_t2MilliSecondsDouble(w->get_liveliness_announcement_period());
@@ -773,6 +772,7 @@ bool WLP::remove_local_writer(
             logError(RTPS_LIVELINESS, "Could not remove writer " << W->getGuid() << " from liveliness manager");
         }
 
+        min_manual_by_participant_ms_ = std::numeric_limits<double>::max();
         if (manual_by_participant_writers_.size() == 0)
         {
             manual_liveliness_assertion_->cancel_timer();
@@ -780,8 +780,6 @@ bool WLP::remove_local_writer(
         }
 
         // There are still some writers. Calculate the new minimum announcement period
-
-        min_manual_by_participant_ms_ = std::numeric_limits<double>::max();
         for (const auto& w : manual_by_participant_writers_)
         {
             auto announcement_period = TimeConv::Duration_t2MilliSecondsDouble(w->get_liveliness_announcement_period());

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -371,10 +371,12 @@ public:
         {
             publisher_->delete_datawriter(datawriter_);
         }
+        datawriter_ = nullptr;
         if (publisher_ != nullptr)
         {
             participant_->delete_publisher(publisher_);
         }
+        publisher_ = nullptr;
         return;
     }
 

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -316,16 +316,26 @@ public:
             // Register type
             ASSERT_EQ(participant_->register_type(type_), ReturnCode_t::RETCODE_OK);
 
-            // Create publisher
-            publisher_ = participant_->create_publisher(publisher_qos_);
-            ASSERT_NE(publisher_, nullptr);
-            ASSERT_TRUE(publisher_->is_enabled());
-
             // Create topic
             topic_ = participant_->create_topic(topic_name_, type_->getName(),
                             eprosima::fastdds::dds::TOPIC_QOS_DEFAULT);
             ASSERT_NE(topic_, nullptr);
             ASSERT_TRUE(topic_->is_enabled());
+
+            // Create publisher
+            createPublisher();
+        }
+        return;
+    }
+
+    void createPublisher()
+    {
+        if  (participant_ != nullptr)
+        {
+            // Create publisher
+            publisher_ = participant_->create_publisher(publisher_qos_);
+            ASSERT_NE(publisher_, nullptr);
+            ASSERT_TRUE(publisher_->is_enabled());
 
             if (!xml_file_.empty())
             {
@@ -350,6 +360,20 @@ public:
 
                 initialized_ = datawriter_->is_enabled();
             }
+        }
+        return;
+    }
+
+    void removePublisher()
+    {
+        initialized_ = false;
+        if (datawriter_ != nullptr)
+        {
+            publisher_ ->delete_datawriter(datawriter_ );
+        }
+        if (publisher_  != nullptr)
+        {
+            participant_->delete_publisher(publisher_ );
         }
         return;
     }

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -330,7 +330,7 @@ public:
 
     void createPublisher()
     {
-        if  (participant_ != nullptr)
+        if (participant_ != nullptr)
         {
             // Create publisher
             publisher_ = participant_->create_publisher(publisher_qos_);
@@ -369,11 +369,11 @@ public:
         initialized_ = false;
         if (datawriter_ != nullptr)
         {
-            publisher_ ->delete_datawriter(datawriter_ );
+            publisher_->delete_datawriter(datawriter_);
         }
-        if (publisher_  != nullptr)
+        if (publisher_ != nullptr)
         {
-            participant_->delete_publisher(publisher_ );
+            participant_->delete_publisher(publisher_);
         }
         return;
     }

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
@@ -311,6 +311,32 @@ public:
         }
     }
 
+    void createPublisher()
+    {
+        if (participant_ != nullptr)
+        {
+            //Create publisher
+            publisher_ = eprosima::fastrtps::Domain::createPublisher(participant_, publisher_attr, &listener_);
+
+            if (publisher_ != nullptr)
+            {
+                publisher_guid_ = publisher_->getGuid();
+                std::cout << "Created publisher " << publisher_guid_ << " for topic " <<
+                    publisher_attr_.topic.topicName << std::endl;
+                initialized_ = true;
+                return;
+            }
+        }
+        return;
+    }
+
+    void removePublisher()
+    {
+        initialized_ = false;
+        eprosima::fastrtps::Domain::removePublisher(publisher_);
+        return;
+    }
+
     bool isInitialized() const
     {
         return initialized_;

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
@@ -316,7 +316,7 @@ public:
         if (participant_ != nullptr)
         {
             //Create publisher
-            publisher_ = eprosima::fastrtps::Domain::createPublisher(participant_, publisher_attr, &listener_);
+            publisher_ = eprosima::fastrtps::Domain::createPublisher(participant_, publisher_attr_, &listener_);
 
             if (publisher_ != nullptr)
             {


### PR DESCRIPTION
min_automatic_ms_ and min_manual_by_participant_ms_ should be reset to max() before canceling the WLP timer, otherwise the WLP timer will not be restarted next time calling add_local_writer.