### PR TITLE
Check valid_data instead on instance_state [10250]

### DIFF
--- a/examples/C++/DDS/Benchmark/BenchmarkPublisher.cpp
+++ b/examples/C++/DDS/Benchmark/BenchmarkPublisher.cpp
@@ -300,7 +300,7 @@ void BenchMarkPublisher::SubListener::on_data_available(
             {
                 if (reader->take_next_sample((void*)&m_Hello, &m_info) == ReturnCode_t::RETCODE_OK)
                 {
-                    if (m_info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+                    if (m_info.valid_data)
                     {
                         if (m_Hello.index() > mParent->m_iCount)
                         {
@@ -321,7 +321,7 @@ void BenchMarkPublisher::SubListener::on_data_available(
             {
                 if (reader->take_next_sample((void*)&m_HelloSmall, &m_info) == ReturnCode_t::RETCODE_OK)
                 {
-                    if (m_info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+                    if (m_info.valid_data)
                     {
                         if (m_HelloSmall.index() > mParent->m_iCount)
                         {
@@ -342,7 +342,7 @@ void BenchMarkPublisher::SubListener::on_data_available(
             {
                 if (reader->take_next_sample((void*)&m_HelloMedium, &m_info) == ReturnCode_t::RETCODE_OK)
                 {
-                    if (m_info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+                    if (m_info.valid_data)
                     {
                         if (m_HelloMedium.index() > mParent->m_iCount)
                         {
@@ -363,7 +363,7 @@ void BenchMarkPublisher::SubListener::on_data_available(
             {
                 if (reader->take_next_sample((void*)&m_HelloBig, &m_info) == ReturnCode_t::RETCODE_OK)
                 {
-                    if (m_info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+                    if (m_info.valid_data)
                     {
                         if (m_HelloBig.index() > mParent->m_iCount)
                         {

--- a/examples/C++/DDS/Benchmark/BenchmarkSubscriber.cpp
+++ b/examples/C++/DDS/Benchmark/BenchmarkSubscriber.cpp
@@ -306,7 +306,7 @@ void BenchMarkSubscriber::SubListener::on_data_available(
         {
             if (reader->take_next_sample((void*)&mParent->m_Hello, &m_info) == ReturnCode_t::RETCODE_OK)
             {
-                if (m_info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+                if (m_info.valid_data)
                 {
                     mParent->m_Hello.index(mParent->m_Hello.index() + 1);
                     mParent->mp_writer->write((void*)&mParent->m_Hello);
@@ -318,7 +318,7 @@ void BenchMarkSubscriber::SubListener::on_data_available(
         {
             if (reader->take_next_sample((void*)&mParent->m_HelloSmall, &m_info) == ReturnCode_t::RETCODE_OK)
             {
-                if (m_info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+                if (m_info.valid_data)
                 {
                     mParent->m_HelloSmall.index(mParent->m_HelloSmall.index() + 1);
                     mParent->mp_writer->write((void*)&mParent->m_HelloSmall);
@@ -330,7 +330,7 @@ void BenchMarkSubscriber::SubListener::on_data_available(
         {
             if (reader->take_next_sample((void*)&mParent->m_HelloMedium, &m_info) == ReturnCode_t::RETCODE_OK)
             {
-                if (m_info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+                if (m_info.valid_data)
                 {
                     mParent->m_HelloMedium.index(mParent->m_HelloMedium.index() + 1);
                     mParent->mp_writer->write((void*)&mParent->m_HelloMedium);
@@ -342,7 +342,7 @@ void BenchMarkSubscriber::SubListener::on_data_available(
         {
             if (reader->take_next_sample((void*)&mParent->m_HelloBig, &m_info) == ReturnCode_t::RETCODE_OK)
             {
-                if (m_info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+                if (m_info.valid_data)
                 {
                     mParent->m_HelloBig.index(mParent->m_HelloBig.index() + 1);
                     mParent->mp_writer->write((void*)&mParent->m_HelloBig);

--- a/examples/C++/DDS/ClientServerTest/EprosimaServer.cpp
+++ b/examples/C++/DDS/ClientServerTest/EprosimaServer.cpp
@@ -216,7 +216,7 @@ void EprosimaServer::OperationListener::on_data_available(
 {
     SampleInfo m_sampleInfo;
     mp_up->mp_operation_reader->take_next_sample((void*)&m_operation, &m_sampleInfo);
-    if (m_sampleInfo.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+    if (m_sampleInfo.valid_data)
     {
         ++mp_up->m_n_served;
         m_result.m_guid = m_operation.m_guid;

--- a/examples/C++/DDS/DeadlineQoSExample/deadlinepayloadSubscriber.cxx
+++ b/examples/C++/DDS/DeadlineQoSExample/deadlinepayloadSubscriber.cxx
@@ -126,7 +126,7 @@ void deadlinepayloadSubscriber::SubListener::on_data_available(
     HelloMsg st;
     if (reader->take_next_sample(&st, &info) == ReturnCode_t::RETCODE_OK)
     {
-        if (info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+        if (info.valid_data)
         {
             std::cout << "Message with key " << st.deadlinekey() << " received" << std::endl;
         }

--- a/examples/C++/DDS/DisablePositiveACKs/DisablePositiveACKsSubscriber.cpp
+++ b/examples/C++/DDS/DisablePositiveACKs/DisablePositiveACKsSubscriber.cpp
@@ -127,7 +127,7 @@ void DisablePositiveACKsSubscriber::SubListener::on_data_available(
     SampleInfo info;
     if (reader->take_next_sample(&hello, &info) == ReturnCode_t::RETCODE_OK)
     {
-        if (info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+        if (info.valid_data)
         {
             this->n_samples++;
             std::cout << "Message with index " << hello.index() << " RECEIVED" << std::endl;

--- a/examples/C++/DDS/Filtering/FilteringExampleSubscriber.cxx
+++ b/examples/C++/DDS/Filtering/FilteringExampleSubscriber.cxx
@@ -129,7 +129,7 @@ void FilteringExampleSubscriber::SubListener::on_data_available(
     FilteringExample st;
     if (reader->take_next_sample(&st, &info) == ReturnCode_t::RETCODE_OK)
     {
-        if (info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+        if (info.valid_data)
         {
             ++n_msg;
             std::cout << "Sample received, count=" << n_msg << std::endl;

--- a/examples/C++/DDS/FlowControlExample/FlowControlExampleSubscriber.cxx
+++ b/examples/C++/DDS/FlowControlExample/FlowControlExampleSubscriber.cxx
@@ -126,7 +126,7 @@ void FlowControlExampleSubscriber::SubListener::on_data_available(
     FlowControlExample st;
     if (reader->take_next_sample(&st, &info) == ReturnCode_t::RETCODE_OK)
     {
-        if (info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+        if (info.valid_data)
         {
             ++n_msg;
             static unsigned int fastMessages = 0;

--- a/examples/C++/DDS/HelloWorldExampleSharedMem/HelloWorldSubscriber.cpp
+++ b/examples/C++/DDS/HelloWorldExampleSharedMem/HelloWorldSubscriber.cpp
@@ -149,7 +149,7 @@ void HelloWorldSubscriber::SubListener::on_data_available(
     SampleInfo info;
     if (reader->take_next_sample(hello_.get(), &info) == ReturnCode_t::RETCODE_OK)
     {
-        if (info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+        if (info.valid_data)
         {
             samples_++;
             const size_t data_size = hello_->data().size();

--- a/examples/C++/DDS/HelloWorldExampleTCP/HelloWorldSubscriber.cpp
+++ b/examples/C++/DDS/HelloWorldExampleTCP/HelloWorldSubscriber.cpp
@@ -180,7 +180,7 @@ void HelloWorldSubscriber::SubListener::on_data_available(
     SampleInfo info;
     if (reader->take_next_sample(&hello_, &info) == ReturnCode_t::RETCODE_OK)
     {
-        if (info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+        if (info.valid_data)
         {
             samples_++;
             // Print your structure data here.

--- a/examples/C++/DDS/Keys/keys.cpp
+++ b/examples/C++/DDS/Keys/keys.cpp
@@ -141,7 +141,7 @@ public:
         SampleInfo info;
         if (reader->take_next_sample(&m_sample, &info) == ReturnCode_t::RETCODE_OK)
         {
-            if (info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+            if (info.valid_data)
             {
                 this->n_samples++;
                 // Print your structure data here.

--- a/examples/C++/DDS/LifespanQoSExample/LifespanSubscriber.cpp
+++ b/examples/C++/DDS/LifespanQoSExample/LifespanSubscriber.cpp
@@ -129,7 +129,7 @@ void LifespanSubscriber::SubListener::on_data_available(
     SampleInfo info;
     if (reader->read_next_sample(&hello, &info) == ReturnCode_t::RETCODE_OK)
     {
-        if (info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+        if (info.valid_data)
         {
             this->n_samples++;
             // Print your structure data here.

--- a/examples/C++/DDS/LivelinessQoS/LivelinessSubscriber.cpp
+++ b/examples/C++/DDS/LivelinessQoS/LivelinessSubscriber.cpp
@@ -137,7 +137,7 @@ void LivelinessSubscriber::SubListener::on_data_available(
     SampleInfo info;
     if (reader->take_next_sample(&topic, &info) == ReturnCode_t::RETCODE_OK)
     {
-        if (info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+        if (info.valid_data)
         {
             this->n_samples++;
 

--- a/examples/C++/DDS/OwnershipStrengthQoSExample/OwnershipStrengthSubscriber.cxx
+++ b/examples/C++/DDS/OwnershipStrengthQoSExample/OwnershipStrengthSubscriber.cxx
@@ -176,7 +176,7 @@ void OwnershipStrengthSubscriber::SubListener::on_data_available(
     ExampleMessage st;
     if (reader->take_next_sample(&st, &info) == ReturnCode_t::RETCODE_OK)
     {
-        if (info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE && m_hierarchy.IsMessageStrong(st, info))
+        if (info.valid_data && m_hierarchy.IsMessageStrong(st, info))
         {
             // User message handling here, for a strong message
             ++n_msg;

--- a/examples/C++/DDS/TypeLookupService/TypeLookupSubscriber.cpp
+++ b/examples/C++/DDS/TypeLookupService/TypeLookupSubscriber.cpp
@@ -146,7 +146,7 @@ void TypeLookupSubscriber::SubListener::on_data_available(
         SampleInfo info;
         if (reader->take_next_sample(data.get(), &info) == ReturnCode_t::RETCODE_OK)
         {
-            if (info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+            if (info.valid_data)
             {
                 types::DynamicType_ptr type = subscriber_->readers_[reader];
                 this->n_samples++;

--- a/test/blackbox/api/dds-pim/ReqRepHelloWorldReplier.cpp
+++ b/test/blackbox/api/dds-pim/ReqRepHelloWorldReplier.cpp
@@ -175,7 +175,7 @@ void ReqRepHelloWorldReplier::ReplyListener::on_data_available(
 
     if (ReturnCode_t::RETCODE_OK == datareader->take_next_sample((void*)&hello, &info))
     {
-        if (info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+        if (info.valid_data)
         {
             ASSERT_EQ(hello.message().compare("HelloWorld"), 0);
             replier_.newNumber(info.sample_identity, hello.index());

--- a/test/blackbox/api/dds-pim/ReqRepHelloWorldRequester.cpp
+++ b/test/blackbox/api/dds-pim/ReqRepHelloWorldRequester.cpp
@@ -199,7 +199,7 @@ void ReqRepHelloWorldRequester::ReplyListener::on_data_available(
 
     if (ReturnCode_t::RETCODE_OK == datareader->take_next_sample((void*)&hello, &info))
     {
-        if (info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+        if (info.valid_data)
         {
             ASSERT_EQ(hello.message().compare("GoodBye"), 0);
             requester_.newNumber(info.related_sample_identity, hello.index());

--- a/test/dds/communication/Subscriber.cpp
+++ b/test/dds/communication/Subscriber.cpp
@@ -236,7 +236,7 @@ public:
 
             if (nullptr != reader && !!reader->take_next_sample(sample.get(), &info))
             {
-                if (info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+                if (info.valid_data)
                 {
                     std::unique_lock<std::mutex> lock(mutex_);
                     ++number_samples_;

--- a/test/xtypes/TestSubscriber.cpp
+++ b/test/xtypes/TestSubscriber.cpp
@@ -276,7 +276,7 @@ void TestSubscriber::SubListener::on_data_available(
     SampleInfo info;
     if (!!reader->take_next_sample(mParent->m_Data, &info))
     {
-        if (info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+        if (info.valid_data)
         {
             ++n_samples;
             mParent->cv_.notify_one();


### PR DESCRIPTION
This PR replaces the checks for `instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE` with checks for `valid_data`, as it is the way indicated on the DDS standard to check if we can use the sample or not.