### PR TITLE
Remove unnecessary waiting in ResourceEvent loop [10028]

### DIFF
--- a/src/cpp/rtps/resources/ResourceEvent.cpp
+++ b/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -157,6 +157,12 @@ void ResourceEvent::event_service()
 
         std::unique_lock<TimedMutex> lock(mutex_);
 
+        // If the thread has already been instructed to stop, do it.
+        if (stop_.load())
+        {
+            break;
+        }
+
         // If pending timers exist, there is some work to be done, so no need to wait.
         if (!pending_timers_.empty())
         {

--- a/src/cpp/rtps/resources/ResourceEvent.cpp
+++ b/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -173,7 +173,6 @@ void ResourceEvent::event_service()
         allow_vector_manipulation_ = true;
         cv_manipulation_.notify_all();
 
-        // If pending timers exist, there is some work to be done, so no need to wait.
         // Wait for the first timer to be triggered
         std::chrono::steady_clock::time_point next_trigger =
                 active_timers_.empty() ?

--- a/src/cpp/rtps/resources/ResourceEvent.cpp
+++ b/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -162,13 +162,17 @@ void ResourceEvent::event_service()
         allow_vector_manipulation_ = true;
         cv_manipulation_.notify_all();
 
-        // Wait for the first timer to be triggered
-        std::chrono::steady_clock::time_point next_trigger =
-                active_timers_.empty() ?
-                current_time_ + std::chrono::seconds(1) :
-                active_timers_[0]->next_trigger_time();
+        // If pending timers exist, there is some work to be done, so no need to wait.
+        if (pending_timers_.empty())
+        {
+            // Wait for the first timer to be triggered
+            std::chrono::steady_clock::time_point next_trigger =
+                    active_timers_.empty() ?
+                    current_time_ + std::chrono::seconds(1) :
+                    active_timers_[0]->next_trigger_time();
 
-        cv_.wait_until(lock, next_trigger);
+            cv_.wait_until(lock, next_trigger);
+        }
 
         // Don't allow other threads to manipulate the timer collections
         allow_vector_manipulation_ = false;

--- a/src/cpp/rtps/resources/ResourceEvent.cpp
+++ b/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 /**
- * @file ThreadEvent.cpp
- *
+ * @file ResourceEvent.cpp
  */
 
 #include <fastdds/rtps/resources/ResourceEvent.h>
@@ -75,9 +74,9 @@ void ResourceEvent::unregister_timer(
     std::unique_lock<TimedMutex> lock(mutex_);
 
     cv_manipulation_.wait(lock, [&]()
-                {
-                    return allow_vector_manipulation_;
-                });
+            {
+                return allow_vector_manipulation_;
+            });
 
     bool should_notify = false;
     std::vector<TimedEventImpl*>::iterator it;
@@ -247,10 +246,10 @@ void ResourceEvent::do_timer_actions()
             [cancel_time](
                 TimedEventImpl* a,
                 TimedEventImpl* b)
-                    {
-                        (void)b;
-                        return a->next_trigger_time() < cancel_time;
-                    }),
+            {
+                (void)b;
+                return a->next_trigger_time() < cancel_time;
+            }),
             active_timers_.end()
             );
     }

--- a/test/unittest/rtps/resources/timedevent/TimedEventTests.cpp
+++ b/test/unittest/rtps/resources/timedevent/TimedEventTests.cpp
@@ -392,10 +392,10 @@ TEST(TimedEventMultithread, PendingRaceCheck)
             {
                 return true;
             };
-    TimedEvent main_event(*env->service_, periodic_callback, 1.0 * periodic_ms.count());
+    TimedEvent periodic_event(*env->service_, periodic_callback, 1.0 * periodic_ms.count());
 
     // Let the periodic event run for several periods
-    main_event.restart_timer();
+    periodic_event.restart_timer();
     std::this_thread::sleep_for(periodic_ms * 2);
 
     // Launch the checking thread and let it run for several periods

--- a/test/unittest/rtps/resources/timedevent/TimedEventTests.cpp
+++ b/test/unittest/rtps/resources/timedevent/TimedEventTests.cpp
@@ -333,6 +333,77 @@ TEST(TimedEventMultithread, Event_FourAutoRestart)
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 }
 
+TEST(TimedEventMultithread, PendingRaceCheck)
+{
+    using TimedEvent = eprosima::fastrtps::rtps::TimedEvent;
+    using TimeClock = std::chrono::high_resolution_clock;
+    using TimePoint = std::chrono::time_point<TimeClock>;
+
+    constexpr auto periodic_ms = std::chrono::milliseconds(1000);
+    constexpr auto newcomer_ms = std::chrono::milliseconds(10);
+
+    bool stop_test = false;
+
+    // Code to check the newcomer event
+    auto newcomer_thread_code = [&]()
+    {
+        std::condition_variable cv;
+        std::mutex mtx;
+        bool triggered = false;
+
+        // The event will just inform it has been triggered
+        auto callback = [&]()
+        {
+            std::lock_guard<std::mutex> guard(mtx);
+            triggered = true;
+            cv.notify_one();
+
+            return false;
+        };
+
+        // We create the timed event and then enter in a loop where we will start
+        // it and wait for its completion. We will then check that it is triggered
+        // in less time than half the periodic timed event 
+        TimedEvent newcomer_event(*env->service_, callback, 1.0 * newcomer_ms.count());
+        while (!stop_test)
+        {
+            TimePoint start_time;
+            TimePoint stop_time;
+
+            start_time = TimeClock::now();
+
+            {
+                std::unique_lock<std::mutex> lock(mtx);
+                triggered = false;
+                newcomer_event.restart_timer();
+                cv.wait(lock, [&]() { return triggered; });
+                stop_time = TimeClock::now();
+            }
+
+            EXPECT_LT(stop_time - start_time, periodic_ms / 2);
+        }
+    };
+
+    // Periodic event that triggers every second
+    auto periodic_callback = []()
+    {
+        return true;
+    };
+    TimedEvent main_event(*env->service_, periodic_callback, 1.0 * periodic_ms.count());
+
+    // Let the periodic event run for several periods
+    main_event.restart_timer();
+    std::this_thread::sleep_for(periodic_ms * 2);
+
+    // Launch the checking thread and let it run for several periods
+    std::thread* checking_thr = new std::thread(newcomer_thread_code);
+    std::this_thread::sleep_for(periodic_ms * 10);
+
+    stop_test = true;
+    checking_thr->join();
+    delete checking_thr;
+}
+
 int main(
         int argc,
         char** argv)


### PR DESCRIPTION
This PR fixes random freezes when large data is transferring using RELIABLE reliability.
Tested for local participants only.

### Details of issue
There is some kind of race condition in ResourceEvent class.
When timer put into pending list, its execution might be delayed depending on what step is being executed in `ResourceEvent::event_service` loop.

For StatefulReader there are two timers that fire periodically and use the same ResourceEvent. One timer is in WriterProxy (`heartbeat_response_`), another is in PDP (`resend_participant_info_event_`).

#### The following sequence shows how issue appears.
Thread 1: calls `heartbeat_response_->restart()`
Thread 1: successfully locks `ResourceEvent::mutex_`.
Thread 2: `ResourceEvent::event_service` waits on `ResourceEvent::mutex_`.
Thread 1: puts `heartbeat_response_` in pending list
Thread 1: releases lock
Thread 2: `ResourceEvent::event_service` calculates the next trigger time as the trigger time of `resend_participant_info_event_` timer.
As a result, data transferring hangs for up to `m_discovery.discovery_config.leaseDuration_announcementperiod` seconds, as there are no answers to heartbeat messages from the affected reader.

This issue appeared on large data (>20 MB) - the larger data the more probability that this issue arises. For example, for 200 MB data chunk it appears in ~90%.
But it seems that it might appear for any kind of data.

The issue this PR fixes looks similar to the following issues:
https://github.com/eProsima/Fast-DDS/issues/1107
https://github.com/eProsima/Fast-DDS/issues/1120
https://github.com/eProsima/Fast-DDS/issues/1062