### PR TITLE
Added tests for XMLParser functions

### DIFF
--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -754,6 +754,35 @@ TEST_F(XMLParserTests, parseXMLProfilesRoot)
 }
 
 /*
+ * This test checks the postive cases of the TLS configuration via XML.
+ * 1. Check that parse_tls_config() return an XML_OK code for a valid configurations of <verify_paths>.
+ */
+TEST_F(XMLParserTests, parseTLSConfigPositiveClauses)
+{
+    tinyxml2::XMLDocument xml_doc;
+    std::unique_ptr<BaseNode> root;
+    tinyxml2::XMLElement* titleElement;
+    std::shared_ptr<eprosima::fastdds::rtps::TransportDescriptorInterface> tcp_transport =
+            std::make_shared<rtps::TCPv4TransportDescriptor>();
+
+    // Parametrized XML
+    const char* xml =
+            "\
+            <tls>\
+                <verify_paths>\
+                    <verify_path>path_1</verify_path>\
+                    <verify_path>path_2</verify_path>\
+                </verify_paths>\
+            </tls>\
+            ";
+
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    // Check that parse_tls_config() return an XML_OK code for a valid configurations of <verify_paths>.
+    EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::parse_tls_config_wrapper(titleElement, tcp_transport));
+}
+
+/*
  * This test checks the negative cases of the TLS configuration via XML.
  * 1. Check that elements <password>, <private_key_file>, <rsa_private_key_file>, <cert_chain_file>, <tmp_dh_file>,
  * <verify_file>, <verify_depth>, <default_verify_path>, and <bad_element> return an xml error if their value is empty.

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -1339,6 +1339,71 @@ TEST_F(XMLParserTests, loadXMLEmptyFileName)
     std::unique_ptr<BaseNode> root;
     ASSERT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("", root));
 }
+
+/*
+ * This test checks the negative case in the fillDataNode function when it refers to a publisher node.
+ * 1. Check that an XML_ERROR is triggered when the xml element is nullptr.
+ * 2. Check that an XML_ERROR is triggered when the <publisher> element does not contains any attributes.
+ */
+TEST_F(XMLParserTests, fillDataNodePublisherNegativeClauses)
+{
+    std::unique_ptr<PublisherAttributes> publisher_atts{new PublisherAttributes};
+    std::unique_ptr<DataNode<PublisherAttributes>> publisher_node{
+            new DataNode<PublisherAttributes>{ NodeType::PUBLISHER, std::move(publisher_atts) }};
+
+    // Check that an XML_ERROR is triggered when the xml element is nullptr.
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(nullptr, *publisher_node));
+
+    tinyxml2::XMLDocument xml_doc;
+    tinyxml2::XMLElement* titleElement;
+
+    // XML snippet
+    const char* xml =
+            "\
+            <publisher>\
+                <bad_element></bad_element>\
+            </publisher>\
+            ";
+
+    // Load the xml
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    // Check that an XML_ERROR is triggered when the <publisher> element does not contains any attributes.
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(titleElement, *publisher_node));
+}
+
+/*
+ * This test checks the negative case in the fillDataNode function when it refers to a subscriber node.
+ * 1. Check that an XML_ERROR is triggered when the xml element is nullptr.
+ * 2. Check that an XML_ERROR is triggered when the <subscriber> element does not contains any attributes.
+ */
+TEST_F(XMLParserTests, fillDataNodeSubscriberNegativeClauses)
+{
+    std::unique_ptr<SubscriberAttributes> subscriber_atts{new SubscriberAttributes};
+    std::unique_ptr<DataNode<SubscriberAttributes>> subscriber_node{
+            new DataNode<SubscriberAttributes>{ NodeType::PUBLISHER, std::move(subscriber_atts) }};
+
+    // Check that an XML_ERROR is triggered when the xml element is nullptr.
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(nullptr, *subscriber_node));
+
+    tinyxml2::XMLDocument xml_doc;
+    tinyxml2::XMLElement* titleElement;
+
+    // XML snippet
+    const char* xml =
+            "\
+            <subscriber>\
+                <bad_element></bad_element>\
+            </subscriber>\
+            ";
+
+    // Load the xml
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    // Check that an XML_ERROR is triggered when the <subscriber> element does not contains any attributes.
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(titleElement, *subscriber_node));
+}
+
 // FINISH RAUL SECTION
 
 // INIT PARIS SECTION

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -622,15 +622,104 @@ TEST_F(XMLParserTests, DataBuffer)
 
 // INIT NACHO SECTION
 
-// FINISH NACHO SECTION	
+// FINISH NACHO SECTION
 
-// INIT RAUL SECTION	
+// INIT RAUL SECTION
+/*
+ * This test checks the correct functioning of the parseXML function when the <dds> root element does not exist.
+ * 1. Check that elements <profiles>, <types> and <log> are read as root elements.
+ * 2. Check that it triggers an error when reading an wrong element.
+ */
+TEST_F(XMLParserTests, parseXMLNoRoot)
+{
+    tinyxml2::XMLDocument xml_doc;
+    std::unique_ptr<BaseNode> root;
 
-// FINISH RAUL SECTION	
+    // Parametrized XML
+    const char* xml_p =
+            "\
+            <%s>\
+            </%s>\
+            ";
 
-// INIT PARIS SECTION	
+    char xml[600];
 
-// FINISH PARIS SECTION	
+    // Check that elements <profiles>, <types> and <log> are read as root elements.
+    std::vector<std::string> elements {
+        "profiles",
+        "types",
+        "log"
+    };
+
+    for (std::string e : elements)
+    {
+        sprintf(xml, xml_p, e.c_str(), e.c_str());
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::parseXML_wrapper(xml_doc, root));
+    }
+
+    // Check that it triggers an error when reading an wrong element.
+    sprintf(xml, xml_p, "bad_root", "bad_root");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::parseXML_wrapper(xml_doc, root));
+}
+
+/*
+ * This test checks the correct functioning of the parseXML function for all xml child elements of <profile>
+ * when the <profiles> element is an xml child element of the <dds> root element.
+ * 1. Check that elements library_settings <participant>, <publisher>, <data_writer>, <subscriber>, <data_reader>,
+ * <topic>, <requester>, <replier>, <types>, and <log> are read as xml child elements of the <profiles> root element.
+ * 2. Check that it triggers an error when reading an wrong element.
+ */
+TEST_F(XMLParserTests, parseXMLProfilesRoot)
+{
+    tinyxml2::XMLDocument xml_doc;
+    std::unique_ptr<BaseNode> root;
+
+    // Parametrized XML
+    const char* xml_p =
+            "\
+            <dds>\
+                <%s>\
+                </%s>\
+            </dds>\
+            ";
+
+    char xml[600];
+
+    // Check that elements library_settings <participant>, <publisher>, <data_writer>, <subscriber>, <data_reader>,
+    // <topic>, <requester>, <replier>, <types>, and <log> are read as xml child elements of the <profiles> root element.
+    std::vector<std::string> elements {
+        "library_settings",
+        "participant",
+        "publisher",
+        "data_writer",
+        "subscriber",
+        "data_reader",
+        "topic",
+        "requester",
+        "replier",
+        "types",
+        "log"
+    };
+
+    for (std::string e : elements)
+    {
+        sprintf(xml, xml_p, e.c_str(), e.c_str());
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::parseXML_wrapper(xml_doc, root));
+    }
+
+    // Check that it triggers an error when reading an wrong element.
+    sprintf(xml, xml_p, "bad_element", "bad_element");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::parseXML_wrapper(xml_doc, root));
+}
+// FINISH RAUL SECTION
+
+// INIT PARIS SECTION
+
+// FINISH PARIS SECTION
 
 int main(
         int argc,

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -1404,6 +1404,38 @@ TEST_F(XMLParserTests, fillDataNodeSubscriberNegativeClauses)
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(titleElement, *subscriber_node));
 }
 
+/*
+ * This test checks the negative case in the fillDataNode function when it refers to a topic node.
+ * 1. Check that an XML_ERROR is triggered when the xml element is nullptr.
+ * 2. Check that an XML_ERROR is triggered when the <topic> element does not contains any attributes.
+ */
+TEST_F(XMLParserTests, fillDataNodeTopicNegativeClauses)
+{
+    std::unique_ptr<TopicAttributes> topic_atts{new TopicAttributes};
+    std::unique_ptr<DataNode<TopicAttributes>> topic_node{
+            new DataNode<TopicAttributes>{ NodeType::PUBLISHER, std::move(topic_atts) }};
+
+    // Check that an XML_ERROR is triggered when the xml element is nullptr.
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(nullptr, *topic_node));
+
+    tinyxml2::XMLDocument xml_doc;
+    tinyxml2::XMLElement* titleElement;
+
+    // XML snippet
+    const char* xml =
+            "\
+            <topic>\
+                <bad_element></bad_element>\
+            </topic>\
+            ";
+
+    // Load the xml
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    // Check that an XML_ERROR is triggered when the <topic> element does not contains any attributes.
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(titleElement, *topic_node));
+}
+
 // FINISH RAUL SECTION
 
 // INIT PARIS SECTION

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -1308,6 +1308,9 @@ TEST_F(XMLParserTests, parseUnsupportedProfiles)
     EXPECT_EQ(num_errors, 3);
 }
 
+/*
+ * This test checks the negative case in the <library_settings> xml element.
+ */
 TEST_F(XMLParserTests, parseXMLLibrarySettingsNegativeClauses)
 {
     tinyxml2::XMLDocument xml_doc;
@@ -1324,7 +1327,17 @@ TEST_F(XMLParserTests, parseXMLLibrarySettingsNegativeClauses)
     // Load the xml
     ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
     titleElement = xml_doc.RootElement();
+    // Check that it returns an xml error when <intraprocess_delivery> is empty
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::parseXMLLibrarySettings_wrapper(titleElement));
+}
+
+/*
+ * This test checks an error is triggered when the xml file name is empty.
+ */
+TEST_F(XMLParserTests, loadXMLEmptyFileName)
+{
+    std::unique_ptr<BaseNode> root;
+    ASSERT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("", root));
 }
 // FINISH RAUL SECTION
 

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -1381,7 +1381,7 @@ TEST_F(XMLParserTests, fillDataNodeSubscriberNegativeClauses)
 {
     std::unique_ptr<SubscriberAttributes> subscriber_atts{new SubscriberAttributes};
     std::unique_ptr<DataNode<SubscriberAttributes>> subscriber_node{
-            new DataNode<SubscriberAttributes>{ NodeType::PUBLISHER, std::move(subscriber_atts) }};
+            new DataNode<SubscriberAttributes>{ NodeType::SUBSCRIBER, std::move(subscriber_atts) }};
 
     // Check that an XML_ERROR is triggered when the xml element is nullptr.
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(nullptr, *subscriber_node));
@@ -1413,7 +1413,7 @@ TEST_F(XMLParserTests, fillDataNodeTopicNegativeClauses)
 {
     std::unique_ptr<TopicAttributes> topic_atts{new TopicAttributes};
     std::unique_ptr<DataNode<TopicAttributes>> topic_node{
-            new DataNode<TopicAttributes>{ NodeType::PUBLISHER, std::move(topic_atts) }};
+            new DataNode<TopicAttributes>{ NodeType::TOPIC, std::move(topic_atts) }};
 
     // Check that an XML_ERROR is triggered when the xml element is nullptr.
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(nullptr, *topic_node));
@@ -1434,6 +1434,135 @@ TEST_F(XMLParserTests, fillDataNodeTopicNegativeClauses)
     titleElement = xml_doc.RootElement();
     // Check that an XML_ERROR is triggered when the <topic> element does not contains any attributes.
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(titleElement, *topic_node));
+}
+
+/*
+ * This test checks the negative case in the fillDataNode function when it refers to a requester node.
+ * 1. Check that fillDataNode() returns an XML_ERROR when the xml element is nullptr.
+ * 2. Check that fillDataNode() returns an XML_ERROR when the profile_name attribute is missing.
+ * 3. Check that fillDataNode() returns an XML_ERROR when the service_name attribute is missing.
+ * 4. Check that fillDataNode() returns an XML_ERROR when the request_type attribute is missing.
+ * 5. Check that fillDataNode() returns an XML_ERROR when the reply_type attribute is missing.
+ * 5. Check that fillDataNode() returns an XML_ERROR when the <request_topic_name>, <reply_topic_name>, <publisher>, and <subscriber>
+ *    does not contains a valid xml element.
+ * 6. Check that fillDataNode() returns an XML_ERROR when child xml element of <requester> is not valid.
+ */
+TEST_F(XMLParserTests, fillDataNodeRequesterNegativeClauses)
+{
+    std::unique_ptr<RequesterAttributes> requester_atts_error{new RequesterAttributes};
+    std::unique_ptr<DataNode<RequesterAttributes>> requester_node_error{
+            new DataNode<RequesterAttributes>{ NodeType::REQUESTER, std::move(requester_atts_error) }};
+
+    // Check that an XML_ERROR is triggered when the xml element is nullptr.
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(nullptr, *requester_node_error));
+
+    tinyxml2::XMLDocument xml_doc;
+    tinyxml2::XMLElement* titleElement;
+
+    // Check that fillDataNode() returns an XML_ERROR when the profile_name attribute is missing.
+    {
+        const char* xml =
+                "\
+                <requester>\
+                </requester>\
+                ";
+
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        std::unique_ptr<RequesterAttributes> requester_atts{new RequesterAttributes};
+        std::unique_ptr<DataNode<RequesterAttributes>> requester_node{
+            new DataNode<RequesterAttributes>{ NodeType::REQUESTER, std::move(requester_atts) }};
+        EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(titleElement, *requester_node));
+    }
+
+    // Check that fillDataNode() returns an XML_ERROR when the service_name attribute is missing.
+    {
+        const char* xml =
+                "\
+                <requester profile_name=\"test_requester_profile\">\
+                </requester>\
+                ";
+
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        std::unique_ptr<RequesterAttributes> requester_atts{new RequesterAttributes};
+        std::unique_ptr<DataNode<RequesterAttributes>> requester_node{
+            new DataNode<RequesterAttributes>{ NodeType::REQUESTER, std::move(requester_atts) }};
+        EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(titleElement, *requester_node));
+    }
+
+    // Check that fillDataNode() returns an XML_ERROR when the request_type attribute is missing.
+    {
+        const char* xml =
+                "\
+                <requester profile_name=\"test_requester_profile\"\
+                           service_name=\"service_name\">\
+                </requester>\
+                ";
+
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        std::unique_ptr<RequesterAttributes> requester_atts{new RequesterAttributes};
+        std::unique_ptr<DataNode<RequesterAttributes>> requester_node{
+            new DataNode<RequesterAttributes>{ NodeType::REQUESTER, std::move(requester_atts) }};
+        EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(titleElement, *requester_node));
+    }
+
+    // Check that fillDataNode() returns an XML_ERROR when the reply_type attribute is missing.
+    {
+        const char* xml =
+                "\
+                <requester profile_name=\"test_requester_profile\"\
+                           service_name=\"service_name\"\
+                           request_type=\"request_type\">\
+                </requester>\
+                ";
+
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        std::unique_ptr<RequesterAttributes> requester_atts{new RequesterAttributes};
+        std::unique_ptr<DataNode<RequesterAttributes>> requester_node{
+            new DataNode<RequesterAttributes>{ NodeType::REQUESTER, std::move(requester_atts) }};
+        EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(titleElement, *requester_node));
+    }
+
+    // Check that fillDataNode() returns an XML_ERROR when the <request_topic_name>, <reply_topic_name>, <publisher>,
+    // and <subscriber> does not contains a valid xml element.
+    // Check that fillDataNode() returns an XML_ERROR when child xml element of <requester> is not valid.
+    {
+        std::unique_ptr<RequesterAttributes> requester_atts;
+        std::unique_ptr<DataNode<RequesterAttributes>> requester_node;
+
+        const char* xml_p =
+                "\
+                <requester profile_name=\"test_requester_profile\"\
+                           service_name=\"service_name\"\
+                           request_type=\"request_type\"\
+                           reply_type=\"reply_type\">\
+                    <%s>\
+                        <bad_element></bad_element>\
+                    </%s>\
+                </requester>\
+                ";
+        char xml[800];
+
+        std::vector<std::string> elements {
+            "request_topic_name",
+            "reply_topic_name",
+            "publisher",
+            "subscriber",
+            "bad_element"
+        };
+        for (std::string e : elements)
+        {
+            sprintf(xml, xml_p, e.c_str(), e.c_str());
+            ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+            titleElement = xml_doc.RootElement();
+            requester_atts.reset(new RequesterAttributes);
+            requester_node.reset(new DataNode<RequesterAttributes>{ NodeType::REQUESTER, std::move(requester_atts) });
+            EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(titleElement, *requester_node));
+        }
+    }
 }
 
 // FINISH RAUL SECTION

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -1565,6 +1565,134 @@ TEST_F(XMLParserTests, fillDataNodeRequesterNegativeClauses)
     }
 }
 
+/*
+ * This test checks the negative case in the fillDataNode function when it refers to a replier node.
+ * 1. Check that fillDataNode() returns an XML_ERROR when the xml element is nullptr.
+ * 2. Check that fillDataNode() returns an XML_ERROR when the profile_name attribute is missing.
+ * 3. Check that fillDataNode() returns an XML_ERROR when the service_name attribute is missing.
+ * 4. Check that fillDataNode() returns an XML_ERROR when the request_type attribute is missing.
+ * 5. Check that fillDataNode() returns an XML_ERROR when the reply_type attribute is missing.
+ * 5. Check that fillDataNode() returns an XML_ERROR when the <request_topic_name>, <reply_topic_name>, <publisher>, and <subscriber>
+ *    does not contains a valid xml element.
+ * 6. Check that fillDataNode() returns an XML_ERROR when child xml element of <replier> is not valid.
+ */
+TEST_F(XMLParserTests, fillDataNodeReplierNegativeClauses)
+{
+    std::unique_ptr<ReplierAttributes> replier_atts_error{new ReplierAttributes};
+    std::unique_ptr<DataNode<ReplierAttributes>> replier_node_error{
+            new DataNode<ReplierAttributes>{ NodeType::REQUESTER, std::move(replier_atts_error) }};
+
+    // Check that an XML_ERROR is triggered when the xml element is nullptr.
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(nullptr, *replier_node_error));
+
+    tinyxml2::XMLDocument xml_doc;
+    tinyxml2::XMLElement* titleElement;
+
+    // Check that fillDataNode() returns an XML_ERROR when the profile_name attribute is missing.
+    {
+        const char* xml =
+                "\
+                <replier>\
+                </replier>\
+                ";
+
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        std::unique_ptr<ReplierAttributes> replier_atts{new ReplierAttributes};
+        std::unique_ptr<DataNode<ReplierAttributes>> replier_node{
+            new DataNode<ReplierAttributes>{ NodeType::REQUESTER, std::move(replier_atts) }};
+        EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(titleElement, *replier_node));
+    }
+
+    // Check that fillDataNode() returns an XML_ERROR when the service_name attribute is missing.
+    {
+        const char* xml =
+                "\
+                <replier profile_name=\"test_replier_profile\">\
+                </replier>\
+                ";
+
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        std::unique_ptr<ReplierAttributes> replier_atts{new ReplierAttributes};
+        std::unique_ptr<DataNode<ReplierAttributes>> replier_node{
+            new DataNode<ReplierAttributes>{ NodeType::REQUESTER, std::move(replier_atts) }};
+        EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(titleElement, *replier_node));
+    }
+
+    // Check that fillDataNode() returns an XML_ERROR when the request_type attribute is missing.
+    {
+        const char* xml =
+                "\
+                <replier profile_name=\"test_replier_profile\"\
+                           service_name=\"service_name\">\
+                </replier>\
+                ";
+
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        std::unique_ptr<ReplierAttributes> replier_atts{new ReplierAttributes};
+        std::unique_ptr<DataNode<ReplierAttributes>> replier_node{
+            new DataNode<ReplierAttributes>{ NodeType::REQUESTER, std::move(replier_atts) }};
+        EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(titleElement, *replier_node));
+    }
+
+    // Check that fillDataNode() returns an XML_ERROR when the reply_type attribute is missing.
+    {
+        const char* xml =
+                "\
+                <replier profile_name=\"test_replier_profile\"\
+                           service_name=\"service_name\"\
+                           request_type=\"request_type\">\
+                </replier>\
+                ";
+
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        std::unique_ptr<ReplierAttributes> replier_atts{new ReplierAttributes};
+        std::unique_ptr<DataNode<ReplierAttributes>> replier_node{
+            new DataNode<ReplierAttributes>{ NodeType::REQUESTER, std::move(replier_atts) }};
+        EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(titleElement, *replier_node));
+    }
+
+    // Check that fillDataNode() returns an XML_ERROR when the <request_topic_name>, <reply_topic_name>, <publisher>,
+    // and <subscriber> does not contains a valid xml element.
+    // Check that fillDataNode() returns an XML_ERROR when child xml element of <replier> is not valid.
+    {
+        std::unique_ptr<ReplierAttributes> replier_atts;
+        std::unique_ptr<DataNode<ReplierAttributes>> replier_node;
+
+        const char* xml_p =
+                "\
+                <replier profile_name=\"test_replier_profile\"\
+                           service_name=\"service_name\"\
+                           request_type=\"request_type\"\
+                           reply_type=\"reply_type\">\
+                    <%s>\
+                        <bad_element></bad_element>\
+                    </%s>\
+                </replier>\
+                ";
+        char xml[800];
+
+        std::vector<std::string> elements {
+            "request_topic_name",
+            "reply_topic_name",
+            "publisher",
+            "subscriber",
+            "bad_element"
+        };
+        for (std::string e : elements)
+        {
+            sprintf(xml, xml_p, e.c_str(), e.c_str());
+            ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+            titleElement = xml_doc.RootElement();
+            replier_atts.reset(new ReplierAttributes);
+            replier_node.reset(new DataNode<ReplierAttributes>{ NodeType::REQUESTER, std::move(replier_atts) });
+            EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(titleElement, *replier_node));
+        }
+    }
+}
 // FINISH RAUL SECTION
 
 // INIT PARIS SECTION

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -1307,6 +1307,25 @@ TEST_F(XMLParserTests, parseUnsupportedProfiles)
     }
     EXPECT_EQ(num_errors, 3);
 }
+
+TEST_F(XMLParserTests, parseXMLLibrarySettingsNegativeClauses)
+{
+    tinyxml2::XMLDocument xml_doc;
+    tinyxml2::XMLElement* titleElement;
+
+    // XML snippet
+    const char* xml =
+            "\
+            <library_settings>\
+                <intraprocess_delivery></intraprocess_delivery>\
+            </library_settings>\
+            ";
+
+    // Load the xml
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::parseXMLLibrarySettings_wrapper(titleElement));
+}
 // FINISH RAUL SECTION
 
 // INIT PARIS SECTION

--- a/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
+++ b/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
@@ -412,6 +412,12 @@ public:
         return parse_tls_config(p_root, tcp_transport);
     }
 
+    static XMLP_ret parseXMLLibrarySettings_wrapper(
+        tinyxml2::XMLElement* p_root)
+    {
+        return parseXMLLibrarySettings(p_root);
+    }
+
 // FINISH RAUL SECTION
 
 // INIT PARIS SECTION

--- a/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
+++ b/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
@@ -397,6 +397,13 @@ public:
         return parseXML(xmlDoc, root);
     }
 
+    static XMLP_ret parse_tls_config_wrapper(
+        tinyxml2::XMLElement* p_root,
+        eprosima::fastrtps::xmlparser::sp_transport_t tcp_transport)
+    {
+        return parse_tls_config(p_root, tcp_transport);
+    }
+
 // FINISH RAUL SECTION
 
 // INIT PARIS SECTION

--- a/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
+++ b/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
@@ -432,6 +432,13 @@ public:
         return fillDataNode(p_profile, subscriber_node);
     }
 
+    static XMLP_ret fillDataNode_wrapper(
+        tinyxml2::XMLElement* p_profile,
+        DataNode<TopicAttributes>& topic_node)
+    {
+        return fillDataNode(p_profile, topic_node);
+    }
+
 // FINISH RAUL SECTION
 
 // INIT PARIS SECTION

--- a/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
+++ b/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
@@ -439,6 +439,13 @@ public:
         return fillDataNode(p_profile, topic_node);
     }
 
+    static XMLP_ret fillDataNode_wrapper(
+        tinyxml2::XMLElement* p_profile,
+        DataNode<RequesterAttributes>& requester_node)
+    {
+        return fillDataNode(p_profile, requester_node);
+    }
+
 // FINISH RAUL SECTION
 
 // INIT PARIS SECTION

--- a/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
+++ b/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
@@ -385,16 +385,22 @@ public:
         return getXMLOctetVector(elem, e, ident);
     }
 
-// INIT NACHO SECTION	
+// INIT NACHO SECTION
 
-// FINISH NACHO SECTION	
+// FINISH NACHO SECTION
 
-// INIT RAUL SECTION	
+// INIT RAUL SECTION
+    static XMLP_ret parseXML_wrapper(
+        tinyxml2::XMLDocument& xmlDoc,
+        eprosima::fastrtps::xmlparser::up_base_node_t& root)
+    {
+        return parseXML(xmlDoc, root);
+    }
 
-// FINISH RAUL SECTION	
+// FINISH RAUL SECTION
 
-// INIT PARIS SECTION	
+// INIT PARIS SECTION
 
-// FINISH PARIS SECTION	
+// FINISH PARIS SECTION
 
 };

--- a/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
+++ b/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
@@ -418,6 +418,20 @@ public:
         return parseXMLLibrarySettings(p_root);
     }
 
+    static XMLP_ret fillDataNode_wrapper(
+        tinyxml2::XMLElement* p_profile,
+        DataNode<PublisherAttributes>& publisher_node)
+    {
+        return fillDataNode(p_profile, publisher_node);
+    }
+
+    static XMLP_ret fillDataNode_wrapper(
+        tinyxml2::XMLElement* p_profile,
+        DataNode<SubscriberAttributes>& subscriber_node)
+    {
+        return fillDataNode(p_profile, subscriber_node);
+    }
+
 // FINISH RAUL SECTION
 
 // INIT PARIS SECTION

--- a/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
+++ b/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
@@ -20,6 +20,7 @@ using namespace eprosima::fastrtps::rtps;
 using eprosima::fastrtps::xmlparser::XMLP_ret;
 using eprosima::fastrtps::xmlparser::XMLParser;
 using eprosima::fastrtps::xmlparser::DataNode;
+using eprosima::fastrtps::xmlparser::BaseNode;
 
 // Class to test protected methods
 class XMLParserTest : public XMLParser
@@ -395,6 +396,13 @@ public:
         eprosima::fastrtps::xmlparser::up_base_node_t& root)
     {
         return parseXML(xmlDoc, root);
+    }
+
+    static XMLP_ret parseProfiles_wrapper(
+        tinyxml2::XMLElement* p_root,
+        BaseNode& profilesNode)
+    {
+        return parseProfiles(p_root, profilesNode);
     }
 
     static XMLP_ret parse_tls_config_wrapper(

--- a/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
+++ b/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
@@ -446,6 +446,13 @@ public:
         return fillDataNode(p_profile, requester_node);
     }
 
+    static XMLP_ret fillDataNode_wrapper(
+        tinyxml2::XMLElement* p_profile,
+        DataNode<ReplierAttributes>& replier_node)
+    {
+        return fillDataNode(p_profile, replier_node);
+    }
+
 // FINISH RAUL SECTION
 
 // INIT PARIS SECTION


### PR DESCRIPTION
This PR adds unit tests for the following functions in `XMLParser.cpp`:
- `parseXML`
- `parse_tls_config`
- `parseProfiles`
- `parseXMLLibrarySettings`
- `loadXML`
- `fillDataNode` (publisher)
- `fillDataNode` (subscriber)
- `fillDataNode` (topic)
- `fillDataNode` (requester)
- `fillDataNode` (replier)