### PR TITLE
DomainParticipant new methods [10310]

### DIFF
--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -80,6 +80,13 @@ class DomainParticipant : public Entity
 public:
 
     /**
+     * @brief Destructor
+     */
+    RTPS_DllAPI virtual ~DomainParticipant();
+
+    // Superclass methods
+
+    /**
      * This operation returns the value of the DomainParticipant QoS policies
      * @param qos DomainParticipantQos reference where the qos is going to be returned
      * @return RETCODE_OK
@@ -94,12 +101,6 @@ public:
     RTPS_DllAPI const DomainParticipantQos& get_qos() const;
 
     /**
-     * @brief This operation enables the DomainParticipant
-     * @return RETCODE_OK
-     */
-    RTPS_DllAPI ReturnCode_t enable() override;
-
-    /**
      * This operation sets the value of the DomainParticipant QoS policies.
      * @param qos DomainParticipantQos to be set
      * @return RETCODE_IMMUTABLE_POLICY if any of the Qos cannot be changed, RETCODE_INCONSISTENT_POLICY if the Qos is not
@@ -107,6 +108,12 @@ public:
      */
     RTPS_DllAPI ReturnCode_t set_qos(
             const DomainParticipantQos& qos) const;
+
+    /**
+     * Allows accessing the DomainParticipantListener.
+     * @return DomainParticipantListener pointer
+     */
+    RTPS_DllAPI const DomainParticipantListener* get_listener() const;
 
     /**
      * Modifies the DomainParticipantListener, sets the mask to StatusMask::all()
@@ -127,10 +134,12 @@ public:
             const StatusMask& mask);
 
     /**
-     * Allows accessing the DomainParticipantListener.
-     * @return DomainParticipantListener pointer
+     * @brief This operation enables the DomainParticipant
+     * @return RETCODE_OK
      */
-    RTPS_DllAPI const DomainParticipantListener* get_listener() const;
+    RTPS_DllAPI ReturnCode_t enable() override;
+
+    // DomainParticipant specific methods from DDS API
 
     /**
      * Create a Publisher in this Participant.
@@ -199,35 +208,6 @@ public:
             Subscriber* subscriber);
 
     /**
-     * Register a type in this participant.
-     * @param type TypeSupport.
-     * @param type_name The name that will be used to identify the Type.
-     * @return RETCODE_BAD_PARAMETER if the size of the name is 0, RERCODE_PRECONDITION_NOT_MET if there is another TypeSupport
-     * with the same name and RETCODE_OK if it is correctly registered.
-     */
-    RTPS_DllAPI ReturnCode_t register_type(
-            TypeSupport type,
-            const std::string& type_name);
-
-    /**
-     * Register a type in this participant.
-     * @param type TypeSupport.
-     * @return RETCODE_BAD_PARAMETER if the size of the name is 0, RERCODE_PRECONDITION_NOT_MET if there is another TypeSupport
-     * with the same name and RETCODE_OK if it is correctly registered.
-     */
-    RTPS_DllAPI ReturnCode_t register_type(
-            TypeSupport type);
-
-    /**
-     * Unregister a type in this participant.
-     * @param typeName Name of the type
-     * @return RETCODE_BAD_PARAMETER if the size of the name is 0, RERCODE_PRECONDITION_NOT_MET if there are entities using that
-     * TypeSupport and RETCODE_OK if it is correctly unregistered.
-     */
-    RTPS_DllAPI ReturnCode_t unregister_type(
-            const std::string& typeName);
-
-    /**
      * Create a Topic in this Participant.
      * @param topic_name Name of the Topic.
      * @param type_name Data type of the Topic.
@@ -271,39 +251,12 @@ public:
     /**
      * Looks up an existing, locally created @ref TopicDescription, based on its name.
      * May be called on a disabled participant.
-     *
      * @param topic_name Name of the @ref TopicDescription to search for.
-     *
      * @return Pointer to the topic description, if it has been created locally. Otherwise, nullptr is returned.
-     *
      * @remark UNSAFE. It is unsafe to lookup a topic description while another thread is creating a topic.
      */
     RTPS_DllAPI TopicDescription* lookup_topicdescription(
             const std::string& topic_name) const;
-
-    /* TODO
-       Subscriber* get_builtin_subscriber();
-     */
-
-    /* TODO
-       bool ignore_participant(
-            const InstanceHandle_t& handle);
-     */
-
-    /* TODO
-       bool ignore_topic(
-            const InstanceHandle_t& handle);
-     */
-
-    /* TODO
-       bool ignore_publication(
-            const InstanceHandle_t& handle);
-     */
-
-    /* TODO
-       bool ignore_subscription(
-            const InstanceHandle_t& handle);
-     */
 
     /**
      * This operation retrieves the domain_id used to create the DomainParticipant.
@@ -311,10 +264,6 @@ public:
      * @return The Participant's domain_id
      */
     RTPS_DllAPI DomainId_t get_domain_id() const;
-
-    /* TODO
-       bool delete_contained_entities();
-     */
 
     /**
      * This operation manually asserts the liveliness of the DomainParticipant.
@@ -482,29 +431,6 @@ public:
             const std::string& profile_name,
             TopicQos& qos) const;
 
-
-    /* TODO
-       bool get_discovered_participants(
-            std::vector<InstanceHandle_t>& participant_handles) const;
-     */
-
-    /* TODO
-       bool get_discovered_participant_data(
-            ParticipantBuiltinTopicData& participant_data,
-            const InstanceHandle_t& participant_handle) const;
-     */
-
-    /* TODO
-       bool get_discovered_topics(
-            std::vector<InstanceHandle_t>& topic_handles) const;
-     */
-
-    /* TODO
-       bool get_discovered_topic_data(
-            TopicBuiltinTopicData& topic_data,
-            const InstanceHandle_t& topic_handle) const;
-     */
-
     /**
      * This operation checks whether or not the given handle represents an Entity that was created from the
      * DomainParticipant.
@@ -526,6 +452,37 @@ public:
      */
     RTPS_DllAPI ReturnCode_t get_current_time(
             fastrtps::Time_t& current_time) const;
+
+    // DomainParticipant methods specific from Fast-DDS
+
+    /**
+     * Register a type in this participant.
+     * @param type TypeSupport.
+     * @param type_name The name that will be used to identify the Type.
+     * @return RETCODE_BAD_PARAMETER if the size of the name is 0, RERCODE_PRECONDITION_NOT_MET if there is another TypeSupport
+     * with the same name and RETCODE_OK if it is correctly registered.
+     */
+    RTPS_DllAPI ReturnCode_t register_type(
+            TypeSupport type,
+            const std::string& type_name);
+
+    /**
+     * Register a type in this participant.
+     * @param type TypeSupport.
+     * @return RETCODE_BAD_PARAMETER if the size of the name is 0, RERCODE_PRECONDITION_NOT_MET if there is another TypeSupport
+     * with the same name and RETCODE_OK if it is correctly registered.
+     */
+    RTPS_DllAPI ReturnCode_t register_type(
+            TypeSupport type);
+
+    /**
+     * Unregister a type in this participant.
+     * @param typeName Name of the type
+     * @return RETCODE_BAD_PARAMETER if the size of the name is 0, RERCODE_PRECONDITION_NOT_MET if there are entities using that
+     * TypeSupport and RETCODE_OK if it is correctly unregistered.
+     */
+    RTPS_DllAPI ReturnCode_t unregister_type(
+            const std::string& typeName);
 
     /**
      * This method gives access to a registered type based on its name.
@@ -613,11 +570,6 @@ public:
             const fastrtps::types::TypeInformation& type_information,
             const std::string& type_name,
             std::function<void(const std::string& name, const fastrtps::types::DynamicType_ptr type)>& callback);
-
-    /**
-     * @brief Destructor
-     */
-    RTPS_DllAPI virtual ~DomainParticipant();
 
     /**
      * @brief Check if the Participant has any Publisher, Subscriber or Topic

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -546,7 +546,7 @@ public:
 
     /**
      * Retrieves the list of DomainParticipants that have been discovered in the domain and are not "ignored".
-     * @param participant_handles Reference to the vector where discovered participants will be returned
+     * @param participant_handles [out] Reference to the vector where discovered participants will be returned
      * @return RETCODE_OK if everything correct, error code otherwise
      */
     RTPS_DllAPI ReturnCode_t get_discovered_participants(
@@ -554,7 +554,7 @@ public:
 
     /**
      * Retrieves the DomainParticipant data of a discovered not ignored participant.
-     * @param participant_data Reference to the ParticipantBuiltinTopicData object to return the data
+     * @param participant_data [out] Reference to the ParticipantBuiltinTopicData object to return the data
      * @param participant_handle InstanceHandle of DomainParticipant to retrieve the data from
      * @return RETCODE_OK if everything correct, PRECONDITION_NOT_MET if participant does not exist
      */
@@ -564,7 +564,7 @@ public:
 
     /**
      * Retrieves the list of topics that have been discovered in the domain and are not "ignored".
-     * @param topic_handles Reference to the vector where discovered topics will be returned
+     * @param topic_handles [out] Reference to the vector where discovered topics will be returned
      * @return RETCODE_OK if everything correct, error code otherwise
      */
     RTPS_DllAPI ReturnCode_t get_discovered_topics(
@@ -572,7 +572,7 @@ public:
 
     /**
      * Retrieves the Topic data of a discovered not ignored topic.
-     * @param topic_data Reference to the TopicBuiltinTopicData object to return the data
+     * @param topic_data [out] Reference to the TopicBuiltinTopicData object to return the data
      * @param topic_handle InstanceHandle of Topic to retrieve the data from
      * @return RETCODE_OK if everything correct, PRECONDITION_NOT_MET if topic does not exist
      */

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -570,7 +570,7 @@ public:
             std::vector<InstanceHandle_t>& topic_handles) const;
 
     /**
-     * Retrieves the Topic ata of a discovered not ignored topic.
+     * Retrieves the Topic data of a discovered not ignored topic.
      * @param topic_data Reference to the TopicBuiltinTopicData object to return the data
      * @param topic_handle InstanceHandle of Topic to retrieve the data from
      * @return RETCODE_OK if everything correct, PRECONDITION_NOT_MET if topic does not exist
@@ -589,7 +589,7 @@ public:
      * @return True if entity is contained. False otherwise.
      */
     RTPS_DllAPI bool contains_entity(
-            const InstanceHandle_t& handle,
+            const InstanceHandle_t& a_handle,
             bool recursive = true) const;
 
     /**

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -546,7 +546,7 @@ public:
 
     /**
      * Retrieves the list of DomainParticipants that have been discovered in the domain and are not "ignored".
-     * @param participant_handles [out] Reference to the vector where discovered participants will be returned
+     * @param[out]  participant_handles Reference to the vector where discovered participants will be returned
      * @return RETCODE_OK if everything correct, error code otherwise
      */
     RTPS_DllAPI ReturnCode_t get_discovered_participants(
@@ -554,7 +554,7 @@ public:
 
     /**
      * Retrieves the DomainParticipant data of a discovered not ignored participant.
-     * @param participant_data [out] Reference to the ParticipantBuiltinTopicData object to return the data
+     * @param[out]  participant_data Reference to the ParticipantBuiltinTopicData object to return the data
      * @param participant_handle InstanceHandle of DomainParticipant to retrieve the data from
      * @return RETCODE_OK if everything correct, PRECONDITION_NOT_MET if participant does not exist
      */
@@ -564,7 +564,7 @@ public:
 
     /**
      * Retrieves the list of topics that have been discovered in the domain and are not "ignored".
-     * @param topic_handles [out] Reference to the vector where discovered topics will be returned
+     * @param[out]  topic_handles Reference to the vector where discovered topics will be returned
      * @return RETCODE_OK if everything correct, error code otherwise
      */
     RTPS_DllAPI ReturnCode_t get_discovered_topics(
@@ -572,7 +572,7 @@ public:
 
     /**
      * Retrieves the Topic data of a discovered not ignored topic.
-     * @param topic_data [out] Reference to the TopicBuiltinTopicData object to return the data
+     * @param[out]  topic_data Reference to the TopicBuiltinTopicData object to return the data
      * @param topic_handle InstanceHandle of Topic to retrieve the data from
      * @return RETCODE_OK if everything correct, PRECONDITION_NOT_MET if topic does not exist
      */

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -25,13 +25,16 @@
 #include <fastdds/rtps/common/Time_t.h>
 #include <fastrtps/types/TypeIdentifier.h>
 
-#include <fastdds/rtps/common/Guid.h>
-#include <fastdds/rtps/common/SampleIdentity.h>
-#include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
-#include <fastrtps/types/TypesBase.h>
+#include <fastdds/dds/builtin/topic/ParticipantBuiltinTopicData.hpp>
+#include <fastdds/dds/builtin/topic/TopicBuiltinTopicData.hpp>
 #include <fastdds/dds/core/status/StatusMask.hpp>
 #include <fastdds/dds/core/Entity.hpp>
 #include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
+#include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
+#include <fastdds/rtps/common/Guid.h>
+#include <fastdds/rtps/common/SampleIdentity.h>
+#include <fastrtps/types/TypesBase.h>
+
 
 #include <utility>
 
@@ -75,8 +78,6 @@ class TopicQos;
 // Not implemented classes
 class ContentFilteredTopic;
 class MultiTopic;
-class ParticipantBuiltinTopicData;
-class TopicBuiltinTopicData;
 
 /**
  * Class DomainParticipant used to group Publishers and Subscribers into a single working unit.
@@ -558,7 +559,7 @@ public:
      * @return RETCODE_OK if everything correct, PRECONDITION_NOT_MET if participant does not exist
      */
     RTPS_DllAPI ReturnCode_t get_discovered_participant_data(
-            ParticipantBuiltinTopicData& participant_data,
+            builtin::ParticipantBuiltinTopicData& participant_data,
             const InstanceHandle_t& participant_handle) const;
 
     /**
@@ -576,7 +577,7 @@ public:
      * @return RETCODE_OK if everything correct, PRECONDITION_NOT_MET if topic does not exist
      */
     RTPS_DllAPI ReturnCode_t get_discovered_topic_data(
-            TopicBuiltinTopicData& topic_data,
+            builtin::TopicBuiltinTopicData& topic_data,
             const InstanceHandle_t& topic_handle) const;
 
     /**

--- a/src/cpp/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipant.cpp
@@ -351,7 +351,6 @@ ReturnCode_t DomainParticipant::get_discovered_participants(
     return ReturnCode_t::RETCODE_UNSUPPORTED;
 }
 
-
 ReturnCode_t DomainParticipant::get_discovered_participant_data(
         ParticipantBuiltinTopicData& participant_data,
         const InstanceHandle_t& participant_handle) const
@@ -361,14 +360,12 @@ ReturnCode_t DomainParticipant::get_discovered_participant_data(
     return ReturnCode_t::RETCODE_UNSUPPORTED;
 }
 
-
 ReturnCode_t DomainParticipant::get_discovered_topics(
         std::vector<InstanceHandle_t>& topic_handles) const
 {
     static_cast<void> (topic_handles);
     return ReturnCode_t::RETCODE_UNSUPPORTED;
 }
-
 
 ReturnCode_t DomainParticipant::get_discovered_topic_data(
         TopicBuiltinTopicData& topic_data,

--- a/src/cpp/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipant.cpp
@@ -42,25 +42,6 @@ DomainParticipant::~DomainParticipant()
     }
 }
 
-ReturnCode_t DomainParticipant::enable()
-{
-    if (enable_)
-    {
-        return ReturnCode_t::RETCODE_OK;
-    }
-
-    enable_ = true;
-    ReturnCode_t ret_code = impl_->enable();
-    enable_ = !!ret_code;
-    return ret_code;
-}
-
-ReturnCode_t DomainParticipant::set_qos(
-        const DomainParticipantQos& qos) const
-{
-    return impl_->set_qos(qos);
-}
-
 ReturnCode_t DomainParticipant::get_qos(
         DomainParticipantQos& qos) const
 {
@@ -70,6 +51,17 @@ ReturnCode_t DomainParticipant::get_qos(
 const DomainParticipantQos& DomainParticipant::get_qos() const
 {
     return impl_->get_qos();
+}
+
+ReturnCode_t DomainParticipant::set_qos(
+        const DomainParticipantQos& qos) const
+{
+    return impl_->set_qos(qos);
+}
+
+const DomainParticipantListener* DomainParticipant::get_listener() const
+{
+    return impl_->get_listener();
 }
 
 ReturnCode_t DomainParticipant::set_listener(
@@ -91,9 +83,17 @@ ReturnCode_t DomainParticipant::set_listener(
     return ret_val;
 }
 
-const DomainParticipantListener* DomainParticipant::get_listener() const
+ReturnCode_t DomainParticipant::enable()
 {
-    return impl_->get_listener();
+    if (enable_)
+    {
+        return ReturnCode_t::RETCODE_OK;
+    }
+
+    enable_ = true;
+    ReturnCode_t ret_code = impl_->enable();
+    enable_ = !!ret_code;
+    return ret_code;
 }
 
 Publisher* DomainParticipant::create_publisher(
@@ -172,75 +172,10 @@ TopicDescription* DomainParticipant::lookup_topicdescription(
     return impl_->lookup_topicdescription(topic_name);
 }
 
-ReturnCode_t DomainParticipant::register_type(
-        TypeSupport type,
-        const std::string& type_name)
-{
-    return impl_->register_type(type, type_name);
-}
-
-ReturnCode_t DomainParticipant::register_type(
-        TypeSupport type)
-{
-    return impl_->register_type(type, type.get_type_name());
-}
-
-ReturnCode_t DomainParticipant::unregister_type(
-        const std::string& typeName)
-{
-    return impl_->unregister_type(typeName);
-}
-
-/* TODO
-   Subscriber* DomainParticipant::get_builtin_subscriber()
-   {
-    return impl_->get_builtin_subscriber();
-   }
- */
-
-/* TODO
-   bool DomainParticipant::ignore_participant(
-        const InstanceHandle_t& handle)
-   {
-    return impl_->ignore_participant(handle);
-   }
- */
-
-/* TODO
-   bool DomainParticipant::ignore_topic(
-        const InstanceHandle_t& handle)
-   {
-    return impl_->ignore_topic(handle);
-   }
- */
-
-/* TODO
-   bool DomainParticipant::ignore_publication(
-        const InstanceHandle_t& handle)
-   {
-    return impl_->ignore_publication(handle);
-   }
- */
-
-/* TODO
-   bool DomainParticipant::ignore_subscription(
-        const InstanceHandle_t& handle)
-   {
-    return impl_->ignore_subscription(handle);
-   }
- */
-
 DomainId_t DomainParticipant::get_domain_id() const
 {
     return impl_->get_domain_id();
 }
-
-/* TODO
-   bool DomainParticipant::delete_contained_entities()
-   {
-    return impl_->delete_contained_entities();
-   }
- */
 
 ReturnCode_t DomainParticipant::assert_liveliness()
 {
@@ -349,6 +284,25 @@ ReturnCode_t DomainParticipant::get_current_time(
         fastrtps::Time_t& current_time) const
 {
     return impl_->get_current_time(current_time);
+}
+
+ReturnCode_t DomainParticipant::register_type(
+        TypeSupport type,
+        const std::string& type_name)
+{
+    return impl_->register_type(type, type_name);
+}
+
+ReturnCode_t DomainParticipant::register_type(
+        TypeSupport type)
+{
+    return impl_->register_type(type, type.get_type_name());
+}
+
+ReturnCode_t DomainParticipant::unregister_type(
+        const std::string& typeName)
+{
+    return impl_->unregister_type(typeName);
 }
 
 TypeSupport DomainParticipant::find_type(

--- a/src/cpp/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipant.cpp
@@ -352,7 +352,7 @@ ReturnCode_t DomainParticipant::get_discovered_participants(
 }
 
 ReturnCode_t DomainParticipant::get_discovered_participant_data(
-        ParticipantBuiltinTopicData& participant_data,
+        builtin::ParticipantBuiltinTopicData& participant_data,
         const InstanceHandle_t& participant_handle) const
 {
     static_cast<void> (participant_data);
@@ -368,7 +368,7 @@ ReturnCode_t DomainParticipant::get_discovered_topics(
 }
 
 ReturnCode_t DomainParticipant::get_discovered_topic_data(
-        TopicBuiltinTopicData& topic_data,
+        builtin::TopicBuiltinTopicData& topic_data,
         const InstanceHandle_t& topic_handle) const
 {
     static_cast<void> (topic_data);

--- a/src/cpp/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipant.cpp
@@ -377,10 +377,10 @@ ReturnCode_t DomainParticipant::get_discovered_topic_data(
 }
 
 bool DomainParticipant::contains_entity(
-        const InstanceHandle_t& handle,
-        bool recursive) const
+        const InstanceHandle_t& a_handle,
+        bool recursive /* = true */) const
 {
-    return impl_->contains_entity(handle, recursive);
+    return impl_->contains_entity(a_handle, recursive);
 }
 
 ReturnCode_t DomainParticipant::get_current_time(

--- a/src/cpp/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipant.cpp
@@ -166,15 +166,102 @@ ReturnCode_t DomainParticipant::delete_topic(
     return impl_->delete_topic(topic);
 }
 
+ContentFilteredTopic* DomainParticipant::create_contentfilteredtopic(
+        const std::string& name,
+        const Topic* related_topic,
+        const std::string& filter_expression,
+        const std::vector<std::string>& expression_parameters)
+{
+    static_cast<void> (name);
+    static_cast<void> (related_topic);
+    static_cast<void> (filter_expression);
+    static_cast<void> (expression_parameters);
+    return nullptr;
+}
+
+ReturnCode_t DomainParticipant::delete_contentfilteredtopic(
+        const ContentFilteredTopic* a_contentfilteredtopic)
+{
+    static_cast<void> (a_contentfilteredtopic);
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
+MultiTopic* DomainParticipant::create_multitopic(
+        const std::string& name,
+        const std::string& type_name,
+        const std::string& subscription_expression,
+        const std::vector<std::string>& expression_parameters)
+{
+    static_cast<void> (name);
+    static_cast<void> (type_name);
+    static_cast<void> (subscription_expression);
+    static_cast<void> (expression_parameters);
+    return nullptr;
+}
+
+ReturnCode_t DomainParticipant::delete_multitopic(
+        const MultiTopic* a_multitopic)
+{
+    static_cast<void> (a_multitopic);
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
+Topic* DomainParticipant::find_topic(
+        const std::string& topic_name,
+        const fastrtps::Duration_t& timeout)
+{
+    static_cast<void> (topic_name);
+    static_cast<void> (timeout);
+    return nullptr;
+}
+
 TopicDescription* DomainParticipant::lookup_topicdescription(
         const std::string& topic_name) const
 {
     return impl_->lookup_topicdescription(topic_name);
 }
 
+const Subscriber* DomainParticipant::get_builtin_subscriber() const
+{
+    return nullptr;
+}
+
+ReturnCode_t DomainParticipant::ignore_participant(
+        const InstanceHandle_t& handle)
+{
+    static_cast<void> (handle);
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
+ReturnCode_t DomainParticipant::ignore_topic(
+        const InstanceHandle_t& handle)
+{
+    static_cast<void> (handle);
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
+ReturnCode_t DomainParticipant::ignore_publictaion(
+        const InstanceHandle_t& handle)
+{
+    static_cast<void> (handle);
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
+ReturnCode_t DomainParticipant::ignore_subscription(
+        const InstanceHandle_t& handle)
+{
+    static_cast<void> (handle);
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
 DomainId_t DomainParticipant::get_domain_id() const
 {
     return impl_->get_domain_id();
+}
+
+ReturnCode_t DomainParticipant::delete_contained_entities()
+{
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
 }
 
 ReturnCode_t DomainParticipant::assert_liveliness()
@@ -257,21 +344,40 @@ ReturnCode_t DomainParticipant::get_topic_qos_from_profile(
     return impl_->get_topic_qos_from_profile(profile_name, qos);
 }
 
-/* TODO
-   bool DomainParticipant::get_discovered_participants(
+ReturnCode_t DomainParticipant::get_discovered_participants(
         std::vector<InstanceHandle_t>& participant_handles) const
-   {
-    return impl_->get_discovered_participants(participant_handles);
-   }
- */
+{
+    static_cast<void> (participant_handles);
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
 
-/* TODO
-   bool DomainParticipant::get_discovered_topics(
+
+ReturnCode_t DomainParticipant::get_discovered_participant_data(
+        ParticipantBuiltinTopicData& participant_data,
+        const InstanceHandle_t& participant_handle) const
+{
+    static_cast<void> (participant_data);
+    static_cast<void> (participant_handle);
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
+
+ReturnCode_t DomainParticipant::get_discovered_topics(
         std::vector<InstanceHandle_t>& topic_handles) const
-   {
-    return impl_->get_discovered_topics(topic_handles);
-   }
- */
+{
+    static_cast<void> (topic_handles);
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
+
+ReturnCode_t DomainParticipant::get_discovered_topic_data(
+        TopicBuiltinTopicData& topic_data,
+        const InstanceHandle_t& topic_handle) const
+{
+    static_cast<void> (topic_data);
+    static_cast<void> (topic_handle);
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
 
 bool DomainParticipant::contains_entity(
         const InstanceHandle_t& handle,

--- a/src/cpp/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipant.cpp
@@ -18,8 +18,9 @@
  */
 
 #include <fastdds/dds/domain/DomainParticipant.hpp>
-#include <fastdds/domain/DomainParticipantImpl.hpp>
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
+#include <fastdds/dds/log/Log.hpp>
+#include <fastdds/domain/DomainParticipantImpl.hpp>
 
 using namespace eprosima;
 using namespace eprosima::fastdds::dds;
@@ -176,6 +177,7 @@ ContentFilteredTopic* DomainParticipant::create_contentfilteredtopic(
     static_cast<void> (related_topic);
     static_cast<void> (filter_expression);
     static_cast<void> (expression_parameters);
+    logWarning(DOMAIN_PARTICIPANT, "create_contentfilteredtopic method not implemented");
     return nullptr;
 }
 
@@ -196,6 +198,7 @@ MultiTopic* DomainParticipant::create_multitopic(
     static_cast<void> (type_name);
     static_cast<void> (subscription_expression);
     static_cast<void> (expression_parameters);
+    logWarning(DOMAIN_PARTICIPANT, "create_multitopic method not implemented");
     return nullptr;
 }
 
@@ -212,6 +215,7 @@ Topic* DomainParticipant::find_topic(
 {
     static_cast<void> (topic_name);
     static_cast<void> (timeout);
+    logWarning(DOMAIN_PARTICIPANT, "find_topic method not implemented");
     return nullptr;
 }
 
@@ -223,6 +227,7 @@ TopicDescription* DomainParticipant::lookup_topicdescription(
 
 const Subscriber* DomainParticipant::get_builtin_subscriber() const
 {
+    logWarning(DOMAIN_PARTICIPANT, "get_builtin_subscriber method not implemented");
     return nullptr;
 }
 

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -2027,6 +2027,78 @@ TEST(ParticipantTests, RegisterRemoteTypePreconditionNotMet)
     ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), ReturnCode_t::RETCODE_OK);
 }
 
+
+/*
+ * This test checks that following methods are not implemented and returns an error
+ *  create_contentfilteredtopic
+ *  delete_contentfilteredtopic
+ *  create_multitopic
+ *  delete_multitopic
+ *  find_topic
+ *  get_builtin_subscriber
+ *  ignore_participant
+ *  ignore_topic
+ *  ignore_publictaion
+ *  ignore_subscription
+ *  delete_contained_entities
+ *  get_discovered_participants
+ *  get_discovered_topics
+ *
+ * Tests missing: get_discovered_participant_data & get_discovered_topic_data
+ * These methods cannot be tested because there are no implementation of their parameter classes
+ */
+TEST(ParticipantTests, unsupportedMethods)
+{
+    // Create the participant
+    DomainParticipant* participant =
+            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+
+    // Create a type and a topic
+    TypeSupport type(new TopicDataTypeMock());
+    type.register_type(participant);
+
+    Topic* topic = participant->create_topic("topic", type.get_type_name(), TOPIC_QOS_DEFAULT);
+    ASSERT_NE(topic, nullptr);
+
+    ASSERT_EQ(
+        participant->create_contentfilteredtopic(
+            "contentfilteredtopic",
+            topic,
+            "filter_expression",
+            std::vector<std::string>({"a","b"})),
+        nullptr);
+
+    // nullptr use as there are not such a class
+    ASSERT_EQ(participant->delete_contentfilteredtopic(nullptr), ReturnCode_t::RETCODE_UNSUPPORTED);
+
+    ASSERT_EQ(
+        participant->create_multitopic(
+            "multitopic",
+            "type",
+            "subscription_expression",
+            std::vector<std::string>({"a","b"})),
+        nullptr);
+
+    // nullptr use as there are not such a class
+    ASSERT_EQ(participant->delete_multitopic(nullptr), ReturnCode_t::RETCODE_UNSUPPORTED);
+
+    ASSERT_EQ(participant->find_topic("topic", Duration_t(1,0)), nullptr);
+
+    ASSERT_EQ(participant->get_builtin_subscriber(), nullptr);
+
+    ASSERT_EQ(participant->ignore_participant(InstanceHandle_t()), ReturnCode_t::RETCODE_UNSUPPORTED);
+    ASSERT_EQ(participant->ignore_topic(InstanceHandle_t()), ReturnCode_t::RETCODE_UNSUPPORTED);
+    ASSERT_EQ(participant->ignore_publictaion(InstanceHandle_t()), ReturnCode_t::RETCODE_UNSUPPORTED);
+    ASSERT_EQ(participant->ignore_subscription(InstanceHandle_t()), ReturnCode_t::RETCODE_UNSUPPORTED);
+
+    ASSERT_EQ(participant->delete_contained_entities(), ReturnCode_t::RETCODE_UNSUPPORTED);
+
+    std::vector<InstanceHandle_t> handle_vector({InstanceHandle_t()});
+
+    ASSERT_EQ(participant->get_discovered_participants(handle_vector), ReturnCode_t::RETCODE_UNSUPPORTED);
+    ASSERT_EQ(participant->get_discovered_topics(handle_vector), ReturnCode_t::RETCODE_UNSUPPORTED);
+}
+
 } // namespace dds
 } // namespace fastdds
 } // namespace eprosima

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -2029,7 +2029,7 @@ TEST(ParticipantTests, RegisterRemoteTypePreconditionNotMet)
 
 
 /*
- * This test checks that following methods are not implemented and returns an error
+ * This test checks that the following methods are not implemented and returns an error
  *  create_contentfilteredtopic
  *  delete_contentfilteredtopic
  *  create_multitopic
@@ -2047,15 +2047,16 @@ TEST(ParticipantTests, RegisterRemoteTypePreconditionNotMet)
  * Tests missing: get_discovered_participant_data & get_discovered_topic_data
  * These methods cannot be tested because there are no implementation of their parameter classes
  */
-TEST(ParticipantTests, unsupportedMethods)
+TEST(ParticipantTests, UnsupportedMethods)
 {
     // Create the participant
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
 
     // Create a type and a topic
     TypeSupport type(new TopicDataTypeMock());
-    type.register_type(participant);
+    ASSERT_EQ(type.register_type(participant), ReturnCode_t::RETCODE_OK);
 
     Topic* topic = participant->create_topic("topic", type.get_type_name(), TOPIC_QOS_DEFAULT);
     ASSERT_NE(topic, nullptr);
@@ -2097,6 +2098,9 @@ TEST(ParticipantTests, unsupportedMethods)
 
     ASSERT_EQ(participant->get_discovered_participants(handle_vector), ReturnCode_t::RETCODE_UNSUPPORTED);
     ASSERT_EQ(participant->get_discovered_topics(handle_vector), ReturnCode_t::RETCODE_UNSUPPORTED);
+
+    ASSERT_EQ(participant->delete_topic(topic), ReturnCode_t::RETCODE_OK);
+    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), ReturnCode_t::RETCODE_OK);
 }
 
 } // namespace dds

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -2096,6 +2096,7 @@ TEST(ParticipantTests, UnsupportedMethods)
 
     ASSERT_EQ(participant->delete_contained_entities(), ReturnCode_t::RETCODE_UNSUPPORTED);
 
+    // Discovery methods
     std::vector<InstanceHandle_t> handle_vector({InstanceHandle_t()});
     builtin::ParticipantBuiltinTopicData pbtd;
     builtin::TopicBuiltinTopicData tbtd;

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -15,33 +15,35 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <dds/core/types.hpp>
+#include <dds/domain/DomainParticipant.hpp>
+#include <dds/domain/qos/DomainParticipantQos.hpp>
+#include <dds/pub/Publisher.hpp>
+#include <dds/pub/qos/PublisherQos.hpp>
+#include <dds/sub/qos/SubscriberQos.hpp>
+#include <dds/sub/Subscriber.hpp>
+#include <dds/topic/Topic.hpp>
+#include <fastdds/dds/builtin/topic/ParticipantBuiltinTopicData.hpp>
+#include <fastdds/dds/builtin/topic/TopicBuiltinTopicData.hpp>
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/DomainParticipantListener.hpp>
 #include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
+#include <fastdds/dds/publisher/DataWriter.hpp>
 #include <fastdds/dds/publisher/Publisher.hpp>
 #include <fastdds/dds/publisher/qos/PublisherQos.hpp>
-#include <fastdds/dds/subscriber/Subscriber.hpp>
-#include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
-#include <fastdds/dds/topic/qos/TopicQos.hpp>
-#include <fastdds/dds/publisher/DataWriter.hpp>
 #include <fastdds/dds/subscriber/DataReader.hpp>
-#include <dds/domain/DomainParticipant.hpp>
-#include <dds/domain/qos/DomainParticipantQos.hpp>
-#include <dds/pub/qos/PublisherQos.hpp>
-#include <dds/sub/qos/SubscriberQos.hpp>
-#include <dds/core/types.hpp>
-#include <dds/sub/Subscriber.hpp>
-#include <dds/pub/Publisher.hpp>
-#include <dds/topic/Topic.hpp>
+#include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
+#include <fastdds/dds/subscriber/Subscriber.hpp>
+#include <fastdds/dds/topic/qos/TopicQos.hpp>
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
 #include <fastrtps/attributes/PublisherAttributes.h>
 #include <fastrtps/attributes/SubscriberAttributes.h>
-#include <fastrtps/xmlparser/XMLProfileManager.h>
 #include <fastrtps/types/DynamicDataFactory.h>
-#include <fastrtps/types/TypeDescriptor.h>
 #include <fastrtps/types/DynamicType.h>
 #include <fastrtps/types/DynamicTypePtr.h>
+#include <fastrtps/types/TypeDescriptor.h>
 #include <fastrtps/types/TypeObjectFactory.h>
+#include <fastrtps/xmlparser/XMLProfileManager.h>
 
 
 namespace eprosima {
@@ -2095,9 +2097,16 @@ TEST(ParticipantTests, UnsupportedMethods)
     ASSERT_EQ(participant->delete_contained_entities(), ReturnCode_t::RETCODE_UNSUPPORTED);
 
     std::vector<InstanceHandle_t> handle_vector({InstanceHandle_t()});
+    builtin::ParticipantBuiltinTopicData pbtd;
+    builtin::TopicBuiltinTopicData tbtd;
 
     ASSERT_EQ(participant->get_discovered_participants(handle_vector), ReturnCode_t::RETCODE_UNSUPPORTED);
+    ASSERT_EQ(
+        participant->get_discovered_participant_data(pbtd, InstanceHandle_t()), ReturnCode_t::RETCODE_UNSUPPORTED);
+
     ASSERT_EQ(participant->get_discovered_topics(handle_vector), ReturnCode_t::RETCODE_UNSUPPORTED);
+    ASSERT_EQ(
+        participant->get_discovered_topic_data(tbtd, InstanceHandle_t()), ReturnCode_t::RETCODE_UNSUPPORTED);
 
     ASSERT_EQ(participant->delete_topic(topic), ReturnCode_t::RETCODE_OK);
     ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), ReturnCode_t::RETCODE_OK);

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -2065,7 +2065,7 @@ TEST(ParticipantTests, unsupportedMethods)
             "contentfilteredtopic",
             topic,
             "filter_expression",
-            std::vector<std::string>({"a","b"})),
+            std::vector<std::string>({"a", "b"})),
         nullptr);
 
     // nullptr use as there are not such a class
@@ -2076,13 +2076,13 @@ TEST(ParticipantTests, unsupportedMethods)
             "multitopic",
             "type",
             "subscription_expression",
-            std::vector<std::string>({"a","b"})),
+            std::vector<std::string>({"a", "b"})),
         nullptr);
 
     // nullptr use as there are not such a class
     ASSERT_EQ(participant->delete_multitopic(nullptr), ReturnCode_t::RETCODE_UNSUPPORTED);
 
-    ASSERT_EQ(participant->find_topic("topic", Duration_t(1,0)), nullptr);
+    ASSERT_EQ(participant->find_topic("topic", Duration_t(1, 0)), nullptr);
 
     ASSERT_EQ(participant->get_builtin_subscriber(), nullptr);
 


### PR DESCRIPTION
new methods:
 *  create_contentfilteredtopic
 *  delete_contentfilteredtopic
 *  create_multitopic
 *  delete_multitopic
 *  find_topic
 *  get_builtin_subscriber
 *  ignore_participant
 *  ignore_topic
 *  ignore_publictaion
 *  ignore_subscription
 *  delete_contained_entities
 *  get_discovered_participants
 *  get_discovered_participant_data
 *  get_discovered_topics
 *  get_discovered_topic_data

NOTE: Tests missing: get_discovered_participant_data & get_discovered_topic_data
These methods cannot be tested because there are no implementation of their parameter classes.