### PR TITLE
Force semicolon on log* calls

### DIFF
--- a/include/fastdds/dds/log/Log.hpp
+++ b/include/fastdds/dds/log/Log.hpp
@@ -241,29 +241,29 @@ protected:
 // Name of variables inside macros must be unique, or it could produce an error with external variables
 #ifndef LOG_NO_ERROR
 #define logError_(cat, msg)                                                                                            \
-    {                                                                                                                  \
+    do{                                                                                                                \
         using namespace eprosima::fastdds::dds;                                                                        \
         std::stringstream fastdds_log_ss_tmp__;                                                                        \
         fastdds_log_ss_tmp__ << msg;                                                                                   \
         Log::QueueLog(fastdds_log_ss_tmp__.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, Log::Kind::Error); \
-    }
+    }while (0)
 #elif (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG))
 #define logError_(cat, msg)                                     \
-    {                                                           \
+    do{                                                         \
         auto fastdds_log_lambda_tmp__ = [&]()                   \
                 {                                               \
                     std::stringstream fastdds_log_ss_tmp__;     \
                     fastdds_log_ss_tmp__ << msg;                \
                 };                                              \
         (void)fastdds_log_lambda_tmp__;                         \
-    }
+    }while (0)
 #else
 #define logError_(cat, msg)
 #endif // ifndef LOG_NO_ERROR
 
 #ifndef LOG_NO_WARNING
 #define logWarning_(cat, msg)                                                                                       \
-    {                                                                                                               \
+    do{                                                                                                             \
         using namespace eprosima::fastdds::dds;                                                                     \
         if (Log::GetVerbosity() >= Log::Kind::Warning)                                                              \
         {                                                                                                           \
@@ -272,17 +272,17 @@ protected:
             Log::QueueLog(                                                                                          \
                 fastdds_log_ss_tmp__.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, Log::Kind::Warning);  \
         }                                                                                                           \
-    }
+    }while (0)
 #elif (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG))
 #define logWarning_(cat, msg)                                   \
-    {                                                           \
+    do{                                                         \
         auto fastdds_log_lambda_tmp__ = [&]()                   \
                 {                                               \
                     std::stringstream fastdds_log_ss_tmp__;     \
                     fastdds_log_ss_tmp__ << msg;                \
                 };                                              \
         (void)fastdds_log_lambda_tmp__;                         \
-    }
+    }while (0)
 #else
 #define logWarning_(cat, msg)
 #endif // ifndef LOG_NO_WARNING
@@ -290,7 +290,7 @@ protected:
 #if (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG)) && (defined(_DEBUG) || defined(__DEBUG)) &&   \
     (!defined(LOG_NO_INFO))
 #define logInfo_(cat, msg)                                                                              \
-    {                                                                                                   \
+    do{                                                                                                 \
         using namespace eprosima::fastdds::dds;                                                         \
         if (Log::GetVerbosity() >= Log::Kind::Info)                                                     \
         {                                                                                               \
@@ -299,17 +299,17 @@ protected:
             Log::QueueLog(fastdds_log_ss_tmp__.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, \
                     Log::Kind::Info);                                                                   \
         }                                                                                               \
-    }
+    }while (0)
 #elif (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG))
 #define logInfo_(cat, msg)                                  \
-    {                                                       \
+    do{                                                     \
         auto fastdds_log_lambda_tmp__ = [&]()               \
                 {                                           \
                     std::stringstream fastdds_log_ss_tmp__; \
                     fastdds_log_ss_tmp__ << msg;            \
                 };                                          \
         (void)fastdds_log_lambda_tmp__;                     \
-    }
+    }while (0)
 #else
 #define logInfo_(cat, msg)
 #endif // if (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG)) && (defined(_DEBUG) || defined(__DEBUG)) && (!defined(LOG_NO_INFO))

--- a/versions.md
+++ b/versions.md
@@ -4,6 +4,7 @@ Forthcoming
 * TopicDataType interface extended (ABI break)
 * Upgrade to Quality Level 1
 * New DataWriter API for loaning samples (DataWriter API extension)
+* Calls to `logInfo`, `logWarning`, and `logError` are forced to end with semicolon.
 
 Version 2.1.0
 -------------


### PR DESCRIPTION
This PR forces calls to `logInfo`, `logWarning`, and `logError` are forced to end with semicolon.