### PR TITLE
Code coverage policy [10005]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,12 @@
+# Contribution Guidelines
+
+The following documents constitutes a set of guidelines to which contributors must adhere.
+
+* [Contributions Licensing](#contributions-licensing)
+* [Developer Certificate of Origin](#developer-certificate-of-origin)
+* [Code Coverage](#code-coverage)
+## Contributions Licensing
+
 Any contribution that you make to this repository will
 be under the Apache 2 License, as dictated by that
 [license](http://www.apache.org/licenses/LICENSE-2.0.html):
@@ -12,7 +21,14 @@ be under the Apache 2 License, as dictated by that
    with Licensor regarding such Contributions.
 ~~~
 
+## Developer Certificate of Origin
+
 Contributors must sign-off each commit by adding a `Signed-off-by: ...`
 line to commit messages to certify that they have the right to submit
 the code they are contributing to the project according to the
 [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
+
+## Code Coverage
+
+As stated in [QUALITY.md](QUALITY.md), all contributions to the project must increase line code coverage.
+Because of this, contributors are asked to locally run a coverage assessment that ensures that code coverage has increased when compared to the latest execution of the [nightly coverage CI job](http://jenkins.eprosima.com:8080/job/nightly_fastdds_coverage_linux/).

--- a/QUALITY.md
+++ b/QUALITY.md
@@ -1,7 +1,6 @@
 This document is a declaration of software quality for *eprosima Fast DDS* inspired on the guidelines provided in the [ROS 2 REP-2004 document](https://www.ros.org/reps/rep-2004.html).
 
-Quality Declaration
-=============================
+# Quality Declaration
 
 *eprosima Fast DDS* (formerly Fast RTPS) is a C++ implementation of the DDS (Data Distribution Service) standard of the OMG (Object Management Group).
 eProsima Fast DDS implements the RTPS (Real Time Publish Subscribe) protocol, which provides publisher-subscriber communications over unreliable transports such as UDP,
@@ -112,12 +111,18 @@ The tests aim to cover typical usage. Currently, efforts are being made to impro
 
 ### Coverage [4.iii]
 
-*eprosima Fast DDS* coverage reports can be accessed from the CI nightly results. These reports provide statistics of line and conditional coverage.
+[![Coverage](https://img.shields.io/jenkins/coverage/cobertura.svg?jobUrl=http%3A%2F%2Fjenkins.eprosima.com%3A8080%2Fjob%2Fnightly_fastdds_coverage_linux)](http://jenkins.eprosima.com:8080/job/nightly_fastdds_coverage_linux)
+*eProsima Fast DDS* aims to provide a line coverage **above 95%**.
+*Fast DDS* code coverage policy comprises:
+1. All contributions to *Fast DDS* must increase (or at least keep) current line coverage.
+   This is done to ensure that the **95%** line coverage goal is in time met,
+1. Line coverage regressions only are permitted if properly justified and accepted by maintainers.
+1. If the CI system reports a coverage regression after a pull request has been merged, the maintainers must study the case and decide how to proceed, mostly reverting the changes and asking for a more thorough testing of the committed changes.
+1. External dependencies are excluded from the coverage report.
+1. *Fast DDS* examples are excluded from the coverage report.
+1. This policy is enforced through the [nightly Fast DDS coverage CI job](http://jenkins.eprosima.com:8080/job/nightly_fastdds_coverage_linux/).
 
-* [Linux Coverage Report](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_linux/cobertura)
-* [Mac Coverage Report](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_mac/cobertura)
-
-Changes are required to make a best effort to keep or increase coverage before being accepted, but decreases are allowed if properly justified and accepted by maintainers.
+As stated in [CONTRIBUTING.md](CONTRIBUTING.md), developers and contributors are asked to run a line coverage assessment locally before submitting a PR.
 
 ### Performance [4.iv]
 
@@ -207,7 +212,7 @@ The chart below compares the requirements in the [REP-2004](https://www.ros.org/
 |4.i| Feature items tests |✓|
 |4.ii| Public API tests |✓|
 |4.iii.a| Using coverage |✓|
-|4.iii.b| Coverage policy ||
+|4.iii.b| Coverage policy |✓|
 |4.iv.a| Performance tests (if applicable) |✓|
 |4.iv.b| Performance tests policy|✓|
 |4.v.a| Code style enforcement (linters)|✓|

--- a/QUALITY.md
+++ b/QUALITY.md
@@ -115,8 +115,8 @@ The tests aim to cover typical usage. Currently, efforts are being made to impro
 *eProsima Fast DDS* aims to provide a line coverage **above 95%**.
 *Fast DDS* code coverage policy comprises:
 1. All contributions to *Fast DDS* must increase (or at least keep) current line coverage.
-   This is done to ensure that the **95%** line coverage goal is in time met,
-1. Line coverage regressions only are permitted if properly justified and accepted by maintainers.
+   This is done to ensure that the **95%** line coverage goal is eventually met.
+1. Line coverage regressions are only permitted if properly justified and accepted by maintainers.
 1. If the CI system reports a coverage regression after a pull request has been merged, the maintainers must study the case and decide how to proceed, mostly reverting the changes and asking for a more thorough testing of the committed changes.
 1. External dependencies are excluded from the coverage report.
 1. *Fast DDS* examples are excluded from the coverage report.


### PR DESCRIPTION
This PR adds a code coverage policy which states that all contributions must at least keep (if not increase) the project's line coverage.

Signed-off-by: EduPonz <eduardoponz@eprosima.com>