### PR TITLE
Fix seg fault in throughput test [10206]

### DIFF
--- a/test/performance/throughput/ThroughputSubscriber.cpp
+++ b/test/performance/throughput/ThroughputSubscriber.cpp
@@ -85,6 +85,9 @@ void ThroughputSubscriber::DataSubListener::onSubscriptionMatched(
 void ThroughputSubscriber::DataSubListener::onNewDataMessage(
         Subscriber* subscriber)
 {
+    // In case the TSubscriber is removing entities because a TEST_ENDS msg, it waits
+    std::unique_lock<std::mutex> lecture_lock(throughput_subscriber_.lecture_available_mutex);
+
     if (throughput_subscriber_.dynamic_data_)
     {
         while (subscriber->takeNextData((void*)throughput_subscriber_.dynamic_data_type_, &info_))
@@ -105,7 +108,7 @@ void ThroughputSubscriber::DataSubListener::onNewDataMessage(
     }
     else
     {
-        if (throughput_subscriber_.throughput_type_ != nullptr)
+        if (nullptr != throughput_subscriber_.throughput_type_)
         {
             while (subscriber->takeNextData((void*)throughput_subscriber_.throughput_type_, &info_))
             {
@@ -490,6 +493,11 @@ void ThroughputSubscriber::process_message()
                     std::unique_lock<std::mutex> lock(command_mutex_);
                     stop_count_ = 1;
                     lock.unlock();
+
+                    // It stops the data listener to avoid seg faults with already removed entities
+                    // It waits if the data listener is in the middle of a reading
+                    std::unique_lock<std::mutex> lecture_lock(lecture_available_mutex);
+
                     if (dynamic_data_)
                     {
                         DynamicTypeBuilderFactory::delete_instance();
@@ -500,6 +508,8 @@ void ThroughputSubscriber::process_message()
                         delete(throughput_type_);
                         throughput_type_ = nullptr;
                     }
+                    lecture_lock.unlock();
+
                     sub_attrs_ = data_subscriber_->getAttributes();
                     break;
                 }

--- a/test/performance/throughput/ThroughputSubscriber.cpp
+++ b/test/performance/throughput/ThroughputSubscriber.cpp
@@ -86,7 +86,7 @@ void ThroughputSubscriber::DataSubListener::onNewDataMessage(
         Subscriber* subscriber)
 {
     // In case the TSubscriber is removing entities because a TEST_ENDS msg, it waits
-    std::unique_lock<std::mutex> lecture_lock(throughput_subscriber_.lecture_available_mutex);
+    std::unique_lock<std::mutex> lecture_lock(throughput_subscriber_.data_mutex_);
 
     if (throughput_subscriber_.dynamic_data_)
     {
@@ -496,7 +496,7 @@ void ThroughputSubscriber::process_message()
 
                     // It stops the data listener to avoid seg faults with already removed entities
                     // It waits if the data listener is in the middle of a reading
-                    std::unique_lock<std::mutex> lecture_lock(lecture_available_mutex);
+                    std::unique_lock<std::mutex> lecture_lock(data_mutex_);
 
                     if (dynamic_data_)
                     {

--- a/test/performance/throughput/ThroughputSubscriber.hpp
+++ b/test/performance/throughput/ThroughputSubscriber.hpp
@@ -85,8 +85,8 @@ private:
 
     // Test synchronization
     std::mutex command_mutex_;
+    // Block data input processing in Listeners
     std::mutex data_mutex_;
-    std::mutex lecture_available_mutex;
     std::condition_variable command_discovery_cv_;
     std::condition_variable data_discovery_cv_;
     uint32_t command_discovery_count_;

--- a/test/performance/throughput/ThroughputSubscriber.hpp
+++ b/test/performance/throughput/ThroughputSubscriber.hpp
@@ -85,6 +85,7 @@ private:
     // Test synchronization
     std::mutex command_mutex_;
     std::mutex data_mutex_;
+    std::mutex lecture_available_mutex;
     std::condition_variable command_discovery_cv_;
     std::condition_variable data_discovery_cv_;
     uint32_t command_discovery_count_;

--- a/test/performance/throughput/ThroughputSubscriber.hpp
+++ b/test/performance/throughput/ThroughputSubscriber.hpp
@@ -69,6 +69,7 @@ public:
     void run();
 
 private:
+
     void process_message();
 
     // Entities
@@ -138,6 +139,7 @@ private:
 
         uint32_t saved_last_seq_num_;
         uint32_t saved_lost_samples_;
+
     private:
 
         ThroughputSubscriber& throughput_subscriber_;
@@ -145,13 +147,13 @@ private:
         uint32_t lost_samples_;
         bool first_;
         eprosima::fastrtps::SampleInfo_t info_;
-    } data_sub_listener_;
+    }
+    data_sub_listener_;
 
     // Command listeners
     class CommandSubListener : public eprosima::fastrtps::SubscriberListener
     {
     public:
-
 
         CommandSubListener(
                 ThroughputSubscriber& throughput_subscriber);
@@ -173,9 +175,10 @@ private:
 
     private:
 
-        CommandSubListener& operator=(
-            const CommandSubListener&);
-    } command_sub_listener_;
+        CommandSubListener& operator =(
+                const CommandSubListener&);
+    }
+    command_sub_listener_;
 
     class CommandPubListener : public eprosima::fastrtps::PublisherListener
     {
@@ -194,8 +197,9 @@ private:
 
     private:
 
-        CommandPubListener& operator=(
-            const CommandPubListener&);
-    } command_pub_listener_;
+        CommandPubListener& operator =(
+                const CommandPubListener&);
+    }
+    command_pub_listener_;
 };
 #endif /* THROUGHPUTSUBSCRIBER_H_ */


### PR DESCRIPTION
Error in Throughput Test. Type is removed from Subscriber when `TEST_ENDS` finishes, but `DataSubListener` can still be reading.

Fix: #1664 

Signed-off-by: jparisu <javierparis@eprosima.com>