### PR TITLE
Feature/coverage/xml parser nacho

### DIFF
--- a/src/cpp/rtps/xmlparser/XMLParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLParser.cpp
@@ -1872,7 +1872,8 @@ XMLP_ret XMLParser::fillDataNode(
             // userData
             if (XMLP_ret::XML_OK != getXMLOctetVector(p_aux0, participant_node.get()->rtps.userData, ident))
             {
-                return XMLP_ret::XML_ERROR;
+                // Not supported for now - never returns Error
+                // return XMLP_ret::XML_ERROR;
             }
         }
         else if (strcmp(name, PART_ID) == 0)

--- a/src/cpp/rtps/xmlparser/XMLParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLParser.cpp
@@ -293,7 +293,15 @@ XMLP_ret XMLParser::parseXMLTransportData(
     }
     else
     {
-        sId = p_aux0->GetText();
+        if(p_aux0->GetText() != nullptr)
+        {
+            sId = p_aux0->GetText();
+        }
+        else
+        {
+            logError(XMLPARSER, "'" << TRANSPORT_ID << "' attribute cannot be empty");
+            return XMLP_ret::XML_ERROR;
+        }
     }
 
     p_aux0 = p_root->FirstChildElement(TYPE);
@@ -304,7 +312,17 @@ XMLP_ret XMLParser::parseXMLTransportData(
     }
     else
     {
-        std::string sType = p_aux0->GetText();
+        std::string sType;
+        if(p_aux0->GetText() != nullptr)
+        {
+            sType = p_aux0->GetText();
+        }
+        else
+        {
+            logError(XMLPARSER, "'" << TYPE << "' attribute cannot be empty");
+            return XMLP_ret::XML_ERROR;
+        }
+
         if (sType == UDPv4 || sType == UDPv6)
         {
             if (sType == UDPv4)
@@ -1584,7 +1602,8 @@ XMLP_ret XMLParser::parseXMLConsumer(
 
                         if (std::strcmp(s.c_str(), "filename") == 0)
                         {
-                            if (nullptr != (p_auxValue = property->FirstChildElement(VALUE)))
+                            if (nullptr != (p_auxValue = property->FirstChildElement(VALUE)) &&
+                                nullptr != p_auxValue->GetText())
                             {
                                 outputFile = p_auxValue->GetText();
                             }
@@ -1597,7 +1616,8 @@ XMLP_ret XMLParser::parseXMLConsumer(
                         }
                         else if (std::strcmp(s.c_str(), "append") == 0)
                         {
-                            if (nullptr != (p_auxValue = property->FirstChildElement(VALUE)))
+                            if (nullptr != (p_auxValue = property->FirstChildElement(VALUE)) &&
+                                nullptr != p_auxValue->GetText())
                             {
                                 std::string auxBool = p_auxValue->GetText();
                                 if (std::strcmp(auxBool.c_str(), "TRUE") == 0)

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -16,7 +16,16 @@
 #include <fastrtps/xmlparser/XMLTree.h>
 #include <fastdds/dds/log/Log.hpp>
 #include <fastrtps/utils/IPLocator.h>
+#include <fastrtps/xmlparser/XMLProfileManager.h>
+#include <fastrtps/transport/UDPv4TransportDescriptor.h>
+#include <fastrtps/transport/UDPv6TransportDescriptor.h>
 #include <fastrtps/transport/TCPv4TransportDescriptor.h>
+#include <fastrtps/transport/TCPv6TransportDescriptor.h>
+#include <fastdds/dds/log/Log.hpp>
+#include <fastdds/dds/log/OStreamConsumer.hpp>
+#include <fastdds/dds/log/FileConsumer.hpp>
+#include <fastdds/dds/log/StdoutConsumer.hpp>
+#include <fastdds/dds/log/StdoutErrConsumer.hpp>
 #include "mock/XMLMockConsumer.h"
 #include "wrapper/XMLParserTest.hpp"
 
@@ -28,12 +37,16 @@
 
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
+using namespace ::testing;
 
 using eprosima::fastrtps::xmlparser::BaseNode;
 using eprosima::fastrtps::xmlparser::DataNode;
 using eprosima::fastrtps::xmlparser::NodeType;
 using eprosima::fastrtps::xmlparser::XMLP_ret;
 using eprosima::fastrtps::xmlparser::XMLParser;
+
+using eprosima::fastdds::dds::Log;
+using eprosima::fastdds::dds::LogConsumer;
 
 class XMLTreeTests : public ::testing::Test
 {
@@ -649,6 +662,41 @@ TEST_F(XMLParserTests, DataBuffer)
 }
 
 // INIT NACHO SECTION
+/*
+ * This test checks The return of the loadXMLProfiles method when a correct xml is parsed
+ */
+TEST_F(XMLParserTests, loadXMLProfiles)
+{
+
+    xmlparser::up_base_node_t root_node;
+    tinyxml2::XMLDocument xml_doc;
+    tinyxml2::XMLElement* titleElement;
+
+    const char * xml =
+    "\
+    <profiles>\
+        <publisher profile_name=\"test_publisher_profile\"\
+        is_default_profile=\"true\">\
+            <qos>\
+                <durability>\
+                    <kind>TRANSIENT_LOCAL</kind>\
+                </durability>\
+            </qos>\
+        </publisher>\
+        <subscriber profile_name=\"test_subscriber_profile\" is_default_profile=\"true\">\
+            <historyMemoryPolicy>PREALLOCATED_WITH_REALLOC</historyMemoryPolicy>\
+            <userDefinedID>13</userDefinedID>\
+            <entityID>31</entityID>\
+        </subscriber>\
+    </profiles>\
+    ";
+
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::loadXMLProfiles(*titleElement, root_node));
+
+}
+
 
 // FINISH NACHO SECTION
 

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -697,6 +697,160 @@ TEST_F(XMLParserTests, loadXMLProfiles)
 
 }
 
+/*
+ * This test checks the return of the parseXMLTransportData method  and the storage of the values in the XMLProfileManager
+ * xml is parsed
+ * 1. Check the correct parsing of a UDP transport descriptor for birth v4 and v6
+ * 2. Check the correct parsing of a TCP transport descriptor for birth v4 and v6
+ * 3. Check the correct parsing of a SHM transport descriptor
+ */
+TEST_F(XMLParserTests, parseXMLTransportData)
+{
+    // Test UDPv4 and UDPv6
+    {
+        tinyxml2::XMLDocument xml_doc;
+        tinyxml2::XMLElement* titleElement;
+
+        const char * xml_p = 
+        "\
+        <transport_descriptor>\
+            <transport_id>TransportId1</transport_id>\
+            <type>UDPv%s</type>\
+            <sendBufferSize>8192</sendBufferSize>\
+            <receiveBufferSize>8192</receiveBufferSize>\
+            <TTL>250</TTL>\
+            <non_blocking_send>false</non_blocking_send>\
+            <maxMessageSize>16384</maxMessageSize>\
+            <maxInitialPeersRange>100</maxInitialPeersRange>\
+            <interfaceWhiteList>\
+                <address>192.168.1.41</address>\
+                <address>127.0.0.1</address>\
+            </interfaceWhiteList>\
+            <wan_addr>80.80.55.44</wan_addr>\
+            <output_port>5101</output_port>\
+            <keep_alive_frequency_ms>5000</keep_alive_frequency_ms>\
+            <keep_alive_timeout_ms>25000</keep_alive_timeout_ms>\
+            <max_logical_port>9000</max_logical_port>\
+            <logical_port_range>100</logical_port_range>\
+            <logical_port_increment>2</logical_port_increment>\
+            <listening_ports>\
+                <port>5100</port>\
+                <port>5200</port>\
+            </listening_ports>\
+            <calculate_crc>false</calculate_crc>\
+            <check_crc>false</check_crc>\
+            <enable_tcp_nodelay>false</enable_tcp_nodelay>\
+            <tls><!-- TLS Section --></tls>\
+            <segment_size>262144</segment_size>\
+            <port_queue_capacity>512</port_queue_capacity>\
+            <healthy_check_timeout_ms>1000</healthy_check_timeout_ms>\
+            <rtps_dump_file>rtsp_messages.log</rtps_dump_file>\
+        </transport_descriptor>\
+        ";
+        char xml[1600];
+
+        // UDPv4
+        sprintf(xml, xml_p, "4");
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::parseXMLTransportData_wrapper(titleElement));
+        EXPECT_EQ(xmlparser::XMLProfileManager::getTransportById("TransportId1")->max_initial_peers_range(), 100);
+        EXPECT_EQ(xmlparser::XMLProfileManager::getTransportById("TransportId1")->max_message_size(), 16384);
+        xmlparser::XMLProfileManager::DeleteInstance();
+
+        // UDPv6
+        sprintf(xml, xml_p, "6");
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::parseXMLTransportData_wrapper(titleElement));
+        EXPECT_EQ(xmlparser::XMLProfileManager::getTransportById("TransportId1")->max_initial_peers_range(), 100);
+        EXPECT_EQ(xmlparser::XMLProfileManager::getTransportById("TransportId1")->max_message_size(), 16384);
+        xmlparser::XMLProfileManager::DeleteInstance();
+    }
+
+    // Test TCPv4 and TCPv6
+    {
+        tinyxml2::XMLDocument xml_doc;
+        tinyxml2::XMLElement* titleElement;
+
+        const char * xml_p = 
+        "\
+        <transport_descriptor>\
+            <transport_id>TransportId1</transport_id>\
+            <type>TCPv%s</type>\
+            <sendBufferSize>8192</sendBufferSize>\
+            <receiveBufferSize>8192</receiveBufferSize>\
+            <TTL>250</TTL>\
+            <maxMessageSize>16384</maxMessageSize>\
+            <maxInitialPeersRange>100</maxInitialPeersRange>\
+            <interfaceWhiteList>\
+                <address>192.168.1.41</address>\
+                <address>127.0.0.1</address>\
+            </interfaceWhiteList>\
+            <wan_addr>80.80.55.44</wan_addr>\
+            <keep_alive_frequency_ms>5000</keep_alive_frequency_ms>\
+            <keep_alive_timeout_ms>25000</keep_alive_timeout_ms>\
+            <max_logical_port>9000</max_logical_port>\
+            <logical_port_range>100</logical_port_range>\
+            <logical_port_increment>2</logical_port_increment>\
+            <listening_ports>\
+                <port>5100</port>\
+                <port>5200</port>\
+            </listening_ports>\
+            <calculate_crc>false</calculate_crc>\
+            <check_crc>false</check_crc>\
+            <enable_tcp_nodelay>false</enable_tcp_nodelay>\
+            <tls><!-- TLS Section --></tls>\
+        </transport_descriptor>\
+        ";
+        char xml[1600];
+
+        // TCPv4
+        sprintf(xml, xml_p, "4");
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::parseXMLTransportData_wrapper(titleElement));
+        EXPECT_EQ(xmlparser::XMLProfileManager::getTransportById("TransportId1")->max_initial_peers_range(), 100);
+        EXPECT_EQ(xmlparser::XMLProfileManager::getTransportById("TransportId1")->max_message_size(), 16384);
+        xmlparser::XMLProfileManager::DeleteInstance();
+        
+        // TCPv6
+        sprintf(xml, xml_p, "6");
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::parseXMLTransportData_wrapper(titleElement));
+        EXPECT_EQ(xmlparser::XMLProfileManager::getTransportById("TransportId1")->max_initial_peers_range(), 100);
+        EXPECT_EQ(xmlparser::XMLProfileManager::getTransportById("TransportId1")->max_message_size(), 16384);
+        xmlparser::XMLProfileManager::DeleteInstance();
+    }
+
+    // SHM
+    {
+        tinyxml2::XMLDocument xml_doc;
+        tinyxml2::XMLElement* titleElement;
+
+        const char * xml = 
+        "\
+        <transport_descriptor>\
+            <transport_id>TransportId1</transport_id>\
+            <type>SHM</type>\
+            <segment_size>262144</segment_size>\
+            <port_queue_capacity>512</port_queue_capacity>\
+            <healthy_check_timeout_ms>1000</healthy_check_timeout_ms>\
+            <rtps_dump_file>rtsp_messages.log</rtps_dump_file>\
+            <maxMessageSize>16384</maxMessageSize>\
+            <maxInitialPeersRange>100</maxInitialPeersRange>\
+        </transport_descriptor>\
+        ";
+
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::parseXMLTransportData_wrapper(titleElement));
+        EXPECT_EQ(xmlparser::XMLProfileManager::getTransportById("TransportId1")->max_initial_peers_range(), 100);
+        EXPECT_EQ(xmlparser::XMLProfileManager::getTransportById("TransportId1")->max_message_size(), 16384);
+        xmlparser::XMLProfileManager::DeleteInstance();
+    }
+}
 
 // FINISH NACHO SECTION
 

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -673,23 +673,23 @@ TEST_F(XMLParserTests, loadXMLProfiles)
     tinyxml2::XMLElement* titleElement;
 
     const char * xml =
-    "\
-    <profiles>\
-        <publisher profile_name=\"test_publisher_profile\"\
-        is_default_profile=\"true\">\
-            <qos>\
-                <durability>\
-                    <kind>TRANSIENT_LOCAL</kind>\
-                </durability>\
-            </qos>\
-        </publisher>\
-        <subscriber profile_name=\"test_subscriber_profile\" is_default_profile=\"true\">\
-            <historyMemoryPolicy>PREALLOCATED_WITH_REALLOC</historyMemoryPolicy>\
-            <userDefinedID>13</userDefinedID>\
-            <entityID>31</entityID>\
-        </subscriber>\
-    </profiles>\
-    ";
+            "\
+            <profiles>\
+                <publisher profile_name=\"test_publisher_profile\"\
+                is_default_profile=\"true\">\
+                    <qos>\
+                        <durability>\
+                            <kind>TRANSIENT_LOCAL</kind>\
+                        </durability>\
+                    </qos>\
+                </publisher>\
+                <subscriber profile_name=\"test_subscriber_profile\" is_default_profile=\"true\">\
+                    <historyMemoryPolicy>PREALLOCATED_WITH_REALLOC</historyMemoryPolicy>\
+                    <userDefinedID>13</userDefinedID>\
+                    <entityID>31</entityID>\
+                </subscriber>\
+            </profiles>\
+            ";
 
     ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
     titleElement = xml_doc.RootElement();
@@ -712,41 +712,41 @@ TEST_F(XMLParserTests, parseXMLTransportData)
         tinyxml2::XMLElement* titleElement;
 
         const char * xml_p =
-        "\
-        <transport_descriptor>\
-            <transport_id>TransportId1</transport_id>\
-            <type>UDPv%s</type>\
-            <sendBufferSize>8192</sendBufferSize>\
-            <receiveBufferSize>8192</receiveBufferSize>\
-            <TTL>250</TTL>\
-            <non_blocking_send>false</non_blocking_send>\
-            <maxMessageSize>16384</maxMessageSize>\
-            <maxInitialPeersRange>100</maxInitialPeersRange>\
-            <interfaceWhiteList>\
-                <address>192.168.1.41</address>\
-                <address>127.0.0.1</address>\
-            </interfaceWhiteList>\
-            <wan_addr>80.80.55.44</wan_addr>\
-            <output_port>5101</output_port>\
-            <keep_alive_frequency_ms>5000</keep_alive_frequency_ms>\
-            <keep_alive_timeout_ms>25000</keep_alive_timeout_ms>\
-            <max_logical_port>9000</max_logical_port>\
-            <logical_port_range>100</logical_port_range>\
-            <logical_port_increment>2</logical_port_increment>\
-            <listening_ports>\
-                <port>5100</port>\
-                <port>5200</port>\
-            </listening_ports>\
-            <calculate_crc>false</calculate_crc>\
-            <check_crc>false</check_crc>\
-            <enable_tcp_nodelay>false</enable_tcp_nodelay>\
-            <tls><!-- TLS Section --></tls>\
-            <segment_size>262144</segment_size>\
-            <port_queue_capacity>512</port_queue_capacity>\
-            <healthy_check_timeout_ms>1000</healthy_check_timeout_ms>\
-            <rtps_dump_file>rtsp_messages.log</rtps_dump_file>\
-        </transport_descriptor>\
-        ";
+                "\
+                <transport_descriptor>\
+                    <transport_id>TransportId1</transport_id>\
+                    <type>UDPv%s</type>\
+                    <sendBufferSize>8192</sendBufferSize>\
+                    <receiveBufferSize>8192</receiveBufferSize>\
+                    <TTL>250</TTL>\
+                    <non_blocking_send>false</non_blocking_send>\
+                    <maxMessageSize>16384</maxMessageSize>\
+                    <maxInitialPeersRange>100</maxInitialPeersRange>\
+                    <interfaceWhiteList>\
+                        <address>192.168.1.41</address>\
+                        <address>127.0.0.1</address>\
+                    </interfaceWhiteList>\
+                    <wan_addr>80.80.55.44</wan_addr>\
+                    <output_port>5101</output_port>\
+                    <keep_alive_frequency_ms>5000</keep_alive_frequency_ms>\
+                    <keep_alive_timeout_ms>25000</keep_alive_timeout_ms>\
+                    <max_logical_port>9000</max_logical_port>\
+                    <logical_port_range>100</logical_port_range>\
+                    <logical_port_increment>2</logical_port_increment>\
+                    <listening_ports>\
+                        <port>5100</port>\
+                        <port>5200</port>\
+                    </listening_ports>\
+                    <calculate_crc>false</calculate_crc>\
+                    <check_crc>false</check_crc>\
+                    <enable_tcp_nodelay>false</enable_tcp_nodelay>\
+                    <tls><!-- TLS Section --></tls>\
+                    <segment_size>262144</segment_size>\
+                    <port_queue_capacity>512</port_queue_capacity>\
+                    <healthy_check_timeout_ms>1000</healthy_check_timeout_ms>\
+                    <rtps_dump_file>rtsp_messages.log</rtps_dump_file>\
+                </transport_descriptor>\
+                ";
         char xml[1600];
 
         // UDPv4
@@ -774,35 +774,35 @@ TEST_F(XMLParserTests, parseXMLTransportData)
         tinyxml2::XMLElement* titleElement;
 
         const char * xml_p =
-        "\
-        <transport_descriptor>\
-            <transport_id>TransportId1</transport_id>\
-            <type>TCPv%s</type>\
-            <sendBufferSize>8192</sendBufferSize>\
-            <receiveBufferSize>8192</receiveBufferSize>\
-            <TTL>250</TTL>\
-            <maxMessageSize>16384</maxMessageSize>\
-            <maxInitialPeersRange>100</maxInitialPeersRange>\
-            <interfaceWhiteList>\
-                <address>192.168.1.41</address>\
-                <address>127.0.0.1</address>\
-            </interfaceWhiteList>\
-            <wan_addr>80.80.55.44</wan_addr>\
-            <keep_alive_frequency_ms>5000</keep_alive_frequency_ms>\
-            <keep_alive_timeout_ms>25000</keep_alive_timeout_ms>\
-            <max_logical_port>9000</max_logical_port>\
-            <logical_port_range>100</logical_port_range>\
-            <logical_port_increment>2</logical_port_increment>\
-            <listening_ports>\
-                <port>5100</port>\
-                <port>5200</port>\
-            </listening_ports>\
-            <calculate_crc>false</calculate_crc>\
-            <check_crc>false</check_crc>\
-            <enable_tcp_nodelay>false</enable_tcp_nodelay>\
-            <tls><!-- TLS Section --></tls>\
-        </transport_descriptor>\
-        ";
+                "\
+                <transport_descriptor>\
+                    <transport_id>TransportId1</transport_id>\
+                    <type>TCPv%s</type>\
+                    <sendBufferSize>8192</sendBufferSize>\
+                    <receiveBufferSize>8192</receiveBufferSize>\
+                    <TTL>250</TTL>\
+                    <maxMessageSize>16384</maxMessageSize>\
+                    <maxInitialPeersRange>100</maxInitialPeersRange>\
+                    <interfaceWhiteList>\
+                        <address>192.168.1.41</address>\
+                        <address>127.0.0.1</address>\
+                    </interfaceWhiteList>\
+                    <wan_addr>80.80.55.44</wan_addr>\
+                    <keep_alive_frequency_ms>5000</keep_alive_frequency_ms>\
+                    <keep_alive_timeout_ms>25000</keep_alive_timeout_ms>\
+                    <max_logical_port>9000</max_logical_port>\
+                    <logical_port_range>100</logical_port_range>\
+                    <logical_port_increment>2</logical_port_increment>\
+                    <listening_ports>\
+                        <port>5100</port>\
+                        <port>5200</port>\
+                    </listening_ports>\
+                    <calculate_crc>false</calculate_crc>\
+                    <check_crc>false</check_crc>\
+                    <enable_tcp_nodelay>false</enable_tcp_nodelay>\
+                    <tls><!-- TLS Section --></tls>\
+                </transport_descriptor>\
+                ";
         char xml[1600];
 
         // TCPv4
@@ -830,18 +830,18 @@ TEST_F(XMLParserTests, parseXMLTransportData)
         tinyxml2::XMLElement* titleElement;
 
         const char * xml =
-        "\
-        <transport_descriptor>\
-            <transport_id>TransportId1</transport_id>\
-            <type>SHM</type>\
-            <segment_size>262144</segment_size>\
-            <port_queue_capacity>512</port_queue_capacity>\
-            <healthy_check_timeout_ms>1000</healthy_check_timeout_ms>\
-            <rtps_dump_file>rtsp_messages.log</rtps_dump_file>\
-            <maxMessageSize>16384</maxMessageSize>\
-            <maxInitialPeersRange>100</maxInitialPeersRange>\
-        </transport_descriptor>\
-        ";
+                "\
+                <transport_descriptor>\
+                    <transport_id>TransportId1</transport_id>\
+                    <type>SHM</type>\
+                    <segment_size>262144</segment_size>\
+                    <port_queue_capacity>512</port_queue_capacity>\
+                    <healthy_check_timeout_ms>1000</healthy_check_timeout_ms>\
+                    <rtps_dump_file>rtsp_messages.log</rtps_dump_file>\
+                    <maxMessageSize>16384</maxMessageSize>\
+                    <maxInitialPeersRange>100</maxInitialPeersRange>\
+                </transport_descriptor>\
+                ";
 
         ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
         titleElement = xml_doc.RootElement();
@@ -862,7 +862,7 @@ TEST_F(XMLParserTests, parseXMLTransportData)
  * 5. Check missing type
  * 6. Check wrong type
  */
-TEST_F(XMLParserTests, parseXMLTransportData_negative)
+TEST_F(XMLParserTests, parseXMLTransportDataNegativeClauses)
 {
     tinyxml2::XMLDocument xml_doc;
     tinyxml2::XMLElement* titleElement;
@@ -939,13 +939,13 @@ TEST_F(XMLParserTests, parseXMLTransportData_negative)
         for (std::vector<std::string>::iterator it = parameters.begin(); it != parameters.end(); ++it)
         {
             xml =
-            "\
-            <transport_descriptor>\
-                <transport_id>TransportId1</transport_id>\
-                <type>"+*transport_type+"</type>\
-                <"+*it+"><bad_element></bad_element></"+*it+">\
-            </transport_descriptor>\
-            ";
+                    "\
+                    <transport_descriptor>\
+                        <transport_id>TransportId1</transport_id>\
+                        <type>"+*transport_type+"</type>\
+                        <"+*it+"><bad_element></bad_element></"+*it+">\
+                    </transport_descriptor>\
+                    ";
 
             ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml.c_str()));
             titleElement = xml_doc.RootElement();
@@ -956,15 +956,15 @@ TEST_F(XMLParserTests, parseXMLTransportData_negative)
         if ( (*transport_type).substr(0,3) == "TCP" )
         {
             xml =
-            "\
-            <transport_descriptor>\
-                <transport_id>TransportId1</transport_id>\
-                <type>"+*transport_type+"</type>\
-                <listening_ports>\
-                    <port>not_an_int</port>\
-                </listening_ports>\
-            </transport_descriptor>\
-            ";
+                    "\
+                    <transport_descriptor>\
+                        <transport_id>TransportId1</transport_id>\
+                        <type>"+*transport_type+"</type>\
+                        <listening_ports>\
+                            <port>not_an_int</port>\
+                        </listening_ports>\
+                    </transport_descriptor>\
+                    ";
 
             ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml.c_str()));
             titleElement = xml_doc.RootElement();
@@ -983,11 +983,11 @@ TEST_F(XMLParserTests, parseXMLTransportData_negative)
 
     // missing type tag
     xml =
-    "\
-    <transport_descriptor>\
-        <transport_id>TransportId1</transport_id>\
-    </transport_descriptor>\
-    ";
+            "\
+            <transport_descriptor>\
+                <transport_id>TransportId1</transport_id>\
+            </transport_descriptor>\
+            ";
     ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml.c_str()));
     titleElement = xml_doc.RootElement();
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::parseXMLTransportData_wrapper(titleElement));
@@ -995,12 +995,12 @@ TEST_F(XMLParserTests, parseXMLTransportData_negative)
 
     // missing type value
     xml =
-    "\
-    <transport_descriptor>\
-        <transport_id>TransportId1</transport_id>\
-        <type></type>\
-    </transport_descriptor>\
-    ";
+            "\
+            <transport_descriptor>\
+                <transport_id>TransportId1</transport_id>\
+                <type></type>\
+            </transport_descriptor>\
+            ";
     ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml.c_str()));
     titleElement = xml_doc.RootElement();
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::parseXMLTransportData_wrapper(titleElement));
@@ -1008,12 +1008,12 @@ TEST_F(XMLParserTests, parseXMLTransportData_negative)
 
     // invalid type
     xml =
-    "\
-    <transport_descriptor>\
-        <transport_id>TransportId1</transport_id>\
-        <type>bad_type</type>\
-    </transport_descriptor>\
-    ";
+            "\
+            <transport_descriptor>\
+                <transport_id>TransportId1</transport_id>\
+                <type>bad_type</type>\
+            </transport_descriptor>\
+            ";
     ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml.c_str()));
     titleElement = xml_doc.RootElement();
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::parseXMLTransportData_wrapper(titleElement));
@@ -1021,12 +1021,12 @@ TEST_F(XMLParserTests, parseXMLTransportData_negative)
 
     // missing id tag
     xml =
-    "\
-    <transport_descriptor>\
-        <transport_id></transport_id>\
-        <type>UDPv4</type>\
-    </transport_descriptor>\
-    ";
+            "\
+            <transport_descriptor>\
+                <transport_id></transport_id>\
+                <type>UDPv4</type>\
+            </transport_descriptor>\
+            ";
     ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml.c_str()));
     titleElement = xml_doc.RootElement();
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::parseXMLTransportData_wrapper(titleElement));
@@ -1034,11 +1034,11 @@ TEST_F(XMLParserTests, parseXMLTransportData_negative)
 
     // missing id value
     xml =
-    "\
-    <transport_descriptor>\
-        <type>UDPv4</type>\
-    </transport_descriptor>\
-    ";
+            "\
+            <transport_descriptor>\
+                <type>UDPv4</type>\
+            </transport_descriptor>\
+            ";
     ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml.c_str()));
     titleElement = xml_doc.RootElement();
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::parseXMLTransportData_wrapper(titleElement));
@@ -1062,26 +1062,25 @@ TEST_F(XMLParserTests, parseXMLConsumer)
     {
         // StdoutConsumer
         const char * xml =
-        "\
-        <consumer>\
-            <class>StdoutConsumer</class>\
-        </consumer>\
-        ";
+                "\
+                <consumer>\
+                    <class>StdoutConsumer</class>\
+                </consumer>\
+                ";
 
         ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
         titleElement = xml_doc.RootElement();
         EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::parseXMLConsumer_wrapper(*titleElement));
     }
 
-
     {
         // StdoutErrConsumer without properties
         const char * xml =
-        "\
-        <consumer>\
-            <class>StdoutErrConsumer</class>\
-        </consumer>\
-        ";
+                "\
+                <consumer>\
+                    <class>StdoutErrConsumer</class>\
+                </consumer>\
+                ";
         ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
         titleElement = xml_doc.RootElement();
         EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::parseXMLConsumer_wrapper(*titleElement));
@@ -1090,15 +1089,15 @@ TEST_F(XMLParserTests, parseXMLConsumer)
     {
         // StdoutErrConsumer with properties
         const char * xml_p =
-        "\
-        <consumer>\
-            <class>StdoutErrConsumer</class>\
-            <property>\
-                <name>stderr_threshold</name>\
-                <value>Log::Kind::%s</value>\
-            </property>\
-        </consumer>\
-        ";
+                "\
+                <consumer>\
+                    <class>StdoutErrConsumer</class>\
+                    <property>\
+                        <name>stderr_threshold</name>\
+                        <value>Log::Kind::%s</value>\
+                    </property>\
+                </consumer>\
+                ";
         char xml[500];
 
         std::vector<std::string> log_levels = {"Info", "Warning", "Error"};
@@ -1116,11 +1115,11 @@ TEST_F(XMLParserTests, parseXMLConsumer)
     {
         // FileConsumer without properties
         const char * xml =
-        "\
-        <consumer>\
-            <class>FileConsumer</class>\
-        </consumer>\
-        ";
+                "\
+                <consumer>\
+                    <class>FileConsumer</class>\
+                </consumer>\
+                ";
 
         ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
         titleElement = xml_doc.RootElement();
@@ -1131,19 +1130,19 @@ TEST_F(XMLParserTests, parseXMLConsumer)
     {
         // FileConsumer
         const char * xml =
-        "\
-        <consumer>\
-            <class>FileConsumer</class>\
-            <property>\
-                <name>filename</name>\
-                <value>execution.log</value>\
-            </property>\
-            <property>\
-                <name>append</name>\
-                <value>TRUE</value>\
-            </property>\
-        </consumer>\
-        ";
+                "\
+                <consumer>\
+                    <class>FileConsumer</class>\
+                    <property>\
+                        <name>filename</name>\
+                        <value>execution.log</value>\
+                    </property>\
+                    <property>\
+                        <name>append</name>\
+                        <value>TRUE</value>\
+                    </property>\
+                </consumer>\
+                ";
 
         ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
         titleElement = xml_doc.RootElement();
@@ -1164,7 +1163,7 @@ TEST_F(XMLParserTests, parseXMLConsumer)
  * 7. Check a FileConsumer without a value for the append property.
  * 8. Check a FileConsumer with an incorrect property.
  */
-TEST_F(XMLParserTests, parseXMLConsumer_negative)
+TEST_F(XMLParserTests, parseXMLConsumerNegativeClauses)
 {
     tinyxml2::XMLDocument xml_doc;
     tinyxml2::XMLElement* titleElement;
@@ -1173,11 +1172,11 @@ TEST_F(XMLParserTests, parseXMLConsumer_negative)
         Log::ClearConsumers();
         // Unknown consumer class
         const char * xml =
-        "\
-        <consumer>\
-            <class>UnknownConsumer</class>\
-        </consumer>\
-        ";
+                "\
+                <consumer>\
+                    <class>UnknownConsumer</class>\
+                </consumer>\
+                ";
 
         ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
         titleElement = xml_doc.RootElement();
@@ -1188,15 +1187,15 @@ TEST_F(XMLParserTests, parseXMLConsumer_negative)
         Log::ClearConsumers();
         // StdoutErrConsumer with properties
         const char * xml =
-        "\
-        <consumer>\
-            <class>StdoutErrConsumer</class>\
-            <property>\
-                <name>stderr_threshold</name>\
-                <value>bad_value</value>\
-            </property>\
-        </consumer>\
-        ";
+                "\
+                <consumer>\
+                    <class>StdoutErrConsumer</class>\
+                    <property>\
+                        <name>stderr_threshold</name>\
+                        <value>bad_value</value>\
+                    </property>\
+                </consumer>\
+                ";
         ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
         titleElement = xml_doc.RootElement();
         EXPECT_EQ(XMLP_ret::XML_NOK, XMLParserTest::parseXMLConsumer_wrapper(*titleElement));
@@ -1207,19 +1206,19 @@ TEST_F(XMLParserTests, parseXMLConsumer_negative)
         Log::ClearConsumers();
         // StdoutErrConsumer with two stderr_threshold
         const char * xml =
-        "\
-        <consumer>\
-            <class>StdoutErrConsumer</class>\
-            <property>\
-                <name>stderr_threshold</name>\
-                <value>Log::Kind::Error</value>\
-            </property>\
-            <property>\
-                <name>stderr_threshold</name>\
-                <value>Log::Kind::Error</value>\
-            </property>\
-        </consumer>\
-        ";
+                "\
+                <consumer>\
+                    <class>StdoutErrConsumer</class>\
+                    <property>\
+                        <name>stderr_threshold</name>\
+                        <value>Log::Kind::Error</value>\
+                    </property>\
+                    <property>\
+                        <name>stderr_threshold</name>\
+                        <value>Log::Kind::Error</value>\
+                    </property>\
+                </consumer>\
+                ";
         ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
         titleElement = xml_doc.RootElement();
         EXPECT_EQ(XMLP_ret::XML_NOK, XMLParserTest::parseXMLConsumer_wrapper(*titleElement));
@@ -1230,14 +1229,14 @@ TEST_F(XMLParserTests, parseXMLConsumer_negative)
         Log::ClearConsumers();
         // StdoutErrConsumer with wrong property name
         const char * xml =
-        "\
-        <consumer>\
-            <class>StdoutErrConsumer</class>\
-            <property>\
-                <name>bad_property</name>\
-            </property>\
-        </consumer>\
-        ";
+                "\
+                <consumer>\
+                    <class>StdoutErrConsumer</class>\
+                    <property>\
+                        <name>bad_property</name>\
+                    </property>\
+                </consumer>\
+                ";
         ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
         titleElement = xml_doc.RootElement();
         EXPECT_EQ(XMLP_ret::XML_NOK, XMLParserTest::parseXMLConsumer_wrapper(*titleElement));
@@ -1248,15 +1247,15 @@ TEST_F(XMLParserTests, parseXMLConsumer_negative)
         Log::ClearConsumers();
         // FileConsumer no filename
         const char * xml =
-        "\
-        <consumer>\
-            <class>FileConsumer</class>\
-            <property>\
-                <name>filename</name>\
-                <value></value>\
-            </property>\
-        </consumer>\
-        ";
+                "\
+                <consumer>\
+                    <class>FileConsumer</class>\
+                    <property>\
+                        <name>filename</name>\
+                        <value></value>\
+                    </property>\
+                </consumer>\
+                ";
 
         ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
         titleElement = xml_doc.RootElement();
@@ -1267,15 +1266,15 @@ TEST_F(XMLParserTests, parseXMLConsumer_negative)
         Log::ClearConsumers();
         // FileConsumer no append value
         const char * xml =
-        "\
-        <consumer>\
-            <class>FileConsumer</class>\
-            <property>\
-                <name>append</name>\
-                <value></value>\
-            </property>\
-        </consumer>\
-        ";
+                "\
+                <consumer>\
+                    <class>FileConsumer</class>\
+                    <property>\
+                        <name>append</name>\
+                        <value></value>\
+                    </property>\
+                </consumer>\
+                ";
 
         ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
         titleElement = xml_doc.RootElement();
@@ -1286,14 +1285,14 @@ TEST_F(XMLParserTests, parseXMLConsumer_negative)
         Log::ClearConsumers();
         // FileConsumer bad property
         const char * xml =
-        "\
-        <consumer>\
-            <class>FileConsumer</class>\
-            <property>\
-                <name>bad_property</name>\
-            </property>\
-        </consumer>\
-        ";
+                "\
+                <consumer>\
+                    <class>FileConsumer</class>\
+                    <property>\
+                        <name>bad_property</name>\
+                    </property>\
+                </consumer>\
+                ";
 
         ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
         titleElement = xml_doc.RootElement();
@@ -1316,15 +1315,15 @@ TEST_F(XMLParserTests, parseLogConfig)
     {
         // Bad parameters
         const char * xml_p =
-        "\
-        <log>\
-            <use_default>%s</use_default>\
-            <consumer>\
-                <class>%s</class>\
-            </consumer>\
-            %s\
-        </log>\
-        ";
+                "\
+                <log>\
+                    <use_default>%s</use_default>\
+                    <consumer>\
+                        <class>%s</class>\
+                    </consumer>\
+                    %s\
+                </log>\
+                ";
         char xml[500];
 
         // Check wrong class of consumer
@@ -1362,7 +1361,7 @@ TEST_F(XMLParserTests, parseLogConfig)
  * 4. Check bad values for all attributes
  * 5. Check a non existant atribute tag
  */
-TEST_F(XMLParserTests, fillDataNodeParticipant_negative)
+TEST_F(XMLParserTests, fillDataNodeParticipantNegativeClauses)
 {
     tinyxml2::XMLDocument xml_doc;
     tinyxml2::XMLElement* titleElement;
@@ -1375,11 +1374,11 @@ TEST_F(XMLParserTests, fillDataNodeParticipant_negative)
 
     {
         const char * xml_p =
-        "\
-        <participant profile_name=\"domainparticipant_profile_name\">\
-            %s\
-        </participant>\
-        ";
+                "\
+                <participant profile_name=\"domainparticipant_profile_name\">\
+                    %s\
+                </participant>\
+                ";
         char xml[500];
 
         // Misssing rtps tag
@@ -1398,14 +1397,14 @@ TEST_F(XMLParserTests, fillDataNodeParticipant_negative)
     {
         // Wrong rtps child tags
         const char * xml_p =
-        "\
-        <participant profile_name=\"domainparticipant_profile_name\">\
-            <domainId>0</domainId>\
-            <rtps>\
-                %s\
-            </rtps>\
-        </participant>\
-        ";
+                "\
+                <participant profile_name=\"domainparticipant_profile_name\">\
+                    <domainId>0</domainId>\
+                    <rtps>\
+                        %s\
+                    </rtps>\
+                </participant>\
+                ";
         char xml[500];
 
         std::vector<std::string> parameters = {

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -747,7 +747,7 @@ TEST_F(XMLParserTests, parseXMLTransportData)
                     <rtps_dump_file>rtsp_messages.log</rtps_dump_file>\
                 </transport_descriptor>\
                 ";
-        char xml[1600];
+        char xml[2000];
 
         // UDPv4
         sprintf(xml, xml_p, "4");
@@ -803,7 +803,7 @@ TEST_F(XMLParserTests, parseXMLTransportData)
                     <tls><!-- TLS Section --></tls>\
                 </transport_descriptor>\
                 ";
-        char xml[1600];
+        char xml[2000];
 
         // TCPv4
         sprintf(xml, xml_p, "4");
@@ -1043,6 +1043,24 @@ TEST_F(XMLParserTests, parseXMLTransportDataNegativeClauses)
     titleElement = xml_doc.RootElement();
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::parseXMLTransportData_wrapper(titleElement));
     xmlparser::XMLProfileManager::DeleteInstance();
+}
+
+TEST_F(XMLParserTests, parseXMLTransportsProf)
+{
+    tinyxml2::XMLDocument xml_doc;
+    tinyxml2::XMLElement* titleElement;
+    std::string xml =
+            "\
+            <transport_descriptors>\
+                <transport_descriptor>\
+                    <bad_element></bad_element>\
+                </transport_descriptor>\
+            </transport_descriptors>\
+            ";
+
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml.c_str()));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::parseXMLTransportsProf_wrapper(titleElement));
 }
 
 /*
@@ -1321,30 +1339,37 @@ TEST_F(XMLParserTests, parseLogConfig)
                     <consumer>\
                         <class>%s</class>\
                     </consumer>\
-                    %s\
                 </log>\
                 ";
         char xml[500];
 
         // Check wrong class of consumer
-        sprintf(xml, xml_p, "FALSE", "wrong_class", "");
+        sprintf(xml, xml_p, "FALSE", "wrong_class");
         ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
         titleElement = xml_doc.RootElement();
         EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::parseLogConfig_wrapper(titleElement));
 
         // Check both values of use_default
-        sprintf(xml, xml_p, "TRUE", "StdoutConsumer", "");
+        sprintf(xml, xml_p, "TRUE", "StdoutConsumer");
         ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
         titleElement = xml_doc.RootElement();
-        EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::parseLogConfig_wrapper(titleElement));
+        EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::parseLogConfig_wrapper(titleElement));
 
-        sprintf(xml, xml_p, "FALSE", "StdoutConsumer", "");
+        sprintf(xml, xml_p, "FALSE", "StdoutConsumer");
         ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
         titleElement = xml_doc.RootElement();
-        EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::parseLogConfig_wrapper(titleElement));
+        EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::parseLogConfig_wrapper(titleElement));
+    }
 
+    {
         // Check bad tag
-        sprintf(xml, xml_p, "FALSE", "StdoutConsumer", "<bad_element></bad_element>");
+        const char * xml =
+                "\
+                <log>\
+                    <bad_element></bad_element>\
+                </log>\
+                ";
+
         ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
         titleElement = xml_doc.RootElement();
         EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::parseLogConfig_wrapper(titleElement));

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -1287,6 +1287,40 @@ TEST_F(XMLParserTests, parseXMLConsumer_negative)
 
 }
 
+/*
+ * This test checks the return of the negative cases of the parseLogConfig method.
+ * 1. Check a consummer with a missing class
+ * 2. Check the use_default tag without value
+ */
+TEST_F(XMLParserTests, parseLogConfig_negative)
+{
+    xmlparser::up_base_node_t root_node;
+    tinyxml2::XMLDocument xml_doc;
+    tinyxml2::XMLElement* titleElement;
+
+    const char * xml_p =
+    "\
+    <log>\
+        <use_default>%s</use_default>\
+        <consumer>\
+            <class>%s</class>\
+        </consumer>\
+    </log>\
+    ";
+    char xml[500];
+
+    sprintf(xml, xml_p, "FALSE", "");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::loadXMLProfiles(*titleElement, root_node));
+
+    sprintf(xml, xml_p, "", "StdoutConsumer");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::loadXMLProfiles(*titleElement, root_node));
+
+}
+
 // FINISH NACHO SECTION
 
 // INIT RAUL SECTION

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -1045,6 +1045,98 @@ TEST_F(XMLParserTests, parseXMLTransportData_negative)
     xmlparser::XMLProfileManager::DeleteInstance();
 }
 
+/*
+ * This test checks the return of the parseXMLConsumer method.
+ * 1. Check an XMLP_ret::XML_ERROR retur on an incorrectly formated parameter of every posible parameter of the
+ * UDPv4, UDPv6, TCPv4, UDPv6, and SHM.
+ * 2. Check the correct return parsing a StdoutConsumer.
+ * 3. Check the correct return parsing a StdoutErrConsumer with default configuration.
+ * 4. Check the correct return parsing a StdoutErrConsumer with a custom configuration.
+ * 5. Check the correct return parsing a FileConsumer with default configuration.
+ */
+TEST_F(XMLParserTests, parseXMLConsumer)
+{
+    tinyxml2::XMLDocument xml_doc;
+    tinyxml2::XMLElement* titleElement;
+
+    {
+        // StdoutConsumer
+        const char * xml =
+        "\
+        <consumer>\
+            <class>StdoutConsumer</class>\
+        </consumer>\
+        ";
+
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::parseXMLConsumer_wrapper(*titleElement));
+    }
+
+
+    {
+        // StdoutErrConsumer without properties
+        const char * xml =
+        "\
+        <consumer>\
+            <class>StdoutErrConsumer</class>\
+        </consumer>\
+        ";
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::parseXMLConsumer_wrapper(*titleElement));
+    }
+
+    {
+        // StdoutErrConsumer with properties
+        const char * xml_p =
+        "\
+        <consumer>\
+            <class>StdoutErrConsumer</class>\
+            <property>\
+                <name>stderr_threshold</name>\
+                <value>Log::Kind::%s</value>\
+            </property>\
+        </consumer>\
+        ";
+        char xml[500];
+
+        std::vector<std::string> log_levels = {"Info", "Warning", "Error"};
+        for (std::vector<std::string>::iterator it = log_levels.begin(); it != log_levels.end(); ++it)
+        {
+            sprintf(xml, xml_p, (*it).c_str());
+            ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+            titleElement = xml_doc.RootElement();
+            EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::parseXMLConsumer_wrapper(*titleElement));
+        }
+
+
+    }
+
+    {
+        // FileConsumer
+        const char * xml =
+        "\
+        <consumer>\
+            <class>FileConsumer</class>\
+            <property>\
+                <name>filename</name>\
+                <value>execution.log</value>\
+            </property>\
+            <property>\
+                <name>append</name>\
+                <value>TRUE</value>\
+            </property>\
+        </consumer>\
+        ";
+
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::parseXMLConsumer_wrapper(*titleElement));
+    }
+
+}
+
 // FINISH NACHO SECTION
 
 // INIT RAUL SECTION

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -1137,6 +1137,156 @@ TEST_F(XMLParserTests, parseXMLConsumer)
 
 }
 
+/*
+ * This test checks the return of the negative cases of the parseXMLConsumer method.
+ * 1. Check an XMLP_ret::XML_ERROR retur on an incorrectly formated parameter of every posible parameter of the
+ * UDPv4, UDPv6, TCPv4, UDPv6, and SHM.
+ * 2. Check a non-existant Consumer class.
+ * 3. Check a StdoutErrConsumer with incorrect propertiy values.
+ * 4. Check a StdoutErrConsumer with std_threshold set twice.
+ * 5. Check a StdoutErrConsumer with an incorrect property.
+ * 6. Check a FileConsumer without a filename property.
+ * 7. Check a FileConsumer without a value for the append property.
+ * 8. Check a FileConsumer with an incorrect property.
+ */
+TEST_F(XMLParserTests, parseXMLConsumer_negative)
+{
+    tinyxml2::XMLDocument xml_doc;
+    tinyxml2::XMLElement* titleElement;
+
+    {
+        Log::ClearConsumers();
+        // Unknown consumer class
+        const char * xml =
+        "\
+        <consumer>\
+            <class>UnknownConsumer</class>\
+        </consumer>\
+        ";
+
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::parseXMLConsumer_wrapper(*titleElement));
+    }
+
+    {
+        Log::ClearConsumers();
+        // StdoutErrConsumer with properties
+        const char * xml =
+        "\
+        <consumer>\
+            <class>StdoutErrConsumer</class>\
+            <property>\
+                <name>stderr_threshold</name>\
+                <value>bad_value</value>\
+            </property>\
+        </consumer>\
+        ";
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_NOK, XMLParserTest::parseXMLConsumer_wrapper(*titleElement));
+
+    }
+
+    {
+        Log::ClearConsumers();
+        // StdoutErrConsumer with two stderr_threshold
+        const char * xml =
+        "\
+        <consumer>\
+            <class>StdoutErrConsumer</class>\
+            <property>\
+                <name>stderr_threshold</name>\
+                <value>Log::Kind::Error</value>\
+            </property>\
+            <property>\
+                <name>stderr_threshold</name>\
+                <value>Log::Kind::Error</value>\
+            </property>\
+        </consumer>\
+        ";
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_NOK, XMLParserTest::parseXMLConsumer_wrapper(*titleElement));
+
+    }
+
+    {
+        Log::ClearConsumers();
+        // StdoutErrConsumer with wrong property name
+        const char * xml =
+        "\
+        <consumer>\
+            <class>StdoutErrConsumer</class>\
+            <property>\
+                <name>bad_property</name>\
+            </property>\
+        </consumer>\
+        ";
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_NOK, XMLParserTest::parseXMLConsumer_wrapper(*titleElement));
+
+    }
+
+    {
+        Log::ClearConsumers();
+        // FileConsumer no filename
+        const char * xml =
+        "\
+        <consumer>\
+            <class>FileConsumer</class>\
+            <property>\
+                <name>filename</name>\
+                <value></value>\
+            </property>\
+        </consumer>\
+        ";
+
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_NOK, XMLParserTest::parseXMLConsumer_wrapper(*titleElement));
+    }
+
+    {
+        Log::ClearConsumers();
+        // FileConsumer no append value
+        const char * xml =
+        "\
+        <consumer>\
+            <class>FileConsumer</class>\
+            <property>\
+                <name>append</name>\
+                <value></value>\
+            </property>\
+        </consumer>\
+        ";
+
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_NOK, XMLParserTest::parseXMLConsumer_wrapper(*titleElement));
+    }
+
+    {
+        Log::ClearConsumers();
+        // FileConsumer bad property
+        const char * xml =
+        "\
+        <consumer>\
+            <class>FileConsumer</class>\
+            <property>\
+                <name>bad_property</name>\
+            </property>\
+        </consumer>\
+        ";
+
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_NOK, XMLParserTest::parseXMLConsumer_wrapper(*titleElement));
+    }
+
+}
+
 // FINISH NACHO SECTION
 
 // INIT RAUL SECTION

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -1377,6 +1377,7 @@ TEST_F(XMLParserTests, fillDataNodeParticipant_negative)
 
         std::vector<std::string> parameters = {
             "<name></name>",
+            "<prefix><bad_element></bad_element></prefix>",
             "<defaultUnicastLocatorList><bad_element></bad_element></defaultUnicastLocatorList>",
             "<defaultMulticastLocatorList><bad_element></bad_element></defaultMulticastLocatorList>",
             "<sendSocketBufferSize><bad_element></bad_element></sendSocketBufferSize>",

--- a/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
+++ b/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
@@ -436,6 +436,13 @@ public:
     {
         return parseLogConfig(p_root);
     }
+
+    static XMLP_ret parseXMLTransportsProf_wrapper(
+        tinyxml2::XMLElement* p_root)
+    {
+        return parseXMLTransportsProf(p_root);
+    }
+
 // FINISH NACHO SECTION
 
 // INIT RAUL SECTION

--- a/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
+++ b/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
@@ -20,11 +20,8 @@ using namespace eprosima::fastrtps::rtps;
 using eprosima::fastrtps::xmlparser::XMLP_ret;
 using eprosima::fastrtps::xmlparser::XMLParser;
 using eprosima::fastrtps::xmlparser::DataNode;
-<<<<<<< HEAD
 using eprosima::fastrtps::xmlparser::BaseNode;
-=======
 using eprosima::fastrtps::xmlparser::sp_transport_t;
->>>>>>> d116cf92b... Refs #9965: Added Wrapped methods
 
 // Class to test protected methods
 class XMLParserTest : public XMLParser
@@ -392,9 +389,6 @@ public:
 
 // INIT NACHO SECTION
 
-<<<<<<< HEAD
-// FINISH NACHO SECTION
-=======
     static XMLP_ret parseXMLTypes_wrapper(
         tinyxml2::XMLElement* p_root)
     {
@@ -426,15 +420,14 @@ public:
         eprosima::fastrtps::xmlparser::sp_transport_t p_transport)
     {
         return parseXMLCommonTCPTransportData(p_root, p_transport);
-    }   
-    
+    }
+
     static XMLP_ret parseXMLConsumer_wrapper(
         tinyxml2::XMLElement& p_root)
     {
         return parseXMLConsumer(p_root);
     }
-// FINISH NACHO SECTION	
->>>>>>> d116cf92b... Refs #9965: Added Wrapped methods
+// FINISH NACHO SECTION
 
 // INIT RAUL SECTION
     static XMLP_ret parseXML_wrapper(

--- a/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
+++ b/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
@@ -22,6 +22,9 @@ using eprosima::fastrtps::xmlparser::XMLParser;
 using eprosima::fastrtps::xmlparser::DataNode;
 using eprosima::fastrtps::xmlparser::BaseNode;
 using eprosima::fastrtps::xmlparser::sp_transport_t;
+using eprosima::fastrtps::xmlparser::up_participant_t;
+using eprosima::fastrtps::xmlparser::up_node_participant_t;
+using eprosima::fastrtps::xmlparser::node_participant_t;
 
 // Class to test protected methods
 class XMLParserTest : public XMLParser

--- a/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
+++ b/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
@@ -20,7 +20,11 @@ using namespace eprosima::fastrtps::rtps;
 using eprosima::fastrtps::xmlparser::XMLP_ret;
 using eprosima::fastrtps::xmlparser::XMLParser;
 using eprosima::fastrtps::xmlparser::DataNode;
+<<<<<<< HEAD
 using eprosima::fastrtps::xmlparser::BaseNode;
+=======
+using eprosima::fastrtps::xmlparser::sp_transport_t;
+>>>>>>> d116cf92b... Refs #9965: Added Wrapped methods
 
 // Class to test protected methods
 class XMLParserTest : public XMLParser
@@ -388,7 +392,49 @@ public:
 
 // INIT NACHO SECTION
 
+<<<<<<< HEAD
 // FINISH NACHO SECTION
+=======
+    static XMLP_ret parseXMLTypes_wrapper(
+        tinyxml2::XMLElement* p_root)
+    {
+        return parseXMLTypes(p_root);
+    }
+
+    static XMLP_ret parseXMLTransportData_wrapper(
+        tinyxml2::XMLElement* p_root)
+    {
+        return parseXMLTransportData(p_root);
+    }
+
+    static XMLP_ret parseXMLCommonTransportData_wrapper(
+        tinyxml2::XMLElement* p_root,
+        sp_transport_t p_transport)
+    {
+        return parseXMLCommonTransportData(p_root, p_transport);
+    }
+
+    static XMLP_ret parseXMLCommonSharedMemTransportData_wrapper(
+        tinyxml2::XMLElement* p_root,
+        sp_transport_t p_transport)
+    {
+        return parseXMLCommonSharedMemTransportData(p_root, p_transport);
+    }
+
+    static XMLP_ret parseXMLCommonTCPTransportData_wrapper(
+        tinyxml2::XMLElement* p_root,
+        eprosima::fastrtps::xmlparser::sp_transport_t p_transport)
+    {
+        return parseXMLCommonTCPTransportData(p_root, p_transport);
+    }   
+    
+    static XMLP_ret parseXMLConsumer_wrapper(
+        tinyxml2::XMLElement& p_root)
+    {
+        return parseXMLConsumer(p_root);
+    }
+// FINISH NACHO SECTION	
+>>>>>>> d116cf92b... Refs #9965: Added Wrapped methods
 
 // INIT RAUL SECTION
     static XMLP_ret parseXML_wrapper(

--- a/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
+++ b/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
@@ -430,6 +430,12 @@ public:
     {
         return parseXMLConsumer(p_root);
     }
+
+    static XMLP_ret parseLogConfig_wrapper(
+        tinyxml2::XMLElement* p_root)
+    {
+        return parseLogConfig(p_root);
+    }
 // FINISH NACHO SECTION
 
 // INIT RAUL SECTION


### PR DESCRIPTION
This Pr adds unit tests for the following methods:

- `parseLogConfig`
- `parseXMLConsumer`
- `parseXMLTransportData`
- `loadXMLProfiles`
- `fillDataNode<ParticipantAttributes>`

Also fixes following errors in `XMLParser.cpp`:

- segfault on missing data in some XML tags
- commented inaccessible error code for unsupported method `getXMLOctetVector`