### PR TITLE
Add copy assignment operator to TypeSupport [10204]

### DIFF
--- a/include/fastdds/dds/topic/TypeSupport.hpp
+++ b/include/fastdds/dds/topic/TypeSupport.hpp
@@ -233,7 +233,7 @@ public:
     RTPS_DllAPI TypeSupport& operator =(
             const TypeSupport& other)
     {
-        *this = other;
+        Base::operator=(other);
         return *this;
     }
 

--- a/include/fastdds/dds/topic/TypeSupport.hpp
+++ b/include/fastdds/dds/topic/TypeSupport.hpp
@@ -227,6 +227,14 @@ public:
         return !*this;
     }
 
+    /**
+     * Copy assignment operator
+     */
+    RTPS_DllAPI TypeSupport& operator =(const TypeSupport& other)
+    {
+      *this = other;
+      return *this;
+    }
 };
 
 } /* namespace dds */

--- a/include/fastdds/dds/topic/TypeSupport.hpp
+++ b/include/fastdds/dds/topic/TypeSupport.hpp
@@ -236,6 +236,7 @@ public:
         *this = other;
         return *this;
     }
+
 };
 
 } /* namespace dds */

--- a/include/fastdds/dds/topic/TypeSupport.hpp
+++ b/include/fastdds/dds/topic/TypeSupport.hpp
@@ -230,7 +230,8 @@ public:
     /**
      * Copy assignment operator
      */
-    RTPS_DllAPI TypeSupport& operator =(const TypeSupport& other)
+    RTPS_DllAPI TypeSupport& operator =(
+            const TypeSupport& other)
     {
       *this = other;
       return *this;

--- a/include/fastdds/dds/topic/TypeSupport.hpp
+++ b/include/fastdds/dds/topic/TypeSupport.hpp
@@ -233,8 +233,8 @@ public:
     RTPS_DllAPI TypeSupport& operator =(
             const TypeSupport& other)
     {
-      *this = other;
-      return *this;
+        *this = other;
+        return *this;
     }
 };
 

--- a/include/fastdds/dds/topic/TypeSupport.hpp
+++ b/include/fastdds/dds/topic/TypeSupport.hpp
@@ -233,7 +233,8 @@ public:
     RTPS_DllAPI TypeSupport& operator =(
             const TypeSupport& other)
     {
-        Base::operator=(other);
+        Base::operator =(
+                other);
         return *this;
     }
 


### PR DESCRIPTION
"eprosima::fastdds::dds::TypeSupport" is missing the copy assignment operator while it has the copy constructor.
This prohibits users from copying instances.
This PR adds the missing copy assignment operator to the class.

I'm not sure whether is this a designated behavior.
As this class inherits `std::shared_ptr`, I think it should behave as a value type.
I think this PR (#794) will improve the class design but it's not active for a while.