### PR TITLE
Avoid calling FindAtomic in Fast-DDS config module [10239]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,7 +224,6 @@ eprosima_find_thirdparty(TinyXML2 tinyxml2)
 
 find_package(foonathan_memory REQUIRED)
 message(STATUS "Found foonathan_memory: ${foonathan_memory_DIR}")
-find_package(Atomic MODULE)
 find_package(ThirdpartyBoost REQUIRED)
 
 if(ANDROID)

--- a/cmake/modules/FindAtomic.cmake
+++ b/cmake/modules/FindAtomic.cmake
@@ -1,9 +1,9 @@
 # Check if platform needs to explicitly specify linking with libatomic.
-# It creates an interface target eProsima::atomic that will include the dependency if needed.
+# It creates an interface target eProsima_atomic that will include the dependency if needed.
 # The variable FASTDDS_REQUIRED_FLAGS can be used to pass specific compiler flags use in the build
 # and that we want to mimick in the testing like --std=c++20
 
-if(TARGET eProsima::atomic)
+if(TARGET eProsima_atomic)
     return()
 endif()
 
@@ -68,17 +68,17 @@ if (HAVE_LIBATOMIC)
     )
 endif()
 
-# add interface target associated
-add_library(eProsima::atomic INTERFACE IMPORTED)
+# add interface target associated (cannot be imported to avoid propagation on static libraries)
+add_library(eProsima_atomic INTERFACE)
 
-# Set LINK_LIBATOMIC to true only if linking with atomic is required
+# Populate the interface target properties
 if (NOT ATOMIC_WITHOUT_LIB)
     if (ATOMIC_WITH_LIB)
         # force to link to atomic when the dummy target is present
         if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.11.4")
-            target_link_libraries(eProsima::atomic INTERFACE atomic)
+            target_link_libraries(eProsima_atomic INTERFACE atomic)
         else()
-            set_property(TARGET eProsima::atomic PROPERTY INTERFACE_LINK_LIBRARIES atomic)
+            set_property(TARGET eProsima_atomic PROPERTY INTERFACE_LINK_LIBRARIES atomic)
         endif()
     else()
         message(FATAL_ERROR "Unable to create binaries with atomic dependencies")

--- a/cmake/packaging/Config.cmake.in
+++ b/cmake/packaging/Config.cmake.in
@@ -25,17 +25,6 @@ set_and_check(@PROJECT_NAME@_LIB_DIR "@PACKAGE_LIB_INSTALL_DIR@")
 find_package(fastcdr REQUIRED)
 find_package(foonathan_memory REQUIRED)
 find_package(TinyXML2 QUIET)
-
-# Find atomic using Fast DDS FindAtomic.cmake
-#    1. Save incoming CMAKE_MODULE_PATH
-#    2. Extend CMAKE_MODULE_PATH so atomic can be found
-#    3. Reset CMAKE_MODULE_PATH to incoming value
-#    4. Unset temp variable
-set(TEMP_CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}")
-set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_LIST_DIR}/modules")
-find_package(Atomic MODULE REQUIRED)
-set(CMAKE_MODULE_PATH "${TEMP_CMAKE_MODULE_PATH}")
-unset(TEMP_CMAKE_MODULE_PATH)
 @FASTRTPS_PACKAGE_OPT_DEPS@
 
 include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake)

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -405,9 +405,6 @@ elseif(NOT EPROSIMA_INSTALLER)
         ${THIRDPARTY_BOOST_INCLUDE_DIR}
         )
 
-    # PRIVACY is PUBLIC by default
-    set(PRIVACY "PUBLIC")
-
     # Made linked libraries PRIVATE to prevent local directories in Windows installer.
     if(EPROSIMA_INSTALLER_MINION)
         set(PRIVACY "PRIVATE")
@@ -630,12 +627,6 @@ elseif(NOT EPROSIMA_INSTALLER)
     install(FILES ${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-config.cmake
         ${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-config-version.cmake
         DESTINATION ${INSTALL_DESTINATION_PATH}
-        COMPONENT cmake
-        )
-
-    # Install FindAtomic.cmake in case external application want to make use of it
-    install(FILES ${PROJECT_SOURCE_DIR}/cmake/modules/FindAtomic.cmake
-        DESTINATION ${INSTALL_DESTINATION_PATH}/modules
         COMPONENT cmake
         )
 

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -406,14 +406,16 @@ elseif(NOT EPROSIMA_INSTALLER)
         )
 
     # Made linked libraries PRIVATE to prevent local directories in Windows installer.
-    if(EPROSIMA_INSTALLER_MINION)
+    if(EPROSIMA_INSTALLER_MINION
+        # No need to expose linked libs when target is a shared library on MSVC.
+            OR (BUILD_SHARED_LIBS AND MSVC))
         set(PRIVACY "PRIVATE")
+    else()
+        set(PRIVACY "PUBLIC")
     endif()
 
-    # No need to expose linked libs when target is a shared library on MSVC.
-    if(BUILD_SHARED_LIBS AND MSVC)
-        set(PRIVACY "PRIVATE")
-    endif()
+    # Find out if libatomic link is required in this platform
+    find_package(Atomic MODULE)
 
     # Link library to external libraries.
     target_link_libraries(${PROJECT_NAME} ${PRIVACY} fastcdr foonathan_memory
@@ -422,7 +424,7 @@ elseif(NOT EPROSIMA_INSTALLER)
         $<$<BOOL:${LINK_SSL}>:OpenSSL::SSL$<SEMICOLON>OpenSSL::Crypto>
         $<$<BOOL:${WIN32}>:iphlpapi$<SEMICOLON>Shlwapi>
         ${THIRDPARTY_BOOST_LINK_LIBS}
-        eProsima::atomic
+        PRIVATE eProsima_atomic
         )
 
     if(MSVC OR MSVC_IDE)
@@ -536,7 +538,7 @@ if((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER)
         COMPONENT cmake
         )
 elseif(NOT EPROSIMA_INSTALLER)
-    install(TARGETS ${PROJECT_NAME}
+    install(TARGETS ${PROJECT_NAME} eProsima_atomic
         EXPORT ${PROJECT_NAME}-targets
         RUNTIME DESTINATION ${BIN_INSTALL_DIR}${MSVCARCH_DIR_EXTENSION}
         LIBRARY DESTINATION ${LIB_INSTALL_DIR}${MSVCARCH_DIR_EXTENSION}
@@ -544,7 +546,7 @@ elseif(NOT EPROSIMA_INSTALLER)
         COMPONENT libraries${MSVCARCH_EXTENSION}
         )
 
-    export(TARGETS ${PROJECT_NAME} FILE ${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-targets.cmake)
+    export(TARGETS ${PROJECT_NAME} eProsima_atomic FILE ${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-targets.cmake)
 
     if(INSTALLER_PLATFORM)
         set(INSTALL_DESTINATION_PATH ${DATA_INSTALL_DIR}/${PROJECT_NAME}-${INSTALLER_PLATFORM}/cmake)

--- a/test/unittest/transport/CMakeLists.txt
+++ b/test/unittest/transport/CMakeLists.txt
@@ -333,7 +333,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             target_link_libraries(SharedMemTests ${GTEST_LIBRARIES} ${MOCKS}
                 $<$<BOOL:${TLS_FOUND}>:OpenSSL::SSL$<SEMICOLON>OpenSSL::Crypto>
                 ${THIRDPARTY_BOOST_LINK_LIBS}
-                eProsima::atomic
+                eProsima_atomic
                 )
             if(MSVC OR MSVC_IDE)
                 target_link_libraries(SharedMemTests ${PRIVACY} iphlpapi Shlwapi )


### PR DESCRIPTION
#1634 modifies how atomic dependencies were handled to solve issues in some platforms (mac or clang on linux). In particular global variables were replaced by interface targets for link dependencies. Because all dependent targets were PUBLIC in non-windows platforms it generated issues of target propagation in external projects because the new interface target was not exported.

#1652 worarounds the above mentioned issue by exporting the FindAtomic module and calling it from Fast-DDS config files.  This is not a good practice because the FindAtomic is not a real module (it doesn't actually search for a library but check if a library is required for build) and will soon be removed (libatomic dependency is deprecated in clang and gcc).

#1678 solves the #1634 issues by declaring the atomic interface target as PRIVATE in all platforms. This way the
dependency is not propagated and is not necessary to export the FindAtomic module.

There is an exception when the target: Fast-DDS as static library. In this case PRIVATE targets must be propagated
because the project importing Fast-DDS will directly call the dependent targets exports. In order to prevent issues
the interface target is exported (this way the external project doesn't need to call FindAtomic but relies on the
Fast-DDS build result).

All changes are in commit 15df77646abfaef5baddb1157e543a56b9ab682d I rebased in order to have all atomic related commits together.