### PR TITLE
Do not exit the process if the IP detection fails

### DIFF
--- a/src/cpp/utils/IPFinder.cpp
+++ b/src/cpp/utils/IPFinder.cpp
@@ -138,7 +138,7 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
     // TODO arm64 doesn't seem to support getifaddrs
     if (getifaddrs(&ifaddr) == -1) {
         perror("getifaddrs");
-        exit(EXIT_FAILURE);
+        return false;
     }
 
     for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next)
@@ -153,9 +153,8 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
             s = getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in),
                     host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
             if (s != 0) {
-                printf("getnameinfo() failed: %s\n", gai_strerror(s));
-                freeifaddrs(ifaddr);
-                exit(EXIT_FAILURE);
+                fprintf(stderr, "getnameinfo() failed: %s\n", gai_strerror(s));
+                continue;
             }
             info_IP info;
             info.type = IP4;
@@ -171,9 +170,8 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
             s = getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in6),
                     host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
             if (s != 0) {
-                printf("getnameinfo() failed: %s\n", gai_strerror(s));
-                freeifaddrs(ifaddr);
-                exit(EXIT_FAILURE);
+                fprintf(stderr, "getnameinfo() failed: %s\n", gai_strerror(s));
+                continue;
             }
             info_IP info;
             info.type = IP6;

--- a/src/cpp/utils/IPFinder.cpp
+++ b/src/cpp/utils/IPFinder.cpp
@@ -37,28 +37,32 @@
 #include <unistd.h>
 #include <string.h>
 #include <net/if.h>
-#endif
+#endif // if defined(_WIN32)
 
 #if defined(__FreeBSD__)
 #include <netinet/in.h>
-#endif
+#endif // if defined(__FreeBSD__)
 
 #include <cstddef>
 #include <cstring>
 
 using namespace eprosima::fastrtps::rtps;
 
-IPFinder::IPFinder() {
+IPFinder::IPFinder()
+{
 }
 
-IPFinder::~IPFinder() {
+IPFinder::~IPFinder()
+{
 }
 
 #if defined(_WIN32)
 
 #define DEFAULT_ADAPTER_ADDRESSES_SIZE 15360
 
-bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
+bool IPFinder::getIPs(
+        std::vector<info_IP>* vec_name,
+        bool return_loopback)
 {
     DWORD rv, size = DEFAULT_ADAPTER_ADDRESSES_SIZE;
     PIP_ADAPTER_ADDRESSES adapter_addresses, aa;
@@ -82,10 +86,12 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
         return false;
     }
 
-    for (aa = adapter_addresses; aa != NULL; aa = aa->Next) {
+    for (aa = adapter_addresses; aa != NULL; aa = aa->Next)
+    {
         if (aa->OperStatus == 1) //is ENABLED
         {
-            for (ua = aa->FirstUnicastAddress; ua != NULL; ua = ua->Next) {
+            for (ua = aa->FirstUnicastAddress; ua != NULL; ua = ua->Next)
+            {
                 char buf[BUFSIZ];
 
                 int family = ua->Address.lpSockaddr->sa_family;
@@ -94,15 +100,18 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
                 {
                     //printf("\t%s ",  family == AF_INET ? "IPv4":"IPv6");
                     memset(buf, 0, BUFSIZ);
-                    getnameinfo(ua->Address.lpSockaddr, ua->Address.iSockaddrLength, buf, sizeof(buf), NULL, 0, NI_NUMERICHOST);
+                    getnameinfo(ua->Address.lpSockaddr, ua->Address.iSockaddrLength, buf, sizeof(buf), NULL, 0,
+                            NI_NUMERICHOST);
                     info_IP info;
                     info.type = family == AF_INET ? IP4 : IP6;
                     info.name = std::string(buf);
                     info.dev = std::string(aa->AdapterName);
 
                     // Currently not supported interfaces that not support multicast.
-                    if(aa->Flags & 0x0010)
+                    if (aa->Flags & 0x0010)
+                    {
                         continue;
+                    }
 
                     if (info.type == IP4)
                     {
@@ -113,7 +122,7 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
                         parseIP6(info);
                     }
 
-                    if(return_loopback || (info.type != IP6_LOCAL && info.type != IP4_LOCAL))
+                    if (return_loopback || (info.type != IP6_LOCAL && info.type != IP4_LOCAL))
                     {
                         vec_name->push_back(info);
                     }
@@ -129,14 +138,17 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
 
 #else
 
-bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
+bool IPFinder::getIPs(
+        std::vector<info_IP>* vec_name,
+        bool return_loopback)
 {
-    struct ifaddrs *ifaddr, *ifa;
+    struct ifaddrs* ifaddr, * ifa;
     int family, s;
     char host[NI_MAXHOST];
 
     // TODO arm64 doesn't seem to support getifaddrs
-    if (getifaddrs(&ifaddr) == -1) {
+    if (getifaddrs(&ifaddr) == -1)
+    {
         perror("getifaddrs");
         return false;
     }
@@ -144,15 +156,18 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
     for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next)
     {
         if (ifa->ifa_addr == NULL || (ifa->ifa_flags & IFF_RUNNING) == 0)
+        {
             continue;
+        }
 
         family = ifa->ifa_addr->sa_family;
 
         if (family == AF_INET)
         {
             s = getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in),
-                    host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
-            if (s != 0) {
+                            host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
+            if (s != 0)
+            {
                 fprintf(stderr, "getnameinfo() failed: %s\n", gai_strerror(s));
                 continue;
             }
@@ -163,13 +178,16 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
             parseIP4(info);
 
             if (return_loopback || info.type != IP4_LOCAL)
+            {
                 vec_name->push_back(info);
+            }
         }
-        else if(family == AF_INET6)
+        else if (family == AF_INET6)
         {
             s = getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in6),
-                    host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
-            if (s != 0) {
+                            host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
+            if (s != 0)
+            {
                 fprintf(stderr, "getnameinfo() failed: %s\n", gai_strerror(s));
                 continue;
             }
@@ -177,10 +195,12 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
             info.type = IP6;
             info.name = std::string(host);
             info.dev = std::string(ifa->ifa_name);
-            if(parseIP6(info))
+            if (parseIP6(info))
             {
                 if (return_loopback || info.type != IP6_LOCAL)
+                {
                     vec_name->push_back(info);
+                }
             }
             //printf("<Interface>: %s \t <Address> %s\n", ifa->ifa_name, host);
         }
@@ -189,17 +209,19 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
     freeifaddrs(ifaddr);
     return true;
 }
-#endif
 
-bool IPFinder::getIP4Address(LocatorList_t* locators)
+#endif // if defined(_WIN32)
+
+bool IPFinder::getIP4Address(
+        LocatorList_t* locators)
 {
     std::vector<info_IP> ip_names;
-    if(IPFinder::getIPs(&ip_names))
+    if (IPFinder::getIPs(&ip_names))
     {
 
         locators->clear();
-        for(auto it=ip_names.begin();
-                it!=ip_names.end();++it)
+        for (auto it = ip_names.begin();
+                it != ip_names.end(); ++it)
         {
             if (it->type == IP4)
             {
@@ -211,7 +233,8 @@ bool IPFinder::getIP4Address(LocatorList_t* locators)
     return false;
 }
 
-bool IPFinder::getAllIPAddress(LocatorList_t* locators)
+bool IPFinder::getAllIPAddress(
+        LocatorList_t* locators)
 {
     std::vector<info_IP> ip_names;
     if (IPFinder::getIPs(&ip_names))
@@ -234,7 +257,8 @@ bool IPFinder::getAllIPAddress(LocatorList_t* locators)
     return false;
 }
 
-bool IPFinder::getIP6Address(LocatorList_t* locators)
+bool IPFinder::getIP6Address(
+        LocatorList_t* locators)
 {
     std::vector<info_IP> ip_names;
     if (IPFinder::getIPs(&ip_names))
@@ -254,7 +278,8 @@ bool IPFinder::getIP6Address(LocatorList_t* locators)
     return false;
 }
 
-bool IPFinder::parseIP4(info_IP& info)
+bool IPFinder::parseIP4(
+        info_IP& info)
 {
     info.locator.kind = 1;
     info.locator.port = 0;
@@ -265,7 +290,9 @@ bool IPFinder::parseIP4(info_IP& info)
     }
     return true;
 }
-bool IPFinder::parseIP6(info_IP& info)
+
+bool IPFinder::parseIP6(
+        info_IP& info)
 {
     info.locator.kind = LOCATOR_KIND_UDPv6;
     info.locator.port = 0;
@@ -280,14 +307,15 @@ bool IPFinder::parseIP6(info_IP& info)
        cout << it << " ";
        cout << endl;
        cout << "LOCATOR: " << *loc << endl;
-       */
+     */
     return true;
 }
 
-std::string IPFinder::getIPv4Address(const std::string &name)
+std::string IPFinder::getIPv4Address(
+        const std::string& name)
 {
     addrinfo hints;
-    addrinfo *result;
+    addrinfo* result;
     char str[INET_ADDRSTRLEN];
 
     memset(&hints, 0, sizeof(addrinfo));
@@ -301,7 +329,7 @@ std::string IPFinder::getIPv4Address(const std::string &name)
 
     int s = getaddrinfo(name.c_str(), nullptr, &hints, &result);
 
-    if ( (s == 0) && (inet_ntop(AF_INET, result[0].ai_addr, str, INET_ADDRSTRLEN) != nullptr) )
+    if ((s == 0) && (inet_ntop(AF_INET, result[0].ai_addr, str, INET_ADDRSTRLEN) != nullptr))
     {
         freeaddrinfo(result);
         return str;
@@ -311,10 +339,11 @@ std::string IPFinder::getIPv4Address(const std::string &name)
     return "";
 }
 
-std::string IPFinder::getIPv6Address(const std::string &name)
+std::string IPFinder::getIPv6Address(
+        const std::string& name)
 {
     addrinfo hints;
-    addrinfo *result;
+    addrinfo* result;
     char str[INET6_ADDRSTRLEN];
 
     memset(&hints, 0, sizeof(addrinfo));
@@ -328,7 +357,7 @@ std::string IPFinder::getIPv6Address(const std::string &name)
 
     int s = getaddrinfo(name.c_str(), nullptr, &hints, &result);
 
-    if ( (s == 0) && (inet_ntop(AF_INET6, result[0].ai_addr, str, INET6_ADDRSTRLEN) != nullptr) )
+    if ((s == 0) && (inet_ntop(AF_INET6, result[0].ai_addr, str, INET6_ADDRSTRLEN) != nullptr))
     {
         freeaddrinfo(result);
         return str;


### PR DESCRIPTION
It is considered bad style to call exit() within a library function, as
this kind of error "handling" cannot be overridden by the calling
program.

As the function getIPs() has a boolean return type already, and the
Windows version actually uses it to convey success or failure, I
adjusted the behavior for the non-Windows version accordingly.