### PR TITLE
Change LoanableCollection::size_type to int32_t [10221]

### DIFF
--- a/include/fastdds/dds/core/LoanableCollection.hpp
+++ b/include/fastdds/dds/core/LoanableCollection.hpp
@@ -34,7 +34,7 @@ class LoanableCollection
 {
 public:
 
-    using size_type = uint32_t;
+    using size_type = int32_t;
     using element_type = void*;
 
     /**
@@ -89,6 +89,8 @@ public:
      * (i.e. @ref has_ownership() is false) then no allocation will be performed, the length will
      * remain unchanged, and false will be returned.
      *
+     * @pre new_length >= 0
+     *
      * @param [in] new_length New number of elements to be accessible.
      *
      * @return true if the new length was correcly set.
@@ -99,6 +101,11 @@ public:
     bool length(
             size_type new_length)
     {
+        if (new_length < 0)
+        {
+            return false;
+        }
+
         if (new_length <= maximum_)
         {
             length_ = new_length;
@@ -186,8 +193,8 @@ public:
         maximum = maximum_;
         length = length_;
 
-        maximum_ = 0u;
-        length_ = 0u;
+        maximum_ = 0;
+        length_ = 0;
         elements_ = nullptr;
         has_ownership_ = true;
 
@@ -230,8 +237,8 @@ protected:
     virtual void resize(
             size_type new_length) = 0;
 
-    size_type maximum_ = 0u;
-    size_type length_ = 0u;
+    size_type maximum_ = 0;
+    size_type length_ = 0;
     element_type* elements_ = nullptr;
     bool has_ownership_ = true;
 };

--- a/include/fastdds/dds/core/LoanableSequence.hpp
+++ b/include/fastdds/dds/core/LoanableSequence.hpp
@@ -244,7 +244,7 @@ private:
     {
         if (has_ownership_ && elements_)
         {
-            for (size_t n = 0; n < maximum_; ++n)
+            for (size_type n = 0; n < maximum_; ++n)
             {
                 T* elem = data_[n];
                 delete elem;

--- a/include/fastdds/dds/core/LoanableSequence.hpp
+++ b/include/fastdds/dds/core/LoanableSequence.hpp
@@ -78,7 +78,7 @@ public:
      * Pre-allocation constructor.
      *
      * Creates the sequence with an initial number of allocated elements.
-     * When the input parameter is 0, the behavior is equivalent to the default constructor.
+     * When the input parameter is less than or equal to 0, the behavior is equivalent to the default constructor.
      * Otherwise, the post-conditions below will apply.
      *
      * @param [in] max Number of elements to pre-allocate.
@@ -91,7 +91,7 @@ public:
     LoanableSequence(
             size_type max)
     {
-        if (!max)
+        if (max <= 0)
         {
             return;
         }

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -271,9 +271,7 @@ ReturnCode_t DataReaderImpl::check_collection_preconditions_and_calc_max_samples
             return ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;
         }
 
-        uint32_t collection_input_max = data_values.maximum();
-        int32_t collection_max = (collection_input_max > std::numeric_limits<uint32_t>::max() / 2u) ?
-                std::numeric_limits<int32_t>::max() : static_cast<int32_t>(collection_input_max);
+        int32_t collection_max = data_values.maximum();
 
         // We consider all negative value to be LENGTH_UNLIMITED
         if (0 > max_samples)

--- a/test/unittest/dds/collections/LoanableSequenceTests.cpp
+++ b/test/unittest/dds/collections/LoanableSequenceTests.cpp
@@ -349,6 +349,141 @@ TEST(LoanableSequenceTests, copy_assign)
     check_result(loaned, num_test_elements);
 }
 
+TEST(LoanableSequenceTests, length)
+{
+    // Checks on default constructed sequence
+    {
+        TestSeq uut;
+        EXPECT_EQ(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_EQ(0, uut.maximum());
+        EXPECT_EQ(0, uut.length());
+
+        // Positive should grow collection
+        EXPECT_TRUE(uut.length(num_test_elements));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(num_test_elements, uut.length());
+
+        // Negative should fail
+        EXPECT_FALSE(uut.length(-100));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(num_test_elements, uut.length());
+
+        // Decreasing should not shrink
+        EXPECT_TRUE(uut.length(1));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(1, uut.length());
+    }
+
+    // Checks on sequence constructed with maximum
+    {
+        TestSeq uut(1);
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_LE(1, uut.maximum());
+        EXPECT_EQ(0, uut.length());
+
+        // Positive should grow collection
+        EXPECT_TRUE(uut.length(num_test_elements));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(num_test_elements, uut.length());
+
+        // Negative should fail
+        EXPECT_FALSE(uut.length(-100));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(num_test_elements, uut.length());
+
+        // Decreasing should not shrink
+        EXPECT_TRUE(uut.length(1));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(1, uut.length());
+    }
+
+    // Checks on stack-allocated sequence
+    {
+        StackAllocatedSeq uut;
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(0, uut.length());
+
+        // Positive should be ok
+        EXPECT_TRUE(uut.length(num_test_elements));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(num_test_elements, uut.length());
+
+        // Negative should fail
+        EXPECT_FALSE(uut.length(-100));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(num_test_elements, uut.length());
+
+        // Decreasing should not shrink
+        EXPECT_TRUE(uut.length(1));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(1, uut.length());
+    }
+
+    // Checks on loaned sequence
+    {
+        StackAllocatedBuffer<int> stack;
+        TestSeq uut;
+        uut.loan(stack.buffer_for_loans(), stack.size(), 0);
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_FALSE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(0, uut.length());
+
+        // Positive should be ok
+        EXPECT_TRUE(uut.length(num_test_elements));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_FALSE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(num_test_elements, uut.length());
+
+        // Negative should fail
+        EXPECT_FALSE(uut.length(-100));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_FALSE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(num_test_elements, uut.length());
+
+        // Growing should fail
+        EXPECT_FALSE(uut.length(num_test_elements + 1));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_FALSE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(num_test_elements, uut.length());
+
+        // Decreasing should be ok
+        EXPECT_TRUE(uut.length(1));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_FALSE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(1, uut.length());
+
+        // Return loan
+        uut.unloan();
+    }
+}
+
 TEST(LoanableSequenceTests, loan_unloan)
 {
     StackAllocatedBuffer<int> stack;

--- a/test/unittest/dds/collections/LoanableSequenceTests.cpp
+++ b/test/unittest/dds/collections/LoanableSequenceTests.cpp
@@ -118,6 +118,15 @@ TEST(LoanableSequenceTests, construct)
         EXPECT_EQ(0, uut.length());
     }
 
+    // Check negative maximum behaves as default
+    {
+        TestSeq uut(-100);
+        EXPECT_EQ(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_EQ(0, uut.maximum());
+        EXPECT_EQ(0, uut.length());
+    }
+
     // Check stack-allocated behaves as TestSeq costructed with maximum
     {
         StackAllocatedSeq uut;

--- a/test/unittest/dds/collections/LoanableSequenceTests.cpp
+++ b/test/unittest/dds/collections/LoanableSequenceTests.cpp
@@ -96,8 +96,8 @@ TEST(LoanableSequenceTests, construct)
         TestSeq uut;
         EXPECT_EQ(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(0u, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.maximum());
+        EXPECT_EQ(0, uut.length());
     }
 
     // Check post-conditions of constructor with maximum
@@ -106,16 +106,16 @@ TEST(LoanableSequenceTests, construct)
         EXPECT_NE(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
         EXPECT_EQ(num_test_elements, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.length());
     }
 
     // Check maximum of 0 behaves as default
     {
-        TestSeq uut(0u);
+        TestSeq uut(0);
         EXPECT_EQ(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(0u, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.maximum());
+        EXPECT_EQ(0, uut.length());
     }
 
     // Check stack-allocated behaves as TestSeq costructed with maximum
@@ -124,10 +124,10 @@ TEST(LoanableSequenceTests, construct)
         EXPECT_NE(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
         EXPECT_EQ(num_test_elements, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.length());
 
         // Trying to grow beyond maximum will throw
-        EXPECT_THROW(uut.length(uut.maximum() + 1u), std::bad_alloc);
+        EXPECT_THROW(uut.length(uut.maximum() + 1), std::bad_alloc);
     }
 }
 
@@ -147,8 +147,8 @@ TEST(LoanableSequenceTests, copy_construct)
         TestSeq uut(empty);
         EXPECT_EQ(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(0u, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.maximum());
+        EXPECT_EQ(0, uut.length());
     }
 
     // Copy-constructing an empty allocated sequence behaves as default constructor
@@ -156,8 +156,8 @@ TEST(LoanableSequenceTests, copy_construct)
         TestSeq uut(owned);
         EXPECT_EQ(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(0u, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.maximum());
+        EXPECT_EQ(0, uut.length());
     }
 
     // Copy-constructing an empty loaned sequence behaves as default constructor
@@ -165,8 +165,8 @@ TEST(LoanableSequenceTests, copy_construct)
         TestSeq uut(loaned);
         EXPECT_EQ(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(0u, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.maximum());
+        EXPECT_EQ(0, uut.length());
     }
 
     // Give length and values to sequences
@@ -194,9 +194,9 @@ TEST(LoanableSequenceTests, copy_construct)
     }
 
     // Reduce length of sequences
-    EXPECT_TRUE(owned.length(1u));
+    EXPECT_TRUE(owned.length(1));
     EXPECT_GT(owned.maximum(), owned.length());
-    EXPECT_TRUE(loaned.length(1u));
+    EXPECT_TRUE(loaned.length(1));
     EXPECT_GT(loaned.maximum(), loaned.length());
 
     // Copy-constructing a non-empty allocated sequence with max > len allocates and copies
@@ -205,8 +205,8 @@ TEST(LoanableSequenceTests, copy_construct)
         EXPECT_NE(nullptr, uut.buffer());
         EXPECT_NE(owned.buffer(), uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(1u, uut.maximum());
-        check_result(uut, 1u);
+        EXPECT_EQ(1, uut.maximum());
+        check_result(uut, 1);
     }
 
     // Copy-constructing a non-empty loaned sequence with max > len allocates and copies
@@ -215,8 +215,8 @@ TEST(LoanableSequenceTests, copy_construct)
         EXPECT_NE(nullptr, uut.buffer());
         EXPECT_NE(loaned.buffer(), uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(1u, uut.maximum());
-        check_result(uut, 1u);
+        EXPECT_EQ(1, uut.maximum());
+        check_result(uut, 1);
     }
 
     // Return loan to avoid warning on destructor
@@ -239,8 +239,8 @@ TEST(LoanableSequenceTests, copy_assign)
         TestSeq uut = empty;
         EXPECT_EQ(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(0u, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.maximum());
+        EXPECT_EQ(0, uut.length());
     }
 
     // Copying an empty allocated sequence behaves as default constructor
@@ -248,8 +248,8 @@ TEST(LoanableSequenceTests, copy_assign)
         TestSeq uut = owned;
         EXPECT_EQ(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(0u, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.maximum());
+        EXPECT_EQ(0, uut.length());
     }
 
     // Copying an empty loaned sequence behaves as default constructor
@@ -257,8 +257,8 @@ TEST(LoanableSequenceTests, copy_assign)
         TestSeq uut = loaned;
         EXPECT_EQ(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(0u, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.maximum());
+        EXPECT_EQ(0, uut.length());
     }
 
     // Give length and values to sequences
@@ -286,9 +286,9 @@ TEST(LoanableSequenceTests, copy_assign)
     }
 
     // Reduce length of sequences
-    EXPECT_TRUE(owned.length(1u));
+    EXPECT_TRUE(owned.length(1));
     EXPECT_GT(owned.maximum(), owned.length());
-    EXPECT_TRUE(loaned.length(1u));
+    EXPECT_TRUE(loaned.length(1));
     EXPECT_GT(loaned.maximum(), loaned.length());
 
     // Copying a non-empty allocated sequence with max > len allocates and copies
@@ -297,8 +297,8 @@ TEST(LoanableSequenceTests, copy_assign)
         EXPECT_NE(nullptr, uut.buffer());
         EXPECT_NE(owned.buffer(), uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(1u, uut.maximum());
-        check_result(uut, 1u);
+        EXPECT_EQ(1, uut.maximum());
+        check_result(uut, 1);
     }
 
     // Copying a non-empty loaned sequence with max > len allocates and copies
@@ -307,8 +307,8 @@ TEST(LoanableSequenceTests, copy_assign)
         EXPECT_NE(nullptr, uut.buffer());
         EXPECT_NE(loaned.buffer(), uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(1u, uut.maximum());
-        check_result(uut, 1u);
+        EXPECT_EQ(1, uut.maximum());
+        check_result(uut, 1);
     }
 
     // Copying loaned into allocated changes length
@@ -322,13 +322,13 @@ TEST(LoanableSequenceTests, copy_assign)
     check_result(owned, num_test_elements);
 
     // Copying allocated into loaned releases loan
-    EXPECT_TRUE(owned.length(1u));
+    EXPECT_TRUE(owned.length(1));
     loaned = owned;
     EXPECT_EQ(loaned.length(), owned.length());
     EXPECT_NE(loaned.buffer(), owned.buffer());
     EXPECT_TRUE(loaned.has_ownership());
-    EXPECT_EQ(1u, loaned.maximum());
-    check_result(loaned, 1u);
+    EXPECT_EQ(1, loaned.maximum());
+    check_result(loaned, 1);
 
     // Copying a bigger collection makes collection grow
     EXPECT_TRUE(owned.length(num_test_elements));
@@ -343,7 +343,7 @@ TEST(LoanableSequenceTests, copy_assign)
 TEST(LoanableSequenceTests, loan_unloan)
 {
     StackAllocatedBuffer<int> stack;
-    test_size_type max = 0u, len = 0u;
+    test_size_type max = 0, len = 0;
     void** result_buffer;
 
     {
@@ -351,8 +351,8 @@ TEST(LoanableSequenceTests, loan_unloan)
         TestSeq uut;
         EXPECT_EQ(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(0u, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.maximum());
+        EXPECT_EQ(0, uut.length());
 
         // Check that loan cannot be returned
         EXPECT_EQ(nullptr, uut.unloan());
@@ -370,7 +370,7 @@ TEST(LoanableSequenceTests, loan_unloan)
         EXPECT_EQ(nullptr, uut.unloan(max, len));
 
         // Check that loan cannot be performed
-        EXPECT_FALSE(uut.loan(stack.buffer_for_loans(), num_test_elements, 0u));
+        EXPECT_FALSE(uut.loan(stack.buffer_for_loans(), num_test_elements, 0));
     }
 
     {
@@ -379,14 +379,14 @@ TEST(LoanableSequenceTests, loan_unloan)
         EXPECT_NE(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
         EXPECT_EQ(num_test_elements, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.length());
 
         // Check that loan cannot be returned
         EXPECT_EQ(nullptr, uut.unloan());
         EXPECT_EQ(nullptr, uut.unloan(max, len));
 
         // Check that loan cannot be performed
-        EXPECT_FALSE(uut.loan(stack.buffer_for_loans(), num_test_elements, 0u));
+        EXPECT_FALSE(uut.loan(stack.buffer_for_loans(), num_test_elements, 0));
     }
 
     {
@@ -395,14 +395,14 @@ TEST(LoanableSequenceTests, loan_unloan)
         EXPECT_NE(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
         EXPECT_EQ(num_test_elements, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.length());
 
         // Check that loan cannot be returned
         EXPECT_EQ(nullptr, uut.unloan());
         EXPECT_EQ(nullptr, uut.unloan(max, len));
 
         // Check that loan cannot be performed
-        EXPECT_FALSE(uut.loan(stack.buffer_for_loans(), num_test_elements, 0u));
+        EXPECT_FALSE(uut.loan(stack.buffer_for_loans(), num_test_elements, 0));
     }
 
     // Note: When uut is deleted upon exiting its scope, a warning log will be produced.
@@ -445,7 +445,7 @@ TEST(LoanableSequenceTests, loan_unloan)
         EXPECT_TRUE(uut.loan(stack.buffer_for_loans(), num_test_elements, 0));
         EXPECT_FALSE(uut.has_ownership());
         EXPECT_EQ(num_test_elements, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.length());
         EXPECT_EQ(stack.buffer_for_loans(), uut.buffer());
         EXPECT_TRUE(uut.length(num_test_elements));
         EXPECT_EQ(num_test_elements, uut.length());
@@ -459,14 +459,14 @@ TEST(LoanableSequenceTests, loan_unloan)
         // Check unloan postconditions
         EXPECT_EQ(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(0u, uut.length());
-        EXPECT_EQ(0u, uut.maximum());
+        EXPECT_EQ(0, uut.length());
+        EXPECT_EQ(0, uut.maximum());
 
         // Loan again
         EXPECT_TRUE(uut.loan(stack.buffer_for_loans(), num_test_elements, 0));
         EXPECT_FALSE(uut.has_ownership());
         EXPECT_EQ(num_test_elements, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.length());
         EXPECT_EQ(stack.buffer_for_loans(), uut.buffer());
 
         // Check other version of unloan
@@ -478,19 +478,19 @@ TEST(LoanableSequenceTests, loan_unloan)
         // Check unloan postconditions
         EXPECT_EQ(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(0u, uut.length());
-        EXPECT_EQ(0u, uut.maximum());
+        EXPECT_EQ(0, uut.length());
+        EXPECT_EQ(0, uut.maximum());
 
         // Check with wrong parameters
-        EXPECT_FALSE(uut.loan(stack.buffer_for_loans(), 0u, 0u));
-        EXPECT_FALSE(uut.loan(stack.buffer_for_loans(), 1u, 2u));
-        EXPECT_FALSE(uut.loan(nullptr, 1u, 1u));
+        EXPECT_FALSE(uut.loan(stack.buffer_for_loans(), 0, 0));
+        EXPECT_FALSE(uut.loan(stack.buffer_for_loans(), 1, 2u));
+        EXPECT_FALSE(uut.loan(nullptr, 1, 1));
 
         // Check that we can loan more than once
-        EXPECT_TRUE(uut.loan(stack.buffer_for_loans(), num_test_elements, 0u));
+        EXPECT_TRUE(uut.loan(stack.buffer_for_loans(), num_test_elements, 0));
         EXPECT_FALSE(uut.has_ownership());
         EXPECT_EQ(num_test_elements, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.length());
         EXPECT_EQ(stack.buffer_for_loans(), uut.buffer());
         EXPECT_TRUE(uut.loan(stack.buffer_for_loans(), num_test_elements, num_test_elements));
         EXPECT_FALSE(uut.has_ownership());
@@ -499,19 +499,19 @@ TEST(LoanableSequenceTests, loan_unloan)
         EXPECT_EQ(stack.buffer_for_loans(), uut.buffer());
 
         // Now loan a different buffer
-        StackAllocatedBuffer<int, 1u> stack2;
-        EXPECT_TRUE(uut.loan(stack2.buffer_for_loans(), 1u, 0u));
+        StackAllocatedBuffer<int, 1> stack2;
+        EXPECT_TRUE(uut.loan(stack2.buffer_for_loans(), 1, 0));
         EXPECT_FALSE(uut.has_ownership());
-        EXPECT_EQ(1u, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(1, uut.maximum());
+        EXPECT_EQ(0, uut.length());
         EXPECT_EQ(stack2.buffer_for_loans(), uut.buffer());
 
         // Check that loaned buffer cannot grow above maximum
-        EXPECT_TRUE(uut.length(1u));
+        EXPECT_TRUE(uut.length(1));
         EXPECT_FALSE(uut.length(10u));
         EXPECT_FALSE(uut.has_ownership());
-        EXPECT_EQ(1u, uut.maximum());
-        EXPECT_EQ(1u, uut.length());
+        EXPECT_EQ(1, uut.maximum());
+        EXPECT_EQ(1, uut.length());
         EXPECT_EQ(stack2.buffer_for_loans(), uut.buffer());
     }
 
@@ -628,7 +628,7 @@ TEST(LoanableSequenceTests, sum_collections)
         EXPECT_TRUE(result.loan(stack.buffer_for_loans(), num_test_elements, 0));
         EXPECT_FALSE(result.has_ownership());
         EXPECT_EQ(num_test_elements, result.maximum());
-        EXPECT_EQ(0u, result.length());
+        EXPECT_EQ(0, result.length());
         EXPECT_EQ(stack.buffer_for_loans(), result.buffer());
 
         // Test increasing length and accessors
@@ -648,8 +648,8 @@ TEST(LoanableSequenceTests, sum_collections)
         // Check unloan postconditions
         EXPECT_EQ(nullptr, result.buffer());
         EXPECT_TRUE(result.has_ownership());
-        EXPECT_EQ(0u, result.length());
-        EXPECT_EQ(0u, result.maximum());
+        EXPECT_EQ(0, result.length());
+        EXPECT_EQ(0, result.maximum());
     }
 }
 

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -44,7 +44,7 @@ namespace eprosima {
 namespace fastdds {
 namespace dds {
 
-static constexpr LoanableCollection::size_type num_test_elements = 10u;
+static constexpr LoanableCollection::size_type num_test_elements = 10;
 
 FASTDDS_SEQUENCE(FooSeq, FooType);
 using FooArray = LoanableArray<FooType, num_test_elements>;
@@ -139,8 +139,8 @@ protected:
     {
         if (ReturnCode_t::RETCODE_OK == code)
         {
-            data_values.length(0u);
-            infos.length(0u);
+            data_values.length(0);
+            infos.length(0);
         }
     }
 
@@ -150,7 +150,7 @@ protected:
     {
         LoanableCollection::size_type n = infos.length();
         auto buffer = data_values.buffer();
-        for (LoanableCollection::size_type i = 0u; i < n; ++i)
+        for (LoanableCollection::size_type i = 0; i < n; ++i)
         {
             if (infos[i].valid_data)
             {
@@ -175,9 +175,9 @@ protected:
         if (ReturnCode_t::RETCODE_OK == expected_return_loan_ret)
         {
             EXPECT_TRUE(data_values.has_ownership());
-            EXPECT_EQ(0u, data_values.maximum());
+            EXPECT_EQ(0, data_values.maximum());
             EXPECT_TRUE(infos.has_ownership());
-            EXPECT_EQ(0u, infos.maximum());
+            EXPECT_EQ(0, infos.maximum());
         }
     }
 
@@ -290,8 +290,8 @@ protected:
 
         // Check read/take and variants without loan
         {
-            FooSeq data_values(1u);
-            SampleInfoSeq infos(1u);
+            FooSeq data_values(1);
+            SampleInfoSeq infos(1);
 
             ReturnCode_t expected_return_loan_ret = code;
             if (ReturnCode_t::RETCODE_OK == code)
@@ -382,7 +382,7 @@ TEST_F(DataReaderTests, read_take_apis)
 
     // Send data
     FooType data;
-    data.index(1u);
+    data.index(1);
     EXPECT_EQ(ReturnCode_t::RETCODE_OK, data_writer_->write(&data, HANDLE_NIL));
 
     // Wait for data to arrive and check OK should be returned
@@ -444,24 +444,24 @@ TEST_F(DataReaderTests, collection_preconditions)
     SampleInfoSeq info_false_10_1;
 
     // Make the sequences have the corresponding values
-    true_10_1.length(1u);
-    false_10_0.loan(arr.buffer_for_loans(), num_test_elements, 0u);
-    false_10_1.loan(arr.buffer_for_loans(), num_test_elements, 1u);
-    info_true_10_1.length(1u);
-    info_false_10_0.loan(info_arr.buffer_for_loans(), num_test_elements, 0u);
-    info_false_10_1.loan(info_arr.buffer_for_loans(), num_test_elements, 1u);
+    true_10_1.length(1);
+    false_10_0.loan(arr.buffer_for_loans(), num_test_elements, 0);
+    false_10_1.loan(arr.buffer_for_loans(), num_test_elements, 1);
+    info_true_10_1.length(1);
+    info_false_10_0.loan(info_arr.buffer_for_loans(), num_test_elements, 0);
+    info_false_10_1.loan(info_arr.buffer_for_loans(), num_test_elements, 1);
 
     // Check we did it right
-    check_collection(true_0_0, true, 0u, 0u);
-    check_collection(true_10_0, true, 10u, 0u);
-    check_collection(true_10_1, true, 10u, 1u);
-    check_collection(false_10_0, false, 10u, 0u);
-    check_collection(false_10_1, false, 10u, 1u);
-    check_collection(info_true_0_0, true, 0u, 0u);
-    check_collection(info_true_10_0, true, 10u, 0u);
-    check_collection(info_true_10_1, true, 10u, 1u);
-    check_collection(info_false_10_0, false, 10u, 0u);
-    check_collection(info_false_10_1, false, 10u, 1u);
+    check_collection(true_0_0, true, 0, 0);
+    check_collection(true_10_0, true, 10, 0);
+    check_collection(true_10_1, true, 10, 1);
+    check_collection(false_10_0, false, 10, 0);
+    check_collection(false_10_1, false, 10, 1);
+    check_collection(info_true_0_0, true, 0, 0);
+    check_collection(info_true_10_0, true, 10, 0);
+    check_collection(info_true_10_1, true, 10, 1);
+    check_collection(info_false_10_0, false, 10, 0);
+    check_collection(info_false_10_1, false, 10, 1);
 
     // Check all wrong combinations
     using test_case_t = std::pair<LoanableCollection&, SampleInfoSeq&>;
@@ -607,7 +607,7 @@ TEST_F(DataReaderTests, return_loan)
     EXPECT_EQ(ok_code, reader2->enable());
 
     FooType data;
-    data.index(1u);
+    data.index(1);
 
     // Send a bunch of samples
     for (int32_t i = 0; i < num_samples; ++i)
@@ -753,7 +753,7 @@ TEST_F(DataReaderTests, resource_limits)
     create_entities(nullptr, reader_qos, SUBSCRIBER_QOS_DEFAULT, writer_qos);
 
     FooType data;
-    data.index(1u);
+    data.index(1);
 
     // Send a bunch of samples
     for (int32_t i = 0; i < num_samples; ++i)


### PR DESCRIPTION
The [review](https://github.com/eProsima/Fast-DDS/pull/1662#discussion_r553365805) of #1662 revealed a design flaw in the API of `LoanableCollection`. As the `max_samples` parameter of the `read / take` APIs is a signed integer, and there is a precondition on it being less than the collection's maximum, it doesn't make sense that the type for `LoanableCollection::size_type` is `uint32_t`.

This PR changes it to `int32_t`, adds a precondition to the `length` setter of `LoanableCollection`, and adds a test for the `length` setter.

It also changes the offending code found on the review of #1662.