### PR TITLE
Install FindAtomic.cmake [9825]

### DIFF
--- a/cmake/packaging/Config.cmake.in
+++ b/cmake/packaging/Config.cmake.in
@@ -24,7 +24,7 @@ set_and_check(@PROJECT_NAME@_LIB_DIR "@PACKAGE_LIB_INSTALL_DIR@")
 
 find_package(fastcdr REQUIRED)
 find_package(foonathan_memory REQUIRED)
-find_package(Atomic MODULE HINTS "${CMAKE_CURRENT_LIST_DIR}/modules")
+find_package(Atomic REQUIRED HINTS "${CMAKE_CURRENT_LIST_DIR}/modules")
 find_package(TinyXML2 QUIET)
 @FASTRTPS_PACKAGE_OPT_DEPS@
 

--- a/cmake/packaging/Config.cmake.in
+++ b/cmake/packaging/Config.cmake.in
@@ -24,6 +24,7 @@ set_and_check(@PROJECT_NAME@_LIB_DIR "@PACKAGE_LIB_INSTALL_DIR@")
 
 find_package(fastcdr REQUIRED)
 find_package(foonathan_memory REQUIRED)
+find_package(Atomic MODULE)
 find_package(TinyXML2 QUIET)
 @FASTRTPS_PACKAGE_OPT_DEPS@
 

--- a/cmake/packaging/Config.cmake.in
+++ b/cmake/packaging/Config.cmake.in
@@ -24,8 +24,9 @@ set_and_check(@PROJECT_NAME@_LIB_DIR "@PACKAGE_LIB_INSTALL_DIR@")
 
 find_package(fastcdr REQUIRED)
 find_package(foonathan_memory REQUIRED)
-find_package(Atomic REQUIRED HINTS "${CMAKE_CURRENT_LIST_DIR}/modules")
 find_package(TinyXML2 QUIET)
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_LIST_DIR}/modules")
+find_package(Atomic MODULE REQUIRED)
 @FASTRTPS_PACKAGE_OPT_DEPS@
 
 include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake)

--- a/cmake/packaging/Config.cmake.in
+++ b/cmake/packaging/Config.cmake.in
@@ -25,8 +25,17 @@ set_and_check(@PROJECT_NAME@_LIB_DIR "@PACKAGE_LIB_INSTALL_DIR@")
 find_package(fastcdr REQUIRED)
 find_package(foonathan_memory REQUIRED)
 find_package(TinyXML2 QUIET)
+
+# Find atomic using Fast DDS FindAtomic.cmake
+#    1. Save incoming CMAKE_MODULE_PATH
+#    2. Extend CMAKE_MODULE_PATH so atomic can be found
+#    3. Reset CMAKE_MODULE_PATH to incoming value
+#    4. Unset temp variable
+set(TEMP_CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}")
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_LIST_DIR}/modules")
 find_package(Atomic MODULE REQUIRED)
+set(CMAKE_MODULE_PATH "${TEMP_CMAKE_MODULE_PATH}")
+unset(TEMP_CMAKE_MODULE_PATH)
 @FASTRTPS_PACKAGE_OPT_DEPS@
 
 include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake)

--- a/cmake/packaging/Config.cmake.in
+++ b/cmake/packaging/Config.cmake.in
@@ -24,7 +24,7 @@ set_and_check(@PROJECT_NAME@_LIB_DIR "@PACKAGE_LIB_INSTALL_DIR@")
 
 find_package(fastcdr REQUIRED)
 find_package(foonathan_memory REQUIRED)
-find_package(Atomic MODULE)
+find_package(Atomic MODULE HINTS "${CMAKE_CURRENT_LIST_DIR}/modules")
 find_package(TinyXML2 QUIET)
 @FASTRTPS_PACKAGE_OPT_DEPS@
 

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -630,6 +630,11 @@ elseif(NOT EPROSIMA_INSTALLER)
         COMPONENT cmake
         )
 
+    install(FILES ${PROJECT_SOURCE_DIR}/cmake/modules/FindAtomic.cmake
+        DESTINATION ${INSTALL_DESTINATION_PATH}/modules
+        COMPONENT cmake
+        )
+
     if(MSVCARCH_EXTENSION)
         string(TOUPPER "${MSVC_ARCH}" MSVC_ARCH_UPPER)
         set(CPACK_COMPONENT_LIBRARIES_${MSVC_ARCH_UPPER}_DISPLAY_NAME "${MSVC_ARCH}" PARENT_SCOPE)

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -425,10 +425,11 @@ elseif(NOT EPROSIMA_INSTALLER)
         $<$<BOOL:${LINK_SSL}>:OpenSSL::SSL$<SEMICOLON>OpenSSL::Crypto>
         $<$<BOOL:${WIN32}>:iphlpapi$<SEMICOLON>Shlwapi>
         ${THIRDPARTY_BOOST_LINK_LIBS}
+        eProsima::atomic
         )
 
     # Link library to eProsima::atomic privately
-    target_link_libraries(${PROJECT_NAME} PRIVATE eProsima::atomic)
+    # target_link_libraries(${PROJECT_NAME} PRIVATE eProsima::atomic)
 
     if(MSVC OR MSVC_IDE)
         set_target_properties(${PROJECT_NAME} PROPERTIES RELEASE_POSTFIX -${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR})

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -428,9 +428,6 @@ elseif(NOT EPROSIMA_INSTALLER)
         eProsima::atomic
         )
 
-    # Link library to eProsima::atomic privately
-    # target_link_libraries(${PROJECT_NAME} PRIVATE eProsima::atomic)
-
     if(MSVC OR MSVC_IDE)
         set_target_properties(${PROJECT_NAME} PROPERTIES RELEASE_POSTFIX -${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR})
         set_target_properties(${PROJECT_NAME} PROPERTIES RELWITHDEBINFO_POSTFIX -${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR})

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -405,6 +405,9 @@ elseif(NOT EPROSIMA_INSTALLER)
         ${THIRDPARTY_BOOST_INCLUDE_DIR}
         )
 
+    # PRIVACY is PUBLIC by default
+    set(PRIVACY "PUBLIC")
+
     # Made linked libraries PRIVATE to prevent local directories in Windows installer.
     if(EPROSIMA_INSTALLER_MINION)
         set(PRIVACY "PRIVATE")
@@ -422,8 +425,10 @@ elseif(NOT EPROSIMA_INSTALLER)
         $<$<BOOL:${LINK_SSL}>:OpenSSL::SSL$<SEMICOLON>OpenSSL::Crypto>
         $<$<BOOL:${WIN32}>:iphlpapi$<SEMICOLON>Shlwapi>
         ${THIRDPARTY_BOOST_LINK_LIBS}
-        eProsima::atomic
         )
+
+    # Link library to eProsima::atomic privately
+    target_link_libraries(${PROJECT_NAME} PRIVATE eProsima::atomic)
 
     if(MSVC OR MSVC_IDE)
         set_target_properties(${PROJECT_NAME} PROPERTIES RELEASE_POSTFIX -${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR})
@@ -630,6 +635,7 @@ elseif(NOT EPROSIMA_INSTALLER)
         COMPONENT cmake
         )
 
+    # Install FindAtomic.cmake in case external application want to make use of it
     install(FILES ${PROJECT_SOURCE_DIR}/cmake/modules/FindAtomic.cmake
         DESTINATION ${INSTALL_DESTINATION_PATH}/modules
         COMPONENT cmake


### PR DESCRIPTION
This PR fixes compilation of targets performing `find_package(fastrtps)` after #1634.

#1634 added a public dependency on `eProsima::atomic`, but external projects don't have the means to locate that package. To deal with this, this PR installs `FindAtomic.cmake` under `share/fastrtps/cmake/modules`, and extends `fastrtps-config.cmake` so it can locate it.