### PR TITLE
Correctly set participant subentities multicast default locators [10134]

### DIFF
--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1094,6 +1094,7 @@ bool RTPSParticipantImpl::createAndAssociateReceiverswithEndpoint(
     {
         //Default unicast
         pend->getAttributes().unicastLocatorList = m_att.defaultUnicastLocatorList;
+        pend->getAttributes().multicastLocatorList = m_att.defaultMulticastLocatorList;
     }
     createReceiverResources(pend->getAttributes().unicastLocatorList, false, true);
     createReceiverResources(pend->getAttributes().multicastLocatorList, false, true);

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -291,6 +291,12 @@ RTPSParticipantImpl::RTPSParticipantImpl(
                     m_network_Factory.fill_default_locator_port(domain_id_, loc, m_att, false);
                 });
 
+        std::for_each(m_att.defaultMulticastLocatorList.begin(), m_att.defaultMulticastLocatorList.end(),
+                [&](Locator_t& loc)
+                {
+                    m_network_Factory.fill_default_locator_port(domain_id_, loc, m_att, false);
+                });
+
     }
 
     // Normalize unicast locators.
@@ -1092,7 +1098,7 @@ bool RTPSParticipantImpl::createAndAssociateReceiverswithEndpoint(
     //In that case, just use the standard
     if (pend->getAttributes().unicastLocatorList.empty() && pend->getAttributes().multicastLocatorList.empty())
     {
-        //Default unicast
+        // Take default locators from the participant.
         pend->getAttributes().unicastLocatorList = m_att.defaultUnicastLocatorList;
         pend->getAttributes().multicastLocatorList = m_att.defaultMulticastLocatorList;
     }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -294,7 +294,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         std::for_each(m_att.defaultMulticastLocatorList.begin(), m_att.defaultMulticastLocatorList.end(),
                 [&](Locator_t& loc)
                 {
-                    m_network_Factory.fill_default_locator_port(domain_id_, loc, m_att, false);
+                    m_network_Factory.fill_default_locator_port(domain_id_, loc, m_att, true);
                 });
 
     }

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -904,6 +904,44 @@ public:
         return *this;
     }
 
+    PubSubReader& set_default_unicast_locators(
+            const eprosima::fastrtps::rtps::LocatorList_t& locators)
+    {
+        participant_qos_.wire_protocol().default_unicast_locator_list = locators;
+        return *this;
+    }
+
+    PubSubReader& add_to_default_unicast_locator_list(
+            const std::string& ip,
+            uint32_t port)
+    {
+        eprosima::fastrtps::rtps::Locator_t loc;
+        IPLocator::setIPv4(loc, ip);
+        loc.port = port;
+        participant_qos_.wire_protocol().default_unicast_locator_list.push_back(loc);
+
+        return *this;
+    }
+
+    PubSubReader& set_default_multicast_locators(
+            const eprosima::fastrtps::rtps::LocatorList_t& locators)
+    {
+        participant_qos_.wire_protocol().default_multicast_locator_list = locators;
+        return *this;
+    }
+
+    PubSubReader& add_to_default_multicast_locator_list(
+            const std::string& ip,
+            uint32_t port)
+    {
+        eprosima::fastrtps::rtps::Locator_t loc;
+        IPLocator::setIPv4(loc, ip);
+        loc.port = port;
+        participant_qos_.wire_protocol().default_multicast_locator_list.push_back(loc);
+
+        return *this;
+    }
+
     PubSubReader& initial_peers(
             eprosima::fastrtps::rtps::LocatorList_t initial_peers)
     {

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -829,9 +829,9 @@ public:
     }
 
     PubSubReader& unicastLocatorList(
-            eprosima::fastrtps::rtps::LocatorList_t unicastLocators)
+            const eprosima::fastrtps::rtps::LocatorList_t& unicast_locators)
     {
-        datareader_qos_.endpoint().unicast_locator_list = unicastLocators;
+        datareader_qos_.endpoint().unicast_locator_list = unicast_locators;
         return *this;
     }
 
@@ -840,7 +840,14 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
         loc.port = port;
         datareader_qos_.endpoint().unicast_locator_list.push_back(loc);
 
@@ -848,9 +855,9 @@ public:
     }
 
     PubSubReader& multicastLocatorList(
-            eprosima::fastrtps::rtps::LocatorList_t multicastLocators)
+            eprosima::fastrtps::rtps::LocatorList_t multicast_locators)
     {
-        datareader_qos_.endpoint().multicast_locator_list = multicastLocators;
+        datareader_qos_.endpoint().multicast_locator_list = multicast_locators;
         return *this;
     }
 
@@ -859,7 +866,15 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
+
         loc.port = port;
         datareader_qos_.endpoint().multicast_locator_list.push_back(loc);
 
@@ -867,9 +882,9 @@ public:
     }
 
     PubSubReader& metatraffic_unicast_locator_list(
-            eprosima::fastrtps::rtps::LocatorList_t unicastLocators)
+            const eprosima::fastrtps::rtps::LocatorList_t& unicast_locators)
     {
-        participant_qos_.wire_protocol().builtin.metatrafficUnicastLocatorList = unicastLocators;
+        participant_qos_.wire_protocol().builtin.metatrafficUnicastLocatorList = unicast_locators;
         return *this;
     }
 
@@ -878,7 +893,15 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
+
         loc.port = port;
         participant_qos_.wire_protocol().builtin.metatrafficUnicastLocatorList.push_back(loc);
 
@@ -886,9 +909,9 @@ public:
     }
 
     PubSubReader& metatraffic_multicast_locator_list(
-            eprosima::fastrtps::rtps::LocatorList_t unicastLocators)
+            const eprosima::fastrtps::rtps::LocatorList_t& multicast_locators)
     {
-        participant_qos_.wire_protocol().builtin.metatrafficMulticastLocatorList = unicastLocators;
+        participant_qos_.wire_protocol().builtin.metatrafficMulticastLocatorList = multicast_locators;
         return *this;
     }
 
@@ -897,7 +920,15 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
+
         loc.port = port;
         participant_qos_.wire_protocol().builtin.metatrafficMulticastLocatorList.push_back(loc);
 
@@ -916,7 +947,15 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
+
         loc.port = port;
         participant_qos_.wire_protocol().default_unicast_locator_list.push_back(loc);
 
@@ -935,7 +974,15 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
+
         loc.port = port;
         participant_qos_.wire_protocol().default_multicast_locator_list.push_back(loc);
 

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -966,6 +966,44 @@ public:
         return *this;
     }
 
+    PubSubWriter& set_default_unicast_locators(
+            const eprosima::fastrtps::rtps::LocatorList_t& locators)
+    {
+        participant_qos_.wire_protocol().default_unicast_locator_list = locators;
+        return *this;
+    }
+
+    PubSubWriter& add_to_default_unicast_locator_list(
+            const std::string& ip,
+            uint32_t port)
+    {
+        eprosima::fastrtps::rtps::Locator_t loc;
+        IPLocator::setIPv4(loc, ip);
+        loc.port = port;
+        participant_qos_.wire_protocol().default_unicast_locator_list.push_back(loc);
+
+        return *this;
+    }
+
+    PubSubWriter& set_default_multicast_locators(
+            const eprosima::fastrtps::rtps::LocatorList_t& locators)
+    {
+        participant_qos_.wire_protocol().default_multicast_locator_list = locators;
+        return *this;
+    }
+
+    PubSubWriter& add_to_default_multicast_locator_list(
+            const std::string& ip,
+            uint32_t port)
+    {
+        eprosima::fastrtps::rtps::Locator_t loc;
+        IPLocator::setIPv4(loc, ip);
+        loc.port = port;
+        participant_qos_.wire_protocol().default_multicast_locator_list.push_back(loc);
+
+        return *this;
+    }
+
     PubSubWriter& initial_peers(
             eprosima::fastrtps::rtps::LocatorList_t initial_peers)
     {

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -902,7 +902,15 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
+
         loc.port = port;
         datawriter_qos_.endpoint().unicast_locator_list.push_back(loc);
 
@@ -921,7 +929,15 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
+
         loc.port = port;
         datawriter_qos_.endpoint().multicast_locator_list.push_back(loc);
 
@@ -940,7 +956,15 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
+
         loc.port = port;
         participant_qos_.wire_protocol().builtin.metatrafficUnicastLocatorList.push_back(loc);
 
@@ -959,7 +983,15 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
+
         loc.port = port;
         participant_qos_.wire_protocol().builtin.metatrafficMulticastLocatorList.push_back(loc);
 
@@ -978,7 +1010,15 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
+
         loc.port = port;
         participant_qos_.wire_protocol().default_unicast_locator_list.push_back(loc);
 
@@ -997,7 +1037,15 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
+
         loc.port = port;
         participant_qos_.wire_protocol().default_multicast_locator_list.push_back(loc);
 

--- a/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
@@ -791,6 +791,44 @@ public:
         return *this;
     }
 
+    PubSubReader& defaultUnicastLocatorList(
+            eprosima::fastrtps::rtps::LocatorList_t unicastLocators)
+    {
+        participant_attr_.rtps.defaultUnicastLocatorList = unicastLocators;
+        return *this;
+    }
+
+    PubSubReader& add_to_default_unicast_locator_list(
+            const std::string& ip,
+            uint32_t port)
+    {
+        eprosima::fastrtps::rtps::Locator_t loc;
+        IPLocator::setIPv4(loc, ip);
+        loc.port = port;
+        participant_attr_.rtps.defaultUnicastLocatorList.push_back(loc);
+
+        return *this;
+    }
+
+    PubSubReader& defaultMulticastLocatorList(
+            eprosima::fastrtps::rtps::LocatorList_t multicastLocators)
+    {
+        participant_attr_.rtps.defaultMulticastLocatorList = multicastLocators;
+        return *this;
+    }
+
+    PubSubReader& add_to_default_multicast_locator_list(
+            const std::string& ip,
+            uint32_t port)
+    {
+        eprosima::fastrtps::rtps::Locator_t loc;
+        IPLocator::setIPv4(loc, ip);
+        loc.port = port;
+        participant_attr_.rtps.defaultMulticastLocatorList.push_back(loc);
+
+        return *this;
+    }
+
     PubSubReader& initial_peers(
             eprosima::fastrtps::rtps::LocatorList_t initial_peers)
     {

--- a/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
@@ -791,10 +791,10 @@ public:
         return *this;
     }
 
-    PubSubReader& defaultUnicastLocatorList(
-            eprosima::fastrtps::rtps::LocatorList_t unicastLocators)
+    PubSubReader& set_default_unicast_locators(
+            const eprosima::fastrtps::rtps::LocatorList_t& locators)
     {
-        participant_attr_.rtps.defaultUnicastLocatorList = unicastLocators;
+        participant_attr_.rtps.defaultUnicastLocatorList = locators;
         return *this;
     }
 
@@ -810,10 +810,10 @@ public:
         return *this;
     }
 
-    PubSubReader& defaultMulticastLocatorList(
-            eprosima::fastrtps::rtps::LocatorList_t multicastLocators)
+    PubSubReader& set_default_multicast_locators(
+            const eprosima::fastrtps::rtps::LocatorList_t& locators)
     {
-        participant_attr_.rtps.defaultMulticastLocatorList = multicastLocators;
+        participant_attr_.rtps.defaultMulticastLocatorList = locators;
         return *this;
     }
 

--- a/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
@@ -727,7 +727,15 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
+
         loc.port = port;
         subscriber_attr_.unicastLocatorList.push_back(loc);
 
@@ -746,7 +754,15 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
+
         loc.port = port;
         subscriber_attr_.multicastLocatorList.push_back(loc);
 
@@ -765,7 +781,15 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
+
         loc.port = port;
         participant_attr_.rtps.builtin.metatrafficUnicastLocatorList.push_back(loc);
 
@@ -784,7 +808,15 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
+
         loc.port = port;
         participant_attr_.rtps.builtin.metatrafficMulticastLocatorList.push_back(loc);
 
@@ -803,7 +835,15 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
+
         loc.port = port;
         participant_attr_.rtps.defaultUnicastLocatorList.push_back(loc);
 
@@ -822,7 +862,15 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
+
         loc.port = port;
         participant_attr_.rtps.defaultMulticastLocatorList.push_back(loc);
 

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
@@ -858,6 +858,44 @@ public:
         return *this;
     }
 
+    PubSubWriter& defaultUnicastLocatorList(
+            eprosima::fastrtps::rtps::LocatorList_t unicastLocators)
+    {
+        participant_attr_.rtps.defaultUnicastLocatorList = unicastLocators;
+        return *this;
+    }
+
+    PubSubWriter& add_to_default_unicast_locator_list(
+            const std::string& ip,
+            uint32_t port)
+    {
+        eprosima::fastrtps::rtps::Locator_t loc;
+        IPLocator::setIPv4(loc, ip);
+        loc.port = port;
+        participant_attr_.rtps.defaultUnicastLocatorList.push_back(loc);
+
+        return *this;
+    }
+
+    PubSubWriter& defaultMulticastLocatorList(
+            eprosima::fastrtps::rtps::LocatorList_t multicastLocators)
+    {
+        participant_attr_.rtps.defaultMulticastLocatorList = multicastLocators;
+        return *this;
+    }
+
+    PubSubWriter& add_to_default_multicast_locator_list(
+            const std::string& ip,
+            uint32_t port)
+    {
+        eprosima::fastrtps::rtps::Locator_t loc;
+        IPLocator::setIPv4(loc, ip);
+        loc.port = port;
+        participant_attr_.rtps.defaultMulticastLocatorList.push_back(loc);
+
+        return *this;
+    }
+
     PubSubWriter& initial_peers(
             eprosima::fastrtps::rtps::LocatorList_t initial_peers)
     {

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
@@ -858,10 +858,10 @@ public:
         return *this;
     }
 
-    PubSubWriter& defaultUnicastLocatorList(
-            eprosima::fastrtps::rtps::LocatorList_t unicastLocators)
+    PubSubWriter& set_default_unicast_locators(
+            const eprosima::fastrtps::rtps::LocatorList_t& locators)
     {
-        participant_attr_.rtps.defaultUnicastLocatorList = unicastLocators;
+        participant_attr_.rtps.defaultUnicastLocatorList = locators;
         return *this;
     }
 
@@ -877,10 +877,10 @@ public:
         return *this;
     }
 
-    PubSubWriter& defaultMulticastLocatorList(
-            eprosima::fastrtps::rtps::LocatorList_t multicastLocators)
+    PubSubWriter& set_default_multicast_locators(
+            const eprosima::fastrtps::rtps::LocatorList_t& locators)
     {
-        participant_attr_.rtps.defaultMulticastLocatorList = multicastLocators;
+        participant_attr_.rtps.defaultMulticastLocatorList = locators;
         return *this;
     }
 

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
@@ -794,7 +794,15 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
+
         loc.port = port;
         publisher_attr_.unicastLocatorList.push_back(loc);
 
@@ -813,7 +821,15 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
+
         loc.port = port;
         publisher_attr_.multicastLocatorList.push_back(loc);
 
@@ -832,7 +848,15 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
+
         loc.port = port;
         participant_attr_.rtps.builtin.metatrafficUnicastLocatorList.push_back(loc);
 
@@ -851,7 +875,15 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
+
         loc.port = port;
         participant_attr_.rtps.builtin.metatrafficMulticastLocatorList.push_back(loc);
 
@@ -870,7 +902,15 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
+
         loc.port = port;
         participant_attr_.rtps.defaultUnicastLocatorList.push_back(loc);
 
@@ -889,7 +929,15 @@ public:
             uint32_t port)
     {
         eprosima::fastrtps::rtps::Locator_t loc;
-        IPLocator::setIPv4(loc, ip);
+        if (!IPLocator::setIPv4(loc, ip))
+        {
+            loc.kind = LOCATOR_KIND_UDPv6;
+            if (!IPLocator::setIPv6(loc, ip))
+            {
+                return *this;
+            }
+        }
+
         loc.port = port;
         participant_attr_.rtps.defaultMulticastLocatorList.push_back(loc);
 

--- a/test/blackbox/common/BlackboxTestsTransportUDP.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportUDP.cpp
@@ -33,7 +33,7 @@ TEST(BlackBox, UDPv4TransportWrongConfig)
         testTransport->maxMessageSize = 100000;
 
         writer.disable_builtin_transport().
-        add_user_transport_to_pparams(testTransport).init();
+                add_user_transport_to_pparams(testTransport).init();
 
         ASSERT_FALSE(writer.isInitialized());
     }
@@ -45,7 +45,7 @@ TEST(BlackBox, UDPv4TransportWrongConfig)
         testTransport->sendBufferSize = 64000;
 
         writer.disable_builtin_transport().
-        add_user_transport_to_pparams(testTransport).init();
+                add_user_transport_to_pparams(testTransport).init();
 
         ASSERT_FALSE(writer.isInitialized());
     }
@@ -57,7 +57,7 @@ TEST(BlackBox, UDPv4TransportWrongConfig)
         testTransport->receiveBufferSize = 64000;
 
         writer.disable_builtin_transport().
-        add_user_transport_to_pparams(testTransport).init();
+                add_user_transport_to_pparams(testTransport).init();
 
         ASSERT_FALSE(writer.isInitialized());
     }
@@ -305,6 +305,76 @@ TEST(BlackBox, MetatraficMulticastLocatorsParticipant)
     PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
     reader.disable_builtin_transport().add_user_transport_to_pparams(transport);
     reader.add_to_metatraffic_multicast_locator_list("239.255.1.1", 22222);
+    reader.init();
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Wait for discovery.
+    writer.wait_discovery(std::chrono::seconds(3));
+    reader.wait_discovery(std::chrono::seconds(3));
+    ASSERT_TRUE(writer.is_matched());
+    ASSERT_TRUE(reader.is_matched());
+
+    auto data = default_helloworld_data_generator(writer_samples);
+    reader.startReception(data);
+    // Send data
+    writer.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+
+    // Block reader until reception finished or timeout.
+    reader.block_for_all();
+}
+
+// Checking correct copying of participant user data locators to the writers/readers
+TEST(BlackBox, DefaultMulticastLocatorsParticipantZeroPort)
+{
+    size_t writer_samples = 5;
+
+    PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+    writer.add_to_default_multicast_locator_list("239.255.0.2", 0);
+    writer.init();
+    ASSERT_TRUE(writer.isInitialized());
+
+    PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
+    reader.add_to_default_multicast_locator_list("239.255.0.1", 0);
+    reader.init();
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Wait for discovery.
+    writer.wait_discovery(std::chrono::seconds(3));
+    reader.wait_discovery(std::chrono::seconds(3));
+    ASSERT_TRUE(writer.is_matched());
+    ASSERT_TRUE(reader.is_matched());
+
+    auto data = default_helloworld_data_generator(writer_samples);
+    reader.startReception(data);
+    // Send data
+    writer.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+
+    // Block reader until reception finished or timeout.
+    reader.block_for_all();
+}
+
+// Checking correct copying of participant metatraffic locators to the datawriters/datatreaders
+TEST(BlackBox, MetatraficMulticastLocatorsParticipantZeroPort)
+{
+    Log::SetVerbosity(Log::Kind::Warning);
+
+    size_t writer_samples = 5;
+
+    auto transport = std::make_shared<UDPv4TransportDescriptor>();
+
+    PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+    writer.disable_builtin_transport().add_user_transport_to_pparams(transport);
+    writer.add_to_metatraffic_multicast_locator_list("239.255.1.2", 0);
+    writer.init();
+    ASSERT_TRUE(writer.isInitialized());
+
+    PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
+    reader.disable_builtin_transport().add_user_transport_to_pparams(transport);
+    reader.add_to_metatraffic_multicast_locator_list("239.255.1.1", 0);
     reader.init();
     ASSERT_TRUE(reader.isInitialized());
 

--- a/test/blackbox/common/BlackboxTestsTransportUDP.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportUDP.cpp
@@ -261,7 +261,7 @@ TEST(BlackBox, DefaultMulticastLocatorsParticipant)
     size_t writer_samples = 5;
 
     PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
-    writer.add_to_default_multicast_locator_list("239.255.0.2", 22222);
+    writer.add_to_default_multicast_locator_list("239.255.0.1", 22222);
     writer.init();
     ASSERT_TRUE(writer.isInitialized());
 
@@ -298,7 +298,7 @@ TEST(BlackBox, MetatraficMulticastLocatorsParticipant)
 
     PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
     writer.disable_builtin_transport().add_user_transport_to_pparams(transport);
-    writer.add_to_metatraffic_multicast_locator_list("239.255.1.2", 22222);
+    writer.add_to_metatraffic_multicast_locator_list("239.255.1.1", 22222);
     writer.init();
     ASSERT_TRUE(writer.isInitialized());
 
@@ -331,7 +331,7 @@ TEST(BlackBox, DefaultMulticastLocatorsParticipantZeroPort)
     size_t writer_samples = 5;
 
     PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
-    writer.add_to_default_multicast_locator_list("239.255.0.2", 0);
+    writer.add_to_default_multicast_locator_list("239.255.0.1", 0);
     writer.init();
     ASSERT_TRUE(writer.isInitialized());
 
@@ -368,7 +368,7 @@ TEST(BlackBox, MetatraficMulticastLocatorsParticipantZeroPort)
 
     PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
     writer.disable_builtin_transport().add_user_transport_to_pparams(transport);
-    writer.add_to_metatraffic_multicast_locator_list("239.255.1.2", 0);
+    writer.add_to_metatraffic_multicast_locator_list("239.255.1.1", 0);
     writer.init();
     ASSERT_TRUE(writer.isInitialized());
 


### PR DESCRIPTION
- Correctly set participant sub-entities multicast default locators when they are specified at the participant level and not at writer level.
- Added tests to check multicast discovery and user traffic.