### PR TITLE
Test against RFC4291 for IPv6 address strings [10190]

### DIFF
--- a/test/unittest/transport/UDPv6Tests.cpp
+++ b/test/unittest/transport/UDPv6Tests.cpp
@@ -143,7 +143,7 @@ TEST_F(UDPv6Tests, conversion_to_ip6_string)
     locator.address[15] = 0x20;
     ASSERT_EQ("::1020", IPLocator::toIPv6string(locator));
 
-    //Embedded Zeros in 2001:DB8:a::/48
+    //Embedded Zeros in 2001:DB8:a::
     reset_locator_address(locator);
     locator.address[0] = 0x20;
     locator.address[1] = 0x01;


### PR DESCRIPTION
This PR is add tests for IPv6 address representation. Adhering to [RFC4291](https://tools.ietf.org/html/rfc4291#section-2.3) will test for some issues found in #1613. 
The underlying issues still need to be fixed; this PR only addresses the lack of test coverage for them.

* Test zero compression
* Test handling uppercase/lowercase
* Test equivalance of toIPv6string overrides
* Add utility for resetting a locator's address to default

Signed-off-by: Ryan Friedman <ryan_friedman@trimble.com>