### PR TITLE
[Discovery-Server] Fix timing errors [10081]

### DIFF
--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -572,10 +572,9 @@ void DiscoveryDataBase::create_participant_from_change_(
             // The change could be newer and at the same time not being an update.
             // This happens with DATAs coming from servers, since they take their own DATAs in and out frequently,
             // so the sequence number in `write_params` changes.
-            // To account for that, we discard the DATA if the payload is exactly the same as what wee have.
+            // To account for that, we discard the DATA if the payload is exactly the same as what we have.
             if (!(ch->serializedPayload == participant_it->second.change()->serializedPayload))
             {
-                // Update the change related to the participant and return the old change to the pool
                 logInfo(DISCOVERY_DATABASE, "Participant updating. Marking old change to release");
                 // Update participant's change in the database, set all relevant participants ACK status to 0, and add
                 // old change to changes_to_release_.

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -1638,7 +1638,7 @@ void DiscoveryDataBase::AckedFunctor::operator () (
                     if (remote_server_it == db_->participants_.end())
                     {
                         logInfo(DISCOVERY_DATABASE, "Change " << change_->instanceHandle <<
-                            "check as acked for " << reader_proxy->guid() << " as it has not answered pinging yet");
+                                "check as acked for " << reader_proxy->guid() << " as it has not answered pinging yet");
                         return;
                     }
                 }
@@ -2416,7 +2416,7 @@ bool DiscoveryDataBase::from_json(
 
             logInfo(DISCOVERY_DATABASE,
                     "Writer " << guid_aux << " created with instance handle " <<
-                                    wit.first->second.change()->instanceHandle);
+                    wit.first->second.change()->instanceHandle);
 
             if (change->kind != fastrtps::rtps::ALIVE)
             {

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
@@ -331,6 +331,11 @@ public:
         return virtual_topic_;
     }
 
+    int get_etinties_updated_and_reset()
+    {
+            return entities_updated_.exchange(0);
+    }
+
 protected:
 
     // change a cacheChange by update or new disposal
@@ -533,6 +538,9 @@ protected:
 
     // Whether the database is enabled
     std::atomic<bool> enabled_;
+
+    // Whether it has been a new entity discovered or updated in this subroutine loop
+    std::atomic<int> entities_updated_;
 
     // Wheter the database is restoring a backup
     std::atomic<bool> processing_backup_;

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
@@ -333,7 +333,7 @@ public:
 
     int get_etinties_updated_and_reset()
     {
-            return entities_updated_.exchange(0);
+        return entities_updated_.exchange(0);
     }
 
 protected:

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -949,8 +949,8 @@ History::iterator PDPServer::process_change_acknowledgement(
                 {
                     // Remove the entry from writer history, but do not release the cache.
                     // This CacheChange will only be released in the case that is substituted by a DATA(Up|Uw|Ur).
-                    logInfo(RTPS_PDP_SERVER, "Removingfix de DS change " << c->instanceHandle
-                        << " from history as it has been acked");
+                    logInfo(RTPS_PDP_SERVER, "Removing change " << c->instanceHandle
+                        << " from history as it has been acked for everyone");
                     return writer_history->remove_change(cit, false);
                 }
             }
@@ -1281,7 +1281,7 @@ bool PDPServer::remove_change_from_history_nts(
     {
         // We compare by pointer because we maintain the same pointer everywhere and it is unique
         // We cannot compare by cache info because there is no distinct attributes for the same change arrived
-        //  from different servers, and one of them could be in the history while the other arrive to ddb
+        // from different servers, and one of them could be in the history while the other arrive to db
         if (change == (*chit))
         {
             if (release_change)

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -950,7 +950,7 @@ History::iterator PDPServer::process_change_acknowledgement(
                     // Remove the entry from writer history, but do not release the cache.
                     // This CacheChange will only be released in the case that is substituted by a DATA(Up|Uw|Ur).
                     logInfo(RTPS_PDP_SERVER, "Removing change " << c->instanceHandle
-                        << " from history as it has been acked for everyone");
+                                                                << " from history as it has been acked for everyone");
                     return writer_history->remove_change(cit, false);
                 }
             }


### PR DESCRIPTION
With the new change of ResourceEvent, the DDB does not work properly due to it resends the data (this means it erases the old data and create send it with new sequence number). If this happens before the ack arrives (this happens now that the routine starts faster) the Discovery Server get stucked in an infinite loop.