### PR TITLE
Locator coverage [10119]

### DIFF
--- a/include/fastdds/dds/log/Log.hpp
+++ b/include/fastdds/dds/log/Log.hpp
@@ -246,7 +246,7 @@ protected:
         std::stringstream fastdds_log_ss_tmp__;                                                                        \
         fastdds_log_ss_tmp__ << msg;                                                                                   \
         Log::QueueLog(fastdds_log_ss_tmp__.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, Log::Kind::Error); \
-    }while(0)
+    }while (0)
 #elif (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG))
 #define logError_(cat, msg)                                     \
     do{                                                         \
@@ -256,7 +256,7 @@ protected:
                     fastdds_log_ss_tmp__ << msg;                \
                 };                                              \
         (void)fastdds_log_lambda_tmp__;                         \
-    }while(0)
+    }while (0)
 #else
 #define logError_(cat, msg)
 #endif // ifndef LOG_NO_ERROR
@@ -272,7 +272,7 @@ protected:
             Log::QueueLog(                                                                                          \
                 fastdds_log_ss_tmp__.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, Log::Kind::Warning);  \
         }                                                                                                           \
-    }while(0)
+    }while (0)
 #elif (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG))
 #define logWarning_(cat, msg)                                   \
     do{                                                         \
@@ -282,7 +282,7 @@ protected:
                     fastdds_log_ss_tmp__ << msg;                \
                 };                                              \
         (void)fastdds_log_lambda_tmp__;                         \
-    }while(0)
+    }while (0)
 #else
 #define logWarning_(cat, msg)
 #endif // ifndef LOG_NO_WARNING
@@ -299,7 +299,7 @@ protected:
             Log::QueueLog(fastdds_log_ss_tmp__.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, \
                     Log::Kind::Info);                                                                   \
         }                                                                                               \
-    }while(0)
+    }while (0)
 #elif (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG))
 #define logInfo_(cat, msg)                                  \
     do{                                                     \
@@ -309,7 +309,7 @@ protected:
                     fastdds_log_ss_tmp__ << msg;            \
                 };                                          \
         (void)fastdds_log_lambda_tmp__;                     \
-    }while(0)
+    }while (0)
 #else
 #define logInfo_(cat, msg)
 #endif // if (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG)) && (defined(_DEBUG) || defined(__DEBUG)) && (!defined(LOG_NO_INFO))

--- a/include/fastdds/dds/log/Log.hpp
+++ b/include/fastdds/dds/log/Log.hpp
@@ -238,21 +238,22 @@ protected:
 #define __func__ __FUNCTION__
 #endif // if defined(WIN32)
 
+// Name of variables inside macros must be unique, or it could produce an error with external variables
 #ifndef LOG_NO_ERROR
 #define logError_(cat, msg)                                                                          \
     {                                                                                                \
         using namespace eprosima::fastdds::dds;                                                      \
-        std::stringstream ss;                                                                        \
-        ss << msg;                                                                                   \
-        Log::QueueLog(ss.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, Log::Kind::Error); \
+        std::stringstream fastdds_log_ss_tmp__;                                                                        \
+        fastdds_log_ss_tmp__ << msg;                                                                                   \
+        Log::QueueLog(fastdds_log_ss_tmp__.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, Log::Kind::Error); \
     }
 #elif (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG))
 #define logError_(cat, msg)        \
     {                              \
         auto tmp_lambda = [&]()    \
                 {                          \
-                    std::stringstream ss;  \
-                    ss << msg;             \
+                    std::stringstream fastdds_log_ss_tmp__;  \
+                    fastdds_log_ss_tmp__ << msg;             \
                 };                         \
         (void)tmp_lambda;          \
     }
@@ -266,9 +267,9 @@ protected:
         using namespace eprosima::fastdds::dds;                                                            \
         if (Log::GetVerbosity() >= Log::Kind::Warning)                                                     \
         {                                                                                                  \
-            std::stringstream ss;                                                                          \
-            ss << msg;                                                                                     \
-            Log::QueueLog(ss.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, Log::Kind::Warning); \
+            std::stringstream fastdds_log_ss_tmp__;                                                                          \
+            fastdds_log_ss_tmp__ << msg;                                                                                     \
+            Log::QueueLog(fastdds_log_ss_tmp__.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, Log::Kind::Warning); \
         }                                                                                                  \
     }
 #elif (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG))
@@ -276,8 +277,8 @@ protected:
     {                              \
         auto tmp_lambda = [&]()    \
                 {                          \
-                    std::stringstream ss;  \
-                    ss << msg;             \
+                    std::stringstream fastdds_log_ss_tmp__;  \
+                    fastdds_log_ss_tmp__ << msg;             \
                 };                         \
         (void)tmp_lambda;          \
     }
@@ -292,9 +293,9 @@ protected:
         using namespace eprosima::fastdds::dds;                                                         \
         if (Log::GetVerbosity() >= Log::Kind::Info)                                                     \
         {                                                                                               \
-            std::stringstream ss;                                                                       \
-            ss << msg;                                                                                  \
-            Log::QueueLog(ss.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, Log::Kind::Info); \
+            std::stringstream fastdds_log_ss_tmp__;                                                                       \
+            fastdds_log_ss_tmp__ << msg;                                                                                  \
+            Log::QueueLog(fastdds_log_ss_tmp__.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, Log::Kind::Info); \
         }                                                                                               \
     }
 #elif (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG))
@@ -302,8 +303,8 @@ protected:
     {                              \
         auto tmp_lambda = [&]()    \
                 {                          \
-                    std::stringstream ss;  \
-                    ss << msg;             \
+                    std::stringstream fastdds_log_ss_tmp__;  \
+                    fastdds_log_ss_tmp__ << msg;             \
                 };                         \
         (void)tmp_lambda;          \
     }

--- a/include/fastdds/dds/log/Log.hpp
+++ b/include/fastdds/dds/log/Log.hpp
@@ -241,29 +241,29 @@ protected:
 // Name of variables inside macros must be unique, or it could produce an error with external variables
 #ifndef LOG_NO_ERROR
 #define logError_(cat, msg)                                                                                            \
-    {                                                                                                                  \
+    do{                                                                                                                \
         using namespace eprosima::fastdds::dds;                                                                        \
         std::stringstream fastdds_log_ss_tmp__;                                                                        \
         fastdds_log_ss_tmp__ << msg;                                                                                   \
         Log::QueueLog(fastdds_log_ss_tmp__.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, Log::Kind::Error); \
-    }
+    }while(0)
 #elif (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG))
 #define logError_(cat, msg)                                     \
-    {                                                           \
-        auto tmp_lambda = [&]()                                 \
+    do{                                                         \
+        auto fastdds_log_lambda_tmp__ = [&]()                   \
                 {                                               \
                     std::stringstream fastdds_log_ss_tmp__;     \
                     fastdds_log_ss_tmp__ << msg;                \
                 };                                              \
-        (void)tmp_lambda;                                       \
-    }
+        (void)fastdds_log_lambda_tmp__;                         \
+    }while(0)
 #else
 #define logError_(cat, msg)
 #endif // ifndef LOG_NO_ERROR
 
 #ifndef LOG_NO_WARNING
 #define logWarning_(cat, msg)                                                                                       \
-    {                                                                                                               \
+    do{                                                                                                             \
         using namespace eprosima::fastdds::dds;                                                                     \
         if (Log::GetVerbosity() >= Log::Kind::Warning)                                                              \
         {                                                                                                           \
@@ -272,17 +272,17 @@ protected:
             Log::QueueLog(                                                                                          \
                 fastdds_log_ss_tmp__.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, Log::Kind::Warning);  \
         }                                                                                                           \
-    }
+    }while(0)
 #elif (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG))
 #define logWarning_(cat, msg)                                   \
-    {                                                           \
-        auto tmp_lambda = [&]()                                 \
+    do{                                                         \
+        auto fastdds_log_lambda_tmp__ = [&]()                   \
                 {                                               \
                     std::stringstream fastdds_log_ss_tmp__;     \
                     fastdds_log_ss_tmp__ << msg;                \
                 };                                              \
-        (void)tmp_lambda;                                       \
-    }
+        (void)fastdds_log_lambda_tmp__;                         \
+    }while(0)
 #else
 #define logWarning_(cat, msg)
 #endif // ifndef LOG_NO_WARNING
@@ -290,7 +290,7 @@ protected:
 #if (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG)) && (defined(_DEBUG) || defined(__DEBUG)) && \
     (!defined(LOG_NO_INFO))
 #define logInfo_(cat, msg)                                                                              \
-    {                                                                                                   \
+    do{                                                                                                 \
         using namespace eprosima::fastdds::dds;                                                         \
         if (Log::GetVerbosity() >= Log::Kind::Info)                                                     \
         {                                                                                               \
@@ -299,17 +299,17 @@ protected:
             Log::QueueLog(fastdds_log_ss_tmp__.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, \
                     Log::Kind::Info);                                                                   \
         }                                                                                               \
-    }
+    }while(0)
 #elif (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG))
 #define logInfo_(cat, msg)                                  \
-    {                                                       \
-        auto tmp_lambda = [&]()                             \
+    do{                                                     \
+        auto fastdds_log_lambda_tmp__ = [&]()               \
                 {                                           \
                     std::stringstream fastdds_log_ss_tmp__; \
                     fastdds_log_ss_tmp__ << msg;            \
                 };                                          \
-        (void)tmp_lambda;                                   \
-    }
+        (void)fastdds_log_lambda_tmp__;                     \
+    }while(0)
 #else
 #define logInfo_(cat, msg)
 #endif // if (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG)) && (defined(_DEBUG) || defined(__DEBUG)) && (!defined(LOG_NO_INFO))

--- a/include/fastdds/dds/log/Log.hpp
+++ b/include/fastdds/dds/log/Log.hpp
@@ -269,7 +269,8 @@ protected:
         {                                                                                                  \
             std::stringstream fastdds_log_ss_tmp__;                                                                          \
             fastdds_log_ss_tmp__ << msg;                                                                                     \
-            Log::QueueLog(fastdds_log_ss_tmp__.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, Log::Kind::Warning); \
+            Log::QueueLog( \
+                fastdds_log_ss_tmp__.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, Log::Kind::Warning); \
         }                                                                                                  \
     }
 #elif (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG))
@@ -295,7 +296,8 @@ protected:
         {                                                                                               \
             std::stringstream fastdds_log_ss_tmp__;                                                                       \
             fastdds_log_ss_tmp__ << msg;                                                                                  \
-            Log::QueueLog(fastdds_log_ss_tmp__.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, Log::Kind::Info); \
+            Log::QueueLog(fastdds_log_ss_tmp__.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, \
+                    Log::Kind::Info); \
         }                                                                                               \
     }
 #elif (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG))

--- a/include/fastdds/dds/log/Log.hpp
+++ b/include/fastdds/dds/log/Log.hpp
@@ -240,48 +240,48 @@ protected:
 
 // Name of variables inside macros must be unique, or it could produce an error with external variables
 #ifndef LOG_NO_ERROR
-#define logError_(cat, msg)                                                                          \
-    {                                                                                                \
-        using namespace eprosima::fastdds::dds;                                                      \
+#define logError_(cat, msg)                                                                                            \
+    {                                                                                                                  \
+        using namespace eprosima::fastdds::dds;                                                                        \
         std::stringstream fastdds_log_ss_tmp__;                                                                        \
         fastdds_log_ss_tmp__ << msg;                                                                                   \
         Log::QueueLog(fastdds_log_ss_tmp__.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, Log::Kind::Error); \
     }
 #elif (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG))
-#define logError_(cat, msg)        \
-    {                              \
-        auto tmp_lambda = [&]()    \
-                {                          \
-                    std::stringstream fastdds_log_ss_tmp__;  \
-                    fastdds_log_ss_tmp__ << msg;             \
-                };                         \
-        (void)tmp_lambda;          \
+#define logError_(cat, msg)                                     \
+    {                                                           \
+        auto tmp_lambda = [&]()                                 \
+                {                                               \
+                    std::stringstream fastdds_log_ss_tmp__;     \
+                    fastdds_log_ss_tmp__ << msg;                \
+                };                                              \
+        (void)tmp_lambda;                                       \
     }
 #else
 #define logError_(cat, msg)
 #endif // ifndef LOG_NO_ERROR
 
 #ifndef LOG_NO_WARNING
-#define logWarning_(cat, msg)                                                                              \
-    {                                                                                                      \
-        using namespace eprosima::fastdds::dds;                                                            \
-        if (Log::GetVerbosity() >= Log::Kind::Warning)                                                     \
-        {                                                                                                  \
-            std::stringstream fastdds_log_ss_tmp__;                                                                          \
-            fastdds_log_ss_tmp__ << msg;                                                                                     \
-            Log::QueueLog( \
-                fastdds_log_ss_tmp__.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, Log::Kind::Warning); \
-        }                                                                                                  \
+#define logWarning_(cat, msg)                                                                                       \
+    {                                                                                                               \
+        using namespace eprosima::fastdds::dds;                                                                     \
+        if (Log::GetVerbosity() >= Log::Kind::Warning)                                                              \
+        {                                                                                                           \
+            std::stringstream fastdds_log_ss_tmp__;                                                                 \
+            fastdds_log_ss_tmp__ << msg;                                                                            \
+            Log::QueueLog(                                                                                          \
+                fastdds_log_ss_tmp__.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, Log::Kind::Warning);  \
+        }                                                                                                           \
     }
 #elif (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG))
-#define logWarning_(cat, msg)      \
-    {                              \
-        auto tmp_lambda = [&]()    \
-                {                          \
-                    std::stringstream fastdds_log_ss_tmp__;  \
-                    fastdds_log_ss_tmp__ << msg;             \
-                };                         \
-        (void)tmp_lambda;          \
+#define logWarning_(cat, msg)                                   \
+    {                                                           \
+        auto tmp_lambda = [&]()                                 \
+                {                                               \
+                    std::stringstream fastdds_log_ss_tmp__;     \
+                    fastdds_log_ss_tmp__ << msg;                \
+                };                                              \
+        (void)tmp_lambda;                                       \
     }
 #else
 #define logWarning_(cat, msg)
@@ -294,21 +294,21 @@ protected:
         using namespace eprosima::fastdds::dds;                                                         \
         if (Log::GetVerbosity() >= Log::Kind::Info)                                                     \
         {                                                                                               \
-            std::stringstream fastdds_log_ss_tmp__;                                                                       \
-            fastdds_log_ss_tmp__ << msg;                                                                                  \
+            std::stringstream fastdds_log_ss_tmp__;                                                     \
+            fastdds_log_ss_tmp__ << msg;                                                                \
             Log::QueueLog(fastdds_log_ss_tmp__.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, \
-                    Log::Kind::Info); \
+                    Log::Kind::Info);                                                                   \
         }                                                                                               \
     }
 #elif (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG))
-#define logInfo_(cat, msg)         \
-    {                              \
-        auto tmp_lambda = [&]()    \
-                {                          \
-                    std::stringstream fastdds_log_ss_tmp__;  \
-                    fastdds_log_ss_tmp__ << msg;             \
-                };                         \
-        (void)tmp_lambda;          \
+#define logInfo_(cat, msg)                                  \
+    {                                                       \
+        auto tmp_lambda = [&]()                             \
+                {                                           \
+                    std::stringstream fastdds_log_ss_tmp__; \
+                    fastdds_log_ss_tmp__ << msg;            \
+                };                                          \
+        (void)tmp_lambda;                                   \
     }
 #else
 #define logInfo_(cat, msg)

--- a/include/fastdds/rtps/common/Locator.h
+++ b/include/fastdds/rtps/common/Locator.h
@@ -591,6 +591,8 @@ public:
         }
     }
 
+    FASTDDS_DEPRECATED_UNTIL(3, "eprosima::fastrtps::rtps::LocatorList_t::contains(const Locator_t&)",
+            "Not specify function with unknown functionality.")
     RTPS_DllAPI bool contains(
             const Locator_t& loc)
     {
@@ -650,7 +652,7 @@ inline std::ostream& operator <<(
     if (locList.size() > 0)
     {
         output << *(locList.begin()) ;
-        for (auto it = locList.m_locators.begin(); it != locList.m_locators.end(); ++it)
+        for (auto it = locList.m_locators.begin()+1; it != locList.m_locators.end(); ++it)
         {
             output << "," << *it;
         }

--- a/include/fastdds/rtps/common/Locator.h
+++ b/include/fastdds/rtps/common/Locator.h
@@ -295,6 +295,7 @@ inline std::istream& operator >>(
 
         try
         {
+            std::string str_locator;
             input.exceptions(excp_mask | std::ios_base::failbit | std::ios_base::badbit);
 
             // Locator info

--- a/include/fastdds/rtps/common/Locator.h
+++ b/include/fastdds/rtps/common/Locator.h
@@ -300,7 +300,7 @@ inline std::istream& operator >>(
             input.exceptions(excp_mask | std::ios_base::failbit | std::ios_base::badbit);
 
             // Locator info
-            uint32_t kind;
+            int32_t kind;
             uint32_t port;
             std::string address;
 

--- a/include/fastdds/rtps/common/Locator.h
+++ b/include/fastdds/rtps/common/Locator.h
@@ -24,6 +24,8 @@
 #include <fastdds/rtps/common/Types.h>
 #include <fastrtps/utils/IPLocator.h>
 
+#include <fastdds/dds/log/Log.hpp>
+
 #include <sstream>
 #include <vector>
 #include <cstdint>
@@ -295,15 +297,16 @@ inline std::istream& operator >>(
 
         try
         {
-            std::string str_locator;
             input.exceptions(excp_mask | std::ios_base::failbit | std::ios_base::badbit);
 
             // Locator info
-            uint32_t kind, port;
+            uint32_t kind;
+            uint32_t port;
             std::string address;
 
             // Deserialization variables
-            std::stringbuf sb_kind, sb_address;
+            std::stringbuf sb_kind;
+            std::stringbuf sb_address;
             std::string str_kind;
             char punct;
 
@@ -336,7 +339,7 @@ inline std::istream& operator >>(
                 kind = LOCATOR_KIND_INVALID;
             }
 
-            // Get char :[
+            // Get chars :[
             input >> punct >> punct;
 
             // Get address in string
@@ -354,6 +357,7 @@ inline std::istream& operator >>(
         catch (std::ios_base::failure& )
         {
             loc.kind = LOCATOR_KIND_INVALID;
+            logWarning(LOCATOR, "Error deserializing Locator");
         }
 
         input.exceptions(excp_mask);
@@ -592,7 +596,7 @@ public:
     }
 
     FASTDDS_DEPRECATED_UNTIL(3, "eprosima::fastrtps::rtps::LocatorList_t::contains(const Locator_t&)",
-            "Not specify function with unknown functionality.")
+            "Unused method.")
     RTPS_DllAPI bool contains(
             const Locator_t& loc)
     {
@@ -649,9 +653,9 @@ inline std::ostream& operator <<(
         const LocatorList_t& locList)
 {
     output << "[";
-    if (locList.size() > 0)
+    if (!locList.empty())
     {
-        output << *(locList.begin()) ;
+        output << *(locList.begin());
         for (auto it = locList.m_locators.begin()+1; it != locList.m_locators.end(); ++it)
         {
             output << "," << *it;
@@ -681,7 +685,7 @@ inline std::istream& operator >>(
         {
             input.exceptions(excp_mask | std::ios_base::failbit | std::ios_base::badbit);
 
-            // Get []
+            // Get [
             input >> punct;
 
             while (punct != ']')
@@ -694,6 +698,7 @@ inline std::istream& operator >>(
         }
         catch (std::ios_base::failure& )
         {
+            logWarning(LOCATOR_LIST, "Error deserializing LocatorList");
         }
 
         input.exceptions(excp_mask);

--- a/include/fastdds/rtps/common/Locator.h
+++ b/include/fastdds/rtps/common/Locator.h
@@ -656,7 +656,7 @@ inline std::ostream& operator <<(
     if (!locList.empty())
     {
         output << *(locList.begin());
-        for (auto it = locList.m_locators.begin()+1; it != locList.m_locators.end(); ++it)
+        for (auto it = locList.m_locators.begin() + 1; it != locList.m_locators.end(); ++it)
         {
             output << "," << *it;
         }
@@ -691,7 +691,8 @@ inline std::istream& operator >>(
             while (punct != ']')
             {
                 input >> loc >> punct;
-                if (loc.kind != LOCATOR_KIND_INVALID){
+                if (loc.kind != LOCATOR_KIND_INVALID)
+                {
                     locList.push_back(loc);
                 }
             }

--- a/include/fastdds/rtps/common/Locator.h
+++ b/include/fastdds/rtps/common/Locator.h
@@ -674,6 +674,7 @@ inline std::istream& operator >>(
         LocatorList_t& locList)
 {
     std::istream::sentry s(input);
+    locList = LocatorList_t();
 
     if (s)
     {
@@ -699,6 +700,7 @@ inline std::istream& operator >>(
         }
         catch (std::ios_base::failure& )
         {
+            locList.clear();
             logWarning(LOCATOR_LIST, "Error deserializing LocatorList");
         }
 

--- a/include/fastdds/rtps/common/Locator.h
+++ b/include/fastdds/rtps/common/Locator.h
@@ -333,7 +333,7 @@ inline std::istream& operator >>(
             }
             else
             {
-                kind = LOCATOR_PORT_INVALID;
+                kind = LOCATOR_KIND_INVALID;
             }
 
             // Get char :[
@@ -353,6 +353,7 @@ inline std::istream& operator >>(
         }
         catch (std::ios_base::failure& )
         {
+            loc.kind = LOCATOR_KIND_INVALID;
         }
 
         input.exceptions(excp_mask);
@@ -645,10 +646,20 @@ inline std::ostream& operator <<(
         std::ostream& output,
         const LocatorList_t& locList)
 {
-    for (auto it = locList.m_locators.begin(); it != locList.m_locators.end(); ++it)
+    output << "[";
+    if (locList.size() > 0)
     {
-        output << *it << ",";
+        output << *(locList.begin()) ;
+        for (auto it = locList.m_locators.begin(); it != locList.m_locators.end(); ++it)
+        {
+            output << "," << *it;
+        }
     }
+    else
+    {
+        output << "_";
+    }
+    output << "]";
     return output;
 }
 
@@ -660,25 +671,23 @@ inline std::istream& operator >>(
 
     if (s)
     {
-        char coma;
-        Locator_t l;
+        char punct;
+        Locator_t loc;
         std::ios_base::iostate excp_mask = input.exceptions();
 
         try
         {
             input.exceptions(excp_mask | std::ios_base::failbit | std::ios_base::badbit);
 
-            input >> l;
-            locList.push_back(l);
+            // Get []
+            input >> punct;
 
-            for (int i = 1; i < 12; ++i)
+            while (punct != ']')
             {
-                input >> coma >> l;
-                if ( coma != ',' )
-                {
-                    input.setstate(std::ios_base::failbit);
+                input >> loc >> punct;
+                if (loc.kind != LOCATOR_KIND_INVALID){
+                    locList.push_back(loc);
                 }
-                locList.push_back(l);
             }
         }
         catch (std::ios_base::failure& )

--- a/include/fastdds/rtps/common/RemoteLocators.hpp
+++ b/include/fastdds/rtps/common/RemoteLocators.hpp
@@ -141,7 +141,7 @@ inline std::ostream& operator <<(
 {
     // Stored multicast locators
     output << "{";
-    if (remote_locators.multicast.empty())
+    if (!remote_locators.multicast.empty())
     {
         output << "MULTICAST:[";
         output << remote_locators.multicast[0];
@@ -153,7 +153,7 @@ inline std::ostream& operator <<(
     }
 
     // Stored unicast locators
-    if (remote_locators.unicast.empty())
+    if (!remote_locators.unicast.empty())
     {
         output << "UNICAST:[";
         output << remote_locators.unicast[0];

--- a/include/fastdds/rtps/common/RemoteLocators.hpp
+++ b/include/fastdds/rtps/common/RemoteLocators.hpp
@@ -222,6 +222,8 @@ inline std::istream& operator >>(
         }
         catch (std::ios_base::failure& )
         {
+            locList.unicast.clear();
+            locList.multicast.clear();
             logWarning(REMOTE_LOCATOR_LIST, "Error deserializing RemoteLocatorList");
         }
 

--- a/include/fastdds/rtps/common/RemoteLocators.hpp
+++ b/include/fastdds/rtps/common/RemoteLocators.hpp
@@ -21,6 +21,7 @@
 
 #include <fastdds/rtps/common/Locator.h>
 #include <fastrtps/utils/collections/ResourceLimitedVector.hpp>
+#include <fastdds/dds/log/Log.hpp>
 
 namespace eprosima {
 namespace fastrtps {
@@ -138,9 +139,9 @@ inline std::ostream& operator <<(
         std::ostream& output,
         const RemoteLocatorList& remote_locators)
 {
-    // Store multicast locatos
+    // Stored multicast locators
     output << "{";
-    if (remote_locators.multicast.size() >= 1)
+    if (remote_locators.multicast.empty())
     {
         output << "MULTICAST:[";
         output << remote_locators.multicast[0];
@@ -151,8 +152,8 @@ inline std::ostream& operator <<(
         output << "]";
     }
 
-    // Store unicast locatos
-    if (remote_locators.unicast.size() >= 1)
+    // Stored unicast locators
+    if (remote_locators.unicast.empty())
     {
         output << "UNICAST:[";
         output << remote_locators.unicast[0];
@@ -175,7 +176,8 @@ inline std::istream& operator >>(
 
     if (s)
     {
-        char punct, letter;
+        char punct;
+        char letter;
         Locator_t l;
         std::ios_base::iostate excp_mask = input.exceptions();
 
@@ -220,6 +222,7 @@ inline std::istream& operator >>(
         }
         catch (std::ios_base::failure& )
         {
+            logWarning(REMOTE_LOCATOR_LIST, "Error deserializing RemoteLocatorList");
         }
 
         input.exceptions(excp_mask);

--- a/include/fastrtps/utils/IPLocator.h
+++ b/include/fastrtps/utils/IPLocator.h
@@ -21,6 +21,7 @@
 #define IP_LOCATOR_H_
 
 #include <fastdds/rtps/common/Types.h>
+#include <fastdds/dds/log/Log.hpp>
 
 #include <vector>
 #include <string>
@@ -220,12 +221,12 @@ public:
             const Locator_t& locator);
 
     // Common
-    //! Sets locator's RTPC port. Physical for UDP and logical for TCP (as in RTCP protocol)
+    //! Sets locator's RTCP port. Physical for UDP and logical for TCP (as in RTCP protocol)
     RTPS_DllAPI static bool setPortRTPS(
             Locator_t& locator,
             uint16_t port);
 
-    //! Gets locator's RTPC port. Physical for UDP and logical for TCP (as in RTCP protocol)
+    //! Gets locator's RTCP port. Physical for UDP and logical for TCP (as in RTCP protocol)
     RTPS_DllAPI static uint16_t getPortRTPS(
             Locator_t& locator);
 
@@ -237,7 +238,7 @@ public:
     RTPS_DllAPI static bool isAny(
             const Locator_t& locator);
 
-    //! Checks if a both locators has the same IP address.
+    //! Checks if both locators has the same IP address.
     RTPS_DllAPI static bool compareAddress(
             const Locator_t& loc1,
             const Locator_t& loc2,
@@ -260,7 +261,7 @@ public:
 protected:
 
     // Checks if the locator address is equal to 0
-    // It checks the proper locator address depending the locator kind
+    // It checks the proper locator address depending on the locator kind
     static bool isEmpty(
             const Locator_t& locator);
 

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -206,7 +206,7 @@ DataReader* SubscriberImpl::create_datareader(
         DataReaderListener* listener,
         const StatusMask& mask)
 {
-    logInfo(SUBSCRIBER, "CREATING SUBSCRIBER IN TOPIC: " << topic->get_name())
+    logInfo(SUBSCRIBER, "CREATING SUBSCRIBER IN TOPIC: " << topic->get_name());
     //Look for the correct type registration
     TypeSupport type_support = participant_->find_type(topic->get_type_name());
 

--- a/src/cpp/fastrtps_deprecated/participant/ParticipantImpl.cpp
+++ b/src/cpp/fastrtps_deprecated/participant/ParticipantImpl.cpp
@@ -264,7 +264,7 @@ Subscriber* ParticipantImpl::createSubscriber(
         const SubscriberAttributes& att,
         SubscriberListener* listen)
 {
-    logInfo(PARTICIPANT, "CREATING SUBSCRIBER IN TOPIC: " << att.topic.getTopicName())
+    logInfo(PARTICIPANT, "CREATING SUBSCRIBER IN TOPIC: " << att.topic.getTopicName());
     //Look for the correct type registration
 
     TopicDataType* p_type = nullptr;

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -302,7 +302,7 @@ bool SubscriberHistory::find_key_for_change(
 {
     if (!a_change->instanceHandle.isDefined() && type_ != nullptr)
     {
-        logInfo(SUBSCRIBER, "Getting Key of change with no Key transmitted")
+        logInfo(SUBSCRIBER, "Getting Key of change with no Key transmitted");
         type_->deserialize(&a_change->serializedPayload, get_key_object_);
         bool is_key_protected = false;
 #if HAVE_SECURITY

--- a/src/cpp/rtps/builtin/discovery/participant/timedevent/DSClientEvent.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/timedevent/DSClientEvent.cpp
@@ -69,7 +69,7 @@ bool DSClientEvent::event()
         {
             logInfo(CLIENT_PDP_THREAD,
                     "Client " << mp_PDP->getRTPSParticipant()->getGuid() <<
-                    " not all servers acknowledge PDP info")
+                    " not all servers acknowledge PDP info");
         }
     }
     else
@@ -77,7 +77,7 @@ bool DSClientEvent::event()
         // Not all servers have yet received our DATA(p) thus resend
         mp_PDP->_serverPing = true;
         mp_PDP->announceParticipantState(false);
-        logInfo(CLIENT_PDP_THREAD, "Client " << mp_PDP->getRTPSParticipant()->getGuid() << " PDP announcement")
+        logInfo(CLIENT_PDP_THREAD, "Client " << mp_PDP->getRTPSParticipant()->getGuid() << " PDP announcement");
     }
 
     return restart;

--- a/src/cpp/rtps/history/History.cpp
+++ b/src/cpp/rtps/history/History.cpp
@@ -103,7 +103,7 @@ bool History::remove_change(
 
     if (it == changesEnd())
     {
-        logInfo(RTPS_WRITER_HISTORY, "Trying to remove a change not in history")
+        logInfo(RTPS_WRITER_HISTORY, "Trying to remove a change not in history");
         return false;
     }
 

--- a/src/cpp/rtps/history/ReaderHistory.cpp
+++ b/src/cpp/rtps/history/ReaderHistory.cpp
@@ -98,7 +98,7 @@ bool ReaderHistory::matches_change(
     if (nullptr == outer_change
             || nullptr == inner_change)
     {
-        logError(RTPS_READER_HISTORY, "Pointer is not valid")
+        logError(RTPS_READER_HISTORY, "Pointer is not valid");
         return false;
     }
 

--- a/src/cpp/rtps/history/WriterHistory.cpp
+++ b/src/cpp/rtps/history/WriterHistory.cpp
@@ -123,7 +123,7 @@ bool WriterHistory::matches_change(
     if (nullptr == outer_change
             || nullptr == inner_change)
     {
-        logError(RTPS_WRITER_HISTORY, "Pointer is not valid")
+        logError(RTPS_WRITER_HISTORY, "Pointer is not valid");
         return false;
     }
 

--- a/src/cpp/rtps/xmlparser/XMLEndpointParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLEndpointParser.cpp
@@ -35,7 +35,8 @@ using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 using namespace eprosima::fastrtps::xmlparser;
 
-XMLEndpointParser::XMLEndpointParser() {
+XMLEndpointParser::XMLEndpointParser()
+{
     // TODO Auto-generated constructor stub
 
 }
@@ -43,16 +44,16 @@ XMLEndpointParser::XMLEndpointParser() {
 XMLEndpointParser::~XMLEndpointParser()
 {
     // TODO Auto-generated destructor stub
-    for(std::vector<StaticRTPSParticipantInfo*>::iterator pit = m_RTPSParticipants.begin();
-            pit!=m_RTPSParticipants.end();++pit)
+    for (std::vector<StaticRTPSParticipantInfo*>::iterator pit = m_RTPSParticipants.begin();
+            pit != m_RTPSParticipants.end(); ++pit)
     {
-        for(std::vector<ReaderProxyData*>::iterator rit = (*pit)->m_readers.begin();
-                rit!=(*pit)->m_readers.end();++rit)
+        for (std::vector<ReaderProxyData*>::iterator rit = (*pit)->m_readers.begin();
+                rit != (*pit)->m_readers.end(); ++rit)
         {
             delete(*rit);
         }
-        for(std::vector<WriterProxyData*>::iterator wit = (*pit)->m_writers.begin();
-                wit!=(*pit)->m_writers.end();++wit)
+        for (std::vector<WriterProxyData*>::iterator wit = (*pit)->m_writers.begin();
+                wit != (*pit)->m_writers.end(); ++wit)
         {
             delete(*wit);
         }
@@ -61,103 +62,119 @@ XMLEndpointParser::~XMLEndpointParser()
     }
 }
 
-XMLP_ret XMLEndpointParser::loadXMLFile(std::string& filename)
+XMLP_ret XMLEndpointParser::loadXMLFile(
+        std::string& filename)
 {
-    logInfo(RTPS_EDP,"File: "<<filename);
+    logInfo(RTPS_EDP, "File: " << filename);
 
-        tinyxml2::XMLDocument doc;
-        doc.LoadFile(filename.c_str());
-        tinyxml2::XMLError eResult = doc.LoadFile(filename.c_str());
+    tinyxml2::XMLDocument doc;
+    doc.LoadFile(filename.c_str());
+    tinyxml2::XMLError eResult = doc.LoadFile(filename.c_str());
 
-        if (tinyxml2::XML_SUCCESS != eResult){
-            logError(RTPS_EDP, filename << " bad file (bad path?)");
-            return XMLP_ret::XML_ERROR;
-        }
+    if (tinyxml2::XML_SUCCESS != eResult)
+    {
+        logError(RTPS_EDP, filename << " bad file (bad path?)");
+        return XMLP_ret::XML_ERROR;
+    }
 
-        tinyxml2::XMLNode* root = doc.FirstChildElement(STATICDISCOVERY);
-        if(!root){
-            logError(RTPS_EDP, filename << " XML has errors");
-            return XMLP_ret::XML_ERROR;
-        }
+    tinyxml2::XMLNode* root = doc.FirstChildElement(STATICDISCOVERY);
+    if (!root)
+    {
+        logError(RTPS_EDP, filename << " XML has errors");
+        return XMLP_ret::XML_ERROR;
+    }
 
 
-        tinyxml2::XMLElement* xml_RTPSParticipant = root->FirstChildElement();
+    tinyxml2::XMLElement* xml_RTPSParticipant = root->FirstChildElement();
 
-        while(xml_RTPSParticipant != nullptr)
+    while (xml_RTPSParticipant != nullptr)
+    {
+        std::string key(xml_RTPSParticipant->Name());
+        if (key == PARTICIPANT)
         {
-            std::string key(xml_RTPSParticipant->Name());
-            if(key == PARTICIPANT)
-            {
-                StaticRTPSParticipantInfo* pdata = new StaticRTPSParticipantInfo();
-                loadXMLParticipantEndpoint(xml_RTPSParticipant, pdata);
-                m_RTPSParticipants.push_back(pdata);
-            }
-            xml_RTPSParticipant = xml_RTPSParticipant->NextSiblingElement();
+            StaticRTPSParticipantInfo* pdata = new StaticRTPSParticipantInfo();
+            loadXMLParticipantEndpoint(xml_RTPSParticipant, pdata);
+            m_RTPSParticipants.push_back(pdata);
         }
+        xml_RTPSParticipant = xml_RTPSParticipant->NextSiblingElement();
+    }
 
-    logInfo(RTPS_EDP, "Finished parsing, "<< m_RTPSParticipants.size()<< " participants found.");
+    logInfo(RTPS_EDP, "Finished parsing, " << m_RTPSParticipants.size() << " participants found.");
     return XMLP_ret::XML_OK;
 }
 
-XMLP_ret XMLEndpointParser::loadXMLNode(tinyxml2::XMLDocument& doc)
+XMLP_ret XMLEndpointParser::loadXMLNode(
+        tinyxml2::XMLDocument& doc)
 {
-    logInfo(RTPS_EDP,"XML node");
+    logInfo(RTPS_EDP, "XML node");
 
-        tinyxml2::XMLNode* root = doc.FirstChildElement(STATICDISCOVERY);
-        if(!root){
-            logError(RTPS_EDP, "XML node has errors");
-            return XMLP_ret::XML_ERROR;
-        }
+    tinyxml2::XMLNode* root = doc.FirstChildElement(STATICDISCOVERY);
+    if (!root)
+    {
+        logError(RTPS_EDP, "XML node has errors");
+        return XMLP_ret::XML_ERROR;
+    }
 
 
-        tinyxml2::XMLElement* xml_RTPSParticipant = root->FirstChildElement();
+    tinyxml2::XMLElement* xml_RTPSParticipant = root->FirstChildElement();
 
-        while(xml_RTPSParticipant != nullptr)
+    while (xml_RTPSParticipant != nullptr)
+    {
+        std::string key(xml_RTPSParticipant->Name());
+        if (key == PARTICIPANT)
         {
-            std::string key(xml_RTPSParticipant->Name());
-            if(key == PARTICIPANT)
-            {
-                StaticRTPSParticipantInfo* pdata = new StaticRTPSParticipantInfo();
-                loadXMLParticipantEndpoint(xml_RTPSParticipant, pdata);
-                m_RTPSParticipants.push_back(pdata);
-            }
-            xml_RTPSParticipant = xml_RTPSParticipant->NextSiblingElement();
+            StaticRTPSParticipantInfo* pdata = new StaticRTPSParticipantInfo();
+            loadXMLParticipantEndpoint(xml_RTPSParticipant, pdata);
+            m_RTPSParticipants.push_back(pdata);
         }
+        xml_RTPSParticipant = xml_RTPSParticipant->NextSiblingElement();
+    }
 
-    logInfo(RTPS_EDP, "Finished parsing, "<< m_RTPSParticipants.size()<< " participants found.");
+    logInfo(RTPS_EDP, "Finished parsing, " << m_RTPSParticipants.size() << " participants found.");
     return XMLP_ret::XML_OK;
 }
 
-void XMLEndpointParser::loadXMLParticipantEndpoint(tinyxml2::XMLElement* xml_endpoint, StaticRTPSParticipantInfo* pdata)
+void XMLEndpointParser::loadXMLParticipantEndpoint(
+        tinyxml2::XMLElement* xml_endpoint,
+        StaticRTPSParticipantInfo* pdata)
 {
-        tinyxml2::XMLNode* xml_RTPSParticipant_child = xml_endpoint;
-        tinyxml2::XMLElement* element = xml_RTPSParticipant_child->FirstChildElement();
+    tinyxml2::XMLNode* xml_RTPSParticipant_child = xml_endpoint;
+    tinyxml2::XMLElement* element = xml_RTPSParticipant_child->FirstChildElement();
 
-        while(element != nullptr)
+    while (element != nullptr)
+    {
+        std::string key(element->Name());
+
+        if (key == NAME)
         {
-            std::string key(element->Name());
-
-            if(key == NAME) {
-                pdata->m_RTPSParticipantName = element->GetText();
-            } else if(key == READER) {
-                if(loadXMLReaderEndpoint(element, pdata) != XMLP_ret::XML_OK)
-                {
-                    logError(RTPS_EDP,"Reader Endpoint has error, ignoring");
-                }
-            } else if(key == WRITER) {
-                if(loadXMLWriterEndpoint(element, pdata) != XMLP_ret::XML_OK)
-                {
-                    logError(RTPS_EDP,"Writer Endpoint has error, ignoring");
-                }
-            } else {
-                logError(RTPS_EDP,"Unknown XMK tag: " << key);
-            }
-
-            element = element->NextSiblingElement();
+            pdata->m_RTPSParticipantName = element->GetText();
         }
+        else if (key == READER)
+        {
+            if (loadXMLReaderEndpoint(element, pdata) != XMLP_ret::XML_OK)
+            {
+                logError(RTPS_EDP, "Reader Endpoint has error, ignoring");
+            }
+        }
+        else if (key == WRITER)
+        {
+            if (loadXMLWriterEndpoint(element, pdata) != XMLP_ret::XML_OK)
+            {
+                logError(RTPS_EDP, "Writer Endpoint has error, ignoring");
+            }
+        }
+        else
+        {
+            logError(RTPS_EDP, "Unknown XMK tag: " << key);
+        }
+
+        element = element->NextSiblingElement();
+    }
 }
 
-XMLP_ret XMLEndpointParser::loadXMLReaderEndpoint(tinyxml2::XMLElement* xml_endpoint, StaticRTPSParticipantInfo* pdata)
+XMLP_ret XMLEndpointParser::loadXMLReaderEndpoint(
+        tinyxml2::XMLElement* xml_endpoint,
+        StaticRTPSParticipantInfo* pdata)
 {
     LocatorList_t unicast_locators;
     LocatorList_t multicast_locators;
@@ -173,7 +190,7 @@ XMLP_ret XMLEndpointParser::loadXMLReaderEndpoint(tinyxml2::XMLElement* xml_endp
         {
             Locator_t loc;
             loc.kind = 1;
-            const char *address = element->Attribute(ADDRESS);
+            const char* address = element->Attribute(ADDRESS);
             std::string auxString(address ? address : "");
             IPLocator::setIPv4(loc, auxString);
             int port = 0;
@@ -185,7 +202,7 @@ XMLP_ret XMLEndpointParser::loadXMLReaderEndpoint(tinyxml2::XMLElement* xml_endp
         {
             Locator_t loc;
             loc.kind = 1;
-            const char *address = element->Attribute(ADDRESS);
+            const char* address = element->Attribute(ADDRESS);
             std::string auxString(address ? address : "");
             IPLocator::setIPv4(loc, auxString);
             int port = 0;
@@ -281,9 +298,13 @@ XMLP_ret XMLEndpointParser::loadXMLReaderEndpoint(tinyxml2::XMLElement* xml_endp
         {
             std::string auxString(element->GetText());
             if (auxString == _RELIABLE_RELIABILITY_QOS)
+            {
                 rdata->m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+            }
             else if (auxString == _BEST_EFFORT_RELIABILITY_QOS)
+            {
                 rdata->m_qos.m_reliability.kind = BEST_EFFORT_RELIABILITY_QOS;
+            }
             else
             {
                 logError(RTPS_EDP, "Bad XML file, endpoint of stateKind: " << auxString << " is not valid");
@@ -301,9 +322,9 @@ XMLP_ret XMLEndpointParser::loadXMLReaderEndpoint(tinyxml2::XMLElement* xml_endp
         }
         else if (key == TOPIC)
         {
-            const char *topicName = element->Attribute(NAME);
-            const char *typeName = element->Attribute(DATA_TYPE);
-            const char *kind = element->Attribute(KIND);
+            const char* topicName = element->Attribute(NAME);
+            const char* typeName = element->Attribute(DATA_TYPE);
+            const char* kind = element->Attribute(KIND);
 
             rdata->topicName() = topicName ? std::string(topicName) : std::string("");
             rdata->typeName() = typeName ? std::string(typeName) : std::string("");
@@ -326,7 +347,9 @@ XMLP_ret XMLEndpointParser::loadXMLReaderEndpoint(tinyxml2::XMLElement* xml_endp
             }
             if (rdata->topicName() == EPROSIMA_UNKNOWN_STRING || rdata->typeName() == EPROSIMA_UNKNOWN_STRING)
             {
-                logError(RTPS_EDP, "Bad XML file, topic: " << rdata->topicName() << " or typeName: " << rdata->typeName() << " undefined");
+                logError(RTPS_EDP,
+                        "Bad XML file, topic: " << rdata->topicName() << " or typeName: " << rdata->typeName() <<
+                        " undefined");
                 delete(rdata);
                 return XMLP_ret::XML_ERROR;
             }
@@ -335,9 +358,13 @@ XMLP_ret XMLEndpointParser::loadXMLReaderEndpoint(tinyxml2::XMLElement* xml_endp
         {
             std::string auxstring(element->GetText());
             if (auxstring == _TRANSIENT_LOCAL_DURABILITY_QOS)
+            {
                 rdata->m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
+            }
             else if (auxstring == _VOLATILE_DURABILITY_QOS)
+            {
                 rdata->m_qos.m_durability.kind = VOLATILE_DURABILITY_QOS;
+            }
             else
             {
                 logError(RTPS_EDP, "Bad XML file, durability of kind: " << auxstring << " is not valid");
@@ -347,12 +374,16 @@ XMLP_ret XMLEndpointParser::loadXMLReaderEndpoint(tinyxml2::XMLElement* xml_endp
         }
         else if (key == OWNERSHIP_QOS)
         {
-            const char *ownership = element->Attribute(KIND);
+            const char* ownership = element->Attribute(KIND);
             std::string auxstring(ownership ? ownership : OWNERSHIP_KIND_NOT_PRESENT);
             if (auxstring == _SHARED_OWNERSHIP_QOS)
+            {
                 rdata->m_qos.m_ownership.kind = SHARED_OWNERSHIP_QOS;
+            }
             else if (auxstring == _EXCLUSIVE_OWNERSHIP_QOS)
+            {
                 rdata->m_qos.m_ownership.kind = EXCLUSIVE_OWNERSHIP_QOS;
+            }
             else
             {
                 logError(RTPS_EDP, "Bad XML file, ownership of kind: " << auxstring << " is not valid");
@@ -366,32 +397,40 @@ XMLP_ret XMLEndpointParser::loadXMLReaderEndpoint(tinyxml2::XMLElement* xml_endp
         }
         else if (key == LIVELINESS_QOS)
         {
-            const char *kind = element->Attribute(KIND);
+            const char* kind = element->Attribute(KIND);
             std::string auxstring(kind ? kind : LIVELINESS_KIND_NOT_PRESENT);
             if (auxstring == _AUTOMATIC_LIVELINESS_QOS)
+            {
                 rdata->m_qos.m_liveliness.kind = AUTOMATIC_LIVELINESS_QOS;
+            }
             else if (auxstring == _MANUAL_BY_PARTICIPANT_LIVELINESS_QOS)
+            {
                 rdata->m_qos.m_liveliness.kind = MANUAL_BY_PARTICIPANT_LIVELINESS_QOS;
+            }
             else if (auxstring == _MANUAL_BY_TOPIC_LIVELINESS_QOS)
+            {
                 rdata->m_qos.m_liveliness.kind = MANUAL_BY_TOPIC_LIVELINESS_QOS;
+            }
             else
             {
                 logError(RTPS_EDP, "Bad XML file, liveliness of kind: " << auxstring << " is not valid");
                 delete(rdata);
                 return XMLP_ret::XML_ERROR;
             }
-            const char *leaseDuration_ms = element->Attribute(LEASE_DURATION_MS);
+            const char* leaseDuration_ms = element->Attribute(LEASE_DURATION_MS);
             auxstring = std::string(leaseDuration_ms ? leaseDuration_ms : _INF);
             if (auxstring == _INF)
+            {
                 rdata->m_qos.m_liveliness.lease_duration = c_TimeInfinite;
+            }
             else
             {
                 uint32_t milliseclease = std::strtoul(auxstring.c_str(), nullptr, 10);
                 rdata->m_qos.m_liveliness.lease_duration =
-                    TimeConv::MilliSeconds2Time_t((double)milliseclease).to_duration_t();
-                if(milliseclease == 0)
+                        TimeConv::MilliSeconds2Time_t((double)milliseclease).to_duration_t();
+                if (milliseclease == 0)
                 {
-                    logWarning(RTPS_EDP,"BAD XML:livelinessQos leaseDuration is 0");
+                    logWarning(RTPS_EDP, "BAD XML:livelinessQos leaseDuration is 0");
                 }
             }
         }
@@ -403,9 +442,9 @@ XMLP_ret XMLEndpointParser::loadXMLReaderEndpoint(tinyxml2::XMLElement* xml_endp
         element = element->NextSiblingElement();
     }
 
-    if(rdata->userDefinedId() == 0)
+    if (rdata->userDefinedId() == 0)
     {
-        logError(RTPS_EDP,"Reader XML endpoint with NO ID defined");
+        logError(RTPS_EDP, "Reader XML endpoint with NO ID defined");
         delete(rdata);
         return XMLP_ret::XML_ERROR;
     }
@@ -424,8 +463,9 @@ XMLP_ret XMLEndpointParser::loadXMLReaderEndpoint(tinyxml2::XMLElement* xml_endp
     return XMLP_ret::XML_OK;
 }
 
-
-XMLP_ret XMLEndpointParser::loadXMLWriterEndpoint(tinyxml2::XMLElement* xml_endpoint, StaticRTPSParticipantInfo* pdata)
+XMLP_ret XMLEndpointParser::loadXMLWriterEndpoint(
+        tinyxml2::XMLElement* xml_endpoint,
+        StaticRTPSParticipantInfo* pdata)
 {
     LocatorList_t unicast_locators;
     LocatorList_t multicast_locators;
@@ -433,14 +473,14 @@ XMLP_ret XMLEndpointParser::loadXMLWriterEndpoint(tinyxml2::XMLElement* xml_endp
     tinyxml2::XMLNode* xml_endpoint_child = xml_endpoint;
     tinyxml2::XMLElement* element = xml_endpoint_child->FirstChildElement();
 
-    while(element != nullptr)
+    while (element != nullptr)
     {
         std::string key(element->Name());
         if (key == UNICAST_LOCATOR)
         {
             Locator_t loc;
             loc.kind = 1;
-            const char *address = element->Attribute(ADDRESS);
+            const char* address = element->Attribute(ADDRESS);
             std::string auxString(address ? address : "");
             IPLocator::setIPv4(loc, auxString);
             int port = 0;
@@ -452,7 +492,7 @@ XMLP_ret XMLEndpointParser::loadXMLWriterEndpoint(tinyxml2::XMLElement* xml_endp
         {
             Locator_t loc;
             loc.kind = 1;
-            const char *address = element->Attribute(ADDRESS);
+            const char* address = element->Attribute(ADDRESS);
             std::string auxString(address ? address : "");
             IPLocator::setIPv4(loc, auxString);
             int port = 0;
@@ -467,26 +507,26 @@ XMLP_ret XMLEndpointParser::loadXMLWriterEndpoint(tinyxml2::XMLElement* xml_endp
 
     xml_endpoint_child = xml_endpoint;
     element = xml_endpoint_child->FirstChildElement();
-    while(element != nullptr)
+    while (element != nullptr)
     {
         std::string key(element->Name());
-        if(key == USER_ID)
+        if (key == USER_ID)
         {
             int16_t id = static_cast<int16_t>(std::strtol(element->GetText(), nullptr, 10));
-            if(id<=0 || m_endpointIds.insert(id).second == false)
+            if (id <= 0 || m_endpointIds.insert(id).second == false)
             {
-                logError(RTPS_EDP,"Repeated or negative ID in XML file");
+                logError(RTPS_EDP, "Repeated or negative ID in XML file");
                 delete(wdata);
                 return XMLP_ret::XML_ERROR;
             }
             wdata->userDefinedId(id);
         }
-        else if(key == ENTITY_ID)
+        else if (key == ENTITY_ID)
         {
             int32_t id = std::strtol(element->GetText(), nullptr, 10);
-            if(id<=0 || m_entityIds.insert(id).second == false)
+            if (id <= 0 || m_entityIds.insert(id).second == false)
             {
-                logError(RTPS_EDP,"Repeated or negative entityId in XML file");
+                logError(RTPS_EDP, "Repeated or negative entityId in XML file");
                 delete(wdata);
                 return XMLP_ret::XML_ERROR;
             }
@@ -495,22 +535,22 @@ XMLP_ret XMLEndpointParser::loadXMLWriterEndpoint(tinyxml2::XMLElement* xml_endp
             wdata->guid().entityId.value[1] = c[1];
             wdata->guid().entityId.value[0] = c[2];
         }
-        else if(key == EXPECT_INLINE_QOS)
+        else if (key == EXPECT_INLINE_QOS)
         {
-            logWarning(RTPS_EDP,"BAD XML tag: Writers don't use expectInlineQos tag");
+            logWarning(RTPS_EDP, "BAD XML tag: Writers don't use expectInlineQos tag");
         }
-        else if(key == TOPIC_NAME)
+        else if (key == TOPIC_NAME)
         {
             wdata->topicName(std::string(element->GetText()));
         }
-        else if(key == TOPIC_DATA_TYPE)
+        else if (key == TOPIC_DATA_TYPE)
         {
             wdata->typeName(std::string(element->GetText()));
         }
-        else if(key == TOPIC_KIND)
+        else if (key == TOPIC_KIND)
         {
             std::string auxString = std::string(element->GetText());
-            if(auxString == _NO_KEY)
+            if (auxString == _NO_KEY)
             {
                 wdata->topicKind(NO_KEY);
                 wdata->guid().entityId.value[3] = 0x03;
@@ -522,42 +562,46 @@ XMLP_ret XMLEndpointParser::loadXMLWriterEndpoint(tinyxml2::XMLElement* xml_endp
             }
             else
             {
-                logError(RTPS_EDP,"Bad XML file, topic of kind: " << auxString << " is not valid");
+                logError(RTPS_EDP, "Bad XML file, topic of kind: " << auxString << " is not valid");
                 delete(wdata);
                 return XMLP_ret::XML_ERROR;
             }
         }
-        else if(key == RELIABILITY_QOS)
+        else if (key == RELIABILITY_QOS)
         {
             std::string auxString = std::string(element->GetText());
-            if(auxString == _RELIABLE_RELIABILITY_QOS)
-            wdata->m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+            if (auxString == _RELIABLE_RELIABILITY_QOS)
+            {
+                wdata->m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+            }
             else if (auxString == _BEST_EFFORT_RELIABILITY_QOS)
-            wdata->m_qos.m_reliability.kind = BEST_EFFORT_RELIABILITY_QOS;
+            {
+                wdata->m_qos.m_reliability.kind = BEST_EFFORT_RELIABILITY_QOS;
+            }
             else
             {
-                logError(RTPS_EDP,"Bad XML file, endpoint of stateKind: " << auxString << " is not valid");
+                logError(RTPS_EDP, "Bad XML file, endpoint of stateKind: " << auxString << " is not valid");
                 delete(wdata);
                 return XMLP_ret::XML_ERROR;
             }
         }
-        else if(key == UNICAST_LOCATOR)
+        else if (key == UNICAST_LOCATOR)
         {
             // Empty but necessary to avoid warning on last else
         }
-        else if(key == MULTICAST_LOCATOR)
+        else if (key == MULTICAST_LOCATOR)
         {
             // Empty but necessary to avoid warning on last else
         }
-        else if(key == TOPIC)
+        else if (key == TOPIC)
         {
-            const char * topicName = element->Attribute(NAME);
+            const char* topicName = element->Attribute(NAME);
             wdata->topicName(std::string(topicName ? topicName : EPROSIMA_UNKNOWN_STRING));
-            const char * typeName = element->Attribute(DATA_TYPE);
+            const char* typeName = element->Attribute(DATA_TYPE);
             wdata->typeName(std::string(typeName ? typeName : EPROSIMA_UNKNOWN_STRING));
-            const char * kind = element->Attribute(KIND);
+            const char* kind = element->Attribute(KIND);
             std::string auxString(kind ? kind : "");
-            if(auxString == _NO_KEY)
+            if (auxString == _NO_KEY)
             {
                 wdata->topicKind(NO_KEY);
                 wdata->guid().entityId.value[3] = 0x03;
@@ -569,42 +613,52 @@ XMLP_ret XMLEndpointParser::loadXMLWriterEndpoint(tinyxml2::XMLElement* xml_endp
             }
             else
             {
-                logError(RTPS_EDP,"Bad XML file, topic of kind: " << auxString << " is not valid");
+                logError(RTPS_EDP, "Bad XML file, topic of kind: " << auxString << " is not valid");
                 delete(wdata);
                 return XMLP_ret::XML_ERROR;
             }
-            if(wdata->topicName() == EPROSIMA_UNKNOWN_STRING || wdata->typeName() == EPROSIMA_UNKNOWN_STRING)
+            if (wdata->topicName() == EPROSIMA_UNKNOWN_STRING || wdata->typeName() == EPROSIMA_UNKNOWN_STRING)
             {
-                logError(RTPS_EDP,"Bad XML file, topic: "<<wdata->topicName() << " or typeName: "<<wdata->typeName() << " undefined");
+                logError(RTPS_EDP,
+                        "Bad XML file, topic: " << wdata->topicName() << " or typeName: " << wdata->typeName() <<
+                        " undefined");
                 delete(wdata);
                 return XMLP_ret::XML_ERROR;
             }
         }
-        else if(key == DURABILITY_QOS)
+        else if (key == DURABILITY_QOS)
         {
             std::string auxstring = std::string(element->GetText());
-            if(auxstring == _TRANSIENT_LOCAL_DURABILITY_QOS)
+            if (auxstring == _TRANSIENT_LOCAL_DURABILITY_QOS)
+            {
                 wdata->m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
-            else if(auxstring == _VOLATILE_DURABILITY_QOS)
+            }
+            else if (auxstring == _VOLATILE_DURABILITY_QOS)
+            {
                 wdata->m_qos.m_durability.kind = VOLATILE_DURABILITY_QOS;
+            }
             else
             {
-                logError(RTPS_EDP,"Bad XML file, durability of kind: " << auxstring << " is not valid");
+                logError(RTPS_EDP, "Bad XML file, durability of kind: " << auxstring << " is not valid");
                 delete(wdata);
                 return XMLP_ret::XML_ERROR;
             }
         }
-        else if(key == OWNERSHIP_QOS)
+        else if (key == OWNERSHIP_QOS)
         {
-            const char * kind = element->Attribute(KIND);
+            const char* kind = element->Attribute(KIND);
             std::string auxstring(kind ? kind : OWNERSHIP_KIND_NOT_PRESENT);
-            if(auxstring == _SHARED_OWNERSHIP_QOS)
+            if (auxstring == _SHARED_OWNERSHIP_QOS)
+            {
                 wdata->m_qos.m_ownership.kind = SHARED_OWNERSHIP_QOS;
-            else if(auxstring == _EXCLUSIVE_OWNERSHIP_QOS)
+            }
+            else if (auxstring == _EXCLUSIVE_OWNERSHIP_QOS)
+            {
                 wdata->m_qos.m_ownership.kind = EXCLUSIVE_OWNERSHIP_QOS;
+            }
             else
             {
-                logError(RTPS_EDP,"Bad XML file, ownership of kind: " << auxstring << " is not valid");
+                logError(RTPS_EDP, "Bad XML file, ownership of kind: " << auxstring << " is not valid");
                 delete(wdata);
                 return XMLP_ret::XML_ERROR;
             }
@@ -612,51 +666,60 @@ XMLP_ret XMLEndpointParser::loadXMLWriterEndpoint(tinyxml2::XMLElement* xml_endp
             element->QueryIntAttribute(STRENGTH, &strength);
             wdata->m_qos.m_ownershipStrength.value = strength;
         }
-        else if(key == PARTITION_QOS)
+        else if (key == PARTITION_QOS)
         {
             wdata->m_qos.m_partition.push_back(element->GetText());
         }
-        else if(key == LIVELINESS_QOS)
+        else if (key == LIVELINESS_QOS)
         {
-            const char * kind = element->Attribute(KIND);
+            const char* kind = element->Attribute(KIND);
             std::string auxstring(kind ? kind : LIVELINESS_KIND_NOT_PRESENT);
-            if(auxstring == _AUTOMATIC_LIVELINESS_QOS)
+            if (auxstring == _AUTOMATIC_LIVELINESS_QOS)
+            {
                 wdata->m_qos.m_liveliness.kind = AUTOMATIC_LIVELINESS_QOS;
-            else if(auxstring == _MANUAL_BY_PARTICIPANT_LIVELINESS_QOS)
+            }
+            else if (auxstring == _MANUAL_BY_PARTICIPANT_LIVELINESS_QOS)
+            {
                 wdata->m_qos.m_liveliness.kind = MANUAL_BY_PARTICIPANT_LIVELINESS_QOS;
-            else if(auxstring == _MANUAL_BY_TOPIC_LIVELINESS_QOS)
+            }
+            else if (auxstring == _MANUAL_BY_TOPIC_LIVELINESS_QOS)
+            {
                 wdata->m_qos.m_liveliness.kind = MANUAL_BY_TOPIC_LIVELINESS_QOS;
+            }
             else
             {
-                logError(RTPS_EDP,"Bad XML file, liveliness of kind: " << auxstring << " is not valid");
+                logError(RTPS_EDP, "Bad XML file, liveliness of kind: " << auxstring << " is not valid");
                 delete(wdata);
                 return XMLP_ret::XML_ERROR;
             }
-            const char * leaseDuration_ms = element->Attribute(LEASE_DURATION_MS);
+            const char* leaseDuration_ms = element->Attribute(LEASE_DURATION_MS);
             auxstring = std::string(leaseDuration_ms ? leaseDuration_ms : _INF);
-            if(auxstring == _INF)
+            if (auxstring == _INF)
+            {
                 wdata->m_qos.m_liveliness.lease_duration = c_TimeInfinite;
+            }
             else
             {
                 uint32_t milliseclease = std::strtoul(auxstring.c_str(), nullptr, 10);
                 wdata->m_qos.m_liveliness.lease_duration =
-                    TimeConv::MilliSeconds2Time_t((double)milliseclease).to_duration_t();
-                if(milliseclease == 0){
-                    logWarning(RTPS_EDP,"BAD XML:livelinessQos leaseDuration is 0");
+                        TimeConv::MilliSeconds2Time_t((double)milliseclease).to_duration_t();
+                if (milliseclease == 0)
+                {
+                    logWarning(RTPS_EDP, "BAD XML:livelinessQos leaseDuration is 0");
                 }
             }
         }
         else
         {
-            logWarning(RTPS_EDP,"Unkown Endpoint-XML tag, ignoring "<< key);
+            logWarning(RTPS_EDP, "Unkown Endpoint-XML tag, ignoring " << key);
         }
 
         element = element->NextSiblingElement();
     }
 
-    if(wdata->userDefinedId() == 0)
+    if (wdata->userDefinedId() == 0)
     {
-        logError(RTPS_EDP,"Writer XML endpoint with NO ID defined");
+        logError(RTPS_EDP, "Writer XML endpoint with NO ID defined");
         delete(wdata);
         return XMLP_ret::XML_ERROR;
     }
@@ -675,18 +738,20 @@ XMLP_ret XMLEndpointParser::loadXMLWriterEndpoint(tinyxml2::XMLElement* xml_endp
     return XMLP_ret::XML_OK;
 }
 
-XMLP_ret XMLEndpointParser::lookforReader(const char* partname, uint16_t id,
+XMLP_ret XMLEndpointParser::lookforReader(
+        const char* partname,
+        uint16_t id,
         ReaderProxyData** rdataptr)
 {
-    for(std::vector<StaticRTPSParticipantInfo*>::iterator pit = m_RTPSParticipants.begin();
-            pit!=m_RTPSParticipants.end();++pit)
+    for (std::vector<StaticRTPSParticipantInfo*>::iterator pit = m_RTPSParticipants.begin();
+            pit != m_RTPSParticipants.end(); ++pit)
     {
-        if((*pit)->m_RTPSParticipantName == partname || true) //it doenst matter the name fo the RTPSParticipant, only for organizational purposes
+        if ((*pit)->m_RTPSParticipantName == partname || true) //it doenst matter the name fo the RTPSParticipant, only for organizational purposes
         {
-            for(std::vector<ReaderProxyData*>::iterator rit = (*pit)->m_readers.begin();
-                    rit!=(*pit)->m_readers.end();++rit)
+            for (std::vector<ReaderProxyData*>::iterator rit = (*pit)->m_readers.begin();
+                    rit != (*pit)->m_readers.end(); ++rit)
             {
-                if((*rit)->userDefinedId() == id)
+                if ((*rit)->userDefinedId() == id)
                 {
                     *rdataptr = *rit;
                     return XMLP_ret::XML_OK;
@@ -697,18 +762,20 @@ XMLP_ret XMLEndpointParser::lookforReader(const char* partname, uint16_t id,
     return XMLP_ret::XML_ERROR;
 }
 
-XMLP_ret XMLEndpointParser::lookforWriter(const char* partname, uint16_t id,
+XMLP_ret XMLEndpointParser::lookforWriter(
+        const char* partname,
+        uint16_t id,
         WriterProxyData** wdataptr)
 {
-    for(std::vector<StaticRTPSParticipantInfo*>::iterator pit = m_RTPSParticipants.begin();
-            pit!=m_RTPSParticipants.end();++pit)
+    for (std::vector<StaticRTPSParticipantInfo*>::iterator pit = m_RTPSParticipants.begin();
+            pit != m_RTPSParticipants.end(); ++pit)
     {
-        if((*pit)->m_RTPSParticipantName == partname || true) //it doenst matter the name fo the RTPSParticipant, only for organizational purposes
+        if ((*pit)->m_RTPSParticipantName == partname || true) //it doenst matter the name fo the RTPSParticipant, only for organizational purposes
         {
-            for(std::vector<WriterProxyData*>::iterator wit = (*pit)->m_writers.begin();
-                    wit!=(*pit)->m_writers.end();++wit)
+            for (std::vector<WriterProxyData*>::iterator wit = (*pit)->m_writers.begin();
+                    wit != (*pit)->m_writers.end(); ++wit)
             {
-                if((*wit)->userDefinedId() == id)
+                if ((*wit)->userDefinedId() == id)
                 {
                     *wdataptr = *wit;
                     return XMLP_ret::XML_OK;

--- a/src/cpp/rtps/xmlparser/XMLEndpointParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLEndpointParser.cpp
@@ -397,7 +397,7 @@ XMLP_ret XMLEndpointParser::loadXMLReaderEndpoint(tinyxml2::XMLElement* xml_endp
         }
         else
         {
-            logWarning(RTPS_EDP, "Unkown Endpoint-XML tag, ignoring " << key)
+            logWarning(RTPS_EDP, "Unkown Endpoint-XML tag, ignoring " << key);
         }
 
         element = element->NextSiblingElement();
@@ -648,7 +648,7 @@ XMLP_ret XMLEndpointParser::loadXMLWriterEndpoint(tinyxml2::XMLElement* xml_endp
         }
         else
         {
-            logWarning(RTPS_EDP,"Unkown Endpoint-XML tag, ignoring "<< key)
+            logWarning(RTPS_EDP,"Unkown Endpoint-XML tag, ignoring "<< key);
         }
 
         element = element->NextSiblingElement();

--- a/src/cpp/rtps/xmlparser/XMLParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLParser.cpp
@@ -1479,7 +1479,7 @@ XMLP_ret XMLParser::parseXMLConsumer(
                             {
                                 // Continue with the next property if `stderr_threshold` had been already specified.
                                 logError(XMLParser, classStr << " only supports one occurrence of 'stderr_threshold'."
-                                                             << " Only the first one is applied.")
+                                                             << " Only the first one is applied.");
                                 property = property->NextSiblingElement(PROPERTY);
                                 ret = XMLP_ret::XML_NOK;
                                 continue;
@@ -1505,7 +1505,7 @@ XMLP_ret XMLParser::parseXMLConsumer(
                                 else
                                 {
                                     logError(XMLParser, "Unkown Log::Kind '" << threshold_str
-                                                                             << "'. Using default threshold.")
+                                                                             << "'. Using default threshold.");
                                     ret = XMLP_ret::XML_NOK;
                                 }
                             }

--- a/src/cpp/utils/IPLocator.cpp
+++ b/src/cpp/utils/IPLocator.cpp
@@ -539,7 +539,7 @@ bool IPLocator::setLogicalPort(
 {
     uint16_t* loc_logical = reinterpret_cast<uint16_t*>(&locator.port);
 #if FASTDDS_IS_BIG_ENDIAN_TARGET
-    loc_logical[0] = port; // Logical port is stored at 2nd and 3rd bytes of port
+    loc_logical[0] = port; // Logical port is stored at 0th and 1st bytes of port
 #else
     loc_logical[1] = port; // Logical port is stored at 2nd and 3rd bytes of port
 #endif // if FASTDDS_IS_BIG_ENDIAN_TARGET

--- a/src/cpp/utils/IPLocator.cpp
+++ b/src/cpp/utils/IPLocator.cpp
@@ -118,7 +118,7 @@ bool IPLocator::setIPv4(
         // If there are more info to read, it fails
         return ss.rdbuf()->in_avail() == 0;
     }
-    logError(IP_LOCATOR, "IPv4 " << ipv4 << " error format. Expected X.X.X.X");
+    logWarning(IP_LOCATOR, "IPv4 " << ipv4 << " error format. Expected X.X.X.X");
     return false;
 }
 
@@ -247,7 +247,7 @@ bool IPLocator::setIPv6(
 
     if (!IPv6isCorrect(ipv6))
     {
-        logError(IP_LOCATOR, "IPv6 " << ipv6 << " is not well defined");
+        logWarning(IP_LOCATOR, "IPv6 " << ipv6 << " is not well defined");
         return false;
     }
 
@@ -334,7 +334,7 @@ bool IPLocator::setIPv6(
             ss >> punct >> input_aux;
             if (input_aux >= 65536)
             {
-                logError(IP_LOCATOR, "IPv6 " << ipv6 << " has values higher than expected (65536)");
+                logWarning(IP_LOCATOR, "IPv6 " << ipv6 << " has values higher than expected (65536)");
                 return false;
             }
             locator.address[i++] = octet(input_aux >> 8);
@@ -355,7 +355,7 @@ bool IPLocator::setIPv6(
             ss >> input_aux >> punct;
             if (input_aux >= 65536)
             {
-                logError(IP_LOCATOR, "IPv6 " << ipv6 << " has values higher than expected (65536)");
+                logWarning(IP_LOCATOR, "IPv6 " << ipv6 << " has values higher than expected (65536)");
                 return false;
             }
             locator.address[i++] = octet(input_aux >> 8);
@@ -377,7 +377,7 @@ bool IPLocator::setIPv6(
             ss >> input_aux >> punct;
             if (input_aux >= 65536)
             {
-                logError(IP_LOCATOR, "IPv6 " << ipv6 << " has values higher than expected (65536)");
+                logWarning(IP_LOCATOR, "IPv6 " << ipv6 << " has values higher than expected (65536)");
                 return false;
             }
             locator.address[i++] = octet(input_aux >> 8);
@@ -394,7 +394,7 @@ bool IPLocator::setIPv6(
             ss >> punct >> input_aux;
             if (input_aux >= 65536)
             {
-                logError(IP_LOCATOR, "IPv6 " << ipv6 << " has values higher than expected (65536)");
+                logWarning(IP_LOCATOR, "IPv6 " << ipv6 << " has values higher than expected (65536)");
                 return false;
             }
             locator.address[i++] = octet(input_aux >> 8);
@@ -412,7 +412,7 @@ bool IPLocator::setIPv6(
             ss >> punct >> input_aux;
             if (input_aux >= 65536)
             {
-                logError(IP_LOCATOR, "IPv6 " << ipv6 << " has values higher than expected (65536)");
+                logWarning(IP_LOCATOR, "IPv6 " << ipv6 << " has values higher than expected (65536)");
                 return false;
             }
             locator.address[i++] = octet(input_aux >> 8);

--- a/src/cpp/utils/IPLocator.cpp
+++ b/src/cpp/utils/IPLocator.cpp
@@ -57,6 +57,11 @@ bool IPLocator::setIPv4(
         Locator_t& locator,
         const unsigned char* addr)
 {
+    if (locator.kind != LOCATOR_KIND_TCPv4 && locator.kind != LOCATOR_KIND_UDPv4)
+    {
+        logWarning(IP_LOCATOR, "Trying to set an IPv4 in a non IPv4 Locator");
+        return false;
+    }
     memcpy(&locator.address[12], addr, 4 * sizeof(char));
     return true;
 }
@@ -68,6 +73,11 @@ bool IPLocator::setIPv4(
         octet o3,
         octet o4)
 {
+    if (locator.kind != LOCATOR_KIND_TCPv4 && locator.kind != LOCATOR_KIND_UDPv4)
+    {
+        logWarning(IP_LOCATOR, "Trying to set an IPv4 in a non IPv4 Locator");
+        return false;
+    }
     locator.address[12] = o1;
     locator.address[13] = o2;
     locator.address[14] = o3;
@@ -79,11 +89,19 @@ bool IPLocator::setIPv4(
         Locator_t& locator,
         const std::string& ipv4)
 {
+    if (locator.kind != LOCATOR_KIND_TCPv4 && locator.kind != LOCATOR_KIND_UDPv4)
+    {
+        logWarning(IP_LOCATOR, "Trying to set an IPv4 in a non IPv4 Locator");
+        return false;
+    }
     // This function do not set address to 0 in case it fails
     // Be careful, do not set all IP to 0 because WAN and LAN could be set beforehand
 
     std::stringstream ss(ipv4);
-    uint32_t a, b, c, d; //to store the 4 ints
+    uint32_t a;
+    uint32_t b;
+    uint32_t c;
+    uint32_t d; //to store the 4 ints
     char ch; //to temporarily store the '.'
 
     if (ss >> a >> ch >> b >> ch >> c >> ch >> d)
@@ -100,7 +118,7 @@ bool IPLocator::setIPv4(
         // If there are more info to read, it fails
         return ss.rdbuf()->in_avail() == 0;
     }
-
+    logError(IP_LOCATOR, "IPv4 " << ipv4 << " error format. Expected X.X.X.X");
     return false;
 }
 
@@ -108,6 +126,11 @@ bool IPLocator::setIPv4(
         Locator_t& destlocator,
         const Locator_t& origlocator)
 {
+    if (destlocator.kind != LOCATOR_KIND_TCPv4 && destlocator.kind != LOCATOR_KIND_UDPv4)
+    {
+        logWarning(IP_LOCATOR, "Trying to set an IPv4 in a non IPv4 Locator");
+        return false;
+    }
     return setIPv4(destlocator, getIPv4(origlocator));
 }
 
@@ -151,6 +174,11 @@ bool IPLocator::setIPv6(
         Locator_t& locator,
         const unsigned char* addr)
 {
+    if (locator.kind != LOCATOR_KIND_TCPv6 && locator.kind != LOCATOR_KIND_UDPv6)
+    {
+        logWarning(IP_LOCATOR, "Trying to set an IPv6 in a non IPv6 Locator");
+        return false;
+    }
     memcpy(locator.address, addr, 16 * sizeof(char));
     return true;
 }
@@ -166,6 +194,11 @@ bool IPLocator::setIPv6(
         uint16_t group6,
         uint16_t group7)
 {
+    if (locator.kind != LOCATOR_KIND_TCPv6 && locator.kind != LOCATOR_KIND_UDPv6)
+    {
+        logWarning(IP_LOCATOR, "Trying to set an IPv6 in a non IPv6 Locator");
+        return false;
+    }
     locator.address[0] = (octet)(group0 >> 8);
     locator.address[1] = (octet)group0;
     locator.address[2] = (octet)(group1 >> 8);
@@ -197,7 +230,7 @@ bool IPLocator::setIPv6(
      *  2. Encapsulating following blocks of zeros as leaving empty an space
      *     X:0000:0000:Y = X::Y
      *
-     * This fcuntion implements the following:
+     * This function implements the following:
      *  1. Check if the string is in correct format : IPv6isCorrect
      *  2. Analyze the string to know if:
      *      - it starts with blocks of zeros
@@ -206,11 +239,15 @@ bool IPLocator::setIPv6(
      *    and it stores the size of the zeros block to build the address afterwards
      *  3. Build the bytes array by reading the string or either filling with 0 the zero blocks
      * */
+    if (locator.kind != LOCATOR_KIND_TCPv6 && locator.kind != LOCATOR_KIND_UDPv6)
+    {
+        logWarning(IP_LOCATOR, "Trying to set an IPv6 in a non IPv6 Locator");
+        return false;
+    }
 
     if (!IPv6isCorrect(ipv6))
     {
-        // ERROR
-        // Does not send a log for avoid API functionallity break
+        logError(IP_LOCATOR, "IPv6 " << ipv6 << " is not well defined");
         return false;
     }
 
@@ -220,16 +257,20 @@ bool IPLocator::setIPv6(
                         return c == ':';
                     }); // C type cast to avoid Windows warnings
 
-    uint16_t initial_zeros = 0, final_zeros = 0, position_zeros = 0, number_zeros = 0;
-    size_t aux, aux_prev; // This must be size_t as string::npos could change value depending on size_t size
+    uint16_t initial_zeros = 0;
+    uint16_t final_zeros = 0;
+    uint16_t position_zeros = 0;
+    uint16_t number_zeros = 0;
+    size_t aux;
+    size_t aux_prev; // This must be size_t as string::npos could change value depending on size_t size
 
     // Check whether is a zero block and where
-    if (ipv6.at(0) == ':')
+    if (ipv6.front() == ':')
     {
         // First element equal : -> starts with zeros
-        if (ipv6.at(ipv6.size() - 1) == ':')
+        if (ipv6.back() == ':')
         {
-            // Empty string (we already know it is a correct ipv6 format)
+            // Empty string (correct ipv6 format)
             initial_zeros = 16;
         }
         else
@@ -241,7 +282,7 @@ bool IPLocator::setIPv6(
             initial_zeros = (7 - (count - 2)) * 2;
         }
     }
-    else if (ipv6.at(ipv6.size() - 1) == ':')
+    else if (ipv6.back() == ':')
     {
         // Last element equal : -> ends with zeros
         // It does not start with :: (previous if)
@@ -293,6 +334,7 @@ bool IPLocator::setIPv6(
             ss >> punct >> input_aux;
             if (input_aux >= 65536)
             {
+                logError(IP_LOCATOR, "IPv6 " << ipv6 << " has values higher than expected (65536)");
                 return false;
             }
             locator.address[i++] = octet(input_aux >> 8);
@@ -313,6 +355,7 @@ bool IPLocator::setIPv6(
             ss >> input_aux >> punct;
             if (input_aux >= 65536)
             {
+                logError(IP_LOCATOR, "IPv6 " << ipv6 << " has values higher than expected (65536)");
                 return false;
             }
             locator.address[i++] = octet(input_aux >> 8);
@@ -334,6 +377,7 @@ bool IPLocator::setIPv6(
             ss >> input_aux >> punct;
             if (input_aux >= 65536)
             {
+                logError(IP_LOCATOR, "IPv6 " << ipv6 << " has values higher than expected (65536)");
                 return false;
             }
             locator.address[i++] = octet(input_aux >> 8);
@@ -350,6 +394,7 @@ bool IPLocator::setIPv6(
             ss >> punct >> input_aux;
             if (input_aux >= 65536)
             {
+                logError(IP_LOCATOR, "IPv6 " << ipv6 << " has values higher than expected (65536)");
                 return false;
             }
             locator.address[i++] = octet(input_aux >> 8);
@@ -367,6 +412,7 @@ bool IPLocator::setIPv6(
             ss >> punct >> input_aux;
             if (input_aux >= 65536)
             {
+                logError(IP_LOCATOR, "IPv6 " << ipv6 << " has values higher than expected (65536)");
                 return false;
             }
             locator.address[i++] = octet(input_aux >> 8);
@@ -381,6 +427,11 @@ bool IPLocator::setIPv6(
         Locator_t& destlocator,
         const Locator_t& origlocator)
 {
+    if (destlocator.kind != LOCATOR_KIND_TCPv6 && destlocator.kind != LOCATOR_KIND_UDPv6)
+    {
+        logWarning(IP_LOCATOR, "Trying to set an IPv6 in a non IPv6 Locator");
+        return false;
+    }
     return setIPv6(destlocator, getIPv6(origlocator));
 }
 
@@ -872,7 +923,7 @@ bool IPLocator::IPv6isCorrect(
     }
 
     // only case of 8 : is with a :: at the beggining or end
-    if (count == 8 && (ipv6.at(0) != ':' && ipv6.at(ipv6.size() - 1) != ':'))
+    if (count == 8 && (ipv6.front() != ':' && ipv6.back() != ':'))
     {
         return false;
     }
@@ -888,13 +939,13 @@ bool IPLocator::IPv6isCorrect(
     }
 
     // does not start with only one ':'
-    if (ipv6.at(0) == ':' && ipv6.at(1) != ':')
+    if (ipv6.front() == ':' && ipv6.at(1) != ':')
     {
         return false;
     }
 
     // does not end with only one ':'
-    if (ipv6.at(ipv6.size() - 1) == ':' && ipv6.at(ipv6.size() - 2) != ':')
+    if (ipv6.back() == ':' && ipv6.at(ipv6.size() - 2) != ':')
     {
         return false;
     }

--- a/test/unittest/rtps/common/CMakeLists.txt
+++ b/test/unittest/rtps/common/CMakeLists.txt
@@ -20,6 +20,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         set(CACHECHANGETESTS_SOURCE CacheChangeTests.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp)
         set(GUID_UTILS_TESTS_SOURCE GuidUtilsTests.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPFinder.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPLocator.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/md5.cpp)

--- a/test/unittest/rtps/network/NetworkFactoryTests.cpp
+++ b/test/unittest/rtps/network/NetworkFactoryTests.cpp
@@ -32,105 +32,109 @@ using namespace std;
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 
-class NetworkTests: public ::testing::Test
+class NetworkTests : public ::testing::Test
 {
-   public:
-   NetworkFactory networkFactoryUnderTest;
-   void HELPER_RegisterTransportWithKindAndChannels(int kind, unsigned int channels);
+public:
+
+    NetworkFactory networkFactoryUnderTest;
+    void HELPER_RegisterTransportWithKindAndChannels(
+            int kind,
+            unsigned int channels);
 };
 
-TEST_F(NetworkTests, registering_transport_with_descriptor_instantiates_and_populates_a_transport_with_descriptor_options)
+TEST_F(NetworkTests,
+        registering_transport_with_descriptor_instantiates_and_populates_a_transport_with_descriptor_options)
 {
-   // Given
-   const int ExpectedMaximumChannels = 10;
-   const int ExpectedSupportedKind = 3;
+    // Given
+    const int ExpectedMaximumChannels = 10;
+    const int ExpectedSupportedKind = 3;
 
-   // When
-   HELPER_RegisterTransportWithKindAndChannels(ExpectedSupportedKind, ExpectedMaximumChannels);
+    // When
+    HELPER_RegisterTransportWithKindAndChannels(ExpectedSupportedKind, ExpectedMaximumChannels);
 
-   // Then
-   const MockTransport* lastRegisteredTransport = MockTransport::mockTransportInstances.back();
-   ASSERT_EQ(ExpectedMaximumChannels, lastRegisteredTransport->mockMaximumChannels);
-   ASSERT_EQ(ExpectedSupportedKind, lastRegisteredTransport->kind());
+    // Then
+    const MockTransport* lastRegisteredTransport = MockTransport::mockTransportInstances.back();
+    ASSERT_EQ(ExpectedMaximumChannels, lastRegisteredTransport->mockMaximumChannels);
+    ASSERT_EQ(ExpectedSupportedKind, lastRegisteredTransport->kind());
 }
 
 TEST_F(NetworkTests, build_sender_resource_returns_send_resource_for_a_kind_compatible_transport)
 {
-   // Given
-   int ArbitraryKind = 1;
-   HELPER_RegisterTransportWithKindAndChannels(ArbitraryKind, 10);
+    // Given
+    int ArbitraryKind = 1;
+    HELPER_RegisterTransportWithKindAndChannels(ArbitraryKind, 10);
 
-   SendResourceList send_resource_list;
+    SendResourceList send_resource_list;
 
-   Locator_t kindCompatibleLocator;
-   kindCompatibleLocator.kind = ArbitraryKind;
+    Locator_t kindCompatibleLocator;
+    kindCompatibleLocator.kind = ArbitraryKind;
 
-   // When
-   ASSERT_TRUE(networkFactoryUnderTest.build_send_resources(send_resource_list, kindCompatibleLocator));
+    // When
+    ASSERT_TRUE(networkFactoryUnderTest.build_send_resources(send_resource_list, kindCompatibleLocator));
 
-   // Then
-   ASSERT_EQ(1u, send_resource_list.size());
+    // Then
+    ASSERT_EQ(1u, send_resource_list.size());
 }
 
 TEST_F(NetworkTests, BuildReceiverResource_returns_receive_resource_for_a_kind_compatible_transport)
 {
-   // Given
-   int ArbitraryKind = 1;
-   HELPER_RegisterTransportWithKindAndChannels(ArbitraryKind, 10);
+    // Given
+    int ArbitraryKind = 1;
+    HELPER_RegisterTransportWithKindAndChannels(ArbitraryKind, 10);
 
-   Locator_t kindCompatibleLocator;
-   kindCompatibleLocator.kind = ArbitraryKind;
+    Locator_t kindCompatibleLocator;
+    kindCompatibleLocator.kind = ArbitraryKind;
 
-   // When
-   std::vector<std::shared_ptr<ReceiverResource>> resources;
-   bool ret = networkFactoryUnderTest.BuildReceiverResources(kindCompatibleLocator, resources, 0x8FFF);
+    // When
+    std::vector<std::shared_ptr<ReceiverResource>> resources;
+    bool ret = networkFactoryUnderTest.BuildReceiverResources(kindCompatibleLocator, resources, 0x8FFF);
 
-   // Then
-   ASSERT_TRUE(ret);
-   ASSERT_EQ(1u, resources.size());
+    // Then
+    ASSERT_TRUE(ret);
+    ASSERT_EQ(1u, resources.size());
 }
 
 TEST_F(NetworkTests, BuildReceiverResource_returns_multiple_resources_if_multiple_transports_compatible)
 {
-   // Given
-   HELPER_RegisterTransportWithKindAndChannels(3, 10);
-   HELPER_RegisterTransportWithKindAndChannels(2, 10);
-   HELPER_RegisterTransportWithKindAndChannels(2, 10);
+    // Given
+    HELPER_RegisterTransportWithKindAndChannels(3, 10);
+    HELPER_RegisterTransportWithKindAndChannels(2, 10);
+    HELPER_RegisterTransportWithKindAndChannels(2, 10);
 
-   Locator_t locatorCompatibleWithTwoTransports;
-   locatorCompatibleWithTwoTransports.kind = 2;
+    Locator_t locatorCompatibleWithTwoTransports;
+    locatorCompatibleWithTwoTransports.kind = 2;
 
-   // When
-   std::vector<std::shared_ptr<ReceiverResource>> resources;
-   bool ret = networkFactoryUnderTest.BuildReceiverResources(locatorCompatibleWithTwoTransports, resources, 0x8FFF);
+    // When
+    std::vector<std::shared_ptr<ReceiverResource>> resources;
+    bool ret = networkFactoryUnderTest.BuildReceiverResources(locatorCompatibleWithTwoTransports, resources, 0x8FFF);
 
-   // Then
-   ASSERT_TRUE(ret);
-   ASSERT_EQ(2u, resources.size());
+    // Then
+    ASSERT_TRUE(ret);
+    ASSERT_EQ(2u, resources.size());
 }
 
 TEST_F(NetworkTests, build_sender_resource_returns_multiple_resources_if_multiple_transports_compatible)
 {
-   // Given
-   HELPER_RegisterTransportWithKindAndChannels(3, 10);
-   HELPER_RegisterTransportWithKindAndChannels(2, 10);
-   HELPER_RegisterTransportWithKindAndChannels(2, 10);
+    // Given
+    HELPER_RegisterTransportWithKindAndChannels(3, 10);
+    HELPER_RegisterTransportWithKindAndChannels(2, 10);
+    HELPER_RegisterTransportWithKindAndChannels(2, 10);
 
-   SendResourceList send_resource_list;
+    SendResourceList send_resource_list;
 
-   Locator_t locatorCompatibleWithTwoTransports;
-   locatorCompatibleWithTwoTransports.kind = 2;
+    Locator_t locatorCompatibleWithTwoTransports;
+    locatorCompatibleWithTwoTransports.kind = 2;
 
-   // When
-   ASSERT_TRUE(networkFactoryUnderTest.build_send_resources(send_resource_list, locatorCompatibleWithTwoTransports));
+    // When
+    ASSERT_TRUE(networkFactoryUnderTest.build_send_resources(send_resource_list, locatorCompatibleWithTwoTransports));
 
-   // Then
-   ASSERT_EQ(1u, send_resource_list.size());
+    // Then
+    ASSERT_EQ(1u, send_resource_list.size());
 }
 
 /*
-TEST_F(NetworkTests, creating_send_resource_from_locator_opens_channels_mapped_to_that_locator)
-{
+   TEST_F(NetworkTests, creating_send_resource_from_locator_opens_channels_mapped_to_that_locator)
+   {
    // Given
    int ArbitraryKind = 1;
    HELPER_RegisterTransportWithKindAndChannels(ArbitraryKind, 10);
@@ -144,32 +148,32 @@ TEST_F(NetworkTests, creating_send_resource_from_locator_opens_channels_mapped_t
    // Then
    const MockTransport* lastRegisteredTransport = MockTransport::mockTransportInstances.back();
    ASSERT_TRUE(lastRegisteredTransport->IsOutputChannelOpen(locator));
-}
-*/
+   }
+ */
 
 TEST_F(NetworkTests, creating_receive_resource_from_locator_opens_channels_mapped_to_that_locator)
 {
-   // Given
-   int ArbitraryKind = 1;
-   HELPER_RegisterTransportWithKindAndChannels(ArbitraryKind, 10);
+    // Given
+    int ArbitraryKind = 1;
+    HELPER_RegisterTransportWithKindAndChannels(ArbitraryKind, 10);
 
-   Locator_t locator;
-   locator.kind = ArbitraryKind;
+    Locator_t locator;
+    locator.kind = ArbitraryKind;
 
-   // When
-   std::vector<std::shared_ptr<ReceiverResource>> resources;
-   bool ret = networkFactoryUnderTest.BuildReceiverResources(locator, resources, 0x8FFF);
+    // When
+    std::vector<std::shared_ptr<ReceiverResource>> resources;
+    bool ret = networkFactoryUnderTest.BuildReceiverResources(locator, resources, 0x8FFF);
 
-   ASSERT_TRUE(ret);
+    ASSERT_TRUE(ret);
 
-   // Then
-   const MockTransport* lastRegisteredTransport = MockTransport::mockTransportInstances.back();
-   ASSERT_TRUE(lastRegisteredTransport->IsInputChannelOpen(locator));
+    // Then
+    const MockTransport* lastRegisteredTransport = MockTransport::mockTransportInstances.back();
+    ASSERT_TRUE(lastRegisteredTransport->IsInputChannelOpen(locator));
 }
 
 /*
-TEST_F(NetworkTests, destroying_a_send_resource_will_close_all_channels_mapped_to_it_on_destruction)
-{
+   TEST_F(NetworkTests, destroying_a_send_resource_will_close_all_channels_mapped_to_it_on_destruction)
+   {
    // Given
    int ArbitraryKind = 1;
    HELPER_RegisterTransportWithKindAndChannels(ArbitraryKind, 10);
@@ -187,97 +191,98 @@ TEST_F(NetworkTests, destroying_a_send_resource_will_close_all_channels_mapped_t
    // Then
    const MockTransport* lastRegisteredTransport = MockTransport::mockTransportInstances.back();
    ASSERT_FALSE(lastRegisteredTransport->IsOutputChannelOpen(locator));
-}
-*/
+   }
+ */
 
 TEST_F(NetworkTests, destroying_a_receive_resource_will_close_all_channels_mapped_to_it_on_destruction)
 {
-   // Given
-   int ArbitraryKind = 1;
-   HELPER_RegisterTransportWithKindAndChannels(ArbitraryKind, 10);
-   Locator_t locator;
-   locator.kind = ArbitraryKind;
+    // Given
+    int ArbitraryKind = 1;
+    HELPER_RegisterTransportWithKindAndChannels(ArbitraryKind, 10);
+    Locator_t locator;
+    locator.kind = ArbitraryKind;
 
-   std::vector<std::shared_ptr<ReceiverResource>> resources;
-   bool ret = networkFactoryUnderTest.BuildReceiverResources(locator, resources, 0x8FFF);
-   ASSERT_TRUE(ret);
+    std::vector<std::shared_ptr<ReceiverResource>> resources;
+    bool ret = networkFactoryUnderTest.BuildReceiverResources(locator, resources, 0x8FFF);
+    ASSERT_TRUE(ret);
 
-   // When
-   resources.clear();
+    // When
+    resources.clear();
 
-   // Then
-   const MockTransport* lastRegisteredTransport = MockTransport::mockTransportInstances.back();
-   ASSERT_FALSE(lastRegisteredTransport->IsInputChannelOpen(locator));
+    // Then
+    const MockTransport* lastRegisteredTransport = MockTransport::mockTransportInstances.back();
+    ASSERT_FALSE(lastRegisteredTransport->IsInputChannelOpen(locator));
 }
 
 TEST_F(NetworkTests, BuildSenderResources_returns_empty_vector_if_no_registered_transport_is_kind_compatible)
 {
-   // Given
-   MockTransportDescriptor mockTransportDescriptor;
-   mockTransportDescriptor.supportedKind = 1;
-   mockTransportDescriptor.maximumChannels = 10;
-   networkFactoryUnderTest.RegisterTransport<MockTransport, MockTransportDescriptor>(mockTransportDescriptor);
+    // Given
+    MockTransportDescriptor mockTransportDescriptor;
+    mockTransportDescriptor.supportedKind = 1;
+    mockTransportDescriptor.maximumChannels = 10;
+    networkFactoryUnderTest.RegisterTransport<MockTransport, MockTransportDescriptor>(mockTransportDescriptor);
 
-   SendResourceList send_resource_list;
+    SendResourceList send_resource_list;
 
-   Locator_t locatorOfDifferentKind;
-   locatorOfDifferentKind.kind = 2;
+    Locator_t locatorOfDifferentKind;
+    locatorOfDifferentKind.kind = 2;
 
-   // When
-   ASSERT_FALSE(networkFactoryUnderTest.build_send_resources(send_resource_list, locatorOfDifferentKind));
+    // When
+    ASSERT_FALSE(networkFactoryUnderTest.build_send_resources(send_resource_list, locatorOfDifferentKind));
 
-   // Then
-   ASSERT_TRUE(send_resource_list.empty());
+    // Then
+    ASSERT_TRUE(send_resource_list.empty());
 }
 
-TEST_F(NetworkTests, BuildSenderResources_returns_empty_vector_if_all_compatible_transports_have_that_channel_open_already)
+TEST_F(NetworkTests,
+        BuildSenderResources_returns_empty_vector_if_all_compatible_transports_have_that_channel_open_already)
 {
-   // Given
-   int ArbitraryKind = 1;
-   HELPER_RegisterTransportWithKindAndChannels(ArbitraryKind, 10);
-   SendResourceList send_resource_list;
-   Locator_t locator;
-   locator.kind = ArbitraryKind;
+    // Given
+    int ArbitraryKind = 1;
+    HELPER_RegisterTransportWithKindAndChannels(ArbitraryKind, 10);
+    SendResourceList send_resource_list;
+    Locator_t locator;
+    locator.kind = ArbitraryKind;
 
-   ASSERT_TRUE(networkFactoryUnderTest.build_send_resources(send_resource_list, locator));
+    ASSERT_TRUE(networkFactoryUnderTest.build_send_resources(send_resource_list, locator));
 
-   ASSERT_EQ(1u, send_resource_list.size());
+    ASSERT_EQ(1u, send_resource_list.size());
 
-   // When
-   // We do it again for a locator that maps to the same channel
-   locator.address[0]++; // Address can differ, since they map to the same port
+    // When
+    // We do it again for a locator that maps to the same channel
+    locator.address[0]++; // Address can differ, since they map to the same port
 
-   ASSERT_TRUE(networkFactoryUnderTest.build_send_resources(send_resource_list, locator));
+    ASSERT_TRUE(networkFactoryUnderTest.build_send_resources(send_resource_list, locator));
 
-   // Then
-   ASSERT_EQ(1u, send_resource_list.size());
+    // Then
+    ASSERT_EQ(1u, send_resource_list.size());
 }
 
 TEST_F(NetworkTests, A_receiver_resource_accurately_reports_whether_it_supports_a_locator)
 {
-   // Given
-   int ArbitraryKind = 1;
-   HELPER_RegisterTransportWithKindAndChannels(ArbitraryKind, 10);
-   Locator_t locator;
-   locator.kind = ArbitraryKind;
-   std::vector<std::shared_ptr<ReceiverResource>> resources;
-   bool ret = networkFactoryUnderTest.BuildReceiverResources(locator, resources, 0x8FFF);
-   ASSERT_TRUE(ret);
-   auto& resource = resources.back();
+    // Given
+    int ArbitraryKind = 1;
+    HELPER_RegisterTransportWithKindAndChannels(ArbitraryKind, 10);
+    Locator_t locator;
+    locator.kind = ArbitraryKind;
+    std::vector<std::shared_ptr<ReceiverResource>> resources;
+    bool ret = networkFactoryUnderTest.BuildReceiverResources(locator, resources, 0x8FFF);
+    ASSERT_TRUE(ret);
+    auto& resource = resources.back();
 
-   // Then
-   ASSERT_TRUE(resource->SupportsLocator(locator));
+    // Then
+    ASSERT_TRUE(resource->SupportsLocator(locator));
 
-   // When
-   locator.port++;
+    // When
+    locator.port++;
 
-   // Then
-   ASSERT_FALSE(resource->SupportsLocator(locator));
+    // Then
+    ASSERT_FALSE(resource->SupportsLocator(locator));
 }
 
 /*
-TEST_F(NetworkTests, A_sender_resource_accurately_reports_whether_it_supports_a_locator)
-{
+   TEST_F(NetworkTests, A_sender_resource_accurately_reports_whether_it_supports_a_locator)
+   {
    // Given
    int ArbitraryKind = 1;
    HELPER_RegisterTransportWithKindAndChannels(ArbitraryKind, 10);
@@ -295,12 +300,12 @@ TEST_F(NetworkTests, A_sender_resource_accurately_reports_whether_it_supports_a_
 
    // Then
    ASSERT_TRUE(resource.SupportsLocator(locator));
-}
-*/
+   }
+ */
 
 /*
-TEST_F(NetworkTests, A_Sender_Resource_will_always_send_through_its_original_outbound_locator)
-{
+   TEST_F(NetworkTests, A_Sender_Resource_will_always_send_through_its_original_outbound_locator)
+   {
    // Given
    int ArbitraryKind = 1;
    HELPER_RegisterTransportWithKindAndChannels(ArbitraryKind, 10);
@@ -323,12 +328,12 @@ TEST_F(NetworkTests, A_Sender_Resource_will_always_send_through_its_original_out
 
    ASSERT_TRUE(0 == memcmp(messageSent.data.data(), testData, testDataLength));
    ASSERT_EQ(messageSent.destination, destinationLocator);
-}
-*/
+   }
+ */
 
 /*
-TEST_F(NetworkTests, A_Receiver_Resource_will_always_receive_through_its_original_inbound_locator_and_from_the_specified_remote_locator)
-{
+   TEST_F(NetworkTests, A_Receiver_Resource_will_always_receive_through_its_original_inbound_locator_and_from_the_specified_remote_locator)
+   {
    // Given
    int ArbitraryKind = 1;
    HELPER_RegisterTransportWithKindAndChannels(ArbitraryKind, 10);
@@ -357,15 +362,17 @@ TEST_F(NetworkTests, A_Receiver_Resource_will_always_receive_through_its_origina
    // Then
    ASSERT_EQ(memcmp(receivedData, testData.data(), 3), 0);
    ASSERT_EQ(receivedLocator, originLocator);
-}
-*/
+   }
+ */
 
-void NetworkTests::HELPER_RegisterTransportWithKindAndChannels(int kind, unsigned int channels)
+void NetworkTests::HELPER_RegisterTransportWithKindAndChannels(
+        int kind,
+        unsigned int channels)
 {
-   MockTransportDescriptor mockTransportDescriptor;
-   mockTransportDescriptor.supportedKind = kind;
-   mockTransportDescriptor.maximumChannels = channels;
-   networkFactoryUnderTest.RegisterTransport<MockTransport>(mockTransportDescriptor);
+    MockTransportDescriptor mockTransportDescriptor;
+    mockTransportDescriptor.supportedKind = kind;
+    mockTransportDescriptor.maximumChannels = channels;
+    networkFactoryUnderTest.RegisterTransport<MockTransport>(mockTransportDescriptor);
 }
 
 #define SHRINK_TEST_MAX_ENTRIES 4u
@@ -384,14 +391,16 @@ struct ShrinkLocatorCase_t
 
     std::vector<LocatorSelectorEntry> temp_entries;
 
-    void clear(const char* case_name)
+    void clear(
+            const char* case_name)
     {
         name = case_name;
         input.clear();
         output.clear();
     }
 
-    void prepare_selector(LocatorSelector& selector)
+    void prepare_selector(
+            LocatorSelector& selector)
     {
         uint32_t id = 1;
         selector.clear();
@@ -418,7 +427,8 @@ struct ShrinkLocatorCase_t
         }
     }
 
-    void perform_selector_test(const NetworkFactory& network)
+    void perform_selector_test(
+            const NetworkFactory& network)
     {
         LocatorSelector selector(ResourceLimitedContainerConfig::fixed_size_configuration(SHRINK_TEST_MAX_ENTRIES));
         prepare_selector(selector);
@@ -430,37 +440,40 @@ struct ShrinkLocatorCase_t
             {
                 bool contains = false;
                 for (LocatorListIterator it = output.begin(); it != output.end(); ++it)
-                for (auto locator_in_list : output)
                 {
-                    if (IsAddressDefined(locator_in_list))
+                    for (auto locator_in_list : output)
                     {
-                        if (locator == locator_in_list)
+                        if (IsAddressDefined(locator_in_list))
                         {
-                            contains = true;
-                            break;
+                            if (locator == locator_in_list)
+                            {
+                                contains = true;
+                                break;
+                            }
                         }
-                    }
-                    else
-                    {
-                        if (locator.kind == locator_in_list.kind && locator.port == locator_in_list.port)
+                        else
                         {
-                            contains = true;
-                            break;
+                            if (locator.kind == locator_in_list.kind && locator.port == locator_in_list.port)
+                            {
+                                contains = true;
+                                break;
+                            }
                         }
                     }
                 }
                 ASSERT_TRUE(contains);
             });
     }
+
 };
 
 void add_test_three_lists(
-    const char* case_name,
-    const LocatorList_t& list1,
-    const LocatorList_t& list2,
-    const LocatorList_t& list3,
-    LocatorList_t result,
-    std::vector<ShrinkLocatorCase_t>& cases)
+        const char* case_name,
+        const LocatorList_t& list1,
+        const LocatorList_t& list2,
+        const LocatorList_t& list3,
+        LocatorList_t result,
+        std::vector<ShrinkLocatorCase_t>& cases)
 {
     ShrinkLocatorCase_t test;
 
@@ -486,7 +499,8 @@ void add_test_three_lists(
     cases.push_back(test);
 }
 
-void fill_blackbox_locators_test_cases(std::vector<ShrinkLocatorCase_t>& cases)
+void fill_blackbox_locators_test_cases(
+        std::vector<ShrinkLocatorCase_t>& cases)
 {
     ShrinkLocatorCase_t test;
 
@@ -585,7 +599,7 @@ void fill_blackbox_locators_test_cases(std::vector<ShrinkLocatorCase_t>& cases)
     result.push_back(multicast1);
     result.push_back(unicast3);
     add_test_three_lists("Three UDP lists with shared multicast and unicast",
-        list1, list2, list3, result, cases);
+            list1, list2, list3, result, cases);
 
     // Three. Two use same multicast, the other another multicast.
     list1.clear();
@@ -601,7 +615,7 @@ void fill_blackbox_locators_test_cases(std::vector<ShrinkLocatorCase_t>& cases)
     result.push_back(multicast1);
     result.push_back(unicast3);
     add_test_three_lists("Three UDP lists with shared multicast x2",
-        list1, list2, list3, result, cases);
+            list1, list2, list3, result, cases);
 
     // Three. One uses multicast, the others unicast
     list1.clear();
@@ -616,7 +630,7 @@ void fill_blackbox_locators_test_cases(std::vector<ShrinkLocatorCase_t>& cases)
     result.push_back(unicast2);
     result.push_back(unicast3);
     add_test_three_lists("Three UDP lists with only one multicast",
-        list1, list2, list3, result, cases);
+            list1, list2, list3, result, cases);
 
     // Three using same multicast
     list1.clear();
@@ -629,7 +643,7 @@ void fill_blackbox_locators_test_cases(std::vector<ShrinkLocatorCase_t>& cases)
     list3.push_back(unicast3);
     result.push_back(multicast2);
     add_test_three_lists("Three UDP lists with same shared multicast",
-        list1, list2, list3, result, cases);
+            list1, list2, list3, result, cases);
 }
 
 TEST_F(NetworkTests, LocatorShrink)
@@ -648,7 +662,9 @@ TEST_F(NetworkTests, LocatorShrink)
     }
 }
 
-int main(int argc, char **argv)
+int main(
+        int argc,
+        char** argv)
 {
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/test/unittest/rtps/network/NetworkFactoryTests.cpp
+++ b/test/unittest/rtps/network/NetworkFactoryTests.cpp
@@ -428,7 +428,27 @@ struct ShrinkLocatorCase_t
         selector.for_each(
             [this](const Locator_t& locator)
             {
-                ASSERT_TRUE(output.contains(locator));
+                bool contains = false;
+                for (LocatorListIterator it = output.begin(); it != output.end(); ++it)
+                {
+                    if (IsAddressDefined(*it))
+                    {
+                        if (locator == *it)
+                        {
+                            contains = true;
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        if (locator.kind == (*it).kind && locator.port == (*it).port)
+                        {
+                            contains = true;
+                            break;
+                        }
+                    }
+                }
+                ASSERT_TRUE(contains);
             });
     }
 };

--- a/test/unittest/rtps/network/NetworkFactoryTests.cpp
+++ b/test/unittest/rtps/network/NetworkFactoryTests.cpp
@@ -430,10 +430,11 @@ struct ShrinkLocatorCase_t
             {
                 bool contains = false;
                 for (LocatorListIterator it = output.begin(); it != output.end(); ++it)
+                for (auto locator_in_list : output)
                 {
-                    if (IsAddressDefined(*it))
+                    if (IsAddressDefined(locator_in_list))
                     {
-                        if (locator == *it)
+                        if (locator == locator_in_list)
                         {
                             contains = true;
                             break;
@@ -441,7 +442,7 @@ struct ShrinkLocatorCase_t
                     }
                     else
                     {
-                        if (locator.kind == (*it).kind && locator.port == (*it).port)
+                        if (locator.kind == locator_in_list.kind && locator.port == locator_in_list.port)
                         {
                             contains = true;
                             break;

--- a/test/unittest/rtps/network/NetworkFactoryTests.cpp
+++ b/test/unittest/rtps/network/NetworkFactoryTests.cpp
@@ -42,8 +42,9 @@ public:
             unsigned int channels);
 };
 
-TEST_F(NetworkTests,
-        registering_transport_with_descriptor_instantiates_and_populates_a_transport_with_descriptor_options)
+// for uncrustify sake *INDENT-OFF*
+TEST_F(NetworkTests, registering_transport_with_descriptor_instantiates_and_populates_a_transport_with_descriptor_options)
+// *INDENT-ON*
 {
     // Given
     const int ExpectedMaximumChannels = 10;
@@ -234,8 +235,9 @@ TEST_F(NetworkTests, BuildSenderResources_returns_empty_vector_if_no_registered_
     ASSERT_TRUE(send_resource_list.empty());
 }
 
-TEST_F(NetworkTests,
-        BuildSenderResources_returns_empty_vector_if_all_compatible_transports_have_that_channel_open_already)
+// for uncrustify sake *INDENT-OFF*
+TEST_F(NetworkTests, BuildSenderResources_returns_empty_vector_if_all_compatible_transports_have_that_channel_open_already)
+// *INDENT-ON*
 {
     // Given
     int ArbitraryKind = 1;
@@ -439,25 +441,22 @@ struct ShrinkLocatorCase_t
             [this](const Locator_t& locator)
             {
                 bool contains = false;
-                for (LocatorListIterator it = output.begin(); it != output.end(); ++it)
+                for (auto locator_in_list : output)
                 {
-                    for (auto locator_in_list : output)
+                    if (IsAddressDefined(locator_in_list))
                     {
-                        if (IsAddressDefined(locator_in_list))
+                        if (locator == locator_in_list)
                         {
-                            if (locator == locator_in_list)
-                            {
-                                contains = true;
-                                break;
-                            }
+                            contains = true;
+                            break;
                         }
-                        else
+                    }
+                    else
+                    {
+                        if (locator.kind == locator_in_list.kind && locator.port == locator_in_list.port)
                         {
-                            if (locator.kind == locator_in_list.kind && locator.port == locator_in_list.port)
-                            {
-                                contains = true;
-                                break;
-                            }
+                            contains = true;
+                            break;
                         }
                     }
                 }

--- a/test/unittest/utils/CMakeLists.txt
+++ b/test/unittest/utils/CMakeLists.txt
@@ -41,6 +41,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
 
         set(IPLOCATORTESTS_SOURCE
             IPLocatorTests.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPLocator.cpp)
 
         include_directories(mock/)

--- a/test/unittest/utils/CMakeLists.txt
+++ b/test/unittest/utils/CMakeLists.txt
@@ -39,8 +39,8 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         set(RESOURCELIMITEDVECTORTESTS_SOURCE
             ResourceLimitedVectorTests.cpp)
 
-        set(IPLOCATORTESTS_SOURCE
-            IPLocatorTests.cpp
+        set(LOCATORTESTS_SOURCE
+            LocatorTests.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
@@ -85,12 +85,12 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         add_gtest(ResourceLimitedVectorTests SOURCES ${RESOURCELIMITEDVECTORTESTS_SOURCE})
 
 
-        add_executable(IPLocatorTests ${IPLOCATORTESTS_SOURCE})
-        target_compile_definitions(IPLocatorTests PRIVATE FASTRTPS_NO_LIB)
-        target_include_directories(IPLocatorTests PRIVATE ${GTEST_INCLUDE_DIRS}
+        add_executable(LocatorTests ${LOCATORTESTS_SOURCE})
+        target_compile_definitions(LocatorTests PRIVATE FASTRTPS_NO_LIB)
+        target_include_directories(LocatorTests PRIVATE ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
-        target_link_libraries(IPLocatorTests ${GTEST_LIBRARIES} ${MOCKS})
-        add_gtest(IPLocatorTests SOURCES ${IPLOCATORTESTS_SOURCE})
+        target_link_libraries(LocatorTests ${GTEST_LIBRARIES} ${MOCKS})
+        add_gtest(LocatorTests SOURCES ${LOCATORTESTS_SOURCE})
 
     endif()
 endif()

--- a/test/unittest/utils/IPLocatorTests.cpp
+++ b/test/unittest/utils/IPLocatorTests.cpp
@@ -73,8 +73,8 @@ public:
 };
 
 /*******************
- * IPLocator Tests *
- *******************/
+* IPLocator Tests *
+*******************/
 
 /*
  * Check to create an IPv4 by string
@@ -999,8 +999,8 @@ TEST_F(IPLocatorTests, setIPv4address)
 }
 
 /*******************
- * Locator_t Tests *
- *******************/
+* Locator_t Tests *
+*******************/
 
 /*
  * Check creation of a locator from string
@@ -1179,8 +1179,8 @@ TEST(LocatorTests, LocatorList_deserialization)
 
 
 /*******************************
- * RemoteLocators Tests *
- *******************************/
+* RemoteLocators Tests *
+*******************************/
 
 /*
  * Check RemoteLocators add unicast locator that already exists
@@ -1263,8 +1263,8 @@ TEST(RemoteLocatorsTests, RemoteLocator_serialization)
 
     // Check List
     std::string str_result = // this variable is needed to separate string in 2 lines
-        "{MULTICAST:[UDPv4:[224.0.0.0]:1,UDPv4:[239.255.255.255]:2]"
-        "UNICAST:[UDPv4:[1.2.3.4]:3,UDPv4:[4.3.2.1]:4]}";
+            "{MULTICAST:[UDPv4:[224.0.0.0]:1,UDPv4:[239.255.255.255]:2]"
+            "UNICAST:[UDPv4:[1.2.3.4]:3,UDPv4:[4.3.2.1]:4]}";
     serialized_ss << rll;
     ASSERT_EQ(serialized_ss.str(), str_result);
 
@@ -1302,8 +1302,8 @@ TEST(RemoteLocatorsTests, RemoteLocator_deserialization)
 
     // Check Filled list
     std::string str_result = // this variable is needed to separate string in 2 lines
-        "{MULTICAST:[UDPv4:[224.0.0.0]:1,UDPv4:[239.255.255.255]:2]"
-        "UNICAST:[UDPv4:[1.2.3.4]:3,UDPv4:[4.3.2.1]:4]}";
+            "{MULTICAST:[UDPv4:[224.0.0.0]:1,UDPv4:[239.255.255.255]:2]"
+            "UNICAST:[UDPv4:[1.2.3.4]:3,UDPv4:[4.3.2.1]:4]}";
     serialized_ss.clear();
     serialized_ss.str(str_result);
     serialized_ss >> rll;
@@ -1320,8 +1320,8 @@ TEST(RemoteLocatorsTests, RemoteLocator_deserialization)
 }
 
 /*******************************
- * LocatorListComparison Tests *
- *******************************/
+* LocatorListComparison Tests *
+*******************************/
 
 /*
  * Check LocatorLists comparison

--- a/test/unittest/utils/IPLocatorTests.cpp
+++ b/test/unittest/utils/IPLocatorTests.cpp
@@ -1117,6 +1117,53 @@ TEST(LocatorTests, isValid_negative)
     ASSERT_FALSE(locator_list.isValid());
 }
 
+/*
+ * Check LocatorList serialization
+ */
+TEST(LocatorTests, LocatorList_serialization)
+{
+    Locator_t locator;
+    LocatorList_t locator_list;
+    std::stringstream ss_empty, ss_filled;
+
+    // Empty list
+    ss_empty << locator_list;
+    ASSERT_EQ(ss_empty.str(), "[_]");
+
+    IPLocator::createLocator(LOCATOR_KIND_UDPv4, "1.1.1.1", 1, locator);
+    locator_list.push_back(locator);
+    IPLocator::createLocator(LOCATOR_KIND_TCPv4, "2.2.2.2", 2, locator);
+    locator_list.push_back(locator);
+
+    // Full list
+    ss_filled << locator_list;
+    ASSERT_EQ(ss_filled.str(), "[UDPv4:[1.1.1.1]:1,TCPv4:[2.2.2.2]:2]");
+}
+
+/*
+ * Check LocatorList deserialization
+ */
+TEST(LocatorTests, LocatorList_deserialization)
+{
+    Locator_t locator;
+    LocatorList_t locator_list;
+    std::stringstream ss;
+
+    ASSERT_EQ(locator_list.size(), 0);
+
+    // Empty list
+    ss.str("[_]");
+    ss >> locator_list;
+    ASSERT_EQ(locator_list.size(), 0);
+
+    // Filled list
+    ss.clear();
+    ss.str("[UDPv4:[1.1.1.1]:1,TCPv4:[2.2.2.2]:2]");
+    ss >> locator_list;
+    ASSERT_EQ(locator_list.size(), 2);
+}
+
+
 /*******************************
  * RemoteLocators Tests *
  *******************************/

--- a/test/unittest/utils/IPLocatorTests.cpp
+++ b/test/unittest/utils/IPLocatorTests.cpp
@@ -315,6 +315,7 @@ TEST_F(IPLocatorTests, createLocator)
 
     // create UDP IPv4
     kind = LOCATOR_KIND_UDPv4;
+    probe_locator.kind = kind;
     IPLocator::createLocator(kind, ipv4_address, port1, res_locator);
     ASSERT_EQ(res_locator.kind, kind);
     ASSERT_EQ(res_locator.port, port1);
@@ -323,6 +324,7 @@ TEST_F(IPLocatorTests, createLocator)
 
     // create TCP IPv4
     kind = LOCATOR_KIND_TCPv4;
+    probe_locator.kind = kind;
     IPLocator::createLocator(kind, ipv4_lo_address, port2, res_locator);
     ASSERT_EQ(res_locator.kind, kind);
     ASSERT_EQ(res_locator.port, port2);
@@ -331,6 +333,7 @@ TEST_F(IPLocatorTests, createLocator)
 
     // create UDP IPv6
     kind = LOCATOR_KIND_UDPv6;
+    probe_locator.kind = kind;
     IPLocator::createLocator(kind, ipv6_address, port1, res_locator);
     ASSERT_EQ(res_locator.kind, kind);
     ASSERT_EQ(res_locator.port, port1);
@@ -339,6 +342,7 @@ TEST_F(IPLocatorTests, createLocator)
 
     // create TCP IPv6
     kind = LOCATOR_KIND_TCPv6;
+    probe_locator.kind = kind;
     IPLocator::createLocator(kind, ipv6_any, port2, res_locator);
     ASSERT_EQ(res_locator.kind, kind);
     ASSERT_EQ(res_locator.port, port2);
@@ -347,6 +351,7 @@ TEST_F(IPLocatorTests, createLocator)
 
     // create SHM
     kind = LOCATOR_KIND_SHM;
+    probe_locator.kind = kind;
     IPLocator::createLocator(kind, ipv6_address, port1, res_locator);
     ASSERT_EQ(res_locator.kind, kind);
     ASSERT_EQ(res_locator.port, port1);
@@ -394,6 +399,7 @@ TEST_F(IPLocatorTests, setIPv6)
 {
     Locator_t locator;
     Locator_t probe_locator;
+    probe_locator.kind = LOCATOR_KIND_UDPv6;
     IPLocator::createLocator(LOCATOR_KIND_UDPv6, ipv6_lo_address, port1, locator);
 
     // setIPv6 char*
@@ -434,6 +440,7 @@ TEST_F(IPLocatorTests, getIPv4)
 TEST_F(IPLocatorTests, getIPv6)
 {
     Locator_t locator;
+    locator.kind = LOCATOR_KIND_UDPv6;
     IPLocator::setIPv6(locator, ipv6_lo_address);
     auto res = IPLocator::getIPv6(locator);
     for (int i = 0; i < 15; i++)
@@ -501,6 +508,7 @@ TEST_F(IPLocatorTests, toIPv4string)
 TEST_F(IPLocatorTests, toIPv6string)
 {
     Locator_t locator;
+    locator.kind = LOCATOR_KIND_UDPv6;
     IPLocator::setIPv6(locator, 0, 0, 0, 0, 0, 0, 0, 1);
     ASSERT_EQ(IPLocator::toIPv6string(locator), ipv6_lo_address);
     IPLocator::setIPv6(locator, ipv6_address_repeated.c_str());
@@ -539,6 +547,7 @@ TEST_F(IPLocatorTests, copyIPv4)
 TEST_F(IPLocatorTests, copyIPv6)
 {
     Locator_t locator;
+    locator.kind = LOCATOR_KIND_UDPv6;
     IPLocator::setIPv6(locator, ipv6_lo_address);
     unsigned char arr[16];
     ASSERT_TRUE(IPLocator::copyIPv6(locator, arr));
@@ -589,6 +598,7 @@ TEST_F(IPLocatorTests, ip_to_string)
     Locator_t locator;
 
     // v4
+    locator.kind = LOCATOR_KIND_UDPv4;
     IPLocator::setIPv4(locator, 127, 0, 0, 1);
     locator.kind = LOCATOR_KIND_UDPv4;
     ASSERT_EQ(IPLocator::ip_to_string(locator), ipv4_lo_address);
@@ -597,6 +607,7 @@ TEST_F(IPLocatorTests, ip_to_string)
     ASSERT_EQ(IPLocator::ip_to_string(locator), ipv4_address);
 
     // v6
+    locator.kind = LOCATOR_KIND_UDPv6;
     IPLocator::setIPv6(locator, 0, 0, 0, 0, 0, 0, 0, 1);
     locator.kind = LOCATOR_KIND_UDPv6;
     ASSERT_EQ(IPLocator::ip_to_string(locator), ipv6_lo_address);
@@ -993,7 +1004,7 @@ TEST_F(IPLocatorTests, setIPv4address)
 
 /*
  * Check creation of a locator from string
- * Serialization is testing in IPLocatorTests::to_string
+ * Serialization is tested in IPLocatorTests::to_string
  */
 TEST(LocatorTests, locator_deserialization)
 {
@@ -1071,7 +1082,8 @@ TEST(LocatorTests, IsAddressDefined_v6)
 TEST(LocatorTests, LocatorList_equal_negative)
 {
     Locator_t locator;
-    LocatorList_t locator_list_1, locator_list_2;
+    LocatorList_t locator_list_1;
+    LocatorList_t locator_list_2;
 
     IPLocator::createLocator(LOCATOR_KIND_UDPv6, "::1", 1, locator);
     locator_list_1.push_back(locator);
@@ -1082,11 +1094,12 @@ TEST(LocatorTests, LocatorList_equal_negative)
 }
 
 /*
- * Check push_back for LocatorLists in repeated case
+ * Check push_back for LocatorLists when a locator is already within the list
  */
 TEST(LocatorTests, push_back_negative)
 {
-    Locator_t locator_1, locator_2;
+    Locator_t locator_1;
+    Locator_t locator_2;
     LocatorList_t locator_list;
 
     ASSERT_EQ(locator_list.size(), 0);
@@ -1124,7 +1137,8 @@ TEST(LocatorTests, LocatorList_serialization)
 {
     Locator_t locator;
     LocatorList_t locator_list;
-    std::stringstream ss_empty, ss_filled;
+    std::stringstream ss_empty;
+    std::stringstream ss_filled;
 
     // Empty list
     ss_empty << locator_list;
@@ -1174,7 +1188,9 @@ TEST(LocatorTests, LocatorList_deserialization)
 TEST(RemoteLocatorsTests, add_unicast_locator_repetead)
 {
     eprosima::fastrtps::rtps::RemoteLocatorList rll;
-    Locator_t locator_1, locator_2, locator_3;
+    Locator_t locator_1;
+    Locator_t locator_2;
+    Locator_t locator_3;
     ASSERT_EQ(rll.unicast.size(), 0u);
 
     IPLocator::createLocator(LOCATOR_KIND_UDPv4, "1.2.3.4", 1, locator_1);
@@ -1220,7 +1236,10 @@ TEST(RemoteLocatorsTests, RemoteLocator_serialization)
     eprosima::fastrtps::rtps::RemoteLocatorList rll;
     Locator_t locator;
     std::string serialized;
-    std::stringstream serialized_ss, empty_serialized_ss, multicast_ss, unicast_ss;
+    std::stringstream serialized_ss;
+    std::stringstream empty_serialized_ss;
+    std::stringstream multicast_ss;
+    std::stringstream unicast_ss;
 
     // Check empty List
     empty_serialized_ss << rll;
@@ -1249,7 +1268,7 @@ TEST(RemoteLocatorsTests, RemoteLocator_serialization)
     serialized_ss << rll;
     ASSERT_EQ(serialized_ss.str(), str_result);
 
-    // CHeck unicast List
+    // Check unicast List
     eprosima::fastrtps::rtps::RemoteLocatorList rll_2;
     IPLocator::createLocator(LOCATOR_KIND_UDPv4, "1.2.3.4", 3, locator);
     rll_2.add_unicast_locator(locator);
@@ -1310,7 +1329,8 @@ TEST(RemoteLocatorsTests, RemoteLocator_deserialization)
 TEST(LocatorListComparisonTests, locatorList_comparison)
 {
     Locator_t locator;
-    eprosima::fastrtps::ResourceLimitedVector<Locator_t> locator_list_1, locator_list_2;
+    eprosima::fastrtps::ResourceLimitedVector<Locator_t> locator_list_1;
+    eprosima::fastrtps::ResourceLimitedVector<Locator_t> locator_list_2;
 
     IPLocator::createLocator(LOCATOR_KIND_TCPv4, "1.2.3.4", 1, locator);
     locator_list_1.push_back(locator);
@@ -1331,6 +1351,14 @@ TEST(LocatorListComparisonTests, locatorList_comparison)
 
     ASSERT_FALSE(locator_list_1 == locator_list_2);
 
+    locator_list_1.clear();
+    locator_list_2.clear();
+    IPLocator::createLocator(LOCATOR_KIND_TCPv4, "1.2.3.4", 1, locator);
+    locator_list_1.push_back(locator);
+    locator_list_2.push_back(locator);
+    IPLocator::createLocator(LOCATOR_KIND_UDPv6, "1.2.3.4", 2, locator);
+    locator_list_1.push_back(locator);
+    locator_list_2.push_back(locator);
     IPLocator::createLocator(LOCATOR_KIND_TCPv4, "0.0.0.1", 4, locator);
     locator_list_1.push_back(locator);
     IPLocator::createLocator(LOCATOR_KIND_TCPv4, "0.0.0.1", 5, locator);

--- a/test/unittest/utils/LocatorTests.cpp
+++ b/test/unittest/utils/LocatorTests.cpp
@@ -70,6 +70,9 @@ public:
 
     const uint32_t port1 = 6666;
     const uint32_t port2 = 7400;
+
+    const uint16_t rtps_port1 = 6666;
+    const uint16_t rtps_port2 = 7400;
 };
 
 /*******************
@@ -677,11 +680,11 @@ TEST_F(IPLocatorTests, ip_to_string)
 TEST_F(IPLocatorTests, logicalPort)
 {
     Locator_t locator;
-    ASSERT_TRUE(IPLocator::setLogicalPort(locator, port1));
-    ASSERT_EQ(IPLocator::getLogicalPort(locator), port1);
-    ASSERT_NE(IPLocator::getLogicalPort(locator), port2);
-    ASSERT_TRUE(IPLocator::setLogicalPort(locator, port2));
-    ASSERT_EQ(IPLocator::getLogicalPort(locator), port2);
+    ASSERT_TRUE(IPLocator::setLogicalPort(locator, rtps_port1));
+    ASSERT_EQ(IPLocator::getLogicalPort(locator), rtps_port1);
+    ASSERT_NE(IPLocator::getLogicalPort(locator), rtps_port2);
+    ASSERT_TRUE(IPLocator::setLogicalPort(locator, rtps_port2));
+    ASSERT_EQ(IPLocator::getLogicalPort(locator), rtps_port2);
 }
 
 /*
@@ -690,11 +693,11 @@ TEST_F(IPLocatorTests, logicalPort)
 TEST_F(IPLocatorTests, physicalPort)
 {
     Locator_t locator;
-    ASSERT_TRUE(IPLocator::setPhysicalPort(locator, port1));
-    ASSERT_EQ(IPLocator::getPhysicalPort(locator), port1);
-    ASSERT_NE(IPLocator::getPhysicalPort(locator), port2);
-    ASSERT_TRUE(IPLocator::setPhysicalPort(locator, port2));
-    ASSERT_EQ(IPLocator::getPhysicalPort(locator), port2);
+    ASSERT_TRUE(IPLocator::setPhysicalPort(locator, rtps_port1));
+    ASSERT_EQ(IPLocator::getPhysicalPort(locator), rtps_port1);
+    ASSERT_NE(IPLocator::getPhysicalPort(locator), rtps_port2);
+    ASSERT_TRUE(IPLocator::setPhysicalPort(locator, rtps_port2));
+    ASSERT_EQ(IPLocator::getPhysicalPort(locator), rtps_port2);
 }
 
 /*
@@ -794,10 +797,10 @@ TEST_F(IPLocatorTests, toLanIDstring)
 TEST_F(IPLocatorTests, toPhysicalLocator)
 {
     Locator_t locator;
-    ASSERT_TRUE(IPLocator::setLogicalPort(locator, port1));
-    ASSERT_EQ(IPLocator::getLogicalPort(locator), port1);
+    ASSERT_TRUE(IPLocator::setLogicalPort(locator, rtps_port1));
+    ASSERT_EQ(IPLocator::getLogicalPort(locator), rtps_port1);
     locator = IPLocator::toPhysicalLocator(locator);
-    ASSERT_NE(IPLocator::getLogicalPort(locator), port1);
+    ASSERT_NE(IPLocator::getLogicalPort(locator), rtps_port1);
 }
 
 /*
@@ -821,23 +824,23 @@ TEST_F(IPLocatorTests, setPortRTPS)
 {
     Locator_t locator;
     IPLocator::createLocator(LOCATOR_KIND_UDPv4, ipv4_address, port1, locator);
-    ASSERT_TRUE(IPLocator::setPortRTPS(locator, port2));
-    ASSERT_EQ(IPLocator::getPortRTPS(locator), static_cast<uint16_t>(port2));
+    ASSERT_TRUE(IPLocator::setPortRTPS(locator, rtps_port2));
+    ASSERT_EQ(IPLocator::getPortRTPS(locator), static_cast<uint16_t>(rtps_port2));
 
     IPLocator::createLocator(LOCATOR_KIND_UDPv6, ipv6_address, port2, locator);
-    IPLocator::setPortRTPS(locator, port1);
-    ASSERT_EQ(IPLocator::getPortRTPS(locator), static_cast<uint16_t>(port1));
+    IPLocator::setPortRTPS(locator, rtps_port1);
+    ASSERT_EQ(IPLocator::getPortRTPS(locator), static_cast<uint16_t>(rtps_port1));
 
     IPLocator::createLocator(LOCATOR_KIND_TCPv4, ipv4_address_2, port1, locator);
-    ASSERT_TRUE(IPLocator::setPortRTPS(locator, port2));
-    ASSERT_EQ(IPLocator::getPortRTPS(locator), static_cast<uint16_t>(port2));
+    ASSERT_TRUE(IPLocator::setPortRTPS(locator, rtps_port2));
+    ASSERT_EQ(IPLocator::getPortRTPS(locator), static_cast<uint16_t>(rtps_port2));
 
     IPLocator::createLocator(LOCATOR_KIND_TCPv6, ipv6_address_2, port2, locator);
-    ASSERT_TRUE(IPLocator::setPortRTPS(locator, port1));
-    ASSERT_EQ(IPLocator::getPortRTPS(locator), static_cast<uint16_t>(port1));
+    ASSERT_TRUE(IPLocator::setPortRTPS(locator, rtps_port1));
+    ASSERT_EQ(IPLocator::getPortRTPS(locator), static_cast<uint16_t>(rtps_port1));
 
     IPLocator::createLocator(LOCATOR_KIND_SHM, ipv4_lo_address, port1, locator);
-    ASSERT_FALSE(IPLocator::setPortRTPS(locator, port1));
+    ASSERT_FALSE(IPLocator::setPortRTPS(locator, rtps_port1));
     ASSERT_EQ(IPLocator::getPortRTPS(locator), 0u);
 }
 

--- a/test/unittest/utils/LocatorTests.cpp
+++ b/test/unittest/utils/LocatorTests.cpp
@@ -1309,6 +1309,12 @@ TEST(LocatorTests, LocatorList_deserialization)
     ss.str("[UDPv4:[1.1.1.1]:1,TCPv4:[2.2.2.2]:2]");
     ss >> locator_list;
     ASSERT_EQ(locator_list.size(), 2u);
+
+    // Error
+    ss.clear();
+    ss.str("[UDP_ERROR:]");
+    ss >> locator_list;
+    ASSERT_EQ(locator_list.size(), 0u);
 }
 
 /*******************************

--- a/test/unittest/utils/LocatorTests.cpp
+++ b/test/unittest/utils/LocatorTests.cpp
@@ -1335,7 +1335,7 @@ TEST(LocatorListComparisonTests, locatorList_comparison)
     IPLocator::createLocator(LOCATOR_KIND_TCPv4, "1.2.3.4", 1, locator);
     locator_list_1.push_back(locator);
     locator_list_2.push_back(locator);
-    IPLocator::createLocator(LOCATOR_KIND_UDPv6, "1.2.3.4", 2, locator);
+    IPLocator::createLocator(LOCATOR_KIND_UDPv4, "1.2.3.4", 2, locator);
     locator_list_1.push_back(locator);
     locator_list_2.push_back(locator);
 
@@ -1356,7 +1356,7 @@ TEST(LocatorListComparisonTests, locatorList_comparison)
     IPLocator::createLocator(LOCATOR_KIND_TCPv4, "1.2.3.4", 1, locator);
     locator_list_1.push_back(locator);
     locator_list_2.push_back(locator);
-    IPLocator::createLocator(LOCATOR_KIND_UDPv6, "1.2.3.4", 2, locator);
+    IPLocator::createLocator(LOCATOR_KIND_UDPv4, "1.2.3.4", 2, locator);
     locator_list_1.push_back(locator);
     locator_list_2.push_back(locator);
     IPLocator::createLocator(LOCATOR_KIND_TCPv4, "0.0.0.1", 4, locator);

--- a/test/unittest/utils/LocatorTests.cpp
+++ b/test/unittest/utils/LocatorTests.cpp
@@ -68,8 +68,8 @@ public:
     const std::string ipv6_any = "::";
     const std::string ipv6_invalid = "0:0:0:0:0:0:0:0";
 
-    const uint16_t port1 = 6666;
-    const uint16_t port2 = 7400;
+    const uint32_t port1 = 6666;
+    const uint32_t port2 = 7400;
 };
 
 /*******************
@@ -88,10 +88,10 @@ TEST_F(IPLocatorTests, setIPv4_from_string)
     {
         // Empty string
         ASSERT_TRUE(IPLocator::setIPv4(locator, "0.0.0.0"));
-        std::vector<int> vec{0, 0, 0, 0};
+        std::vector<unsigned int> vec{0, 0, 0, 0};
         for (int i = 0; i < 12; i++)
         {
-            ASSERT_EQ(locator.address[i], 0);
+            ASSERT_EQ(locator.address[i], 0u);
         }
         for (int i = 0; i < 4; i++)
         {
@@ -102,11 +102,11 @@ TEST_F(IPLocatorTests, setIPv4_from_string)
     {
         // Std random string
         ASSERT_TRUE(IPLocator::setIPv4(locator, "1.2.3.4"));
-        std::vector<int> vec{1, 2, 3, 4};
+        std::vector<unsigned int> vec{1, 2, 3, 4};
 
         for (int i = 0; i < 12; i++)
         {
-            ASSERT_EQ(locator.address[i], 0);
+            ASSERT_EQ(locator.address[i], 0u);
         }
         for (int i = 0; i < 4; i++)
         {
@@ -117,11 +117,11 @@ TEST_F(IPLocatorTests, setIPv4_from_string)
     {
         // Std string with 0 forwarding number
         ASSERT_TRUE(IPLocator::setIPv4(locator, "01.002.0003.000104"));
-        std::vector<int> vec{1, 2, 3, 104};
+        std::vector<unsigned int> vec{1, 2, 3, 104};
 
         for (int i = 0; i < 12; i++)
         {
-            ASSERT_EQ(locator.address[i], 0);
+            ASSERT_EQ(locator.address[i], 0u);
         }
         for (int i = 0; i < 4; i++)
         {
@@ -132,11 +132,11 @@ TEST_F(IPLocatorTests, setIPv4_from_string)
     {
         // Multicast address
         ASSERT_TRUE(IPLocator::setIPv4(locator, "255.255.255.255"));
-        std::vector<int> vec{255, 255, 255, 255};
+        std::vector<unsigned int> vec{255, 255, 255, 255};
 
         for (int i = 0; i < 12; i++)
         {
-            ASSERT_EQ(locator.address[i], 0);
+            ASSERT_EQ(locator.address[i], 0u);
         }
         for (int i = 0; i < 4; i++)
         {
@@ -166,7 +166,7 @@ TEST_F(IPLocatorTests, setIPv6_from_string_empty)
     locator.kind = LOCATOR_KIND_UDPv6;
 
     // Empty string
-    std::vector<int> vec(16, 0);
+    std::vector<unsigned int> vec(16, 0);
     std::vector<std::string> str_vec
     {
         "::",
@@ -200,7 +200,7 @@ TEST_F(IPLocatorTests, setIPv6_from_string_std)
     // Localhost address
     {
         // Localhost IPv6 = 0:0:0:0:0:0:0:1
-        std::vector<int> vec(15, 0);
+        std::vector<unsigned int> vec(15, 0);
         vec.push_back(1);
 
         ASSERT_TRUE(IPLocator::setIPv6(locator, "::1"));
@@ -218,7 +218,7 @@ TEST_F(IPLocatorTests, setIPv6_from_string_std)
 
     // Std random address
     {
-        std::vector<int> vec(16, 0);
+        std::vector<unsigned int> vec(16, 0);
         vec[2] = 2;
         vec[3] = 3;
         vec[6] = 6;
@@ -479,10 +479,10 @@ TEST_F(IPLocatorTests, getIPv4)
     Locator_t locator;
     IPLocator::setIPv4(locator, ipv4_lo_address);
     auto res = IPLocator::getIPv4(locator);
-    ASSERT_EQ(res[0], 127);
-    ASSERT_EQ(res[1], 0);
-    ASSERT_EQ(res[2], 0);
-    ASSERT_EQ(res[3], 1);
+    ASSERT_EQ(res[0], 127u);
+    ASSERT_EQ(res[1], 0u);
+    ASSERT_EQ(res[2], 0u);
+    ASSERT_EQ(res[3], 1u);
 }
 
 /*
@@ -496,9 +496,9 @@ TEST_F(IPLocatorTests, getIPv6)
     auto res = IPLocator::getIPv6(locator);
     for (int i = 0; i < 15; i++)
     {
-        ASSERT_EQ(res[i], 0);
+        ASSERT_EQ(res[i], 0u);
     }
-    ASSERT_EQ(res[15], 1);
+    ASSERT_EQ(res[15], 1u);
 }
 
 /*
@@ -586,10 +586,10 @@ TEST_F(IPLocatorTests, copyIPv4)
     IPLocator::setIPv4(locator, ipv4_lo_address);
     unsigned char arr[4];
     ASSERT_TRUE(IPLocator::copyIPv4(locator, arr));
-    ASSERT_EQ(arr[0], 127);
-    ASSERT_EQ(arr[1], 0);
-    ASSERT_EQ(arr[2], 0);
-    ASSERT_EQ(arr[3], 1);
+    ASSERT_EQ(arr[0], 127u);
+    ASSERT_EQ(arr[1], 0u);
+    ASSERT_EQ(arr[2], 0u);
+    ASSERT_EQ(arr[3], 1u);
 }
 
 /*
@@ -604,9 +604,9 @@ TEST_F(IPLocatorTests, copyIPv6)
     ASSERT_TRUE(IPLocator::copyIPv6(locator, arr));
     for (int i = 0; i < 15; i++)
     {
-        ASSERT_EQ(arr[i], 0);
+        ASSERT_EQ(arr[i], 0u);
     }
-    ASSERT_EQ(arr[15], 1);
+    ASSERT_EQ(arr[15], 1u);
 }
 
 /*
@@ -705,18 +705,18 @@ TEST_F(IPLocatorTests, wan)
     Locator_t locator;
     IPLocator::createLocator(LOCATOR_KIND_TCPv4, ipv4_address, port1, locator);
     ASSERT_TRUE(IPLocator::setWan(locator, "0.1.2.3"));
-    for (int i = 0; i < 4; i++)
+    for (unsigned int i = 0; i < 4; i++)
     {
         ASSERT_EQ(locator.address[8 + i], i);
     }
 
-    ASSERT_TRUE(IPLocator::setWan(locator, 3, 2, 1, 0));
-    for (int i = 0; i < 4; i++)
+    ASSERT_TRUE(IPLocator::setWan(locator, 3u, 2u, 1u, 0u));
+    for (unsigned int i = 0; i < 4; i++)
     {
         ASSERT_EQ(locator.address[8 + i], 3 - i);
     }
 
-    for (int i = 0; i < 4; i++)
+    for (unsigned int i = 0; i < 4; i++)
     {
         ASSERT_EQ(IPLocator::getWan(locator)[i], 3 - i);
     }
@@ -838,7 +838,7 @@ TEST_F(IPLocatorTests, setPortRTPS)
 
     IPLocator::createLocator(LOCATOR_KIND_SHM, ipv4_lo_address, port1, locator);
     ASSERT_FALSE(IPLocator::setPortRTPS(locator, port1));
-    ASSERT_EQ(IPLocator::getPortRTPS(locator), 0);
+    ASSERT_EQ(IPLocator::getPortRTPS(locator), 0u);
 }
 
 /*
@@ -966,31 +966,31 @@ TEST_F(IPLocatorTests, to_string)
     Locator_t locator;
 
     // Invalid
-    IPLocator::createLocator(LOCATOR_KIND_INVALID, "1", 10, locator);
+    IPLocator::createLocator(LOCATOR_KIND_INVALID, "1", 10u, locator);
     ASSERT_EQ(IPLocator::to_string(locator), "Invalid_locator:[_]:0");
 
     // UDPv4
-    IPLocator::createLocator(LOCATOR_KIND_UDPv4, "0.1.0.1", 1, locator);
+    IPLocator::createLocator(LOCATOR_KIND_UDPv4, "0.1.0.1", 1u, locator);
     ASSERT_EQ(IPLocator::to_string(locator), "UDPv4:[0.1.0.1]:1");
 
     // TCPv4
-    IPLocator::createLocator(LOCATOR_KIND_TCPv4, "0.0.1.1", 2, locator);
+    IPLocator::createLocator(LOCATOR_KIND_TCPv4, "0.0.1.1", 2u, locator);
     ASSERT_EQ(IPLocator::to_string(locator), "TCPv4:[0.0.1.1]:2");
 
     // UDPv6
-    IPLocator::createLocator(LOCATOR_KIND_UDPv6, "200::", 3, locator);
+    IPLocator::createLocator(LOCATOR_KIND_UDPv6, "200::", 3u, locator);
     ASSERT_EQ(IPLocator::to_string(locator), "UDPv6:[200::]:3");
 
     // TCPv6
-    IPLocator::createLocator(LOCATOR_KIND_TCPv6, "::2", 4, locator);
+    IPLocator::createLocator(LOCATOR_KIND_TCPv6, "::2", 4u, locator);
     ASSERT_EQ(IPLocator::to_string(locator), "TCPv6:[::2]:4");
 
     // SHM
-    IPLocator::createLocator(LOCATOR_KIND_SHM, "", 5, locator);
+    IPLocator::createLocator(LOCATOR_KIND_SHM, "", 5u, locator);
     ASSERT_EQ(IPLocator::to_string(locator), "SHM:[_]:5");
 
     // SHM M
-    IPLocator::createLocator(LOCATOR_KIND_SHM, "", 6, locator);
+    IPLocator::createLocator(LOCATOR_KIND_SHM, "", 6u, locator);
     locator.address[0] = 'M';
     ASSERT_EQ(IPLocator::to_string(locator), "SHM:[M]:6");
 }
@@ -1036,7 +1036,7 @@ TEST_F(IPLocatorTests, setIPv4address)
     locator.kind = LOCATOR_KIND_TCPv4;
 
     ASSERT_TRUE(IPLocator::setIPv4address(locator, "1.2.3.4.5.6.7.8", "9.10.11.12", "13.14.15.16"));
-    for (int i = 0; i < 16; i++)
+    for (unsigned int i = 0; i < 16; i++)
     {
         ASSERT_EQ(locator.address[i], i + 1);
     }
@@ -1058,8 +1058,8 @@ TEST_F(IPLocatorTests, setIPv4address)
  */
 TEST(LocatorTests, locator_port_constructor)
 {
-    Locator_t locator(314);
-    ASSERT_EQ(locator.port, 314);
+    Locator_t locator(314u);
+    ASSERT_EQ(locator.port, 314u);
     ASSERT_EQ(locator.kind, LOCATOR_KIND_UDPv4);
     ASSERT_FALSE(IPLocator::hasIPv4(locator));
 }

--- a/test/unittest/utils/LocatorTests.cpp
+++ b/test/unittest/utils/LocatorTests.cpp
@@ -1102,15 +1102,15 @@ TEST(LocatorTests, push_back_negative)
     Locator_t locator_2;
     LocatorList_t locator_list;
 
-    ASSERT_EQ(locator_list.size(), 0);
+    ASSERT_EQ(locator_list.size(), 0u);
 
     IPLocator::createLocator(LOCATOR_KIND_UDPv6, "::1", 1, locator_1);
     locator_list.push_back(locator_1);
-    ASSERT_EQ(locator_list.size(), 1);
+    ASSERT_EQ(locator_list.size(), 1u);
 
     IPLocator::createLocator(LOCATOR_KIND_UDPv6, "::1", 1, locator_2);
     locator_list.push_back(locator_2);
-    ASSERT_EQ(locator_list.size(), 1);
+    ASSERT_EQ(locator_list.size(), 1u);
 }
 
 /*
@@ -1163,18 +1163,18 @@ TEST(LocatorTests, LocatorList_deserialization)
     LocatorList_t locator_list;
     std::stringstream ss;
 
-    ASSERT_EQ(locator_list.size(), 0);
+    ASSERT_EQ(locator_list.size(), 0u);
 
     // Empty list
     ss.str("[_]");
     ss >> locator_list;
-    ASSERT_EQ(locator_list.size(), 0);
+    ASSERT_EQ(locator_list.size(), 0u);
 
     // Filled list
     ss.clear();
     ss.str("[UDPv4:[1.1.1.1]:1,TCPv4:[2.2.2.2]:2]");
     ss >> locator_list;
-    ASSERT_EQ(locator_list.size(), 2);
+    ASSERT_EQ(locator_list.size(), 2u);
 }
 
 
@@ -1292,13 +1292,13 @@ TEST(RemoteLocatorsTests, RemoteLocator_deserialization)
     IPLocator::createLocator(LOCATOR_KIND_UDPv4, "224.0.0.0", 1, locator);
     rll.add_multicast_locator(locator);
     rll.add_unicast_locator(locator);
-    ASSERT_EQ(rll.multicast.size(), 1);
-    ASSERT_EQ(rll.unicast.size(), 1);
+    ASSERT_EQ(rll.multicast.size(), 1u);
+    ASSERT_EQ(rll.unicast.size(), 1u);
 
     serialized_ss.str("{}");
     serialized_ss >> rll;
-    ASSERT_EQ(rll.multicast.size(), 0);
-    ASSERT_EQ(rll.unicast.size(), 0);
+    ASSERT_EQ(rll.multicast.size(), 0u);
+    ASSERT_EQ(rll.unicast.size(), 0u);
 
     // Check Filled list
     std::string str_result = // this variable is needed to separate string in 2 lines
@@ -1307,16 +1307,16 @@ TEST(RemoteLocatorsTests, RemoteLocator_deserialization)
     serialized_ss.clear();
     serialized_ss.str(str_result);
     serialized_ss >> rll;
-    ASSERT_EQ(rll.multicast.size(), 2);
-    ASSERT_EQ(rll.unicast.size(), 2);
+    ASSERT_EQ(rll.multicast.size(), 2u);
+    ASSERT_EQ(rll.unicast.size(), 2u);
 
     // Check error List
     str_result = "{ERROR}";
     serialized_ss.clear();
     serialized_ss.str(str_result);
     serialized_ss >> rll;
-    ASSERT_EQ(rll.multicast.size(), 0);
-    ASSERT_EQ(rll.unicast.size(), 0);
+    ASSERT_EQ(rll.multicast.size(), 0u);
+    ASSERT_EQ(rll.unicast.size(), 0u);
 }
 
 /*******************************


### PR DESCRIPTION
Merge after #1594.

- Modify serialization/deserialization functions of Locator related classes.
- Add unittest for `Locatot.h`, `RemoteLocators.hpp` and `LocatorListComparisons.hpp`.
- Deprecate function of `LocatorList_t` and change test where is used.
 Note: Coverage has not been raised till 100% in every case due to some very specific error cases.