### PR TITLE
Add new APIs returning unsupported [10143]

### DIFF
--- a/include/dds/core/detail/InstanceHandle.hpp
+++ b/include/dds/core/detail/InstanceHandle.hpp
@@ -18,7 +18,7 @@
 #ifndef EPROSIMA_DDS_CORE_DETAIL_INSTANCE_HANDLE_HPP_
 #define EPROSIMA_DDS_CORE_DETAIL_INSTANCE_HANDLE_HPP_
 
-#include <fastdds/rtps/common/InstanceHandle.h>
+#include <fastdds/dds/topic/TypeSupport.hpp>
 
 /**
  * @cond
@@ -29,7 +29,7 @@ namespace dds {
 namespace core {
 namespace detail {
 
-using InstanceHandle = eprosima::fastrtps::rtps::InstanceHandle_t;
+using InstanceHandle = eprosima::fastdds::dds::InstanceHandle_t;
 
 } //namespace detail
 } //namespace core

--- a/include/fastdds/dds/core/Entity.hpp
+++ b/include/fastdds/dds/core/Entity.hpp
@@ -21,7 +21,7 @@
 #define _FASTDDS_ENTITY_HPP_
 
 #include <fastdds/dds/core/status/StatusMask.hpp>
-#include <fastdds/rtps/common/InstanceHandle.h>
+#include <fastdds/dds/topic/TypeSupport.hpp>
 #include <fastrtps/types/TypesBase.h>
 
 namespace eprosima {
@@ -99,7 +99,7 @@ public:
      * @brief Retrieves the instance handler that represents the Entity
      * @return Reference to the InstanceHandle
      */
-    const fastrtps::rtps::InstanceHandle_t& get_instance_handle() const
+    const InstanceHandle_t& get_instance_handle() const
     {
         return instance_handle_;
     }
@@ -126,7 +126,7 @@ protected:
      * @param handle Instance Handle
      */
     RTPS_DllAPI void set_instance_handle(
-            const fastrtps::rtps::InstanceHandle_t& handle)
+            const InstanceHandle_t& handle)
     {
         instance_handle_ = handle;
     }
@@ -138,7 +138,7 @@ protected:
     StatusMask status_changes_;
 
     //! InstanceHandle associated to the Entity
-    fastrtps::rtps::InstanceHandle_t instance_handle_;
+    InstanceHandle_t instance_handle_;
 
     //! Boolean that states if the Entity is enabled or disabled
     bool enable_;

--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -1656,6 +1656,9 @@ public:
     int32_t depth;
 };
 
+//! A special value indicating an unlimited quantity
+constexpr int32_t LENGTH_UNLIMITED = -1;
+
 /**
  * Specifies the resources that the Service can consume in order to meet the requested QoS
  * @note Immutable Qos Policy
@@ -1746,9 +1749,9 @@ public:
         , QosPolicy(false)
         , history_kind(KEEP_LAST_HISTORY_QOS)
         , history_depth(1)
-        , max_samples(-1)
-        , max_instances(-1)
-        , max_samples_per_instance(-1)
+        , max_samples(LENGTH_UNLIMITED)
+        , max_instances(LENGTH_UNLIMITED)
+        , max_samples_per_instance(LENGTH_UNLIMITED)
     {
     }
 
@@ -1799,20 +1802,20 @@ public:
      * Specifies the maximum number of data-samples the DataWriter (or DataReader) can manage across all the instances
      * associated with it. Represents the maximum samples the middleware can store for any one DataWriter (or DataReader).
      * It is inconsistent for this value to be less than max_samples_per_instance. <br>
-     * By default, -1 (Length Unlimited).
+     * By default, LENGTH_UNLIMITED.
      */
     int32_t max_samples;
     /**
      * @brief Control the ResourceLimitsQos of the implied DataReader that stores the data within the durability service.
      * Represents the maximum number of instances DataWriter (or DataReader) can manage. <br>
-     * By default, -1 (Length Unlimited).
+     * By default, LENGTH_UNLIMITED.
      */
     int32_t max_instances;
     /**
      * @brief Control the ResourceLimitsQos of the implied DataReader that stores the data within the durability service.
      * Represents the maximum number of samples of any one instance a DataWriter(or DataReader) can manage.
      * It is inconsistent for this value to be greater than max_samples. <br>
-     * By default, -1 (Length Unlimited).
+     * By default, LENGTH_UNLIMITED.
      */
     int32_t max_samples_per_instance;
 };

--- a/include/fastdds/dds/core/status/DeadlineMissedStatus.hpp
+++ b/include/fastdds/dds/core/status/DeadlineMissedStatus.hpp
@@ -19,7 +19,7 @@
 #ifndef _FASTDDS_DDS_QOS_DEADLINEMISSEDSTATUS_HPP_
 #define _FASTDDS_DDS_QOS_DEADLINEMISSEDSTATUS_HPP_
 
-#include <fastdds/rtps/common/InstanceHandle.h>
+#include <fastdds/dds/topic/TypeSupport.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -50,7 +50,7 @@ struct DeadlineMissedStatus
     uint32_t total_count_change;
 
     //! @brief Handle to the last instance missing the deadline
-    fastrtps::rtps::InstanceHandle_t last_instance_handle;
+    InstanceHandle_t last_instance_handle;
 };
 
 //! Typedef of DeadlineMissedStatus

--- a/include/fastdds/dds/core/status/LivelinessChangedStatus.hpp
+++ b/include/fastdds/dds/core/status/LivelinessChangedStatus.hpp
@@ -19,7 +19,7 @@
 #ifndef _FASTDDS_DDS_QOS_LIVELINESSCHANGEDSTATUS_HPP_
 #define _FASTDDS_DDS_QOS_LIVELINESSCHANGEDSTATUS_HPP_
 
-#include <fastdds/rtps/common/InstanceHandle.h>
+#include <fastdds/dds/topic/TypeSupport.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -49,7 +49,7 @@ struct LivelinessChangedStatus
     int32_t not_alive_count_change = 0;
 
     //! @brief Handle to the last publisher whose change in liveliness caused this status to change
-    fastrtps::rtps::InstanceHandle_t last_publication_handle;
+    InstanceHandle_t last_publication_handle;
 };
 
 } //namespace dds

--- a/include/fastdds/dds/core/status/PublicationMatchedStatus.hpp
+++ b/include/fastdds/dds/core/status/PublicationMatchedStatus.hpp
@@ -20,8 +20,8 @@
 #define _PUBLICATION_MATCHED_STATUS_HPP_
 
 #include <cstdint>
-#include <fastrtps/rtps/common/InstanceHandle.h>
 #include <fastdds/dds/core/status/MatchedStatus.hpp>
+#include <fastdds/dds/topic/TypeSupport.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -31,7 +31,7 @@ namespace dds {
 struct PublicationMatchedStatus: public MatchedStatus
 {
 	//! @brief Handle to the last reader that matched the writer causing the status to change
-	eprosima::fastrtps::rtps::InstanceHandle_t last_subscription_handle;
+	InstanceHandle_t last_subscription_handle;
 };
 
 } // namespace dds

--- a/include/fastdds/dds/core/status/PublicationMatchedStatus.hpp
+++ b/include/fastdds/dds/core/status/PublicationMatchedStatus.hpp
@@ -14,7 +14,7 @@
 
 /**
  * @file PublicationMatchedStatus.hpp
-*/
+ */
 
 #ifndef _PUBLICATION_MATCHED_STATUS_HPP_
 #define _PUBLICATION_MATCHED_STATUS_HPP_
@@ -28,10 +28,10 @@ namespace fastdds {
 namespace dds {
 
 //! @brief A structure storing the publication status
-struct PublicationMatchedStatus: public MatchedStatus
+struct PublicationMatchedStatus : public MatchedStatus
 {
-	//! @brief Handle to the last reader that matched the writer causing the status to change
-	InstanceHandle_t last_subscription_handle;
+    //! @brief Handle to the last reader that matched the writer causing the status to change
+    InstanceHandle_t last_subscription_handle;
 };
 
 } // namespace dds

--- a/include/fastdds/dds/core/status/SampleRejectedStatus.hpp
+++ b/include/fastdds/dds/core/status/SampleRejectedStatus.hpp
@@ -20,7 +20,8 @@
 #define _FASTDDS_DDS_QOS_SAMPLEREJECTEDSTATUS_HPP_
 
 #include <cstdint>
-#include <fastdds/rtps/common/InstanceHandle.h>
+
+#include <fastdds/dds/topic/TypeSupport.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -61,7 +62,7 @@ struct SampleRejectedStatus
     /**
      * Handle to the instance being updated by the last sample that was rejected.
      */
-    fastrtps::rtps::InstanceHandle_t last_instance_handle;
+    InstanceHandle_t last_instance_handle;
 };
 
 } //namespace dds

--- a/include/fastdds/dds/core/status/SubscriptionMatchedStatus.hpp
+++ b/include/fastdds/dds/core/status/SubscriptionMatchedStatus.hpp
@@ -21,8 +21,8 @@
 
 #include <cstdint>
 
-#include <fastrtps/rtps/common/InstanceHandle.h>
 #include <fastdds/dds/core/status/MatchedStatus.hpp>
+#include <fastdds/dds/topic/TypeSupport.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -32,7 +32,7 @@ namespace dds {
 struct SubscriptionMatchedStatus: public MatchedStatus
 {
 	//! @brief Handle to the last writer that matched the reader causing the status change
-	eprosima::fastrtps::rtps::InstanceHandle_t last_publication_handle;
+	InstanceHandle_t last_publication_handle;
 };
 
 } // namespace dds

--- a/include/fastdds/dds/core/status/SubscriptionMatchedStatus.hpp
+++ b/include/fastdds/dds/core/status/SubscriptionMatchedStatus.hpp
@@ -14,7 +14,7 @@
 
 /**
  * @file SubscriptionMatchedStatus.hpp
-*/
+ */
 
 #ifndef _SUBSCRIPTION_MATCHED_STATUS_HPP_
 #define _SUBSCRIPTION_MATCHED_STATUS_HPP_
@@ -29,10 +29,10 @@ namespace fastdds {
 namespace dds {
 
 //! @brief A structure storing the subscription status
-struct SubscriptionMatchedStatus: public MatchedStatus
+struct SubscriptionMatchedStatus : public MatchedStatus
 {
-	//! @brief Handle to the last writer that matched the reader causing the status change
-	InstanceHandle_t last_publication_handle;
+    //! @brief Handle to the last writer that matched the reader causing the status change
+    InstanceHandle_t last_publication_handle;
 };
 
 } // namespace dds

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -287,22 +287,22 @@ public:
 
     /* TODO
        bool ignore_participant(
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
      */
 
     /* TODO
        bool ignore_topic(
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
      */
 
     /* TODO
        bool ignore_publication(
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
      */
 
     /* TODO
        bool ignore_subscription(
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
      */
 
     /**
@@ -485,24 +485,24 @@ public:
 
     /* TODO
        bool get_discovered_participants(
-            std::vector<fastrtps::rtps::InstanceHandle_t>& participant_handles) const;
+            std::vector<InstanceHandle_t>& participant_handles) const;
      */
 
     /* TODO
        bool get_discovered_participant_data(
             ParticipantBuiltinTopicData& participant_data,
-            const fastrtps::rtps::InstanceHandle_t& participant_handle) const;
+            const InstanceHandle_t& participant_handle) const;
      */
 
     /* TODO
        bool get_discovered_topics(
-            std::vector<fastrtps::rtps::InstanceHandle_t>& topic_handles) const;
+            std::vector<InstanceHandle_t>& topic_handles) const;
      */
 
     /* TODO
        bool get_discovered_topic_data(
             TopicBuiltinTopicData& topic_data,
-            const fastrtps::rtps::InstanceHandle_t& topic_handle) const;
+            const InstanceHandle_t& topic_handle) const;
      */
 
     /**
@@ -515,7 +515,7 @@ public:
      * @return True if entity is contained. False otherwise.
      */
     RTPS_DllAPI bool contains_entity(
-            const fastrtps::rtps::InstanceHandle_t& handle,
+            const InstanceHandle_t& handle,
             bool recursive = true) const;
 
     /**
@@ -539,7 +539,7 @@ public:
      * Returns the DomainParticipant's handle.
      * @return InstanceHandle of this DomainParticipant.
      */
-    RTPS_DllAPI const fastrtps::rtps::InstanceHandle_t& get_instance_handle() const;
+    RTPS_DllAPI const InstanceHandle_t& get_instance_handle() const;
 
     // From here legacy RTPS methods.
 

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -39,7 +39,6 @@ namespace rtps {
 
 class WriteParams;
 class WriterAttributes;
-struct InstanceHandle_t;
 struct GUID_t;
 
 } // namespace rtps
@@ -159,7 +158,7 @@ public:
      */
     RTPS_DllAPI ReturnCode_t write(
             void* data,
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
 
     /*!
      * @brief Informs that the application will be modifying a particular instance.
@@ -169,7 +168,7 @@ public:
      * This handle could be used in successive `write` or `dispose` operations.
      * In case of error, HANDLE_NIL will be returned.
      */
-    RTPS_DllAPI fastrtps::rtps::InstanceHandle_t register_instance(
+    RTPS_DllAPI InstanceHandle_t register_instance(
             void* instance);
 
     /*!
@@ -184,7 +183,7 @@ public:
      */
     RTPS_DllAPI ReturnCode_t unregister_instance(
             void* instance,
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
 
     /**
      * Returns the DataWriter's GUID
@@ -196,7 +195,7 @@ public:
      * Returns the DataWriter's InstanceHandle
      * @return Copy of the DataWriter InstanceHandle
      */
-    RTPS_DllAPI fastrtps::rtps::InstanceHandle_t get_instance_handle() const;
+    RTPS_DllAPI InstanceHandle_t get_instance_handle() const;
 
     /**
      * Get data type associated to the DataWriter
@@ -284,7 +283,7 @@ public:
     /* TODO
        bool get_key_value(
             void* key_holder,
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
      */
 
     /**
@@ -303,7 +302,7 @@ public:
      */
     RTPS_DllAPI ReturnCode_t dispose(
             void* data,
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
 
     /**
      * @brief Returns the liveliness lost status

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -19,14 +19,15 @@
 #ifndef _FASTRTPS_DATAWRITER_HPP_
 #define _FASTRTPS_DATAWRITER_HPP_
 
-#include <fastdds/rtps/common/Time_t.h>
-#include <fastrtps/qos/DeadlineMissedStatus.h>
-#include <fastdds/dds/core/status/IncompatibleQosStatus.hpp>
-#include <fastdds/dds/core/status/BaseStatus.hpp>
-#include <fastrtps/types/TypesBase.h>
 #include <fastdds/dds/core/Entity.hpp>
+#include <fastdds/dds/core/status/BaseStatus.hpp>
+#include <fastdds/dds/core/status/DeadlineMissedStatus.hpp>
+#include <fastdds/dds/core/status/IncompatibleQosStatus.hpp>
 #include <fastdds/dds/core/status/StatusMask.hpp>
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
+#include <fastdds/dds/topic/TypeSupport.hpp>
+#include <fastdds/rtps/common/Time_t.h>
+#include <fastrtps/types/TypesBase.h>
 
 using eprosima::fastrtps::types::ReturnCode_t;
 
@@ -217,7 +218,7 @@ public:
      * @return RETCODE_OK
      */
     RTPS_DllAPI ReturnCode_t get_offered_deadline_missed_status(
-            fastrtps::OfferedDeadlineMissedStatus& status);
+            OfferedDeadlineMissedStatus& status);
 
     /**
      * @brief Returns the offered incompatible qos status

--- a/include/fastdds/dds/publisher/Publisher.hpp
+++ b/include/fastdds/dds/publisher/Publisher.hpp
@@ -309,7 +309,7 @@ public:
      * Returns the Publisher's handle.
      * @return InstanceHandle of this Publisher.
      */
-    RTPS_DllAPI const fastrtps::rtps::InstanceHandle_t& get_instance_handle() const;
+    RTPS_DllAPI const InstanceHandle_t& get_instance_handle() const;
 
 protected:
 

--- a/include/fastdds/dds/publisher/Publisher.hpp
+++ b/include/fastdds/dds/publisher/Publisher.hpp
@@ -20,13 +20,14 @@
 #ifndef _FASTDDS_PUBLISHER_HPP_
 #define _FASTDDS_PUBLISHER_HPP_
 
-#include <fastrtps/fastrtps_dll.h>
-#include <fastdds/rtps/common/Time_t.h>
-#include <fastrtps/attributes/PublisherAttributes.h>
-#include <fastrtps/types/TypesBase.h>
 #include <fastdds/dds/core/Entity.hpp>
 #include <fastdds/dds/publisher/qos/PublisherQos.hpp>
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
+#include <fastdds/dds/topic/TypeSupport.hpp>
+#include <fastdds/rtps/common/Time_t.h>
+
+#include <fastrtps/fastrtps_dll.h>
+#include <fastrtps/types/TypesBase.h>
 
 using eprosima::fastrtps::types::ReturnCode_t;
 

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -20,8 +20,8 @@
 #ifndef _FASTDDS_DDS_SUBSCRIBER_DATAREADER_HPP_
 #define _FASTDDS_DDS_SUBSCRIBER_DATAREADER_HPP_
 
-#include <vector>
 #include <cstdint>
+#include <vector>
 
 #include <fastdds/dds/core/Entity.hpp>
 #include <fastdds/dds/core/LoanableCollection.hpp>

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -26,9 +26,9 @@
 #include <fastdds/dds/core/Entity.hpp>
 #include <fastdds/dds/core/LoanableCollection.hpp>
 #include <fastdds/dds/core/LoanableSequence.hpp>
-#include <fastdds/dds/core/status/StatusMask.hpp>
-#include <fastdds/dds/core/status/IncompatibleQosStatus.hpp>
 #include <fastdds/dds/core/status/DeadlineMissedStatus.hpp>
+#include <fastdds/dds/core/status/IncompatibleQosStatus.hpp>
+#include <fastdds/dds/core/status/StatusMask.hpp>
 #include <fastdds/dds/subscriber/SampleInfo.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
 #include <fastdds/rtps/common/Time_t.h>

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -98,20 +98,23 @@ protected:
 public:
 
     /**
-     * @brief Destructor
+     * @brief Destructor.
      */
     RTPS_DllAPI virtual ~DataReader();
 
     /**
-     * @brief This operation enables the DataReader
+     * @brief This operation enables the DataReader.
+     *
      * @return RETCODE_OK is successfully enabled. RETCODE_PRECONDITION_NOT_MET if the Subscriber creating this
      *         DataReader is not enabled.
      */
     RTPS_DllAPI ReturnCode_t enable() override;
 
     /**
-     * Method to block the current thread until an unread message is available
-     * @param timeout Max blocking time for this operation
+     * Method to block the current thread until an unread message is available.
+     *
+     * @param [in] timeout Max blocking time for this operation.
+     *
      * @return true if there is new unread message, false if timeout
      */
     RTPS_DllAPI bool wait_for_unread_message(
@@ -379,20 +382,23 @@ public:
             InstanceStateMask instance_states = ANY_INSTANCE_STATE);
 
     /**
-     * @brief This operation copies the next, non-previously accessed Data value from the DataReader; the operation also
-     * copies the corresponding SampleInfo. The implied order among the samples stored in the DataReader is the same as for
-     * the read operation.
+     * @brief This operation copies the next, non-previously accessed Data value from the DataReader; the operation
+     * also copies the corresponding SampleInfo. The implied order among the samples stored in the DataReader is the
+     * same as for the read operation.
      *
-     * The read_next_sample operation is semantically equivalent to the read operation where the input Data sequence has
-     * max_length=1, the sample_states=NOT_READ, the view_states=ANY_VIEW_STATE, and the instance_states=ANY_INSTANCE_STATE.
+     * The read_next_sample operation is semantically equivalent to the read operation where the input Data sequence
+     * has <tt> max_length = 1 </tt>, the <tt> sample_states = NOT_READ_SAMPLE_STATE </tt>, the
+     * <tt> view_states = ANY_VIEW_STATE </tt>, and the <tt> instance_states = ANY_INSTANCE_STATE </tt>.
      *
-     * The read_next_sample operation provides a simplified API to ‘read’ samples avoiding the need for the application to
-     * manage sequences and specify states.
+     * The read_next_sample operation provides a simplified API to ‘read’ samples avoiding the need for the
+     * application to manage sequences and specify states.
      *
-     * If there is no unread data in the DataReader, the operation will return NO_DATA and nothing is copied
-     * @param data Data pointer to store the sample
-     * @param info SampleInfo pointer to store the sample information
-     * @return RETCODE_NO_DATA if the history is empty, RETCODE_OK if the next sample is returned and RETCODE_ERROR otherwise
+     * If there is no unread data in the DataReader, the operation will return RETCODE_NO_DATA and nothing is copied
+     *
+     * @param [out] data Data pointer to store the sample
+     * @param [out] info SampleInfo pointer to store the sample information
+     *
+     * @return Any of the standard return codes.
      */
     RTPS_DllAPI ReturnCode_t read_next_sample(
             void* data,
@@ -514,20 +520,25 @@ public:
             InstanceStateMask instance_states = ANY_INSTANCE_STATE);
 
     /**
-     * @brief This operation copies the next, non-previously accessed Data value from the DataReader and ‘removes’ it from
-     * the DataReader so it is no longer accessible. The operation also copies the corresponding SampleInfo. This operation
-     * is analogous to the read_next_sample except for the fact that the sample is ‘removed’ from the DataReader.
+     * @brief This operation copies the next, non-previously accessed Data value from the DataReader and ‘removes’ it
+     * from the DataReader so it is no longer accessible. The operation also copies the corresponding SampleInfo.
      *
-     * The take_next_sample operation is semantically equivalent to the take operation where the input sequence has
-     * max_length=1, the sample_states=NOT_READ, the view_states=ANY_VIEW_STATE, and the instance_states=ANY_INSTANCE_STATE.
+     * This operation is analogous to @ref read_next_sample except for the fact that the sample is ‘removed’ from the
+     * DataReader.
      *
-     * This operation provides a simplified API to ’take’ samples avoiding the need for the application to manage sequences
-     * and specify states.
+     * This operation is semantically equivalent to the @ref take operation where the input sequence has
+     * <tt> max_length = 1 </tt>, the <tt> sample_states = NOT_READ_SAMPLE_STATE </tt>, the
+     * <tt> view_states = ANY_VIEW_STATE </tt>, and the <tt> instance_states = ANY_INSTANCE_STATE </tt>.
      *
-     * If there is no unread data in the DataReader, the operation will return NO_DATA and nothing is copied.
-     * @param data Data pointer to store the sample
-     * @param info SampleInfo pointer to store the sample information
-     * @return RETCODE_NO_DATA if the history is empty, RETCODE_OK if the next sample is returned and RETCODE_ERROR otherwise
+     * This operation provides a simplified API to ’take’ samples avoiding the need for the application to manage
+     * sequences and specify states.
+     *
+     * If there is no unread data in the DataReader, the operation will return RETCODE_NO_DATA and nothing is copied.
+     *
+     * @param [out] data Data pointer to store the sample
+     * @param [out] info SampleInfo pointer to store the sample information
+     *
+     * @return Any of the standard return codes.
      */
     RTPS_DllAPI ReturnCode_t take_next_sample(
             void* data,
@@ -574,77 +585,93 @@ public:
 
     /**
      * @brief Returns information about the first untaken sample.
+     *
      * @param [out] info Pointer to a SampleInfo_t structure to store first untaken sample information.
+     *
      * @return RETCODE_OK if sample info was returned. RETCODE_NO_DATA if there is no sample to take.
      */
     RTPS_DllAPI ReturnCode_t get_first_untaken_info(
             SampleInfo* info);
 
     /**
-     * Get associated GUID
+     * Get associated GUID.
+     *
      * @return Associated GUID
      */
     RTPS_DllAPI const fastrtps::rtps::GUID_t& guid();
 
     /**
-     * @brief Getter for the associated InstanceHandle
+     * @brief Getter for the associated InstanceHandle.
+     *
      * @return Copy of the InstanceHandle
      */
     RTPS_DllAPI InstanceHandle_t get_instance_handle() const;
 
     /**
-     * Getter for the data type
-     * @return TypeSupport associated to the DataReader
+     * Getter for the data type.
+     *
+     * @return TypeSupport associated to the DataReader.
      */
     TypeSupport type();
 
     /**
-     * Get TopicDescription
-     * @return TopicDescription pointer
+     * Get TopicDescription.
+     *
+     * @return TopicDescription pointer.
      */
     RTPS_DllAPI const TopicDescription* get_topicdescription() const;
 
     /**
-     * @brief Get the requested deadline missed status
-     * @return The deadline missed status
+     * @brief Get the requested deadline missed status.
+     *
+     * @return The deadline missed status.
      */
     RTPS_DllAPI ReturnCode_t get_requested_deadline_missed_status(
             RequestedDeadlineMissedStatus& status);
 
     /**
-     * @brief Get the requested incompatible qos status
-     * @param[out] status Requested incompatible qos status
+     * @brief Get the requested incompatible qos status.
+     *
+     * @param [out] status Requested incompatible qos status.
+     *
      * @return RETCODE_OK
      */
     RTPS_DllAPI ReturnCode_t get_requested_incompatible_qos_status(
             RequestedIncompatibleQosStatus& status);
 
     /**
-     * @brief Setter for the DataReaderQos
-     * @param qos new value for the DataReaderQos
-     * @return RETCODE_IMMUTABLE_POLICY if any of the Qos cannot be changed, RETCODE_INCONSISTENT_POLICY if the Qos is not
-     * self consistent and RETCODE_OK if the qos is changed correctly.
+     * @brief Setter for the DataReaderQos.
+     *
+     * @param [in] qos new value for the DataReaderQos.
+     *
+     * @return RETCODE_IMMUTABLE_POLICY if any of the Qos cannot be changed, RETCODE_INCONSISTENT_POLICY if the Qos is
+     *         not self consistent and RETCODE_OK if the qos is changed correctly.
      */
     RTPS_DllAPI ReturnCode_t set_qos(
             const DataReaderQos& qos);
 
     /**
-     * @brief Getter for the DataReaderQos
-     * @return Pointer to the DataReaderQos
+     * @brief Getter for the DataReaderQos.
+     *
+     * @return Pointer to the DataReaderQos.
      */
     RTPS_DllAPI const DataReaderQos& get_qos() const;
 
     /**
-     * @brief Getter for the DataReaderQos
-     * @param qos DataReaderQos where the qos is returned
+     * @brief Getter for the DataReaderQos.
+     *
+     * @param [in] qos DataReaderQos where the qos is returned.
+     *
      * @return RETCODE_OK
      */
     RTPS_DllAPI ReturnCode_t get_qos(
             DataReaderQos& qos) const;
 
     /**
-     * Modifies the DataReaderListener, sets the mask to StatusMask::all()
-     * @param listener new value for the DataReaderListener
+     * Modifies the DataReaderListener, sets the mask to StatusMask::all().
+     *
+     * @param [in] listener new value for the DataReaderListener.
+     *
      * @return RETCODE_OK
      */
     RTPS_DllAPI ReturnCode_t set_listener(
@@ -652,8 +679,10 @@ public:
 
     /**
      * Modifies the DataReaderListener.
-     * @param listener new value for the DataReaderListener
-     * @param mask StatusMask that holds statuses the listener responds to (default: all).
+     *
+     * @param [in] listener new value for the DataReaderListener.
+     * @param [in] mask StatusMask that holds statuses the listener responds to (default: all).
+     *
      * @return RETCODE_OK
      */
     RTPS_DllAPI ReturnCode_t set_listener(
@@ -672,8 +701,10 @@ public:
      */
 
     /**
-     * @brief Get the liveliness changed status
-     * @param status LivelinessChangedStatus object where the status is returned
+     * @brief Get the liveliness changed status.
+     *
+     * @param [out] status LivelinessChangedStatus object where the status is returned.
+     *
      * @return RETCODE_OK
      */
     RTPS_DllAPI ReturnCode_t get_liveliness_changed_status(

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -401,6 +401,45 @@ public:
     /**
      * Access a collection of data samples from the DataReader.
      *
+     * This operation accesses a collection of data-samples from the DataReader and a corresponding collection of
+     * SampleInfo structures, and 'removes' them from the DataReader. The operation will return either a 'list' of
+     * samples or else a single sample. This is controlled by the @ref PresentationQosPolicy using the same logic
+     * as for the @ref read operation.
+     *
+     * The act of taking a sample removes it from the DataReader so it cannot be 'read' or 'taken' again. If the
+     * sample belongs to the most recent generation of the instance, it will also set the @c view_state of the
+     * instance to NOT_NEW. It will not affect the @c instance_state of the instance.
+     *
+     * The behavior of the take operation follows the same rules than the @ref read operation regarding the
+     * pre-conditions and post-conditions for the @c data_values and @c sample_infos collections. Similar to
+     * @ref read, the take operation may 'loan' elements to the output collections which must then be returned by
+     * means of @ref return_loan. The only difference with @ref read is that, as stated, the samples returned by
+     * take will no longer be accessible to successive calls to read or take.
+     *
+     * If the DataReader has no samples that meet the constraints, the operations fails with RETCODE_NO_DATA.
+     *
+     * @param [in,out] data_values     A LoanableCollection object where the received data samples will be returned.
+     * @param [in,out] sample_infos    A SampleInfoSeq object where the received sample info will be returned.
+     * @param [in]     max_samples     The maximum number of samples to be returned. If the special value
+     *                                 @ref LENGTH_UNLIMITED is provided, as many samples will be returned as are
+     *                                 available, up to the limits described in the documentation for @ref read().
+     * @param [in]     sample_states   Only data samples with @c sample_state matching one of these will be returned.
+     * @param [in]     view_states     Only data samples with @c view_state matching one of these will be returned.
+     * @param [in]     instance_states Only data samples with @c instance_state matching one of these will be returned.
+     *
+     * @return Any of the standard return codes.
+     */
+    RTPS_DllAPI ReturnCode_t take(
+            LoanableCollection& data_values,
+            SampleInfoSeq& sample_infos,
+            int32_t max_samples = LENGTH_UNLIMITED,
+            SampleStateMask sample_states = ANY_SAMPLE_STATE,
+            ViewStateMask view_states = ANY_VIEW_STATE,
+            InstanceStateMask instance_states = ANY_INSTANCE_STATE);
+
+    /**
+     * Access a collection of data samples from the DataReader.
+     *
      * This operation accesses a collection of data values from the DataReader and 'removes' them from the DataReader.
      *
      * This operation has the same behavior as @ref read_instance, except that the samples are 'taken' from the

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -398,12 +398,44 @@ public:
             void* data,
             SampleInfo* info);
 
-    /* TODO
-       RTPS_DllAPI bool take(
-            std::vector<void*>& data_values,
-            std::vector<SampleInfo>& sample_infos,
-            uint32_t max_samples);
+    /**
+     * Access a collection of data samples from the DataReader.
+     *
+     * This operation accesses a collection of data values from the DataReader and 'removes' them from the DataReader.
+     *
+     * This operation has the same behavior as @ref read_next_instance, except that the samples are 'taken' from the
+     * DataReader such that they are no longer accessible via subsequent 'read' or 'take' operations.
+     *
+     * Similar to the operation @ref read_next_instance, it is possible to call this operation with a
+     * @c previous_handle that does not correspond to an instance currently managed by the DataReader.
+     *
+     * The behavior of this operation follows the same rules as the @read operation regarding the pre-conditions and
+     * post-conditions for the @c data_values and @c sample_infos. Similar to @ref read, this operation may 'loan'
+     * elements to the output collections, which must then be returned by means of @ref return_loan.
+     *
+     * If the DataReader has no samples that meet the constraints, the operations fails with RETCODE_NO_DATA.
+     *
+     * @param [in,out] data_values     A LoanableCollection object where the received data samples will be returned.
+     * @param [in,out] sample_infos    A SampleInfoSeq object where the received sample info will be returned.
+     * @param [in]     max_samples     The maximum number of samples to be returned. If the special value
+     *                                 @ref LENGTH_UNLIMITED is provided, as many samples will be returned as are
+     *                                 available, up to the limits described in the documentation for @ref read().
+     * @param [in]     previous_handle The 'next smallest' instance with a value greater than this value that has
+     *                                 available samples will be returned.
+     * @param [in]     sample_states   Only data samples with @c sample_state matching one of these will be returned.
+     * @param [in]     view_states     Only data samples with @c view_state matching one of these will be returned.
+     * @param [in]     instance_states Only data samples with @c instance_state matching one of these will be returned.
+     *
+     * @return Any of the standard return codes.
      */
+    RTPS_DllAPI ReturnCode_t take_next_instance(
+            LoanableCollection& data_values,
+            SampleInfoSeq& sample_infos,
+            int32_t max_samples = LENGTH_UNLIMITED,
+            const InstanceHandle_t& previous_handle = HANDLE_NIL,
+            SampleStateMask sample_states = ANY_SAMPLE_STATE,
+            ViewStateMask view_states = ANY_VIEW_STATE,
+            InstanceStateMask instance_states = ANY_INSTANCE_STATE);
 
     /**
      * @brief This operation copies the next, non-previously accessed Data value from the DataReader and ‘removes’ it from

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -536,6 +536,43 @@ public:
     ///@}
 
     /**
+     * This operation indicates to the DataReader that the application is done accessing the collection of
+     * @c data_values and @c sample_infos obtained by some earlier invocation of @ref read or @ref take on the
+     * DataReader.
+     *
+     * The @c data_values and @c sample_infos must belong to a single related ‘pair’; that is, they should correspond
+     * to a pair returned from a single call to read or take. The @c data_values and @c sample_infos must also have
+     * been obtained from the same DataReader to which they are returned. If either of these conditions is not met,
+     * the operation will fail and return RETCODE_PRECONDITION_NOT_MET.
+     *
+     * This operation allows implementations of the @ref read and @ref take operations to "loan" buffers from the
+     * DataReader to the application and in this manner provide "zero-copy" access to the data. During the loan, the
+     * DataReader will guarantee that the data and sample-information are not modified.
+     *
+     * It is not necessary for an application to return the loans immediately after the read or take calls. However,
+     * as these buffers correspond to internal resources inside the DataReader, the application should not retain them
+     * indefinitely.
+     *
+     * The use of the @ref return_loan operation is only necessary if the read or take calls "loaned" buffers to the
+     * application. This only occurs if the @c data_values and @c sample_infos collections had <tt> max_len == 0 </tt>
+     * at the time read or take was called. The application may also examine the @c owns property of the collection to
+     * determine if there is an outstanding loan. However, calling @ref return_loan on a collection that does not have
+     * a loan is safe and has no side effects.
+     *
+     * If the collections had a loan, upon return from return_loan the collections will have <tt> max_len == 0 </tt>.
+     *
+     * @param [in,out] data_values   A LoanableCollection object where the received data samples were obtained from
+     *                               an earlier invocation of read or take on this DataReader.
+     * @param [in,out] sample_infos  A SampleInfoSeq object where the received sample infos were obtained from
+     *                               an earlier invocation of read or take on this DataReader.
+     *
+     * @return Any of the standard return codes.
+     */
+    RTPS_DllAPI ReturnCode_t return_loan(
+            LoanableCollection& data_values,
+            SampleInfoSeq& sample_infos);
+
+    /**
      * @brief Returns information about the first untaken sample.
      * @param [out] info Pointer to a SampleInfo_t structure to store first untaken sample information.
      * @return RETCODE_OK if sample info was returned. RETCODE_NO_DATA if there is no sample to take.

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -403,6 +403,43 @@ public:
      *
      * This operation accesses a collection of data values from the DataReader and 'removes' them from the DataReader.
      *
+     * This operation has the same behavior as @ref read_instance, except that the samples are 'taken' from the
+     * DataReader such that they are no longer accessible via subsequent 'read' or 'take' operations.
+     *
+     * The behavior of this operation follows the same rules as the @read operation regarding the pre-conditions and
+     * post-conditions for the @c data_values and @c sample_infos. Similar to @ref read, this operation may 'loan'
+     * elements to the output collections, which must then be returned by means of @ref return_loan.
+     *
+     * If the DataReader has no samples that meet the constraints, the operations fails with RETCODE_NO_DATA.
+     *
+     * @param [in,out] data_values     A LoanableCollection object where the received data samples will be returned.
+     * @param [in,out] sample_infos    A SampleInfoSeq object where the received sample info will be returned.
+     * @param [in]     max_samples     The maximum number of samples to be returned. If the special value
+     *                                 @ref LENGTH_UNLIMITED is provided, as many samples will be returned as are
+     *                                 available, up to the limits described in the documentation for @ref read().
+     * @param [in]     a_handle        The specified instance to return samples for. The method will fail with
+     *                                 RETCODE_BAD_PARAMETER if the handle does not correspond to an existing
+     *                                 data-object known to the DataReader.
+     * @param [in]     sample_states   Only data samples with @c sample_state matching one of these will be returned.
+     * @param [in]     view_states     Only data samples with @c view_state matching one of these will be returned.
+     * @param [in]     instance_states Only data samples with @c instance_state matching one of these will be returned.
+     *
+     * @return Any of the standard return codes.
+     */
+    RTPS_DllAPI ReturnCode_t take_instance(
+            LoanableCollection& data_values,
+            SampleInfoSeq& sample_infos,
+            int32_t max_samples = LENGTH_UNLIMITED,
+            const InstanceHandle_t& a_handle = HANDLE_NIL,
+            SampleStateMask sample_states = ANY_SAMPLE_STATE,
+            ViewStateMask view_states = ANY_VIEW_STATE,
+            InstanceStateMask instance_states = ANY_INSTANCE_STATE);
+
+    /**
+     * Access a collection of data samples from the DataReader.
+     *
+     * This operation accesses a collection of data values from the DataReader and 'removes' them from the DataReader.
+     *
      * This operation has the same behavior as @ref read_next_instance, except that the samples are 'taken' from the
      * DataReader such that they are no longer accessible via subsequent 'read' or 'take' operations.
      *

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -338,7 +338,7 @@ public:
      * @brief Getter for the associated InstanceHandle
      * @return Copy of the InstanceHandle
      */
-    RTPS_DllAPI fastrtps::rtps::InstanceHandle_t get_instance_handle() const;
+    RTPS_DllAPI InstanceHandle_t get_instance_handle() const;
 
     /**
      * Getter for the data type
@@ -357,7 +357,7 @@ public:
      * @return The deadline missed status
      */
     RTPS_DllAPI ReturnCode_t get_requested_deadline_missed_status(
-            fastrtps::RequestedDeadlineMissedStatus& status);
+            RequestedDeadlineMissedStatus& status);
 
     /**
      * @brief Get the requested incompatible qos status
@@ -416,7 +416,7 @@ public:
     /* TODO
        RTPS_DllAPI bool get_key_value(
             void* data,
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
      */
 
     /**

--- a/include/fastdds/dds/subscriber/SampleInfo.hpp
+++ b/include/fastdds/dds/subscriber/SampleInfo.hpp
@@ -25,9 +25,9 @@
 #include <fastdds/dds/subscriber/ViewState.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
 
-#include <fastdds/rtps/common/Types.h>
-#include <fastdds/rtps/common/Time_t.h>
 #include <fastdds/rtps/common/SampleIdentity.h>
+#include <fastdds/rtps/common/Time_t.h>
+#include <fastdds/rtps/common/Types.h>
 
 namespace eprosima {
 namespace fastdds {

--- a/include/fastdds/dds/subscriber/SampleInfo.hpp
+++ b/include/fastdds/dds/subscriber/SampleInfo.hpp
@@ -23,10 +23,10 @@
 #include <fastdds/dds/subscriber/InstanceState.hpp>
 #include <fastdds/dds/subscriber/SampleState.hpp>
 #include <fastdds/dds/subscriber/ViewState.hpp>
+#include <fastdds/dds/topic/TypeSupport.hpp>
 
 #include <fastdds/rtps/common/Types.h>
 #include <fastdds/rtps/common/Time_t.h>
-#include <fastdds/rtps/common/InstanceHandle.h>
 #include <fastdds/rtps/common/SampleIdentity.h>
 
 namespace eprosima {
@@ -95,12 +95,12 @@ struct SampleInfo
     fastrtps::rtps::Time_t source_timestamp;
 
     //! identifies locally the corresponding instance
-    fastrtps::rtps::InstanceHandle_t instance_handle;
+    InstanceHandle_t instance_handle;
 
     //! identifies locally the DataWriter that modified the instance
     //!
     //! Is the same InstanceHandle_t that is returned by the operation get_matched_publications on the DataReader
-    fastrtps::rtps::InstanceHandle_t publication_handle;
+    InstanceHandle_t publication_handle;
 
     //! whether the DataSample contains data or is only used to communicate of a change in the instance
     bool valid_data;

--- a/include/fastdds/dds/subscriber/Subscriber.hpp
+++ b/include/fastdds/dds/subscriber/Subscriber.hpp
@@ -311,7 +311,7 @@ public:
      * Returns the Subscriber's handle.
      * @return InstanceHandle of this Subscriber.
      */
-    RTPS_DllAPI const fastrtps::rtps::InstanceHandle_t& get_instance_handle() const;
+    RTPS_DllAPI const InstanceHandle_t& get_instance_handle() const;
 
 protected:
 

--- a/include/fastdds/dds/subscriber/Subscriber.hpp
+++ b/include/fastdds/dds/subscriber/Subscriber.hpp
@@ -16,16 +16,15 @@
  * @file Subscriber.hpp
  */
 
-
 #ifndef _FASTDDS_SUBSCRIBER_HPP_
 #define _FASTDDS_SUBSCRIBER_HPP_
 
-#include <fastrtps/attributes/SubscriberAttributes.h>
-
+#include <fastdds/dds/core/Entity.hpp>
 #include <fastdds/dds/subscriber/DataReaderListener.hpp>
 #include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
+#include <fastdds/dds/topic/TypeSupport.hpp>
+
 #include <fastrtps/types/TypesBase.h>
-#include <fastdds/dds/core/Entity.hpp>
 
 using eprosima::fastrtps::types::ReturnCode_t;
 

--- a/include/fastdds/dds/subscriber/qos/DataReaderQos.hpp
+++ b/include/fastdds/dds/subscriber/qos/DataReaderQos.hpp
@@ -84,9 +84,7 @@ public:
     /**
      * @brief Constructor
      */
-    RTPS_DllAPI ReaderResourceLimitsQos()
-    {
-    }
+    RTPS_DllAPI ReaderResourceLimitsQos() = default;
 
     /**
      * @brief Destructor
@@ -105,8 +103,14 @@ public:
         std::swap(*this, reset);
     }
 
-    //!Matched publishers allocation limits.
-    fastrtps::ResourceLimitedContainerConfig matched_publisher_allocation;
+    //! Matched publishers allocation limits.
+    fastrtps::ResourceLimitedContainerConfig matched_publisher_allocation{ 1u };
+    //! SampleInfo allocation limits.
+    fastrtps::ResourceLimitedContainerConfig sample_infos_allocation{ 32u };
+    //! Loaned collections allocation limits.
+    fastrtps::ResourceLimitedContainerConfig outstanding_reads_allocation{ 2u };
+    //! Maximum number of samples to return on a single call to read / take
+    uint32_t max_samples_per_read = 32u;
 };
 
 //! Qos Policy to configure the XTypes Qos associated to the DataReader

--- a/include/fastdds/dds/topic/TopicDataType.hpp
+++ b/include/fastdds/dds/topic/TopicDataType.hpp
@@ -19,11 +19,14 @@
 #ifndef _FASTDDS_TOPICDATATYPE_HPP_
 #define _FASTDDS_TOPICDATATYPE_HPP_
 
-#include <fastrtps/fastrtps_dll.h>
-#include <fastdds/dds/core/policy/QosPolicies.hpp>
-
 #include <string>
 #include <functional>
+
+#include <fastdds/dds/core/policy/QosPolicies.hpp>
+#include <fastdds/rtps/common/InstanceHandle.h>
+
+#include <fastrtps/fastrtps_dll.h>
+#include <fastrtps/utils/md5.h>
 
 // This version of TypeSupport has `is_bounded()`
 #define TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED

--- a/include/fastdds/dds/topic/TypeSupport.hpp
+++ b/include/fastdds/dds/topic/TypeSupport.hpp
@@ -195,7 +195,7 @@ public:
      */
     RTPS_DllAPI virtual bool get_key(
             void* data,
-            fastrtps::rtps::InstanceHandle_t* i_handle,
+            InstanceHandle_t* i_handle,
             bool force_md5 = false)
     {
         return get()->getKey(data, i_handle, force_md5);

--- a/include/fastdds/dds/topic/TypeSupport.hpp
+++ b/include/fastdds/dds/topic/TypeSupport.hpp
@@ -31,6 +31,12 @@ namespace eprosima {
 namespace fastdds {
 namespace dds {
 
+//! Handle to identiy different instances of the same Topic of a certain type.
+using InstanceHandle_t = eprosima::fastrtps::rtps::InstanceHandle_t;
+
+//! The NIL instance handle.
+extern RTPS_DllAPI const InstanceHandle_t HANDLE_NIL;
+
 class DomainParticipant;
 
 /**

--- a/include/fastrtps/TopicDataType.h
+++ b/include/fastrtps/TopicDataType.h
@@ -20,9 +20,6 @@
 #define TOPICDATATYPE_H_
 
 #include <fastdds/dds/topic/TopicDataType.hpp>
-#include <fastdds/rtps/common/SerializedPayload.h>
-#include <fastdds/rtps/common/InstanceHandle.h>
-#include <fastrtps/utils/md5.h>
 
 namespace eprosima {
 namespace fastrtps {

--- a/include/fastrtps/qos/DeadlineMissedStatus.h
+++ b/include/fastrtps/qos/DeadlineMissedStatus.h
@@ -21,8 +21,6 @@
 
 #include <fastdds/dds/core/status/DeadlineMissedStatus.hpp>
 
-#include <fastdds/rtps/common/InstanceHandle.h>
-
 namespace eprosima {
 namespace fastrtps {
 

--- a/include/fastrtps/qos/LivelinessChangedStatus.h
+++ b/include/fastrtps/qos/LivelinessChangedStatus.h
@@ -21,8 +21,6 @@
 
 #include <fastdds/dds/core/status/LivelinessChangedStatus.hpp>
 
-#include <fastdds/rtps/common/InstanceHandle.h>
-
 namespace eprosima {
 namespace fastrtps {
 

--- a/include/fastrtps/qos/SampleRejectedStatus.hpp
+++ b/include/fastrtps/qos/SampleRejectedStatus.hpp
@@ -21,8 +21,6 @@
 
 #include <fastdds/dds/core/status/SampleRejectedStatus.hpp>
 
-#include <fastdds/rtps/common/InstanceHandle.h>
-
 namespace eprosima {
 namespace fastrtps {
 

--- a/src/cpp/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipant.cpp
@@ -210,7 +210,7 @@ ReturnCode_t DomainParticipant::unregister_type(
 
 /* TODO
    bool DomainParticipant::ignore_participant(
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
    {
     return impl_->ignore_participant(handle);
    }
@@ -218,7 +218,7 @@ ReturnCode_t DomainParticipant::unregister_type(
 
 /* TODO
    bool DomainParticipant::ignore_topic(
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
    {
     return impl_->ignore_topic(handle);
    }
@@ -226,7 +226,7 @@ ReturnCode_t DomainParticipant::unregister_type(
 
 /* TODO
    bool DomainParticipant::ignore_publication(
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
    {
     return impl_->ignore_publication(handle);
    }
@@ -234,7 +234,7 @@ ReturnCode_t DomainParticipant::unregister_type(
 
 /* TODO
    bool DomainParticipant::ignore_subscription(
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
    {
     return impl_->ignore_subscription(handle);
    }
@@ -334,7 +334,7 @@ ReturnCode_t DomainParticipant::get_topic_qos_from_profile(
 
 /* TODO
    bool DomainParticipant::get_discovered_participants(
-        std::vector<fastrtps::rtps::InstanceHandle_t>& participant_handles) const
+        std::vector<InstanceHandle_t>& participant_handles) const
    {
     return impl_->get_discovered_participants(participant_handles);
    }
@@ -342,14 +342,14 @@ ReturnCode_t DomainParticipant::get_topic_qos_from_profile(
 
 /* TODO
    bool DomainParticipant::get_discovered_topics(
-        std::vector<fastrtps::rtps::InstanceHandle_t>& topic_handles) const
+        std::vector<InstanceHandle_t>& topic_handles) const
    {
     return impl_->get_discovered_topics(topic_handles);
    }
  */
 
 bool DomainParticipant::contains_entity(
-        const fastrtps::rtps::InstanceHandle_t& handle,
+        const InstanceHandle_t& handle,
         bool recursive) const
 {
     return impl_->contains_entity(handle, recursive);
@@ -367,7 +367,7 @@ TypeSupport DomainParticipant::find_type(
     return impl_->find_type(type_name);
 }
 
-const fastrtps::rtps::InstanceHandle_t& DomainParticipant::get_instance_handle() const
+const InstanceHandle_t& DomainParticipant::get_instance_handle() const
 {
     return impl_->get_instance_handle();
 }

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -75,7 +75,6 @@ using fastrtps::rtps::ReaderDiscoveryInfo;
 using fastrtps::rtps::ReaderProxyData;
 using fastrtps::rtps::WriterDiscoveryInfo;
 using fastrtps::rtps::WriterProxyData;
-using fastrtps::rtps::InstanceHandle_t;
 using fastrtps::rtps::GUID_t;
 using fastrtps::rtps::EndpointKind_t;
 using fastrtps::rtps::ResourceEvent;
@@ -521,7 +520,7 @@ Publisher* DomainParticipantImpl::create_publisher_with_profile(
 
 /* TODO
    bool DomainParticipantImpl::ignore_participant(
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
    {
     (void)handle;
     logError(PARTICIPANT, "Not implemented.");
@@ -531,7 +530,7 @@ Publisher* DomainParticipantImpl::create_publisher_with_profile(
 
 /* TODO
    bool DomainParticipantImpl::ignore_topic(
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
    {
     (void)handle;
     logError(PARTICIPANT, "Not implemented.");
@@ -541,7 +540,7 @@ Publisher* DomainParticipantImpl::create_publisher_with_profile(
 
 /* TODO
    bool DomainParticipantImpl::ignore_publication(
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
    {
     (void)handle;
     logError(PARTICIPANT, "Not implemented.");
@@ -551,7 +550,7 @@ Publisher* DomainParticipantImpl::create_publisher_with_profile(
 
 /* TODO
    bool DomainParticipantImpl::ignore_subscription(
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
    {
     (void)handle;
     logError(PARTICIPANT, "Not implemented.");
@@ -736,7 +735,7 @@ const ReturnCode_t DomainParticipantImpl::get_topic_qos_from_profile(
 
 /* TODO
    bool DomainParticipantImpl::get_discovered_participants(
-        std::vector<fastrtps::rtps::InstanceHandle_t>& participant_handles) const
+        std::vector<InstanceHandle_t>& participant_handles) const
    {
     (void)participant_handles;
     logError(PARTICIPANT, "Not implemented.");
@@ -746,7 +745,7 @@ const ReturnCode_t DomainParticipantImpl::get_topic_qos_from_profile(
 
 /* TODO
    bool DomainParticipantImpl::get_discovered_topics(
-        std::vector<fastrtps::rtps::InstanceHandle_t>& topic_handles) const
+        std::vector<InstanceHandle_t>& topic_handles) const
    {
     (void)topic_handles;
     logError(PARTICIPANT, "Not implemented.");
@@ -755,7 +754,7 @@ const ReturnCode_t DomainParticipantImpl::get_topic_qos_from_profile(
  */
 
 bool DomainParticipantImpl::contains_entity(
-        const fastrtps::rtps::InstanceHandle_t& handle,
+        const InstanceHandle_t& handle,
         bool recursive) const
 {
     // Look for publishers
@@ -1801,7 +1800,7 @@ bool DomainParticipantImpl::can_qos_be_updated(
 }
 
 void DomainParticipantImpl::create_instance_handle(
-        fastrtps::rtps::InstanceHandle_t& handle)
+        InstanceHandle_t& handle)
 {
     using eprosima::fastrtps::rtps::octet;
 

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -233,22 +233,22 @@ public:
 
     /* TODO
        bool ignore_participant(
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
      */
 
     /* TODO
        bool ignore_topic(
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
      */
 
     /* TODO
        bool ignore_publication(
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
      */
 
     /* TODO
        bool ignore_subscription(
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
      */
 
     DomainId_t get_domain_id() const;
@@ -292,28 +292,28 @@ public:
 
     /* TODO
        bool get_discovered_participants(
-            std::vector<fastrtps::rtps::InstanceHandle_t>& participant_handles) const;
+            std::vector<InstanceHandle_t>& participant_handles) const;
      */
 
     /* TODO
        bool get_discovered_participant_data(
             ParticipantBuiltinTopicData& participant_data,
-            const fastrtps::rtps::InstanceHandle_t& participant_handle) const;
+            const InstanceHandle_t& participant_handle) const;
      */
 
     /* TODO
        bool get_discovered_topics(
-            std::vector<fastrtps::rtps::InstanceHandle_t>& topic_handles) const;
+            std::vector<InstanceHandle_t>& topic_handles) const;
      */
 
     /* TODO
        bool get_discovered_topic_data(
             TopicBuiltinTopicData& topic_data,
-            const fastrtps::rtps::InstanceHandle_t& topic_handle) const;
+            const InstanceHandle_t& topic_handle) const;
      */
 
     bool contains_entity(
-            const fastrtps::rtps::InstanceHandle_t& handle,
+            const InstanceHandle_t& handle,
             bool recursive = true) const;
 
     ReturnCode_t get_current_time(
@@ -336,7 +336,7 @@ public:
     const TypeSupport find_type(
             const std::string& type_name) const;
 
-    const fastrtps::rtps::InstanceHandle_t& get_instance_handle() const;
+    const InstanceHandle_t& get_instance_handle() const;
 
     // From here legacy RTPS methods.
 
@@ -418,14 +418,14 @@ protected:
 
     //!Publisher maps
     std::map<Publisher*, PublisherImpl*> publishers_;
-    std::map<fastrtps::rtps::InstanceHandle_t, Publisher*> publishers_by_handle_;
+    std::map<InstanceHandle_t, Publisher*> publishers_by_handle_;
     mutable std::mutex mtx_pubs_;
 
     PublisherQos default_pub_qos_;
 
     //!Subscriber maps
     std::map<Subscriber*, SubscriberImpl*> subscribers_;
-    std::map<fastrtps::rtps::InstanceHandle_t, Subscriber*> subscribers_by_handle_;
+    std::map<InstanceHandle_t, Subscriber*> subscribers_by_handle_;
     mutable std::mutex mtx_subs_;
 
     SubscriberQos default_sub_qos_;
@@ -436,7 +436,7 @@ protected:
 
     //!Topic map
     std::map<std::string, TopicImpl*> topics_;
-    std::map<fastrtps::rtps::InstanceHandle_t, Topic*> topics_by_handle_;
+    std::map<InstanceHandle_t, Topic*> topics_by_handle_;
     mutable std::mutex mtx_topics_;
 
     TopicQos default_topic_qos_;
@@ -513,7 +513,7 @@ protected:
     rtps_listener_;
 
     void create_instance_handle(
-            fastrtps::rtps::InstanceHandle_t& handle);
+            InstanceHandle_t& handle);
 
     bool exists_entity_id(
             const fastrtps::rtps::EntityId_t& entity_id) const;

--- a/src/cpp/fastdds/publisher/DataWriter.cpp
+++ b/src/cpp/fastdds/publisher/DataWriter.cpp
@@ -93,12 +93,12 @@ bool DataWriter::write(
 
 ReturnCode_t DataWriter::write(
         void* data,
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
 {
     return impl_->write(data, handle);
 }
 
-fastrtps::rtps::InstanceHandle_t DataWriter::register_instance(
+InstanceHandle_t DataWriter::register_instance(
         void* instance)
 {
     return impl_->register_instance(instance);
@@ -106,14 +106,14 @@ fastrtps::rtps::InstanceHandle_t DataWriter::register_instance(
 
 ReturnCode_t DataWriter::unregister_instance(
         void* instance,
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
 {
     return impl_->unregister_instance(instance, handle);
 }
 
 ReturnCode_t DataWriter::dispose(
         void* data,
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
 {
     return impl_->unregister_instance(data, handle, true);
 }
@@ -123,7 +123,7 @@ const fastrtps::rtps::GUID_t& DataWriter::guid() const
     return impl_->guid();
 }
 
-fastrtps::rtps::InstanceHandle_t DataWriter::get_instance_handle() const
+InstanceHandle_t DataWriter::get_instance_handle() const
 {
     return impl_->get_instance_handle();
 }

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -423,7 +423,7 @@ bool DataWriterImpl::write(
 
 ReturnCode_t DataWriterImpl::write(
         void* data,
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
 {
     if (writer_ == nullptr)
     {
@@ -451,7 +451,7 @@ ReturnCode_t DataWriterImpl::write(
     return create_new_change_with_params(ALIVE, data, wparams, instance_handle);
 }
 
-fastrtps::rtps::InstanceHandle_t DataWriterImpl::register_instance(
+InstanceHandle_t DataWriterImpl::register_instance(
         void* key)
 {
     /// Preconditions
@@ -715,7 +715,7 @@ ReturnCode_t DataWriterImpl::create_new_change_with_params(
         ChangeKind_t changeKind,
         void* data,
         WriteParams& wparams,
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
 {
     ReturnCode_t ret_code = check_new_change_preconditions(changeKind, data);
     if (!ret_code)

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -156,7 +156,7 @@ public:
      */
     ReturnCode_t write(
             void* data,
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
 
     /*!
      * @brief Implementation of the DDS `register_instance` operation.
@@ -166,7 +166,7 @@ public:
      * This handle could be used in successive `write` or `dispose` operations.
      * In case of error, HANDLE_NIL will be returned.
      */
-    fastrtps::rtps::InstanceHandle_t register_instance(
+    InstanceHandle_t register_instance(
             void* instance);
 
     /*!
@@ -184,7 +184,7 @@ public:
      */
     ReturnCode_t unregister_instance(
             void* instance,
-            const fastrtps::rtps::InstanceHandle_t& handle,
+            const InstanceHandle_t& handle,
             bool dispose = false);
 
     /**
@@ -193,7 +193,7 @@ public:
      */
     const fastrtps::rtps::GUID_t& guid() const;
 
-    fastrtps::rtps::InstanceHandle_t get_instance_handle() const;
+    InstanceHandle_t get_instance_handle() const;
 
     /**
      * Get topic data type
@@ -228,7 +228,7 @@ public:
     /* TODO
        bool get_key_value(
             void* key_holder,
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
      */
 
     ReturnCode_t get_liveliness_lost_status(
@@ -316,7 +316,7 @@ protected:
     std::chrono::duration<double, std::ratio<1, 1000000>> deadline_duration_us_;
 
     //! The current timer owner, i.e. the instance which started the deadline timer
-    fastrtps::rtps::InstanceHandle_t timer_owner_;
+    InstanceHandle_t timer_owner_;
 
     //! The offered deadline missed status
     fastrtps::OfferedDeadlineMissedStatus deadline_missed_status_;
@@ -372,7 +372,7 @@ protected:
             fastrtps::rtps::ChangeKind_t kind,
             void* data,
             fastrtps::rtps::WriteParams& wparams,
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
 
     /**
      * Removes the cache change with the minimum sequence number
@@ -403,7 +403,7 @@ protected:
             fastrtps::rtps::ChangeKind_t change_kind,
             void* data,
             fastrtps::rtps::WriteParams& wparams,
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
 
     static fastrtps::TopicAttributes get_topic_attributes(
             const DataWriterQos& qos,

--- a/src/cpp/fastdds/subscriber/DataReader.cpp
+++ b/src/cpp/fastdds/subscriber/DataReader.cpp
@@ -136,6 +136,26 @@ ReturnCode_t DataReader::read_next_instance(
     return ReturnCode_t::RETCODE_UNSUPPORTED;
 }
 
+ReturnCode_t DataReader::take_next_instance(
+        LoanableCollection& data_values,
+        SampleInfoSeq& sample_infos,
+        int32_t max_samples,
+        const InstanceHandle_t& previous_handle,
+        SampleStateMask sample_states,
+        ViewStateMask view_states,
+        InstanceStateMask instance_states)
+{
+    static_cast<void>(data_values);
+    static_cast<void>(sample_infos);
+    static_cast<void>(max_samples);
+    static_cast<void>(previous_handle);
+    static_cast<void>(sample_states);
+    static_cast<void>(view_states);
+    static_cast<void>(instance_states);
+
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
 ReturnCode_t DataReader::read_next_sample(
         void* data,
         SampleInfo* info)

--- a/src/cpp/fastdds/subscriber/DataReader.cpp
+++ b/src/cpp/fastdds/subscriber/DataReader.cpp
@@ -96,6 +96,26 @@ ReturnCode_t DataReader::read(
     return ReturnCode_t::RETCODE_UNSUPPORTED;
 }
 
+ReturnCode_t DataReader::read_instance(
+        LoanableCollection& data_values,
+        SampleInfoSeq& sample_infos,
+        int32_t max_samples,
+        const InstanceHandle_t& a_handle,
+        SampleStateMask sample_states,
+        ViewStateMask view_states,
+        InstanceStateMask instance_states)
+{
+    static_cast<void>(data_values);
+    static_cast<void>(sample_infos);
+    static_cast<void>(max_samples);
+    static_cast<void>(a_handle);
+    static_cast<void>(sample_states);
+    static_cast<void>(view_states);
+    static_cast<void>(instance_states);
+
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
 ReturnCode_t DataReader::read_next_sample(
         void* data,
         SampleInfo* info)

--- a/src/cpp/fastdds/subscriber/DataReader.cpp
+++ b/src/cpp/fastdds/subscriber/DataReader.cpp
@@ -201,7 +201,7 @@ const DataReaderListener* DataReader::get_listener() const
 /* TODO
    bool DataReader::get_key_value(
         void* data,
-        const rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
    {
     return impl->get_key_value(...);
    }

--- a/src/cpp/fastdds/subscriber/DataReader.cpp
+++ b/src/cpp/fastdds/subscriber/DataReader.cpp
@@ -194,6 +194,16 @@ ReturnCode_t DataReader::take_next_instance(
     return ReturnCode_t::RETCODE_UNSUPPORTED;
 }
 
+ReturnCode_t DataReader::return_loan(
+        LoanableCollection& data_values,
+        SampleInfoSeq& sample_infos)
+{
+    static_cast<void>(data_values);
+    static_cast<void>(sample_infos);
+
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
 ReturnCode_t DataReader::read_next_sample(
         void* data,
         SampleInfo* info)

--- a/src/cpp/fastdds/subscriber/DataReader.cpp
+++ b/src/cpp/fastdds/subscriber/DataReader.cpp
@@ -116,6 +116,26 @@ ReturnCode_t DataReader::read_instance(
     return ReturnCode_t::RETCODE_UNSUPPORTED;
 }
 
+ReturnCode_t DataReader::read_next_instance(
+        LoanableCollection& data_values,
+        SampleInfoSeq& sample_infos,
+        int32_t max_samples,
+        const InstanceHandle_t& previous_handle,
+        SampleStateMask sample_states,
+        ViewStateMask view_states,
+        InstanceStateMask instance_states)
+{
+    static_cast<void>(data_values);
+    static_cast<void>(sample_infos);
+    static_cast<void>(max_samples);
+    static_cast<void>(previous_handle);
+    static_cast<void>(sample_states);
+    static_cast<void>(view_states);
+    static_cast<void>(instance_states);
+
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
 ReturnCode_t DataReader::read_next_sample(
         void* data,
         SampleInfo* info)

--- a/src/cpp/fastdds/subscriber/DataReader.cpp
+++ b/src/cpp/fastdds/subscriber/DataReader.cpp
@@ -136,6 +136,24 @@ ReturnCode_t DataReader::read_next_instance(
     return ReturnCode_t::RETCODE_UNSUPPORTED;
 }
 
+ReturnCode_t DataReader::take(
+        LoanableCollection& data_values,
+        SampleInfoSeq& sample_infos,
+        int32_t max_samples,
+        SampleStateMask sample_states,
+        ViewStateMask view_states,
+        InstanceStateMask instance_states)
+{
+    static_cast<void>(data_values);
+    static_cast<void>(sample_infos);
+    static_cast<void>(max_samples);
+    static_cast<void>(sample_states);
+    static_cast<void>(view_states);
+    static_cast<void>(instance_states);
+
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
 ReturnCode_t DataReader::take_instance(
         LoanableCollection& data_values,
         SampleInfoSeq& sample_infos,

--- a/src/cpp/fastdds/subscriber/DataReader.cpp
+++ b/src/cpp/fastdds/subscriber/DataReader.cpp
@@ -136,6 +136,26 @@ ReturnCode_t DataReader::read_next_instance(
     return ReturnCode_t::RETCODE_UNSUPPORTED;
 }
 
+ReturnCode_t DataReader::take_instance(
+        LoanableCollection& data_values,
+        SampleInfoSeq& sample_infos,
+        int32_t max_samples,
+        const InstanceHandle_t& a_handle,
+        SampleStateMask sample_states,
+        ViewStateMask view_states,
+        InstanceStateMask instance_states)
+{
+    static_cast<void>(data_values);
+    static_cast<void>(sample_infos);
+    static_cast<void>(max_samples);
+    static_cast<void>(a_handle);
+    static_cast<void>(sample_states);
+    static_cast<void>(view_states);
+    static_cast<void>(instance_states);
+
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
 ReturnCode_t DataReader::take_next_instance(
         LoanableCollection& data_values,
         SampleInfoSeq& sample_infos,

--- a/src/cpp/fastdds/subscriber/DataReader.cpp
+++ b/src/cpp/fastdds/subscriber/DataReader.cpp
@@ -78,6 +78,24 @@ bool DataReader::wait_for_unread_message(
     return impl_->wait_for_unread_message(timeout);
 }
 
+ReturnCode_t DataReader::read(
+        LoanableCollection& data_values,
+        SampleInfoSeq& sample_infos,
+        int32_t max_samples,
+        SampleStateMask sample_states,
+        ViewStateMask view_states,
+        InstanceStateMask instance_states)
+{
+    static_cast<void>(data_values);
+    static_cast<void>(sample_infos);
+    static_cast<void>(max_samples);
+    static_cast<void>(sample_states);
+    static_cast<void>(view_states);
+    static_cast<void>(instance_states);
+
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
 ReturnCode_t DataReader::read_next_sample(
         void* data,
         SampleInfo* info)

--- a/src/cpp/fastdds/topic/TypeSupport.cpp
+++ b/src/cpp/fastdds/topic/TypeSupport.cpp
@@ -20,7 +20,11 @@
 #include <fastdds/dds/topic/TypeSupport.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 
-using namespace eprosima::fastdds::dds;
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+
+const InstanceHandle_t HANDLE_NIL;
 
 ReturnCode_t TypeSupport::register_type(
         DomainParticipant* participant,
@@ -34,3 +38,7 @@ ReturnCode_t TypeSupport::register_type(
 {
     return participant->register_type(*this, get_type_name());
 }
+
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima


### PR DESCRIPTION
This PR adds standard read/take APIs to the DataReader.

NB:
* destination is not master branch, but the main branch for the DataReader new APIs
* they all return UNSUPPORTED, as this PR just adds the APIs, not the implementation

This will be followed with a PR adding (failing) tests