### PR TITLE
DataReader read and take APIs [10211]

### DIFF
--- a/include/dds/core/detail/InstanceHandle.hpp
+++ b/include/dds/core/detail/InstanceHandle.hpp
@@ -18,7 +18,7 @@
 #ifndef EPROSIMA_DDS_CORE_DETAIL_INSTANCE_HANDLE_HPP_
 #define EPROSIMA_DDS_CORE_DETAIL_INSTANCE_HANDLE_HPP_
 
-#include <fastdds/rtps/common/InstanceHandle.h>
+#include <fastdds/dds/topic/TypeSupport.hpp>
 
 /**
  * @cond
@@ -29,7 +29,7 @@ namespace dds {
 namespace core {
 namespace detail {
 
-using InstanceHandle = eprosima::fastrtps::rtps::InstanceHandle_t;
+using InstanceHandle = eprosima::fastdds::dds::InstanceHandle_t;
 
 } //namespace detail
 } //namespace core

--- a/include/fastdds/dds/core/Entity.hpp
+++ b/include/fastdds/dds/core/Entity.hpp
@@ -21,7 +21,7 @@
 #define _FASTDDS_ENTITY_HPP_
 
 #include <fastdds/dds/core/status/StatusMask.hpp>
-#include <fastdds/rtps/common/InstanceHandle.h>
+#include <fastdds/dds/topic/TypeSupport.hpp>
 #include <fastrtps/types/TypesBase.h>
 
 namespace eprosima {
@@ -99,7 +99,7 @@ public:
      * @brief Retrieves the instance handler that represents the Entity
      * @return Reference to the InstanceHandle
      */
-    const fastrtps::rtps::InstanceHandle_t& get_instance_handle() const
+    const InstanceHandle_t& get_instance_handle() const
     {
         return instance_handle_;
     }
@@ -126,7 +126,7 @@ protected:
      * @param handle Instance Handle
      */
     RTPS_DllAPI void set_instance_handle(
-            const fastrtps::rtps::InstanceHandle_t& handle)
+            const InstanceHandle_t& handle)
     {
         instance_handle_ = handle;
     }
@@ -138,7 +138,7 @@ protected:
     StatusMask status_changes_;
 
     //! InstanceHandle associated to the Entity
-    fastrtps::rtps::InstanceHandle_t instance_handle_;
+    InstanceHandle_t instance_handle_;
 
     //! Boolean that states if the Entity is enabled or disabled
     bool enable_;

--- a/include/fastdds/dds/core/LoanableCollection.hpp
+++ b/include/fastdds/dds/core/LoanableCollection.hpp
@@ -34,7 +34,7 @@ class LoanableCollection
 {
 public:
 
-    using size_type = uint32_t;
+    using size_type = int32_t;
     using element_type = void*;
 
     /**
@@ -89,6 +89,8 @@ public:
      * (i.e. @ref has_ownership() is false) then no allocation will be performed, the length will
      * remain unchanged, and false will be returned.
      *
+     * @pre new_length >= 0
+     *
      * @param [in] new_length New number of elements to be accessible.
      *
      * @return true if the new length was correcly set.
@@ -99,6 +101,11 @@ public:
     bool length(
             size_type new_length)
     {
+        if (new_length < 0)
+        {
+            return false;
+        }
+
         if (new_length <= maximum_)
         {
             length_ = new_length;
@@ -186,8 +193,8 @@ public:
         maximum = maximum_;
         length = length_;
 
-        maximum_ = 0u;
-        length_ = 0u;
+        maximum_ = 0;
+        length_ = 0;
         elements_ = nullptr;
         has_ownership_ = true;
 
@@ -230,8 +237,8 @@ protected:
     virtual void resize(
             size_type new_length) = 0;
 
-    size_type maximum_ = 0u;
-    size_type length_ = 0u;
+    size_type maximum_ = 0;
+    size_type length_ = 0;
     element_type* elements_ = nullptr;
     bool has_ownership_ = true;
 };

--- a/include/fastdds/dds/core/LoanableSequence.hpp
+++ b/include/fastdds/dds/core/LoanableSequence.hpp
@@ -78,7 +78,7 @@ public:
      * Pre-allocation constructor.
      *
      * Creates the sequence with an initial number of allocated elements.
-     * When the input parameter is 0, the behavior is equivalent to the default constructor.
+     * When the input parameter is less than or equal to 0, the behavior is equivalent to the default constructor.
      * Otherwise, the post-conditions below will apply.
      *
      * @param [in] max Number of elements to pre-allocate.
@@ -91,7 +91,7 @@ public:
     LoanableSequence(
             size_type max)
     {
-        if (!max)
+        if (max <= 0)
         {
             return;
         }
@@ -244,7 +244,7 @@ private:
     {
         if (has_ownership_ && elements_)
         {
-            for (size_t n = 0; n < maximum_; ++n)
+            for (size_type n = 0; n < maximum_; ++n)
             {
                 T* elem = data_[n];
                 delete elem;

--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -1656,6 +1656,9 @@ public:
     int32_t depth;
 };
 
+//! A special value indicating an unlimited quantity
+constexpr int32_t LENGTH_UNLIMITED = -1;
+
 /**
  * Specifies the resources that the Service can consume in order to meet the requested QoS
  * @note Immutable Qos Policy
@@ -1746,9 +1749,9 @@ public:
         , QosPolicy(false)
         , history_kind(KEEP_LAST_HISTORY_QOS)
         , history_depth(1)
-        , max_samples(-1)
-        , max_instances(-1)
-        , max_samples_per_instance(-1)
+        , max_samples(LENGTH_UNLIMITED)
+        , max_instances(LENGTH_UNLIMITED)
+        , max_samples_per_instance(LENGTH_UNLIMITED)
     {
     }
 
@@ -1799,20 +1802,20 @@ public:
      * Specifies the maximum number of data-samples the DataWriter (or DataReader) can manage across all the instances
      * associated with it. Represents the maximum samples the middleware can store for any one DataWriter (or DataReader).
      * It is inconsistent for this value to be less than max_samples_per_instance. <br>
-     * By default, -1 (Length Unlimited).
+     * By default, LENGTH_UNLIMITED.
      */
     int32_t max_samples;
     /**
      * @brief Control the ResourceLimitsQos of the implied DataReader that stores the data within the durability service.
      * Represents the maximum number of instances DataWriter (or DataReader) can manage. <br>
-     * By default, -1 (Length Unlimited).
+     * By default, LENGTH_UNLIMITED.
      */
     int32_t max_instances;
     /**
      * @brief Control the ResourceLimitsQos of the implied DataReader that stores the data within the durability service.
      * Represents the maximum number of samples of any one instance a DataWriter(or DataReader) can manage.
      * It is inconsistent for this value to be greater than max_samples. <br>
-     * By default, -1 (Length Unlimited).
+     * By default, LENGTH_UNLIMITED.
      */
     int32_t max_samples_per_instance;
 };

--- a/include/fastdds/dds/core/status/DeadlineMissedStatus.hpp
+++ b/include/fastdds/dds/core/status/DeadlineMissedStatus.hpp
@@ -19,7 +19,7 @@
 #ifndef _FASTDDS_DDS_QOS_DEADLINEMISSEDSTATUS_HPP_
 #define _FASTDDS_DDS_QOS_DEADLINEMISSEDSTATUS_HPP_
 
-#include <fastdds/rtps/common/InstanceHandle.h>
+#include <fastdds/dds/topic/TypeSupport.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -50,7 +50,7 @@ struct DeadlineMissedStatus
     uint32_t total_count_change;
 
     //! @brief Handle to the last instance missing the deadline
-    fastrtps::rtps::InstanceHandle_t last_instance_handle;
+    InstanceHandle_t last_instance_handle;
 };
 
 //! Typedef of DeadlineMissedStatus

--- a/include/fastdds/dds/core/status/LivelinessChangedStatus.hpp
+++ b/include/fastdds/dds/core/status/LivelinessChangedStatus.hpp
@@ -19,7 +19,7 @@
 #ifndef _FASTDDS_DDS_QOS_LIVELINESSCHANGEDSTATUS_HPP_
 #define _FASTDDS_DDS_QOS_LIVELINESSCHANGEDSTATUS_HPP_
 
-#include <fastdds/rtps/common/InstanceHandle.h>
+#include <fastdds/dds/topic/TypeSupport.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -49,7 +49,7 @@ struct LivelinessChangedStatus
     int32_t not_alive_count_change = 0;
 
     //! @brief Handle to the last publisher whose change in liveliness caused this status to change
-    fastrtps::rtps::InstanceHandle_t last_publication_handle;
+    InstanceHandle_t last_publication_handle;
 };
 
 } //namespace dds

--- a/include/fastdds/dds/core/status/PublicationMatchedStatus.hpp
+++ b/include/fastdds/dds/core/status/PublicationMatchedStatus.hpp
@@ -14,24 +14,24 @@
 
 /**
  * @file PublicationMatchedStatus.hpp
-*/
+ */
 
 #ifndef _PUBLICATION_MATCHED_STATUS_HPP_
 #define _PUBLICATION_MATCHED_STATUS_HPP_
 
 #include <cstdint>
-#include <fastrtps/rtps/common/InstanceHandle.h>
 #include <fastdds/dds/core/status/MatchedStatus.hpp>
+#include <fastdds/dds/topic/TypeSupport.hpp>
 
 namespace eprosima {
 namespace fastdds {
 namespace dds {
 
 //! @brief A structure storing the publication status
-struct PublicationMatchedStatus: public MatchedStatus
+struct PublicationMatchedStatus : public MatchedStatus
 {
-	//! @brief Handle to the last reader that matched the writer causing the status to change
-	eprosima::fastrtps::rtps::InstanceHandle_t last_subscription_handle;
+    //! @brief Handle to the last reader that matched the writer causing the status to change
+    InstanceHandle_t last_subscription_handle;
 };
 
 } // namespace dds

--- a/include/fastdds/dds/core/status/SampleRejectedStatus.hpp
+++ b/include/fastdds/dds/core/status/SampleRejectedStatus.hpp
@@ -20,7 +20,8 @@
 #define _FASTDDS_DDS_QOS_SAMPLEREJECTEDSTATUS_HPP_
 
 #include <cstdint>
-#include <fastdds/rtps/common/InstanceHandle.h>
+
+#include <fastdds/dds/topic/TypeSupport.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -61,7 +62,7 @@ struct SampleRejectedStatus
     /**
      * Handle to the instance being updated by the last sample that was rejected.
      */
-    fastrtps::rtps::InstanceHandle_t last_instance_handle;
+    InstanceHandle_t last_instance_handle;
 };
 
 } //namespace dds

--- a/include/fastdds/dds/core/status/SubscriptionMatchedStatus.hpp
+++ b/include/fastdds/dds/core/status/SubscriptionMatchedStatus.hpp
@@ -14,25 +14,25 @@
 
 /**
  * @file SubscriptionMatchedStatus.hpp
-*/
+ */
 
 #ifndef _SUBSCRIPTION_MATCHED_STATUS_HPP_
 #define _SUBSCRIPTION_MATCHED_STATUS_HPP_
 
 #include <cstdint>
 
-#include <fastrtps/rtps/common/InstanceHandle.h>
 #include <fastdds/dds/core/status/MatchedStatus.hpp>
+#include <fastdds/dds/topic/TypeSupport.hpp>
 
 namespace eprosima {
 namespace fastdds {
 namespace dds {
 
 //! @brief A structure storing the subscription status
-struct SubscriptionMatchedStatus: public MatchedStatus
+struct SubscriptionMatchedStatus : public MatchedStatus
 {
-	//! @brief Handle to the last writer that matched the reader causing the status change
-	eprosima::fastrtps::rtps::InstanceHandle_t last_publication_handle;
+    //! @brief Handle to the last writer that matched the reader causing the status change
+    InstanceHandle_t last_publication_handle;
 };
 
 } // namespace dds

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -287,22 +287,22 @@ public:
 
     /* TODO
        bool ignore_participant(
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
      */
 
     /* TODO
        bool ignore_topic(
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
      */
 
     /* TODO
        bool ignore_publication(
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
      */
 
     /* TODO
        bool ignore_subscription(
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
      */
 
     /**
@@ -485,24 +485,24 @@ public:
 
     /* TODO
        bool get_discovered_participants(
-            std::vector<fastrtps::rtps::InstanceHandle_t>& participant_handles) const;
+            std::vector<InstanceHandle_t>& participant_handles) const;
      */
 
     /* TODO
        bool get_discovered_participant_data(
             ParticipantBuiltinTopicData& participant_data,
-            const fastrtps::rtps::InstanceHandle_t& participant_handle) const;
+            const InstanceHandle_t& participant_handle) const;
      */
 
     /* TODO
        bool get_discovered_topics(
-            std::vector<fastrtps::rtps::InstanceHandle_t>& topic_handles) const;
+            std::vector<InstanceHandle_t>& topic_handles) const;
      */
 
     /* TODO
        bool get_discovered_topic_data(
             TopicBuiltinTopicData& topic_data,
-            const fastrtps::rtps::InstanceHandle_t& topic_handle) const;
+            const InstanceHandle_t& topic_handle) const;
      */
 
     /**
@@ -515,7 +515,7 @@ public:
      * @return True if entity is contained. False otherwise.
      */
     RTPS_DllAPI bool contains_entity(
-            const fastrtps::rtps::InstanceHandle_t& handle,
+            const InstanceHandle_t& handle,
             bool recursive = true) const;
 
     /**
@@ -539,7 +539,7 @@ public:
      * Returns the DomainParticipant's handle.
      * @return InstanceHandle of this DomainParticipant.
      */
-    RTPS_DllAPI const fastrtps::rtps::InstanceHandle_t& get_instance_handle() const;
+    RTPS_DllAPI const InstanceHandle_t& get_instance_handle() const;
 
     // From here legacy RTPS methods.
 

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -19,14 +19,15 @@
 #ifndef _FASTRTPS_DATAWRITER_HPP_
 #define _FASTRTPS_DATAWRITER_HPP_
 
-#include <fastdds/rtps/common/Time_t.h>
-#include <fastrtps/qos/DeadlineMissedStatus.h>
-#include <fastdds/dds/core/status/IncompatibleQosStatus.hpp>
-#include <fastdds/dds/core/status/BaseStatus.hpp>
-#include <fastrtps/types/TypesBase.h>
 #include <fastdds/dds/core/Entity.hpp>
+#include <fastdds/dds/core/status/BaseStatus.hpp>
+#include <fastdds/dds/core/status/DeadlineMissedStatus.hpp>
+#include <fastdds/dds/core/status/IncompatibleQosStatus.hpp>
 #include <fastdds/dds/core/status/StatusMask.hpp>
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
+#include <fastdds/dds/topic/TypeSupport.hpp>
+#include <fastdds/rtps/common/Time_t.h>
+#include <fastrtps/types/TypesBase.h>
 
 using eprosima::fastrtps::types::ReturnCode_t;
 
@@ -39,7 +40,6 @@ namespace rtps {
 
 class WriteParams;
 class WriterAttributes;
-struct InstanceHandle_t;
 struct GUID_t;
 
 } // namespace rtps
@@ -159,7 +159,7 @@ public:
      */
     RTPS_DllAPI ReturnCode_t write(
             void* data,
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
 
     /*!
      * @brief Informs that the application will be modifying a particular instance.
@@ -169,7 +169,7 @@ public:
      * This handle could be used in successive `write` or `dispose` operations.
      * In case of error, HANDLE_NIL will be returned.
      */
-    RTPS_DllAPI fastrtps::rtps::InstanceHandle_t register_instance(
+    RTPS_DllAPI InstanceHandle_t register_instance(
             void* instance);
 
     /*!
@@ -184,7 +184,7 @@ public:
      */
     RTPS_DllAPI ReturnCode_t unregister_instance(
             void* instance,
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
 
     /**
      * Returns the DataWriter's GUID
@@ -196,7 +196,7 @@ public:
      * Returns the DataWriter's InstanceHandle
      * @return Copy of the DataWriter InstanceHandle
      */
-    RTPS_DllAPI fastrtps::rtps::InstanceHandle_t get_instance_handle() const;
+    RTPS_DllAPI InstanceHandle_t get_instance_handle() const;
 
     /**
      * Get data type associated to the DataWriter
@@ -218,7 +218,7 @@ public:
      * @return RETCODE_OK
      */
     RTPS_DllAPI ReturnCode_t get_offered_deadline_missed_status(
-            fastrtps::OfferedDeadlineMissedStatus& status);
+            OfferedDeadlineMissedStatus& status);
 
     /**
      * @brief Returns the offered incompatible qos status
@@ -284,7 +284,7 @@ public:
     /* TODO
        bool get_key_value(
             void* key_holder,
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
      */
 
     /**
@@ -303,7 +303,7 @@ public:
      */
     RTPS_DllAPI ReturnCode_t dispose(
             void* data,
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
 
     /**
      * @brief Returns the liveliness lost status

--- a/include/fastdds/dds/publisher/Publisher.hpp
+++ b/include/fastdds/dds/publisher/Publisher.hpp
@@ -20,13 +20,14 @@
 #ifndef _FASTDDS_PUBLISHER_HPP_
 #define _FASTDDS_PUBLISHER_HPP_
 
-#include <fastrtps/fastrtps_dll.h>
-#include <fastdds/rtps/common/Time_t.h>
-#include <fastrtps/attributes/PublisherAttributes.h>
-#include <fastrtps/types/TypesBase.h>
 #include <fastdds/dds/core/Entity.hpp>
 #include <fastdds/dds/publisher/qos/PublisherQos.hpp>
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
+#include <fastdds/dds/topic/TypeSupport.hpp>
+#include <fastdds/rtps/common/Time_t.h>
+
+#include <fastrtps/fastrtps_dll.h>
+#include <fastrtps/types/TypesBase.h>
 
 using eprosima::fastrtps::types::ReturnCode_t;
 
@@ -309,7 +310,7 @@ public:
      * Returns the Publisher's handle.
      * @return InstanceHandle of this Publisher.
      */
-    RTPS_DllAPI const fastrtps::rtps::InstanceHandle_t& get_instance_handle() const;
+    RTPS_DllAPI const InstanceHandle_t& get_instance_handle() const;
 
 protected:
 

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -17,22 +17,23 @@
  *
  */
 
-#ifndef _FASTRTPS_DATAREADER_HPP_
-#define _FASTRTPS_DATAREADER_HPP_
-#ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+#ifndef _FASTDDS_DDS_SUBSCRIBER_DATAREADER_HPP_
+#define _FASTDDS_DDS_SUBSCRIBER_DATAREADER_HPP_
 
-#include <fastrtps/qos/DeadlineMissedStatus.h>
-#include <fastdds/rtps/common/Time_t.h>
-#include <fastdds/dds/core/status/StatusMask.hpp>
-#include <fastdds/dds/core/status/IncompatibleQosStatus.hpp>
+#include <cstdint>
+#include <vector>
+
 #include <fastdds/dds/core/Entity.hpp>
+#include <fastdds/dds/core/LoanableCollection.hpp>
+#include <fastdds/dds/core/LoanableSequence.hpp>
+#include <fastdds/dds/core/status/DeadlineMissedStatus.hpp>
+#include <fastdds/dds/core/status/IncompatibleQosStatus.hpp>
+#include <fastdds/dds/core/status/StatusMask.hpp>
 #include <fastdds/dds/subscriber/SampleInfo.hpp>
+#include <fastdds/dds/topic/TypeSupport.hpp>
+#include <fastdds/rtps/common/Time_t.h>
 
 #include <fastrtps/types/TypesBase.h>
-
-
-#include <vector>
-#include <cstdint>
 
 using eprosima::fastrtps::types::ReturnCode_t;
 
@@ -52,7 +53,6 @@ class TopicAttributes;
 namespace rtps {
 class ReaderAttributes;
 struct GUID_t;
-struct InstanceHandle_t;
 } // namespace rtps
 } // namespace fastrtps
 
@@ -63,10 +63,11 @@ class Subscriber;
 class SubscriberImpl;
 class DataReaderImpl;
 class DataReaderListener;
-class TypeSupport;
 class DataReaderQos;
 class TopicDescription;
 struct LivelinessChangedStatus;
+
+using SampleInfoSeq = LoanableSequence<SampleInfo>;
 
 /**
  * Class DataReader, contains the actual implementation of the behaviour of the Subscriber.
@@ -97,20 +98,23 @@ protected:
 public:
 
     /**
-     * @brief Destructor
+     * @brief Destructor.
      */
     RTPS_DllAPI virtual ~DataReader();
 
     /**
-     * @brief This operation enables the DataReader
+     * @brief This operation enables the DataReader.
+     *
      * @return RETCODE_OK is successfully enabled. RETCODE_PRECONDITION_NOT_MET if the Subscriber creating this
      *         DataReader is not enabled.
      */
     RTPS_DllAPI ReturnCode_t enable() override;
 
     /**
-     * Method to block the current thread until an unread message is available
-     * @param timeout Max blocking time for this operation
+     * Method to block the current thread until an unread message is available.
+     *
+     * @param [in] timeout Max blocking time for this operation.
+     *
      * @return true if there is new unread message, false if timeout
      */
     RTPS_DllAPI bool wait_for_unread_message(
@@ -123,55 +127,418 @@ public:
 
     ///@{
 
-    /* TODO
-       RTPS_DllAPI bool read(
-            std::vector<void*>& data_values,
-            std::vector<SampleInfo>& sample_infos,
-            uint32_t max_samples);
+    /**
+     * Access a collection of data samples from the DataReader.
+     *
+     * This operation accesses a collection of Data values from the DataReader. The caller can limit the size
+     * of the returned collection with the @c max_samples parameter.
+     *
+     * The properties of the @c data_values collection and the setting of the @ref PresentationQosPolicy may
+     * impose further limits on the size of the returned ‘list.’
+     *
+     * 1. If @ref PresentationQosPolicy::access_scope is @ref INSTANCE_PRESENTATION_QOS, then the returned
+     *    collection is a 'list' where samples belonging to the same data-instance are consecutive.
+     * 2. If @ref PresentationQosPolicy::access_scope is @ref TOPIC_PRESENTATION_QOS and
+     *    @ref PresentationQosPolicy::ordered_access is set to @c false, then the returned collection is a
+     *    'list' where samples belonging to the same data-instance are consecutive.
+     * 3. If @ref PresentationQosPolicy::access_scope is @ref TOPIC_PRESENTATION_QOS and
+     *    @ref PresentationQosPolicy::ordered_access is set to @c true, then the returned collection is a
+     *    'list' where samples belonging to the same instance may or may not be consecutive. This is because to
+     *    preserve order it may be necessary to mix samples from different instances.
+     * 4. If @ref PresentationQosPolicy::access_scope is @ref GROUP_PRESENTATION_QOS and
+     *    @ref PresentationQosPolicy::ordered_access is set to @c false, then the returned collection is a
+     *    'list' where samples belonging to the same data instance are consecutive.
+     * 5. If @ref PresentationQosPolicy::access_scope is @ref GROUP_PRESENTATION_QOS and
+     *    @ref PresentationQosPolicy::ordered_access is set to @c true, then the returned collection contains at
+     *    most one sample. The difference in this case is due to the fact that it is required that the application
+     *    is able to read samples belonging to different DataReader objects in a specific order.
+     *
+     * In any case, the relative order between the samples of one instance is consistent with the
+     * @ref DestinationOrderQosPolicy:
+     *
+     * - If @ref DestinationOrderQosPolicy::kind is @ref BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS, samples
+     *   belonging to the same instances will appear in the relative order in which there were received (FIFO,
+     *   earlier samples ahead of the later samples).
+     * - If @ref DestinationOrderQosPolicy::kind is @ref BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS, samples
+     *   belonging to the same instances will appear in the relative order implied by the source_timestamp (FIFO,
+     *   smaller values of source_timestamp ahead of the larger values).
+     *
+     * The actual number of samples returned depends on the information that has been received by the middleware
+     * as well as the @ref HistoryQosPolicy, @ref ResourceLimitsQosPolicy, and @ref ReaderResourceLimitsQos:
+     *
+     * - In the case where the @ref HistoryQosPolicy::kind is KEEP_LAST_HISTORY_QOS, the call will return at most
+     *   @ref HistoryQosPolicy::depth samples per instance.
+     * - The maximum number of samples returned is limited by @ref ResourceLimitsQosPolicy::max_samples, and by
+     *   @ref ReaderResourceLimitsQos::max_samples_per_read.
+     * - For multiple instances, the number of samples returned is additionally limited by the product
+     *   (@ref ResourceLimitsQosPolicy::max_samples_per_instance * @ref ResourceLimitsQosPolicy::max_instances).
+     * - If ReaderResourceLimitsQos::sample_infos_allocation has a maximum limit, the number of samples returned
+     *   may also be limited if insufficient @ref SampleInfo resources are available.
+     *
+     * If the operation succeeds and the number of samples returned has been limited (by means of a maximum limit,
+     * as listed above, or insufficient @ref SampleInfo resources), the call will complete successfully and provide
+     * those samples the reader is able to return. The user may need to make additional calls, or return outstanding
+     * loaned buffers in the case of insufficient resources, in order to access remaining samples.
+     *
+     * In addition to the collection of samples, the read operation also uses a collection of @ref SampleInfo
+     * structures (@c sample_infos).
+     *
+     * The initial (input) properties of the @c data_values and @c sample_infos collections will determine the
+     * precise behavior of this operation. For the purposes of this description the collections are modeled as having
+     * three properties:
+     * - the current length (@c len, see @ref LoanableCollection::length())
+     * - the maximum length (@c max_len, see @ref LoanableCollection::maximum())
+     * - whether the collection container owns the memory of the elements within
+     *   (@c owns, see @ref LoanableCollection::has_ownership())
+     *
+     * The initial (input) values of the @c len, @c max_len, and @c owns properties for the @c data_values and
+     * @c sample_infos collections govern the behavior of the read operation as specified by the following rules:
+     *
+     * 1. The values of @c len, @c max_len, and @c owns for the two collections must be identical. Otherwise read
+     *    will fail with RETCODE_PRECONDITION_NOT_MET.
+     * 2. On successful output, the values of @c len, @c max_len, and @c owns will be the same for both collections.
+     * 3. If the input <tt> max_len == 0 </tt>, then the @c data_values and @c sample_infos collections will be
+     *    filled with elements that are 'loaned' by the DataReader. On output, @c owns will be @c false, @c len will
+     *    be set to the number of values returned, and @c max_len will be set to a value verifying
+     *    <tt> max_len >= len </tt>. The use of this variant allows for zero-copy access to the data and the
+     *    application will need to return the loan to the DataReader using the @ref return_loan operation.
+     * 4. If the input <tt> max_len > 0 </tt> and the input <tt> owns == false </tt>, then the read operation will
+     *    fail with RETCODE_PRECONDITION_NOT_MET. This avoids the potential hard-to-detect memory leaks caused by an
+     *    application forgetting to return the loan.
+     * 5. If input <tt> max_len > 0 </tt> and the input <tt> owns == true </tt>, then the read operation will copy
+     *    the Data values and SampleInfo values into the elements already inside the collections. On output, @c owns
+     *    will be @c true, @c len will be set to the number of values copied, and @c max_len will remain unchanged.
+     *    The use of this variant forces a copy but the application can control where the copy is placed and the
+     *    application will not need to return the loan. The number of samples copied depends on the values of
+     *    @c max_len and @c max_samples:
+     *    - If <tt> max_samples == LENGTH_UNLIMITED </tt>, then at most @c max_len values will be copied. The use of
+     *      this variant lets the application limit the number of samples returned to what the sequence can
+     *      accommodate.
+     *    - If <tt> max_samples <= max_len </tt>, then at most @c max_samples values will be copied. The use of this
+     *      variant lets the application limit the number of samples returned to fewer that what the sequence can
+     *      accommodate.
+     *    - If <tt> max_samples > max_len </tt>, then the read operation will fail with RETCODE_PRECONDITION_NOT_MET.
+     *      This avoids the potential confusion where the application expects to be able to access up to
+     *      @c max_samples, but that number can never be returned, even if they are available in the DataReader,
+     *      because the output sequence cannot accommodate them.
+     *
+     * As described above, upon return the @c data_values and @c sample_infos collections may contain elements
+     * 'loaned' from the DataReader. If this is the case, the application will need to use the @ref return_loan
+     * operation to return the loan once it is no longer using the Data in the collection. Upon return from
+     * @ref return_loan, the collection will have <tt> max_len == 0 </tt> and <tt> owns == false </tt>.
+     *
+     * The application can determine whether it is necessary to return the loan or not based on the state of the
+     * collections when the read operation was called, or by accessing the @c owns property. However, in many cases
+     * it may be simpler to always call @ref return_loan, as this operation is harmless (i.e., leaves all elements
+     * unchanged) if the collection does not have a loan.
+     *
+     * On output, the collection of Data values and the collection of SampleInfo structures are of the same length
+     * and are in a one-to-one correspondence. Each SampleInfo provides information, such as the @c source_timestamp,
+     * the @c sample_state, @c view_state, and @c instance_state, etc., about the corresponding sample.
+     *
+     * Some elements in the returned collection may not have valid data. If the @c instance_state in the SampleInfo is
+     * @ref NOT_ALIVE_DISPOSED_INSTANCE_STATE or @ref NOT_ALIVE_NO_WRITERS_INSTANCE_STATE, then the last sample for
+     * that instance in the collection, that is, the one whose SampleInfo has <tt> sample_rank == 0 </tt> does not
+     * contain valid data. Samples that contain no data do not count towards the limits imposed by the
+     * @ref ResourceLimitsQosPolicy.
+     *
+     * The act of reading a sample changes its @c sample_state to @ref READ_SAMPLE_STATE. If the sample belongs
+     * to the most recent generation of the instance, it will also set the @c view_state of the instance to be
+     * @ref NOT_NEW_VIEW_STATE. It will not affect the @c instance_state of the instance.
+     *
+     * If the DataReader has no samples that meet the constraints, the operations fails with RETCODE_NO_DATA.
+     *
+     * @em Important: If the samples "returned" by this method are loaned from the middleware (see @ref take
+     * for more information on memory loaning), it is important that their contents not be changed. Because the
+     * memory in which the data is stored belongs to the middleware, any modifications made to the data will be
+     * seen the next time the same samples are read or taken; the samples will no longer reflect the state that
+     * was received from the network.
+     *
+     * @param [in,out] data_values     A LoanableCollection object where the received data samples will be returned.
+     * @param [in,out] sample_infos    A SampleInfoSeq object where the received sample info will be returned.
+     * @param [in]     max_samples     The maximum number of samples to be returned. If the special value
+     *                                 @ref LENGTH_UNLIMITED is provided, as many samples will be returned as are
+     *                                 available, up to the limits described above.
+     * @param [in]     sample_states   Only data samples with @c sample_state matching one of these will be returned.
+     * @param [in]     view_states     Only data samples with @c view_state matching one of these will be returned.
+     * @param [in]     instance_states Only data samples with @c instance_state matching one of these will be returned.
+     *
+     * @return Any of the standard return codes.
      */
+    RTPS_DllAPI ReturnCode_t read(
+            LoanableCollection& data_values,
+            SampleInfoSeq& sample_infos,
+            int32_t max_samples = LENGTH_UNLIMITED,
+            SampleStateMask sample_states = ANY_SAMPLE_STATE,
+            ViewStateMask view_states = ANY_VIEW_STATE,
+            InstanceStateMask instance_states = ANY_INSTANCE_STATE);
 
     /**
-     * @brief This operation copies the next, non-previously accessed Data value from the DataReader; the operation also
-     * copies the corresponding SampleInfo. The implied order among the samples stored in the DataReader is the same as for
-     * the read operation.
+     * Access a collection of data samples from the DataReader.
      *
-     * The read_next_sample operation is semantically equivalent to the read operation where the input Data sequence has
-     * max_length=1, the sample_states=NOT_READ, the view_states=ANY_VIEW_STATE, and the instance_states=ANY_INSTANCE_STATE.
+     * This operation accesses a collection of data values from the DataReader. The behavior is identical to
+     * @ref read, except that all samples returned belong to the single specified instance whose handle is
+     * @c a_handle.
      *
-     * The read_next_sample operation provides a simplified API to ‘read’ samples avoiding the need for the application to
-     * manage sequences and specify states.
+     * Upon successful completion, the data collection will contain samples all belonging to the same instance.
+     * The corresponding @ref SampleInfo verifies ef SampleInfo::instance_handle == @c a_handle.
      *
-     * If there is no unread data in the DataReader, the operation will return NO_DATA and nothing is copied
-     * @param data Data pointer to store the sample
-     * @param info SampleInfo pointer to store the sample information
-     * @return RETCODE_NO_DATA if the history is empty, RETCODE_OK if the next sample is returned and RETCODE_ERROR otherwise
+     * This operation is semantically equivalent to the @ref read operation, except in building the collection.
+     * The DataReader will check that the sample belongs to the specified instance and otherwise it will not place
+     * the sample in the returned collection.
+     *
+     * The behavior of this operation follows the same rules as the @read operation regarding the pre-conditions and
+     * post-conditions for the @c data_values and @c sample_infos. Similar to @ref read, this operation may 'loan'
+     * elements to the output collections, which must then be returned by means of @ref return_loan.
+     *
+     * If the DataReader has no samples that meet the constraints, the operations fails with RETCODE_NO_DATA.
+     *
+     * @param [in,out] data_values     A LoanableCollection object where the received data samples will be returned.
+     * @param [in,out] sample_infos    A SampleInfoSeq object where the received sample info will be returned.
+     * @param [in]     max_samples     The maximum number of samples to be returned. If the special value
+     *                                 @ref LENGTH_UNLIMITED is provided, as many samples will be returned as are
+     *                                 available, up to the limits described in the documentation for @ref read().
+     * @param [in]     a_handle        The specified instance to return samples for. The method will fail with
+     *                                 RETCODE_BAD_PARAMETER if the handle does not correspond to an existing
+     *                                 data-object known to the DataReader.
+     * @param [in]     sample_states   Only data samples with @c sample_state matching one of these will be returned.
+     * @param [in]     view_states     Only data samples with @c view_state matching one of these will be returned.
+     * @param [in]     instance_states Only data samples with @c instance_state matching one of these will be returned.
+     *
+     * @return Any of the standard return codes.
+     */
+    RTPS_DllAPI ReturnCode_t read_instance(
+            LoanableCollection& data_values,
+            SampleInfoSeq& sample_infos,
+            int32_t max_samples = LENGTH_UNLIMITED,
+            const InstanceHandle_t& a_handle = HANDLE_NIL,
+            SampleStateMask sample_states = ANY_SAMPLE_STATE,
+            ViewStateMask view_states = ANY_VIEW_STATE,
+            InstanceStateMask instance_states = ANY_INSTANCE_STATE);
+
+    /**
+     * Access a collection of data samples from the DataReader.
+     *
+     * This operation accesses a collection of data values from the DataReader where all the samples belong to a
+     * single instance. The behavior is similar to @ref read_instance, except that the actual instance is not
+     * directly specified. Rather, the samples will all belong to the 'next' instance with @c instance_handle
+     * 'greater' than the specified 'previous_handle' that has available samples.
+     *
+     * This operation implies the existence of a total order 'greater-than' relationship between the instance
+     * handles. The specifics of this relationship are not all important and are implementation specific. The
+     * important thing is that, according to the middleware, all instances are ordered relative to each other.
+     * This ordering is between the instance handles, and should not depend on the state of the instance (e.g.
+     * whether it has data or not) and must be defined even for instance handles that do not correspond to instances
+     * currently managed by the DataReader. For the purposes of the ordering, it should be 'as if' each instance
+     * handle was represented as an integer.
+     *
+     * The behavior of this operation is 'as if' the DataReader invoked @ref read_instance, passing the smallest
+     * @c instance_handle among all the ones that: (a) are greater than @c previous_handle, and (b) have available
+     * samples (i.e. samples that meet the constraints imposed by the specified states).
+     *
+     * The special value @ref HANDLE_NIL is guaranteed to be 'less than' any valid @c instance_handle. So the use
+     * of the parameter value @c previous_handle == @ref HANDLE_NIL will return the samples for the instance which
+     * has the smallest @c instance_handle among all the instances that contain available samples.
+     *
+     * This operation is intended to be used in an application-driven iteration, where the application starts by
+     * passing @c previous_handle == @ref HANDLE_NIL, examines the samples returned, and then uses the
+     * @c instance_handle returned in the @ref SampleInfo as the value of the @c previous_handle argument to the
+     * next call to @ref read_next_instance. The iteration continues until @ref read_next_instance fails with
+     * RETCODE_NO_DATA.
+     *
+     * Note that it is possible to call the @ref read_next_instance operation with a @c previous_handle that does not
+     * correspond to an instance currently managed by the DataReader. This is because as stated earlier the
+     * 'greater-than' relationship is defined even for handles not managed by the DataReader. One practical situation
+     * where this may occur is when an application is iterating through all the instances, takes all the samples of a
+     * @ref NOT_ALIVE_NO_WRITERS_INSTANCE_STATE instance, returns the loan (at which point the instance information
+     * may be removed, and thus the handle becomes invalid), and tries to read the next instance.
+     *
+     * The behavior of this operation follows the same rules as the @read operation regarding the pre-conditions and
+     * post-conditions for the @c data_values and @c sample_infos. Similar to @ref read, this operation may 'loan'
+     * elements to the output collections, which must then be returned by means of @ref return_loan.
+     *
+     * If the DataReader has no samples that meet the constraints, the operations fails with RETCODE_NO_DATA.
+     *
+     * @param [in,out] data_values     A LoanableCollection object where the received data samples will be returned.
+     * @param [in,out] sample_infos    A SampleInfoSeq object where the received sample info will be returned.
+     * @param [in]     max_samples     The maximum number of samples to be returned. If the special value
+     *                                 @ref LENGTH_UNLIMITED is provided, as many samples will be returned as are
+     *                                 available, up to the limits described in the documentation for @ref read().
+     * @param [in]     previous_handle The 'next smallest' instance with a value greater than this value that has
+     *                                 available samples will be returned.
+     * @param [in]     sample_states   Only data samples with @c sample_state matching one of these will be returned.
+     * @param [in]     view_states     Only data samples with @c view_state matching one of these will be returned.
+     * @param [in]     instance_states Only data samples with @c instance_state matching one of these will be returned.
+     *
+     * @return Any of the standard return codes.
+     */
+    RTPS_DllAPI ReturnCode_t read_next_instance(
+            LoanableCollection& data_values,
+            SampleInfoSeq& sample_infos,
+            int32_t max_samples = LENGTH_UNLIMITED,
+            const InstanceHandle_t& previous_handle = HANDLE_NIL,
+            SampleStateMask sample_states = ANY_SAMPLE_STATE,
+            ViewStateMask view_states = ANY_VIEW_STATE,
+            InstanceStateMask instance_states = ANY_INSTANCE_STATE);
+
+    /**
+     * @brief This operation copies the next, non-previously accessed Data value from the DataReader; the operation
+     * also copies the corresponding SampleInfo. The implied order among the samples stored in the DataReader is the
+     * same as for the read operation.
+     *
+     * The read_next_sample operation is semantically equivalent to the read operation where the input Data sequence
+     * has <tt> max_length = 1 </tt>, the <tt> sample_states = NOT_READ_SAMPLE_STATE </tt>, the
+     * <tt> view_states = ANY_VIEW_STATE </tt>, and the <tt> instance_states = ANY_INSTANCE_STATE </tt>.
+     *
+     * The read_next_sample operation provides a simplified API to ‘read’ samples avoiding the need for the
+     * application to manage sequences and specify states.
+     *
+     * If there is no unread data in the DataReader, the operation will return RETCODE_NO_DATA and nothing is copied
+     *
+     * @param [out] data Data pointer to store the sample
+     * @param [out] info SampleInfo pointer to store the sample information
+     *
+     * @return Any of the standard return codes.
      */
     RTPS_DllAPI ReturnCode_t read_next_sample(
             void* data,
             SampleInfo* info);
 
-    /* TODO
-       RTPS_DllAPI bool take(
-            std::vector<void*>& data_values,
-            std::vector<SampleInfo>& sample_infos,
-            uint32_t max_samples);
+    /**
+     * Access a collection of data samples from the DataReader.
+     *
+     * This operation accesses a collection of data-samples from the DataReader and a corresponding collection of
+     * SampleInfo structures, and 'removes' them from the DataReader. The operation will return either a 'list' of
+     * samples or else a single sample. This is controlled by the @ref PresentationQosPolicy using the same logic
+     * as for the @ref read operation.
+     *
+     * The act of taking a sample removes it from the DataReader so it cannot be 'read' or 'taken' again. If the
+     * sample belongs to the most recent generation of the instance, it will also set the @c view_state of the
+     * instance to NOT_NEW. It will not affect the @c instance_state of the instance.
+     *
+     * The behavior of the take operation follows the same rules than the @ref read operation regarding the
+     * pre-conditions and post-conditions for the @c data_values and @c sample_infos collections. Similar to
+     * @ref read, the take operation may 'loan' elements to the output collections which must then be returned by
+     * means of @ref return_loan. The only difference with @ref read is that, as stated, the samples returned by
+     * take will no longer be accessible to successive calls to read or take.
+     *
+     * If the DataReader has no samples that meet the constraints, the operations fails with RETCODE_NO_DATA.
+     *
+     * @param [in,out] data_values     A LoanableCollection object where the received data samples will be returned.
+     * @param [in,out] sample_infos    A SampleInfoSeq object where the received sample info will be returned.
+     * @param [in]     max_samples     The maximum number of samples to be returned. If the special value
+     *                                 @ref LENGTH_UNLIMITED is provided, as many samples will be returned as are
+     *                                 available, up to the limits described in the documentation for @ref read().
+     * @param [in]     sample_states   Only data samples with @c sample_state matching one of these will be returned.
+     * @param [in]     view_states     Only data samples with @c view_state matching one of these will be returned.
+     * @param [in]     instance_states Only data samples with @c instance_state matching one of these will be returned.
+     *
+     * @return Any of the standard return codes.
      */
+    RTPS_DllAPI ReturnCode_t take(
+            LoanableCollection& data_values,
+            SampleInfoSeq& sample_infos,
+            int32_t max_samples = LENGTH_UNLIMITED,
+            SampleStateMask sample_states = ANY_SAMPLE_STATE,
+            ViewStateMask view_states = ANY_VIEW_STATE,
+            InstanceStateMask instance_states = ANY_INSTANCE_STATE);
 
     /**
-     * @brief This operation copies the next, non-previously accessed Data value from the DataReader and ‘removes’ it from
-     * the DataReader so it is no longer accessible. The operation also copies the corresponding SampleInfo. This operation
-     * is analogous to the read_next_sample except for the fact that the sample is ‘removed’ from the DataReader.
+     * Access a collection of data samples from the DataReader.
      *
-     * The take_next_sample operation is semantically equivalent to the take operation where the input sequence has
-     * max_length=1, the sample_states=NOT_READ, the view_states=ANY_VIEW_STATE, and the instance_states=ANY_INSTANCE_STATE.
+     * This operation accesses a collection of data values from the DataReader and 'removes' them from the DataReader.
      *
-     * This operation provides a simplified API to ’take’ samples avoiding the need for the application to manage sequences
-     * and specify states.
+     * This operation has the same behavior as @ref read_instance, except that the samples are 'taken' from the
+     * DataReader such that they are no longer accessible via subsequent 'read' or 'take' operations.
      *
-     * If there is no unread data in the DataReader, the operation will return NO_DATA and nothing is copied.
-     * @param data Data pointer to store the sample
-     * @param info SampleInfo pointer to store the sample information
-     * @return RETCODE_NO_DATA if the history is empty, RETCODE_OK if the next sample is returned and RETCODE_ERROR otherwise
+     * The behavior of this operation follows the same rules as the @read operation regarding the pre-conditions and
+     * post-conditions for the @c data_values and @c sample_infos. Similar to @ref read, this operation may 'loan'
+     * elements to the output collections, which must then be returned by means of @ref return_loan.
+     *
+     * If the DataReader has no samples that meet the constraints, the operations fails with RETCODE_NO_DATA.
+     *
+     * @param [in,out] data_values     A LoanableCollection object where the received data samples will be returned.
+     * @param [in,out] sample_infos    A SampleInfoSeq object where the received sample info will be returned.
+     * @param [in]     max_samples     The maximum number of samples to be returned. If the special value
+     *                                 @ref LENGTH_UNLIMITED is provided, as many samples will be returned as are
+     *                                 available, up to the limits described in the documentation for @ref read().
+     * @param [in]     a_handle        The specified instance to return samples for. The method will fail with
+     *                                 RETCODE_BAD_PARAMETER if the handle does not correspond to an existing
+     *                                 data-object known to the DataReader.
+     * @param [in]     sample_states   Only data samples with @c sample_state matching one of these will be returned.
+     * @param [in]     view_states     Only data samples with @c view_state matching one of these will be returned.
+     * @param [in]     instance_states Only data samples with @c instance_state matching one of these will be returned.
+     *
+     * @return Any of the standard return codes.
+     */
+    RTPS_DllAPI ReturnCode_t take_instance(
+            LoanableCollection& data_values,
+            SampleInfoSeq& sample_infos,
+            int32_t max_samples = LENGTH_UNLIMITED,
+            const InstanceHandle_t& a_handle = HANDLE_NIL,
+            SampleStateMask sample_states = ANY_SAMPLE_STATE,
+            ViewStateMask view_states = ANY_VIEW_STATE,
+            InstanceStateMask instance_states = ANY_INSTANCE_STATE);
+
+    /**
+     * Access a collection of data samples from the DataReader.
+     *
+     * This operation accesses a collection of data values from the DataReader and 'removes' them from the DataReader.
+     *
+     * This operation has the same behavior as @ref read_next_instance, except that the samples are 'taken' from the
+     * DataReader such that they are no longer accessible via subsequent 'read' or 'take' operations.
+     *
+     * Similar to the operation @ref read_next_instance, it is possible to call this operation with a
+     * @c previous_handle that does not correspond to an instance currently managed by the DataReader.
+     *
+     * The behavior of this operation follows the same rules as the @read operation regarding the pre-conditions and
+     * post-conditions for the @c data_values and @c sample_infos. Similar to @ref read, this operation may 'loan'
+     * elements to the output collections, which must then be returned by means of @ref return_loan.
+     *
+     * If the DataReader has no samples that meet the constraints, the operations fails with RETCODE_NO_DATA.
+     *
+     * @param [in,out] data_values     A LoanableCollection object where the received data samples will be returned.
+     * @param [in,out] sample_infos    A SampleInfoSeq object where the received sample info will be returned.
+     * @param [in]     max_samples     The maximum number of samples to be returned. If the special value
+     *                                 @ref LENGTH_UNLIMITED is provided, as many samples will be returned as are
+     *                                 available, up to the limits described in the documentation for @ref read().
+     * @param [in]     previous_handle The 'next smallest' instance with a value greater than this value that has
+     *                                 available samples will be returned.
+     * @param [in]     sample_states   Only data samples with @c sample_state matching one of these will be returned.
+     * @param [in]     view_states     Only data samples with @c view_state matching one of these will be returned.
+     * @param [in]     instance_states Only data samples with @c instance_state matching one of these will be returned.
+     *
+     * @return Any of the standard return codes.
+     */
+    RTPS_DllAPI ReturnCode_t take_next_instance(
+            LoanableCollection& data_values,
+            SampleInfoSeq& sample_infos,
+            int32_t max_samples = LENGTH_UNLIMITED,
+            const InstanceHandle_t& previous_handle = HANDLE_NIL,
+            SampleStateMask sample_states = ANY_SAMPLE_STATE,
+            ViewStateMask view_states = ANY_VIEW_STATE,
+            InstanceStateMask instance_states = ANY_INSTANCE_STATE);
+
+    /**
+     * @brief This operation copies the next, non-previously accessed Data value from the DataReader and ‘removes’ it
+     * from the DataReader so it is no longer accessible. The operation also copies the corresponding SampleInfo.
+     *
+     * This operation is analogous to @ref read_next_sample except for the fact that the sample is ‘removed’ from the
+     * DataReader.
+     *
+     * This operation is semantically equivalent to the @ref take operation where the input sequence has
+     * <tt> max_length = 1 </tt>, the <tt> sample_states = NOT_READ_SAMPLE_STATE </tt>, the
+     * <tt> view_states = ANY_VIEW_STATE </tt>, and the <tt> instance_states = ANY_INSTANCE_STATE </tt>.
+     *
+     * This operation provides a simplified API to ’take’ samples avoiding the need for the application to manage
+     * sequences and specify states.
+     *
+     * If there is no unread data in the DataReader, the operation will return RETCODE_NO_DATA and nothing is copied.
+     *
+     * @param [out] data Data pointer to store the sample
+     * @param [out] info SampleInfo pointer to store the sample information
+     *
+     * @return Any of the standard return codes.
      */
     RTPS_DllAPI ReturnCode_t take_next_sample(
             void* data,
@@ -180,78 +547,131 @@ public:
     ///@}
 
     /**
+     * This operation indicates to the DataReader that the application is done accessing the collection of
+     * @c data_values and @c sample_infos obtained by some earlier invocation of @ref read or @ref take on the
+     * DataReader.
+     *
+     * The @c data_values and @c sample_infos must belong to a single related ‘pair’; that is, they should correspond
+     * to a pair returned from a single call to read or take. The @c data_values and @c sample_infos must also have
+     * been obtained from the same DataReader to which they are returned. If either of these conditions is not met,
+     * the operation will fail and return RETCODE_PRECONDITION_NOT_MET.
+     *
+     * This operation allows implementations of the @ref read and @ref take operations to "loan" buffers from the
+     * DataReader to the application and in this manner provide "zero-copy" access to the data. During the loan, the
+     * DataReader will guarantee that the data and sample-information are not modified.
+     *
+     * It is not necessary for an application to return the loans immediately after the read or take calls. However,
+     * as these buffers correspond to internal resources inside the DataReader, the application should not retain them
+     * indefinitely.
+     *
+     * The use of the @ref return_loan operation is only necessary if the read or take calls "loaned" buffers to the
+     * application. This only occurs if the @c data_values and @c sample_infos collections had <tt> max_len == 0 </tt>
+     * at the time read or take was called. The application may also examine the @c owns property of the collection to
+     * determine if there is an outstanding loan. However, calling @ref return_loan on a collection that does not have
+     * a loan is safe and has no side effects.
+     *
+     * If the collections had a loan, upon return from return_loan the collections will have <tt> max_len == 0 </tt>.
+     *
+     * @param [in,out] data_values   A LoanableCollection object where the received data samples were obtained from
+     *                               an earlier invocation of read or take on this DataReader.
+     * @param [in,out] sample_infos  A SampleInfoSeq object where the received sample infos were obtained from
+     *                               an earlier invocation of read or take on this DataReader.
+     *
+     * @return Any of the standard return codes.
+     */
+    RTPS_DllAPI ReturnCode_t return_loan(
+            LoanableCollection& data_values,
+            SampleInfoSeq& sample_infos);
+
+    /**
      * @brief Returns information about the first untaken sample.
+     *
      * @param [out] info Pointer to a SampleInfo_t structure to store first untaken sample information.
+     *
      * @return RETCODE_OK if sample info was returned. RETCODE_NO_DATA if there is no sample to take.
      */
     RTPS_DllAPI ReturnCode_t get_first_untaken_info(
             SampleInfo* info);
 
     /**
-     * Get associated GUID
+     * Get associated GUID.
+     *
      * @return Associated GUID
      */
     RTPS_DllAPI const fastrtps::rtps::GUID_t& guid();
 
     /**
-     * @brief Getter for the associated InstanceHandle
+     * @brief Getter for the associated InstanceHandle.
+     *
      * @return Copy of the InstanceHandle
      */
-    RTPS_DllAPI fastrtps::rtps::InstanceHandle_t get_instance_handle() const;
+    RTPS_DllAPI InstanceHandle_t get_instance_handle() const;
 
     /**
-     * Getter for the data type
-     * @return TypeSupport associated to the DataReader
+     * Getter for the data type.
+     *
+     * @return TypeSupport associated to the DataReader.
      */
     TypeSupport type();
 
     /**
-     * Get TopicDescription
-     * @return TopicDescription pointer
+     * Get TopicDescription.
+     *
+     * @return TopicDescription pointer.
      */
     RTPS_DllAPI const TopicDescription* get_topicdescription() const;
 
     /**
-     * @brief Get the requested deadline missed status
-     * @return The deadline missed status
+     * @brief Get the requested deadline missed status.
+     *
+     * @return The deadline missed status.
      */
     RTPS_DllAPI ReturnCode_t get_requested_deadline_missed_status(
-            fastrtps::RequestedDeadlineMissedStatus& status);
+            RequestedDeadlineMissedStatus& status);
 
     /**
-     * @brief Get the requested incompatible qos status
-     * @param[out] status Requested incompatible qos status
+     * @brief Get the requested incompatible qos status.
+     *
+     * @param [out] status Requested incompatible qos status.
+     *
      * @return RETCODE_OK
      */
     RTPS_DllAPI ReturnCode_t get_requested_incompatible_qos_status(
             RequestedIncompatibleQosStatus& status);
 
     /**
-     * @brief Setter for the DataReaderQos
-     * @param qos new value for the DataReaderQos
-     * @return RETCODE_IMMUTABLE_POLICY if any of the Qos cannot be changed, RETCODE_INCONSISTENT_POLICY if the Qos is not
-     * self consistent and RETCODE_OK if the qos is changed correctly.
+     * @brief Setter for the DataReaderQos.
+     *
+     * @param [in] qos new value for the DataReaderQos.
+     *
+     * @return RETCODE_IMMUTABLE_POLICY if any of the Qos cannot be changed, RETCODE_INCONSISTENT_POLICY if the Qos is
+     *         not self consistent and RETCODE_OK if the qos is changed correctly.
      */
     RTPS_DllAPI ReturnCode_t set_qos(
             const DataReaderQos& qos);
 
     /**
-     * @brief Getter for the DataReaderQos
-     * @return Pointer to the DataReaderQos
+     * @brief Getter for the DataReaderQos.
+     *
+     * @return Pointer to the DataReaderQos.
      */
     RTPS_DllAPI const DataReaderQos& get_qos() const;
 
     /**
-     * @brief Getter for the DataReaderQos
-     * @param qos DataReaderQos where the qos is returned
+     * @brief Getter for the DataReaderQos.
+     *
+     * @param [in] qos DataReaderQos where the qos is returned.
+     *
      * @return RETCODE_OK
      */
     RTPS_DllAPI ReturnCode_t get_qos(
             DataReaderQos& qos) const;
 
     /**
-     * Modifies the DataReaderListener, sets the mask to StatusMask::all()
-     * @param listener new value for the DataReaderListener
+     * Modifies the DataReaderListener, sets the mask to StatusMask::all().
+     *
+     * @param [in] listener new value for the DataReaderListener.
+     *
      * @return RETCODE_OK
      */
     RTPS_DllAPI ReturnCode_t set_listener(
@@ -259,8 +679,10 @@ public:
 
     /**
      * Modifies the DataReaderListener.
-     * @param listener new value for the DataReaderListener
-     * @param mask StatusMask that holds statuses the listener responds to (default: all).
+     *
+     * @param [in] listener new value for the DataReaderListener.
+     * @param [in] mask StatusMask that holds statuses the listener responds to (default: all).
+     *
      * @return RETCODE_OK
      */
     RTPS_DllAPI ReturnCode_t set_listener(
@@ -275,12 +697,14 @@ public:
     /* TODO
        RTPS_DllAPI bool get_key_value(
             void* data,
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
      */
 
     /**
-     * @brief Get the liveliness changed status
-     * @param status LivelinessChangedStatus object where the status is returned
+     * @brief Get the liveliness changed status.
+     *
+     * @param [out] status LivelinessChangedStatus object where the status is returned.
+     *
      * @return RETCODE_OK
      */
     RTPS_DllAPI ReturnCode_t get_liveliness_changed_status(
@@ -323,5 +747,5 @@ protected:
 } /* namespace dds */
 } /* namespace fastdds */
 } /* namespace eprosima */
-#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
-#endif /* _FASTRTPS_DATAREADER_HPP_*/
+
+#endif /* _FASTDDS_DDS_SUBSCRIBER_DATAREADER_HPP_*/

--- a/include/fastdds/dds/subscriber/SampleInfo.hpp
+++ b/include/fastdds/dds/subscriber/SampleInfo.hpp
@@ -23,11 +23,11 @@
 #include <fastdds/dds/subscriber/InstanceState.hpp>
 #include <fastdds/dds/subscriber/SampleState.hpp>
 #include <fastdds/dds/subscriber/ViewState.hpp>
+#include <fastdds/dds/topic/TypeSupport.hpp>
 
-#include <fastdds/rtps/common/Types.h>
-#include <fastdds/rtps/common/Time_t.h>
-#include <fastdds/rtps/common/InstanceHandle.h>
 #include <fastdds/rtps/common/SampleIdentity.h>
+#include <fastdds/rtps/common/Time_t.h>
+#include <fastdds/rtps/common/Types.h>
 
 namespace eprosima {
 namespace fastdds {
@@ -95,12 +95,12 @@ struct SampleInfo
     fastrtps::rtps::Time_t source_timestamp;
 
     //! identifies locally the corresponding instance
-    fastrtps::rtps::InstanceHandle_t instance_handle;
+    InstanceHandle_t instance_handle;
 
     //! identifies locally the DataWriter that modified the instance
     //!
     //! Is the same InstanceHandle_t that is returned by the operation get_matched_publications on the DataReader
-    fastrtps::rtps::InstanceHandle_t publication_handle;
+    InstanceHandle_t publication_handle;
 
     //! whether the DataSample contains data or is only used to communicate of a change in the instance
     bool valid_data;

--- a/include/fastdds/dds/subscriber/Subscriber.hpp
+++ b/include/fastdds/dds/subscriber/Subscriber.hpp
@@ -16,16 +16,15 @@
  * @file Subscriber.hpp
  */
 
-
 #ifndef _FASTDDS_SUBSCRIBER_HPP_
 #define _FASTDDS_SUBSCRIBER_HPP_
 
-#include <fastrtps/attributes/SubscriberAttributes.h>
-
+#include <fastdds/dds/core/Entity.hpp>
 #include <fastdds/dds/subscriber/DataReaderListener.hpp>
 #include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
+#include <fastdds/dds/topic/TypeSupport.hpp>
+
 #include <fastrtps/types/TypesBase.h>
-#include <fastdds/dds/core/Entity.hpp>
 
 using eprosima::fastrtps::types::ReturnCode_t;
 
@@ -311,7 +310,7 @@ public:
      * Returns the Subscriber's handle.
      * @return InstanceHandle of this Subscriber.
      */
-    RTPS_DllAPI const fastrtps::rtps::InstanceHandle_t& get_instance_handle() const;
+    RTPS_DllAPI const InstanceHandle_t& get_instance_handle() const;
 
 protected:
 

--- a/include/fastdds/dds/subscriber/qos/DataReaderQos.hpp
+++ b/include/fastdds/dds/subscriber/qos/DataReaderQos.hpp
@@ -84,9 +84,7 @@ public:
     /**
      * @brief Constructor
      */
-    RTPS_DllAPI ReaderResourceLimitsQos()
-    {
-    }
+    RTPS_DllAPI ReaderResourceLimitsQos() = default;
 
     /**
      * @brief Destructor
@@ -105,8 +103,14 @@ public:
         std::swap(*this, reset);
     }
 
-    //!Matched publishers allocation limits.
-    fastrtps::ResourceLimitedContainerConfig matched_publisher_allocation;
+    //! Matched publishers allocation limits.
+    fastrtps::ResourceLimitedContainerConfig matched_publisher_allocation{ 1u };
+    //! SampleInfo allocation limits.
+    fastrtps::ResourceLimitedContainerConfig sample_infos_allocation{ 32u };
+    //! Loaned collections allocation limits.
+    fastrtps::ResourceLimitedContainerConfig outstanding_reads_allocation{ 2u };
+    //! Maximum number of samples to return on a single call to read / take
+    uint32_t max_samples_per_read = 32u;
 };
 
 //! Qos Policy to configure the XTypes Qos associated to the DataReader

--- a/include/fastdds/dds/subscriber/qos/DataReaderQos.hpp
+++ b/include/fastdds/dds/subscriber/qos/DataReaderQos.hpp
@@ -94,7 +94,11 @@ public:
     bool operator ==(
             const ReaderResourceLimitsQos& b) const
     {
-        return (this->matched_publisher_allocation == b.matched_publisher_allocation);
+        return
+            (matched_publisher_allocation == b.matched_publisher_allocation) &&
+            (sample_infos_allocation == b.sample_infos_allocation) &&
+            (outstanding_reads_allocation == b.outstanding_reads_allocation) &&
+            (max_samples_per_read == b.max_samples_per_read);
     }
 
     inline void clear()
@@ -104,13 +108,23 @@ public:
     }
 
     //! Matched publishers allocation limits.
-    fastrtps::ResourceLimitedContainerConfig matched_publisher_allocation{ 1u };
+    fastrtps::ResourceLimitedContainerConfig matched_publisher_allocation;
     //! SampleInfo allocation limits.
     fastrtps::ResourceLimitedContainerConfig sample_infos_allocation{ 32u };
     //! Loaned collections allocation limits.
     fastrtps::ResourceLimitedContainerConfig outstanding_reads_allocation{ 2u };
-    //! Maximum number of samples to return on a single call to read / take
-    uint32_t max_samples_per_read = 32u;
+
+    /**
+     * Maximum number of samples to return on a single call to read / take.
+     *
+     * This attribute is a signed integer to be consistent with the @c max_samples argument of
+     * @ref DataReader methods, but should always have a strict positive value. Bear in mind that
+     * a big number here may cause the creation of the DataReader to fail due to pre-allocation of
+     * internal resources.
+     *
+     * Default value: 32.
+     */
+    int32_t max_samples_per_read = 32;
 };
 
 //! Qos Policy to configure the XTypes Qos associated to the DataReader

--- a/include/fastdds/dds/topic/TopicDataType.hpp
+++ b/include/fastdds/dds/topic/TopicDataType.hpp
@@ -19,11 +19,14 @@
 #ifndef _FASTDDS_TOPICDATATYPE_HPP_
 #define _FASTDDS_TOPICDATATYPE_HPP_
 
-#include <fastrtps/fastrtps_dll.h>
-#include <fastdds/dds/core/policy/QosPolicies.hpp>
-
 #include <string>
 #include <functional>
+
+#include <fastdds/dds/core/policy/QosPolicies.hpp>
+#include <fastdds/rtps/common/InstanceHandle.h>
+
+#include <fastrtps/fastrtps_dll.h>
+#include <fastrtps/utils/md5.h>
 
 // This version of TypeSupport has `is_bounded()`
 #define TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED

--- a/include/fastdds/dds/topic/TypeSupport.hpp
+++ b/include/fastdds/dds/topic/TypeSupport.hpp
@@ -31,6 +31,12 @@ namespace eprosima {
 namespace fastdds {
 namespace dds {
 
+//! Handle to identiy different instances of the same Topic of a certain type.
+using InstanceHandle_t = eprosima::fastrtps::rtps::InstanceHandle_t;
+
+//! The NIL instance handle.
+extern RTPS_DllAPI const InstanceHandle_t HANDLE_NIL;
+
 class DomainParticipant;
 
 /**
@@ -189,7 +195,7 @@ public:
      */
     RTPS_DllAPI virtual bool get_key(
             void* data,
-            fastrtps::rtps::InstanceHandle_t* i_handle,
+            InstanceHandle_t* i_handle,
             bool force_md5 = false)
     {
         return get()->getKey(data, i_handle, force_md5);

--- a/include/fastrtps/TopicDataType.h
+++ b/include/fastrtps/TopicDataType.h
@@ -20,9 +20,6 @@
 #define TOPICDATATYPE_H_
 
 #include <fastdds/dds/topic/TopicDataType.hpp>
-#include <fastdds/rtps/common/SerializedPayload.h>
-#include <fastdds/rtps/common/InstanceHandle.h>
-#include <fastrtps/utils/md5.h>
 
 namespace eprosima {
 namespace fastrtps {

--- a/include/fastrtps/qos/DeadlineMissedStatus.h
+++ b/include/fastrtps/qos/DeadlineMissedStatus.h
@@ -21,8 +21,6 @@
 
 #include <fastdds/dds/core/status/DeadlineMissedStatus.hpp>
 
-#include <fastdds/rtps/common/InstanceHandle.h>
-
 namespace eprosima {
 namespace fastrtps {
 

--- a/include/fastrtps/qos/LivelinessChangedStatus.h
+++ b/include/fastrtps/qos/LivelinessChangedStatus.h
@@ -21,8 +21,6 @@
 
 #include <fastdds/dds/core/status/LivelinessChangedStatus.hpp>
 
-#include <fastdds/rtps/common/InstanceHandle.h>
-
 namespace eprosima {
 namespace fastrtps {
 

--- a/include/fastrtps/qos/SampleRejectedStatus.hpp
+++ b/include/fastrtps/qos/SampleRejectedStatus.hpp
@@ -21,8 +21,6 @@
 
 #include <fastdds/dds/core/status/SampleRejectedStatus.hpp>
 
-#include <fastdds/rtps/common/InstanceHandle.h>
-
 namespace eprosima {
 namespace fastrtps {
 

--- a/include/fastrtps/subscriber/SubscriberHistory.h
+++ b/include/fastrtps/subscriber/SubscriberHistory.h
@@ -130,12 +130,19 @@ public:
             std::chrono::steady_clock::time_point& next_deadline_us);
 
     /**
-     * @brief Get an iterator to the instances map corresponding to certain instance handle.
+     * @brief Get the list of changes corresponding to an instance handle.
      * @param handle The handle to the instance.
      * @param exact  Indicates if the handle should match exactly (true) or if the first instance greater than the
      *               input handle should be returned.
-     * @return A pair where @c first is a boolean indicating if an instance was found, and second is an iterator to
-     *         the instance map pointing to the relevant instance.
+     * @return A pair where:
+     *         - @c first is a boolean indicating if an instance was found
+     *         - @c second is a pair where:
+     *           - @c first is the handle of the returned instance
+     *           - @c second is a pointer to a std::vector<rtps::CacheChange_t*> with the list of changes for the
+     *             returned instance
+     *
+     * @remarks When used on a NO_KEY topic, an instance will only be returned when called with
+     *          `handle = HANDLE_NIL` and `exact = false`.
      */
     std::pair<bool, instance_info> lookup_instance(
             const rtps::InstanceHandle_t& handle,

--- a/include/fastrtps/subscriber/SubscriberHistory.h
+++ b/include/fastrtps/subscriber/SubscriberHistory.h
@@ -44,6 +44,8 @@ class SubscriberHistory : public rtps::ReaderHistory
 {
 public:
 
+    using instance_info = std::pair<rtps::InstanceHandle_t, std::vector<rtps::CacheChange_t*>*>;
+
     /**
      * Constructor. Requires information about the subscriber.
      * @param topic_att TopicAttributes.
@@ -126,6 +128,18 @@ public:
     bool get_next_deadline(
             rtps::InstanceHandle_t& handle,
             std::chrono::steady_clock::time_point& next_deadline_us);
+
+    /**
+     * @brief Get an iterator to the instances map corresponding to certain instance handle.
+     * @param handle The handle to the instance.
+     * @param exact  Indicates if the handle should match exactly (true) or if the first instance greater than the
+     *               input handle should be returned.
+     * @return A pair where @c first is a boolean indicating if an instance was found, and second is an iterator to
+     *         the instance map pointing to the relevant instance.
+     */
+    std::pair<bool, instance_info> lookup_instance(
+            const rtps::InstanceHandle_t& handle,
+            bool exact);
 
 private:
 
@@ -214,6 +228,6 @@ private:
 } // namespace fastrtps
 } // namespace eprosima
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 #endif /* SUBSCRIBERHISTORY_H_ */

--- a/src/cpp/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipant.cpp
@@ -200,7 +200,7 @@ ReturnCode_t DomainParticipant::unregister_type(
 
 /* TODO
    bool DomainParticipant::ignore_participant(
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
    {
     return impl_->ignore_participant(handle);
    }
@@ -208,7 +208,7 @@ ReturnCode_t DomainParticipant::unregister_type(
 
 /* TODO
    bool DomainParticipant::ignore_topic(
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
    {
     return impl_->ignore_topic(handle);
    }
@@ -216,7 +216,7 @@ ReturnCode_t DomainParticipant::unregister_type(
 
 /* TODO
    bool DomainParticipant::ignore_publication(
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
    {
     return impl_->ignore_publication(handle);
    }
@@ -224,7 +224,7 @@ ReturnCode_t DomainParticipant::unregister_type(
 
 /* TODO
    bool DomainParticipant::ignore_subscription(
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
    {
     return impl_->ignore_subscription(handle);
    }
@@ -324,7 +324,7 @@ ReturnCode_t DomainParticipant::get_topic_qos_from_profile(
 
 /* TODO
    bool DomainParticipant::get_discovered_participants(
-        std::vector<fastrtps::rtps::InstanceHandle_t>& participant_handles) const
+        std::vector<InstanceHandle_t>& participant_handles) const
    {
     return impl_->get_discovered_participants(participant_handles);
    }
@@ -332,14 +332,14 @@ ReturnCode_t DomainParticipant::get_topic_qos_from_profile(
 
 /* TODO
    bool DomainParticipant::get_discovered_topics(
-        std::vector<fastrtps::rtps::InstanceHandle_t>& topic_handles) const
+        std::vector<InstanceHandle_t>& topic_handles) const
    {
     return impl_->get_discovered_topics(topic_handles);
    }
  */
 
 bool DomainParticipant::contains_entity(
-        const fastrtps::rtps::InstanceHandle_t& handle,
+        const InstanceHandle_t& handle,
         bool recursive) const
 {
     return impl_->contains_entity(handle, recursive);
@@ -357,7 +357,7 @@ TypeSupport DomainParticipant::find_type(
     return impl_->find_type(type_name);
 }
 
-const fastrtps::rtps::InstanceHandle_t& DomainParticipant::get_instance_handle() const
+const InstanceHandle_t& DomainParticipant::get_instance_handle() const
 {
     return impl_->get_instance_handle();
 }

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -75,7 +75,6 @@ using fastrtps::rtps::ReaderDiscoveryInfo;
 using fastrtps::rtps::ReaderProxyData;
 using fastrtps::rtps::WriterDiscoveryInfo;
 using fastrtps::rtps::WriterProxyData;
-using fastrtps::rtps::InstanceHandle_t;
 using fastrtps::rtps::GUID_t;
 using fastrtps::rtps::EndpointKind_t;
 using fastrtps::rtps::ResourceEvent;
@@ -524,7 +523,7 @@ Publisher* DomainParticipantImpl::create_publisher_with_profile(
 
 /* TODO
    bool DomainParticipantImpl::ignore_participant(
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
    {
     (void)handle;
     logError(PARTICIPANT, "Not implemented.");
@@ -534,7 +533,7 @@ Publisher* DomainParticipantImpl::create_publisher_with_profile(
 
 /* TODO
    bool DomainParticipantImpl::ignore_topic(
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
    {
     (void)handle;
     logError(PARTICIPANT, "Not implemented.");
@@ -544,7 +543,7 @@ Publisher* DomainParticipantImpl::create_publisher_with_profile(
 
 /* TODO
    bool DomainParticipantImpl::ignore_publication(
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
    {
     (void)handle;
     logError(PARTICIPANT, "Not implemented.");
@@ -554,7 +553,7 @@ Publisher* DomainParticipantImpl::create_publisher_with_profile(
 
 /* TODO
    bool DomainParticipantImpl::ignore_subscription(
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
    {
     (void)handle;
     logError(PARTICIPANT, "Not implemented.");
@@ -743,7 +742,7 @@ const ReturnCode_t DomainParticipantImpl::get_topic_qos_from_profile(
 
 /* TODO
    bool DomainParticipantImpl::get_discovered_participants(
-        std::vector<fastrtps::rtps::InstanceHandle_t>& participant_handles) const
+        std::vector<InstanceHandle_t>& participant_handles) const
    {
     (void)participant_handles;
     logError(PARTICIPANT, "Not implemented.");
@@ -753,7 +752,7 @@ const ReturnCode_t DomainParticipantImpl::get_topic_qos_from_profile(
 
 /* TODO
    bool DomainParticipantImpl::get_discovered_topics(
-        std::vector<fastrtps::rtps::InstanceHandle_t>& topic_handles) const
+        std::vector<InstanceHandle_t>& topic_handles) const
    {
     (void)topic_handles;
     logError(PARTICIPANT, "Not implemented.");
@@ -762,7 +761,7 @@ const ReturnCode_t DomainParticipantImpl::get_topic_qos_from_profile(
  */
 
 bool DomainParticipantImpl::contains_entity(
-        const fastrtps::rtps::InstanceHandle_t& handle,
+        const InstanceHandle_t& handle,
         bool recursive) const
 {
     // Look for publishers
@@ -1796,7 +1795,7 @@ bool DomainParticipantImpl::can_qos_be_updated(
 }
 
 void DomainParticipantImpl::create_instance_handle(
-        fastrtps::rtps::InstanceHandle_t& handle)
+        InstanceHandle_t& handle)
 {
     using eprosima::fastrtps::rtps::octet;
 

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -233,22 +233,22 @@ public:
 
     /* TODO
        bool ignore_participant(
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
      */
 
     /* TODO
        bool ignore_topic(
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
      */
 
     /* TODO
        bool ignore_publication(
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
      */
 
     /* TODO
        bool ignore_subscription(
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
      */
 
     DomainId_t get_domain_id() const;
@@ -292,28 +292,28 @@ public:
 
     /* TODO
        bool get_discovered_participants(
-            std::vector<fastrtps::rtps::InstanceHandle_t>& participant_handles) const;
+            std::vector<InstanceHandle_t>& participant_handles) const;
      */
 
     /* TODO
        bool get_discovered_participant_data(
             ParticipantBuiltinTopicData& participant_data,
-            const fastrtps::rtps::InstanceHandle_t& participant_handle) const;
+            const InstanceHandle_t& participant_handle) const;
      */
 
     /* TODO
        bool get_discovered_topics(
-            std::vector<fastrtps::rtps::InstanceHandle_t>& topic_handles) const;
+            std::vector<InstanceHandle_t>& topic_handles) const;
      */
 
     /* TODO
        bool get_discovered_topic_data(
             TopicBuiltinTopicData& topic_data,
-            const fastrtps::rtps::InstanceHandle_t& topic_handle) const;
+            const InstanceHandle_t& topic_handle) const;
      */
 
     bool contains_entity(
-            const fastrtps::rtps::InstanceHandle_t& handle,
+            const InstanceHandle_t& handle,
             bool recursive = true) const;
 
     ReturnCode_t get_current_time(
@@ -336,7 +336,7 @@ public:
     const TypeSupport find_type(
             const std::string& type_name) const;
 
-    const fastrtps::rtps::InstanceHandle_t& get_instance_handle() const;
+    const InstanceHandle_t& get_instance_handle() const;
 
     // From here legacy RTPS methods.
 
@@ -418,14 +418,14 @@ protected:
 
     //!Publisher maps
     std::map<Publisher*, PublisherImpl*> publishers_;
-    std::map<fastrtps::rtps::InstanceHandle_t, Publisher*> publishers_by_handle_;
+    std::map<InstanceHandle_t, Publisher*> publishers_by_handle_;
     mutable std::mutex mtx_pubs_;
 
     PublisherQos default_pub_qos_;
 
     //!Subscriber maps
     std::map<Subscriber*, SubscriberImpl*> subscribers_;
-    std::map<fastrtps::rtps::InstanceHandle_t, Subscriber*> subscribers_by_handle_;
+    std::map<InstanceHandle_t, Subscriber*> subscribers_by_handle_;
     mutable std::mutex mtx_subs_;
 
     SubscriberQos default_sub_qos_;
@@ -436,7 +436,7 @@ protected:
 
     //!Topic map
     std::map<std::string, TopicImpl*> topics_;
-    std::map<fastrtps::rtps::InstanceHandle_t, Topic*> topics_by_handle_;
+    std::map<InstanceHandle_t, Topic*> topics_by_handle_;
     mutable std::mutex mtx_topics_;
 
     TopicQos default_topic_qos_;
@@ -513,7 +513,7 @@ protected:
     rtps_listener_;
 
     void create_instance_handle(
-            fastrtps::rtps::InstanceHandle_t& handle);
+            InstanceHandle_t& handle);
 
     ReturnCode_t register_dynamic_type(
             fastrtps::types::DynamicType_ptr dyn_type);

--- a/src/cpp/fastdds/publisher/DataWriter.cpp
+++ b/src/cpp/fastdds/publisher/DataWriter.cpp
@@ -93,12 +93,12 @@ bool DataWriter::write(
 
 ReturnCode_t DataWriter::write(
         void* data,
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
 {
     return impl_->write(data, handle);
 }
 
-fastrtps::rtps::InstanceHandle_t DataWriter::register_instance(
+InstanceHandle_t DataWriter::register_instance(
         void* instance)
 {
     return impl_->register_instance(instance);
@@ -106,14 +106,14 @@ fastrtps::rtps::InstanceHandle_t DataWriter::register_instance(
 
 ReturnCode_t DataWriter::unregister_instance(
         void* instance,
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
 {
     return impl_->unregister_instance(instance, handle);
 }
 
 ReturnCode_t DataWriter::dispose(
         void* data,
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
 {
     return impl_->unregister_instance(data, handle, true);
 }
@@ -123,7 +123,7 @@ const fastrtps::rtps::GUID_t& DataWriter::guid() const
     return impl_->guid();
 }
 
-fastrtps::rtps::InstanceHandle_t DataWriter::get_instance_handle() const
+InstanceHandle_t DataWriter::get_instance_handle() const
 {
     return impl_->get_instance_handle();
 }

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -423,7 +423,7 @@ bool DataWriterImpl::write(
 
 ReturnCode_t DataWriterImpl::write(
         void* data,
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
 {
     if (writer_ == nullptr)
     {
@@ -451,7 +451,7 @@ ReturnCode_t DataWriterImpl::write(
     return create_new_change_with_params(ALIVE, data, wparams, instance_handle);
 }
 
-fastrtps::rtps::InstanceHandle_t DataWriterImpl::register_instance(
+InstanceHandle_t DataWriterImpl::register_instance(
         void* key)
 {
     /// Preconditions
@@ -715,7 +715,7 @@ ReturnCode_t DataWriterImpl::create_new_change_with_params(
         ChangeKind_t changeKind,
         void* data,
         WriteParams& wparams,
-        const fastrtps::rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
 {
     ReturnCode_t ret_code = check_new_change_preconditions(changeKind, data);
     if (!ret_code)

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -156,7 +156,7 @@ public:
      */
     ReturnCode_t write(
             void* data,
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
 
     /*!
      * @brief Implementation of the DDS `register_instance` operation.
@@ -166,7 +166,7 @@ public:
      * This handle could be used in successive `write` or `dispose` operations.
      * In case of error, HANDLE_NIL will be returned.
      */
-    fastrtps::rtps::InstanceHandle_t register_instance(
+    InstanceHandle_t register_instance(
             void* instance);
 
     /*!
@@ -184,7 +184,7 @@ public:
      */
     ReturnCode_t unregister_instance(
             void* instance,
-            const fastrtps::rtps::InstanceHandle_t& handle,
+            const InstanceHandle_t& handle,
             bool dispose = false);
 
     /**
@@ -193,7 +193,7 @@ public:
      */
     const fastrtps::rtps::GUID_t& guid() const;
 
-    fastrtps::rtps::InstanceHandle_t get_instance_handle() const;
+    InstanceHandle_t get_instance_handle() const;
 
     /**
      * Get topic data type
@@ -228,7 +228,7 @@ public:
     /* TODO
        bool get_key_value(
             void* key_holder,
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
      */
 
     ReturnCode_t get_liveliness_lost_status(
@@ -316,7 +316,7 @@ protected:
     std::chrono::duration<double, std::ratio<1, 1000000>> deadline_duration_us_;
 
     //! The current timer owner, i.e. the instance which started the deadline timer
-    fastrtps::rtps::InstanceHandle_t timer_owner_;
+    InstanceHandle_t timer_owner_;
 
     //! The offered deadline missed status
     fastrtps::OfferedDeadlineMissedStatus deadline_missed_status_;
@@ -372,7 +372,7 @@ protected:
             fastrtps::rtps::ChangeKind_t kind,
             void* data,
             fastrtps::rtps::WriteParams& wparams,
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
 
     /**
      * Removes the cache change with the minimum sequence number
@@ -403,7 +403,7 @@ protected:
             fastrtps::rtps::ChangeKind_t change_kind,
             void* data,
             fastrtps::rtps::WriteParams& wparams,
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const InstanceHandle_t& handle);
 
     static fastrtps::TopicAttributes get_topic_attributes(
             const DataWriterQos& qos,

--- a/src/cpp/fastdds/subscriber/DataReader.cpp
+++ b/src/cpp/fastdds/subscriber/DataReader.cpp
@@ -86,14 +86,7 @@ ReturnCode_t DataReader::read(
         ViewStateMask view_states,
         InstanceStateMask instance_states)
 {
-    static_cast<void>(data_values);
-    static_cast<void>(sample_infos);
-    static_cast<void>(max_samples);
-    static_cast<void>(sample_states);
-    static_cast<void>(view_states);
-    static_cast<void>(instance_states);
-
-    return ReturnCode_t::RETCODE_UNSUPPORTED;
+    return impl_->read(data_values, sample_infos, max_samples, sample_states, view_states, instance_states);
 }
 
 ReturnCode_t DataReader::read_instance(
@@ -105,15 +98,8 @@ ReturnCode_t DataReader::read_instance(
         ViewStateMask view_states,
         InstanceStateMask instance_states)
 {
-    static_cast<void>(data_values);
-    static_cast<void>(sample_infos);
-    static_cast<void>(max_samples);
-    static_cast<void>(a_handle);
-    static_cast<void>(sample_states);
-    static_cast<void>(view_states);
-    static_cast<void>(instance_states);
-
-    return ReturnCode_t::RETCODE_UNSUPPORTED;
+    return impl_->read_instance(data_values, sample_infos, max_samples, a_handle, sample_states, view_states,
+                   instance_states);
 }
 
 ReturnCode_t DataReader::read_next_instance(
@@ -125,15 +111,8 @@ ReturnCode_t DataReader::read_next_instance(
         ViewStateMask view_states,
         InstanceStateMask instance_states)
 {
-    static_cast<void>(data_values);
-    static_cast<void>(sample_infos);
-    static_cast<void>(max_samples);
-    static_cast<void>(previous_handle);
-    static_cast<void>(sample_states);
-    static_cast<void>(view_states);
-    static_cast<void>(instance_states);
-
-    return ReturnCode_t::RETCODE_UNSUPPORTED;
+    return impl_->read_next_instance(data_values, sample_infos, max_samples, previous_handle, sample_states,
+                   view_states, instance_states);
 }
 
 ReturnCode_t DataReader::take(
@@ -144,14 +123,7 @@ ReturnCode_t DataReader::take(
         ViewStateMask view_states,
         InstanceStateMask instance_states)
 {
-    static_cast<void>(data_values);
-    static_cast<void>(sample_infos);
-    static_cast<void>(max_samples);
-    static_cast<void>(sample_states);
-    static_cast<void>(view_states);
-    static_cast<void>(instance_states);
-
-    return ReturnCode_t::RETCODE_UNSUPPORTED;
+    return impl_->take(data_values, sample_infos, max_samples, sample_states, view_states, instance_states);
 }
 
 ReturnCode_t DataReader::take_instance(
@@ -163,15 +135,8 @@ ReturnCode_t DataReader::take_instance(
         ViewStateMask view_states,
         InstanceStateMask instance_states)
 {
-    static_cast<void>(data_values);
-    static_cast<void>(sample_infos);
-    static_cast<void>(max_samples);
-    static_cast<void>(a_handle);
-    static_cast<void>(sample_states);
-    static_cast<void>(view_states);
-    static_cast<void>(instance_states);
-
-    return ReturnCode_t::RETCODE_UNSUPPORTED;
+    return impl_->take_instance(data_values, sample_infos, max_samples, a_handle, sample_states, view_states,
+                   instance_states);
 }
 
 ReturnCode_t DataReader::take_next_instance(
@@ -183,25 +148,15 @@ ReturnCode_t DataReader::take_next_instance(
         ViewStateMask view_states,
         InstanceStateMask instance_states)
 {
-    static_cast<void>(data_values);
-    static_cast<void>(sample_infos);
-    static_cast<void>(max_samples);
-    static_cast<void>(previous_handle);
-    static_cast<void>(sample_states);
-    static_cast<void>(view_states);
-    static_cast<void>(instance_states);
-
-    return ReturnCode_t::RETCODE_UNSUPPORTED;
+    return impl_->take_next_instance(data_values, sample_infos, max_samples, previous_handle, sample_states,
+                   view_states, instance_states);
 }
 
 ReturnCode_t DataReader::return_loan(
         LoanableCollection& data_values,
         SampleInfoSeq& sample_infos)
 {
-    static_cast<void>(data_values);
-    static_cast<void>(sample_infos);
-
-    return ReturnCode_t::RETCODE_UNSUPPORTED;
+    return impl_->return_loan(data_values, sample_infos);
 }
 
 ReturnCode_t DataReader::read_next_sample(
@@ -263,24 +218,6 @@ ReturnCode_t DataReader::get_requested_incompatible_qos_status(
 {
     return impl_->get_requested_incompatible_qos_status(status);
 }
-
-/* TODO
-   bool DataReader::read(
-        std::vector<void *>& data_values,
-        std::vector<SampleInfo>& sample_infos,
-        uint32_t max_samples)
-   {
-    return impl_->read(...);
-   }
-
-   bool DataReader::take(
-        std::vector<void *>& data_values,
-        std::vector<SampleInfo>& sample_infos,
-        uint32_t max_samples)
-   {
-    return impl_->take(...);
-   }
- */
 
 ReturnCode_t DataReader::set_listener(
         DataReaderListener* listener)

--- a/src/cpp/fastdds/subscriber/DataReader.cpp
+++ b/src/cpp/fastdds/subscriber/DataReader.cpp
@@ -78,6 +78,132 @@ bool DataReader::wait_for_unread_message(
     return impl_->wait_for_unread_message(timeout);
 }
 
+ReturnCode_t DataReader::read(
+        LoanableCollection& data_values,
+        SampleInfoSeq& sample_infos,
+        int32_t max_samples,
+        SampleStateMask sample_states,
+        ViewStateMask view_states,
+        InstanceStateMask instance_states)
+{
+    static_cast<void>(data_values);
+    static_cast<void>(sample_infos);
+    static_cast<void>(max_samples);
+    static_cast<void>(sample_states);
+    static_cast<void>(view_states);
+    static_cast<void>(instance_states);
+
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
+ReturnCode_t DataReader::read_instance(
+        LoanableCollection& data_values,
+        SampleInfoSeq& sample_infos,
+        int32_t max_samples,
+        const InstanceHandle_t& a_handle,
+        SampleStateMask sample_states,
+        ViewStateMask view_states,
+        InstanceStateMask instance_states)
+{
+    static_cast<void>(data_values);
+    static_cast<void>(sample_infos);
+    static_cast<void>(max_samples);
+    static_cast<void>(a_handle);
+    static_cast<void>(sample_states);
+    static_cast<void>(view_states);
+    static_cast<void>(instance_states);
+
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
+ReturnCode_t DataReader::read_next_instance(
+        LoanableCollection& data_values,
+        SampleInfoSeq& sample_infos,
+        int32_t max_samples,
+        const InstanceHandle_t& previous_handle,
+        SampleStateMask sample_states,
+        ViewStateMask view_states,
+        InstanceStateMask instance_states)
+{
+    static_cast<void>(data_values);
+    static_cast<void>(sample_infos);
+    static_cast<void>(max_samples);
+    static_cast<void>(previous_handle);
+    static_cast<void>(sample_states);
+    static_cast<void>(view_states);
+    static_cast<void>(instance_states);
+
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
+ReturnCode_t DataReader::take(
+        LoanableCollection& data_values,
+        SampleInfoSeq& sample_infos,
+        int32_t max_samples,
+        SampleStateMask sample_states,
+        ViewStateMask view_states,
+        InstanceStateMask instance_states)
+{
+    static_cast<void>(data_values);
+    static_cast<void>(sample_infos);
+    static_cast<void>(max_samples);
+    static_cast<void>(sample_states);
+    static_cast<void>(view_states);
+    static_cast<void>(instance_states);
+
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
+ReturnCode_t DataReader::take_instance(
+        LoanableCollection& data_values,
+        SampleInfoSeq& sample_infos,
+        int32_t max_samples,
+        const InstanceHandle_t& a_handle,
+        SampleStateMask sample_states,
+        ViewStateMask view_states,
+        InstanceStateMask instance_states)
+{
+    static_cast<void>(data_values);
+    static_cast<void>(sample_infos);
+    static_cast<void>(max_samples);
+    static_cast<void>(a_handle);
+    static_cast<void>(sample_states);
+    static_cast<void>(view_states);
+    static_cast<void>(instance_states);
+
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
+ReturnCode_t DataReader::take_next_instance(
+        LoanableCollection& data_values,
+        SampleInfoSeq& sample_infos,
+        int32_t max_samples,
+        const InstanceHandle_t& previous_handle,
+        SampleStateMask sample_states,
+        ViewStateMask view_states,
+        InstanceStateMask instance_states)
+{
+    static_cast<void>(data_values);
+    static_cast<void>(sample_infos);
+    static_cast<void>(max_samples);
+    static_cast<void>(previous_handle);
+    static_cast<void>(sample_states);
+    static_cast<void>(view_states);
+    static_cast<void>(instance_states);
+
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
+ReturnCode_t DataReader::return_loan(
+        LoanableCollection& data_values,
+        SampleInfoSeq& sample_infos)
+{
+    static_cast<void>(data_values);
+    static_cast<void>(sample_infos);
+
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
 ReturnCode_t DataReader::read_next_sample(
         void* data,
         SampleInfo* info)
@@ -183,7 +309,7 @@ const DataReaderListener* DataReader::get_listener() const
 /* TODO
    bool DataReader::get_key_value(
         void* data,
-        const rtps::InstanceHandle_t& handle)
+        const InstanceHandle_t& handle)
    {
     return impl->get_key_value(...);
    }

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -271,9 +271,7 @@ ReturnCode_t DataReaderImpl::check_collection_preconditions_and_calc_max_samples
             return ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;
         }
 
-        uint32_t collection_input_max = data_values.maximum();
-        int32_t collection_max = (collection_input_max > std::numeric_limits<uint32_t>::max() / 2u) ?
-                std::numeric_limits<int32_t>::max() : static_cast<int32_t>(collection_input_max);
+        int32_t collection_max = data_values.maximum();
 
         // We consider all negative value to be LENGTH_UNLIMITED
         if (0 > max_samples)

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/DataReaderLoanManager.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/DataReaderLoanManager.hpp
@@ -1,0 +1,152 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file DataReaderLoanManager.hpp
+ */
+
+#ifndef _FASTDDS_SUBSCRIBER_DATAREADERIMPL_DATAREADERLOANMANAGER_HPP_
+#define _FASTDDS_SUBSCRIBER_DATAREADERIMPL_DATAREADERLOANMANAGER_HPP_
+
+#include <algorithm>
+#include <cassert>
+
+#include <fastdds/dds/core/LoanableCollection.hpp>
+#include <fastdds/dds/core/LoanableSequence.hpp>
+#include <fastdds/dds/subscriber/SampleInfo.hpp>
+#include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
+
+#include <fastrtps/types/TypesBase.h>
+#include <fastrtps/utils/collections/ResourceLimitedContainerConfig.hpp>
+#include <fastrtps/utils/collections/ResourceLimitedVector.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace detail {
+
+struct DataReaderLoanManager
+{
+    using SampleInfoSeq = LoanableSequence<SampleInfo>;
+    using ReturnCode_t = eprosima::fastrtps::types::ReturnCode_t;
+
+    explicit DataReaderLoanManager(
+            const DataReaderQos& qos)
+        : max_samples_(qos.reader_resource_limits().max_samples_per_read)
+        , free_loans_(qos.reader_resource_limits().outstanding_reads_allocation)
+        , used_loans_(qos.reader_resource_limits().outstanding_reads_allocation)
+    {
+        for (size_t n = 0; n < qos.reader_resource_limits().outstanding_reads_allocation.initial; ++n)
+        {
+            OutstandingLoanItem tmp;
+            tmp.data_values = new LoanableCollection::element_type[max_samples_];
+            tmp.sample_infos = new LoanableCollection::element_type[max_samples_];
+            OutstandingLoanItem* result = free_loans_.push_back(tmp);
+            static_cast<void>(result);
+            assert(result != nullptr);
+        }
+    }
+
+    ~DataReaderLoanManager()
+    {
+        for (OutstandingLoanItem& it : free_loans_)
+        {
+            delete[] it.data_values;
+            delete[] it.sample_infos;
+        }
+    }
+
+    bool has_outstanding_loans() const
+    {
+        return !used_loans_.empty();
+    }
+
+    ReturnCode_t get_loan(
+            LoanableCollection& data_values,
+            SampleInfoSeq& sample_infos)
+    {
+        OutstandingLoanItem* result = nullptr;
+
+        if (free_loans_.empty())
+        {
+            OutstandingLoanItem tmp;
+            result = used_loans_.push_back(tmp);
+            if (nullptr == result)
+            {
+                return ReturnCode_t::RETCODE_OUT_OF_RESOURCES;
+            }
+
+            result->data_values = new LoanableCollection::element_type[max_samples_];
+            result->sample_infos = new LoanableCollection::element_type[max_samples_];
+        }
+        else
+        {
+            result = used_loans_.push_back(free_loans_.back());
+            static_cast<void>(result);
+            assert(result != nullptr);
+            free_loans_.pop_back();
+        }
+
+        data_values.loan(result->data_values, max_samples_, 0);
+        sample_infos.loan(result->sample_infos, max_samples_, 0);
+        return ReturnCode_t::RETCODE_OK;
+    }
+
+    ReturnCode_t return_loan(
+            LoanableCollection& data_values,
+            SampleInfoSeq& sample_infos)
+    {
+        OutstandingLoanItem tmp;
+        tmp.data_values = const_cast<LoanableCollection::element_type*>(data_values.buffer());
+        tmp.sample_infos = const_cast<LoanableCollection::element_type*>(sample_infos.buffer());
+
+        if (!used_loans_.remove(tmp))
+        {
+            return ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;
+        }
+
+        OutstandingLoanItem* result = free_loans_.push_back(tmp);
+        static_cast<void>(result);
+        assert(result != nullptr);
+        return ReturnCode_t::RETCODE_OK;
+    }
+
+private:
+
+    struct OutstandingLoanItem
+    {
+        LoanableCollection::element_type* data_values = nullptr;
+        LoanableCollection::element_type* sample_infos = nullptr;
+
+        bool operator == (
+                const OutstandingLoanItem& other) const
+        {
+            return other.data_values == data_values && other.sample_infos == sample_infos;
+        }
+
+    };
+
+    using collection_type = eprosima::fastrtps::ResourceLimitedVector<OutstandingLoanItem>;
+
+    int32_t max_samples_ = 0;
+    collection_type free_loans_;
+    collection_type used_loans_;
+};
+
+} /* namespace detail */
+} /* namespace dds */
+} /* namespace fastdds */
+} /* namespace eprosima */
+
+#endif  // _FASTDDS_SUBSCRIBER_DATAREADERIMPL_DATAREADERLOANMANAGER_HPP_

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
@@ -119,10 +119,10 @@ struct ReadTakeCommand
                         continue;
                     }
                 }
-
-                // Go to next sample on instance
-                ++it;
             }
+
+            // Go to next sample on instance
+            ++it;
         }
 
         if (current_slot_ > first_slot)
@@ -305,6 +305,8 @@ private:
                 info.instance_state = ALIVE_INSTANCE_STATE;
                 break;
         }
+
+        change->isRead = true;
     }
 
 };

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
@@ -1,0 +1,317 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file ReadTakeCommand.hpp
+ */
+
+#ifndef _FASTDDS_SUBSCRIBER_DATAREADERIMPL_READTAKECOMMAND_HPP_
+#define _FASTDDS_SUBSCRIBER_DATAREADERIMPL_READTAKECOMMAND_HPP_
+
+#include <cassert>
+#include <cstdint>
+
+#include <fastdds/dds/core/LoanableCollection.hpp>
+#include <fastdds/dds/core/LoanableSequence.hpp>
+#include <fastdds/dds/topic/TypeSupport.hpp>
+#include <fastdds/dds/subscriber/SampleInfo.hpp>
+
+#include <fastrtps/subscriber/SubscriberHistory.h>
+#include <fastrtps/types/TypesBase.h>
+
+#include <fastdds/subscriber/DataReaderImpl.hpp>
+#include <fastdds/subscriber/DataReaderImpl/DataReaderLoanManager.hpp>
+#include <fastdds/subscriber/DataReaderImpl/StateFilter.hpp>
+#include <fastdds/subscriber/DataReaderImpl/SampleInfoPool.hpp>
+#include <fastdds/subscriber/DataReaderImpl/SampleLoanManager.hpp>
+
+#include <fastdds/rtps/common/CacheChange.h>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace detail {
+
+struct ReadTakeCommand
+{
+    using ReturnCode_t = eprosima::fastrtps::types::ReturnCode_t;
+    using history_type = eprosima::fastrtps::SubscriberHistory;
+    using CacheChange_t = eprosima::fastrtps::rtps::CacheChange_t;
+    using SampleInfoSeq = LoanableSequence<SampleInfo>;
+
+    ReadTakeCommand(
+            DataReaderImpl& reader,
+            LoanableCollection& data_values,
+            SampleInfoSeq& sample_infos,
+            int32_t max_samples,
+            const StateFilter& states,
+            history_type::instance_info instance,
+            bool single_instance = false)
+        : type_(reader.type_)
+        , loan_manager_(reader.loan_manager_)
+        , history_(reader.history_)
+        , info_pool_(reader.sample_info_pool_)
+        , sample_pool_(reader.sample_pool_)
+        , data_values_(data_values)
+        , sample_infos_(sample_infos)
+        , remaining_samples_(max_samples)
+        , states_(states)
+        , instance_(instance)
+        , handle_(instance.first)
+        , single_instance_(single_instance)
+    {
+        assert(0 <= remaining_samples_);
+
+        current_slot_ = data_values_.length();
+        finished_ = nullptr == instance.second;
+    }
+
+    ~ReadTakeCommand()
+    {
+        if (!data_values_.has_ownership() && ReturnCode_t::RETCODE_NO_DATA == return_value_)
+        {
+            loan_manager_.return_loan(data_values_, sample_infos_);
+            data_values_.unloan();
+            sample_infos_.unloan();
+        }
+    }
+
+    bool add_instance(
+            bool take_samples)
+    {
+        // Advance to the first instance with a valid state
+        if (!go_to_first_valid_instance())
+        {
+            return false;
+        }
+
+        // Traverse changes on current instance
+        bool ret_val = false;
+        LoanableCollection::size_type first_slot = current_slot_;
+        auto it = instance_.second->begin();
+        while (!finished_ && it != instance_.second->end())
+        {
+            CacheChange_t* change = *it;
+            SampleStateKind check;
+            check = change->isRead ? SampleStateKind::READ_SAMPLE_STATE : SampleStateKind::NOT_READ_SAMPLE_STATE;
+            if ((check & states_.sample_states) != 0)
+            {
+                // Add sample and info to collections
+                if (add_sample(*it))
+                {
+                    if (take_samples)
+                    {
+                        // Remove from history
+                        history_.remove_change_sub(change);
+
+                        // Current iterator will point to change next to the one removed. Avoid incrementing.
+                        continue;
+                    }
+                }
+
+                // Go to next sample on instance
+                ++it;
+            }
+        }
+
+        if (current_slot_ > first_slot)
+        {
+            ret_val = true;
+
+            // complete sample infos
+            LoanableCollection::size_type slot = current_slot_;
+            LoanableCollection::size_type n = 0;
+            while (slot > first_slot)
+            {
+                --slot;
+                sample_infos_[slot].sample_rank = n;
+                ++n;
+            }
+        }
+
+        next_instance();
+        return ret_val;
+    }
+
+    inline bool is_finished() const
+    {
+        return finished_;
+    }
+
+    inline ReturnCode_t return_value() const
+    {
+        return return_value_;
+    }
+
+private:
+
+    const TypeSupport& type_;
+    DataReaderLoanManager& loan_manager_;
+    history_type& history_;
+    SampleInfoPool& info_pool_;
+    std::shared_ptr<detail::SampleLoanManager> sample_pool_;
+    LoanableCollection& data_values_;
+    SampleInfoSeq& sample_infos_;
+    int32_t remaining_samples_;
+    StateFilter states_;
+    history_type::instance_info instance_;
+    InstanceHandle_t handle_;
+    bool single_instance_;
+
+    bool finished_ = false;
+    ReturnCode_t return_value_ = ReturnCode_t::RETCODE_NO_DATA;
+
+    LoanableCollection::size_type current_slot_ = 0;
+
+    bool go_to_first_valid_instance()
+    {
+        while (!is_current_instance_valid())
+        {
+            if (!next_instance())
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool is_current_instance_valid()
+    {
+        // We are not implementing instance_state or view_state yet, so all instances will be considered to have
+        // a valid state. In the future this should check instance_state against states_.instance_states and
+        // view_state against states_.view_states
+        return true;
+    }
+
+    bool next_instance()
+    {
+        if (single_instance_)
+        {
+            finished_ = true;
+            return false;
+        }
+
+        auto result = history_.lookup_instance(handle_, false);
+        if (!result.first)
+        {
+            finished_ = true;
+            return false;
+        }
+
+        instance_ = result.second;
+        handle_ = instance_.first;
+        return true;
+    }
+
+    bool add_sample(
+            CacheChange_t* change)
+    {
+        // Mark that some data is available
+        return_value_ = ReturnCode_t::RETCODE_OK;
+        bool ret_val = false;
+
+        if (remaining_samples_ > 0)
+        {
+            // Increment length of collections
+            auto new_len = current_slot_ + 1;
+            data_values_.length(new_len);
+            sample_infos_.length(new_len);
+
+            // Add information
+            generate_info(change);
+            if (sample_infos_[current_slot_].valid_data)
+            {
+                deserialize_sample(change);
+            }
+
+            ++current_slot_;
+            --remaining_samples_;
+            ret_val = true;
+        }
+
+        // Finish when there are no remaining samples
+        finished_ = (remaining_samples_ == 0);
+        return ret_val;
+    }
+
+    void deserialize_sample(
+            CacheChange_t* change)
+    {
+        auto payload = &(change->serializedPayload);
+        if (data_values_.has_ownership())
+        {
+            // perform deserialization
+            type_->deserialize(payload, data_values_.buffer()[current_slot_]);
+        }
+        else
+        {
+            // loan
+            void* sample;
+            sample_pool_->get_loan(change, sample);
+            const_cast<void**>(data_values_.buffer())[current_slot_] = sample;
+        }
+    }
+
+    void generate_info(
+            CacheChange_t* change)
+    {
+        // Loan when necessary
+        if (!sample_infos_.has_ownership())
+        {
+            SampleInfo* item = info_pool_.get_item();
+            assert(item != nullptr);
+            const_cast<void**>(sample_infos_.buffer())[current_slot_] = item;
+        }
+
+        SampleInfo& info = sample_infos_[current_slot_];
+        info.sample_state = change->isRead ? READ_SAMPLE_STATE : NOT_READ_SAMPLE_STATE;
+        info.view_state = NOT_NEW_VIEW_STATE;
+        info.disposed_generation_count = 0;
+        info.no_writers_generation_count = 1;
+        info.sample_rank = 0;
+        info.generation_rank = 0;
+        info.absoulte_generation_rank = 0;
+        info.source_timestamp = change->sourceTimestamp;
+        info.instance_handle = handle_;
+        info.publication_handle = InstanceHandle_t(change->writerGUID);
+        info.sample_identity.writer_guid(change->writerGUID);
+        info.sample_identity.sequence_number(change->sequenceNumber);
+        info.related_sample_identity = change->write_params.sample_identity();
+        info.valid_data = true;
+
+        switch (change->kind)
+        {
+            case eprosima::fastrtps::rtps::ALIVE:
+                info.instance_state = ALIVE_INSTANCE_STATE;
+                break;
+            case eprosima::fastrtps::rtps::NOT_ALIVE_DISPOSED:
+            case eprosima::fastrtps::rtps::NOT_ALIVE_DISPOSED_UNREGISTERED:
+                info.instance_state = NOT_ALIVE_DISPOSED_INSTANCE_STATE;
+                info.valid_data = false;
+                break;
+            default:
+                //TODO [ILG] change this if the other kinds ever get implemented
+                info.instance_state = ALIVE_INSTANCE_STATE;
+                break;
+        }
+    }
+
+};
+
+} /* namespace detail */
+} /* namespace dds */
+} /* namespace fastdds */
+} /* namespace eprosima */
+
+#endif  // _FASTDDS_SUBSCRIBER_DATAREADERIMPL_READTAKECOMMAND_HPP_

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/Readme.md
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/Readme.md
@@ -1,0 +1,7 @@
+## Internal support classes for DataReaderImpl
+
+This folder contains the declaration of several internal support classes to improve
+maintenance and readability of the DataReaderImpl class.
+
+They are not meant to be used outside DataReaderImpl and their functionality should be
+fully covered by the unit tests of the DataReader(Impl).

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/SampleInfoPool.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/SampleInfoPool.hpp
@@ -1,0 +1,111 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file SampleInfoPool.hpp
+ */
+
+#ifndef _FASTDDS_SUBSCRIBER_DATAREADERIMPL_SAMPLEINFOPOOL_HPP_
+#define _FASTDDS_SUBSCRIBER_DATAREADERIMPL_SAMPLEINFOPOOL_HPP_
+
+#include <algorithm>
+#include <cassert>
+
+#include <fastdds/dds/core/LoanableCollection.hpp>
+#include <fastdds/dds/core/LoanableSequence.hpp>
+#include <fastdds/dds/subscriber/SampleInfo.hpp>
+#include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
+
+#include <fastrtps/types/TypesBase.h>
+#include <fastrtps/utils/collections/ResourceLimitedContainerConfig.hpp>
+#include <fastrtps/utils/collections/ResourceLimitedVector.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace detail {
+
+struct SampleInfoPool
+{
+    using ReturnCode_t = eprosima::fastrtps::types::ReturnCode_t;
+
+    explicit SampleInfoPool(
+            const DataReaderQos& qos)
+        : free_items_(qos.reader_resource_limits().sample_infos_allocation)
+        , used_items_(qos.reader_resource_limits().sample_infos_allocation)
+    {
+        for (size_t n = 0; n < qos.reader_resource_limits().sample_infos_allocation.initial; ++n)
+        {
+            free_items_.push_back(new SampleInfo());
+        }
+    }
+
+    ~SampleInfoPool()
+    {
+        for (SampleInfo* it : free_items_)
+        {
+            delete it;
+        }
+    }
+
+    size_t num_allocated()
+    {
+        return used_items_.size();
+    }
+
+    SampleInfo* get_item()
+    {
+        SampleInfo** result = nullptr;
+
+        if (free_items_.empty())
+        {
+            result = used_items_.push_back(new SampleInfo());
+        }
+        else
+        {
+            result = used_items_.push_back(free_items_.back());
+            static_cast<void>(result);
+            assert(result != nullptr);
+            free_items_.pop_back();
+        }
+
+        return result ? *result : nullptr;
+    }
+
+    void return_item(
+            SampleInfo* item)
+    {
+        bool removed = used_items_.remove(item);
+        static_cast<void>(removed);
+        assert(removed);
+
+        SampleInfo** result = free_items_.push_back(item);
+        static_cast<void>(result);
+        assert(result != nullptr);
+    }
+
+private:
+
+    using collection_type = eprosima::fastrtps::ResourceLimitedVector<SampleInfo*>;
+
+    collection_type free_items_;
+    collection_type used_items_;
+};
+
+} /* namespace detail */
+} /* namespace dds */
+} /* namespace fastdds */
+} /* namespace eprosima */
+
+#endif  // _FASTDDS_SUBSCRIBER_DATAREADERIMPL_SAMPLEINFOPOOL_HPP_

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/SampleLoanManager.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/SampleLoanManager.hpp
@@ -1,0 +1,258 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file SampleLoanManager.hpp
+ */
+
+#ifndef _FASTDDS_SUBSCRIBER_DATAREADERIMPL_SAMPLELOANMANAGER_HPP_
+#define _FASTDDS_SUBSCRIBER_DATAREADERIMPL_SAMPLELOANMANAGER_HPP_
+
+#include <algorithm>
+#include <cassert>
+
+#include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
+#include <fastdds/dds/topic/TypeSupport.hpp>
+
+#include <fastdds/rtps/common/CacheChange.h>
+#include <fastdds/rtps/common/SerializedPayload.h>
+#include <fastdds/rtps/history/IPayloadPool.h>
+
+#include <fastrtps/types/TypesBase.h>
+#include <fastrtps/utils/collections/ResourceLimitedContainerConfig.hpp>
+#include <fastrtps/utils/collections/ResourceLimitedVector.hpp>
+
+#include <rtps/history/PoolConfig.h>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace detail {
+
+struct SampleLoanManager
+{
+    using CacheChange_t = eprosima::fastrtps::rtps::CacheChange_t;
+    using IPayloadPool = eprosima::fastrtps::rtps::IPayloadPool;
+    using PoolConfig = eprosima::fastrtps::rtps::PoolConfig;
+    using ReturnCode_t = eprosima::fastrtps::types::ReturnCode_t;
+    using SampleIdentity = eprosima::fastrtps::rtps::SampleIdentity;
+    using SerializedPayload_t = eprosima::fastrtps::rtps::SerializedPayload_t;
+
+    SampleLoanManager(
+            const PoolConfig& pool_config,
+            const TypeSupport& type)
+        : limits_(pool_config.initial_size,
+                pool_config.maximum_size ? pool_config.maximum_size : std::numeric_limits<size_t>::max(),
+                1)
+        , free_loans_(limits_)
+        , used_loans_(limits_)
+        , type_(type)
+    {
+        for (size_t n = 0; n < limits_.initial; ++n)
+        {
+            OutstandingLoanItem item;
+            if (!type_->is_plain())
+            {
+                item.sample = type_->createData();
+            }
+            free_loans_.push_back(item);
+        }
+    }
+
+    ~SampleLoanManager()
+    {
+        if (!type_->is_plain())
+        {
+            for (const OutstandingLoanItem& item : free_loans_)
+            {
+                type_->deleteData(item.sample);
+            }
+        }
+    }
+
+    int32_t num_allocated() const
+    {
+        assert(used_loans_.size() <= static_cast<size_t>(std::numeric_limits<int32_t>::max()));
+        return static_cast<int32_t>(used_loans_.size());
+    }
+
+    void get_loan(
+            CacheChange_t* change,
+            void*& sample)
+    {
+        // Early return an already loaned item
+        OutstandingLoanItem* item = find_by_change(change);
+        if (nullptr != item)
+        {
+            item->num_refs += 1;
+            sample = item->sample;
+            return;
+        }
+
+        // Get an item from the pool
+        if (free_loans_.empty())
+        {
+            // Try to create a new entry
+            item = used_loans_.push_back({});
+            if (nullptr != item)
+            {
+                // Create sample if necessary
+                if (!type_->is_plain())
+                {
+                    item->sample = type_->createData();
+                }
+            }
+        }
+        else
+        {
+            // Reuse a free entry
+            item = used_loans_.push_back(free_loans_.back());
+            assert(nullptr != item);
+            free_loans_.pop_back();
+        }
+
+        // Should always find an entry, as resource limits are checked before calling this method
+        assert(nullptr != item);
+
+        // Should be the first time we loan this item
+        assert(item->num_refs == 0);
+
+        // Increment references of input payload
+        CacheChange_t tmp;
+        tmp.copy_not_memcpy(change);
+        item->owner = change->payload_owner();
+        change->payload_owner()->get_payload(change->serializedPayload, item->owner, tmp);
+        item->owner = tmp.payload_owner();
+        item->payload = tmp.serializedPayload;
+        tmp.payload_owner(nullptr);
+        tmp.serializedPayload.data = nullptr;
+
+        // Perform deserialization
+        if (type_->is_plain())
+        {
+            auto ptr = item->payload.data;
+            ptr += item->payload.representation_header_size;
+            item->sample = ptr;
+        }
+        else
+        {
+            type_->deserialize(&item->payload, item->sample);
+        }
+
+        // Increment reference counter and return sample
+        item->num_refs += 1;
+        sample = item->sample;
+    }
+
+    void return_loan(
+            void* sample)
+    {
+        OutstandingLoanItem* item = find_by_sample(sample);
+        assert(nullptr != item);
+
+        item->num_refs -= 1;
+        if (item->num_refs == 0)
+        {
+            CacheChange_t tmp;
+            tmp.payload_owner(item->owner);
+            tmp.serializedPayload = item->payload;
+            item->owner->release_payload(tmp);
+            item->payload.data = nullptr;
+            item->owner = nullptr;
+
+            item = free_loans_.push_back(*item);
+            assert(nullptr != item);
+            used_loans_.remove(*item);
+        }
+    }
+
+private:
+
+    struct OutstandingLoanItem
+    {
+        void* sample = nullptr;
+        SampleIdentity identity;
+        SerializedPayload_t payload;
+        IPayloadPool* owner = nullptr;
+        uint32_t num_refs = 0;
+
+        ~OutstandingLoanItem()
+        {
+            payload.data = nullptr;
+        }
+
+        OutstandingLoanItem() = default;
+        OutstandingLoanItem(
+                const OutstandingLoanItem&) = default;
+        OutstandingLoanItem& operator =(
+                const OutstandingLoanItem&) = default;
+        OutstandingLoanItem(
+                OutstandingLoanItem&&) = default;
+        OutstandingLoanItem& operator =(
+                OutstandingLoanItem&&) = default;
+
+        bool operator == (
+                const OutstandingLoanItem& other) const
+        {
+            return other.sample == sample && other.payload.data == payload.data;
+        }
+
+    };
+
+    using collection_type = eprosima::fastrtps::ResourceLimitedVector<OutstandingLoanItem>;
+
+    eprosima::fastrtps::ResourceLimitedContainerConfig limits_;
+    collection_type free_loans_;
+    collection_type used_loans_;
+    TypeSupport type_;
+
+    OutstandingLoanItem* find_by_change(
+            CacheChange_t* change)
+    {
+        SampleIdentity id;
+        id.writer_guid(change->writerGUID);
+        id.sequence_number(change->sequenceNumber);
+
+        auto comp = [id](const OutstandingLoanItem& item)
+                {
+                    return id == item.identity;
+                };
+        auto it = std::find_if(used_loans_.begin(), used_loans_.end(), comp);
+        if (it != used_loans_.end())
+        {
+            return &(*it);
+        }
+        return nullptr;
+    }
+
+    OutstandingLoanItem* find_by_sample(
+            void* sample)
+    {
+        auto comp = [sample](const OutstandingLoanItem& item)
+                {
+                    return sample == item.sample;
+                };
+        auto it = std::find_if(used_loans_.begin(), used_loans_.end(), comp);
+        assert(it != used_loans_.end());
+        return &(*it);
+    }
+
+};
+
+} /* namespace detail */
+} /* namespace dds */
+} /* namespace fastdds */
+} /* namespace eprosima */
+
+#endif  // _FASTDDS_SUBSCRIBER_DATAREADERIMPL_SAMPLELOANMANAGER_HPP_

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/StateFilter.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/StateFilter.hpp
@@ -1,0 +1,43 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file StateFilter.hpp
+ */
+
+#ifndef _FASTDDS_SUBSCRIBER_DATAREADERIMPL_STATEFILTER_HPP_
+#define _FASTDDS_SUBSCRIBER_DATAREADERIMPL_STATEFILTER_HPP_
+
+#include <fastdds/dds/subscriber/InstanceState.hpp>
+#include <fastdds/dds/subscriber/SampleState.hpp>
+#include <fastdds/dds/subscriber/ViewState.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace detail {
+
+struct StateFilter
+{
+    SampleStateMask sample_states;
+    ViewStateMask view_states;
+    InstanceStateMask instance_states;
+};
+
+} /* namespace detail */
+} /* namespace dds */
+} /* namespace fastdds */
+} /* namespace eprosima */
+
+#endif  // _FASTDDS_SUBSCRIBER_DATAREADERIMPL_STATEFILTER_HPP_

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -286,6 +286,11 @@ ReturnCode_t SubscriberImpl::delete_datareader(
         {
             //First extract the reader from the maps to free the mutex
             DataReaderImpl* reader_impl = *dr_it;
+            if (!reader_impl->can_be_deleted())
+            {
+                return ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;
+            }
+
             reader_impl->set_listener(nullptr);
             it->second.erase(dr_it);
             if (it->second.empty())

--- a/src/cpp/fastdds/topic/TypeSupport.cpp
+++ b/src/cpp/fastdds/topic/TypeSupport.cpp
@@ -20,7 +20,11 @@
 #include <fastdds/dds/topic/TypeSupport.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 
-using namespace eprosima::fastdds::dds;
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+
+const InstanceHandle_t HANDLE_NIL;
 
 ReturnCode_t TypeSupport::register_type(
         DomainParticipant* participant,
@@ -34,3 +38,7 @@ ReturnCode_t TypeSupport::register_type(
 {
     return participant->register_type(*this, get_type_name());
 }
+
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -572,5 +572,53 @@ bool SubscriberHistory::get_next_deadline(
     return false;
 }
 
+std::pair<bool, SubscriberHistory::instance_info> SubscriberHistory::lookup_instance(
+        const InstanceHandle_t& handle,
+        bool exact)
+{
+    if (topic_att_.getTopicKind() == NO_KEY)
+    {
+        if (handle.isDefined())
+        {
+            if (exact)
+            {
+                return {true, { handle, &m_changes }};
+            }
+            return { false, {InstanceHandle_t(), nullptr} };
+        }
+        else
+        {
+            if (exact)
+            {
+                return { false, {InstanceHandle_t(), nullptr} };
+            }
+            InstanceHandle_t tmp;
+            tmp.value[0] = 1;
+            return { true, {tmp, &m_changes} };
+        }
+    }
+
+    t_m_Inst_Caches::iterator it;
+
+    if (exact)
+    {
+        it = keyed_changes_.find(handle);
+    }
+    else
+    {
+        auto comp = [](const InstanceHandle_t& h, const std::pair<InstanceHandle_t, KeyedChanges>& it)
+                {
+                    return h < it.first;
+                };
+        it = std::upper_bound(keyed_changes_.begin(), keyed_changes_.end(), handle, comp);
+    }
+
+    if (it != keyed_changes_.end())
+    {
+        return { true, {it->first, &(it->second.cache_changes)} };
+    }
+    return { false, {InstanceHandle_t(), nullptr} };
+}
+
 } // namespace fastrtps
 } // namsepace eprosima

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -580,18 +580,22 @@ std::pair<bool, SubscriberHistory::instance_info> SubscriberHistory::lookup_inst
     {
         if (handle.isDefined())
         {
-            if (exact)
-            {
-                return {true, { handle, &m_changes }};
-            }
+            // NO_KEY topics can only return the ficticious instance.
+            // Execution can only get here for two reasons:
+            // - Looking for a specific instance (exact = true)
+            // - Looking for the next instance to the ficticious one (exact = false)
+            // In both cases, no instance should be returned
             return { false, {InstanceHandle_t(), nullptr} };
         }
         else
         {
             if (exact)
             {
+                // Looking for HANDLE_NIL, nothing to return
                 return { false, {InstanceHandle_t(), nullptr} };
             }
+
+            // Looking for the first instance, return the ficticious one containing all changes
             InstanceHandle_t tmp;
             tmp.value[0] = 1;
             return { true, {tmp, &m_changes} };

--- a/test/unittest/dds/collections/LoanableSequenceTests.cpp
+++ b/test/unittest/dds/collections/LoanableSequenceTests.cpp
@@ -96,8 +96,8 @@ TEST(LoanableSequenceTests, construct)
         TestSeq uut;
         EXPECT_EQ(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(0u, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.maximum());
+        EXPECT_EQ(0, uut.length());
     }
 
     // Check post-conditions of constructor with maximum
@@ -106,16 +106,25 @@ TEST(LoanableSequenceTests, construct)
         EXPECT_NE(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
         EXPECT_EQ(num_test_elements, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.length());
     }
 
     // Check maximum of 0 behaves as default
     {
-        TestSeq uut(0u);
+        TestSeq uut(0);
         EXPECT_EQ(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(0u, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.maximum());
+        EXPECT_EQ(0, uut.length());
+    }
+
+    // Check negative maximum behaves as default
+    {
+        TestSeq uut(-100);
+        EXPECT_EQ(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_EQ(0, uut.maximum());
+        EXPECT_EQ(0, uut.length());
     }
 
     // Check stack-allocated behaves as TestSeq costructed with maximum
@@ -124,10 +133,10 @@ TEST(LoanableSequenceTests, construct)
         EXPECT_NE(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
         EXPECT_EQ(num_test_elements, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.length());
 
         // Trying to grow beyond maximum will throw
-        EXPECT_THROW(uut.length(uut.maximum() + 1u), std::bad_alloc);
+        EXPECT_THROW(uut.length(uut.maximum() + 1), std::bad_alloc);
     }
 }
 
@@ -147,8 +156,8 @@ TEST(LoanableSequenceTests, copy_construct)
         TestSeq uut(empty);
         EXPECT_EQ(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(0u, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.maximum());
+        EXPECT_EQ(0, uut.length());
     }
 
     // Copy-constructing an empty allocated sequence behaves as default constructor
@@ -156,8 +165,8 @@ TEST(LoanableSequenceTests, copy_construct)
         TestSeq uut(owned);
         EXPECT_EQ(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(0u, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.maximum());
+        EXPECT_EQ(0, uut.length());
     }
 
     // Copy-constructing an empty loaned sequence behaves as default constructor
@@ -165,8 +174,8 @@ TEST(LoanableSequenceTests, copy_construct)
         TestSeq uut(loaned);
         EXPECT_EQ(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(0u, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.maximum());
+        EXPECT_EQ(0, uut.length());
     }
 
     // Give length and values to sequences
@@ -194,9 +203,9 @@ TEST(LoanableSequenceTests, copy_construct)
     }
 
     // Reduce length of sequences
-    EXPECT_TRUE(owned.length(1u));
+    EXPECT_TRUE(owned.length(1));
     EXPECT_GT(owned.maximum(), owned.length());
-    EXPECT_TRUE(loaned.length(1u));
+    EXPECT_TRUE(loaned.length(1));
     EXPECT_GT(loaned.maximum(), loaned.length());
 
     // Copy-constructing a non-empty allocated sequence with max > len allocates and copies
@@ -205,8 +214,8 @@ TEST(LoanableSequenceTests, copy_construct)
         EXPECT_NE(nullptr, uut.buffer());
         EXPECT_NE(owned.buffer(), uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(1u, uut.maximum());
-        check_result(uut, 1u);
+        EXPECT_EQ(1, uut.maximum());
+        check_result(uut, 1);
     }
 
     // Copy-constructing a non-empty loaned sequence with max > len allocates and copies
@@ -215,8 +224,8 @@ TEST(LoanableSequenceTests, copy_construct)
         EXPECT_NE(nullptr, uut.buffer());
         EXPECT_NE(loaned.buffer(), uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(1u, uut.maximum());
-        check_result(uut, 1u);
+        EXPECT_EQ(1, uut.maximum());
+        check_result(uut, 1);
     }
 
     // Return loan to avoid warning on destructor
@@ -239,8 +248,8 @@ TEST(LoanableSequenceTests, copy_assign)
         TestSeq uut = empty;
         EXPECT_EQ(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(0u, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.maximum());
+        EXPECT_EQ(0, uut.length());
     }
 
     // Copying an empty allocated sequence behaves as default constructor
@@ -248,8 +257,8 @@ TEST(LoanableSequenceTests, copy_assign)
         TestSeq uut = owned;
         EXPECT_EQ(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(0u, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.maximum());
+        EXPECT_EQ(0, uut.length());
     }
 
     // Copying an empty loaned sequence behaves as default constructor
@@ -257,8 +266,8 @@ TEST(LoanableSequenceTests, copy_assign)
         TestSeq uut = loaned;
         EXPECT_EQ(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(0u, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.maximum());
+        EXPECT_EQ(0, uut.length());
     }
 
     // Give length and values to sequences
@@ -286,9 +295,9 @@ TEST(LoanableSequenceTests, copy_assign)
     }
 
     // Reduce length of sequences
-    EXPECT_TRUE(owned.length(1u));
+    EXPECT_TRUE(owned.length(1));
     EXPECT_GT(owned.maximum(), owned.length());
-    EXPECT_TRUE(loaned.length(1u));
+    EXPECT_TRUE(loaned.length(1));
     EXPECT_GT(loaned.maximum(), loaned.length());
 
     // Copying a non-empty allocated sequence with max > len allocates and copies
@@ -297,8 +306,8 @@ TEST(LoanableSequenceTests, copy_assign)
         EXPECT_NE(nullptr, uut.buffer());
         EXPECT_NE(owned.buffer(), uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(1u, uut.maximum());
-        check_result(uut, 1u);
+        EXPECT_EQ(1, uut.maximum());
+        check_result(uut, 1);
     }
 
     // Copying a non-empty loaned sequence with max > len allocates and copies
@@ -307,8 +316,8 @@ TEST(LoanableSequenceTests, copy_assign)
         EXPECT_NE(nullptr, uut.buffer());
         EXPECT_NE(loaned.buffer(), uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(1u, uut.maximum());
-        check_result(uut, 1u);
+        EXPECT_EQ(1, uut.maximum());
+        check_result(uut, 1);
     }
 
     // Copying loaned into allocated changes length
@@ -322,13 +331,13 @@ TEST(LoanableSequenceTests, copy_assign)
     check_result(owned, num_test_elements);
 
     // Copying allocated into loaned releases loan
-    EXPECT_TRUE(owned.length(1u));
+    EXPECT_TRUE(owned.length(1));
     loaned = owned;
     EXPECT_EQ(loaned.length(), owned.length());
     EXPECT_NE(loaned.buffer(), owned.buffer());
     EXPECT_TRUE(loaned.has_ownership());
-    EXPECT_EQ(1u, loaned.maximum());
-    check_result(loaned, 1u);
+    EXPECT_EQ(1, loaned.maximum());
+    check_result(loaned, 1);
 
     // Copying a bigger collection makes collection grow
     EXPECT_TRUE(owned.length(num_test_elements));
@@ -340,10 +349,145 @@ TEST(LoanableSequenceTests, copy_assign)
     check_result(loaned, num_test_elements);
 }
 
+TEST(LoanableSequenceTests, length)
+{
+    // Checks on default constructed sequence
+    {
+        TestSeq uut;
+        EXPECT_EQ(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_EQ(0, uut.maximum());
+        EXPECT_EQ(0, uut.length());
+
+        // Positive should grow collection
+        EXPECT_TRUE(uut.length(num_test_elements));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(num_test_elements, uut.length());
+
+        // Negative should fail
+        EXPECT_FALSE(uut.length(-100));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(num_test_elements, uut.length());
+
+        // Decreasing should not shrink
+        EXPECT_TRUE(uut.length(1));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(1, uut.length());
+    }
+
+    // Checks on sequence constructed with maximum
+    {
+        TestSeq uut(1);
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_LE(1, uut.maximum());
+        EXPECT_EQ(0, uut.length());
+
+        // Positive should grow collection
+        EXPECT_TRUE(uut.length(num_test_elements));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(num_test_elements, uut.length());
+
+        // Negative should fail
+        EXPECT_FALSE(uut.length(-100));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(num_test_elements, uut.length());
+
+        // Decreasing should not shrink
+        EXPECT_TRUE(uut.length(1));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(1, uut.length());
+    }
+
+    // Checks on stack-allocated sequence
+    {
+        StackAllocatedSeq uut;
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(0, uut.length());
+
+        // Positive should be ok
+        EXPECT_TRUE(uut.length(num_test_elements));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(num_test_elements, uut.length());
+
+        // Negative should fail
+        EXPECT_FALSE(uut.length(-100));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(num_test_elements, uut.length());
+
+        // Decreasing should not shrink
+        EXPECT_TRUE(uut.length(1));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_TRUE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(1, uut.length());
+    }
+
+    // Checks on loaned sequence
+    {
+        StackAllocatedBuffer<int> stack;
+        TestSeq uut;
+        uut.loan(stack.buffer_for_loans(), stack.size(), 0);
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_FALSE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(0, uut.length());
+
+        // Positive should be ok
+        EXPECT_TRUE(uut.length(num_test_elements));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_FALSE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(num_test_elements, uut.length());
+
+        // Negative should fail
+        EXPECT_FALSE(uut.length(-100));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_FALSE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(num_test_elements, uut.length());
+
+        // Growing should fail
+        EXPECT_FALSE(uut.length(num_test_elements + 1));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_FALSE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(num_test_elements, uut.length());
+
+        // Decreasing should be ok
+        EXPECT_TRUE(uut.length(1));
+        EXPECT_NE(nullptr, uut.buffer());
+        EXPECT_FALSE(uut.has_ownership());
+        EXPECT_LE(num_test_elements, uut.maximum());
+        EXPECT_EQ(1, uut.length());
+
+        // Return loan
+        uut.unloan();
+    }
+}
+
 TEST(LoanableSequenceTests, loan_unloan)
 {
     StackAllocatedBuffer<int> stack;
-    test_size_type max = 0u, len = 0u;
+    test_size_type max = 0, len = 0;
     void** result_buffer;
 
     {
@@ -351,8 +495,8 @@ TEST(LoanableSequenceTests, loan_unloan)
         TestSeq uut;
         EXPECT_EQ(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(0u, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.maximum());
+        EXPECT_EQ(0, uut.length());
 
         // Check that loan cannot be returned
         EXPECT_EQ(nullptr, uut.unloan());
@@ -370,7 +514,7 @@ TEST(LoanableSequenceTests, loan_unloan)
         EXPECT_EQ(nullptr, uut.unloan(max, len));
 
         // Check that loan cannot be performed
-        EXPECT_FALSE(uut.loan(stack.buffer_for_loans(), num_test_elements, 0u));
+        EXPECT_FALSE(uut.loan(stack.buffer_for_loans(), num_test_elements, 0));
     }
 
     {
@@ -379,14 +523,14 @@ TEST(LoanableSequenceTests, loan_unloan)
         EXPECT_NE(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
         EXPECT_EQ(num_test_elements, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.length());
 
         // Check that loan cannot be returned
         EXPECT_EQ(nullptr, uut.unloan());
         EXPECT_EQ(nullptr, uut.unloan(max, len));
 
         // Check that loan cannot be performed
-        EXPECT_FALSE(uut.loan(stack.buffer_for_loans(), num_test_elements, 0u));
+        EXPECT_FALSE(uut.loan(stack.buffer_for_loans(), num_test_elements, 0));
     }
 
     {
@@ -395,14 +539,14 @@ TEST(LoanableSequenceTests, loan_unloan)
         EXPECT_NE(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
         EXPECT_EQ(num_test_elements, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.length());
 
         // Check that loan cannot be returned
         EXPECT_EQ(nullptr, uut.unloan());
         EXPECT_EQ(nullptr, uut.unloan(max, len));
 
         // Check that loan cannot be performed
-        EXPECT_FALSE(uut.loan(stack.buffer_for_loans(), num_test_elements, 0u));
+        EXPECT_FALSE(uut.loan(stack.buffer_for_loans(), num_test_elements, 0));
     }
 
     // Note: When uut is deleted upon exiting its scope, a warning log will be produced.
@@ -445,7 +589,7 @@ TEST(LoanableSequenceTests, loan_unloan)
         EXPECT_TRUE(uut.loan(stack.buffer_for_loans(), num_test_elements, 0));
         EXPECT_FALSE(uut.has_ownership());
         EXPECT_EQ(num_test_elements, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.length());
         EXPECT_EQ(stack.buffer_for_loans(), uut.buffer());
         EXPECT_TRUE(uut.length(num_test_elements));
         EXPECT_EQ(num_test_elements, uut.length());
@@ -459,14 +603,14 @@ TEST(LoanableSequenceTests, loan_unloan)
         // Check unloan postconditions
         EXPECT_EQ(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(0u, uut.length());
-        EXPECT_EQ(0u, uut.maximum());
+        EXPECT_EQ(0, uut.length());
+        EXPECT_EQ(0, uut.maximum());
 
         // Loan again
         EXPECT_TRUE(uut.loan(stack.buffer_for_loans(), num_test_elements, 0));
         EXPECT_FALSE(uut.has_ownership());
         EXPECT_EQ(num_test_elements, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.length());
         EXPECT_EQ(stack.buffer_for_loans(), uut.buffer());
 
         // Check other version of unloan
@@ -478,19 +622,19 @@ TEST(LoanableSequenceTests, loan_unloan)
         // Check unloan postconditions
         EXPECT_EQ(nullptr, uut.buffer());
         EXPECT_TRUE(uut.has_ownership());
-        EXPECT_EQ(0u, uut.length());
-        EXPECT_EQ(0u, uut.maximum());
+        EXPECT_EQ(0, uut.length());
+        EXPECT_EQ(0, uut.maximum());
 
         // Check with wrong parameters
-        EXPECT_FALSE(uut.loan(stack.buffer_for_loans(), 0u, 0u));
-        EXPECT_FALSE(uut.loan(stack.buffer_for_loans(), 1u, 2u));
-        EXPECT_FALSE(uut.loan(nullptr, 1u, 1u));
+        EXPECT_FALSE(uut.loan(stack.buffer_for_loans(), 0, 0));
+        EXPECT_FALSE(uut.loan(stack.buffer_for_loans(), 1, 2u));
+        EXPECT_FALSE(uut.loan(nullptr, 1, 1));
 
         // Check that we can loan more than once
-        EXPECT_TRUE(uut.loan(stack.buffer_for_loans(), num_test_elements, 0u));
+        EXPECT_TRUE(uut.loan(stack.buffer_for_loans(), num_test_elements, 0));
         EXPECT_FALSE(uut.has_ownership());
         EXPECT_EQ(num_test_elements, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(0, uut.length());
         EXPECT_EQ(stack.buffer_for_loans(), uut.buffer());
         EXPECT_TRUE(uut.loan(stack.buffer_for_loans(), num_test_elements, num_test_elements));
         EXPECT_FALSE(uut.has_ownership());
@@ -499,19 +643,19 @@ TEST(LoanableSequenceTests, loan_unloan)
         EXPECT_EQ(stack.buffer_for_loans(), uut.buffer());
 
         // Now loan a different buffer
-        StackAllocatedBuffer<int, 1u> stack2;
-        EXPECT_TRUE(uut.loan(stack2.buffer_for_loans(), 1u, 0u));
+        StackAllocatedBuffer<int, 1> stack2;
+        EXPECT_TRUE(uut.loan(stack2.buffer_for_loans(), 1, 0));
         EXPECT_FALSE(uut.has_ownership());
-        EXPECT_EQ(1u, uut.maximum());
-        EXPECT_EQ(0u, uut.length());
+        EXPECT_EQ(1, uut.maximum());
+        EXPECT_EQ(0, uut.length());
         EXPECT_EQ(stack2.buffer_for_loans(), uut.buffer());
 
         // Check that loaned buffer cannot grow above maximum
-        EXPECT_TRUE(uut.length(1u));
+        EXPECT_TRUE(uut.length(1));
         EXPECT_FALSE(uut.length(10u));
         EXPECT_FALSE(uut.has_ownership());
-        EXPECT_EQ(1u, uut.maximum());
-        EXPECT_EQ(1u, uut.length());
+        EXPECT_EQ(1, uut.maximum());
+        EXPECT_EQ(1, uut.length());
         EXPECT_EQ(stack2.buffer_for_loans(), uut.buffer());
     }
 
@@ -628,7 +772,7 @@ TEST(LoanableSequenceTests, sum_collections)
         EXPECT_TRUE(result.loan(stack.buffer_for_loans(), num_test_elements, 0));
         EXPECT_FALSE(result.has_ownership());
         EXPECT_EQ(num_test_elements, result.maximum());
-        EXPECT_EQ(0u, result.length());
+        EXPECT_EQ(0, result.length());
         EXPECT_EQ(stack.buffer_for_loans(), result.buffer());
 
         // Test increasing length and accessors
@@ -648,8 +792,8 @@ TEST(LoanableSequenceTests, sum_collections)
         // Check unloan postconditions
         EXPECT_EQ(nullptr, result.buffer());
         EXPECT_TRUE(result.has_ownership());
-        EXPECT_EQ(0u, result.length());
-        EXPECT_EQ(0u, result.maximum());
+        EXPECT_EQ(0, result.length());
+        EXPECT_EQ(0, result.maximum());
     }
 }
 

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -12,152 +12,828 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cassert>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <fastcdr/Cdr.h>
+
+#include <fastdds/dds/core/LoanableArray.hpp>
+#include <fastdds/dds/core/StackAllocatedSequence.hpp>
+
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
-#include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
-#include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
-#include <dds/domain/DomainParticipant.hpp>
-#include <dds/core/types.hpp>
-#include <fastdds/dds/subscriber/Subscriber.hpp>
+
+#include <fastdds/dds/publisher/DataWriter.hpp>
+#include <fastdds/dds/publisher/Publisher.hpp>
+#include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
+#include <fastdds/dds/publisher/qos/PublisherQos.hpp>
+
+#include <fastdds/dds/subscriber/DataReader.hpp>
 #include <fastdds/dds/subscriber/DataReaderListener.hpp>
+#include <fastdds/dds/subscriber/Subscriber.hpp>
 #include <fastdds/dds/subscriber/SampleInfo.hpp>
-#include <dds/sub/Subscriber.hpp>
-#include <dds/sub/DataReader.hpp>
-#include <dds/sub/qos/DataReaderQos.hpp>
-#include <dds/topic/Topic.hpp>
+#include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
+#include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
 
-#include <fastrtps/rtps/history/ReaderHistory.h>
-#include <fastrtps/attributes/PublisherAttributes.h>
-#include <fastrtps/attributes/SubscriberAttributes.h>
-#include <fastrtps/xmlparser/XMLProfileManager.h>
-
+#include "./FooType.hpp"
+#include "./FooTypeSupport.hpp"
 
 namespace eprosima {
 namespace fastdds {
 namespace dds {
 
-using fastrtps::PublisherAttributes;
-using fastrtps::SubscriberAttributes;
-using fastrtps::xmlparser::XMLProfileManager;
-using fastrtps::xmlparser::XMLP_ret;
+static constexpr LoanableCollection::size_type num_test_elements = 10u;
 
+FASTDDS_SEQUENCE(FooSeq, FooType);
+using FooArray = LoanableArray<FooType, num_test_elements>;
+using FooStack = StackAllocatedSequence<FooType, num_test_elements>;
+using SampleInfoArray = LoanableArray<SampleInfo, num_test_elements>;
 
-class FooType
+class DataReaderTests : public ::testing::Test
 {
 public:
 
-    FooType()
+    void SetUp() override
     {
+        type_.reset(new FooTypeSupport());
     }
 
-    ~FooType()
+    void TearDown() override
     {
+        if (data_writer_)
+        {
+            ASSERT_EQ(publisher_->delete_datawriter(data_writer_), ReturnCode_t::RETCODE_OK);
+        }
+        if (data_reader_)
+        {
+            ASSERT_EQ(subscriber_->delete_datareader(data_reader_), ReturnCode_t::RETCODE_OK);
+        }
+        if (topic_)
+        {
+            ASSERT_EQ(participant_->delete_topic(topic_), ReturnCode_t::RETCODE_OK);
+        }
+        if (publisher_)
+        {
+            ASSERT_EQ(participant_->delete_publisher(publisher_), ReturnCode_t::RETCODE_OK);
+        }
+        if (subscriber_)
+        {
+            ASSERT_EQ(participant_->delete_subscriber(subscriber_), ReturnCode_t::RETCODE_OK);
+        }
+        if (participant_)
+        {
+            auto factory = DomainParticipantFactory::get_instance();
+            ASSERT_EQ(factory->delete_participant(participant_), ReturnCode_t::RETCODE_OK);
+        }
     }
 
-    inline std::string& message()
+protected:
+
+    void create_entities(
+            DataReaderListener* rlistener = nullptr,
+            const DataReaderQos& rqos = DATAREADER_QOS_DEFAULT,
+            const SubscriberQos& sqos = SUBSCRIBER_QOS_DEFAULT,
+            const DataWriterQos& wqos = DATAWRITER_QOS_DEFAULT,
+            const PublisherQos& pqos = PUBLISHER_QOS_DEFAULT,
+            const TopicQos& tqos = TOPIC_QOS_DEFAULT,
+            const DomainParticipantQos& part_qos = PARTICIPANT_QOS_DEFAULT)
     {
-        return message_;
+        participant_ = DomainParticipantFactory::get_instance()->create_participant(0, part_qos);
+        ASSERT_NE(participant_, nullptr);
+
+        subscriber_ = participant_->create_subscriber(sqos);
+        ASSERT_NE(subscriber_, nullptr);
+
+        publisher_ = participant_->create_publisher(pqos);
+        ASSERT_NE(publisher_, nullptr);
+
+        type_.register_type(participant_);
+
+        topic_ = participant_->create_topic("footopic", type_.get_type_name(), tqos);
+        ASSERT_NE(topic_, nullptr);
+
+        data_reader_ = subscriber_->create_datareader(topic_, rqos, rlistener);
+        ASSERT_NE(data_reader_, nullptr);
+
+        data_writer_ = publisher_->create_datawriter(topic_, wqos);
+        ASSERT_NE(data_reader_, nullptr);
     }
 
-    inline void message(
-            const std::string& message)
+    void create_instance_handles()
     {
-        message_ = message;
+        FooType data;
+
+        data.index(1);
+        type_.get_key(&data, &handle_ok_);
+
+        data.index(2);
+        type_.get_key(&data, &handle_wrong_);
     }
 
-    bool isKeyDefined()
+    void reset_lengths(
+            LoanableCollection& data_values,
+            SampleInfoSeq& infos)
     {
-        return false;
+        data_values.length(0u);
+        infos.length(0u);
     }
 
-private:
+    void send_data(
+            LoanableCollection& data_values,
+            SampleInfoSeq& infos)
+    {
+        LoanableCollection::size_type n = infos.length();
+        auto buffer = data_values.buffer();
+        for (LoanableCollection::size_type i = 0u; i < n; ++i)
+        {
+            if (infos[i].valid_data)
+            {
+                EXPECT_EQ(ReturnCode_t::RETCODE_OK, data_writer_->write(buffer[i], HANDLE_NIL));
+            }
+        }
+    }
 
-    std::string message_;
+    void check_return_loan(
+            const ReturnCode_t& code,
+            DataReader* data_reader,
+            LoanableCollection& data_values,
+            SampleInfoSeq& infos)
+    {
+        ReturnCode_t expected_return_loan_ret = code;
+        if (ReturnCode_t::RETCODE_NO_DATA == code)
+        {
+            // When read returns NO_DATA, no loan will be performed
+            expected_return_loan_ret = ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;
+        }
+        EXPECT_EQ(expected_return_loan_ret, data_reader->return_loan(data_values, infos));
+
+        if (ReturnCode_t::RETCODE_OK == expected_return_loan_ret)
+        {
+            EXPECT_TRUE(data_values.has_ownership());
+            EXPECT_EQ(0u, data_values.maximum());
+            EXPECT_TRUE(infos.has_ownership());
+            EXPECT_EQ(0u, infos.maximum());
+        }
+    }
+
+    void check_instance_methods(
+            const ReturnCode_t& instance_ok_code,
+            const ReturnCode_t& instance_bad_code,
+            const ReturnCode_t& loan_return_code,
+            DataReader* data_reader,
+            LoanableCollection& data_values,
+            SampleInfoSeq& infos)
+    {
+        ReturnCode_t wrong_loan_code = ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;
+        if (ReturnCode_t::RETCODE_NOT_ENABLED == instance_bad_code)
+        {
+            wrong_loan_code = instance_bad_code;
+        }
+
+        EXPECT_EQ(instance_bad_code, data_reader->read_instance(data_values, infos, LENGTH_UNLIMITED, HANDLE_NIL));
+        check_return_loan(wrong_loan_code, data_reader, data_values, infos);
+        EXPECT_EQ(instance_bad_code, data_reader->read_instance(data_values, infos, LENGTH_UNLIMITED, handle_wrong_));
+        check_return_loan(wrong_loan_code, data_reader, data_values, infos);
+        EXPECT_EQ(instance_bad_code, data_reader->take_instance(data_values, infos, LENGTH_UNLIMITED, HANDLE_NIL));
+        check_return_loan(wrong_loan_code, data_reader, data_values, infos);
+        EXPECT_EQ(instance_bad_code, data_reader->take_instance(data_values, infos, LENGTH_UNLIMITED, handle_wrong_));
+        check_return_loan(wrong_loan_code, data_reader, data_values, infos);
+
+        EXPECT_EQ(instance_ok_code, data_reader->read_instance(data_values, infos, LENGTH_UNLIMITED, handle_ok_));
+        check_return_loan(loan_return_code, data_reader, data_values, infos);
+        reset_lengths(data_values, infos);
+
+        EXPECT_EQ(instance_ok_code, data_reader->take_instance(data_values, infos, LENGTH_UNLIMITED, handle_ok_));
+        if (ReturnCode_t::RETCODE_OK == instance_ok_code)
+        {
+            // Write received data so it can be taken again
+            send_data(data_values, infos);
+        }
+        check_return_loan(loan_return_code, data_reader, data_values, infos);
+        reset_lengths(data_values, infos);
+    }
+
+    void basic_read_apis_check(
+            const ReturnCode_t& code,
+            DataReader* data_reader)
+    {
+        static const Duration_t time_to_wait(1, 0);
+
+        // Check read_next_sample / take_next_sample
+        {
+            FooType data;
+            SampleInfo info;
+
+            EXPECT_EQ(code, data_reader->read_next_sample(&data, &info));
+            EXPECT_EQ(code, data_reader->take_next_sample(&data, &info));
+            if (ReturnCode_t::RETCODE_OK == code)
+            {
+                // Send taken sample so it can be read again
+                data_writer_->write(&data);
+                data_reader->wait_for_unread_message(time_to_wait);
+            }
+        }
+
+        // Return code when requesting a bad instance
+        ReturnCode_t instance_bad_code = ReturnCode_t::RETCODE_BAD_PARAMETER;
+        if (ReturnCode_t::RETCODE_NOT_ENABLED == code)
+        {
+            instance_bad_code = code;
+        }
+
+        // Return code when requesting a correct instance
+        ReturnCode_t instance_ok_code = instance_bad_code;
+        if (ReturnCode_t::RETCODE_OK == code)
+        {
+            instance_ok_code = code;
+        }
+
+        // Check read/take and variants with loan
+        {
+            FooSeq data_values;
+            SampleInfoSeq infos;
+
+            EXPECT_EQ(code, data_reader->read(data_values, infos));
+            check_return_loan(code, data_reader, data_values, infos);
+            reset_lengths(data_values, infos);
+            EXPECT_EQ(code, data_reader->read_next_instance(data_values, infos));
+            check_return_loan(code, data_reader, data_values, infos);
+            reset_lengths(data_values, infos);
+
+            EXPECT_EQ(code, data_reader->take(data_values, infos));
+            if (ReturnCode_t::RETCODE_OK == code)
+            {
+                send_data(data_values, infos);
+                data_reader->wait_for_unread_message(time_to_wait);
+            }
+            check_return_loan(code, data_reader, data_values, infos);
+            reset_lengths(data_values, infos);
+
+            EXPECT_EQ(code, data_reader->take_next_instance(data_values, infos));
+            if (ReturnCode_t::RETCODE_OK == code)
+            {
+                send_data(data_values, infos);
+                data_reader->wait_for_unread_message(time_to_wait);
+            }
+            check_return_loan(code, data_reader, data_values, infos);
+            reset_lengths(data_values, infos);
+
+            check_instance_methods(instance_ok_code, instance_bad_code, instance_ok_code,
+                    data_reader, data_values, infos);
+        }
+
+        // Check read/take and variants without loan
+        {
+            FooSeq data_values(1u);
+            SampleInfoSeq infos(1u);
+
+            ReturnCode_t expected_return_loan_ret = code;
+            if (ReturnCode_t::RETCODE_OK == code)
+            {
+                // Even when read returns data, no loan will be performed
+                expected_return_loan_ret = ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;
+            }
+
+            EXPECT_EQ(code, data_reader->read(data_values, infos));
+            check_return_loan(expected_return_loan_ret, data_reader, data_values, infos);
+            reset_lengths(data_values, infos);
+            EXPECT_EQ(code, data_reader->read_next_instance(data_values, infos));
+            check_return_loan(expected_return_loan_ret, data_reader, data_values, infos);
+            reset_lengths(data_values, infos);
+
+            EXPECT_EQ(code, data_reader->take(data_values, infos));
+            if (ReturnCode_t::RETCODE_OK == code)
+            {
+                send_data(data_values, infos);
+                data_reader->wait_for_unread_message(time_to_wait);
+            }
+            check_return_loan(expected_return_loan_ret, data_reader, data_values, infos);
+            reset_lengths(data_values, infos);
+
+            EXPECT_EQ(code, data_reader->take_next_instance(data_values, infos));
+            if (ReturnCode_t::RETCODE_OK == code)
+            {
+                send_data(data_values, infos);
+                data_reader->wait_for_unread_message(time_to_wait);
+            }
+            check_return_loan(expected_return_loan_ret, data_reader, data_values, infos);
+            reset_lengths(data_values, infos);
+
+            check_instance_methods(instance_ok_code, instance_bad_code, expected_return_loan_ret,
+                    data_reader, data_values, infos);
+        }
+    }
+
+    DomainParticipant* participant_ = nullptr;
+    Subscriber* subscriber_ = nullptr;
+    Publisher* publisher_ = nullptr;
+    Topic* topic_ = nullptr;
+    DataReader* data_reader_ = nullptr;
+    DataWriter* data_writer_ = nullptr;
+    TypeSupport type_;
+
+    InstanceHandle_t handle_ok_ = HANDLE_NIL;
+    InstanceHandle_t handle_wrong_ = HANDLE_NIL;
+
 };
 
-class TopicDataTypeMock : public TopicDataType
+/*
+ * This test checks all variants of read / take in several situations.
+ *
+ * The APIs tested are:
+ * - read_next_sample / take_next_sample
+ * - read / take
+ * - read_next_instance / take_next_instance
+ * - read_instance / take_instance
+ * - return_loan
+ *
+ * The test checks that:
+ * - Calling the APIs on a disabled reader return NOT_ENABLED
+ * - Calling the APIs on an enabled reader with no data return NO_DATA
+ * - Calling the xxx_instance APIs with a wrong instance handle return BAD_PARAMETER
+ * - Calling the APIs when data has been received return OK
+ *
+ * Checks are done both with and without loans. A call to return_loan is always performed, and its return value is
+ * checked to be OK when a loan was performed and PRECONDITION_NOT_MET when not.
+ */
+TEST_F(DataReaderTests, read_take_apis)
 {
-public:
+    // We will create a disabled DataReader, so we can check RETCODE_NOT_ENABLED
+    SubscriberQos subscriber_qos = SUBSCRIBER_QOS_DEFAULT;
+    subscriber_qos.entity_factory().autoenable_created_entities = false;
+    create_entities(nullptr, DATAREADER_QOS_DEFAULT, subscriber_qos);
+    EXPECT_FALSE(data_reader_->is_enabled());
 
-    TopicDataTypeMock()
-        : TopicDataType()
-    {
-        m_typeSize = 4u;
-        setName("footype");
-    }
+    // Read / take operations should all return NOT_ENABLED
+    basic_read_apis_check(ReturnCode_t::RETCODE_NOT_ENABLED, data_reader_);
 
-    bool serialize(
-            void* /*data*/,
-            fastrtps::rtps::SerializedPayload_t* /*payload*/) override
-    {
-        return true;
-    }
+    // Enable the DataReader and check NO_DATA should be returned
+    EXPECT_EQ(ReturnCode_t::RETCODE_OK, data_reader_->enable());
+    EXPECT_TRUE(data_reader_->is_enabled());
+    basic_read_apis_check(ReturnCode_t::RETCODE_NO_DATA, data_reader_);
 
-    bool deserialize(
-            fastrtps::rtps::SerializedPayload_t* /*payload*/,
-            void* /*data*/) override
-    {
-        return true;
-    }
-
-    std::function<uint32_t()> getSerializedSizeProvider(
-            void* /*data*/) override
-    {
-        return std::function<uint32_t()>();
-    }
-
-    void* createData() override
-    {
-        return nullptr;
-    }
-
-    void deleteData(
-            void* /*data*/) override
-    {
-    }
-
-    bool getKey(
-            void* /*data*/,
-            fastrtps::rtps::InstanceHandle_t* /*ihandle*/,
-            bool /*force_md5*/) override
-    {
-        return true;
-    }
-
-};
-
-TEST(DataReaderTests, ReadData)
-{
-    DomainParticipant* participant =
-            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
-    ASSERT_NE(participant, nullptr);
-
-    Subscriber* subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
-    ASSERT_NE(subscriber, nullptr);
-
-    TypeSupport type(new TopicDataTypeMock());
-    type.register_type(participant);
-
-    Topic* topic = participant->create_topic("footopic", type.get_type_name(), TOPIC_QOS_DEFAULT);
-    ASSERT_NE(topic, nullptr);
-
-    DataReader* data_reader = subscriber->create_datareader(topic, DATAREADER_QOS_DEFAULT);
-    ASSERT_NE(data_reader, nullptr);
-
+    // Send data
     FooType data;
-    SampleInfo info;
-    ASSERT_EQ(data_reader->read_next_sample(&data, &info), ReturnCode_t::RETCODE_NO_DATA);
+    data.index(1u);
+    EXPECT_EQ(ReturnCode_t::RETCODE_OK, data_writer_->write(&data, HANDLE_NIL));
 
-    ASSERT_EQ(subscriber->delete_datareader(data_reader), ReturnCode_t::RETCODE_OK);
-    ASSERT_EQ(participant->delete_topic(topic), ReturnCode_t::RETCODE_OK);
-    ASSERT_EQ(participant->delete_subscriber(subscriber), ReturnCode_t::RETCODE_OK);
-    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), ReturnCode_t::RETCODE_OK);
+    // Wait for data to arrive and check OK should be returned
+    Duration_t wait_time(1, 0);
+    EXPECT_TRUE(data_reader_->wait_for_unread_message(wait_time));
+    basic_read_apis_check(ReturnCode_t::RETCODE_OK, data_reader_);
 }
 
+void check_collection(
+        const LoanableCollection& collection,
+        bool owns,
+        LoanableCollection::size_type max,
+        LoanableCollection::size_type len)
+{
+    EXPECT_EQ(owns, collection.has_ownership());
+    EXPECT_LE(max, collection.maximum());
+    EXPECT_EQ(len, collection.length());
+    EXPECT_LE(len, collection.maximum());
+}
 
+/*
+ * This test checks the preconditions on the data_values and sample_infos arguments to the read / take APIs
+ *
+ * The APIs tested are:
+ * - read / take
+ * - read_next_instance / take_next_instance
+ * - read_instance / take_instance
+ * - return_loan
+ *
+ * All possible combinations of owns, max_len, and len are used as input on an enabled reader with no data.
+ * For collections where the preconditions are met, NO_DATA will be returned, except for read_instance and
+ * take_instance, where no instance would exist and the return will be BAD_PARAMETER. Otherwise, PRECONDITION_NOT_MET
+ * should be returned.
+ *
+ * As no data will ever be returned, return_loan will always return PRECONDITION_NOT_MET.
+ */
+TEST_F(DataReaderTests, collection_preconditions)
+{
+    create_entities();
+    create_instance_handles();
+
+    const ReturnCode_t& ok_code = ReturnCode_t::RETCODE_NO_DATA;
+    const ReturnCode_t& wrong_code = ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;
+
+    // Helper buffers to create loaned sequences
+    FooArray arr;
+    SampleInfoArray info_arr;
+
+    // This variables are named following the convention owns_len_max
+    FooSeq true_0_0;
+    FooSeq true_10_0(num_test_elements);
+    FooStack true_10_1;
+    FooSeq false_10_0;
+    FooSeq false_10_1;
+    SampleInfoSeq info_true_0_0;
+    SampleInfoSeq info_true_10_0(num_test_elements);
+    SampleInfoSeq info_true_10_1(num_test_elements);
+    SampleInfoSeq info_false_10_0;
+    SampleInfoSeq info_false_10_1;
+
+    // Make the sequences have the corresponding values
+    true_10_1.length(1u);
+    false_10_0.loan(arr.buffer_for_loans(), num_test_elements, 0u);
+    false_10_1.loan(arr.buffer_for_loans(), num_test_elements, 1u);
+    info_true_10_1.length(1u);
+    info_false_10_0.loan(info_arr.buffer_for_loans(), num_test_elements, 0u);
+    info_false_10_1.loan(info_arr.buffer_for_loans(), num_test_elements, 1u);
+
+    // Check we did it right
+    check_collection(true_0_0, true, 0u, 0u);
+    check_collection(true_10_0, true, 10u, 0u);
+    check_collection(true_10_1, true, 10u, 1u);
+    check_collection(false_10_0, false, 10u, 0u);
+    check_collection(false_10_1, false, 10u, 1u);
+    check_collection(info_true_0_0, true, 0u, 0u);
+    check_collection(info_true_10_0, true, 10u, 0u);
+    check_collection(info_true_10_1, true, 10u, 1u);
+    check_collection(info_false_10_0, false, 10u, 0u);
+    check_collection(info_false_10_1, false, 10u, 1u);
+
+    // Check all wrong combinations
+    using test_case_t = std::pair<LoanableCollection&, SampleInfoSeq&>;
+    std::vector<test_case_t> wrong_cases
+    {
+        // true_0_0
+        {true_0_0, info_true_10_0},
+        {true_0_0, info_true_10_1},
+        {true_0_0, info_false_10_0},
+        {true_0_0, info_false_10_1},
+        // true_10_0
+        {true_10_0, info_true_0_0},
+        {true_10_0, info_true_10_1},
+        {true_10_0, info_false_10_0},
+        {true_10_0, info_false_10_1},
+        // true_10_1
+        {true_10_1, info_true_10_0},
+        {true_10_1, info_true_0_0},
+        {true_10_1, info_false_10_0},
+        {true_10_1, info_false_10_1},
+        // false_10_0
+        {false_10_0, info_true_10_0},
+        {false_10_0, info_true_10_1},
+        {false_10_0, info_true_0_0},
+        {false_10_0, info_false_10_1},
+        // false_10_1
+        {false_10_1, info_true_10_0},
+        {false_10_1, info_true_10_1},
+        {false_10_1, info_false_10_0},
+        {false_10_1, info_true_0_0},
+    };
+
+    for (const test_case_t& test : wrong_cases)
+    {
+        EXPECT_EQ(wrong_code, data_reader_->read(test.first, test.second));
+        EXPECT_EQ(wrong_code, data_reader_->read_next_instance(test.first, test.second));
+        EXPECT_EQ(wrong_code, data_reader_->take(test.first, test.second));
+        EXPECT_EQ(wrong_code, data_reader_->take_next_instance(test.first, test.second));
+
+        check_instance_methods(wrong_code, wrong_code, wrong_code,
+                data_reader_, test.first, test.second);
+    }
+
+    // Check compatible combinations
+    using ok_test_case_t = std::pair<test_case_t, const ReturnCode_t&>;
+    std::vector<ok_test_case_t> ok_cases
+    {
+        // max == 0. Loaned data will be returned.
+        { {true_0_0, info_true_0_0}, ok_code},
+        // max > 0 && owns == true. Data will be copied.
+        { {true_10_0, info_true_10_0}, ok_code},
+        { {true_10_1, info_true_10_1}, ok_code},
+        // max > 0 && owns == false. Precondition not met.
+        { {false_10_0, info_false_10_0}, wrong_code},
+        { {false_10_1, info_false_10_1}, wrong_code}
+    };
+
+    const ReturnCode_t& instance_bad_code = ReturnCode_t::RETCODE_BAD_PARAMETER;
+    for (const ok_test_case_t& test : ok_cases)
+    {
+        EXPECT_EQ(test.second, data_reader_->read(test.first.first, test.first.second));
+        EXPECT_EQ(wrong_code, data_reader_->return_loan(test.first.first, test.first.second));
+        EXPECT_EQ(test.second, data_reader_->read_next_instance(test.first.first, test.first.second));
+        EXPECT_EQ(wrong_code, data_reader_->return_loan(test.first.first, test.first.second));
+        EXPECT_EQ(test.second, data_reader_->take(test.first.first, test.first.second));
+        EXPECT_EQ(wrong_code, data_reader_->return_loan(test.first.first, test.first.second));
+        EXPECT_EQ(test.second, data_reader_->take_next_instance(test.first.first, test.first.second));
+        EXPECT_EQ(wrong_code, data_reader_->return_loan(test.first.first, test.first.second));
+
+        // When collection preconditions are ok, as the reader has no data, BAD_PARAMETER will be returned
+        const ReturnCode_t& instance_code = (test.second == ok_code) ? instance_bad_code : test.second;
+        check_instance_methods(instance_code, instance_code, wrong_code,
+                data_reader_, test.first.first, test.first.second);
+    }
+
+    false_10_0.unloan();
+    false_10_1.unloan();
+    info_false_10_0.unloan();
+    info_false_10_1.unloan();
+}
+
+void forward_loan(
+        LoanableCollection& to,
+        const LoanableCollection& from)
+{
+    assert("Cannot forward loan if there is no loan" && (from.has_ownership() == false));
+    auto buf = const_cast<LoanableCollection::element_type*>(from.buffer());
+    to.loan(buf, from.maximum(), from.length());
+}
+
+/*
+ * This test checks the preconditions on the data_values and sample_infos arguments to the return_loan API.
+ */
+TEST_F(DataReaderTests, return_loan)
+{
+    static constexpr int32_t num_samples = 10;
+
+    DataWriterQos writer_qos = DATAWRITER_QOS_DEFAULT;
+    writer_qos.history().kind = KEEP_LAST_HISTORY_QOS;
+    writer_qos.history().depth = num_samples;
+    writer_qos.publish_mode().kind = SYNCHRONOUS_PUBLISH_MODE;
+    writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
+
+    SubscriberQos subscriber_qos = SUBSCRIBER_QOS_DEFAULT;
+    subscriber_qos.entity_factory().autoenable_created_entities = false;
+
+    DataReaderQos reader_qos = DATAREADER_QOS_DEFAULT;
+    reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
+    reader_qos.history().kind = KEEP_ALL_HISTORY_QOS;
+    reader_qos.resource_limits().max_instances = 2;
+    reader_qos.resource_limits().max_samples_per_instance = num_samples;
+    reader_qos.resource_limits().max_samples = num_samples * 2;
+
+    create_instance_handles();
+    create_entities(nullptr, reader_qos, subscriber_qos, writer_qos);
+    DataReader* reader2 = subscriber_->create_datareader(topic_, reader_qos);
+
+    FooSeq data_values;
+    SampleInfoSeq infos;
+    FooSeq data_values_2;
+    SampleInfoSeq infos_2;
+
+    const ReturnCode_t& ok_code = ReturnCode_t::RETCODE_OK;
+    const ReturnCode_t& precondition_code = ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;
+
+    // Calling return loan on disabled reader should return NOT_ENABLED
+    EXPECT_EQ(ReturnCode_t::RETCODE_NOT_ENABLED, data_reader_->return_loan(data_values, infos));
+
+    // Enable both readers
+    EXPECT_EQ(ok_code, data_reader_->enable());
+    EXPECT_EQ(ok_code, reader2->enable());
+
+    FooType data;
+    data.index(1u);
+
+    // Send a bunch of samples
+    for (int32_t i = 0; i < num_samples; ++i)
+    {
+        EXPECT_EQ(ok_code, data_writer_->write(&data, handle_ok_));
+    }
+
+    // Returning a loan without having called read or take should return PRECONDITION_NOT_MET
+    EXPECT_EQ(precondition_code, data_reader_->return_loan(data_values, infos));
+
+    // Read with loan from both readers
+    EXPECT_EQ(ok_code, data_reader_->read(data_values, infos));
+    EXPECT_EQ(ok_code, reader2->read(data_values_2, infos_2));
+    check_collection(data_values, false, num_samples, num_samples);
+    check_collection(infos, false, num_samples, num_samples);
+    check_collection(data_values_2, false, num_samples, num_samples);
+    check_collection(infos_2, false, num_samples, num_samples);
+
+    // Mixing collections on return_loan should fail and keep collections state
+    EXPECT_EQ(precondition_code, data_reader_->return_loan(data_values, infos_2));
+    check_collection(data_values, false, num_samples, num_samples);
+    check_collection(infos_2, false, num_samples, num_samples);
+
+    EXPECT_EQ(precondition_code, data_reader_->return_loan(data_values_2, infos));
+    check_collection(infos, false, num_samples, num_samples);
+    check_collection(data_values_2, false, num_samples, num_samples);
+
+    EXPECT_EQ(precondition_code, reader2->return_loan(data_values, infos_2));
+    check_collection(data_values, false, num_samples, num_samples);
+    check_collection(infos_2, false, num_samples, num_samples);
+
+    EXPECT_EQ(precondition_code, reader2->return_loan(data_values_2, infos));
+    check_collection(infos, false, num_samples, num_samples);
+    check_collection(data_values_2, false, num_samples, num_samples);
+
+    // Return loan to the other reader should fail and keep collections state
+    EXPECT_EQ(precondition_code, reader2->return_loan(data_values, infos));
+    check_collection(data_values, false, num_samples, num_samples);
+    check_collection(infos, false, num_samples, num_samples);
+
+    EXPECT_EQ(precondition_code, data_reader_->return_loan(data_values_2, infos_2));
+    check_collection(data_values_2, false, num_samples, num_samples);
+    check_collection(infos_2, false, num_samples, num_samples);
+
+    // Return loan to original reader should reset collections
+    EXPECT_EQ(ok_code, data_reader_->return_loan(data_values, infos));
+    check_collection(data_values, true, 0, 0);
+    check_collection(infos, true, 0, 0);
+
+    EXPECT_EQ(ok_code, reader2->return_loan(data_values_2, infos_2));
+    check_collection(data_values_2, true, 0, 0);
+    check_collection(infos_2, true, 0, 0);
+
+    // Take with loan from both readers
+    EXPECT_EQ(ok_code, data_reader_->take(data_values, infos));
+    EXPECT_EQ(ok_code, reader2->take(data_values_2, infos_2));
+    check_collection(data_values, false, num_samples, num_samples);
+    check_collection(infos, false, num_samples, num_samples);
+    check_collection(data_values_2, false, num_samples, num_samples);
+    check_collection(infos_2, false, num_samples, num_samples);
+
+    // Save a copy of the loaned buffers to try returning the same loan twice
+    FooSeq aux_values;
+    SampleInfoSeq aux_infos;
+    FooSeq aux_values_2;
+    SampleInfoSeq aux_infos_2;
+
+    forward_loan(aux_values, data_values);
+    forward_loan(aux_infos, infos);
+    forward_loan(aux_values_2, data_values_2);
+    forward_loan(aux_infos_2, infos_2);
+    check_collection(aux_values, false, num_samples, num_samples);
+    check_collection(aux_infos, false, num_samples, num_samples);
+    check_collection(aux_values_2, false, num_samples, num_samples);
+    check_collection(aux_infos_2, false, num_samples, num_samples);
+
+    // Return loan to original reader should reset collections
+    EXPECT_EQ(ok_code, data_reader_->return_loan(data_values, infos));
+    check_collection(data_values, true, 0, 0);
+    check_collection(infos, true, 0, 0);
+
+    EXPECT_EQ(ok_code, reader2->return_loan(data_values_2, infos_2));
+    check_collection(data_values_2, true, 0, 0);
+    check_collection(infos_2, true, 0, 0);
+
+    // Returning the same loans again should fail
+    EXPECT_EQ(precondition_code, data_reader_->return_loan(aux_values, aux_infos));
+    check_collection(aux_values, false, num_samples, num_samples);
+    check_collection(aux_infos, false, num_samples, num_samples);
+
+    EXPECT_EQ(precondition_code, reader2->return_loan(aux_values_2, aux_infos_2));
+    check_collection(aux_values_2, false, num_samples, num_samples);
+    check_collection(aux_infos_2, false, num_samples, num_samples);
+
+    // Return forward loans to avoid warnings when destroying them
+    aux_values.unloan();
+    aux_infos.unloan();
+    aux_values_2.unloan();
+    aux_infos_2.unloan();
+}
+
+/*
+ * This test checks that the limits imposed by reader_resource_limits QoS are taken into account when performing loans.
+ */
+TEST_F(DataReaderTests, resource_limits)
+{
+    using ResLimitCfg = fastrtps::ResourceLimitedContainerConfig;
+
+    static constexpr int32_t num_samples = 100;
+
+    const ReturnCode_t& ok_code = ReturnCode_t::RETCODE_OK;
+    const ReturnCode_t& resources_code = ReturnCode_t::RETCODE_OUT_OF_RESOURCES;
+
+    DataWriterQos writer_qos = DATAWRITER_QOS_DEFAULT;
+    writer_qos.history().kind = KEEP_LAST_HISTORY_QOS;
+    writer_qos.history().depth = num_samples;
+    writer_qos.publish_mode().kind = SYNCHRONOUS_PUBLISH_MODE;
+    writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
+
+    DataReaderQos reader_qos = DATAREADER_QOS_DEFAULT;
+    reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
+    reader_qos.history().kind = KEEP_ALL_HISTORY_QOS;
+    reader_qos.resource_limits().max_instances = 1;
+    reader_qos.resource_limits().max_samples_per_instance = num_samples;
+    reader_qos.resource_limits().max_samples = num_samples;
+
+    // Specify resource limits for this test
+    // - max_samples_per_read = 10. This means that even if the max_samples parameter is greater than 10 (or even
+    //   LENGTH_UNLIMITED, no more than 10 samples will be returned by a single call to read / take
+    // - A maximum of 3 outstanding reads. The 4th call to read / take without a call to return_loan will fail
+    // - A maximum of 15 total SampleInfo structures can be loaned. We use this value so that after a first call to
+    //   read / take returns max_samples_per_read (10), a second one should only return 5 due to this limit
+    reader_qos.reader_resource_limits().max_samples_per_read = 10;
+    reader_qos.reader_resource_limits().outstanding_reads_allocation = ResLimitCfg::fixed_size_configuration(3);
+    reader_qos.reader_resource_limits().sample_infos_allocation = ResLimitCfg::fixed_size_configuration(15);
+
+    create_instance_handles();
+    create_entities(nullptr, reader_qos, SUBSCRIBER_QOS_DEFAULT, writer_qos);
+
+    FooType data;
+    data.index(1u);
+
+    // Send a bunch of samples
+    for (int32_t i = 0; i < num_samples; ++i)
+    {
+        EXPECT_EQ(ok_code, data_writer_->write(&data, handle_ok_));
+    }
+
+    // Check outstanding reads maximum
+    {
+        FooSeq data_seqs[4];
+        SampleInfoSeq info_seqs[4];
+
+        // Loan 1 sample each time, so the other limits are not surpassed
+        for (int32_t i = 0; i < 3; ++i)
+        {
+            EXPECT_EQ(ok_code, data_reader_->read(data_seqs[i], info_seqs[i], 1));
+            check_collection(data_seqs[i], false, 1, 1);
+            check_collection(info_seqs[i], false, 1, 1);
+        }
+        // The 4th should fail
+        EXPECT_EQ(resources_code, data_reader_->read(data_seqs[3], info_seqs[3], 1));
+        check_collection(data_seqs[3], true, 0, 0);
+        check_collection(info_seqs[3], true, 0, 0);
+
+        // Returning a loan will allow a new loan
+        EXPECT_EQ(ok_code, data_reader_->return_loan(data_seqs[2], info_seqs[2]));
+        EXPECT_EQ(ok_code, data_reader_->read(data_seqs[3], info_seqs[3], 1));
+        // Return all remaining loans
+        EXPECT_EQ(ok_code, data_reader_->return_loan(data_seqs[0], info_seqs[0]));
+        EXPECT_EQ(ok_code, data_reader_->return_loan(data_seqs[1], info_seqs[1]));
+        EXPECT_EQ(ok_code, data_reader_->return_loan(data_seqs[3], info_seqs[3]));
+    }
+
+    // Check max_samples and max_samples_per_read
+    {
+        FooSeq data_seq;
+        SampleInfoSeq info_seq;
+
+        // The standard is not clear on what shold be done if max_samples is 0. NO_DATA? OK with length = 0?
+        // EXPECT_EQ(ok_code, data_reader_->read(data_seq, info_seq, 0));
+
+        // Up to max_samples_per_read, max_samples will be returned
+        for (int32_t i = 1; i <= 10; ++i)
+        {
+            EXPECT_EQ(ok_code, data_reader_->read(data_seq, info_seq, i));
+            check_collection(data_seq, false, i, i);
+            check_collection(info_seq, false, i, i);
+            EXPECT_EQ(ok_code, data_reader_->return_loan(data_seq, info_seq));
+        }
+
+        // For values greater than max_samples_per_read, only max_samples_per_read are returned
+        for (int32_t i = 11; i <= 20; ++i)
+        {
+            EXPECT_EQ(ok_code, data_reader_->read(data_seq, info_seq, i));
+            check_collection(data_seq, false, 10, 10);
+            check_collection(info_seq, false, 10, 10);
+            EXPECT_EQ(ok_code, data_reader_->return_loan(data_seq, info_seq));
+        }
+
+        // For LENGTH_UNLIMITED, max_samples_per_read are returned
+        EXPECT_EQ(ok_code, data_reader_->read(data_seq, info_seq, LENGTH_UNLIMITED));
+        check_collection(data_seq, false, 10, 10);
+        check_collection(info_seq, false, 10, 10);
+        EXPECT_EQ(ok_code, data_reader_->return_loan(data_seq, info_seq));
+    }
+
+    // Check SampleInfo allocation limits
+    {
+        FooSeq data_seqs[3];
+        SampleInfoSeq info_seqs[3];
+
+        // On the first call, max_samples_per_read should be returned
+        EXPECT_EQ(ok_code, data_reader_->read(data_seqs[0], info_seqs[0], LENGTH_UNLIMITED));
+        check_collection(data_seqs[0], false, 10, 10);
+        check_collection(info_seqs[0], false, 10, 10);
+
+        // On the second call, sample_infos_max - max_samples_per_read should be returned
+        EXPECT_EQ(ok_code, data_reader_->read(data_seqs[1], info_seqs[1], LENGTH_UNLIMITED));
+        check_collection(data_seqs[1], false, 5, 5);
+        check_collection(info_seqs[1], false, 5, 5);
+
+        // On the third call, no sample_info will be available, and should fail with OUT_OF_RESOURCES
+        EXPECT_EQ(resources_code, data_reader_->read(data_seqs[2], info_seqs[2], LENGTH_UNLIMITED));
+
+        // Return the first loan. Now max_samples_per_read infos are available
+        EXPECT_EQ(ok_code, data_reader_->return_loan(data_seqs[0], info_seqs[0]));
+
+        // Loan max_samples_per_read - 1. 1 sample_info still available
+        EXPECT_EQ(ok_code, data_reader_->read(data_seqs[0], info_seqs[0], 9));
+        check_collection(data_seqs[0], false, 9, 9);
+        check_collection(info_seqs[0], false, 9, 9);
+
+        // This call should loan the last available info
+        EXPECT_EQ(ok_code, data_reader_->read(data_seqs[2], info_seqs[2], LENGTH_UNLIMITED));
+        check_collection(data_seqs[2], false, 1, 1);
+        check_collection(info_seqs[2], false, 1, 1);
+
+        // Return all loans
+        EXPECT_EQ(ok_code, data_reader_->return_loan(data_seqs[0], info_seqs[0]));
+        EXPECT_EQ(ok_code, data_reader_->return_loan(data_seqs[1], info_seqs[1]));
+        EXPECT_EQ(ok_code, data_reader_->return_loan(data_seqs[2], info_seqs[2]));
+    }
+}
 
 void set_listener_test (
         DataReader* reader,
@@ -173,47 +849,36 @@ class CustomListener : public DataReaderListener
 
 };
 
-TEST(DataReaderTests, SetListener)
+/*
+ * This test checks the calls to set_listener and get_status_mask
+ */
+TEST_F(DataReaderTests, SetListener)
 {
     CustomListener listener;
+    create_entities(&listener);
 
-    DomainParticipant* participant =
-            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
-    ASSERT_NE(participant, nullptr);
-
-    Subscriber* subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
-    ASSERT_NE(subscriber, nullptr);
-
-    TypeSupport type(new TopicDataTypeMock());
-    type.register_type(participant);
-
-    Topic* topic = participant->create_topic("footopic", type.get_type_name(), TOPIC_QOS_DEFAULT);
-    ASSERT_NE(topic, nullptr);
-
-    DataReader* datareader = subscriber->create_datareader(topic, DATAREADER_QOS_DEFAULT, &listener);
-    ASSERT_NE(datareader, nullptr);
-    ASSERT_EQ(datareader->get_status_mask(), StatusMask::all());
+    ASSERT_EQ(data_reader_->get_status_mask(), StatusMask::all());
 
     std::vector<std::tuple<DataReader*, DataReaderListener*, StatusMask>> testing_cases{
         //statuses, one by one
-        { datareader, &listener, StatusMask::data_available() },
-        { datareader, &listener, StatusMask::sample_rejected() },
-        { datareader, &listener, StatusMask::liveliness_changed() },
-        { datareader, &listener, StatusMask::requested_deadline_missed() },
-        { datareader, &listener, StatusMask::requested_incompatible_qos() },
-        { datareader, &listener, StatusMask::subscription_matched() },
-        { datareader, &listener, StatusMask::sample_lost() },
+        { data_reader_, &listener, StatusMask::data_available() },
+        { data_reader_, &listener, StatusMask::sample_rejected() },
+        { data_reader_, &listener, StatusMask::liveliness_changed() },
+        { data_reader_, &listener, StatusMask::requested_deadline_missed() },
+        { data_reader_, &listener, StatusMask::requested_incompatible_qos() },
+        { data_reader_, &listener, StatusMask::subscription_matched() },
+        { data_reader_, &listener, StatusMask::sample_lost() },
         //all except one
-        { datareader, &listener, StatusMask::all() >> StatusMask::data_available() },
-        { datareader, &listener, StatusMask::all() >> StatusMask::sample_rejected() },
-        { datareader, &listener, StatusMask::all() >> StatusMask::liveliness_changed() },
-        { datareader, &listener, StatusMask::all() >> StatusMask::requested_deadline_missed() },
-        { datareader, &listener, StatusMask::all() >> StatusMask::requested_incompatible_qos() },
-        { datareader, &listener, StatusMask::all() >> StatusMask::subscription_matched() },
-        { datareader, &listener, StatusMask::all() >> StatusMask::sample_lost() },
+        { data_reader_, &listener, StatusMask::all() >> StatusMask::data_available() },
+        { data_reader_, &listener, StatusMask::all() >> StatusMask::sample_rejected() },
+        { data_reader_, &listener, StatusMask::all() >> StatusMask::liveliness_changed() },
+        { data_reader_, &listener, StatusMask::all() >> StatusMask::requested_deadline_missed() },
+        { data_reader_, &listener, StatusMask::all() >> StatusMask::requested_incompatible_qos() },
+        { data_reader_, &listener, StatusMask::all() >> StatusMask::subscription_matched() },
+        { data_reader_, &listener, StatusMask::all() >> StatusMask::sample_lost() },
         //all and none
-        { datareader, &listener, StatusMask::all() },
-        { datareader, &listener, StatusMask::none() }
+        { data_reader_, &listener, StatusMask::all() },
+        { data_reader_, &listener, StatusMask::none() }
     };
 
     for (auto testing_case : testing_cases)
@@ -222,11 +887,6 @@ TEST(DataReaderTests, SetListener)
                 std::get<1>(testing_case),
                 std::get<2>(testing_case));
     }
-
-    ASSERT_EQ(subscriber->delete_datareader(datareader), ReturnCode_t::RETCODE_OK);
-    ASSERT_EQ(participant->delete_topic(topic), ReturnCode_t::RETCODE_OK);
-    ASSERT_EQ(participant->delete_subscriber(subscriber), ReturnCode_t::RETCODE_OK);
-    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), ReturnCode_t::RETCODE_OK);
 }
 
 } // namespace dds

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -44,7 +44,7 @@ namespace eprosima {
 namespace fastdds {
 namespace dds {
 
-static constexpr LoanableCollection::size_type num_test_elements = 10u;
+static constexpr LoanableCollection::size_type num_test_elements = 10;
 
 FASTDDS_SEQUENCE(FooSeq, FooType);
 using FooArray = LoanableArray<FooType, num_test_elements>;
@@ -139,8 +139,8 @@ protected:
     {
         if (ReturnCode_t::RETCODE_OK == code)
         {
-            data_values.length(0u);
-            infos.length(0u);
+            data_values.length(0);
+            infos.length(0);
         }
     }
 
@@ -150,7 +150,7 @@ protected:
     {
         LoanableCollection::size_type n = infos.length();
         auto buffer = data_values.buffer();
-        for (LoanableCollection::size_type i = 0u; i < n; ++i)
+        for (LoanableCollection::size_type i = 0; i < n; ++i)
         {
             if (infos[i].valid_data)
             {
@@ -175,9 +175,9 @@ protected:
         if (ReturnCode_t::RETCODE_OK == expected_return_loan_ret)
         {
             EXPECT_TRUE(data_values.has_ownership());
-            EXPECT_EQ(0u, data_values.maximum());
+            EXPECT_EQ(0, data_values.maximum());
             EXPECT_TRUE(infos.has_ownership());
-            EXPECT_EQ(0u, infos.maximum());
+            EXPECT_EQ(0, infos.maximum());
         }
     }
 
@@ -290,8 +290,8 @@ protected:
 
         // Check read/take and variants without loan
         {
-            FooSeq data_values(1u);
-            SampleInfoSeq infos(1u);
+            FooSeq data_values(1);
+            SampleInfoSeq infos(1);
 
             ReturnCode_t expected_return_loan_ret = code;
             if (ReturnCode_t::RETCODE_OK == code)
@@ -382,7 +382,7 @@ TEST_F(DataReaderTests, read_take_apis)
 
     // Send data
     FooType data;
-    data.index(1u);
+    data.index(1);
     EXPECT_EQ(ReturnCode_t::RETCODE_OK, data_writer_->write(&data, HANDLE_NIL));
 
     // Wait for data to arrive and check OK should be returned
@@ -444,24 +444,24 @@ TEST_F(DataReaderTests, collection_preconditions)
     SampleInfoSeq info_false_10_1;
 
     // Make the sequences have the corresponding values
-    true_10_1.length(1u);
-    false_10_0.loan(arr.buffer_for_loans(), num_test_elements, 0u);
-    false_10_1.loan(arr.buffer_for_loans(), num_test_elements, 1u);
-    info_true_10_1.length(1u);
-    info_false_10_0.loan(info_arr.buffer_for_loans(), num_test_elements, 0u);
-    info_false_10_1.loan(info_arr.buffer_for_loans(), num_test_elements, 1u);
+    true_10_1.length(1);
+    false_10_0.loan(arr.buffer_for_loans(), num_test_elements, 0);
+    false_10_1.loan(arr.buffer_for_loans(), num_test_elements, 1);
+    info_true_10_1.length(1);
+    info_false_10_0.loan(info_arr.buffer_for_loans(), num_test_elements, 0);
+    info_false_10_1.loan(info_arr.buffer_for_loans(), num_test_elements, 1);
 
     // Check we did it right
-    check_collection(true_0_0, true, 0u, 0u);
-    check_collection(true_10_0, true, 10u, 0u);
-    check_collection(true_10_1, true, 10u, 1u);
-    check_collection(false_10_0, false, 10u, 0u);
-    check_collection(false_10_1, false, 10u, 1u);
-    check_collection(info_true_0_0, true, 0u, 0u);
-    check_collection(info_true_10_0, true, 10u, 0u);
-    check_collection(info_true_10_1, true, 10u, 1u);
-    check_collection(info_false_10_0, false, 10u, 0u);
-    check_collection(info_false_10_1, false, 10u, 1u);
+    check_collection(true_0_0, true, 0, 0);
+    check_collection(true_10_0, true, 10, 0);
+    check_collection(true_10_1, true, 10, 1);
+    check_collection(false_10_0, false, 10, 0);
+    check_collection(false_10_1, false, 10, 1);
+    check_collection(info_true_0_0, true, 0, 0);
+    check_collection(info_true_10_0, true, 10, 0);
+    check_collection(info_true_10_1, true, 10, 1);
+    check_collection(info_false_10_0, false, 10, 0);
+    check_collection(info_false_10_1, false, 10, 1);
 
     // Check all wrong combinations
     using test_case_t = std::pair<LoanableCollection&, SampleInfoSeq&>;
@@ -607,7 +607,7 @@ TEST_F(DataReaderTests, return_loan)
     EXPECT_EQ(ok_code, reader2->enable());
 
     FooType data;
-    data.index(1u);
+    data.index(1);
 
     // Send a bunch of samples
     for (int32_t i = 0; i < num_samples; ++i)
@@ -753,7 +753,7 @@ TEST_F(DataReaderTests, resource_limits)
     create_entities(nullptr, reader_qos, SUBSCRIBER_QOS_DEFAULT, writer_qos);
 
     FooType data;
-    data.index(1u);
+    data.index(1);
 
     // Send a bunch of samples
     for (int32_t i = 0; i < num_samples; ++i)

--- a/test/unittest/dds/subscriber/FooBoundedType.hpp
+++ b/test/unittest/dds/subscriber/FooBoundedType.hpp
@@ -1,0 +1,103 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _TEST_UNITTEST_DDS_SUBSCRIBER_FOOBOUNDEDTYPE_HPP_
+#define _TEST_UNITTEST_DDS_SUBSCRIBER_FOOBOUNDEDTYPE_HPP_
+
+#include <cstdint>
+#include <vector>
+
+#include <fastcdr/Cdr.h>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+
+class FooBoundedType
+{
+public:
+
+    inline uint32_t index() const
+    {
+        return index_;
+    }
+
+    inline uint32_t& index()
+    {
+        return index_;
+    }
+
+    inline void index(
+            uint32_t value)
+    {
+        index_ = value;
+    }
+
+    inline const std::vector<char>& message() const
+    {
+        return message_;
+    }
+
+    inline std::vector<char>& message()
+    {
+        return message_;
+    }
+
+    inline void message(
+            const std::vector<char>& value)
+    {
+        message_ = value;
+    }
+
+    inline static size_t getCdrSerializedSize(
+            const FooBoundedType& data)
+    {
+        return 4u + 4u + data.message().size();
+    }
+
+    inline void serialize(
+            eprosima::fastcdr::Cdr& scdr) const
+    {
+        scdr << index_;
+        scdr << message_;
+    }
+
+    inline void deserialize(
+            eprosima::fastcdr::Cdr& dcdr)
+    {
+        dcdr >> index_;
+        dcdr >> message_;
+    }
+
+    inline bool isKeyDefined()
+    {
+        return false;
+    }
+
+    inline void serializeKey(
+            eprosima::fastcdr::Cdr& /*scdr*/) const
+    {
+    }
+
+private:
+
+    uint32_t index_ = 0;
+    std::vector<char> message_;
+};
+
+} // namespace dds
+} // namespace fastdds
+} // namespace eprosima
+
+#endif  // _TEST_UNITTEST_DDS_SUBSCRIBER_FOOBOUNDEDTYPE_HPP_

--- a/test/unittest/dds/subscriber/FooBoundedTypeSupport.hpp
+++ b/test/unittest/dds/subscriber/FooBoundedTypeSupport.hpp
@@ -1,0 +1,153 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _TEST_UNITTEST_DDS_SUBSCRIBER_FOOBOUNDEDTYPESUPPORT_HPP_
+#define _TEST_UNITTEST_DDS_SUBSCRIBER_FOOBOUNDEDTYPESUPPORT_HPP_
+
+#include <fastcdr/Cdr.h>
+
+#include <fastdds/dds/topic/TopicDataType.hpp>
+
+#include "./FooBoundedType.hpp"
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+
+class FooBoundedTypeSupport : public TopicDataType
+{
+    using type = FooBoundedType;
+
+public:
+
+    FooBoundedTypeSupport()
+        : TopicDataType()
+    {
+        setName("type");
+        m_typeSize = 4u + 4u + 4u + 256u; // encapsulation + index + message len + message data
+        m_isGetKeyDefined = false;
+    }
+
+    bool serialize(
+            void* data,
+            fastrtps::rtps::SerializedPayload_t* payload) override
+    {
+        type* p_type = static_cast<type*>(data);
+
+        // Object that manages the raw buffer.
+        eprosima::fastcdr::FastBuffer fb(reinterpret_cast<char*>(payload->data), payload->max_size);
+        // Object that serializes the data.
+        eprosima::fastcdr::Cdr ser(fb, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::Cdr::DDS_CDR);
+        payload->encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+        // Serialize encapsulation
+        ser.serialize_encapsulation();
+
+        try
+        {
+            // Serialize the object.
+            p_type->serialize(ser);
+        }
+        catch (eprosima::fastcdr::exception::NotEnoughMemoryException& /*exception*/)
+        {
+            return false;
+        }
+
+        // Get the serialized length
+        payload->length = static_cast<uint32_t>(ser.getSerializedDataLength());
+        return true;
+    }
+
+    bool deserialize(
+            fastrtps::rtps::SerializedPayload_t* payload,
+            void* data) override
+    {
+        //Convert DATA to pointer of your type
+        type* p_type = static_cast<type*>(data);
+
+        // Object that manages the raw buffer.
+        eprosima::fastcdr::FastBuffer fb(reinterpret_cast<char*>(payload->data), payload->length);
+
+        // Object that deserializes the data.
+        eprosima::fastcdr::Cdr deser(fb, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::Cdr::DDS_CDR);
+
+        // Deserialize encapsulation.
+        deser.read_encapsulation();
+        payload->encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+
+        try
+        {
+            // Deserialize the object.
+            p_type->deserialize(deser);
+        }
+        catch (eprosima::fastcdr::exception::NotEnoughMemoryException& /*exception*/)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    std::function<uint32_t()> getSerializedSizeProvider(
+            void* data) override
+    {
+        return [data]() -> uint32_t
+               {
+                   return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<type*>(data))) +
+                          4u /*encapsulation*/;
+               };
+    }
+
+    void* createData() override
+    {
+        return static_cast<void*>(new type());
+    }
+
+    void deleteData(
+            void* data) override
+    {
+        type* p_type = static_cast<type*>(data);
+        delete p_type;
+    }
+
+    bool getKey(
+            void* /*data*/,
+            fastrtps::rtps::InstanceHandle_t* /*handle*/,
+            bool /*force_md5*/) override
+    {
+        return false;
+    }
+
+    inline bool is_bounded() const override
+    {
+        return true;
+    }
+
+    inline bool is_plain() const override
+    {
+        return false;
+    }
+
+    inline bool construct_sample(
+            void* /*memory*/) const override
+    {
+        return false;
+    }
+
+};
+
+} // namespace dds
+} // namespace fastdds
+} // namespace eprosima
+
+#endif  // _TEST_UNITTEST_DDS_SUBSCRIBER_FOOBOUNDEDTYPESUPPORT_HPP_

--- a/test/unittest/dds/subscriber/FooType.hpp
+++ b/test/unittest/dds/subscriber/FooType.hpp
@@ -1,0 +1,98 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _TEST_UNITTEST_DDS_SUBSCRIBER_FOOTYPE_HPP_
+#define _TEST_UNITTEST_DDS_SUBSCRIBER_FOOTYPE_HPP_
+
+#include <array>
+#include <cstdint>
+
+#include <fastcdr/Cdr.h>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+
+class FooType
+{
+public:
+
+    inline uint32_t index() const
+    {
+        return index_;
+    }
+
+    inline uint32_t& index()
+    {
+        return index_;
+    }
+
+    inline void index(
+            uint32_t value)
+    {
+        index_ = value;
+    }
+
+    inline const std::array<char, 256>& message() const
+    {
+        return message_;
+    }
+
+    inline std::array<char, 256>& message()
+    {
+        return message_;
+    }
+
+    inline void message(
+            const std::array<char, 256>& value)
+    {
+        message_ = value;
+    }
+
+    inline void serialize(
+            eprosima::fastcdr::Cdr& scdr) const
+    {
+        scdr << index_;
+        scdr << message_;
+    }
+
+    inline void deserialize(
+            eprosima::fastcdr::Cdr& dcdr)
+    {
+        dcdr >> index_;
+        dcdr >> message_;
+    }
+
+    inline bool isKeyDefined()
+    {
+        return true;
+    }
+
+    inline void serializeKey(
+            eprosima::fastcdr::Cdr& scdr) const
+    {
+        scdr << index_;
+    }
+
+private:
+
+    uint32_t index_ = 0;
+    std::array<char, 256> message_;
+};
+
+} // namespace dds
+} // namespace fastdds
+} // namespace eprosima
+
+#endif  // _TEST_UNITTEST_DDS_SUBSCRIBER_FOOTYPE_HPP_

--- a/test/unittest/dds/subscriber/FooTypeSupport.hpp
+++ b/test/unittest/dds/subscriber/FooTypeSupport.hpp
@@ -1,0 +1,178 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _TEST_UNITTEST_DDS_SUBSCRIBER_FOOTYPESUPPORT_HPP_
+#define _TEST_UNITTEST_DDS_SUBSCRIBER_FOOTYPESUPPORT_HPP_
+
+#include <fastcdr/Cdr.h>
+
+#include <fastdds/dds/topic/TopicDataType.hpp>
+
+#include "./FooType.hpp"
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+
+class FooTypeSupport : public TopicDataType
+{
+public:
+
+    FooTypeSupport()
+        : TopicDataType()
+    {
+        setName("FooType");
+        m_typeSize = 4u + 4u + 256u; // encapsulation + index + message
+        m_isGetKeyDefined = true;
+    }
+
+    bool serialize(
+            void* data,
+            fastrtps::rtps::SerializedPayload_t* payload) override
+    {
+        FooType* p_type = static_cast<FooType*>(data);
+
+        // Object that manages the raw buffer.
+        eprosima::fastcdr::FastBuffer fb(reinterpret_cast<char*>(payload->data), payload->max_size);
+        // Object that serializes the data.
+        eprosima::fastcdr::Cdr ser(fb, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::Cdr::DDS_CDR);
+        payload->encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+        // Serialize encapsulation
+        ser.serialize_encapsulation();
+
+        try
+        {
+            // Serialize the object.
+            p_type->serialize(ser);
+        }
+        catch (eprosima::fastcdr::exception::NotEnoughMemoryException& /*exception*/)
+        {
+            return false;
+        }
+
+        // Get the serialized length
+        payload->length = static_cast<uint32_t>(ser.getSerializedDataLength());
+        return true;
+    }
+
+    bool deserialize(
+            fastrtps::rtps::SerializedPayload_t* payload,
+            void* data) override
+    {
+        //Convert DATA to pointer of your type
+        FooType* p_type = static_cast<FooType*>(data);
+
+        // Object that manages the raw buffer.
+        eprosima::fastcdr::FastBuffer fb(reinterpret_cast<char*>(payload->data), payload->length);
+
+        // Object that deserializes the data.
+        eprosima::fastcdr::Cdr deser(fb, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::Cdr::DDS_CDR);
+
+        // Deserialize encapsulation.
+        deser.read_encapsulation();
+        payload->encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+
+        try
+        {
+            // Deserialize the object.
+            p_type->deserialize(deser);
+        }
+        catch (eprosima::fastcdr::exception::NotEnoughMemoryException& /*exception*/)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    std::function<uint32_t()> getSerializedSizeProvider(
+            void* /*data*/) override
+    {
+        return [this]
+               {
+                   return m_typeSize;
+               };
+    }
+
+    void* createData() override
+    {
+        return static_cast<void*>(new FooType());
+    }
+
+    void deleteData(
+            void* data) override
+    {
+        FooType* p_type = static_cast<FooType*>(data);
+        delete p_type;
+    }
+
+    bool getKey(
+            void* data,
+            fastrtps::rtps::InstanceHandle_t* handle,
+            bool force_md5) override
+    {
+        FooType* p_type = static_cast<FooType*>(data);
+        char key_buf[16]{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+        // Object that manages the raw buffer.
+        eprosima::fastcdr::FastBuffer fastbuffer(key_buf, 16);
+
+        // Object that serializes the data.
+        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS);
+        p_type->serializeKey(ser);
+        if (force_md5)
+        {
+            MD5 md5;
+            md5.init();
+            md5.update(key_buf, static_cast<unsigned int>(ser.getSerializedDataLength()));
+            md5.finalize();
+            for (uint8_t i = 0; i < 16; ++i)
+            {
+                handle->value[i] = md5.digest[i];
+            }
+        }
+        else
+        {
+            for (uint8_t i = 0; i < 16; ++i)
+            {
+                handle->value[i] = key_buf[i];
+            }
+        }
+        return true;
+    }
+
+    inline bool is_bounded() const override
+    {
+        return true;
+    }
+
+    inline bool is_plain() const override
+    {
+        return true;
+    }
+
+    inline bool construct_sample(
+            void* memory) const override
+    {
+        new (memory) FooType();
+        return true;
+    }
+
+};
+
+} // namespace dds
+} // namespace fastdds
+} // namespace eprosima
+
+#endif  // _TEST_UNITTEST_DDS_SUBSCRIBER_FOOTYPESUPPORT_HPP_


### PR DESCRIPTION
This PR adds DDS PIM compliant read and take APIs, including:

- `read / take`
- `read_instance / take_instance`
- `read_next_instance / take_next_instance`
- `return_loan`