### PR TITLE
Extend TopicDataType interface

### DIFF
--- a/include/fastdds/dds/topic/TopicDataType.hpp
+++ b/include/fastdds/dds/topic/TopicDataType.hpp
@@ -25,6 +25,12 @@
 #include <string>
 #include <functional>
 
+// This version of TypeSupport has `is_bounded()`
+#define TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
+
+// This version of TypeSupport has `is_plain()`
+#define TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
+
 namespace eprosima {
 
 namespace fastrtps {
@@ -262,6 +268,22 @@ public:
             std::shared_ptr<xtypes::TypeInformation> info)
     {
         type_information_ = std::move(info);
+    }
+
+    /**
+     * Checks if the type is bounded.
+     */
+    RTPS_DllAPI virtual inline bool is_bounded() const
+    {
+        return false;
+    }
+
+    /**
+     * Checks if the type is plain.
+     */
+    RTPS_DllAPI virtual inline bool is_plain() const
+    {
+        return false;
     }
 
     //! Maximum serialized size of the type in bytes.

--- a/include/fastdds/dds/topic/TopicDataType.hpp
+++ b/include/fastdds/dds/topic/TopicDataType.hpp
@@ -31,8 +31,10 @@
 // This version of TypeSupport has `is_plain()`
 #define TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
 
-namespace eprosima {
+// This version of TypeSupport has `construct_sample()`
+#define TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
 
+namespace eprosima {
 namespace fastrtps {
 
 namespace rtps {
@@ -283,6 +285,20 @@ public:
      */
     RTPS_DllAPI virtual inline bool is_plain() const
     {
+        return false;
+    }
+
+    /**
+     * Construct a sample on a memory location.
+     *
+     * @param memory Pointer to the memory location where the sample should be constructed.
+     *
+     * @return whether this type supports in-place construction or not.
+     */
+    RTPS_DllAPI virtual inline bool construct_sample(
+            void* memory) const
+    {
+        static_cast<void>(memory);
         return false;
     }
 

--- a/versions.md
+++ b/versions.md
@@ -1,3 +1,8 @@
+Forthcoming
+-----------
+
+* TopicDataType interface extended (ABI break)
+
 Version 2.1.0
 -------------
 


### PR DESCRIPTION
This PR adds several methods to the `TopicDataType` interface in a backwards compatible way.

See eProsima/Fast-DDS-Gen#42 for the support of these extensions on the code generator