### PR TITLE
Add DYNAMIC_RESERVE XML setting support

### DIFF
--- a/include/fastrtps/xmlparser/XMLParserCommon.h
+++ b/include/fastrtps/xmlparser/XMLParserCommon.h
@@ -157,6 +157,7 @@ extern const char* PREALLOCATED;
 extern const char* PREALLOCATED_WITH_REALLOC;
 extern const char* DYNAMIC;
 extern const char* DYNAMIC_REUSABLE;
+extern const char* DYNAMIC_RESERVE;
 extern const char* LOCATOR;
 extern const char* UDPv4_LOCATOR;
 extern const char* UDPv6_LOCATOR;

--- a/resources/xsd/fastRTPS_profiles.xsd
+++ b/resources/xsd/fastRTPS_profiles.xsd
@@ -51,6 +51,7 @@
             <xs:enumeration value="PREALLOCATED_WITH_REALLOC"/>
             <xs:enumeration value="DYNAMIC"/>
             <xs:enumeration value="DYNAMIC_REUSABLE"/>
+            <xs:enumeration value="DYNAMIC_RESERVE"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/src/cpp/rtps/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLElementParser.cpp
@@ -2790,6 +2790,7 @@ XMLP_ret XMLParser::getXMLHistoryMemoryPolicy(
                 <xs:enumeration value="PREALLOCATED_WITH_REALLOC"/>
                 <xs:enumeration value="DYNAMIC"/>
                 <xs:enumeration value="DYNAMIC_REUSABLE"/>
+                <xs:enumeration value="DYNAMIC_RESERVE"/>
             </xs:restriction>
         </xs:simpleType>
      */
@@ -2814,6 +2815,10 @@ XMLP_ret XMLParser::getXMLHistoryMemoryPolicy(
     else if (strcmp(text, DYNAMIC_REUSABLE) == 0)
     {
         historyMemoryPolicy = MemoryManagementPolicy::DYNAMIC_REUSABLE_MEMORY_MODE;
+    }
+    else if (strcmp(text, DYNAMIC_RESERVE) == 0)
+    {
+        historyMemoryPolicy = MemoryManagementPolicy::DYNAMIC_RESERVE_MEMORY_MODE;
     }
     else
     {

--- a/src/cpp/rtps/xmlparser/XMLParserCommon.cpp
+++ b/src/cpp/rtps/xmlparser/XMLParserCommon.cpp
@@ -138,6 +138,7 @@ const char* PREALLOCATED = "PREALLOCATED";
 const char* PREALLOCATED_WITH_REALLOC = "PREALLOCATED_WITH_REALLOC";
 const char* DYNAMIC = "DYNAMIC";
 const char* DYNAMIC_REUSABLE = "DYNAMIC_REUSABLE";
+const char* DYNAMIC_RESERVE = "DYNAMIC_RESERVE";
 const char* LOCATOR = "locator";
 const char* UDPv4_LOCATOR = "udpv4";
 const char* UDPv6_LOCATOR = "udpv6";


### PR DESCRIPTION
Using the following XML,
```
<?xml version="1.0" encoding="UTF-8"?>
<dds xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles">
  <profiles>

    <publisher profile_name="publisher profile" is_default_profile="true">
      <historyMemoryPolicy>DYNAMIC_RESERVE</historyMemoryPolicy>
    </publisher>

    <subscriber profile_name="subscriber profile" is_default_profile="true">
      <historyMemoryPolicy>DYNAMIC_RESERVE</historyMemoryPolicy>
    </subscriber>

  </profiles>
</dds>
```
results in errors:
```
2020-11-23 11:29:55.720 [XMLPARSER Error] Node 'kind' bad content -> Function getXMLHistoryMemoryPolicy
2020-11-23 11:29:55.720 [XMLPARSER Error] Error parsing publisher profile -> Function parseXMLPublisherProf
2020-11-23 11:29:55.720 [XMLPARSER Error] Error parsing profile's tag publisher -> Function parseProfiles
2020-11-23 11:29:55.720 [XMLPARSER Error] Node 'kind' bad content -> Function getXMLHistoryMemoryPolicy
2020-11-23 11:29:55.720 [XMLPARSER Error] Error parsing subscriber profile -> Function parseXMLSubscriberProf
2020-11-23 11:29:55.720 [XMLPARSER Error] Error parsing profile's tag subscriber -> Function parseProfiles
2020-11-23 11:29:55.720 [XMLPARSER Error] Error parsing 'MY_PROFILE.xml' -> Function loadXMLFile
```
This PR fixes it