### PR TITLE
Load default XML only once [10188]

### DIFF
--- a/include/fastrtps/xmlparser/XMLParser.h
+++ b/include/fastrtps/xmlparser/XMLParser.h
@@ -141,19 +141,19 @@ public:
     RTPS_DllAPI static XMLP_ret loadXMLDynamicTypes(tinyxml2::XMLElement &types);
 
   protected:
-    RTPS_DllAPI static XMLP_ret parseXML(
+    static XMLP_ret parseXML(
         tinyxml2::XMLDocument& xmlDoc,
         up_base_node_t& root);
 
-    RTPS_DllAPI static XMLP_ret parseXMLProfiles(
+    static XMLP_ret parseXMLProfiles(
         tinyxml2::XMLElement& profiles,
         up_base_node_t& root);
 
-    RTPS_DllAPI static XMLP_ret parseProfiles(
+    static XMLP_ret parseProfiles(
         tinyxml2::XMLElement* p_root,
         BaseNode& profilesNode);
 
-    RTPS_DllAPI static XMLP_ret parseRoot(
+    static XMLP_ret parseRoot(
         tinyxml2::XMLElement* p_root,
         BaseNode& rootNode);
 
@@ -163,41 +163,41 @@ public:
      * @param p_root Node to be loaded.
      * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
-    RTPS_DllAPI static XMLP_ret parseLogConfig(tinyxml2::XMLElement* p_root);
+    static XMLP_ret parseLogConfig(tinyxml2::XMLElement* p_root);
 
-    RTPS_DllAPI static XMLP_ret parseXMLLibrarySettings(
+    static XMLP_ret parseXMLLibrarySettings(
         tinyxml2::XMLElement* p_root);
 
-    RTPS_DllAPI static XMLP_ret parseXMLTransportsProf(
+    static XMLP_ret parseXMLTransportsProf(
         tinyxml2::XMLElement* p_root);
 
-    RTPS_DllAPI static XMLP_ret parseXMLParticipantProf(
+    static XMLP_ret parseXMLParticipantProf(
         tinyxml2::XMLElement* p_root,
         BaseNode& rootNode);
 
-    RTPS_DllAPI static XMLP_ret parseXMLPublisherProf(
+    static XMLP_ret parseXMLPublisherProf(
         tinyxml2::XMLElement* p_root,
         BaseNode& rootNode);
 
-    RTPS_DllAPI static XMLP_ret parseXMLSubscriberProf(
+    static XMLP_ret parseXMLSubscriberProf(
         tinyxml2::XMLElement* p_root,
         BaseNode& rootNode);
 
-    RTPS_DllAPI static XMLP_ret parseXMLTopicData(
+    static XMLP_ret parseXMLTopicData(
         tinyxml2::XMLElement* p_root,
         BaseNode& rootNode);
 
-    RTPS_DllAPI static XMLP_ret parseXMLTransportData(tinyxml2::XMLElement* p_root);
+    static XMLP_ret parseXMLTransportData(tinyxml2::XMLElement* p_root);
 
-    RTPS_DllAPI static XMLP_ret parseXMLCommonTransportData(
+    static XMLP_ret parseXMLCommonTransportData(
         tinyxml2::XMLElement* p_root,
         sp_transport_t p_transport);
 
-    RTPS_DllAPI static XMLP_ret parseXMLCommonTCPTransportData(
+    static XMLP_ret parseXMLCommonTCPTransportData(
         tinyxml2::XMLElement* p_root,
         sp_transport_t p_transport);
 
-    RTPS_DllAPI static XMLP_ret parse_tls_config(
+    static XMLP_ret parse_tls_config(
         tinyxml2::XMLElement* p_root,
         sp_transport_t tcp_transport);
 
@@ -206,337 +206,337 @@ public:
      * @param consumer Node to be loaded.
      * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
-    RTPS_DllAPI static XMLP_ret parseXMLConsumer(tinyxml2::XMLElement& consumer);
+    static XMLP_ret parseXMLConsumer(tinyxml2::XMLElement& consumer);
 
-    RTPS_DllAPI static XMLP_ret parseXMLDynamicTypes(tinyxml2::XMLElement& types);
+    static XMLP_ret parseXMLDynamicTypes(tinyxml2::XMLElement& types);
 
-    RTPS_DllAPI static XMLP_ret parseDynamicTypes(tinyxml2::XMLElement* p_root);
+    static XMLP_ret parseDynamicTypes(tinyxml2::XMLElement* p_root);
 
-    RTPS_DllAPI static XMLP_ret parseXMLTypes(tinyxml2::XMLElement* p_root);
+    static XMLP_ret parseXMLTypes(tinyxml2::XMLElement* p_root);
 
-    RTPS_DllAPI static XMLP_ret parseXMLDynamicType(tinyxml2::XMLElement* p_root);
+    static XMLP_ret parseXMLDynamicType(tinyxml2::XMLElement* p_root);
 
-    RTPS_DllAPI static XMLP_ret parseXMLStructDynamicType(tinyxml2::XMLElement* p_root);
+    static XMLP_ret parseXMLStructDynamicType(tinyxml2::XMLElement* p_root);
 
-    RTPS_DllAPI static XMLP_ret parseXMLUnionDynamicType(tinyxml2::XMLElement* p_root);
+    static XMLP_ret parseXMLUnionDynamicType(tinyxml2::XMLElement* p_root);
 
-    RTPS_DllAPI static XMLP_ret parseXMLEnumDynamicType(tinyxml2::XMLElement* p_root);
+    static XMLP_ret parseXMLEnumDynamicType(tinyxml2::XMLElement* p_root);
 
-    RTPS_DllAPI static XMLP_ret parseXMLAliasDynamicType(tinyxml2::XMLElement* p_root);
+    static XMLP_ret parseXMLAliasDynamicType(tinyxml2::XMLElement* p_root);
 
-    RTPS_DllAPI static XMLP_ret parseXMLBitsetDynamicType(tinyxml2::XMLElement* p_root);
+    static XMLP_ret parseXMLBitsetDynamicType(tinyxml2::XMLElement* p_root);
 
-    RTPS_DllAPI static XMLP_ret parseXMLBitmaskDynamicType(tinyxml2::XMLElement* p_root);
+    static XMLP_ret parseXMLBitmaskDynamicType(tinyxml2::XMLElement* p_root);
 
-    RTPS_DllAPI static p_dynamictypebuilder_t parseXMLBitfieldDynamicType(
+    static p_dynamictypebuilder_t parseXMLBitfieldDynamicType(
         tinyxml2::XMLElement* p_root,
         p_dynamictypebuilder_t p_dynamictype,
         types::MemberId mId,
         uint16_t& position);
 
-    RTPS_DllAPI static XMLP_ret parseXMLBitvalueDynamicType(
+    static XMLP_ret parseXMLBitvalueDynamicType(
         tinyxml2::XMLElement* p_root,
         p_dynamictypebuilder_t p_dynamictype,
         uint16_t& position);
 
-    RTPS_DllAPI static p_dynamictypebuilder_t parseXMLMemberDynamicType(
+    static p_dynamictypebuilder_t parseXMLMemberDynamicType(
         tinyxml2::XMLElement* p_root,
         p_dynamictypebuilder_t p_dynamictype,
         types::MemberId mId);
 
-    RTPS_DllAPI static p_dynamictypebuilder_t parseXMLMemberDynamicType(
+    static p_dynamictypebuilder_t parseXMLMemberDynamicType(
         tinyxml2::XMLElement* p_root,
         p_dynamictypebuilder_t p_dynamictype,
         types::MemberId mId,
         const std::string& values);
 
-    RTPS_DllAPI static XMLP_ret fillDataNode(
+    static XMLP_ret fillDataNode(
         tinyxml2::XMLElement* p_profile,
         DataNode<ParticipantAttributes>& participant_node);
 
-    RTPS_DllAPI static XMLP_ret fillDataNode(
+    static XMLP_ret fillDataNode(
         tinyxml2::XMLElement* p_profile,
         DataNode<PublisherAttributes>& publisher_node);
 
-    RTPS_DllAPI static XMLP_ret fillDataNode(
+    static XMLP_ret fillDataNode(
         tinyxml2::XMLElement* p_profile,
         DataNode<SubscriberAttributes>& subscriber_node);
 
-    RTPS_DllAPI static XMLP_ret fillDataNode(
+    static XMLP_ret fillDataNode(
         tinyxml2::XMLElement* node,
         DataNode<TopicAttributes>& topic_node);
 
     template <typename T>
-    RTPS_DllAPI static void addAllAttributes(
+    static void addAllAttributes(
         tinyxml2::XMLElement* p_profile,
         DataNode<T>& node);
 
-    RTPS_DllAPI static XMLP_ret getXMLEnum(
+    static XMLP_ret getXMLEnum(
         tinyxml2::XMLElement* elem,
         fastrtps::IntraprocessDeliveryType * e,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLPropertiesPolicy(
+    static XMLP_ret getXMLPropertiesPolicy(
         tinyxml2::XMLElement* elem,
         rtps::PropertyPolicy& propertiesPolicy,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLHistoryMemoryPolicy(
+    static XMLP_ret getXMLHistoryMemoryPolicy(
         tinyxml2::XMLElement* elem,
         rtps::MemoryManagementPolicy_t& historyMemoryPolicy,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLLocatorList(
+    static XMLP_ret getXMLLocatorList(
         tinyxml2::XMLElement* elem,
         rtps::LocatorList_t& locatorList,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLLocatorUDPv4(
+    static XMLP_ret getXMLLocatorUDPv4(
         tinyxml2::XMLElement* elem,
         rtps::Locator_t& locator,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLLocatorUDPv6(
+    static XMLP_ret getXMLLocatorUDPv6(
         tinyxml2::XMLElement* elem,
         rtps::Locator_t& locator,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLLocatorTCPv4(
+    static XMLP_ret getXMLLocatorTCPv4(
         tinyxml2::XMLElement* elem,
         rtps::Locator_t& locator,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLLocatorTCPv6(
+    static XMLP_ret getXMLLocatorTCPv6(
         tinyxml2::XMLElement* elem,
         rtps::Locator_t& locator,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLWriterTimes(
+    static XMLP_ret getXMLWriterTimes(
         tinyxml2::XMLElement* elem,
         rtps::WriterTimes& times,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLReaderTimes(
+    static XMLP_ret getXMLReaderTimes(
         tinyxml2::XMLElement* elem,
         rtps::ReaderTimes& times,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLDuration(
+    static XMLP_ret getXMLDuration(
         tinyxml2::XMLElement* elem,
         Duration_t& duration,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLWriterQosPolicies(
+    static XMLP_ret getXMLWriterQosPolicies(
         tinyxml2::XMLElement*
         elem, WriterQos& qos,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLReaderQosPolicies(
+    static XMLP_ret getXMLReaderQosPolicies(
         tinyxml2::XMLElement*
         elem, ReaderQos& qos,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLPublishModeQos(
+    static XMLP_ret getXMLPublishModeQos(
         tinyxml2::XMLElement* elem,
         PublishModeQosPolicy& publishMode,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLGroupDataQos(
+    static XMLP_ret getXMLGroupDataQos(
         tinyxml2::XMLElement* elem,
         GroupDataQosPolicy& groupData,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLTopicDataQos(
+    static XMLP_ret getXMLTopicDataQos(
         tinyxml2::XMLElement* elem,
         TopicDataQosPolicy& topicData,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLPartitionQos(
+    static XMLP_ret getXMLPartitionQos(
         tinyxml2::XMLElement* elem,
         PartitionQosPolicy& partition,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLPresentationQos(
+    static XMLP_ret getXMLPresentationQos(
         tinyxml2::XMLElement* elem,
         PresentationQosPolicy& presentation,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLDestinationOrderQos(
+    static XMLP_ret getXMLDestinationOrderQos(
         tinyxml2::XMLElement* elem,
         DestinationOrderQosPolicy& destinationOrder,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLOwnershipStrengthQos(
+    static XMLP_ret getXMLOwnershipStrengthQos(
         tinyxml2::XMLElement* elem,
         OwnershipStrengthQosPolicy& ownershipStrength,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLOwnershipQos(
+    static XMLP_ret getXMLOwnershipQos(
         tinyxml2::XMLElement* elem,
         OwnershipQosPolicy& ownership,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLTimeBasedFilterQos(
+    static XMLP_ret getXMLTimeBasedFilterQos(
         tinyxml2::XMLElement* elem,
         TimeBasedFilterQosPolicy& timeBasedFilter,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLUserDataQos(
+    static XMLP_ret getXMLUserDataQos(
         tinyxml2::XMLElement* elem,
         UserDataQosPolicy& userData,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLLifespanQos(
+    static XMLP_ret getXMLLifespanQos(
         tinyxml2::XMLElement* elem,
         LifespanQosPolicy& lifespan,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLReliabilityQos(
+    static XMLP_ret getXMLReliabilityQos(
         tinyxml2::XMLElement* elem,
         ReliabilityQosPolicy& reliability,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLLivelinessQos(
+    static XMLP_ret getXMLLivelinessQos(
         tinyxml2::XMLElement* elem,
         LivelinessQosPolicy& liveliness,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLLatencyBudgetQos(
+    static XMLP_ret getXMLLatencyBudgetQos(
         tinyxml2::XMLElement* elem,
         LatencyBudgetQosPolicy& latencyBudget,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLDeadlineQos(
+    static XMLP_ret getXMLDeadlineQos(
         tinyxml2::XMLElement* elem,
         DeadlineQosPolicy& deadline,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLDurabilityServiceQos(
+    static XMLP_ret getXMLDurabilityServiceQos(
         tinyxml2::XMLElement* elem,
         DurabilityServiceQosPolicy& durabilityService,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLDurabilityQos(
+    static XMLP_ret getXMLDurabilityQos(
         tinyxml2::XMLElement* elem,
         DurabilityQosPolicy& durability,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLTopicAttributes(
+    static XMLP_ret getXMLTopicAttributes(
         tinyxml2::XMLElement* elem,
         TopicAttributes& topic,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLHistoryQosPolicy(
+    static XMLP_ret getXMLHistoryQosPolicy(
         tinyxml2::XMLElement* elem,
         HistoryQosPolicy& historyQos,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLResourceLimitsQos(
+    static XMLP_ret getXMLResourceLimitsQos(
         tinyxml2::XMLElement* elem,
         ResourceLimitsQosPolicy& resourceLimitsQos,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLContainerAllocationConfig(
+    static XMLP_ret getXMLContainerAllocationConfig(
         tinyxml2::XMLElement* elem,
         ResourceLimitedContainerConfig& resourceLimitsQos,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLThroughputController(
+    static XMLP_ret getXMLThroughputController(
         tinyxml2::XMLElement* elem,
         rtps::ThroughputControllerDescriptor& throughputController,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLPortParameters(
+    static XMLP_ret getXMLPortParameters(
         tinyxml2::XMLElement* elem,
         rtps::PortParameters& port,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLParticipantAllocationAttributes(
+    static XMLP_ret getXMLParticipantAllocationAttributes(
         tinyxml2::XMLElement* elem,
         rtps::RTPSParticipantAllocationAttributes& allocation,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLRemoteLocatorsAllocationAttributes(
+    static XMLP_ret getXMLRemoteLocatorsAllocationAttributes(
         tinyxml2::XMLElement* elem,
         rtps::RemoteLocatorsAllocationAttributes& allocation,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLDiscoverySettings(
+    static XMLP_ret getXMLDiscoverySettings(
         tinyxml2::XMLElement* elem,
         rtps::DiscoverySettings& settings,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLInitialAnnouncementsConfig(
+    static XMLP_ret getXMLInitialAnnouncementsConfig(
         tinyxml2::XMLElement* elem,
         rtps::InitialAnnouncementConfig& config,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLBuiltinAttributes(
+    static XMLP_ret getXMLBuiltinAttributes(
         tinyxml2::XMLElement* elem,
         rtps::BuiltinAttributes& builtin,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLOctetVector(
+    static XMLP_ret getXMLOctetVector(
         tinyxml2::XMLElement* elem,
         std::vector<rtps::octet>& octetVector,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLInt(
+    static XMLP_ret getXMLInt(
         tinyxml2::XMLElement* elem,
         int* i,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLUint(
+    static XMLP_ret getXMLUint(
         tinyxml2::XMLElement* elem,
         unsigned int* ui,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLUint(
+    static XMLP_ret getXMLUint(
         tinyxml2::XMLElement* elem,
         uint16_t* ui16,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLBool(
+    static XMLP_ret getXMLBool(
         tinyxml2::XMLElement* elem,
         bool* b,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLEnum(
+    static XMLP_ret getXMLEnum(
         tinyxml2::XMLElement* elem,
         rtps::DiscoveryProtocol_t * e,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLEnum(
+    static XMLP_ret getXMLEnum(
         tinyxml2::XMLElement* elem,
         rtps::ParticipantFilteringFlags_t * e,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLList(
+    static XMLP_ret getXMLList(
         tinyxml2::XMLElement* elem,
         rtps::RemoteServerList_t & list,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLRemoteServer(
+    static XMLP_ret getXMLRemoteServer(
         tinyxml2::XMLElement* elem,
         rtps::RemoteServerAttributes & server,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLString(
+    static XMLP_ret getXMLString(
         tinyxml2::XMLElement* elem,
         std::string* s,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLTransports(
+    static XMLP_ret getXMLTransports(
         tinyxml2::XMLElement *elem,
         std::vector<std::shared_ptr<rtps::TransportDescriptorInterface>> &transports,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLDisablePositiveAcksQos(
+    static XMLP_ret getXMLDisablePositiveAcksQos(
         tinyxml2::XMLElement* elem,
         DisablePositiveACKsQosPolicy& disablePositiveAcks,
         uint8_t ident);
 
-    RTPS_DllAPI static XMLP_ret getXMLguidPrefix(
+    static XMLP_ret getXMLguidPrefix(
         tinyxml2::XMLElement *elem,
         rtps::GuidPrefix_t &prefix,
         uint8_t ident);

--- a/include/fastrtps/xmlparser/XMLParser.h
+++ b/include/fastrtps/xmlparser/XMLParser.h
@@ -81,7 +81,10 @@ typedef std::unique_ptr<node_topic_t>          up_node_topic_t;
 class XMLParser
 {
 
-  public:
+    friend class XMLParserImpl;
+
+public:
+
     /**
      * Load the default XML file.
      * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.

--- a/include/fastrtps/xmlparser/XMLParser.h
+++ b/include/fastrtps/xmlparser/XMLParser.h
@@ -302,7 +302,8 @@ protected:
             rtps::MemoryManagementPolicy_t& historyMemoryPolicy,
             uint8_t ident);
 
-    static XMLP_ret getXMLLocatorList(
+    // TODO(jlbueno) Remove RTPS_DllAPI once Discovery Server is not using this protected method
+    RTPS_DllAPI static XMLP_ret getXMLLocatorList(
             tinyxml2::XMLElement* elem,
             rtps::LocatorList_t& locatorList,
             uint8_t ident);

--- a/include/fastrtps/xmlparser/XMLParser.h
+++ b/include/fastrtps/xmlparser/XMLParser.h
@@ -36,9 +36,9 @@ class XMLElement;
 class XMLDocument;
 } // namespace tinyxml2
 
-namespace eprosima{
-namespace fastrtps{
-namespace xmlparser{
+namespace eprosima {
+namespace fastrtps {
+namespace xmlparser {
 
 class BaseNode;
 template <class T> class DataNode;
@@ -46,8 +46,8 @@ template <class T> class DataNode;
 typedef std::unique_ptr<BaseNode>              up_base_node_t;
 typedef std::vector<up_base_node_t>            up_base_node_vector_t;
 typedef std::map<std::string, std::string>     node_att_map_t;
-typedef node_att_map_t::iterator               node_att_map_it_t;
-typedef node_att_map_t::const_iterator         node_att_map_cit_t;
+typedef node_att_map_t::iterator node_att_map_it_t;
+typedef node_att_map_t::const_iterator node_att_map_cit_t;
 
 typedef std::shared_ptr<rtps::TransportDescriptorInterface> sp_transport_t;
 typedef std::map<std::string, sp_transport_t>  sp_transport_map_t;
@@ -89,7 +89,8 @@ public:
      * Load the default XML file.
      * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
-    RTPS_DllAPI static XMLP_ret loadDefaultXMLFile(up_base_node_t& root);
+    RTPS_DllAPI static XMLP_ret loadDefaultXMLFile(
+            up_base_node_t& root);
 
     /**
      * Load a XML file.
@@ -98,8 +99,8 @@ public:
      * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
     RTPS_DllAPI static XMLP_ret loadXML(
-        const std::string& filename,
-        up_base_node_t& root);
+            const std::string& filename,
+            up_base_node_t& root);
 
     /**
      * Load a XML data from buffer.
@@ -109,9 +110,9 @@ public:
      * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
     RTPS_DllAPI static XMLP_ret loadXML(
-        const char* data,
-        size_t length,
-        up_base_node_t& root);
+            const char* data,
+            size_t length,
+            up_base_node_t& root);
 
     /**
      * Load a XML node.
@@ -120,8 +121,8 @@ public:
      * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
     RTPS_DllAPI static XMLP_ret loadXML(
-        tinyxml2::XMLDocument &xmlDoc,
-        up_base_node_t& root);
+            tinyxml2::XMLDocument& xmlDoc,
+            up_base_node_t& root);
 
     /**
      * Load a XML node.
@@ -130,32 +131,34 @@ public:
      * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
     RTPS_DllAPI static XMLP_ret loadXMLProfiles(
-        tinyxml2::XMLElement &profiles,
-        up_base_node_t& root);
+            tinyxml2::XMLElement& profiles,
+            up_base_node_t& root);
 
     /**
      * Load a XML node.
      * @param types Node to be loaded.
      * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
-    RTPS_DllAPI static XMLP_ret loadXMLDynamicTypes(tinyxml2::XMLElement &types);
+    RTPS_DllAPI static XMLP_ret loadXMLDynamicTypes(
+            tinyxml2::XMLElement& types);
 
-  protected:
+protected:
+
     static XMLP_ret parseXML(
-        tinyxml2::XMLDocument& xmlDoc,
-        up_base_node_t& root);
+            tinyxml2::XMLDocument& xmlDoc,
+            up_base_node_t& root);
 
     static XMLP_ret parseXMLProfiles(
-        tinyxml2::XMLElement& profiles,
-        up_base_node_t& root);
+            tinyxml2::XMLElement& profiles,
+            up_base_node_t& root);
 
     static XMLP_ret parseProfiles(
-        tinyxml2::XMLElement* p_root,
-        BaseNode& profilesNode);
+            tinyxml2::XMLElement* p_root,
+            BaseNode& profilesNode);
 
     static XMLP_ret parseRoot(
-        tinyxml2::XMLElement* p_root,
-        BaseNode& rootNode);
+            tinyxml2::XMLElement* p_root,
+            BaseNode& rootNode);
 
 
     /**
@@ -163,387 +166,402 @@ public:
      * @param p_root Node to be loaded.
      * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
-    static XMLP_ret parseLogConfig(tinyxml2::XMLElement* p_root);
+    static XMLP_ret parseLogConfig(
+            tinyxml2::XMLElement* p_root);
 
     static XMLP_ret parseXMLLibrarySettings(
-        tinyxml2::XMLElement* p_root);
+            tinyxml2::XMLElement* p_root);
 
     static XMLP_ret parseXMLTransportsProf(
-        tinyxml2::XMLElement* p_root);
+            tinyxml2::XMLElement* p_root);
 
     static XMLP_ret parseXMLParticipantProf(
-        tinyxml2::XMLElement* p_root,
-        BaseNode& rootNode);
+            tinyxml2::XMLElement* p_root,
+            BaseNode& rootNode);
 
     static XMLP_ret parseXMLPublisherProf(
-        tinyxml2::XMLElement* p_root,
-        BaseNode& rootNode);
+            tinyxml2::XMLElement* p_root,
+            BaseNode& rootNode);
 
     static XMLP_ret parseXMLSubscriberProf(
-        tinyxml2::XMLElement* p_root,
-        BaseNode& rootNode);
+            tinyxml2::XMLElement* p_root,
+            BaseNode& rootNode);
 
     static XMLP_ret parseXMLTopicData(
-        tinyxml2::XMLElement* p_root,
-        BaseNode& rootNode);
+            tinyxml2::XMLElement* p_root,
+            BaseNode& rootNode);
 
-    static XMLP_ret parseXMLTransportData(tinyxml2::XMLElement* p_root);
+    static XMLP_ret parseXMLTransportData(
+            tinyxml2::XMLElement* p_root);
 
     static XMLP_ret parseXMLCommonTransportData(
-        tinyxml2::XMLElement* p_root,
-        sp_transport_t p_transport);
+            tinyxml2::XMLElement* p_root,
+            sp_transport_t p_transport);
 
     static XMLP_ret parseXMLCommonTCPTransportData(
-        tinyxml2::XMLElement* p_root,
-        sp_transport_t p_transport);
+            tinyxml2::XMLElement* p_root,
+            sp_transport_t p_transport);
 
     static XMLP_ret parse_tls_config(
-        tinyxml2::XMLElement* p_root,
-        sp_transport_t tcp_transport);
+            tinyxml2::XMLElement* p_root,
+            sp_transport_t tcp_transport);
 
     /**
      * Load a XML consumer node and parses it. Adds the parsed consumer to Log directly.
      * @param consumer Node to be loaded.
      * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
-    static XMLP_ret parseXMLConsumer(tinyxml2::XMLElement& consumer);
+    static XMLP_ret parseXMLConsumer(
+            tinyxml2::XMLElement& consumer);
 
-    static XMLP_ret parseXMLDynamicTypes(tinyxml2::XMLElement& types);
+    static XMLP_ret parseXMLDynamicTypes(
+            tinyxml2::XMLElement& types);
 
-    static XMLP_ret parseDynamicTypes(tinyxml2::XMLElement* p_root);
+    static XMLP_ret parseDynamicTypes(
+            tinyxml2::XMLElement* p_root);
 
-    static XMLP_ret parseXMLTypes(tinyxml2::XMLElement* p_root);
+    static XMLP_ret parseXMLTypes(
+            tinyxml2::XMLElement* p_root);
 
-    static XMLP_ret parseXMLDynamicType(tinyxml2::XMLElement* p_root);
+    static XMLP_ret parseXMLDynamicType(
+            tinyxml2::XMLElement* p_root);
 
-    static XMLP_ret parseXMLStructDynamicType(tinyxml2::XMLElement* p_root);
+    static XMLP_ret parseXMLStructDynamicType(
+            tinyxml2::XMLElement* p_root);
 
-    static XMLP_ret parseXMLUnionDynamicType(tinyxml2::XMLElement* p_root);
+    static XMLP_ret parseXMLUnionDynamicType(
+            tinyxml2::XMLElement* p_root);
 
-    static XMLP_ret parseXMLEnumDynamicType(tinyxml2::XMLElement* p_root);
+    static XMLP_ret parseXMLEnumDynamicType(
+            tinyxml2::XMLElement* p_root);
 
-    static XMLP_ret parseXMLAliasDynamicType(tinyxml2::XMLElement* p_root);
+    static XMLP_ret parseXMLAliasDynamicType(
+            tinyxml2::XMLElement* p_root);
 
-    static XMLP_ret parseXMLBitsetDynamicType(tinyxml2::XMLElement* p_root);
+    static XMLP_ret parseXMLBitsetDynamicType(
+            tinyxml2::XMLElement* p_root);
 
-    static XMLP_ret parseXMLBitmaskDynamicType(tinyxml2::XMLElement* p_root);
+    static XMLP_ret parseXMLBitmaskDynamicType(
+            tinyxml2::XMLElement* p_root);
 
     static p_dynamictypebuilder_t parseXMLBitfieldDynamicType(
-        tinyxml2::XMLElement* p_root,
-        p_dynamictypebuilder_t p_dynamictype,
-        types::MemberId mId,
-        uint16_t& position);
+            tinyxml2::XMLElement* p_root,
+            p_dynamictypebuilder_t p_dynamictype,
+            types::MemberId mId,
+            uint16_t& position);
 
     static XMLP_ret parseXMLBitvalueDynamicType(
-        tinyxml2::XMLElement* p_root,
-        p_dynamictypebuilder_t p_dynamictype,
-        uint16_t& position);
+            tinyxml2::XMLElement* p_root,
+            p_dynamictypebuilder_t p_dynamictype,
+            uint16_t& position);
 
     static p_dynamictypebuilder_t parseXMLMemberDynamicType(
-        tinyxml2::XMLElement* p_root,
-        p_dynamictypebuilder_t p_dynamictype,
-        types::MemberId mId);
+            tinyxml2::XMLElement* p_root,
+            p_dynamictypebuilder_t p_dynamictype,
+            types::MemberId mId);
 
     static p_dynamictypebuilder_t parseXMLMemberDynamicType(
-        tinyxml2::XMLElement* p_root,
-        p_dynamictypebuilder_t p_dynamictype,
-        types::MemberId mId,
-        const std::string& values);
+            tinyxml2::XMLElement* p_root,
+            p_dynamictypebuilder_t p_dynamictype,
+            types::MemberId mId,
+            const std::string& values);
 
     static XMLP_ret fillDataNode(
-        tinyxml2::XMLElement* p_profile,
-        DataNode<ParticipantAttributes>& participant_node);
+            tinyxml2::XMLElement* p_profile,
+            DataNode<ParticipantAttributes>& participant_node);
 
     static XMLP_ret fillDataNode(
-        tinyxml2::XMLElement* p_profile,
-        DataNode<PublisherAttributes>& publisher_node);
+            tinyxml2::XMLElement* p_profile,
+            DataNode<PublisherAttributes>& publisher_node);
 
     static XMLP_ret fillDataNode(
-        tinyxml2::XMLElement* p_profile,
-        DataNode<SubscriberAttributes>& subscriber_node);
+            tinyxml2::XMLElement* p_profile,
+            DataNode<SubscriberAttributes>& subscriber_node);
 
     static XMLP_ret fillDataNode(
-        tinyxml2::XMLElement* node,
-        DataNode<TopicAttributes>& topic_node);
+            tinyxml2::XMLElement* node,
+            DataNode<TopicAttributes>& topic_node);
 
     template <typename T>
     static void addAllAttributes(
-        tinyxml2::XMLElement* p_profile,
-        DataNode<T>& node);
+            tinyxml2::XMLElement* p_profile,
+            DataNode<T>& node);
 
     static XMLP_ret getXMLEnum(
-        tinyxml2::XMLElement* elem,
-        fastrtps::IntraprocessDeliveryType * e,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            fastrtps::IntraprocessDeliveryType* e,
+            uint8_t ident);
 
     static XMLP_ret getXMLPropertiesPolicy(
-        tinyxml2::XMLElement* elem,
-        rtps::PropertyPolicy& propertiesPolicy,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            rtps::PropertyPolicy& propertiesPolicy,
+            uint8_t ident);
 
     static XMLP_ret getXMLHistoryMemoryPolicy(
-        tinyxml2::XMLElement* elem,
-        rtps::MemoryManagementPolicy_t& historyMemoryPolicy,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            rtps::MemoryManagementPolicy_t& historyMemoryPolicy,
+            uint8_t ident);
 
     static XMLP_ret getXMLLocatorList(
-        tinyxml2::XMLElement* elem,
-        rtps::LocatorList_t& locatorList,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            rtps::LocatorList_t& locatorList,
+            uint8_t ident);
 
     static XMLP_ret getXMLLocatorUDPv4(
-        tinyxml2::XMLElement* elem,
-        rtps::Locator_t& locator,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            rtps::Locator_t& locator,
+            uint8_t ident);
 
     static XMLP_ret getXMLLocatorUDPv6(
-        tinyxml2::XMLElement* elem,
-        rtps::Locator_t& locator,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            rtps::Locator_t& locator,
+            uint8_t ident);
 
     static XMLP_ret getXMLLocatorTCPv4(
-        tinyxml2::XMLElement* elem,
-        rtps::Locator_t& locator,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            rtps::Locator_t& locator,
+            uint8_t ident);
 
     static XMLP_ret getXMLLocatorTCPv6(
-        tinyxml2::XMLElement* elem,
-        rtps::Locator_t& locator,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            rtps::Locator_t& locator,
+            uint8_t ident);
 
     static XMLP_ret getXMLWriterTimes(
-        tinyxml2::XMLElement* elem,
-        rtps::WriterTimes& times,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            rtps::WriterTimes& times,
+            uint8_t ident);
 
     static XMLP_ret getXMLReaderTimes(
-        tinyxml2::XMLElement* elem,
-        rtps::ReaderTimes& times,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            rtps::ReaderTimes& times,
+            uint8_t ident);
 
     static XMLP_ret getXMLDuration(
-        tinyxml2::XMLElement* elem,
-        Duration_t& duration,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            Duration_t& duration,
+            uint8_t ident);
 
     static XMLP_ret getXMLWriterQosPolicies(
-        tinyxml2::XMLElement*
-        elem, WriterQos& qos,
-        uint8_t ident);
+            tinyxml2::XMLElement*
+            elem,
+            WriterQos& qos,
+            uint8_t ident);
 
     static XMLP_ret getXMLReaderQosPolicies(
-        tinyxml2::XMLElement*
-        elem, ReaderQos& qos,
-        uint8_t ident);
+            tinyxml2::XMLElement*
+            elem,
+            ReaderQos& qos,
+            uint8_t ident);
 
     static XMLP_ret getXMLPublishModeQos(
-        tinyxml2::XMLElement* elem,
-        PublishModeQosPolicy& publishMode,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            PublishModeQosPolicy& publishMode,
+            uint8_t ident);
 
     static XMLP_ret getXMLGroupDataQos(
-        tinyxml2::XMLElement* elem,
-        GroupDataQosPolicy& groupData,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            GroupDataQosPolicy& groupData,
+            uint8_t ident);
 
     static XMLP_ret getXMLTopicDataQos(
-        tinyxml2::XMLElement* elem,
-        TopicDataQosPolicy& topicData,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            TopicDataQosPolicy& topicData,
+            uint8_t ident);
 
     static XMLP_ret getXMLPartitionQos(
-        tinyxml2::XMLElement* elem,
-        PartitionQosPolicy& partition,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            PartitionQosPolicy& partition,
+            uint8_t ident);
 
     static XMLP_ret getXMLPresentationQos(
-        tinyxml2::XMLElement* elem,
-        PresentationQosPolicy& presentation,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            PresentationQosPolicy& presentation,
+            uint8_t ident);
 
     static XMLP_ret getXMLDestinationOrderQos(
-        tinyxml2::XMLElement* elem,
-        DestinationOrderQosPolicy& destinationOrder,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            DestinationOrderQosPolicy& destinationOrder,
+            uint8_t ident);
 
     static XMLP_ret getXMLOwnershipStrengthQos(
-        tinyxml2::XMLElement* elem,
-        OwnershipStrengthQosPolicy& ownershipStrength,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            OwnershipStrengthQosPolicy& ownershipStrength,
+            uint8_t ident);
 
     static XMLP_ret getXMLOwnershipQos(
-        tinyxml2::XMLElement* elem,
-        OwnershipQosPolicy& ownership,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            OwnershipQosPolicy& ownership,
+            uint8_t ident);
 
     static XMLP_ret getXMLTimeBasedFilterQos(
-        tinyxml2::XMLElement* elem,
-        TimeBasedFilterQosPolicy& timeBasedFilter,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            TimeBasedFilterQosPolicy& timeBasedFilter,
+            uint8_t ident);
 
     static XMLP_ret getXMLUserDataQos(
-        tinyxml2::XMLElement* elem,
-        UserDataQosPolicy& userData,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            UserDataQosPolicy& userData,
+            uint8_t ident);
 
     static XMLP_ret getXMLLifespanQos(
-        tinyxml2::XMLElement* elem,
-        LifespanQosPolicy& lifespan,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            LifespanQosPolicy& lifespan,
+            uint8_t ident);
 
     static XMLP_ret getXMLReliabilityQos(
-        tinyxml2::XMLElement* elem,
-        ReliabilityQosPolicy& reliability,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            ReliabilityQosPolicy& reliability,
+            uint8_t ident);
 
     static XMLP_ret getXMLLivelinessQos(
-        tinyxml2::XMLElement* elem,
-        LivelinessQosPolicy& liveliness,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            LivelinessQosPolicy& liveliness,
+            uint8_t ident);
 
     static XMLP_ret getXMLLatencyBudgetQos(
-        tinyxml2::XMLElement* elem,
-        LatencyBudgetQosPolicy& latencyBudget,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            LatencyBudgetQosPolicy& latencyBudget,
+            uint8_t ident);
 
     static XMLP_ret getXMLDeadlineQos(
-        tinyxml2::XMLElement* elem,
-        DeadlineQosPolicy& deadline,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            DeadlineQosPolicy& deadline,
+            uint8_t ident);
 
     static XMLP_ret getXMLDurabilityServiceQos(
-        tinyxml2::XMLElement* elem,
-        DurabilityServiceQosPolicy& durabilityService,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            DurabilityServiceQosPolicy& durabilityService,
+            uint8_t ident);
 
     static XMLP_ret getXMLDurabilityQos(
-        tinyxml2::XMLElement* elem,
-        DurabilityQosPolicy& durability,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            DurabilityQosPolicy& durability,
+            uint8_t ident);
 
     static XMLP_ret getXMLTopicAttributes(
-        tinyxml2::XMLElement* elem,
-        TopicAttributes& topic,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            TopicAttributes& topic,
+            uint8_t ident);
 
     static XMLP_ret getXMLHistoryQosPolicy(
-        tinyxml2::XMLElement* elem,
-        HistoryQosPolicy& historyQos,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            HistoryQosPolicy& historyQos,
+            uint8_t ident);
 
     static XMLP_ret getXMLResourceLimitsQos(
-        tinyxml2::XMLElement* elem,
-        ResourceLimitsQosPolicy& resourceLimitsQos,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            ResourceLimitsQosPolicy& resourceLimitsQos,
+            uint8_t ident);
 
     static XMLP_ret getXMLContainerAllocationConfig(
-        tinyxml2::XMLElement* elem,
-        ResourceLimitedContainerConfig& resourceLimitsQos,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            ResourceLimitedContainerConfig& resourceLimitsQos,
+            uint8_t ident);
 
     static XMLP_ret getXMLThroughputController(
-        tinyxml2::XMLElement* elem,
-        rtps::ThroughputControllerDescriptor& throughputController,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            rtps::ThroughputControllerDescriptor& throughputController,
+            uint8_t ident);
 
     static XMLP_ret getXMLPortParameters(
-        tinyxml2::XMLElement* elem,
-        rtps::PortParameters& port,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            rtps::PortParameters& port,
+            uint8_t ident);
 
     static XMLP_ret getXMLParticipantAllocationAttributes(
-        tinyxml2::XMLElement* elem,
-        rtps::RTPSParticipantAllocationAttributes& allocation,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            rtps::RTPSParticipantAllocationAttributes& allocation,
+            uint8_t ident);
 
     static XMLP_ret getXMLRemoteLocatorsAllocationAttributes(
-        tinyxml2::XMLElement* elem,
-        rtps::RemoteLocatorsAllocationAttributes& allocation,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            rtps::RemoteLocatorsAllocationAttributes& allocation,
+            uint8_t ident);
 
     static XMLP_ret getXMLDiscoverySettings(
-        tinyxml2::XMLElement* elem,
-        rtps::DiscoverySettings& settings,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            rtps::DiscoverySettings& settings,
+            uint8_t ident);
 
     static XMLP_ret getXMLInitialAnnouncementsConfig(
-        tinyxml2::XMLElement* elem,
-        rtps::InitialAnnouncementConfig& config,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            rtps::InitialAnnouncementConfig& config,
+            uint8_t ident);
 
     static XMLP_ret getXMLBuiltinAttributes(
-        tinyxml2::XMLElement* elem,
-        rtps::BuiltinAttributes& builtin,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            rtps::BuiltinAttributes& builtin,
+            uint8_t ident);
 
     static XMLP_ret getXMLOctetVector(
-        tinyxml2::XMLElement* elem,
-        std::vector<rtps::octet>& octetVector,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            std::vector<rtps::octet>& octetVector,
+            uint8_t ident);
 
     static XMLP_ret getXMLInt(
-        tinyxml2::XMLElement* elem,
-        int* i,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            int* i,
+            uint8_t ident);
 
     static XMLP_ret getXMLUint(
-        tinyxml2::XMLElement* elem,
-        unsigned int* ui,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            unsigned int* ui,
+            uint8_t ident);
 
     static XMLP_ret getXMLUint(
-        tinyxml2::XMLElement* elem,
-        uint16_t* ui16,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            uint16_t* ui16,
+            uint8_t ident);
 
     static XMLP_ret getXMLBool(
-        tinyxml2::XMLElement* elem,
-        bool* b,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            bool* b,
+            uint8_t ident);
 
     static XMLP_ret getXMLEnum(
-        tinyxml2::XMLElement* elem,
-        rtps::DiscoveryProtocol_t * e,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            rtps::DiscoveryProtocol_t* e,
+            uint8_t ident);
 
     static XMLP_ret getXMLEnum(
-        tinyxml2::XMLElement* elem,
-        rtps::ParticipantFilteringFlags_t * e,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            rtps::ParticipantFilteringFlags_t* e,
+            uint8_t ident);
 
     static XMLP_ret getXMLList(
-        tinyxml2::XMLElement* elem,
-        rtps::RemoteServerList_t & list,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            rtps::RemoteServerList_t& list,
+            uint8_t ident);
 
     static XMLP_ret getXMLRemoteServer(
-        tinyxml2::XMLElement* elem,
-        rtps::RemoteServerAttributes & server,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            rtps::RemoteServerAttributes& server,
+            uint8_t ident);
 
     static XMLP_ret getXMLString(
-        tinyxml2::XMLElement* elem,
-        std::string* s,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            std::string* s,
+            uint8_t ident);
 
     static XMLP_ret getXMLTransports(
-        tinyxml2::XMLElement *elem,
-        std::vector<std::shared_ptr<rtps::TransportDescriptorInterface>> &transports,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            std::vector<std::shared_ptr<rtps::TransportDescriptorInterface>>& transports,
+            uint8_t ident);
 
     static XMLP_ret getXMLDisablePositiveAcksQos(
-        tinyxml2::XMLElement* elem,
-        DisablePositiveACKsQosPolicy& disablePositiveAcks,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            DisablePositiveACKsQosPolicy& disablePositiveAcks,
+            uint8_t ident);
 
     static XMLP_ret getXMLguidPrefix(
-        tinyxml2::XMLElement *elem,
-        rtps::GuidPrefix_t &prefix,
-        uint8_t ident);
+            tinyxml2::XMLElement* elem,
+            rtps::GuidPrefix_t& prefix,
+            uint8_t ident);
 };
 
 } // namespace xmlparser
 } // namespace fastrtps
 } // namespace eprosima
 
-#endif
+#endif // ifndef XML_PARSER_H_

--- a/include/fastrtps/xmlparser/XMLProfileManager.h
+++ b/include/fastrtps/xmlparser/XMLProfileManager.h
@@ -232,7 +232,7 @@ private:
 
     static XMLP_ret loadXMLFile(
             const std::string& filename,
-            const bool& is_default);
+            bool is_default);
 
     static XMLP_ret extractDynamicTypes(
             up_base_node_t properties,

--- a/include/fastrtps/xmlparser/XMLProfileManager.h
+++ b/include/fastrtps/xmlparser/XMLProfileManager.h
@@ -230,6 +230,10 @@ public:
 
 private:
 
+    static XMLP_ret loadXMLFile(
+            const std::string& filename,
+            const bool& is_default);
+
     RTPS_DllAPI static XMLP_ret extractDynamicTypes(
             up_base_node_t properties,
             const std::string& filename);

--- a/include/fastrtps/xmlparser/XMLProfileManager.h
+++ b/include/fastrtps/xmlparser/XMLProfileManager.h
@@ -234,27 +234,27 @@ private:
             const std::string& filename,
             const bool& is_default);
 
-    RTPS_DllAPI static XMLP_ret extractDynamicTypes(
+    static XMLP_ret extractDynamicTypes(
             up_base_node_t properties,
             const std::string& filename);
 
-    RTPS_DllAPI static XMLP_ret extractProfiles(
+    static XMLP_ret extractProfiles(
             up_base_node_t properties,
             const std::string& filename);
 
-    RTPS_DllAPI static XMLP_ret extractParticipantProfile(
+    static XMLP_ret extractParticipantProfile(
             up_base_node_t& profile,
             const std::string& filename);
 
-    RTPS_DllAPI static XMLP_ret extractPublisherProfile(
+    static XMLP_ret extractPublisherProfile(
             up_base_node_t& profile,
             const std::string& filename);
 
-    RTPS_DllAPI static XMLP_ret extractSubscriberProfile(
+    static XMLP_ret extractSubscriberProfile(
             up_base_node_t& profile,
             const std::string& filename);
 
-    RTPS_DllAPI static XMLP_ret extractTopicProfile(
+    static XMLP_ret extractTopicProfile(
             up_base_node_t& profile,
             const std::string& filename);
 

--- a/include/fastrtps/xmlparser/XMLProfileManager.h
+++ b/include/fastrtps/xmlparser/XMLProfileManager.h
@@ -281,4 +281,4 @@ private:
 } /* namespace */
 } /* namespace eprosima */
 
-#endif
+#endif // ifndef XML_PROFILE_MANAGER_H_

--- a/src/cpp/xmlparser/XMLParser.cpp
+++ b/src/cpp/xmlparser/XMLParser.cpp
@@ -3247,7 +3247,7 @@ XMLP_ret XMLParser::fillDataNode(
 XMLP_ret XMLParserImpl::loadXML(
         const std::string& filename,
         up_base_node_t& root,
-        const bool& is_default)
+        bool is_default)
 {
     if (filename.empty())
     {

--- a/src/cpp/xmlparser/XMLParser.cpp
+++ b/src/cpp/xmlparser/XMLParser.cpp
@@ -54,7 +54,7 @@ XMLP_ret XMLParser::loadDefaultXMLFile(
     }
     else
     {
-        strcat(current_directory, DEFAULT_FASTRTPS_PROFILES);
+        strcat_s(current_directory, MAX_PATH, DEFAULT_FASTRTPS_PROFILES);
         return XMLParserImpl::loadXML(current_directory, root, true);
     }
 #else

--- a/src/cpp/xmlparser/XMLParser.cpp
+++ b/src/cpp/xmlparser/XMLParser.cpp
@@ -41,7 +41,8 @@ namespace eprosima {
 namespace fastrtps {
 namespace xmlparser {
 
-XMLP_ret XMLParser::loadDefaultXMLFile(up_base_node_t& root)
+XMLP_ret XMLParser::loadDefaultXMLFile(
+        up_base_node_t& root)
 {
     // Use absolute path to ensure that the file is loaded only once
 #ifdef _WIN32
@@ -72,7 +73,9 @@ XMLP_ret XMLParser::loadDefaultXMLFile(up_base_node_t& root)
     return XMLP_ret::XML_ERROR;
 }
 
-XMLP_ret XMLParser::parseXML(tinyxml2::XMLDocument& xmlDoc, up_base_node_t& root)
+XMLP_ret XMLParser::parseXML(
+        tinyxml2::XMLDocument& xmlDoc,
+        up_base_node_t& root)
 {
     XMLP_ret ret = XMLP_ret::XML_OK;
     tinyxml2::XMLElement* p_root = xmlDoc.FirstChildElement(ROOT);
@@ -113,7 +116,7 @@ XMLP_ret XMLParser::parseXML(tinyxml2::XMLDocument& xmlDoc, up_base_node_t& root
         root.reset(new BaseNode{ NodeType::ROOT });
         tinyxml2::XMLElement* node = p_root->FirstChildElement();
         const char* tag = nullptr;
-        while ( (nullptr != node) && (ret == XMLP_ret::XML_OK))
+        while ((nullptr != node) && (ret == XMLP_ret::XML_OK))
         {
             if (nullptr != (tag = node->Value()))
             {
@@ -166,7 +169,9 @@ XMLP_ret XMLParser::parseXML(tinyxml2::XMLDocument& xmlDoc, up_base_node_t& root
     return ret;
 }
 
-XMLP_ret XMLParser::parseXMLProfiles(tinyxml2::XMLElement& profiles, up_base_node_t& root)
+XMLP_ret XMLParser::parseXMLProfiles(
+        tinyxml2::XMLElement& profiles,
+        up_base_node_t& root)
 {
     XMLP_ret ret = XMLP_ret::XML_OK;
     root.reset(new BaseNode{NodeType::PROFILES});
@@ -174,14 +179,17 @@ XMLP_ret XMLParser::parseXMLProfiles(tinyxml2::XMLElement& profiles, up_base_nod
     return ret;
 }
 
-XMLP_ret XMLParser::parseXMLDynamicTypes(tinyxml2::XMLElement& types)
+XMLP_ret XMLParser::parseXMLDynamicTypes(
+        tinyxml2::XMLElement& types)
 {
     XMLP_ret ret = XMLP_ret::XML_OK;
     ret  = parseDynamicTypes(&types);
     return ret;
 }
 
-XMLP_ret XMLParser::parseRoot(tinyxml2::XMLElement* p_root, BaseNode& rootNode)
+XMLP_ret XMLParser::parseRoot(
+        tinyxml2::XMLElement* p_root,
+        BaseNode& rootNode)
 {
     XMLP_ret ret           = XMLP_ret::XML_OK;
     tinyxml2::XMLElement* root_child = nullptr;
@@ -196,7 +204,8 @@ XMLP_ret XMLParser::parseRoot(tinyxml2::XMLElement* p_root, BaseNode& rootNode)
     return ret;
 }
 
-XMLP_ret XMLParser::parseXMLTransportsProf(tinyxml2::XMLElement* p_root)
+XMLP_ret XMLParser::parseXMLTransportsProf(
+        tinyxml2::XMLElement* p_root)
 {
     /*
         <xs:complexType name="TransportDescriptorListType">
@@ -204,11 +213,11 @@ XMLP_ret XMLParser::parseXMLTransportsProf(tinyxml2::XMLElement* p_root)
                 <xs:element name="transport_descriptor" type="rtpsTransportDescriptorType"/>
             </xs:sequence>
         </xs:complexType>
-    */
+     */
 
     XMLP_ret ret = XMLP_ret::XML_OK;
     tinyxml2::XMLElement* p_element = p_root->FirstChildElement(TRANSPORT_DESCRIPTOR);
-    while(p_element != nullptr)
+    while (p_element != nullptr)
     {
         ret = parseXMLTransportData(p_element);
         if (ret != XMLP_ret::XML_OK)
@@ -221,7 +230,8 @@ XMLP_ret XMLParser::parseXMLTransportsProf(tinyxml2::XMLElement* p_root)
     return ret;
 }
 
-XMLP_ret XMLParser::parseXMLTypes(tinyxml2::XMLElement* p_root)
+XMLP_ret XMLParser::parseXMLTypes(
+        tinyxml2::XMLElement* p_root)
 {
     /*
         <xs:element name="types">
@@ -229,10 +239,10 @@ XMLP_ret XMLParser::parseXMLTypes(tinyxml2::XMLElement* p_root)
                 <xs:group ref="moduleElems"/>
             </xs:complexType>
         </xs:element>
-    */
+     */
 
     XMLP_ret ret = XMLP_ret::XML_OK;
-    tinyxml2::XMLElement *p_aux0 = nullptr, *p_aux1 = nullptr;
+    tinyxml2::XMLElement* p_aux0 = nullptr, * p_aux1 = nullptr;
     p_aux0 = p_root->FirstChildElement(TYPES);
     if (p_aux0 != nullptr)
     {
@@ -243,7 +253,9 @@ XMLP_ret XMLParser::parseXMLTypes(tinyxml2::XMLElement* p_root)
             if (strcmp(name, TYPE) == 0)
             {
                 if (XMLP_ret::XML_OK != parseXMLDynamicType(p_aux1))
+                {
                     return XMLP_ret::XML_ERROR;
+                }
             }
             else
             {
@@ -261,14 +273,17 @@ XMLP_ret XMLParser::parseXMLTypes(tinyxml2::XMLElement* p_root)
             if (strcmp(name, TYPE) == 0)
             {
                 if (XMLP_ret::XML_OK != parseXMLDynamicType(p_aux0))
+                {
                     return XMLP_ret::XML_ERROR;
+                }
             }
         }
     }
     return ret;
 }
 
-XMLP_ret XMLParser::parseXMLTransportData(tinyxml2::XMLElement* p_root)
+XMLP_ret XMLParser::parseXMLTransportData(
+        tinyxml2::XMLElement* p_root)
 {
     /*
         <xs:complexType name="rtpsTransportDescriptorType">
@@ -297,13 +312,13 @@ XMLP_ret XMLParser::parseXMLTransportData(tinyxml2::XMLElement* p_root)
                 <xs:element name="tls" type="tlsConfigType" minOccurs="0" maxOccurs="1"/>
             </xs:all>
         </xs:complexType>
-    */
+     */
 
     XMLP_ret ret = XMLP_ret::XML_OK;
     std::string sId = "";
     sp_transport_t pDescriptor = nullptr;
 
-    tinyxml2::XMLElement *p_aux0 = nullptr;
+    tinyxml2::XMLElement* p_aux0 = nullptr;
     p_aux0 = p_root->FirstChildElement(TRANSPORT_ID);
     if (nullptr == p_aux0)
     {
@@ -336,13 +351,15 @@ XMLP_ret XMLParser::parseXMLTransportData(tinyxml2::XMLElement* p_root)
             }
 
             std::shared_ptr<rtps::UDPTransportDescriptor> pUDPDesc =
-                std::dynamic_pointer_cast<rtps::UDPTransportDescriptor>(pDescriptor);
+                    std::dynamic_pointer_cast<rtps::UDPTransportDescriptor>(pDescriptor);
             // Output UDP Socket
             if (nullptr != (p_aux0 = p_root->FirstChildElement(UDP_OUTPUT_PORT)))
             {
                 int iSocket = 0;
                 if (XMLP_ret::XML_OK != getXMLInt(p_aux0, &iSocket, 0) || iSocket < 0 || iSocket > 65535)
+                {
                     return XMLP_ret::XML_ERROR;
+                }
                 pUDPDesc->m_output_udp_socket = static_cast<uint16_t>(iSocket);
             }
             // Non-blocking send
@@ -365,14 +382,16 @@ XMLP_ret XMLParser::parseXMLTransportData(tinyxml2::XMLElement* p_root)
             else
             {
                 std::shared_ptr<rtps::TCPv4TransportDescriptor> pTCPv4Desc =
-                    std::dynamic_pointer_cast<rtps::TCPv4TransportDescriptor>(pDescriptor);
+                        std::dynamic_pointer_cast<rtps::TCPv4TransportDescriptor>(pDescriptor);
 
                 // Wan Address
                 if (nullptr != (p_aux0 = p_root->FirstChildElement(TCP_WAN_ADDR)))
                 {
                     std::string s;
                     if (XMLP_ret::XML_OK != getXMLString(p_aux0, &s, 0))
+                    {
                         return XMLP_ret::XML_ERROR;
+                    }
                     pTCPv4Desc->set_WAN_address(s);
                 }
             }
@@ -402,7 +421,9 @@ XMLP_ret XMLParser::parseXMLTransportData(tinyxml2::XMLElement* p_root)
     return ret;
 }
 
-XMLP_ret XMLParser::parseXMLCommonTransportData(tinyxml2::XMLElement* p_root, sp_transport_t p_transport)
+XMLP_ret XMLParser::parseXMLCommonTransportData(
+        tinyxml2::XMLElement* p_root,
+        sp_transport_t p_transport)
 {
     /*
         <xs:complexType name="rtpsTransportDescriptorType">
@@ -426,12 +447,12 @@ XMLP_ret XMLParser::parseXMLCommonTransportData(tinyxml2::XMLElement* p_root, sp
                 <xs:element name="listening_ports" type="portListType" minOccurs="0" maxOccurs="1"/>
             </xs:all>
         </xs:complexType>
-    */
+     */
 
     std::shared_ptr<rtps::SocketTransportDescriptor> pDesc =
             std::dynamic_pointer_cast<rtps::SocketTransportDescriptor>(p_transport);
 
-    tinyxml2::XMLElement *p_aux0 = nullptr;
+    tinyxml2::XMLElement* p_aux0 = nullptr;
     const char* name = nullptr;
     for (p_aux0 = p_root->FirstChildElement(); p_aux0 != nullptr; p_aux0 = p_aux0->NextSiblingElement())
     {
@@ -441,7 +462,9 @@ XMLP_ret XMLParser::parseXMLCommonTransportData(tinyxml2::XMLElement* p_root, sp
             // sendBufferSize - int32Type
             uint32_t iSize = 0;
             if (XMLP_ret::XML_OK != getXMLUint(p_aux0, &iSize, 0))
+            {
                 return XMLP_ret::XML_ERROR;
+            }
             pDesc->sendBufferSize = iSize;
         }
         else if (strcmp(name, RECEIVE_BUFFER_SIZE) == 0)
@@ -449,7 +472,9 @@ XMLP_ret XMLParser::parseXMLCommonTransportData(tinyxml2::XMLElement* p_root, sp
             // receiveBufferSize - int32Type
             uint32_t iSize = 0;
             if (XMLP_ret::XML_OK != getXMLUint(p_aux0, &iSize, 0))
+            {
                 return XMLP_ret::XML_ERROR;
+            }
             pDesc->receiveBufferSize = iSize;
         }
         else if (strcmp(name, TTL) == 0)
@@ -457,7 +482,9 @@ XMLP_ret XMLParser::parseXMLCommonTransportData(tinyxml2::XMLElement* p_root, sp
             // TTL - int8Type
             int iTTL = 0;
             if (XMLP_ret::XML_OK != getXMLInt(p_aux0, &iTTL, 0) || iTTL < 0 || iTTL > 255)
+            {
                 return XMLP_ret::XML_ERROR;
+            }
             pDesc->TTL = static_cast<uint8_t>(iTTL);
         }
         else if (strcmp(name, MAX_MESSAGE_SIZE) == 0)
@@ -465,7 +492,9 @@ XMLP_ret XMLParser::parseXMLCommonTransportData(tinyxml2::XMLElement* p_root, sp
             // maxMessageSize - uint32Type
             uint32_t uSize = 0;
             if (XMLP_ret::XML_OK != getXMLUint(p_aux0, &uSize, 0))
+            {
                 return XMLP_ret::XML_ERROR;
+            }
             pDesc->maxMessageSize = uSize;
         }
         else if (strcmp(name, MAX_INITIAL_PEERS_RANGE) == 0)
@@ -473,7 +502,9 @@ XMLP_ret XMLParser::parseXMLCommonTransportData(tinyxml2::XMLElement* p_root, sp
             // maxInitialPeersRange - uint32Type
             uint32_t uRange = 0;
             if (XMLP_ret::XML_OK != getXMLUint(p_aux0, &uRange, 0))
+            {
                 return XMLP_ret::XML_ERROR;
+            }
             pDesc->maxInitialPeersRange = uRange;
         }
         else if (strcmp(name, WHITE_LIST) == 0)
@@ -481,7 +512,7 @@ XMLP_ret XMLParser::parseXMLCommonTransportData(tinyxml2::XMLElement* p_root, sp
             // InterfaceWhiteList addressListType
             const char* address = nullptr;
             for (tinyxml2::XMLElement* p_aux1 = p_aux0->FirstChildElement();
-                 p_aux1 != nullptr; p_aux1 = p_aux1->NextSiblingElement())
+                    p_aux1 != nullptr; p_aux1 = p_aux1->NextSiblingElement())
             {
                 address = p_aux1->Name();
                 if (strcmp(address, ADDRESS) == 0)
@@ -500,13 +531,13 @@ XMLP_ret XMLParser::parseXMLCommonTransportData(tinyxml2::XMLElement* p_root, sp
             }
         }
         else if (strcmp(name, TCP_WAN_ADDR) == 0 || strcmp(name, UDP_OUTPUT_PORT) == 0 ||
-            strcmp(name, TRANSPORT_ID) == 0 || strcmp(name, TYPE) == 0 ||
-            strcmp(name, KEEP_ALIVE_FREQUENCY) == 0 || strcmp(name, KEEP_ALIVE_TIMEOUT) == 0 ||
-            strcmp(name, MAX_LOGICAL_PORT) == 0 || strcmp(name, LOGICAL_PORT_RANGE) == 0 ||
-            strcmp(name, LOGICAL_PORT_INCREMENT) == 0 || strcmp(name, LISTENING_PORTS) == 0 ||
-            strcmp(name, CALCULATE_CRC) == 0 || strcmp(name, CHECK_CRC) == 0 ||
-            strcmp(name, ENABLE_TCP_NODELAY) == 0 || strcmp(name, TLS) == 0 ||
-            strcmp(name, NON_BLOCKING_SEND) == 0 )
+                strcmp(name, TRANSPORT_ID) == 0 || strcmp(name, TYPE) == 0 ||
+                strcmp(name, KEEP_ALIVE_FREQUENCY) == 0 || strcmp(name, KEEP_ALIVE_TIMEOUT) == 0 ||
+                strcmp(name, MAX_LOGICAL_PORT) == 0 || strcmp(name, LOGICAL_PORT_RANGE) == 0 ||
+                strcmp(name, LOGICAL_PORT_INCREMENT) == 0 || strcmp(name, LISTENING_PORTS) == 0 ||
+                strcmp(name, CALCULATE_CRC) == 0 || strcmp(name, CHECK_CRC) == 0 ||
+                strcmp(name, ENABLE_TCP_NODELAY) == 0 || strcmp(name, TLS) == 0 ||
+                strcmp(name, NON_BLOCKING_SEND) == 0 )
         {
             // Parsed outside of this method
         }
@@ -519,7 +550,9 @@ XMLP_ret XMLParser::parseXMLCommonTransportData(tinyxml2::XMLElement* p_root, sp
     return XMLP_ret::XML_OK;
 }
 
-XMLP_ret XMLParser::parseXMLCommonTCPTransportData(tinyxml2::XMLElement* p_root, sp_transport_t p_transport)
+XMLP_ret XMLParser::parseXMLCommonTCPTransportData(
+        tinyxml2::XMLElement* p_root,
+        sp_transport_t p_transport)
 {
     /*
         <xs:complexType name="rtpsTransportDescriptorType">
@@ -540,14 +573,14 @@ XMLP_ret XMLParser::parseXMLCommonTCPTransportData(tinyxml2::XMLElement* p_root,
                 <xs:element name="tls" type="tlsConfigType" minOccurs="0" maxOccurs="1"/>
             </xs:all>
         </xs:complexType>
-    */
+     */
 
     XMLP_ret ret = XMLP_ret::XML_OK;
     std::shared_ptr<rtps::TCPTransportDescriptor> pTCPDesc =
-        std::dynamic_pointer_cast<rtps::TCPTransportDescriptor>(p_transport);
+            std::dynamic_pointer_cast<rtps::TCPTransportDescriptor>(p_transport);
     if (pTCPDesc != nullptr)
     {
-        tinyxml2::XMLElement *p_aux0 = nullptr;
+        tinyxml2::XMLElement* p_aux0 = nullptr;
         const char* name = nullptr;
         for (p_aux0 = p_root->FirstChildElement(); p_aux0 != nullptr; p_aux0 = p_aux0->NextSiblingElement())
         {
@@ -557,7 +590,9 @@ XMLP_ret XMLParser::parseXMLCommonTCPTransportData(tinyxml2::XMLElement* p_root,
                 // keep_alive_frequency_ms - uint32Type
                 int iFrequency(0);
                 if (XMLP_ret::XML_OK != getXMLInt(p_aux0, &iFrequency, 0))
+                {
                     return XMLP_ret::XML_ERROR;
+                }
                 pTCPDesc->keep_alive_frequency_ms = static_cast<uint32_t>(iFrequency);
             }
             else if (strcmp(name, KEEP_ALIVE_TIMEOUT) == 0)
@@ -565,7 +600,9 @@ XMLP_ret XMLParser::parseXMLCommonTCPTransportData(tinyxml2::XMLElement* p_root,
                 // keep_alive_timeout_ms - uint32Type
                 int iTimeout(0);
                 if (XMLP_ret::XML_OK != getXMLInt(p_aux0, &iTimeout, 0))
+                {
                     return XMLP_ret::XML_ERROR;
+                }
                 pTCPDesc->keep_alive_timeout_ms = static_cast<uint32_t>(iTimeout);
             }
             else if (strcmp(name, MAX_LOGICAL_PORT) == 0)
@@ -573,7 +610,9 @@ XMLP_ret XMLParser::parseXMLCommonTCPTransportData(tinyxml2::XMLElement* p_root,
                 // max_logical_port - uint16Type
                 int iPort(0);
                 if (XMLP_ret::XML_OK != getXMLInt(p_aux0, &iPort, 0) || iPort < 0 || iPort > 65535)
+                {
                     return XMLP_ret::XML_ERROR;
+                }
                 pTCPDesc->max_logical_port = static_cast<uint16_t>(iPort);
             }
             else if (strcmp(name, LOGICAL_PORT_RANGE) == 0)
@@ -581,7 +620,9 @@ XMLP_ret XMLParser::parseXMLCommonTCPTransportData(tinyxml2::XMLElement* p_root,
                 // logical_port_range - uint16Type
                 int iPort(0);
                 if (XMLP_ret::XML_OK != getXMLInt(p_aux0, &iPort, 0) || iPort < 0 || iPort > 65535)
+                {
                     return XMLP_ret::XML_ERROR;
+                }
                 pTCPDesc->logical_port_range = static_cast<uint16_t>(iPort);
             }
             else if (strcmp(name, LOGICAL_PORT_INCREMENT) == 0)
@@ -589,7 +630,9 @@ XMLP_ret XMLParser::parseXMLCommonTCPTransportData(tinyxml2::XMLElement* p_root,
                 // logical_port_increment - uint16Type
                 int iPort(0);
                 if (XMLP_ret::XML_OK != getXMLInt(p_aux0, &iPort, 0) || iPort < 0 || iPort > 65535)
+                {
                     return XMLP_ret::XML_ERROR;
+                }
                 pTCPDesc->logical_port_increment = static_cast<uint16_t>(iPort);
             }
             // enable_tcp_nodelay - boolType
@@ -608,7 +651,9 @@ XMLP_ret XMLParser::parseXMLCommonTCPTransportData(tinyxml2::XMLElement* p_root,
                 {
                     int iPort = 0;
                     if (XMLP_ret::XML_OK != getXMLInt(p_aux1, &iPort, 0) || iPort < 0 || iPort > 65535)
+                    {
                         return XMLP_ret::XML_ERROR;
+                    }
 
                     pTCPDesc->add_listener_port(static_cast<uint16_t>(iPort));
                     p_aux1 = p_aux1->NextSiblingElement(PORT);
@@ -636,10 +681,10 @@ XMLP_ret XMLParser::parseXMLCommonTCPTransportData(tinyxml2::XMLElement* p_root,
                 }
             }
             else if (strcmp(name, TCP_WAN_ADDR) == 0 || strcmp(name, TRANSPORT_ID) == 0 ||
-                strcmp(name, TYPE) == 0 || strcmp(name, SEND_BUFFER_SIZE) == 0 ||
-                strcmp(name, RECEIVE_BUFFER_SIZE) == 0 || strcmp(name, TTL) == 0 ||
-                strcmp(name, MAX_MESSAGE_SIZE) == 0 || strcmp(name, MAX_INITIAL_PEERS_RANGE) == 0 ||
-                strcmp(name, WHITE_LIST) == 0)
+                    strcmp(name, TYPE) == 0 || strcmp(name, SEND_BUFFER_SIZE) == 0 ||
+                    strcmp(name, RECEIVE_BUFFER_SIZE) == 0 || strcmp(name, TTL) == 0 ||
+                    strcmp(name, MAX_MESSAGE_SIZE) == 0 || strcmp(name, MAX_INITIAL_PEERS_RANGE) == 0 ||
+                    strcmp(name, WHITE_LIST) == 0)
             {
                 // Parsed Outside of this method
             }
@@ -660,8 +705,8 @@ XMLP_ret XMLParser::parseXMLCommonTCPTransportData(tinyxml2::XMLElement* p_root,
 }
 
 XMLP_ret XMLParser::parse_tls_config(
-    tinyxml2::XMLElement* p_root,
-    sp_transport_t tcp_transport)
+        tinyxml2::XMLElement* p_root,
+        sp_transport_t tcp_transport)
 {
     /*
         XSD:
@@ -731,7 +776,7 @@ XMLP_ret XMLParser::parse_tls_config(
                 <option>NO_TLSV1_1</option>
             </options>
         </tls>
-   */
+     */
     using namespace rtps;
     using TCPDescriptor = std::shared_ptr<rtps::TCPTransportDescriptor>;
     using TLSVerifyMode = TCPTransportDescriptor::TLSConfig::TLSVerifyMode;
@@ -743,7 +788,7 @@ XMLP_ret XMLParser::parse_tls_config(
     TCPDescriptor pTCPDesc = std::dynamic_pointer_cast<rtps::TCPTransportDescriptor>(tcp_transport);
     pTCPDesc->apply_security = true;
 
-    tinyxml2::XMLElement *p_aux0 = nullptr;
+    tinyxml2::XMLElement* p_aux0 = nullptr;
 
     for (p_aux0 = p_root->FirstChildElement(); p_aux0 != nullptr; p_aux0 = p_aux0->NextSiblingElement())
     {
@@ -785,7 +830,7 @@ XMLP_ret XMLParser::parse_tls_config(
         }
         else if (config.compare(TLS_VERIFY_PATHS) == 0)
         {
-            tinyxml2::XMLElement *p_path = p_aux0->FirstChildElement();
+            tinyxml2::XMLElement* p_path = p_aux0->FirstChildElement();
 
             while (p_path != nullptr)
             {
@@ -863,14 +908,14 @@ XMLP_ret XMLParser::parse_tls_config(
                 else
                 {
                     logError(XMLPARSER, "Error parsing TLS configuration handshake_mode unrecognized "
-                        << handshake_mode << ".");
+                            << handshake_mode << ".");
                     ret = XMLP_ret::XML_ERROR;
                 }
             }
         }
         else if (config.compare(TLS_VERIFY_MODE) == 0)
         {
-            tinyxml2::XMLElement *p_verify = p_aux0->FirstChildElement();
+            tinyxml2::XMLElement* p_verify = p_aux0->FirstChildElement();
             while (p_verify != nullptr)
             {
                 std::string type = p_verify->Value();
@@ -903,7 +948,7 @@ XMLP_ret XMLParser::parse_tls_config(
                         else
                         {
                             logError(XMLPARSER, "Error parsing TLS configuration verify_mode unrecognized "
-                                << verify_mode << ".");
+                                    << verify_mode << ".");
                             ret = XMLP_ret::XML_ERROR;
                         }
                     }
@@ -911,7 +956,7 @@ XMLP_ret XMLParser::parse_tls_config(
                 else
                 {
                     logError(XMLPARSER, "Error parsing TLS configuration found unrecognized node "
-                        << type << ".");
+                            << type << ".");
                     ret = XMLP_ret::XML_ERROR;
                 }
 
@@ -926,7 +971,7 @@ XMLP_ret XMLParser::parse_tls_config(
         }
         else if (config.compare(TLS_OPTIONS) == 0)
         {
-            tinyxml2::XMLElement *p_option = p_aux0->FirstChildElement();
+            tinyxml2::XMLElement* p_option = p_aux0->FirstChildElement();
             while (p_option != nullptr)
             {
                 std::string type = p_option->Value();
@@ -979,7 +1024,7 @@ XMLP_ret XMLParser::parse_tls_config(
                         else
                         {
                             logError(XMLPARSER, "Error parsing TLS configuration option unrecognized "
-                                << option << ".");
+                                    << option << ".");
                             ret = XMLP_ret::XML_ERROR;
                         }
                     }
@@ -987,7 +1032,7 @@ XMLP_ret XMLParser::parse_tls_config(
                 else
                 {
                     logError(XMLPARSER, "Error parsing TLS options found unrecognized node "
-                        << type << ".");
+                            << type << ".");
                     ret = XMLP_ret::XML_ERROR;
                 }
 
@@ -1018,8 +1063,8 @@ XMLP_ret XMLParser::parse_tls_config(
     return ret;
 }
 
-
-XMLP_ret XMLParser::parseXMLDynamicType(tinyxml2::XMLElement* p_root)
+XMLP_ret XMLParser::parseXMLDynamicType(
+        tinyxml2::XMLElement* p_root)
 {
     /*
         <xs:group name="moduleElems">
@@ -1034,9 +1079,9 @@ XMLP_ret XMLParser::parseXMLDynamicType(tinyxml2::XMLElement* p_root)
                 </xs:choice>
             </xs:sequence>
         </xs:group>
-    */
+     */
     XMLP_ret ret = XMLP_ret::XML_OK;
-    tinyxml2::XMLElement *p_aux0 = nullptr;
+    tinyxml2::XMLElement* p_aux0 = nullptr;
     for (p_aux0 = p_root->FirstChildElement(); p_aux0 != nullptr; p_aux0 = p_aux0->NextSiblingElement())
     {
         const std::string type = p_aux0->Value();
@@ -1079,16 +1124,20 @@ XMLP_ret XMLParser::parseXMLDynamicType(tinyxml2::XMLElement* p_root)
     return ret;
 }
 
-static p_dynamictypebuilder_t getDiscriminatorTypeBuilder(const std::string &disc, uint32_t bound = 0);
+static p_dynamictypebuilder_t getDiscriminatorTypeBuilder(
+        const std::string& disc,
+        uint32_t bound = 0);
 
-static p_dynamictypebuilder_t getDiscriminatorTypeBuilder(const std::string &disc, uint32_t bound)
+static p_dynamictypebuilder_t getDiscriminatorTypeBuilder(
+        const std::string& disc,
+        uint32_t bound)
 {
     /*
-    mKind == TK_BOOLEAN || mKind == TK_BYTE || mKind == TK_INT16 || mKind == TK_INT32 ||
+       mKind == TK_BOOLEAN || mKind == TK_BYTE || mKind == TK_INT16 || mKind == TK_INT32 ||
         mKind == TK_INT64 || mKind == TK_UINT16 || mKind == TK_UINT32 || mKind == TK_UINT64 ||
         mKind == TK_FLOAT32 || mKind == TK_FLOAT64 || mKind == TK_FLOAT128 || mKind == TK_CHAR8 ||
         mKind == TK_CHAR16 || mKind == TK_STRING8 || mKind == TK_STRING16 || mKind == TK_ENUM || mKind == TK_BITMASK
-    */
+     */
     types::DynamicTypeBuilderFactory* factory = types::DynamicTypeBuilderFactory::get_instance();
     if (disc.compare(BOOLEAN) == 0)
     {
@@ -1154,7 +1203,8 @@ static p_dynamictypebuilder_t getDiscriminatorTypeBuilder(const std::string &dis
     return XMLProfileManager::getDynamicTypeByName(disc);
 }
 
-XMLP_ret XMLParser::parseXMLAliasDynamicType(tinyxml2::XMLElement* p_root)
+XMLP_ret XMLParser::parseXMLAliasDynamicType(
+        tinyxml2::XMLElement* p_root)
 {
     /*
         <typedef name="MyAliasEnum" type="nonBasic" nonBasicTypeName="MyEnum"/>
@@ -1170,7 +1220,7 @@ XMLP_ret XMLParser::parseXMLAliasDynamicType(tinyxml2::XMLElement* p_root)
             <xs:attribute name="sequenceMaxLength" type="string" use="optional"/>
             <xs:attribute name="mapMaxLength" type="string" use="optional"/>
         </xs:complexType>
-    */
+     */
     XMLP_ret ret = XMLP_ret::XML_OK;
 
     const char* type = p_root->Attribute(TYPE);
@@ -1192,10 +1242,10 @@ XMLP_ret XMLParser::parseXMLAliasDynamicType(tinyxml2::XMLElement* p_root)
 
         p_dynamictypebuilder_t valueBuilder;
         if ((p_root->Attribute(ARRAY_DIMENSIONS) != nullptr) ||
-            (p_root->Attribute(SEQ_MAXLENGTH) != nullptr) ||
-            (p_root->Attribute(MAP_MAXLENGTH) != nullptr))
+                (p_root->Attribute(SEQ_MAXLENGTH) != nullptr) ||
+                (p_root->Attribute(MAP_MAXLENGTH) != nullptr))
         {
-            valueBuilder = parseXMLMemberDynamicType(p_root , nullptr, MEMBER_ID_INVALID);
+            valueBuilder = parseXMLMemberDynamicType(p_root, nullptr, MEMBER_ID_INVALID);
         }
         else
         {
@@ -1212,7 +1262,7 @@ XMLP_ret XMLParser::parseXMLAliasDynamicType(tinyxml2::XMLElement* p_root)
         {
             const char* name = p_root->Attribute(NAME);
             p_dynamictypebuilder_t typeBuilder =
-                types::DynamicTypeBuilderFactory::get_instance()->create_alias_builder(valueBuilder, name);
+                    types::DynamicTypeBuilderFactory::get_instance()->create_alias_builder(valueBuilder, name);
             XMLProfileManager::insertDynamicTypeByName(name, typeBuilder);
         }
         else
@@ -1229,7 +1279,8 @@ XMLP_ret XMLParser::parseXMLAliasDynamicType(tinyxml2::XMLElement* p_root)
     return ret;
 }
 
-XMLP_ret XMLParser::parseXMLBitsetDynamicType(tinyxml2::XMLElement* p_root)
+XMLP_ret XMLParser::parseXMLBitsetDynamicType(
+        tinyxml2::XMLElement* p_root)
 {
     /*
         <bitset name="MyBitSet">
@@ -1249,7 +1300,7 @@ XMLP_ret XMLParser::parseXMLBitsetDynamicType(tinyxml2::XMLElement* p_root)
             <xs:attribute name="name" type="stringType" use="required"/>
             <xs:attribute name="baseType" type="stringType" use="optional"/>
         </xs:complexType>
-    */
+     */
     XMLP_ret ret = XMLP_ret::XML_OK;
     p_dynamictypebuilder_t typeBuilder;
     uint32_t mId = 0;
@@ -1278,7 +1329,7 @@ XMLP_ret XMLParser::parseXMLBitsetDynamicType(tinyxml2::XMLElement* p_root)
 
     const char* element_name = nullptr;
     uint16_t position = 0;
-    for (tinyxml2::XMLElement *p_element = p_root->FirstChildElement();
+    for (tinyxml2::XMLElement* p_element = p_root->FirstChildElement();
             p_element != nullptr; p_element = p_element->NextSiblingElement())
     {
         element_name = p_element->Name();
@@ -1313,7 +1364,7 @@ p_dynamictypebuilder_t XMLParser::parseXMLBitfieldDynamicType(
             <xs:attribute name="type" type="stringType" use="optional"/>
             <xs:attribute name="bit_bound" type="int16Type" use="required"/>
         </xs:complexType>
-    */
+     */
     if (p_root == nullptr)
     {
         logError(XMLPARSER, "Error parsing bitfield: Node not found.");
@@ -1369,10 +1420,10 @@ p_dynamictypebuilder_t XMLParser::parseXMLBitfieldDynamicType(
                 return nullptr;
             }
         }
-        catch(...)
+        catch (...)
         {
             logError(XMLPARSER, "Failed creating bitfield, invalid bit_bound (must be an unsigned short): "
-                << bit_bound);
+                    << bit_bound);
             return nullptr;
         }
     }
@@ -1436,7 +1487,7 @@ p_dynamictypebuilder_t XMLParser::parseXMLBitfieldDynamicType(
             p_dynamictype->apply_annotation_to_member(mId, types::ANNOTATION_BIT_BOUND_ID, "value", bit_bound);
             //position += static_cast<uint16_t>(mId);
             p_dynamictype->apply_annotation_to_member(mId, types::ANNOTATION_POSITION_ID, "value",
-                std::to_string(position));
+                    std::to_string(position));
         }
         position += static_cast<uint16_t>(atoi(bit_bound));
     }
@@ -1444,7 +1495,8 @@ p_dynamictypebuilder_t XMLParser::parseXMLBitfieldDynamicType(
     return memberBuilder;
 }
 
-XMLP_ret XMLParser::parseXMLBitmaskDynamicType(tinyxml2::XMLElement* p_root)
+XMLP_ret XMLParser::parseXMLBitmaskDynamicType(
+        tinyxml2::XMLElement* p_root)
 {
     /*
         <bitmask name="MyBitMask" bit_bound="8">
@@ -1461,7 +1513,7 @@ XMLP_ret XMLParser::parseXMLBitmaskDynamicType(tinyxml2::XMLElement* p_root)
             <xs:attribute name="name" use="required"/>
             <xs:attribute name="bit_bound" use="optional"/>
         </xs:complexType>
-    */
+     */
     XMLP_ret ret = XMLP_ret::XML_OK;
     uint16_t bit_bound = 32;
     const char* anno_bit_bound = p_root->Attribute(BIT_BOUND);
@@ -1472,12 +1524,12 @@ XMLP_ret XMLParser::parseXMLBitmaskDynamicType(tinyxml2::XMLElement* p_root)
 
     const char* name = p_root->Attribute(NAME);
     p_dynamictypebuilder_t typeBuilder =
-        types::DynamicTypeBuilderFactory::get_instance()->create_bitmask_builder(bit_bound);
+            types::DynamicTypeBuilderFactory::get_instance()->create_bitmask_builder(bit_bound);
     typeBuilder->set_name(name);
     uint16_t position = 0;
 
     const char* element_name = nullptr;
-    for (tinyxml2::XMLElement *p_element = p_root->FirstChildElement();
+    for (tinyxml2::XMLElement* p_element = p_root->FirstChildElement();
             p_element != nullptr; p_element = p_element->NextSiblingElement())
     {
         element_name = p_element->Name();
@@ -1509,7 +1561,7 @@ XMLP_ret XMLParser::parseXMLBitvalueDynamicType(
             <xs:attribute name="name" type="stringType" use="required"/>
             <xs:attribute name="position" type="int16Type" use="optional"/>
         </xs:complexType>
-    */
+     */
     if (p_root == nullptr)
     {
         logError(XMLPARSER, "Error parsing bitmask: Node not found.");
@@ -1525,7 +1577,7 @@ XMLP_ret XMLParser::parseXMLBitvalueDynamicType(
         {
             field_position = static_cast<uint16_t>(std::stoul(position));
         }
-        catch(const std::exception&)
+        catch (const std::exception&)
         {
             logError(XMLPARSER, "Error parsing bit_value position: Invalid (must be an unsigned short).");
             return XMLP_ret::XML_ERROR;
@@ -1546,7 +1598,8 @@ XMLP_ret XMLParser::parseXMLBitvalueDynamicType(
     return XMLP_ret::XML_OK;
 }
 
-XMLP_ret XMLParser::parseXMLEnumDynamicType(tinyxml2::XMLElement* p_root)
+XMLP_ret XMLParser::parseXMLEnumDynamicType(
+        tinyxml2::XMLElement* p_root)
 {
     /*
         <xs:complexType name="enumeratorType">
@@ -1562,7 +1615,7 @@ XMLP_ret XMLParser::parseXMLEnumDynamicType(tinyxml2::XMLElement* p_root)
         </xs:complexType>
 
         //TODO: Enum bitbound to set the internal field
-    */
+     */
     XMLP_ret ret = XMLP_ret::XML_OK;
     const char* enumName = p_root->Attribute(NAME);
     p_dynamictypebuilder_t typeBuilder = types::DynamicTypeBuilderFactory::get_instance()->create_enum_builder();
@@ -1589,7 +1642,8 @@ XMLP_ret XMLParser::parseXMLEnumDynamicType(tinyxml2::XMLElement* p_root)
     return ret;
 }
 
-XMLP_ret XMLParser::parseXMLStructDynamicType(tinyxml2::XMLElement* p_root)
+XMLP_ret XMLParser::parseXMLStructDynamicType(
+        tinyxml2::XMLElement* p_root)
 {
     /*
         <xs:complexType name="structDcl">
@@ -1601,7 +1655,7 @@ XMLP_ret XMLParser::parseXMLStructDynamicType(tinyxml2::XMLElement* p_root)
             <xs:attribute name="name" type="string" use="required"/>
             <xs:attribute name="baseType" type="stringType" use="optional"/>
         </xs:complexType>
-    */
+     */
     XMLP_ret ret = XMLP_ret::XML_OK;
     const char* name = p_root->Attribute(NAME);
     p_dynamictypebuilder_t typeBuilder; // = types::DynamicTypeBuilderFactory::get_instance()->create_struct_builder();
@@ -1629,7 +1683,7 @@ XMLP_ret XMLParser::parseXMLStructDynamicType(tinyxml2::XMLElement* p_root)
     typeBuilder->set_name(name);
 
     const char* element_name = nullptr;
-    for (tinyxml2::XMLElement *p_element = p_root->FirstChildElement();
+    for (tinyxml2::XMLElement* p_element = p_root->FirstChildElement();
             p_element != nullptr; p_element = p_element->NextSiblingElement())
     {
         element_name = p_element->Name();
@@ -1653,7 +1707,8 @@ XMLP_ret XMLParser::parseXMLStructDynamicType(tinyxml2::XMLElement* p_root)
     return ret;
 }
 
-XMLP_ret XMLParser::parseXMLUnionDynamicType(tinyxml2::XMLElement* p_root)
+XMLP_ret XMLParser::parseXMLUnionDynamicType(
+        tinyxml2::XMLElement* p_root)
 {
     /*
         <xs:complexType name="caseDcl">
@@ -1674,11 +1729,11 @@ XMLP_ret XMLParser::parseXMLUnionDynamicType(tinyxml2::XMLElement* p_root)
             </xs:sequence>
             <xs:attribute name="name" type="identifierName" use="required"/>
         </xs:complexType>
-    */
+     */
 
     XMLP_ret ret = XMLP_ret::XML_OK;
     const char* name = p_root->Attribute(NAME);
-    tinyxml2::XMLElement *p_element = p_root->FirstChildElement(DISCRIMINATOR);
+    tinyxml2::XMLElement* p_element = p_root->FirstChildElement(DISCRIMINATOR);
     if (p_element != nullptr)
     {
         const char* disc = p_element->Attribute(TYPE);
@@ -1686,12 +1741,13 @@ XMLP_ret XMLParser::parseXMLUnionDynamicType(tinyxml2::XMLElement* p_root)
         if (discriminator == nullptr)
         {
             logError(XMLPARSER,
-                "Error parsing union discriminator: Only primitive types allowed (found type " << disc << ").");
+                    "Error parsing union discriminator: Only primitive types allowed (found type " << disc << ").");
             ret = XMLP_ret::XML_ERROR;
         }
         else
         {
-            p_dynamictypebuilder_t typeBuilder = types::DynamicTypeBuilderFactory::get_instance()->create_union_builder(discriminator);
+            p_dynamictypebuilder_t typeBuilder = types::DynamicTypeBuilderFactory::get_instance()->create_union_builder(
+                discriminator);
             typeBuilder->set_name(name);
 
             uint32_t mId = 0;
@@ -1699,8 +1755,8 @@ XMLP_ret XMLParser::parseXMLUnionDynamicType(tinyxml2::XMLElement* p_root)
                     p_element != nullptr; p_element = p_element->NextSiblingElement(CASE))
             {
                 std::string valuesStr = "";
-                for (tinyxml2::XMLElement *caseValue = p_element->FirstChildElement(CASE_DISCRIMINATOR);
-                    caseValue != nullptr; caseValue = caseValue->NextSiblingElement(CASE_DISCRIMINATOR))
+                for (tinyxml2::XMLElement* caseValue = p_element->FirstChildElement(CASE_DISCRIMINATOR);
+                        caseValue != nullptr; caseValue = caseValue->NextSiblingElement(CASE_DISCRIMINATOR))
                 {
                     const char* values = caseValue->Attribute(VALUE);
                     if (values == nullptr)
@@ -1719,7 +1775,7 @@ XMLP_ret XMLParser::parseXMLUnionDynamicType(tinyxml2::XMLElement* p_root)
                     }
                 }
 
-                tinyxml2::XMLElement *caseElement = p_element->FirstChildElement();
+                tinyxml2::XMLElement* caseElement = p_element->FirstChildElement();
                 while (caseElement != nullptr && strncmp(caseElement->Value(), CASE_DISCRIMINATOR, 10) == 0)
                 {
                     caseElement = caseElement->NextSiblingElement();
@@ -1727,7 +1783,7 @@ XMLP_ret XMLParser::parseXMLUnionDynamicType(tinyxml2::XMLElement* p_root)
                 if (caseElement != nullptr)
                 {
                     p_dynamictypebuilder_t mType = parseXMLMemberDynamicType
-                                                    (caseElement, typeBuilder, mId++, valuesStr);
+                                (caseElement, typeBuilder, mId++, valuesStr);
                     if (mType == nullptr)
                     {
                         return XMLP_ret::XML_ERROR;
@@ -1752,7 +1808,9 @@ XMLP_ret XMLParser::parseXMLUnionDynamicType(tinyxml2::XMLElement* p_root)
     return ret;
 }
 
-static void dimensionsToArrayBounds(const std::string& dimensions, std::vector<uint32_t>& bounds)
+static void dimensionsToArrayBounds(
+        const std::string& dimensions,
+        std::vector<uint32_t>& bounds)
 {
     std::stringstream ss(dimensions);
     std::string item;
@@ -1765,7 +1823,9 @@ static void dimensionsToArrayBounds(const std::string& dimensions, std::vector<u
     }
 }
 
-static bool dimensionsToLabels(const std::string& labelStr, std::vector<uint64_t>& labels)
+static bool dimensionsToLabels(
+        const std::string& labelStr,
+        std::vector<uint64_t>& labels)
 {
     std::stringstream ss(labelStr);
     std::string item;
@@ -1775,22 +1835,31 @@ static bool dimensionsToLabels(const std::string& labelStr, std::vector<uint64_t
     while (std::getline(ss, item, ','))
     {
         if (item == DEFAULT)
+        {
             def = true;
+        }
         else
+        {
             labels.push_back(static_cast<uint64_t>(std::atoi(item.c_str())));
+        }
     }
 
     return def;
 }
 
-p_dynamictypebuilder_t XMLParser::parseXMLMemberDynamicType(tinyxml2::XMLElement* p_root,
-        p_dynamictypebuilder_t p_dynamictype, types::MemberId mId)
+p_dynamictypebuilder_t XMLParser::parseXMLMemberDynamicType(
+        tinyxml2::XMLElement* p_root,
+        p_dynamictypebuilder_t p_dynamictype,
+        types::MemberId mId)
 {
     return parseXMLMemberDynamicType(p_root, p_dynamictype, mId, "");
 }
 
-p_dynamictypebuilder_t XMLParser::parseXMLMemberDynamicType(tinyxml2::XMLElement* p_root,
-        p_dynamictypebuilder_t p_dynamictype, types::MemberId mId, const std::string& values)
+p_dynamictypebuilder_t XMLParser::parseXMLMemberDynamicType(
+        tinyxml2::XMLElement* p_root,
+        p_dynamictypebuilder_t p_dynamictype,
+        types::MemberId mId,
+        const std::string& values)
 {
     /*
         <xs:complexType name="memberDcl">
@@ -1804,7 +1873,7 @@ p_dynamictypebuilder_t XMLParser::parseXMLMemberDynamicType(tinyxml2::XMLElement
                 <xs:element name="member" type="memberDcl" minOccurs="0"/>
             </xs:sequence>
         </xs:complexType>
-    */
+     */
     if (p_root == nullptr)
     {
         logError(XMLPARSER, "Error parsing member: Node not found.");
@@ -2252,7 +2321,7 @@ p_dynamictypebuilder_t XMLParser::parseXMLMemberDynamicType(tinyxml2::XMLElement
             std::vector<uint64_t> labels;
             bool defaultLabel = dimensionsToLabels(values, labels);
             p_dynamictype->add_member(mId, memberName, memberBuilder,
-                "", labels, defaultLabel);
+                    "", labels, defaultLabel);
         }
         else
         {
@@ -2264,7 +2333,8 @@ p_dynamictypebuilder_t XMLParser::parseXMLMemberDynamicType(tinyxml2::XMLElement
     return memberBuilder;
 }
 
-XMLP_ret XMLParser::parseXMLLibrarySettings(tinyxml2::XMLElement* p_root)
+XMLP_ret XMLParser::parseXMLLibrarySettings(
+        tinyxml2::XMLElement* p_root)
 {
     /*
         <xs:complexType name="LibrarySettingsType">
@@ -2272,13 +2342,13 @@ XMLP_ret XMLParser::parseXMLLibrarySettings(tinyxml2::XMLElement* p_root)
                 <xs:element name="intraprocess_delivery" type="IntraprocessDeliveryType"/>
             </xs:all>
         </xs:complexType>
-    */
+     */
 
     XMLP_ret ret = XMLP_ret::XML_OK;
     std::string sId = "";
 
     uint8_t ident = 1;
-    tinyxml2::XMLElement *p_aux0 = nullptr;
+    tinyxml2::XMLElement* p_aux0 = nullptr;
     p_aux0 = p_root->FirstChildElement(INTRAPROCESS_DELIVERY);
     if (nullptr == p_aux0)
     {
@@ -2299,7 +2369,9 @@ XMLP_ret XMLParser::parseXMLLibrarySettings(tinyxml2::XMLElement* p_root)
     return ret;
 }
 
-XMLP_ret XMLParser::parseXMLParticipantProf(tinyxml2::XMLElement* p_root, BaseNode& rootNode)
+XMLP_ret XMLParser::parseXMLParticipantProf(
+        tinyxml2::XMLElement* p_root,
+        BaseNode& rootNode)
 {
     XMLP_ret ret = XMLP_ret::XML_OK;
     up_participant_t participant_atts{new ParticipantAttributes};
@@ -2317,7 +2389,9 @@ XMLP_ret XMLParser::parseXMLParticipantProf(tinyxml2::XMLElement* p_root, BaseNo
     return ret;
 }
 
-XMLP_ret XMLParser::parseXMLPublisherProf(tinyxml2::XMLElement* p_root, BaseNode& rootNode)
+XMLP_ret XMLParser::parseXMLPublisherProf(
+        tinyxml2::XMLElement* p_root,
+        BaseNode& rootNode)
 {
     XMLP_ret ret = XMLP_ret::XML_OK;
     up_publisher_t publisher_atts{new PublisherAttributes};
@@ -2334,7 +2408,9 @@ XMLP_ret XMLParser::parseXMLPublisherProf(tinyxml2::XMLElement* p_root, BaseNode
     return ret;
 }
 
-XMLP_ret XMLParser::parseXMLSubscriberProf(tinyxml2::XMLElement* p_root, BaseNode& rootNode)
+XMLP_ret XMLParser::parseXMLSubscriberProf(
+        tinyxml2::XMLElement* p_root,
+        BaseNode& rootNode)
 {
     XMLP_ret ret = XMLP_ret::XML_OK;
     up_subscriber_t subscriber_atts{new SubscriberAttributes};
@@ -2351,7 +2427,9 @@ XMLP_ret XMLParser::parseXMLSubscriberProf(tinyxml2::XMLElement* p_root, BaseNod
     return ret;
 }
 
-XMLP_ret XMLParser::parseXMLTopicData(tinyxml2::XMLElement* p_root, BaseNode& rootNode)
+XMLP_ret XMLParser::parseXMLTopicData(
+        tinyxml2::XMLElement* p_root,
+        BaseNode& rootNode)
 {
     XMLP_ret ret = XMLP_ret::XML_OK;
     up_topic_t topic_atts{new TopicAttributes};
@@ -2368,7 +2446,9 @@ XMLP_ret XMLParser::parseXMLTopicData(tinyxml2::XMLElement* p_root, BaseNode& ro
     return ret;
 }
 
-XMLP_ret XMLParser::parseProfiles(tinyxml2::XMLElement* p_root, BaseNode& profilesNode)
+XMLP_ret XMLParser::parseProfiles(
+        tinyxml2::XMLElement* p_root,
+        BaseNode& profilesNode)
 {
     /*
         <xs:element name="profiles">
@@ -2383,7 +2463,7 @@ XMLP_ret XMLParser::parseProfiles(tinyxml2::XMLElement* p_root, BaseNode& profil
                 </xs:sequence>
             </xs:complexType>
         </xs:element>
-    */
+     */
 
     tinyxml2::XMLElement* p_profile = p_root->FirstChildElement();
     const char* tag = nullptr;
@@ -2449,16 +2529,18 @@ XMLP_ret XMLParser::parseProfiles(tinyxml2::XMLElement* p_root, BaseNode& profil
     return XMLP_ret::XML_OK;
 }
 
-XMLP_ret XMLParser::parseDynamicTypes(tinyxml2::XMLElement* p_root)
+XMLP_ret XMLParser::parseDynamicTypes(
+        tinyxml2::XMLElement* p_root)
 {
     return parseXMLTypes(p_root);
 }
 
-XMLP_ret XMLParser::parseLogConfig(tinyxml2::XMLElement* p_root)
+XMLP_ret XMLParser::parseLogConfig(
+        tinyxml2::XMLElement* p_root)
 {
     /*
-    <xs:element name="log">
-      <xs:complexType>
+       <xs:element name="log">
+       <xs:complexType>
         <xs:boolean name="use_default"/>
         <xs:sequence>
           <xs:element maxOccurs="consumer">
@@ -2469,12 +2551,12 @@ XMLP_ret XMLParser::parseLogConfig(tinyxml2::XMLElement* p_root)
               </xs:sequence>
             </xs:complexType>
         </xs:sequence>
-      </xs:complexType>
-    </xs:element>
-    */
+       </xs:complexType>
+       </xs:element>
+     */
 
     XMLP_ret ret = XMLP_ret::XML_OK;
-    tinyxml2::XMLElement *p_aux0 = p_root->FirstChildElement(LOG);
+    tinyxml2::XMLElement* p_aux0 = p_root->FirstChildElement(LOG);
     if (p_aux0 == nullptr)
     {
         p_aux0 = p_root;
@@ -2518,7 +2600,8 @@ XMLP_ret XMLParser::parseLogConfig(tinyxml2::XMLElement* p_root)
     return ret;
 }
 
-XMLP_ret XMLParser::parseXMLConsumer(tinyxml2::XMLElement& consumer)
+XMLP_ret XMLParser::parseXMLConsumer(
+        tinyxml2::XMLElement& consumer)
 {
     XMLP_ret ret = XMLP_ret::XML_OK;
     tinyxml2::XMLElement* p_element = consumer.FirstChildElement(CLASS);
@@ -2561,7 +2644,7 @@ XMLP_ret XMLParser::parseXMLConsumer(tinyxml2::XMLElement& consumer)
                             else
                             {
                                 logError(XMLParser, "Filename value cannot be found for " << classStr
-                                    << " log consumer.");
+                                                                                          << " log consumer.");
                             }
                         }
                         else if (std::strcmp(s.c_str(), "append") == 0)
@@ -2577,13 +2660,13 @@ XMLP_ret XMLParser::parseXMLConsumer(tinyxml2::XMLElement& consumer)
                             else
                             {
                                 logError(XMLParser, "Append value cannot be found for " << classStr
-                                    << " log consumer.");
+                                                                                        << " log consumer.");
                             }
                         }
                         else
                         {
                             logError(XMLParser, "Unknown property " << s << " in " << classStr
-                                << " log consumer.");
+                                                                    << " log consumer.");
                         }
                     }
                     property = property->NextSiblingElement(PROPERTY);
@@ -2609,22 +2692,30 @@ XMLP_ret XMLParser::loadXML(
     return XMLParserImpl::loadXML(filename, root, false);
 }
 
-XMLP_ret XMLParser::loadXMLProfiles(tinyxml2::XMLElement &xmlDoc, up_base_node_t& root)
+XMLP_ret XMLParser::loadXMLProfiles(
+        tinyxml2::XMLElement& xmlDoc,
+        up_base_node_t& root)
 {
     return parseXMLProfiles(xmlDoc, root);
 }
 
-XMLP_ret XMLParser::loadXMLDynamicTypes(tinyxml2::XMLElement &xmlDoc)
+XMLP_ret XMLParser::loadXMLDynamicTypes(
+        tinyxml2::XMLElement& xmlDoc)
 {
     return parseXMLDynamicTypes(xmlDoc);
 }
 
-XMLP_ret XMLParser::loadXML(tinyxml2::XMLDocument &xmlDoc, up_base_node_t& root)
+XMLP_ret XMLParser::loadXML(
+        tinyxml2::XMLDocument& xmlDoc,
+        up_base_node_t& root)
 {
     return parseXML(xmlDoc, root);
 }
 
-XMLP_ret XMLParser::loadXML(const char* data, size_t length, up_base_node_t& root)
+XMLP_ret XMLParser::loadXML(
+        const char* data,
+        size_t length,
+        up_base_node_t& root)
 {
     tinyxml2::XMLDocument xmlDoc;
     if (tinyxml2::XMLError::XML_SUCCESS != xmlDoc.Parse(data, length))
@@ -2636,7 +2727,9 @@ XMLP_ret XMLParser::loadXML(const char* data, size_t length, up_base_node_t& roo
 }
 
 template <typename T>
-void XMLParser::addAllAttributes(tinyxml2::XMLElement* p_profile, DataNode<T>& node)
+void XMLParser::addAllAttributes(
+        tinyxml2::XMLElement* p_profile,
+        DataNode<T>& node)
 {
     const tinyxml2::XMLAttribute* attrib;
     for (attrib = p_profile->FirstAttribute(); attrib != nullptr; attrib = attrib->Next())
@@ -2645,7 +2738,9 @@ void XMLParser::addAllAttributes(tinyxml2::XMLElement* p_profile, DataNode<T>& n
     }
 }
 
-XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* node, DataNode<TopicAttributes>& topic_node)
+XMLP_ret XMLParser::fillDataNode(
+        tinyxml2::XMLElement* node,
+        DataNode<TopicAttributes>& topic_node)
 {
     if (nullptr == node)
     {
@@ -2664,7 +2759,9 @@ XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* node, DataNode<TopicAttri
     return XMLP_ret::XML_OK;
 }
 
-XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<ParticipantAttributes>& participant_node)
+XMLP_ret XMLParser::fillDataNode(
+        tinyxml2::XMLElement* p_profile,
+        DataNode<ParticipantAttributes>& participant_node)
 {
     /*
         <xs:complexType name="rtpsParticipantAttributesType">
@@ -2686,7 +2783,7 @@ XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<Parti
                 <xs:element name="name" type="stringType" minOccurs="0"/>
             </xs:all>
         </xs:complexType>
-    */
+     */
 
     if (nullptr == p_profile)
     {
@@ -2704,7 +2801,7 @@ XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<Parti
     }
 
     uint8_t ident = 1;
-    tinyxml2::XMLElement *p_aux0 = nullptr;
+    tinyxml2::XMLElement* p_aux0 = nullptr;
     const char* name = nullptr;
     for (p_aux0 = p_element->FirstChildElement(); p_aux0 != nullptr; p_aux0 = p_aux0->NextSiblingElement())
     {
@@ -2713,7 +2810,7 @@ XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<Parti
         if (strcmp(name, ALLOCATION) == 0)
         {
             // allocation
-            if (XMLP_ret::XML_OK != 
+            if (XMLP_ret::XML_OK !=
                     getXMLParticipantAllocationAttributes(p_aux0, participant_node.get()->rtps.allocation, ident))
             {
                 return XMLP_ret::XML_ERROR;
@@ -2723,7 +2820,7 @@ XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<Parti
         {
             // prefix
             if (XMLP_ret::XML_OK !=
-                getXMLguidPrefix(p_aux0, participant_node.get()->rtps.prefix, ident))
+                    getXMLguidPrefix(p_aux0, participant_node.get()->rtps.prefix, ident))
             {
                 return XMLP_ret::XML_ERROR;
             }
@@ -2732,7 +2829,7 @@ XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<Parti
         {
             // defaultUnicastLocatorList
             if (XMLP_ret::XML_OK !=
-                getXMLLocatorList(p_aux0, participant_node.get()->rtps.defaultUnicastLocatorList, ident))
+                    getXMLLocatorList(p_aux0, participant_node.get()->rtps.defaultUnicastLocatorList, ident))
             {
                 return XMLP_ret::XML_ERROR;
             }
@@ -2741,7 +2838,7 @@ XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<Parti
         {
             // defaultMulticastLocatorList
             if (XMLP_ret::XML_OK !=
-                getXMLLocatorList(p_aux0, participant_node.get()->rtps.defaultMulticastLocatorList, ident))
+                    getXMLLocatorList(p_aux0, participant_node.get()->rtps.defaultMulticastLocatorList, ident))
             {
                 return XMLP_ret::XML_ERROR;
             }
@@ -2798,7 +2895,7 @@ XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<Parti
         {
             // throughputController
             if (XMLP_ret::XML_OK !=
-                getXMLThroughputController(p_aux0, participant_node.get()->rtps.throughputController, ident))
+                    getXMLThroughputController(p_aux0, participant_node.get()->rtps.throughputController, ident))
             {
                 return XMLP_ret::XML_ERROR;
             }
@@ -2846,7 +2943,9 @@ XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<Parti
     return XMLP_ret::XML_OK;
 }
 
-XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<PublisherAttributes>& publisher_node)
+XMLP_ret XMLParser::fillDataNode(
+        tinyxml2::XMLElement* p_profile,
+        DataNode<PublisherAttributes>& publisher_node)
 {
     /*
         <xs:complexType name="publisherProfileType">
@@ -2864,7 +2963,7 @@ XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<Publi
             </xs:all>
             <xs:attribute name="profile_name" type="stringType" use="required"/>
         </xs:complexType>
-    */
+     */
 
     if (nullptr == p_profile)
     {
@@ -2875,7 +2974,7 @@ XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<Publi
     addAllAttributes(p_profile, publisher_node);
 
     uint8_t ident = 1;
-    tinyxml2::XMLElement *p_aux0 = nullptr;
+    tinyxml2::XMLElement* p_aux0 = nullptr;
     const char* name = nullptr;
     for (p_aux0 = p_profile->FirstChildElement(); p_aux0 != nullptr; p_aux0 = p_aux0->NextSiblingElement())
     {
@@ -2884,63 +2983,83 @@ XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<Publi
         {
             // topic
             if (XMLP_ret::XML_OK != getXMLTopicAttributes(p_aux0, publisher_node.get()->topic, ident))
+            {
                 return XMLP_ret::XML_ERROR;
+            }
         }
         else if (strcmp(name, QOS) == 0)
         {
             // qos
             if (XMLP_ret::XML_OK != getXMLWriterQosPolicies(p_aux0, publisher_node.get()->qos, ident))
+            {
                 return XMLP_ret::XML_ERROR;
+            }
         }
         else if (strcmp(name, TIMES) == 0)
         {
             // times
             if (XMLP_ret::XML_OK != getXMLWriterTimes(p_aux0, publisher_node.get()->times, ident))
+            {
                 return XMLP_ret::XML_ERROR;
+            }
         }
         else if (strcmp(name, UNI_LOC_LIST) == 0)
         {
             // unicastLocatorList
             if (XMLP_ret::XML_OK != getXMLLocatorList(p_aux0, publisher_node.get()->unicastLocatorList, ident))
+            {
                 return XMLP_ret::XML_ERROR;
+            }
         }
         else if (strcmp(name, MULTI_LOC_LIST) == 0)
         {
             // multicastLocatorList
             if (XMLP_ret::XML_OK != getXMLLocatorList(p_aux0, publisher_node.get()->multicastLocatorList, ident))
+            {
                 return XMLP_ret::XML_ERROR;
+            }
         }
         else if (strcmp(name, REM_LOC_LIST) == 0)
         {
             // remoteLocatorList
             if (XMLP_ret::XML_OK != getXMLLocatorList(p_aux0, publisher_node.get()->remoteLocatorList, ident))
+            {
                 return XMLP_ret::XML_ERROR;
+            }
         }
         else if (strcmp(name, THROUGHPUT_CONT) == 0)
         {
             // throughputController
             if (XMLP_ret::XML_OK !=
-                getXMLThroughputController(p_aux0, publisher_node.get()->throughputController, ident))
+                    getXMLThroughputController(p_aux0, publisher_node.get()->throughputController, ident))
+            {
                 return XMLP_ret::XML_ERROR;
+            }
         }
         else if (strcmp(name, HIST_MEM_POLICY) == 0)
         {
             // historyMemoryPolicy
             if (XMLP_ret::XML_OK != getXMLHistoryMemoryPolicy(p_aux0, publisher_node.get()->historyMemoryPolicy, ident))
+            {
                 return XMLP_ret::XML_ERROR;
+            }
         }
         else if (strcmp(name, PROPERTIES_POLICY) == 0)
         {
             // propertiesPolicy
             if (XMLP_ret::XML_OK != getXMLPropertiesPolicy(p_aux0, publisher_node.get()->properties, ident))
+            {
                 return XMLP_ret::XML_ERROR;
+            }
         }
         else if (strcmp(name, USER_DEF_ID) == 0)
         {
             // userDefinedID - int16type
             int i = 0;
             if (XMLP_ret::XML_OK != getXMLInt(p_aux0, &i, ident) || i > 255)
+            {
                 return XMLP_ret::XML_ERROR;
+            }
             publisher_node.get()->setUserDefinedID(static_cast<uint8_t>(i));
         }
         else if (strcmp(name, ENTITY_ID) == 0)
@@ -2948,14 +3067,20 @@ XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<Publi
             // entityID - int16Type
             int i = 0;
             if (XMLP_ret::XML_OK != getXMLInt(p_aux0, &i, ident) || i > 255)
+            {
                 return XMLP_ret::XML_ERROR;
+            }
             publisher_node.get()->setEntityID(static_cast<uint8_t>(i));
         }
         else if (strcmp(name, MATCHED_SUBSCRIBERS_ALLOCATION) == 0)
         {
             // matchedSubscribersAllocation - containerAllocationConfigType
-            if(XMLP_ret::XML_OK != getXMLContainerAllocationConfig(p_aux0, publisher_node.get()->matched_subscriber_allocation, ident))
+            if (XMLP_ret::XML_OK !=
+                    getXMLContainerAllocationConfig(p_aux0,
+                    publisher_node.get()->matched_subscriber_allocation, ident))
+            {
                 return XMLP_ret::XML_ERROR;
+            }
         }
         else
         {
@@ -2966,7 +3091,9 @@ XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<Publi
     return XMLP_ret::XML_OK;
 }
 
-XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<SubscriberAttributes>& subscriber_node)
+XMLP_ret XMLParser::fillDataNode(
+        tinyxml2::XMLElement* p_profile,
+        DataNode<SubscriberAttributes>& subscriber_node)
 {
     /*
         <xs:complexType name="subscriberProfileType">
@@ -2984,7 +3111,7 @@ XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<Subsc
             </xs:all>
             <xs:attribute name="profile_name" type="stringType" use="required"/>
         </xs:complexType>
-    */
+     */
 
     if (nullptr == p_profile)
     {
@@ -2995,7 +3122,7 @@ XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<Subsc
     addAllAttributes(p_profile, subscriber_node);
 
     uint8_t ident = 1;
-    tinyxml2::XMLElement *p_aux0 = nullptr;
+    tinyxml2::XMLElement* p_aux0 = nullptr;
     const char* name = nullptr;
     for (p_aux0 = p_profile->FirstChildElement(); p_aux0 != nullptr; p_aux0 = p_aux0->NextSiblingElement())
     {
@@ -3060,9 +3187,9 @@ XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<Subsc
         {
             // historyMemoryPolicy
             if (XMLP_ret::XML_OK != getXMLHistoryMemoryPolicy(
-                    p_aux0,
-                    subscriber_node.get()->historyMemoryPolicy,
-                    ident))
+                        p_aux0,
+                        subscriber_node.get()->historyMemoryPolicy,
+                        ident))
             {
                 return XMLP_ret::XML_ERROR;
             }
@@ -3099,9 +3226,9 @@ XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<Subsc
         {
             // matchedPublishersAllocation - containerAllocationConfigType
             if (XMLP_ret::XML_OK != getXMLContainerAllocationConfig(
-                    p_aux0,
-                    subscriber_node.get()->matched_publisher_allocation,
-                    ident))
+                        p_aux0,
+                        subscriber_node.get()->matched_publisher_allocation,
+                        ident))
             {
                 return XMLP_ret::XML_ERROR;
             }

--- a/src/cpp/xmlparser/XMLParser.cpp
+++ b/src/cpp/xmlparser/XMLParser.cpp
@@ -16,9 +16,10 @@
 
 #include <iostream>
 #include <cstdlib>
-#include <unistd.h>
 #ifdef _WIN32
 #include <windows.h>
+#else
+#include <unistd.h>
 #endif // _WIN32
 
 #include <tinyxml2.h>

--- a/src/cpp/xmlparser/XMLParserImpl.hpp
+++ b/src/cpp/xmlparser/XMLParserImpl.hpp
@@ -37,9 +37,9 @@ public:
      * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
     static XMLP_ret loadXML(
-        const std::string& filename,
-        up_base_node_t& root,
-        const bool& is_default);
+            const std::string& filename,
+            up_base_node_t& root,
+            const bool& is_default);
 };
 
 } // namespace xmlparser

--- a/src/cpp/xmlparser/XMLParserImpl.hpp
+++ b/src/cpp/xmlparser/XMLParserImpl.hpp
@@ -1,0 +1,49 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef FASTRTPS_XMLPARSER_XMLPARSERIMPL_H_
+#define FASTRTPS_XMLPARSER_XMLPARSERIMPL_H_
+
+#include <fastrtps/xmlparser/XMLParser.h>
+
+namespace eprosima {
+namespace fastrtps {
+namespace xmlparser {
+
+/**
+ * Class XMLParserImpl, contains private implementation of XMLParser.
+ * @ingroup XMLPARSER_MODULE
+ */
+class XMLParserImpl
+{
+public:
+
+    /**
+     * Load a XML file.
+     * @param filename Name for the file to be loaded.
+     * @param root Root node.
+     * @param is_default Is the default XML file.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     */
+    static XMLP_ret loadXML(
+        const std::string& filename,
+        up_base_node_t& root,
+        const bool& is_default);
+};
+
+} // namespace xmlparser
+} // namespace fastrtps
+} // namespace eprosima
+
+#endif // ifndef FASTRTPS_XMLPARSER_XMLPARSERIMPL_H_

--- a/src/cpp/xmlparser/XMLParserImpl.hpp
+++ b/src/cpp/xmlparser/XMLParserImpl.hpp
@@ -15,6 +15,8 @@
 #ifndef FASTRTPS_XMLPARSER_XMLPARSERIMPL_H_
 #define FASTRTPS_XMLPARSER_XMLPARSERIMPL_H_
 
+#include <string>
+
 #include <fastrtps/xmlparser/XMLParser.h>
 
 namespace eprosima {

--- a/src/cpp/xmlparser/XMLParserImpl.hpp
+++ b/src/cpp/xmlparser/XMLParserImpl.hpp
@@ -41,7 +41,7 @@ public:
     static XMLP_ret loadXML(
             const std::string& filename,
             up_base_node_t& root,
-            const bool& is_default);
+            bool is_default);
 };
 
 } // namespace xmlparser

--- a/src/cpp/xmlparser/XMLProfileManager.cpp
+++ b/src/cpp/xmlparser/XMLProfileManager.cpp
@@ -165,6 +165,7 @@ void XMLProfileManager::loadDefaultXMLFile()
     }
     else
     {
+        strcat_s(current_directory, MAX_PATH, "\\");
         strcat_s(current_directory, MAX_PATH, DEFAULT_FASTRTPS_PROFILES);
         loadXMLFile(current_directory, true);
     }

--- a/src/cpp/xmlparser/XMLProfileManager.cpp
+++ b/src/cpp/xmlparser/XMLProfileManager.cpp
@@ -12,16 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#include <tinyxml2.h>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
-#include <fastrtps/xmlparser/XMLTree.h>
-#include <fastrtps/log/Log.h>
 
 #include <cstdlib>
 #include <unistd.h>
 #ifdef _WIN32
 #include <windows.h>
 #endif
+
+#include <tinyxml2.h>
+#include <fastrtps/log/Log.h>
+#include <fastrtps/xmlparser/XMLTree.h>
+#include "XMLParserImpl.hpp"
+
 
 using namespace eprosima::fastrtps;
 using namespace ::xmlparser;
@@ -294,7 +297,7 @@ XMLP_ret XMLProfileManager::loadXMLFile(
     }
 
     up_base_node_t root_node;
-    XMLP_ret loaded_ret = XMLParser::loadXML(filename, root_node);
+    XMLP_ret loaded_ret = XMLParserImpl::loadXML(filename, root_node, true);
     if (!root_node || loaded_ret != XMLP_ret::XML_OK)
     {
         if (!is_default)

--- a/src/cpp/xmlparser/XMLProfileManager.cpp
+++ b/src/cpp/xmlparser/XMLProfileManager.cpp
@@ -283,7 +283,7 @@ XMLP_ret XMLProfileManager::loadXMLFile(
 
 XMLP_ret XMLProfileManager::loadXMLFile(
         const std::string& filename,
-        const bool& is_default)
+        bool is_default)
 {
     if (filename.empty())
     {

--- a/src/cpp/xmlparser/XMLProfileManager.cpp
+++ b/src/cpp/xmlparser/XMLProfileManager.cpp
@@ -165,7 +165,7 @@ void XMLProfileManager::loadDefaultXMLFile()
     }
     else
     {
-        strcat(current_directory, DEFAULT_FASTRTPS_PROFILES);
+        strcat_s(current_directory, MAX_PATH, DEFAULT_FASTRTPS_PROFILES);
         loadXMLFile(current_directory, true);
     }
 #else

--- a/src/cpp/xmlparser/XMLProfileManager.cpp
+++ b/src/cpp/xmlparser/XMLProfileManager.cpp
@@ -143,7 +143,7 @@ void XMLProfileManager::loadDefaultXMLFile()
     char file_path[MAX_PATH];
     char absolute_path[MAX_PATH];
     char current_directory[MAX_PATH];
-    char** filename;
+    char** filename = {nullptr};
     size_t size = MAX_PATH;
     if (getenv_s(&size, file_path, size, DEFAULT_FASTRTPS_ENV_VARIABLE) == 0 && size > 0)
     {

--- a/src/cpp/xmlparser/XMLProfileManager.cpp
+++ b/src/cpp/xmlparser/XMLProfileManager.cpp
@@ -172,8 +172,8 @@ void XMLProfileManager::loadDefaultXMLFile()
 
     if (const char* file_path = std::getenv(DEFAULT_FASTRTPS_ENV_VARIABLE))
     {
-        absolute_path = realpath(file_path, NULL);
-        if (absolute_path == NULL)
+        absolute_path = realpath(file_path, nullptr);
+        if (absolute_path == nullptr)
         {
             logError(XMLPARSER, "realpath failed " << std::strerror(errno));
         }
@@ -184,11 +184,11 @@ void XMLProfileManager::loadDefaultXMLFile()
         }
     }
 
-    absolute_path = NULL;
+    absolute_path = nullptr;
 
     // Try to load the default XML file.
     absolute_path = getcwd(absolute_path, PATH_MAX);
-    if (absolute_path == NULL)
+    if (absolute_path == nullptr)
     {
         logError(XMLPARSER, "getcwd failed " << std::strerror(errno));
     }

--- a/src/cpp/xmlparser/XMLProfileManager.cpp
+++ b/src/cpp/xmlparser/XMLProfileManager.cpp
@@ -15,9 +15,10 @@
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 
 #include <cstdlib>
-#include <unistd.h>
 #ifdef _WIN32
 #include <windows.h>
+#else
+#include <unistd.h>
 #endif // ifdef _WIN32
 
 #include <tinyxml2.h>

--- a/src/cpp/xmlparser/XMLProfileManager.cpp
+++ b/src/cpp/xmlparser/XMLProfileManager.cpp
@@ -18,7 +18,7 @@
 #include <unistd.h>
 #ifdef _WIN32
 #include <windows.h>
-#endif
+#endif // ifdef _WIN32
 
 #include <tinyxml2.h>
 #include <fastrtps/log/Log.h>
@@ -194,11 +194,11 @@ void XMLProfileManager::loadDefaultXMLFile()
     }
     else
     {
-        strcat(absolute_path,"/");
+        strcat(absolute_path, "/");
         strcat(absolute_path, DEFAULT_FASTRTPS_PROFILES);
         loadXMLFile(absolute_path, true);
     }
-#endif
+#endif // ifdef _WIN32
 }
 
 XMLP_ret XMLProfileManager::loadXMLProfiles(
@@ -457,7 +457,7 @@ XMLP_ret XMLProfileManager::extractParticipantProfile(
     if (it != node_part->getAttributes().end() && it->second == "true") // Set as default profile
     {
         // +V+ TODO: LOG ERROR IN SECOND ATTEMPT
-        default_participant_attributes = *(emplace.first->second.get() );
+        default_participant_attributes = *(emplace.first->second.get());
     }
     return XMLP_ret::XML_OK;
 }
@@ -490,7 +490,7 @@ XMLP_ret XMLProfileManager::extractPublisherProfile(
     if (it != node_part->getAttributes().end() && it->second == "true") // Set as default profile
     {
         // +V+ TODO: LOG ERROR IN SECOND ATTEMPT
-        default_publisher_attributes = *(emplace.first->second.get() );
+        default_publisher_attributes = *(emplace.first->second.get());
     }
     return XMLP_ret::XML_OK;
 }
@@ -523,7 +523,7 @@ XMLP_ret XMLProfileManager::extractSubscriberProfile(
     if (it != node_part->getAttributes().end() && it->second == "true") // Set as default profile
     {
         // +V+ TODO: LOG ERROR IN SECOND ATTEMPT
-        default_subscriber_attributes = *(emplace.first->second.get() );
+        default_subscriber_attributes = *(emplace.first->second.get());
     }
     return XMLP_ret::XML_OK;
 }

--- a/test/unittest/logging/mock/MockConsumer.h
+++ b/test/unittest/logging/mock/MockConsumer.h
@@ -23,39 +23,43 @@
 namespace eprosima {
 namespace fastrtps {
 
-class MockConsumer: public LogConsumer {
+class MockConsumer : public LogConsumer
+{
 public:
-   virtual void Consume(const Log::Entry& entry)
-   {
-      std::unique_lock<std::mutex> guard(mMutex);
-      mEntriesConsumed.push_back(entry);
-      cv_.notify_one();
-   }
 
-   const std::vector<Log::Entry> ConsumedEntries() const
-   {
-      std::unique_lock<std::mutex> guard(mMutex);
-      return mEntriesConsumed;
-   }
+    virtual void Consume(
+            const Log::Entry& entry)
+    {
+        std::unique_lock<std::mutex> guard(mMutex);
+        mEntriesConsumed.push_back(entry);
+        cv_.notify_one();
+    }
 
-   size_t ConsumedEntriesSize_nts() const
-   {
-      return mEntriesConsumed.size();
-   }
+    const std::vector<Log::Entry> ConsumedEntries() const
+    {
+        std::unique_lock<std::mutex> guard(mMutex);
+        return mEntriesConsumed;
+    }
 
-   std::condition_variable& cv()
-   {
-      return cv_;
-   }
+    size_t ConsumedEntriesSize_nts() const
+    {
+        return mEntriesConsumed.size();
+    }
+
+    std::condition_variable& cv()
+    {
+        return cv_;
+    }
 
 private:
-   std::vector<Log::Entry> mEntriesConsumed;
-   mutable std::mutex mMutex;
-   std::condition_variable cv_;
+
+    std::vector<Log::Entry> mEntriesConsumed;
+    mutable std::mutex mMutex;
+    std::condition_variable cv_;
 };
 
 } // namespace fastrtps
 } // namespace eprosima
 
-#endif
+#endif // ifndef MOCK_LOG_CONSUMER_H
 

--- a/test/unittest/logging/mock/MockConsumer.h
+++ b/test/unittest/logging/mock/MockConsumer.h
@@ -29,6 +29,7 @@ public:
    {
       std::unique_lock<std::mutex> guard(mMutex);
       mEntriesConsumed.push_back(entry);
+      cv_.notify_one();
    }
 
    const std::vector<Log::Entry> ConsumedEntries() const
@@ -37,9 +38,20 @@ public:
       return mEntriesConsumed;
    }
 
+   size_t ConsumedEntriesSize_nts() const
+   {
+      return mEntriesConsumed.size();
+   }
+
+   std::condition_variable& cv()
+   {
+      return cv_;
+   }
+
 private:
    std::vector<Log::Entry> mEntriesConsumed;
    mutable std::mutex mMutex;
+   std::condition_variable cv_;
 };
 
 } // namespace fastrtps

--- a/test/unittest/xmlparser/CMakeLists.txt
+++ b/test/unittest/xmlparser/CMakeLists.txt
@@ -255,9 +255,9 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         target_compile_definitions(XMLLoadFileTests PRIVATE FASTRTPS_NO_LIB
             $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
             $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
-        )
+            )
         target_include_directories(XMLLoadFileTests PRIVATE
-            ${GTEST_INCLUDE_DIRS}
+            ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/test/unittest/logging/mock
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/TCPTransportDescriptor
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/TCPv4TransportDescriptor
@@ -267,14 +267,14 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/UDPv6TransportDescriptor
             ${PROJECT_SOURCE_DIR}/include
             ${PROJECT_BINARY_DIR}/include
-        )
+            )
 
         target_link_libraries(XMLLoadFileTests ${GTEST_LIBRARIES}
             $<$<BOOL:${WIN32}>:iphlpapi$<SEMICOLON>Shlwapi>
             $<$<BOOL:${WIN32}>:ws2_32>
             ${TINYXML2_LIBRARY}
             fastcdr
-        )
+            )
         add_gtest(XMLLoadFileTests SOURCES XMLLoadFileTests.cpp)
 
     endif()

--- a/test/unittest/xmlparser/CMakeLists.txt
+++ b/test/unittest/xmlparser/CMakeLists.txt
@@ -199,5 +199,83 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             fastcdr
         )
         add_gtest(XMLParserTests SOURCES XMLParserTests.cpp)
+
+
+        set(XMLLOADFILE_SOURCE
+            XMLLoadFileTests.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/xmlparser/XMLProfileManager.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/xmlparser/XMLParser.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/xmlparser/XMLElementParser.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/xmlparser/XMLParserCommon.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/qos/QosPolicies.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/qos/ParameterTypes.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/qos/WriterQos.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/qos/ReaderQos.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/rtps/flowcontrol/ThroughputControllerDescriptor.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/log/FileConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPFinder.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPLocator.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/types/AnnotationDescriptor.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/types/DynamicData.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/types/DynamicDataFactory.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/types/DynamicType.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/types/DynamicPubSubType.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/types/DynamicTypePtr.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/types/DynamicDataPtr.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/types/DynamicTypeBuilder.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/types/DynamicTypeBuilderPtr.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/types/DynamicTypeBuilderFactory.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/types/DynamicTypeMember.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/types/TypeDescriptor.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/types/MemberDescriptor.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/types/AnnotationParameterValue.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/types/TypeIdentifier.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/types/TypeIdentifierTypes.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/types/TypeObject.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/types/TypeObjectFactory.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/types/TypeObjectHashId.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/types/TypeNamesGenerator.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/types/TypesBase.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/types/BuiltinAnnotationsTypeObject.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/utils/md5.cpp
+        )
+
+        # External sources
+        if(TINYXML2_SOURCE_DIR)
+            list(APPEND XMLLOADFILE_SOURCE
+                ${TINYXML2_SOURCE_DIR}/tinyxml2.cpp
+                )
+        endif()
+
+        include_directories(${TINYXML2_INCLUDE_DIR})
+        add_executable(XMLLoadFileTests ${XMLLOADFILE_SOURCE})
+        target_compile_definitions(XMLLoadFileTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+        )
+        target_include_directories(XMLLoadFileTests PRIVATE
+            ${GTEST_INCLUDE_DIRS}
+            ${PROJECT_SOURCE_DIR}/test/unittest/logging/mock
+            ${PROJECT_SOURCE_DIR}/test/mock/rtps/TCPTransportDescriptor
+            ${PROJECT_SOURCE_DIR}/test/mock/rtps/TCPv4TransportDescriptor
+            ${PROJECT_SOURCE_DIR}/test/mock/rtps/TCPv6TransportDescriptor
+            ${PROJECT_SOURCE_DIR}/test/mock/rtps/UDPTransportDescriptor
+            ${PROJECT_SOURCE_DIR}/test/mock/rtps/UDPv4TransportDescriptor
+            ${PROJECT_SOURCE_DIR}/test/mock/rtps/UDPv6TransportDescriptor
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_BINARY_DIR}/include
+        )
+
+        target_link_libraries(XMLLoadFileTests ${GTEST_LIBRARIES}
+            $<$<BOOL:${WIN32}>:iphlpapi$<SEMICOLON>Shlwapi>
+            $<$<BOOL:${WIN32}>:ws2_32>
+            ${TINYXML2_LIBRARY}
+            fastcdr
+        )
+        add_gtest(XMLLoadFileTests SOURCES XMLLoadFileTests.cpp)
+
     endif()
 endif()

--- a/test/unittest/xmlparser/XMLLoadFileTests.cpp
+++ b/test/unittest/xmlparser/XMLLoadFileTests.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
-#include <thread>
 #include <mutex>
 #include <fstream>
 

--- a/test/unittest/xmlparser/XMLLoadFileTests.cpp
+++ b/test/unittest/xmlparser/XMLLoadFileTests.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <limits.h>
 #ifdef _WIN32
 #include <windows.h>
 #else
+#include <limits.h>
 #include <unistd.h>
 #endif // ifdef _WIN32
 

--- a/test/unittest/xmlparser/XMLLoadFileTests.cpp
+++ b/test/unittest/xmlparser/XMLLoadFileTests.cpp
@@ -36,6 +36,7 @@ using namespace ::testing;
 class XMLLoadFileTests : public ::testing::Test
 {
 public:
+
     void helper_block_for_at_least_entries(
             uint32_t amount)
     {
@@ -127,7 +128,9 @@ TEST_F(XMLLoadFileTests, load_twice_default_xml)
     std::remove("DEFAULT_FASTRTPS_PROFILES.xml");
 }
 
-int main(int argc, char **argv)
+int main(
+        int argc,
+        char** argv)
 {
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/test/unittest/xmlparser/XMLLoadFileTests.cpp
+++ b/test/unittest/xmlparser/XMLLoadFileTests.cpp
@@ -12,12 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef _WIN32
-#include <windows.h>
-#else
-#include <limits.h>
-#include <unistd.h>
-#endif // ifdef _WIN32
 
 #include <thread>
 #include <mutex>
@@ -28,6 +22,13 @@
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 #include <fastrtps/xmlparser/XMLParserCommon.h>
 #include "../logging/mock/MockConsumer.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <limits.h>
+#include <unistd.h>
+#endif // ifdef _WIN32
 
 using namespace eprosima::fastrtps;
 using namespace ::xmlparser;
@@ -92,18 +93,20 @@ TEST_F(XMLLoadFileTests, load_twice_default_xml)
 #ifdef _WIN32
     char current_directory[MAX_PATH];
     uint32_t ret = GetCurrentDirectory(MAX_PATH, current_directory);
-    ASSERT_NE(ret, 0);
+    ASSERT_NE(ret, 0u);
     strcat_s(current_directory, MAX_PATH, "\\");
     strcat_s(current_directory, MAX_PATH, DEFAULT_FASTRTPS_PROFILES);
+    // Set environment variable
+    _putenv_s("FASTRTPS_DEFAULT_PROFILES_FILE", current_directory);
 #else
     char* current_directory = nullptr;
     current_directory = getcwd(current_directory, PATH_MAX);
     ASSERT_NE(current_directory, nullptr);
     strcat(current_directory, "/");
     strcat(current_directory, DEFAULT_FASTRTPS_PROFILES);
-#endif // _WIN32
     // Set environment variable
     setenv("FASTRTPS_DEFAULT_PROFILES_FILE", current_directory, 1);
+#endif // _WIN32
 
     // Write DEFAULT_FASTRTPS_PROFILES.xml
     std::ofstream xmlFile;

--- a/test/unittest/xmlparser/XMLLoadFileTests.cpp
+++ b/test/unittest/xmlparser/XMLLoadFileTests.cpp
@@ -1,0 +1,134 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <limits.h>
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif // ifdef _WIN32
+
+#include <thread>
+#include <mutex>
+#include <fstream>
+
+#include <gtest/gtest.h>
+#include <fastrtps/log/Log.h>
+#include <fastrtps/xmlparser/XMLProfileManager.h>
+#include <fastrtps/xmlparser/XMLParserCommon.h>
+#include "../logging/mock/MockConsumer.h"
+
+using namespace eprosima::fastrtps;
+using namespace ::xmlparser;
+using namespace ::testing;
+
+class XMLLoadFileTests : public ::testing::Test
+{
+public:
+    void helper_block_for_at_least_entries(
+            uint32_t amount)
+    {
+        std::unique_lock<std::mutex> lck(*xml_mutex_);
+        mock_consumer_->cv().wait(lck, [this, amount]
+                {
+                    return mock_consumer_->ConsumedEntriesSize_nts() >= amount;
+                });
+    }
+
+protected:
+
+    void SetUp() override
+    {
+        xml_mutex_ = new std::mutex();
+    }
+
+    void TearDown() override
+    {
+        delete xml_mutex_;
+        xml_mutex_ = nullptr;
+    }
+
+    MockConsumer* mock_consumer_;
+
+private:
+
+    mutable std::mutex* xml_mutex_;
+};
+
+/*
+ * This test checks that the default XML file is loaded only once when there is a DEFAULT_FASTRTPS_PROFILES.xml file
+ * in the current directory and the environment variable FASTRTPS_DEFAULT_PROFILES_FILE is set pointing to the same
+ * file.
+ * 1. Initialize Mock Consumer to consume the LogInfo entry that the library generates when the file has been already
+ * parsed. Set filters to consume only the desired entry.
+ * 2. Get current path to set the environment variable to the DEFAULT_FASTRTPS_PROFILES.xml file.
+ * 3. Write the DEFAULT_FASTRTPS_PROFILES.xml file in the current directory.
+ * 4. Load the default XML file.
+ * 5. Wait for the log entry to be consumed.
+ */
+TEST_F(XMLLoadFileTests, load_twice_default_xml)
+{
+    // Initialize Mock Consumer
+    mock_consumer_ = new MockConsumer();
+
+    Log::RegisterConsumer(std::unique_ptr<eprosima::fastrtps::LogConsumer>(mock_consumer_));
+    Log::SetVerbosity(Log::Info);
+    Log::SetCategoryFilter(std::regex("(XMLPARSER)"));
+    Log::SetErrorStringFilter(std::regex("(already parsed)"));
+
+    // Current directory
+#ifdef _WIN32
+    char current_directory[MAX_PATH];
+    uint32_t ret = GetCurrentDirectory(MAX_PATH, current_directory);
+    ASSERT_NE(ret, 0);
+    strcat_s(current_directory, MAX_PATH, "\\");
+    strcat_s(current_directory, MAX_PATH, DEFAULT_FASTRTPS_PROFILES);
+#else
+    char* current_directory = nullptr;
+    current_directory = getcwd(current_directory, PATH_MAX);
+    ASSERT_NE(current_directory, nullptr);
+    strcat(current_directory, "/");
+    strcat(current_directory, DEFAULT_FASTRTPS_PROFILES);
+#endif // _WIN32
+    // Set environment variable
+    setenv("FASTRTPS_DEFAULT_PROFILES_FILE", current_directory, 1);
+
+    // Write DEFAULT_FASTRTPS_PROFILES.xml
+    std::ofstream xmlFile;
+    xmlFile.open("DEFAULT_FASTRTPS_PROFILES.xml");
+    xmlFile << "<dds xmlns=\"http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles\">";
+    xmlFile << "<profiles><participant profile_name=\"test_participant_profile\" is_default_profile=\"true\">";
+    xmlFile << "<rtps><useBuiltinTransports>true</useBuiltinTransports><name>test_name</name></rtps></participant>";
+    xmlFile << "</profiles></dds>";
+    xmlFile.close();
+
+    // Load default XML file
+    xmlparser::XMLProfileManager::loadDefaultXMLFile();
+
+    // Log consumer
+    helper_block_for_at_least_entries(1);
+    auto consumed_entries = mock_consumer_->ConsumedEntries();
+    EXPECT_EQ(consumed_entries.size(), 1u);
+
+    Log::Reset();
+    Log::KillThread();
+
+    std::remove("DEFAULT_FASTRTPS_PROFILES.xml");
+}
+
+int main(int argc, char **argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
When the environment variable `FASTRPS_DEFAULT_PROFILES_FILE` is set pointing to the `DEFAULT_FASTRTPS_PROFILES.xml` file in the current directory, the file is loaded twice and LogErrors are shown stating that the profile already exists. This PR corrects the issue by using the absolute path when the default file is loaded. It also includes a regression test.