### PR TITLE
Use DEBUG and INTERNAL_DEBUG definitions when compiling examples and tests [10192]

### DIFF
--- a/examples/C++/Benchmark/CMakeLists.txt
+++ b/examples/C++/Benchmark/CMakeLists.txt
@@ -52,6 +52,10 @@ file(GLOB BENCHMARK_SOURCES_CPP "*.cpp")
 # configure_file("BenchmarkPublisher.xml" "BenchmarkPublisher.xml" COPYONLY)
 
 add_executable(Benchmark ${BENCHMARK_SOURCES_CXX} ${BENCHMARK_SOURCES_CPP})
+target_compile_definitions(Benchmark PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(Benchmark fastrtps fastcdr foonathan_memory)
 install(TARGETS Benchmark
     RUNTIME DESTINATION examples/C++/Benchmark/${BIN_INSTALL_DIR})

--- a/examples/C++/ClientServerTest/CMakeLists.txt
+++ b/examples/C++/ClientServerTest/CMakeLists.txt
@@ -47,6 +47,10 @@ message(STATUS "Configuring ClientServerTest...")
 file(GLOB CLIENTSERVERTEST_SOURCES "*.cpp")
 
 add_executable(ClientServerTest ${CLIENTSERVERTEST_SOURCES})
+target_compile_definitions(ClientServerTest PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(ClientServerTest fastrtps fastcdr foonathan_memory)
 install(TARGETS ClientServerTest
 	RUNTIME DESTINATION examples/C++/ClientServerTest/${BIN_INSTALL_DIR}

--- a/examples/C++/Configurability/CMakeLists.txt
+++ b/examples/C++/Configurability/CMakeLists.txt
@@ -47,12 +47,20 @@ message(STATUS "Configuring UseCaseDemonstrator example...")
 file(GLOB USECASEDEMONSTRATOR_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(UseCasePublisher ${USECASEDEMONSTRATOR_EXAMPLE_SOURCES} UseCasePublisher.cpp)
+target_compile_definitions(UseCasePublisher PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(UseCasePublisher fastrtps fastcdr foonathan_memory)
 install(TARGETS UseCasePublisher
     RUNTIME DESTINATION examples/C++/UseCaseDemonstrator/${BIN_INSTALL_DIR}
     )
 
 add_executable(UseCaseSubscriber ${USECASEDEMONSTRATOR_EXAMPLE_SOURCES} UseCaseSubscriber.cpp)
+target_compile_definitions(UseCaseSubscriber PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(UseCaseSubscriber fastrtps fastcdr foonathan_memory)
 install(TARGETS UseCaseSubscriber
     RUNTIME DESTINATION examples/C++/UseCaseDemonstrator/${BIN_INSTALL_DIR}

--- a/examples/C++/DDS/Benchmark/CMakeLists.txt
+++ b/examples/C++/DDS/Benchmark/CMakeLists.txt
@@ -52,6 +52,10 @@ file(GLOB DDS_BENCHMARK_SOURCES_CPP "*.cpp")
 # configure_file("BenchmarkPublisher.xml" "BenchmarkPublisher.xml" COPYONLY)
 
 add_executable(DDSBenchmark ${DDS_BENCHMARK_SOURCES_CXX} ${DDS_BENCHMARK_SOURCES_CPP})
+target_compile_definitions(DDSBenchmark PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(DDSBenchmark fastrtps fastcdr foonathan_memory)
 install(TARGETS DDSBenchmark
     RUNTIME DESTINATION examples/C++/DDS/Benchmark/${BIN_INSTALL_DIR})

--- a/examples/C++/DDS/ClientServerTest/CMakeLists.txt
+++ b/examples/C++/DDS/ClientServerTest/CMakeLists.txt
@@ -47,6 +47,10 @@ message(STATUS "Configuring DDSClientServerTest...")
 file(GLOB DDS_CLIENTSERVERTEST_SOURCES "*.cpp")
 
 add_executable(DDSClientServerTest ${DDS_CLIENTSERVERTEST_SOURCES})
+target_compile_definitions(DDSClientServerTest PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(DDSClientServerTest fastrtps fastcdr foonathan_memory)
 install(TARGETS DDSClientServerTest
 	RUNTIME DESTINATION examples/C++/DDS/ClientServerTest/${BIN_INSTALL_DIR}

--- a/examples/C++/DDS/Configurability/CMakeLists.txt
+++ b/examples/C++/DDS/Configurability/CMakeLists.txt
@@ -47,12 +47,20 @@ message(STATUS "Configuring DDS Configurability example...")
 file(GLOB DDS_CONFIGURABILITY_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(DDSUseCasePublisher ${DDS_CONFIGURABILITY_EXAMPLE_SOURCES} UseCasePublisher.cpp)
+target_compile_definitions(DDSUseCasePublisher PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(DDSUseCasePublisher fastrtps fastcdr foonathan_memory)
 install(TARGETS DDSUseCasePublisher
     RUNTIME DESTINATION examples/C++/DDS/UseCaseDemonstrator/${BIN_INSTALL_DIR}
     )
 
 add_executable(DDSUseCaseSubscriber ${DDS_CONFIGURABILITY_EXAMPLE_SOURCES} UseCaseSubscriber.cpp)
+target_compile_definitions(DDSUseCaseSubscriber PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(DDSUseCaseSubscriber fastrtps fastcdr foonathan_memory)
 install(TARGETS DDSUseCaseSubscriber
     RUNTIME DESTINATION examples/C++/DDS/UseCaseDemonstrator/${BIN_INSTALL_DIR}

--- a/examples/C++/DDS/CustomListenerExample/CMakeLists.txt
+++ b/examples/C++/DDS/CustomListenerExample/CMakeLists.txt
@@ -44,6 +44,10 @@ file(GLOB DDS_CUSTOMLISTENER_EXAMPLE_SOURCES_CXX "*.cxx")
 file(GLOB DDS_CUSTOMLISTENER_EXAMPLE_SOURCES_CPP "*.cpp")
 
 add_executable(DDSCustomListenerExample ${DDS_CUSTOMLISTENER_EXAMPLE_SOURCES_CXX} ${DDS_CUSTOMLISTENER_EXAMPLE_SOURCES_CPP})
+target_compile_definitions(DDSCustomListenerExample PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(DDSCustomListenerExample fastrtps fastcdr)
 install(TARGETS DDSCustomListenerExample
     RUNTIME DESTINATION examples/C++/DDS/CustomListenerExample/${BIN_INSTALL_DIR})

--- a/examples/C++/DDS/DeadlineQoSExample/CMakeLists.txt
+++ b/examples/C++/DDS/DeadlineQoSExample/CMakeLists.txt
@@ -69,6 +69,10 @@ add_definitions(
 include_directories(${ASIO_INCLUDE_DIR})
 
 add_executable(DDSDeadlineQoSExample ${DDS_DEADLINEQOS_EXAMPLE_SOURCES})
+target_compile_definitions(DDSDeadlineQoSExample PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
 target_link_libraries(DDSDeadlineQoSExample fastrtps fastcdr foonathan_memory)
 if(UNIX)
   target_link_libraries(DDSDeadlineQoSExample pthread)

--- a/examples/C++/DDS/DisablePositiveACKs/CMakeLists.txt
+++ b/examples/C++/DDS/DisablePositiveACKs/CMakeLists.txt
@@ -44,6 +44,10 @@ file(GLOB DDS_POSITIVEACKS_EXAMPLE_SOURCES_CXX "*.cxx")
 file(GLOB DDS_POSITIVEACKS_EXAMPLE_SOURCES_CPP "*.cpp")
 
 add_executable(DDSDisablePositiveACKs ${DDS_POSITIVEACKS_EXAMPLE_SOURCES_CXX} ${DDS_POSITIVEACKS_EXAMPLE_SOURCES_CPP})
+target_compile_definitions(DDSDisablePositiveACKs PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
 target_link_libraries(DDSDisablePositiveACKs fastrtps fastcdr)
 install(TARGETS DDSDisablePositiveACKs
     RUNTIME DESTINATION examples/C++/DDS/DisablePositiveACKs/${BIN_INSTALL_DIR})

--- a/examples/C++/DDS/DynamicHelloWorldExample/CMakeLists.txt
+++ b/examples/C++/DDS/DynamicHelloWorldExample/CMakeLists.txt
@@ -44,6 +44,11 @@ file(GLOB DDS_DYNAMIC_HELLOWORLD_EXAMPLE_SOURCES_CPP "*.cpp")
 
 add_executable(DDSDynamicHelloWorldExample
     ${DDS_DYNAMIC_HELLOWORLD_EXAMPLE_SOURCES_CPP})
+    
+target_compile_definitions(DDSDynamicHelloWorldExample PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 
 target_link_libraries(DDSDynamicHelloWorldExample fastrtps fastcdr)
 install(TARGETS DDSDynamicHelloWorldExample

--- a/examples/C++/DDS/Filtering/CMakeLists.txt
+++ b/examples/C++/DDS/Filtering/CMakeLists.txt
@@ -47,6 +47,10 @@ message(STATUS "Configuring DDSFiltering example...")
 file(GLOB DDS_FILTERING_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(DDSFiltering ${DDS_FILTERING_EXAMPLE_SOURCES})
+target_compile_definitions(DDSFiltering PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
 target_link_libraries(DDSFiltering fastrtps fastcdr foonathan_memory)
 install(TARGETS DDSFiltering
     RUNTIME DESTINATION examples/C++/DDS/Filtering/${BIN_INSTALL_DIR}

--- a/examples/C++/DDS/FlowControlExample/CMakeLists.txt
+++ b/examples/C++/DDS/FlowControlExample/CMakeLists.txt
@@ -48,6 +48,10 @@ file(GLOB DDS_FLOWCONTROL_EXAMPLE_SOURCES_CXX "*.cxx")
 file(GLOB DDS_FLOWCONTROL_EXAMPLE_SOURCES_CPP "*.cpp")
 
 add_executable(DDSFlowControlExample ${DDS_FLOWCONTROL_EXAMPLE_SOURCES_CXX} ${DDS_FLOWCONTROL_EXAMPLE_SOURCES_CPP})
+target_compile_definitions(DDSFlowControlExample PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
 target_link_libraries(DDSFlowControlExample fastrtps fastcdr foonathan_memory)
 install(TARGETS DDSFlowControlExample
     RUNTIME DESTINATION examples/C++/DDS/FlowControlExample/${BIN_INSTALL_DIR})

--- a/examples/C++/DDS/HelloWorldExample/CMakeLists.txt
+++ b/examples/C++/DDS/HelloWorldExample/CMakeLists.txt
@@ -44,6 +44,10 @@ file(GLOB DDS_HELLOWORLD_EXAMPLE_SOURCES_CXX "*.cxx")
 file(GLOB DDS_HELLOWORLD_EXAMPLE_SOURCES_CPP "*.cpp")
 
 add_executable(DDSHelloWorldExample ${DDS_HELLOWORLD_EXAMPLE_SOURCES_CXX} ${DDS_HELLOWORLD_EXAMPLE_SOURCES_CPP})
+target_compile_definitions(DDSHelloWorldExample PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(DDSHelloWorldExample fastrtps fastcdr)
 install(TARGETS DDSHelloWorldExample
     RUNTIME DESTINATION examples/C++/DDS/HelloWorldExample/${BIN_INSTALL_DIR})

--- a/examples/C++/DDS/HelloWorldExampleSharedMem/CMakeLists.txt
+++ b/examples/C++/DDS/HelloWorldExampleSharedMem/CMakeLists.txt
@@ -52,6 +52,10 @@ if(WIN32)
 endif()
 
 add_executable(DDSHelloWorldExampleSharedMem ${DDS_SHM_HELLOWORLD_EXAMPLE_SOURCES_CXX} ${DDS_SHM_HELLOWORLD_EXAMPLE_SOURCES_CPP})
+target_compile_definitions(DDSHelloWorldExampleSharedMem PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
 target_link_libraries(DDSHelloWorldExampleSharedMem fastrtps fastcdr foonathan_memory)
 install(TARGETS DDSHelloWorldExampleSharedMem
     RUNTIME DESTINATION examples/C++/DDS/HelloWorldExampleSharedMem/${BIN_INSTALL_DIR})

--- a/examples/C++/DDS/HelloWorldExampleTCP/CMakeLists.txt
+++ b/examples/C++/DDS/HelloWorldExampleTCP/CMakeLists.txt
@@ -56,6 +56,10 @@ configure_file("ca.pem" "ca.pem" COPYONLY)
 
 
 add_executable(DDSHelloWorldExampleTCP ${DDS_TCP_HELLOWORLD_EXAMPLE_SOURCES_CXX} ${DDS_TCP_HELLOWORLD_EXAMPLE_SOURCES_CPP})
+target_compile_definitions(DDSHelloWorldExampleTCP PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
 target_link_libraries(DDSHelloWorldExampleTCP fastrtps fastcdr foonathan_memory)
 install(TARGETS DDSHelloWorldExampleTCP
     RUNTIME DESTINATION examples/C++/DDS/HelloWorldExampleTCP/${BIN_INSTALL_DIR})

--- a/examples/C++/DDS/HistoryKind/CMakeLists.txt
+++ b/examples/C++/DDS/HistoryKind/CMakeLists.txt
@@ -47,6 +47,10 @@ message(STATUS "Configuring DDS History Kind example...")
 file(GLOB DDS_HISTORY_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(DDSHistoryKind ${DDS_HISTORY_EXAMPLE_SOURCES} pastsamples.cpp)
+target_compile_definitions(DDSHistoryKind PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
 target_link_libraries(DDSHistoryKind fastrtps fastcdr foonathan_memory)
 install(TARGETS DDSHistoryKind
     RUNTIME DESTINATION examples/C++/DDS/HistoryKind/${BIN_INSTALL_DIR}

--- a/examples/C++/DDS/Keys/CMakeLists.txt
+++ b/examples/C++/DDS/Keys/CMakeLists.txt
@@ -47,6 +47,10 @@ message(STATUS "Configuring DDS Keys example...")
 file(GLOB DDS_KEYS_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(DDSKeys ${DDS_KEYS_EXAMPLE_SOURCES} keys.cpp)
+target_compile_definitions(DDSKeys PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
 target_link_libraries(DDSKeys fastrtps fastcdr foonathan_memory)
 install(TARGETS DDSKeys
     RUNTIME DESTINATION examples/C++/DDS/Keys/${BIN_INSTALL_DIR}

--- a/examples/C++/DDS/LateJoiners/CMakeLists.txt
+++ b/examples/C++/DDS/LateJoiners/CMakeLists.txt
@@ -47,6 +47,10 @@ message(STATUS "Configuring DDS LateJoiners example...")
 file(GLOB DDS_LATEJOINERS_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(DDSLateJoiners ${DDS_LATEJOINERS_EXAMPLE_SOURCES} latejoiners.cpp)
+target_compile_definitions(DDSLateJoiners PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
 target_link_libraries(DDSLateJoiners fastrtps fastcdr foonathan_memory)
 install(TARGETS DDSLateJoiners
     RUNTIME DESTINATION examples/C++/DDS/LateJoiners/${BIN_INSTALL_DIR}

--- a/examples/C++/DDS/LifespanQoSExample/CMakeLists.txt
+++ b/examples/C++/DDS/LifespanQoSExample/CMakeLists.txt
@@ -44,6 +44,10 @@ file(GLOB DDS_LIFESPAN_EXAMPLE_SOURCES_CXX "*.cxx")
 file(GLOB DDS_LIFESPAN_EXAMPLE_SOURCES_CPP "*.cpp")
 
 add_executable(DDSLifespanQoSExample ${DDS_LIFESPAN_EXAMPLE_SOURCES_CXX} ${DDS_LIFESPAN_EXAMPLE_SOURCES_CPP})
+target_compile_definitions(DDSLifespanQoSExample PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
 target_link_libraries(DDSLifespanQoSExample fastrtps fastcdr)
 install(TARGETS DDSLifespanQoSExample
     RUNTIME DESTINATION examples/C++/DDS/LifespanQoSExample/${BIN_INSTALL_DIR})

--- a/examples/C++/DDS/LivelinessQoS/CMakeLists.txt
+++ b/examples/C++/DDS/LivelinessQoS/CMakeLists.txt
@@ -44,6 +44,10 @@ file(GLOB DDS_LIVELINESSQOS_SOURCES_CXX "*.cxx")
 file(GLOB DDS_LIVELINESSQOS_SOURCES_CPP "*.cpp")
 
 add_executable(DDSLivelinessQoS ${DDS_LIVELINESSQOS_SOURCES_CXX} ${DDS_LIVELINESSQOS_SOURCES_CPP})
+target_compile_definitions(DDSLivelinessQoS PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
 target_link_libraries(DDSLivelinessQoS fastrtps fastcdr)
 install(TARGETS DDSLivelinessQoS
     RUNTIME DESTINATION examples/C++/DDS/LivelinessQoS/${BIN_INSTALL_DIR})

--- a/examples/C++/DDS/OwnershipStrengthQoSExample/CMakeLists.txt
+++ b/examples/C++/DDS/OwnershipStrengthQoSExample/CMakeLists.txt
@@ -47,6 +47,10 @@ message(STATUS "Configuring DDS OwnershipStrengthQoS example...")
 file(GLOB DDS_OWNERSHIPSTRENGTH_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(DDSOwnershipStrengthQoSExample ${DDS_OWNERSHIPSTRENGTH_EXAMPLE_SOURCES})
+target_compile_definitions(DDSOwnershipStrengthQoSExample PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
 target_link_libraries(DDSOwnershipStrengthQoSExample fastrtps fastcdr foonathan_memory)
 install(TARGETS DDSOwnershipStrengthQoSExample
     RUNTIME DESTINATION examples/C++/DDS/OwnershipStrengthQoSExample/${BIN_INSTALL_DIR}

--- a/examples/C++/DDS/SampleConfig_Controller/CMakeLists.txt
+++ b/examples/C++/DDS/SampleConfig_Controller/CMakeLists.txt
@@ -47,6 +47,10 @@ message(STATUS "Configuring DDS SampleConfig_Controller example...")
 file(GLOB DDS_SAMPLECONFIG_CONTROLLER_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(DDSSampleConfig_Controller ${DDS_SAMPLECONFIG_CONTROLLER_EXAMPLE_SOURCES} sampleconfig_safest.cpp)
+target_compile_definitions(DDSSampleConfig_Controller PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
 target_link_libraries(DDSSampleConfig_Controller fastrtps fastcdr foonathan_memory)
 install(TARGETS DDSSampleConfig_Controller
     RUNTIME DESTINATION examples/C++/DDS/SampleConfig_Controller/${BIN_INSTALL_DIR}

--- a/examples/C++/DDS/SampleConfig_Events/CMakeLists.txt
+++ b/examples/C++/DDS/SampleConfig_Events/CMakeLists.txt
@@ -47,6 +47,10 @@ message(STATUS "Configuring DDS SampleConfig_Events example...")
 file(GLOB DDS_SAMPLECONFIG_EVENTS_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(DDSSampleConfig_Events ${DDS_SAMPLECONFIG_EVENTS_EXAMPLE_SOURCES} sampleconfig_triggers.cpp)
+target_compile_definitions(DDSSampleConfig_Events PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
 target_link_libraries(DDSSampleConfig_Events fastrtps fastcdr foonathan_memory)
 install(TARGETS DDSSampleConfig_Events
     RUNTIME DESTINATION examples/C++/DDS/SampleConfig_Events/${BIN_INSTALL_DIR}

--- a/examples/C++/DDS/SampleConfig_Multimedia/CMakeLists.txt
+++ b/examples/C++/DDS/SampleConfig_Multimedia/CMakeLists.txt
@@ -47,6 +47,10 @@ message(STATUS "Configuring DDS SampleCondig_Multimedia example...")
 file(GLOB DDS_SAMPLECONFIG_MULTIMEDIA_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(DDSSampleConfig_Multimedia ${DDS_SAMPLECONFIG_MULTIMEDIA_EXAMPLE_SOURCES} sampleconfig_fastest.cpp)
+target_compile_definitions(DDSSampleConfig_Multimedia PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
 target_link_libraries(DDSSampleConfig_Multimedia fastrtps fastcdr foonathan_memory)
 install(TARGETS DDSSampleConfig_Multimedia
     RUNTIME DESTINATION examples/C++/DDS/SampleConfig_Multimedia/${BIN_INSTALL_DIR}

--- a/examples/C++/DDS/SecureHelloWorldExample/CMakeLists.txt
+++ b/examples/C++/DDS/SecureHelloWorldExample/CMakeLists.txt
@@ -48,6 +48,10 @@ file(GLOB DDS_SECURE_HELLOWORLD_EXAMPLE_SOURCES_CXX "*.cxx")
 file(GLOB DDS_SECURE_HELLOWORLD_EXAMPLE_SOURCES_CPP "*.cpp")
 
 add_executable(DDSSecureHelloWorldExample ${DDS_SECURE_HELLOWORLD_EXAMPLE_SOURCES_CXX} ${DDS_SECURE_HELLOWORLD_EXAMPLE_SOURCES_CPP})
+target_compile_definitions(DDSSecureHelloWorldExample PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
 target_include_directories(DDSSecureHelloWorldExample PRIVATE)
 target_link_libraries(DDSSecureHelloWorldExample fastrtps fastcdr foonathan_memory)
 install(TARGETS DDSSecureHelloWorldExample

--- a/examples/C++/DDS/StaticHelloWorldExample/CMakeLists.txt
+++ b/examples/C++/DDS/StaticHelloWorldExample/CMakeLists.txt
@@ -53,6 +53,10 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/HelloWorldPublisher.xml
     )
 
 add_executable(DDSStaticHelloWorldExample ${DDS_STATIC_HELLOWORLD_EXAMPLE_SOURCES_CXX} ${DDS_STATIC_HELLOWORLD_EXAMPLE_SOURCES_CPP})
+target_compile_definitions(DDSStaticHelloWorldExample PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
 target_link_libraries(DDSStaticHelloWorldExample fastrtps fastcdr foonathan_memory)
 install(TARGETS DDSStaticHelloWorldExample
     RUNTIME DESTINATION examples/C++/DDS/StaticHelloWorldExample/${BIN_INSTALL_DIR})

--- a/examples/C++/DDS/TypeLookupService/CMakeLists.txt
+++ b/examples/C++/DDS/TypeLookupService/CMakeLists.txt
@@ -45,6 +45,10 @@ file(GLOB DDS_TYPELOOKUP_EXAMPLE_SOURCES_CPP "*.cpp")
 add_executable(TypeLookupExample
     ${DDS_TYPELOOKUP_EXAMPLE_SOURCES_CPP})
 
+target_compile_definitions(TypeLookupExample PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(TypeLookupExample fastrtps fastcdr)
 install(TARGETS TypeLookupExample
     RUNTIME DESTINATION examples/C++/DDS/TypeLookupService/${BIN_INSTALL_DIR})

--- a/examples/C++/DDS/WriterLoansExample/CMakeLists.txt
+++ b/examples/C++/DDS/WriterLoansExample/CMakeLists.txt
@@ -44,6 +44,10 @@ file(GLOB DDS_WRITER_LOANS_EXAMPLE_SOURCES_CXX "*.cxx")
 file(GLOB DDS_WRITER_LOANS_EXAMPLE_SOURCES_CPP "*.cpp")
 
 add_executable(DDSWriterLoansExample ${DDS_WRITER_LOANS_EXAMPLE_SOURCES_CXX} ${DDS_WRITER_LOANS_EXAMPLE_SOURCES_CPP})
+target_compile_definitions(DDSWriterLoansExample PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
 target_link_libraries(DDSWriterLoansExample fastrtps fastcdr)
 install(TARGETS DDSWriterLoansExample
     RUNTIME DESTINATION examples/C++/DDS/HelloWorldExample/${BIN_INSTALL_DIR})

--- a/examples/C++/DeadlineQoSExample/CMakeLists.txt
+++ b/examples/C++/DeadlineQoSExample/CMakeLists.txt
@@ -69,6 +69,10 @@ add_definitions(
 include_directories(${ASIO_INCLUDE_DIR})
 
 add_executable(DeadlineQoSExample ${DEADLINEQOS_EXAMPLE_SOURCES})
+target_compile_definitions(DeadlineQoSExample PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(DeadlineQoSExample fastrtps fastcdr foonathan_memory)
 if(UNIX)
   target_link_libraries(DeadlineQoSExample pthread)

--- a/examples/C++/DisablePositiveACKs/CMakeLists.txt
+++ b/examples/C++/DisablePositiveACKs/CMakeLists.txt
@@ -44,6 +44,10 @@ file(GLOB POSITIVEACKS_EXAMPLE_SOURCES_CXX "*.cxx")
 file(GLOB POSITIVEACKS_EXAMPLE_SOURCES_CPP "*.cpp")
 
 add_executable(DisablePositiveACKs ${POSITIVEACKS_EXAMPLE_SOURCES_CXX} ${POSITIVEACKS_EXAMPLE_SOURCES_CPP})
+target_compile_definitions(DisablePositiveACKs PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(DisablePositiveACKs fastrtps fastcdr)
 install(TARGETS DisablePositiveACKs
     RUNTIME DESTINATION examples/C++/DisablePositiveACKs/${BIN_INSTALL_DIR})

--- a/examples/C++/DynamicHelloWorldExample/CMakeLists.txt
+++ b/examples/C++/DynamicHelloWorldExample/CMakeLists.txt
@@ -48,6 +48,10 @@ file(GLOB HELLOWORLD_EXAMPLE_SOURCES_CXX "*.cxx")
 file(GLOB HELLOWORLD_EXAMPLE_SOURCES_CPP "*.cpp")
 
 add_executable(DynamicHelloWorldExample ${HELLOWORLD_EXAMPLE_SOURCES_CXX} ${HELLOWORLD_EXAMPLE_SOURCES_CPP})
+target_compile_definitions(DynamicHelloWorldExample PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(DynamicHelloWorldExample fastrtps fastcdr foonathan_memory)
 install(TARGETS DynamicHelloWorldExample
     RUNTIME DESTINATION examples/C++/DynamicHelloWorldExample/${BIN_INSTALL_DIR})

--- a/examples/C++/Filtering/CMakeLists.txt
+++ b/examples/C++/Filtering/CMakeLists.txt
@@ -47,6 +47,10 @@ message(STATUS "Configuring Filtering example...")
 file(GLOB DEADLINEQOS_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(Filtering ${DEADLINEQOS_EXAMPLE_SOURCES})
+target_compile_definitions(Filtering PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(Filtering fastrtps fastcdr foonathan_memory)
 install(TARGETS Filtering
     RUNTIME DESTINATION examples/C++/Filtering/${BIN_INSTALL_DIR}

--- a/examples/C++/FlowControlExample/CMakeLists.txt
+++ b/examples/C++/FlowControlExample/CMakeLists.txt
@@ -48,6 +48,10 @@ file(GLOB FLOWCONTROL_EXAMPLE_SOURCES_CXX "*.cxx")
 file(GLOB FLOWCONTROL_EXAMPLE_SOURCES_CPP "*.cpp")
 
 add_executable(FlowControlExample ${FLOWCONTROL_EXAMPLE_SOURCES_CXX} ${FLOWCONTROL_EXAMPLE_SOURCES_CPP})
+target_compile_definitions(FlowControlExample PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(FlowControlExample fastrtps fastcdr foonathan_memory)
 install(TARGETS FlowControlExample
     RUNTIME DESTINATION examples/C++/FlowControlExample/${BIN_INSTALL_DIR})

--- a/examples/C++/HelloWorldExample/CMakeLists.txt
+++ b/examples/C++/HelloWorldExample/CMakeLists.txt
@@ -48,6 +48,10 @@ file(GLOB HELLOWORLD_EXAMPLE_SOURCES_CXX "*.cxx")
 file(GLOB HELLOWORLD_EXAMPLE_SOURCES_CPP "*.cpp")
 
 add_executable(HelloWorldExample ${HELLOWORLD_EXAMPLE_SOURCES_CXX} ${HELLOWORLD_EXAMPLE_SOURCES_CPP})
+target_compile_definitions(HelloWorldExample PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(HelloWorldExample fastrtps fastcdr foonathan_memory)
 install(TARGETS HelloWorldExample
     RUNTIME DESTINATION examples/C++/HelloWorldExample/${BIN_INSTALL_DIR})

--- a/examples/C++/HelloWorldExampleSharedMem/CMakeLists.txt
+++ b/examples/C++/HelloWorldExampleSharedMem/CMakeLists.txt
@@ -52,6 +52,10 @@ if(WIN32)
 endif()
 
 add_executable(HelloWorldExampleSharedMem ${HELLOWORLD_EXAMPLE_SOURCES_CXX} ${HELLOWORLD_EXAMPLE_SOURCES_CPP})
+target_compile_definitions(HelloWorldExampleSharedMem PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(HelloWorldExampleSharedMem fastrtps fastcdr foonathan_memory)
 install(TARGETS HelloWorldExampleSharedMem
     RUNTIME DESTINATION examples/C++/HelloWorldExampleSharedMem/${BIN_INSTALL_DIR})

--- a/examples/C++/HelloWorldExampleTCP/CMakeLists.txt
+++ b/examples/C++/HelloWorldExampleTCP/CMakeLists.txt
@@ -56,6 +56,10 @@ configure_file("ca.pem" "ca.pem" COPYONLY)
 
 
 add_executable(HelloWorldExampleTCP ${HELLOWORLD_EXAMPLE_SOURCES_CXX} ${HELLOWORLD_EXAMPLE_SOURCES_CPP})
+target_compile_definitions(HelloWorldExampleTCP PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(HelloWorldExampleTCP fastrtps fastcdr foonathan_memory)
 install(TARGETS HelloWorldExampleTCP
     RUNTIME DESTINATION examples/C++/HelloWorldExampleTCP/${BIN_INSTALL_DIR})

--- a/examples/C++/HistoryKind/CMakeLists.txt
+++ b/examples/C++/HistoryKind/CMakeLists.txt
@@ -47,6 +47,10 @@ message(STATUS "Configuring UseCaseDemonstrator example...")
 file(GLOB USECASEDEMONSTRATOR_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(HistoryKind ${USECASEDEMONSTRATOR_EXAMPLE_SOURCES} pastsamples.cpp)
+target_compile_definitions(HistoryKind PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(HistoryKind fastrtps fastcdr foonathan_memory)
 install(TARGETS HistoryKind
     RUNTIME DESTINATION examples/C++/UseCaseDemonstrator/${BIN_INSTALL_DIR}

--- a/examples/C++/Keys/CMakeLists.txt
+++ b/examples/C++/Keys/CMakeLists.txt
@@ -47,6 +47,10 @@ message(STATUS "Configuring UseCaseDemonstrator example...")
 file(GLOB USECASEDEMONSTRATOR_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(Keys ${USECASEDEMONSTRATOR_EXAMPLE_SOURCES} keys.cpp)
+target_compile_definitions(Keys PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(Keys fastrtps fastcdr foonathan_memory)
 install(TARGETS Keys
     RUNTIME DESTINATION examples/C++/UseCaseDemonstrator/${BIN_INSTALL_DIR}

--- a/examples/C++/LateJoiners/CMakeLists.txt
+++ b/examples/C++/LateJoiners/CMakeLists.txt
@@ -47,6 +47,10 @@ message(STATUS "Configuring UseCaseDemonstrator example...")
 file(GLOB USECASEDEMONSTRATOR_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(LateJoiners ${USECASEDEMONSTRATOR_EXAMPLE_SOURCES} latejoiners.cpp)
+target_compile_definitions(LateJoiners PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(LateJoiners fastrtps fastcdr foonathan_memory)
 install(TARGETS LateJoiners
     RUNTIME DESTINATION examples/C++/UseCaseDemonstrator/${BIN_INSTALL_DIR}

--- a/examples/C++/LifespanQoSExample/CMakeLists.txt
+++ b/examples/C++/LifespanQoSExample/CMakeLists.txt
@@ -44,6 +44,10 @@ file(GLOB HELLOWORLD_EXAMPLE_SOURCES_CXX "*.cxx")
 file(GLOB HELLOWORLD_EXAMPLE_SOURCES_CPP "*.cpp")
 
 add_executable(LifespanQoSExample ${HELLOWORLD_EXAMPLE_SOURCES_CXX} ${HELLOWORLD_EXAMPLE_SOURCES_CPP})
+target_compile_definitions(LifespanQoSExample PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(LifespanQoSExample fastrtps fastcdr)
 install(TARGETS LifespanQoSExample
     RUNTIME DESTINATION examples/C++/LifespanQoSExample/${BIN_INSTALL_DIR})

--- a/examples/C++/LivelinessQoS/CMakeLists.txt
+++ b/examples/C++/LivelinessQoS/CMakeLists.txt
@@ -44,6 +44,10 @@ file(GLOB LIVELINESSQOS_SOURCES_CXX "*.cxx")
 file(GLOB LIVELINESSQOS_SOURCES_CPP "*.cpp")
 
 add_executable(LivelinessQoS ${LIVELINESSQOS_SOURCES_CXX} ${LIVELINESSQOS_SOURCES_CPP})
+target_compile_definitions(LivelinessQoS PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(LivelinessQoS fastrtps fastcdr)
 install(TARGETS LivelinessQoS
     RUNTIME DESTINATION examples/C++/LivelinessQoS/${BIN_INSTALL_DIR})

--- a/examples/C++/OwnershipStrengthQoSExample/CMakeLists.txt
+++ b/examples/C++/OwnershipStrengthQoSExample/CMakeLists.txt
@@ -47,6 +47,10 @@ message(STATUS "Configuring OwnershipStrengthQoS example...")
 file(GLOB OWNERSHIPSTRENGTH_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(OwnershipStrengthQoSExample ${OWNERSHIPSTRENGTH_EXAMPLE_SOURCES})
+target_compile_definitions(OwnershipStrengthQoSExample PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(OwnershipStrengthQoSExample fastrtps fastcdr foonathan_memory)
 install(TARGETS OwnershipStrengthQoSExample
     RUNTIME DESTINATION examples/C++/OwnershipStrengthQoSExample/${BIN_INSTALL_DIR}

--- a/examples/C++/RTPSTest_as_socket/CMakeLists.txt
+++ b/examples/C++/RTPSTest_as_socket/CMakeLists.txt
@@ -47,6 +47,10 @@ message(STATUS "Configuring RTPSTest_as_socket...")
 file(GLOB RTPSTESTASSOCKET_SOURCES "*.cpp")
 
 add_executable(RTPSTest_as_socket ${RTPSTESTASSOCKET_SOURCES})
+target_compile_definitions(RTPSTest_as_socket PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(RTPSTest_as_socket fastrtps fastcdr foonathan_memory)
 install(TARGETS RTPSTest_as_socket
     RUNTIME DESTINATION examples/C++/RTPSTest_as_socket/${BIN_INSTALL_DIR}

--- a/examples/C++/RTPSTest_persistent/CMakeLists.txt
+++ b/examples/C++/RTPSTest_persistent/CMakeLists.txt
@@ -47,6 +47,10 @@ message(STATUS "Configuring RTPSTest_persistent...")
 file(GLOB RTPSTESTPERSISTENT_SOURCES "*.cpp")
 
 add_executable(RTPSTest_persistent ${RTPSTESTPERSISTENT_SOURCES})
+target_compile_definitions(RTPSTest_persistent PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
 target_link_libraries(RTPSTest_persistent fastrtps fastcdr foonathan_memory)
 install(TARGETS RTPSTest_persistent
     RUNTIME DESTINATION examples/C++/RTPSTest_persistent/${BIN_INSTALL_DIR}

--- a/examples/C++/RTPSTest_registered/CMakeLists.txt
+++ b/examples/C++/RTPSTest_registered/CMakeLists.txt
@@ -47,6 +47,10 @@ message(STATUS "Configuring RTPSTest_registered...")
 file(GLOB RTPSTESTREGISTERED_SOURCES "*.cpp")
 
 add_executable(RTPSTest_registered ${RTPSTESTREGISTERED_SOURCES})
+target_compile_definitions(RTPSTest_registered PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(RTPSTest_registered fastrtps fastcdr foonathan_memory)
 install(TARGETS RTPSTest_registered
     RUNTIME DESTINATION examples/C++/RTPSTest_registered/${BIN_INSTALL_DIR}

--- a/examples/C++/SampleConfig_Controller/CMakeLists.txt
+++ b/examples/C++/SampleConfig_Controller/CMakeLists.txt
@@ -47,6 +47,10 @@ message(STATUS "Configuring UseCaseDemonstrator example...")
 file(GLOB USECASEDEMONSTRATOR_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(SampleConfig_Controller ${USECASEDEMONSTRATOR_EXAMPLE_SOURCES} sampleconfig_safest.cpp)
+target_compile_definitions(SampleConfig_Controller PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(SampleConfig_Controller fastrtps fastcdr foonathan_memory)
 install(TARGETS SampleConfig_Controller
     RUNTIME DESTINATION examples/C++/UseCaseDemonstrator/${BIN_INSTALL_DIR}

--- a/examples/C++/SampleConfig_Events/CMakeLists.txt
+++ b/examples/C++/SampleConfig_Events/CMakeLists.txt
@@ -47,6 +47,10 @@ message(STATUS "Configuring UseCaseDemonstrator example...")
 file(GLOB USECASEDEMONSTRATOR_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(SampleConfig_Events ${USECASEDEMONSTRATOR_EXAMPLE_SOURCES} sampleconfig_triggers.cpp)
+target_compile_definitions(SampleConfig_Events PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(SampleConfig_Events fastrtps fastcdr foonathan_memory)
 install(TARGETS SampleConfig_Events
     RUNTIME DESTINATION examples/C++/UseCaseDemonstrator/${BIN_INSTALL_DIR}

--- a/examples/C++/SampleConfig_Multimedia/CMakeLists.txt
+++ b/examples/C++/SampleConfig_Multimedia/CMakeLists.txt
@@ -47,6 +47,10 @@ message(STATUS "Configuring UseCaseDemonstrator example...")
 file(GLOB USECASEDEMONSTRATOR_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(SampleConfig_Multimedia ${USECASEDEMONSTRATOR_EXAMPLE_SOURCES} sampleconfig_fastest.cpp)
+target_compile_definitions(SampleConfig_Multimedia PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(SampleConfig_Multimedia fastrtps fastcdr foonathan_memory)
 install(TARGETS SampleConfig_Multimedia
     RUNTIME DESTINATION examples/C++/UseCaseDemonstrator/${BIN_INSTALL_DIR}

--- a/examples/C++/SecureHelloWorldExample/CMakeLists.txt
+++ b/examples/C++/SecureHelloWorldExample/CMakeLists.txt
@@ -48,6 +48,10 @@ file(GLOB HELLOWORLD_EXAMPLE_SOURCES_CXX "*.cxx")
 file(GLOB HELLOWORLD_EXAMPLE_SOURCES_CPP "*.cpp")
 
 add_executable(SecureHelloWorldExample ${HELLOWORLD_EXAMPLE_SOURCES_CXX} ${HELLOWORLD_EXAMPLE_SOURCES_CPP})
+target_compile_definitions(SecureHelloWorldExample PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
 target_include_directories(SecureHelloWorldExample PRIVATE)
 target_link_libraries(SecureHelloWorldExample fastrtps fastcdr foonathan_memory)
 install(TARGETS SecureHelloWorldExample

--- a/examples/C++/StaticHelloWorldExample/CMakeLists.txt
+++ b/examples/C++/StaticHelloWorldExample/CMakeLists.txt
@@ -53,6 +53,10 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/HelloWorldPublisher.xml
     )
 
 add_executable(StaticHelloWorldExample ${HELLOWORLD_EXAMPLE_SOURCES_CXX} ${HELLOWORLD_EXAMPLE_SOURCES_CPP})
+target_compile_definitions(StaticHelloWorldExample PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(StaticHelloWorldExample fastrtps fastcdr foonathan_memory)
 install(TARGETS StaticHelloWorldExample
     RUNTIME DESTINATION examples/C++/HelloWorldExample/${BIN_INSTALL_DIR})

--- a/examples/C++/UserDefinedTransportExample/CMakeLists.txt
+++ b/examples/C++/UserDefinedTransportExample/CMakeLists.txt
@@ -49,6 +49,10 @@ file(GLOB USERDEFINEDTRANSPORTEXAMPLE_SOURCES_HXX "*.cpp")
 include_directories(${PROJECT_SOURCE_DIR}/../../../thirdparty/asio/asio/include)
 
 add_executable(UserDefinedTransportExample ${USERDEFINEDTRANSPORTEXAMPLE_SOURCES_HXX})
+target_compile_definitions(UserDefinedTransportExample PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(UserDefinedTransportExample fastrtps fastcdr foonathan_memory)
 install(TARGETS UserDefinedTransportExample
     RUNTIME DESTINATION examples/C++/UserDefinedTransportExample/${BIN_INSTALL_DIR})

--- a/examples/C++/XMLProfiles/CMakeLists.txt
+++ b/examples/C++/XMLProfiles/CMakeLists.txt
@@ -51,6 +51,10 @@ file(COPY ${PROJECT_SOURCE_DIR}/XMLProfilesExample.xml
     )
 
 add_executable(XMLProfiles ${XMLPROFILESEXAMPLE_SOURCES_CXX} ${XMLPROFILESEXAMPLE_SOURCES_CPP})
+target_compile_definitions(XMLProfiles PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
 target_link_libraries(XMLProfiles fastrtps fastcdr foonathan_memory)
 install(TARGETS XMLProfiles
     RUNTIME DESTINATION examples/C++/XMLProfilesExample/${BIN_INSTALL_DIR})

--- a/test/blackbox/CMakeLists.txt
+++ b/test/blackbox/CMakeLists.txt
@@ -184,6 +184,8 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
         add_executable(BlackboxTests_RTPS ${RTPS_BLACKBOXTESTS_SOURCE})
         target_compile_definitions(BlackboxTests_RTPS PRIVATE
             $<$<NOT:$<BOOL:${IS_THIRDPARTY_BOOST_SUPPORTED}>>:FASTDDS_SHM_TRANSPORT_DISABLED> # Do not compile SHM Transport
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
             )
         target_include_directories(BlackboxTests_RTPS PRIVATE
             ${GTEST_INCLUDE_DIRS})
@@ -248,6 +250,8 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
             add_executable(BlackboxTests_FastRTPS ${BLACKBOXTESTS_FASTRTPS_SOURCE})
             target_compile_definitions(BlackboxTests_FastRTPS PRIVATE
                 $<$<NOT:$<BOOL:${IS_THIRDPARTY_BOOST_SUPPORTED}>>:FASTDDS_SHM_TRANSPORT_DISABLED> # Do not compile SHM Transport
+                $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+                $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
                 )
             target_include_directories(BlackboxTests_FastRTPS PRIVATE
                 api/fastrtps_deprecated
@@ -271,6 +275,8 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
             add_executable(BlackboxTests_DDS_PIM ${BLACKBOXTESTS_FASTDDS_PIM_SOURCE})
             target_compile_definitions(BlackboxTests_DDS_PIM PRIVATE
                 $<$<NOT:$<BOOL:${IS_THIRDPARTY_BOOST_SUPPORTED}>>:FASTDDS_SHM_TRANSPORT_DISABLED> # Do not compile SHM Transport
+                $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+                $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
                 )
             target_include_directories(BlackboxTests_DDS_PIM PRIVATE
                 api/dds-pim

--- a/test/communication/CMakeLists.txt
+++ b/test/communication/CMakeLists.txt
@@ -34,6 +34,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
         PublisherMain.cpp
         )
     add_executable(SimpleCommunicationPublisher ${PUBLISHER_SOURCE})
+    target_compile_definitions(SimpleCommunicationPublisher PRIVATE
+        $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+        $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+        )
     target_include_directories(SimpleCommunicationPublisher PRIVATE ${PROJECT_SOURCE_DIR}/test/blackbox)
     target_link_libraries(SimpleCommunicationPublisher fastrtps fastcdr foonathan_memory ${CMAKE_DL_LIBS})
 
@@ -42,6 +46,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
         SubscriberMain.cpp
         )
     add_executable(SimpleCommunicationSubscriber ${SUBSCRIBER_SOURCE})
+    target_compile_definitions(SimpleCommunicationSubscriber PRIVATE
+        $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+        $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+        )
     target_include_directories(SimpleCommunicationSubscriber PRIVATE ${PROJECT_SOURCE_DIR}/test/blackbox)
     target_link_libraries(SimpleCommunicationSubscriber fastrtps fastcdr foonathan_memory ${CMAKE_DL_LIBS})
 
@@ -52,6 +60,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
         )
 
     add_executable(SimpleCommunicationPubSub ${PUBSUB_SOURCE})
+    target_compile_definitions(SimpleCommunicationPubSub PRIVATE
+        $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+        $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+        )
     target_include_directories(SimpleCommunicationPubSub PRIVATE ${PROJECT_SOURCE_DIR}/test/blackbox)
     target_link_libraries(SimpleCommunicationPubSub fastrtps fastcdr foonathan_memory ${CMAKE_DL_LIBS})
 

--- a/test/dds/communication/CMakeLists.txt
+++ b/test/dds/communication/CMakeLists.txt
@@ -29,12 +29,20 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
         Publisher.cpp
         )
     add_executable(DDSSimpleCommunicationPublisher ${DDS_PUBLISHER_SOURCE})
+    target_compile_definitions(DDSSimpleCommunicationPublisher PRIVATE
+        $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+        $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+        )
     target_link_libraries(DDSSimpleCommunicationPublisher fastrtps fastcdr foonathan_memory ${CMAKE_DL_LIBS})
 
     set(DDS_SUBSCRIBER_SOURCE
         Subscriber.cpp
         )
     add_executable(DDSSimpleCommunicationSubscriber ${DDS_SUBSCRIBER_SOURCE})
+    target_compile_definitions(DDSSimpleCommunicationSubscriber PRIVATE
+        $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+        $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+        )
     target_link_libraries(DDSSimpleCommunicationSubscriber fastrtps fastcdr foonathan_memory ${CMAKE_DL_LIBS})
 
     ###############################################################################

--- a/test/performance/latency/CMakeLists.txt
+++ b/test/performance/latency/CMakeLists.txt
@@ -26,7 +26,7 @@ add_executable(LatencyTest ${LATENCYTEST_SOURCE})
 target_compile_definitions(LatencyTest PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
-)
+    )
 
 target_link_libraries(
     LatencyTest

--- a/test/performance/latency/CMakeLists.txt
+++ b/test/performance/latency/CMakeLists.txt
@@ -23,6 +23,11 @@ set(
 )
 add_executable(LatencyTest ${LATENCYTEST_SOURCE})
 
+target_compile_definitions(LatencyTest PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
+
 target_link_libraries(
     LatencyTest
     fastrtps

--- a/test/performance/throughput/CMakeLists.txt
+++ b/test/performance/throughput/CMakeLists.txt
@@ -23,6 +23,11 @@ set(
 )
 add_executable(ThroughputTest ${THROUGHPUTTEST_SOURCE})
 
+target_compile_definitions(ThroughputTest PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
+
 target_include_directories(ThroughputTest PRIVATE)
 target_link_libraries(
     ThroughputTest

--- a/test/performance/throughput/CMakeLists.txt
+++ b/test/performance/throughput/CMakeLists.txt
@@ -26,7 +26,7 @@ add_executable(ThroughputTest ${THROUGHPUTTEST_SOURCE})
 target_compile_definitions(ThroughputTest PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
-)
+    )
 
 target_include_directories(ThroughputTest PRIVATE)
 target_link_libraries(

--- a/test/performance/video/CMakeLists.txt
+++ b/test/performance/video/CMakeLists.txt
@@ -81,7 +81,7 @@ if(GST_FOUND)
     target_compile_definitions(VideoTest PRIVATE
         $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
         $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
-)
+        )
     target_compile_options(VideoTest PUBLIC ${GST_CFLAGS})
 
     if(NOT WIN32)

--- a/test/performance/video/CMakeLists.txt
+++ b/test/performance/video/CMakeLists.txt
@@ -77,6 +77,11 @@ if(GST_FOUND)
         main_VideoTest.cpp
     )
     add_executable(VideoTest ${VIDEOTEST_SOURCE})
+    
+    target_compile_definitions(VideoTest PRIVATE
+        $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+        $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
     target_compile_options(VideoTest PUBLIC ${GST_CFLAGS})
 
     if(NOT WIN32)

--- a/test/profiling/CMakeLists.txt
+++ b/test/profiling/CMakeLists.txt
@@ -19,6 +19,13 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         target_compile_definitions(${PROJECT_NAME} PRIVATE
             $<$<AND:$<BOOL:${WIN32}>,$<STREQUAL:"${CMAKE_SYSTEM_NAME}","WindowsStore">>:_WIN32_WINNT=0x0603>
             $<$<AND:$<BOOL:${WIN32}>,$<NOT:$<STREQUAL:"${CMAKE_SYSTEM_NAME}","WindowsStore">>>:_WIN32_WINNT=0x0601>
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
+    else()
+        target_compile_definitions(${PROJECT_NAME} PRIVATE
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
             )
     endif()
 

--- a/test/realtime/CMakeLists.txt
+++ b/test/realtime/CMakeLists.txt
@@ -5,6 +5,10 @@ if(GTEST_FOUND)
     set(USER_THREAD_NONBLOCKED_TEST UserThreadNonBlockedTest.cpp)
 
     add_executable(user_thread_nonblocked_test ${USER_THREAD_NONBLOCKED_TEST})
+    target_compile_definitions(DDSSimpleCommunicationSubscriber PRIVATE
+        $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+        $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+        )
     target_include_directories(user_thread_nonblocked_test PRIVATE ${GTEST_INCLUDE_DIRS})
     target_link_libraries(user_thread_nonblocked_test mutex_testing_tool fastrtps fastcdr ${GTEST_LIBRARIES})
 

--- a/test/unittest/dds/collections/CMakeLists.txt
+++ b/test/unittest/dds/collections/CMakeLists.txt
@@ -29,7 +29,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             LoanableSequenceTests.cpp)
 
         add_executable(LoanableSequenceTests ${LOANABLE_SEQUENCE_TESTS_SOURCE})
-        target_compile_definitions(LoanableSequenceTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(LoanableSequenceTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(LoanableSequenceTests PRIVATE ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
         target_link_libraries(LoanableSequenceTests ${GTEST_LIBRARIES})

--- a/test/unittest/dds/participant/CMakeLists.txt
+++ b/test/unittest/dds/participant/CMakeLists.txt
@@ -32,7 +32,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         endif()
 
         add_executable(ParticipantTests ${PARTICIPANTTESTS_SOURCE})
-        target_compile_definitions(ParticipantTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(ParticipantTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(ParticipantTests PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include

--- a/test/unittest/dds/publisher/CMakeLists.txt
+++ b/test/unittest/dds/publisher/CMakeLists.txt
@@ -35,7 +35,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         endif()
 
         add_executable(PublisherTests ${PUBLISHERTESTS_SOURCE})
-        target_compile_definitions(PublisherTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(PublisherTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(PublisherTests PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
@@ -47,7 +50,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         add_gtest(PublisherTests SOURCES ${PUBLISHERTESTS_SOURCE})
 
         add_executable(DataWriterTests ${DATAWRITERTESTS_SOURCE})
-        target_compile_definitions(DataWriterTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(DataWriterTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(DataWriterTests PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include

--- a/test/unittest/dds/status/CMakeLists.txt
+++ b/test/unittest/dds/status/CMakeLists.txt
@@ -103,7 +103,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         endif()
 
         add_executable(ListenerTests ${LISTENERTESTS_SOURCE})
-        target_compile_definitions(ListenerTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(ListenerTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(ListenerTests PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/RTPSReader

--- a/test/unittest/dds/subscriber/CMakeLists.txt
+++ b/test/unittest/dds/subscriber/CMakeLists.txt
@@ -32,7 +32,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         endif()
 
         add_executable(SubscriberTests ${SUBSCRIBERTESTS_SOURCE})
-        target_compile_definitions(SubscriberTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(SubscriberTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(SubscriberTests PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
@@ -44,7 +47,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         add_gtest(SubscriberTests SOURCES ${SUBSCRIBERTESTS_SOURCE})
 
         add_executable(DataReaderTests ${DATAREADERTESTS_SOURCE})
-        target_compile_definitions(DataReaderTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(DataReaderTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(DataReaderTests PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include

--- a/test/unittest/dds/topic/CMakeLists.txt
+++ b/test/unittest/dds/topic/CMakeLists.txt
@@ -31,7 +31,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         endif()
 
         add_executable(TopicTests ${TOPICTESTS_SOURCE})
-        target_compile_definitions(TopicTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(TopicTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(TopicTests PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include

--- a/test/unittest/dynamic_types/CMakeLists.txt
+++ b/test/unittest/dynamic_types/CMakeLists.txt
@@ -104,7 +104,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         include_directories(mock/)
 
         add_executable(DynamicTypesTests ${DYNAMIC_TYPES_TEST_SOURCE})
-        target_compile_definitions(DynamicTypesTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(DynamicTypesTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(DynamicTypesTests PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/TCPTransportDescriptor
@@ -127,7 +130,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
 
 
         add_executable(DynamicComplexTypesTests ${DYNAMIC_COMPLEX_TYPES_TEST_SOURCE})
-        target_compile_definitions(DynamicComplexTypesTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(DynamicComplexTypesTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(DynamicComplexTypesTests PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
@@ -141,7 +147,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
 
 
         add_executable(DynamicTypes_4_2_Tests ${DYNAMIC_TYPES_4_2_TEST_SOURCE})
-        target_compile_definitions(DynamicTypes_4_2_Tests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(DynamicTypes_4_2_Tests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(DynamicTypes_4_2_Tests PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)

--- a/test/unittest/logging/CMakeLists.txt
+++ b/test/unittest/logging/CMakeLists.txt
@@ -37,7 +37,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         include_directories(mock/)
 
         add_executable(LogTests ${LOGTESTS_SOURCE})
-        target_compile_definitions(LogTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(LogTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(LogTests PRIVATE ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
         target_link_libraries(LogTests ${GTEST_LIBRARIES} ${MOCKS}
@@ -62,7 +65,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         include_directories(${TINYXML2_INCLUDE_DIR})
 
         add_executable(LogFileTests ${LOGFILETESTS_SOURCE})
-        target_compile_definitions(LogFileTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(LogFileTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(LogFileTests PRIVATE ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
         target_link_libraries(LogFileTests ${GTEST_LIBRARIES} ${MOCKS}

--- a/test/unittest/rtps/common/CMakeLists.txt
+++ b/test/unittest/rtps/common/CMakeLists.txt
@@ -35,14 +35,20 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp)
 
         add_executable(CacheChangeTests ${CACHECHANGETESTS_SOURCE})
-        target_compile_definitions(CacheChangeTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(CacheChangeTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(CacheChangeTests PRIVATE ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
         target_link_libraries(CacheChangeTests ${GTEST_LIBRARIES})
         add_gtest(CacheChangeTests SOURCES ${CACHECHANGETESTS_SOURCE})
 
         add_executable(GuidUtilsTests ${GUID_UTILS_TESTS_SOURCE})
-        target_compile_definitions(GuidUtilsTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(GuidUtilsTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(GuidUtilsTests PRIVATE
             ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/src/cpp
@@ -54,14 +60,20 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         add_gtest(GuidUtilsTests SOURCES ${GUID_UTILS_TESTS_SOURCE})
 
         add_executable(SequenceNumberTests ${SEQUENCENUMBERTESTS_SOURCE})
-        target_compile_definitions(SequenceNumberTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(SequenceNumberTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(SequenceNumberTests PRIVATE ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
         target_link_libraries(SequenceNumberTests ${GTEST_LIBRARIES})
         add_gtest(SequenceNumberTests SOURCES ${SEQUENCENUMBERTESTS_SOURCE})
 
         add_executable(PortParametersTests ${PORTPARAMETERSTESTS_SOURCE})
-        target_compile_definitions(PortParametersTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(PortParametersTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(PortParametersTests PRIVATE ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
         target_link_libraries(PortParametersTests ${GTEST_LIBRARIES})

--- a/test/unittest/rtps/discovery/CMakeLists.txt
+++ b/test/unittest/rtps/discovery/CMakeLists.txt
@@ -62,7 +62,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         endif()
 
         add_executable(EdpTests ${EDPTESTS_SOURCE})
-        target_compile_definitions(EdpTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(EdpTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(EdpTests PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/PDP

--- a/test/unittest/rtps/flowcontrol/CMakeLists.txt
+++ b/test/unittest/rtps/flowcontrol/CMakeLists.txt
@@ -31,7 +31,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp)
 
         add_executable(ThroughputControllerTests ${THROUGHPUTCONTROLLERTESTS_SOURCE})
-        target_compile_definitions(ThroughputControllerTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(ThroughputControllerTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(ThroughputControllerTests PRIVATE ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/Endpoint
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/AsyncWriterThread

--- a/test/unittest/rtps/history/CMakeLists.txt
+++ b/test/unittest/rtps/history/CMakeLists.txt
@@ -61,7 +61,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         endif()
 
         add_executable(ReaderHistoryTests ${READERHISTORYTESTS_SOURCE})
-        target_compile_definitions(ReaderHistoryTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(ReaderHistoryTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(ReaderHistoryTests PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/Endpoint
@@ -75,7 +78,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         add_gtest(ReaderHistoryTests SOURCES ${READERHISTORYTESTS_SOURCE})
 
         add_executable(BasicPoolsTests ${BASICPOOLSTESTS_SOURCE})
-        target_compile_definitions(BasicPoolsTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(BasicPoolsTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(BasicPoolsTests PRIVATE
             ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/src/cpp
@@ -86,7 +92,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         add_gtest(BasicPoolsTests SOURCES ${BASICPOOLSTESTS_SOURCE})
 
         add_executable(CacheChangePoolTests ${CACHECHANGEPOOLTESTS_SOURCE})
-        target_compile_definitions(CacheChangePoolTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(CacheChangePoolTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(CacheChangePoolTests PRIVATE
             ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/src/cpp
@@ -97,7 +106,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         add_gtest(CacheChangePoolTests SOURCES ${CACHECHANGEPOOLTESTS_SOURCE})
 
         add_executable(TopicPayloadPoolTests ${TOPICPAYLOADPOOLTESTS_SOURCE})
-        target_compile_definitions(TopicPayloadPoolTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(TopicPayloadPoolTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(TopicPayloadPoolTests PRIVATE
             ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/TopicPayloadPoolProxy

--- a/test/unittest/rtps/network/CMakeLists.txt
+++ b/test/unittest/rtps/network/CMakeLists.txt
@@ -77,7 +77,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         include_directories(mock/)
 
         add_executable(NetworkFactoryTests ${NETWORKFACTORYTESTS_SOURCE})
-        target_compile_definitions(NetworkFactoryTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(NetworkFactoryTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(NetworkFactoryTests PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/ParticipantProxyData

--- a/test/unittest/rtps/persistence/CMakeLists.txt
+++ b/test/unittest/rtps/persistence/CMakeLists.txt
@@ -31,7 +31,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp)
 
         add_executable(PersistenceTests ${PERSISTENCETESTS_SOURCE})
-        target_compile_definitions(PersistenceTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(PersistenceTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(PersistenceTests PRIVATE ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
             ${PROJECT_SOURCE_DIR}/src/cpp

--- a/test/unittest/rtps/reader/CMakeLists.txt
+++ b/test/unittest/rtps/reader/CMakeLists.txt
@@ -34,7 +34,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         endif()
 
         add_executable(WriterProxyTests ${WRITERPROXYTESTS_SOURCE})
-        target_compile_definitions(WriterProxyTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(WriterProxyTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(WriterProxyTests PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader

--- a/test/unittest/rtps/resources/timedevent/CMakeLists.txt
+++ b/test/unittest/rtps/resources/timedevent/CMakeLists.txt
@@ -27,6 +27,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEvent.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/ResourceEvent.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/TimedConditionVariable.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
             )
 
@@ -35,7 +39,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         endif()
 
         add_executable(TimedEventTests ${TIMEDEVENTTESTS_SOURCE})
-        target_compile_definitions(TimedEventTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(TimedEventTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(TimedEventTests PRIVATE
             ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include

--- a/test/unittest/rtps/security/CMakeLists.txt
+++ b/test/unittest/rtps/security/CMakeLists.txt
@@ -59,7 +59,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/SecurityValidationRemoteTests.cpp PROPERTIES COMPILE_OPTIONS /bigobj)
         endif()
 
-        target_compile_definitions(SecurityAuthentication PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(SecurityAuthentication PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(SecurityAuthentication PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${OPENSSL_INCLUDE_DIR}

--- a/test/unittest/rtps/writer/CMakeLists.txt
+++ b/test/unittest/rtps/writer/CMakeLists.txt
@@ -39,7 +39,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         include_directories(${ASIO_INCLUDE_DIR})
 
         add_executable(ReaderProxyTests ${WRITERPROXYTESTS_SOURCE})
-        target_compile_definitions(ReaderProxyTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(ReaderProxyTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(ReaderProxyTests PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/Endpoint
@@ -63,44 +66,51 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
 
     # LivelinessManager
 
-    set(LIVELINESSMANAGERTESTS_SOURCE LivelinessManagerTests.cpp
-          ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
-          ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
-          ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
-          ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
-          ${PROJECT_SOURCE_DIR}/src/cpp/rtps/writer/LivelinessManager.cpp
-          ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/ResourceEvent.cpp
-          ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEvent.cpp
-          ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEventImpl.cpp
-          ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
-          ${PROJECT_SOURCE_DIR}/src/cpp/utils/TimedConditionVariable.cpp
-          )
-    add_executable(LivelinessManagerTests ${LIVELINESSMANAGERTESTS_SOURCE})
-        target_compile_definitions(LivelinessManagerTests PRIVATE FASTRTPS_NO_LIB)
+        set(LIVELINESSMANAGERTESTS_SOURCE LivelinessManagerTests.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/rtps/writer/LivelinessManager.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/ResourceEvent.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEvent.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEventImpl.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/utils/TimedConditionVariable.cpp
+            )
+        add_executable(LivelinessManagerTests ${LIVELINESSMANAGERTESTS_SOURCE})
+        target_compile_definitions(LivelinessManagerTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(LivelinessManagerTests PRIVATE
-          ${GTEST_INCLUDE_DIRS}
-          ${GMOCK_INCLUDE_DIRS}
-          ${PROJECT_SOURCE_DIR}/include
-          ${PROJECT_BINARY_DIR}/include
-          ${PROJECT_SOURCE_DIR}/src/cpp
-          )
-    target_link_libraries(LivelinessManagerTests PRIVATE
-        ${GTEST_LIBRARIES}
-        ${GMOCK_LIBRARIES})
-    add_gtest(LivelinessManagerTests SOURCES ${LIVELINESSMANAGERTESTS_SOURCE})
+            ${GTEST_INCLUDE_DIRS}
+            ${GMOCK_INCLUDE_DIRS}
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_BINARY_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/cpp
+            )
+        target_link_libraries(LivelinessManagerTests PRIVATE
+            ${GTEST_LIBRARIES}
+            ${GMOCK_LIBRARIES})
+        add_gtest(LivelinessManagerTests SOURCES ${LIVELINESSMANAGERTESTS_SOURCE})
 
     # RTPSWriter
 
-    set(RTPSWRITERTESTS_SOURCE RTPSWriterTests.cpp)
+        set(RTPSWRITERTESTS_SOURCE RTPSWriterTests.cpp)
 
-    add_executable(RTPSWriterTests ${RTPSWRITERTESTS_SOURCE})
-    target_include_directories(RTPSWriterTests PRIVATE
-        ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
-        )
-    target_link_libraries(RTPSWriterTests fastrtps foonathan_memory
-        ${GTEST_LIBRARIES} ${GMOCK_LIBRARIES}
-        ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
-    add_gtest(RTPSWriterTests SOURCES ${RTPSWRITERTESTS_SOURCE})
+        add_executable(RTPSWriterTests ${RTPSWRITERTESTS_SOURCE})
+        target_compile_definitions(RTPSWriterTests PRIVATE
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
+        target_include_directories(RTPSWriterTests PRIVATE
+            ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
+            )
+        target_link_libraries(RTPSWriterTests fastrtps foonathan_memory
+            ${GTEST_LIBRARIES} ${GMOCK_LIBRARIES}
+            ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+        add_gtest(RTPSWriterTests SOURCES ${RTPSWRITERTESTS_SOURCE})
 
     endif()
 endif()

--- a/test/unittest/security/accesscontrol/CMakeLists.txt
+++ b/test/unittest/security/accesscontrol/CMakeLists.txt
@@ -70,7 +70,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/publisher/qos/WriterQos.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/AccessControlTests.cpp)
             
-        target_compile_definitions(AccessControlTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(AccessControlTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
 
         target_include_directories(AccessControlTests PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}

--- a/test/unittest/security/authentication/CMakeLists.txt
+++ b/test/unittest/security/authentication/CMakeLists.txt
@@ -55,7 +55,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPFinder.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPLocator.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/BuiltinPKIDHTests.cpp)
-        target_compile_definitions(BuiltinPKIDH PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(BuiltinPKIDH PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(BuiltinPKIDH PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/NetworkFactory/

--- a/test/unittest/security/cryptography/CMakeLists.txt
+++ b/test/unittest/security/cryptography/CMakeLists.txt
@@ -44,7 +44,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/security/accesscontrol/AccessPermissionsHandle.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/builtinAESGCMGMACTests.cpp)
 
-        target_compile_definitions(BuiltinAESGCMGMAC PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(BuiltinAESGCMGMAC PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(BuiltinAESGCMGMAC PRIVATE
             ${GTEST_INCLUDE_DIRS}
             ${OPENSSL_INCLUDE_DIR}

--- a/test/unittest/security/logging/CMakeLists.txt
+++ b/test/unittest/security/logging/CMakeLists.txt
@@ -38,7 +38,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/security/logging/LogTopic.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/BuiltinLogTopicTests.cpp)
 
-        target_compile_definitions(BuiltinLogging PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(BuiltinLogging PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(BuiltinLogging PRIVATE
             ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include

--- a/test/unittest/transport/CMakeLists.txt
+++ b/test/unittest/transport/CMakeLists.txt
@@ -201,7 +201,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         include_directories(mock/)
 
         add_executable(UDPv4Tests ${UDPV4TESTS_SOURCE})
-        target_compile_definitions(UDPv4Tests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(UDPv4Tests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(UDPv4Tests PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/MessageReceiver
@@ -220,7 +223,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
 
         if(NOT DISABLE_UDPV6_TESTS)
             add_executable(UDPv6Tests ${UDPV6TESTS_SOURCE})
-            target_compile_definitions(UDPv6Tests PRIVATE FASTRTPS_NO_LIB)
+            target_compile_definitions(UDPv6Tests PRIVATE FASTRTPS_NO_LIB
+                $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+                $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+                )
             target_include_directories(UDPv6Tests PRIVATE
                 ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
                 ${PROJECT_SOURCE_DIR}/test/mock/rtps/MessageReceiver
@@ -236,7 +242,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             set(TRANSPORT_XFAIL_LIST ${TRANSPORT_XFAIL_LIST} XFAIL_UDP6)
 
             add_executable(TCPv6Tests ${TCPV6TESTS_SOURCE})
-            target_compile_definitions(TCPv6Tests PRIVATE FASTRTPS_NO_LIB)
+            target_compile_definitions(TCPv6Tests PRIVATE FASTRTPS_NO_LIB
+                $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+                $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+                )
             target_include_directories(TCPv6Tests PRIVATE
                 ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
                 ${PROJECT_SOURCE_DIR}/test/mock/rtps/ParticipantProxyData
@@ -258,7 +267,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         endif()
 
         add_executable(test_UDPv4Tests ${TEST_UDPV4TESTS_SOURCE})
-        target_compile_definitions(test_UDPv4Tests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(test_UDPv4Tests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(test_UDPv4Tests PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/ParticipantProxyData
@@ -278,7 +290,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         set(TRANSPORT_XFAIL_LIST ${TRANSPORT_XFAIL_LIST} XFAIL_TEST_UDP4)
 
         add_executable(TCPv4Tests ${TCPV4TESTS_SOURCE})
-        target_compile_definitions(TCPv4Tests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(TCPv4Tests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(TCPv4Tests PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/ParticipantProxyData
@@ -302,8 +317,11 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             add_executable(SharedMemTests ${SHAREDMEMTESTS_SOURCE})
 
             target_compile_definitions(SharedMemTests PRIVATE FASTRTPS_NO_LIB
-            $<$<BOOL:${WIN32}>:_ENABLE_ATOMIC_ALIGNMENT_FIX>)
-
+                $<$<BOOL:${WIN32}>:_ENABLE_ATOMIC_ALIGNMENT_FIX>
+                $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+                $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+                )
+    
             target_include_directories(SharedMemTests PRIVATE
                 ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
                 ${PROJECT_SOURCE_DIR}/test/mock/rtps/MessageReceiver

--- a/test/unittest/utils/CMakeLists.txt
+++ b/test/unittest/utils/CMakeLists.txt
@@ -50,7 +50,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         include_directories(mock/)
 
         add_executable(StringMatchingTests ${STRINGMATCHINGTESTS_SOURCE})
-        target_compile_definitions(StringMatchingTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(StringMatchingTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(StringMatchingTests PRIVATE ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
         target_link_libraries(StringMatchingTests ${GTEST_LIBRARIES} ${MOCKS})
@@ -62,7 +65,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
 
 
         add_executable(FixedSizeStringTests ${FIXEDSIZESTRINGTESTS_SOURCE})
-        target_compile_definitions(FixedSizeStringTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(FixedSizeStringTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(FixedSizeStringTests PRIVATE ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
         target_link_libraries(FixedSizeStringTests ${GTEST_LIBRARIES} ${MOCKS})
@@ -70,7 +76,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
 
 
         add_executable(BitmapRangeTests ${BITMAPRANGETESTS_SOURCE})
-        target_compile_definitions(BitmapRangeTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(BitmapRangeTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(BitmapRangeTests PRIVATE ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
         target_link_libraries(BitmapRangeTests ${GTEST_LIBRARIES} ${MOCKS})
@@ -78,15 +87,20 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
 
 
         add_executable(ResourceLimitedVectorTests ${RESOURCELIMITEDVECTORTESTS_SOURCE})
-        target_compile_definitions(ResourceLimitedVectorTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(ResourceLimitedVectorTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(ResourceLimitedVectorTests PRIVATE ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
         target_link_libraries(ResourceLimitedVectorTests ${GTEST_LIBRARIES} ${MOCKS})
         add_gtest(ResourceLimitedVectorTests SOURCES ${RESOURCELIMITEDVECTORTESTS_SOURCE})
 
-
         add_executable(LocatorTests ${LOCATORTESTS_SOURCE})
-        target_compile_definitions(LocatorTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(LocatorTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(LocatorTests PRIVATE ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
         target_link_libraries(LocatorTests ${GTEST_LIBRARIES} ${MOCKS})

--- a/test/unittest/xmlparser/CMakeLists.txt
+++ b/test/unittest/xmlparser/CMakeLists.txt
@@ -120,7 +120,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         include_directories(${TINYXML2_INCLUDE_DIR})
 
         add_executable(XMLProfileParserTests ${XMLPROFILEPARSER_SOURCE})
-        target_compile_definitions(XMLProfileParserTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(XMLProfileParserTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(XMLProfileParserTests PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/Log
@@ -198,7 +201,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         include_directories(${TINYXML2_INCLUDE_DIR})
 
         add_executable(XMLParserTests ${XMLPARSER_SOURCE})
-        target_compile_definitions(XMLParserTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(XMLParserTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(XMLParserTests PRIVATE
             ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/TCPTransportDescriptor
@@ -227,7 +233,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         include_directories(${TINYXML2_INCLUDE_DIR})
 
         add_executable(XMLTreeTests ${XMLTREE_SOURCE})
-        target_compile_definitions(XMLTreeTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(XMLTreeTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(XMLTreeTests PRIVATE
             ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include

--- a/test/unittest/xtypes/CMakeLists.txt
+++ b/test/unittest/xtypes/CMakeLists.txt
@@ -70,7 +70,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         include_directories(mock/)
 
         add_executable(XTypesTests ${XTYPES_TEST_SOURCE})
-        target_compile_definitions(XTypesTests PRIVATE FASTRTPS_NO_LIB)
+        target_compile_definitions(XTypesTests PRIVATE FASTRTPS_NO_LIB
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(XTypesTests PRIVATE
             ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include

--- a/test/xtypes/CMakeLists.txt
+++ b/test/xtypes/CMakeLists.txt
@@ -108,6 +108,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
             )
 
         add_executable(XTypesBlackBoxTests ${XTYPES_TESTS_SOURCE})
+        target_compile_definitions(XTypesBlackBoxTests PRIVATE
+            $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+            $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+            )
         target_include_directories(XTypesBlackBoxTests PRIVATE ${GTEST_INCLUDE_DIRS})
         target_link_libraries(XTypesBlackBoxTests fastrtps fastcdr ${GTEST_LIBRARIES})
         add_xtypes_gtest(XTypesBlackBoxTests SOURCES ${XTYPES_TESTS_SOURCE})


### PR DESCRIPTION
This PR adds to CMakeList files the `DEBUG` and `INTERNAL_DEBUG` definitions so the `LogInfo` macro can be used within the examples and the tests.