### PR TITLE
Guard IO service timer thread against accidental null pointer dereference

### DIFF
--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -136,9 +136,12 @@ void TCPTransportInterface::clean()
     alive_.store(false);
 
     keep_alive_event_.cancel();
-    io_service_timers_.stop();
-    io_service_timers_thread_->join();
-    io_service_timers_thread_ = nullptr;
+    if (io_service_timers_thread_)
+    {
+        io_service_timers_.stop();
+        io_service_timers_thread_->join();
+        io_service_timers_thread_ = nullptr;
+    }
 
     {
         std::vector<std::shared_ptr<TCPChannelResource>> channels;


### PR DESCRIPTION
The TCPTransportInterface may segfault on destruction if a transport instance fails to initialize properly. This is due to the unguarded access to io_service_timers_thread_.

This PR duplicates the defensive logic that is used for io_service_thread_ in the same method.