### PR TITLE
Update full history flag on change removal [10169]

### DIFF
--- a/src/cpp/rtps/history/ReaderHistory.cpp
+++ b/src/cpp/rtps/history/ReaderHistory.cpp
@@ -123,13 +123,16 @@ History::iterator ReaderHistory::remove_change_nts(
     }
 
     CacheChange_t* change = *removal;
+    auto ret_val = m_changes.erase(removal);
+    m_isHistoryFull = false;
+
     mp_reader->change_removed_by_history(change);
-    if ( release )
+    if (release)
     {
         mp_reader->releaseCache(change);
     }
 
-    return m_changes.erase(removal);
+    return ret_val;
 }
 
 bool ReaderHistory::remove_changes_with_guid(


### PR DESCRIPTION
Take a Reader with a full history, where some of the changes in the history com from a given Writer.
When the writer unmatches, its changes should be removed from the reader's history and some space made for new changes.
However, although the changes are being removed, the `m_isHistoryFull` flag is not being updated, making the reader think the history is still full and discarding any new change.

Update the `m_isHistoryFull` flag when removing changes and make a regression test