### PR TITLE
<ros2-eloquent> Backport LOG_NO_INFO refactor [10348]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,21 @@ else()
 endif()
 
 ###############################################################################
+# Log Info default setup
+###############################################################################
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    option(LOG_NO_INFO "Do not compile Info Log level" OFF)
+else()
+    option(LOG_NO_INFO "Do not compile Info Log level" ON)
+endif()
+
+if(LOG_NO_INFO)
+    set(HAVE_LOG_NO_INFO 1)
+else()
+    set(HAVE_LOG_NO_INFO 0)
+endif()
+
+###############################################################################
 # Compile library.
 ###############################################################################
 add_subdirectory(src/cpp)

--- a/include/fastrtps/config.h.in
+++ b/include/fastrtps/config.h.in
@@ -73,6 +73,13 @@
 #define HAVE_STRICT_REALTIME @HAVE_STRICT_REALTIME@
 #endif
 
+/* Log Macros */
+
+// Log Info
+#ifndef HAVE_LOG_NO_INFO
+#define HAVE_LOG_NO_INFO @HAVE_LOG_NO_INFO@
+#endif
+
 // Deprecated macro
 #if __cplusplus >= 201402L
 #define FASTRTPS_DEPRECATED(msg) [[ deprecated(msg) ]]

--- a/include/fastrtps/log/Log.h
+++ b/include/fastrtps/log/Log.h
@@ -251,7 +251,7 @@ class LogConsumer
 #define logWarning_(cat, msg)
 #endif
 
-#if (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG)) && (defined(_DEBUG) || defined(__DEBUG)) && (!defined(LOG_NO_INFO))
+#if !HAVE_LOG_NO_INFO
 #define logInfo_(cat, msg)                                                                              \
     {                                                                                                   \
         if (Log::GetVerbosity() >= Log::Kind::Info)                                                     \

--- a/include/fastrtps/log/Log.h
+++ b/include/fastrtps/log/Log.h
@@ -59,131 +59,142 @@ class LogConsumer;
  */
 class Log
 {
-    public:
-        /**
-        * Types of log entry.
-        * * Error: Maximum priority. Can only be disabled statically through LOG_NO_ERROR.
-        * * Warning: Medium priority.  Can be disabled statically and dynamically.
-        * * Info: Low priority. Useful for debugging. Disabled by default on release branches.
-        */
-        enum Kind
-        {
-            Error,
-            Warning,
-            Info,
-        };
+public:
 
-        /**
-        * Registers an user defined consumer to route log output.
-        * There is a default stdout consumer active as default.
-        * @param consumer r-value to a consumer unique_ptr. It will be invalidated after the call.
-        */
-        RTPS_DllAPI static void RegisterConsumer(std::unique_ptr<LogConsumer>&& consumer);
+    /**
+     * Types of log entry.
+     * * Error: Maximum priority. Can only be disabled statically through LOG_NO_ERROR.
+     * * Warning: Medium priority.  Can be disabled statically and dynamically.
+     * * Info: Low priority. Useful for debugging. Disabled by default on release branches.
+     */
+    enum Kind
+    {
+        Error,
+        Warning,
+        Info,
+    };
 
-        //! Removes all registered consumers, including the default stdout.
-        RTPS_DllAPI static void ClearConsumers();
+    /**
+     * Registers an user defined consumer to route log output.
+     * There is a default stdout consumer active as default.
+     * @param consumer r-value to a consumer unique_ptr. It will be invalidated after the call.
+     */
+    RTPS_DllAPI static void RegisterConsumer(
+            std::unique_ptr<LogConsumer>&& consumer);
 
-        //! Enables the reporting of filenames in log entries. Disabled by default.
-        RTPS_DllAPI static void ReportFilenames(bool);
+    //! Removes all registered consumers, including the default stdout.
+    RTPS_DllAPI static void ClearConsumers();
 
-        //! Enables the reporting of function names in log entries. Enabled by default when supported.
-        RTPS_DllAPI static void ReportFunctions(bool);
+    //! Enables the reporting of filenames in log entries. Disabled by default.
+    RTPS_DllAPI static void ReportFilenames(
+            bool);
 
-        //! Sets the verbosity level, allowing for messages equal or under that priority to be logged.
-        RTPS_DllAPI static void SetVerbosity(Log::Kind);
+    //! Enables the reporting of function names in log entries. Enabled by default when supported.
+    RTPS_DllAPI static void ReportFunctions(
+            bool);
 
-        //! Returns the current verbosity level.
-        RTPS_DllAPI static Log::Kind GetVerbosity();
+    //! Sets the verbosity level, allowing for messages equal or under that priority to be logged.
+    RTPS_DllAPI static void SetVerbosity(
+            Log::Kind);
 
-        //! Sets a filter that will pattern-match against log categories, dropping any unmatched categories.
-        RTPS_DllAPI static void SetCategoryFilter(const std::regex&);
+    //! Returns the current verbosity level.
+    RTPS_DllAPI static Log::Kind GetVerbosity();
 
-        //! Sets a filter that will pattern-match against filenames, dropping any unmatched categories.
-        RTPS_DllAPI static void SetFilenameFilter(const std::regex&);
+    //! Sets a filter that will pattern-match against log categories, dropping any unmatched categories.
+    RTPS_DllAPI static void SetCategoryFilter(
+            const std::regex&);
 
-        //! Sets a filter that will pattern-match against the provided error string, dropping any unmatched categories.
-        RTPS_DllAPI static void SetErrorStringFilter(const std::regex&);
+    //! Sets a filter that will pattern-match against filenames, dropping any unmatched categories.
+    RTPS_DllAPI static void SetFilenameFilter(
+            const std::regex&);
 
-        //! Returns the logging engine to configuration defaults.
-        RTPS_DllAPI static void Reset();
+    //! Sets a filter that will pattern-match against the provided error string, dropping any unmatched categories.
+    RTPS_DllAPI static void SetErrorStringFilter(
+            const std::regex&);
 
-        //! Waits until no more log info is availabel
-        RTPS_DllAPI static void Flush();
+    //! Returns the logging engine to configuration defaults.
+    RTPS_DllAPI static void Reset();
 
-        //! Stops the logging thread. It will re-launch on the next call to a successful log macro.
-        RTPS_DllAPI static void KillThread();
+    //! Waits until no more log info is availabel
+    RTPS_DllAPI static void Flush();
 
-        // Note: In VS2013, if you're linking this class statically, you will have to call KillThread before leaving
-        // main, due to an unsolved MSVC bug.
+    //! Stops the logging thread. It will re-launch on the next call to a successful log macro.
+    RTPS_DllAPI static void KillThread();
 
-        struct Context
-        {
-            const char* filename;
-            int line;
-            const char* function;
-            const char* category;
-        };
+    // Note: In VS2013, if you're linking this class statically, you will have to call KillThread before leaving
+    // main, due to an unsolved MSVC bug.
 
-        struct Entry
-        {
-            std::string message;
-            Log::Context context;
-            Log::Kind kind;
-            std::string timestamp;
-        };
+    struct Context
+    {
+        const char* filename;
+        int line;
+        const char* function;
+        const char* category;
+    };
 
-        /**
-        * Not recommended to call this method directly! Use the following macros:
-        *  * logInfo(cat, msg);
-        *  * logWarning(cat, msg);
-        *  * logError(cat, msg);
-        */
-        RTPS_DllAPI static void QueueLog(
-                const std::string& message,
-                const Log::Context&,
-                Log::Kind);
+    struct Entry
+    {
+        std::string message;
+        Log::Context context;
+        Log::Kind kind;
+        std::string timestamp;
+    };
 
-    private:
-        struct Resources
-        {
-            DBQueue<Entry> mLogs;
-            std::vector<std::unique_ptr<LogConsumer>> mConsumers;
-            std::unique_ptr<std::thread> mLoggingThread;
+    /**
+     * Not recommended to call this method directly! Use the following macros:
+     *  * logInfo(cat, msg);
+     *  * logWarning(cat, msg);
+     *  * logError(cat, msg);
+     */
+    RTPS_DllAPI static void QueueLog(
+            const std::string& message,
+            const Log::Context&,
+            Log::Kind);
 
-            // Condition variable segment.
-            std::condition_variable mCv;
-            std::mutex mCvMutex;
-            bool mLogging;
-            bool mWork;
-            int current_loop;
+private:
 
-            // Context configuration.
-            std::mutex mConfigMutex;
-            bool mFilenames;
-            bool mFunctions;
-            std::unique_ptr<std::regex> mCategoryFilter;
-            std::unique_ptr<std::regex> mFilenameFilter;
-            std::unique_ptr<std::regex> mErrorStringFilter;
+    struct Resources
+    {
+        DBQueue<Entry> mLogs;
+        std::vector<std::unique_ptr<LogConsumer>> mConsumers;
+        std::unique_ptr<std::thread> mLoggingThread;
 
-            std::atomic<Log::Kind> mVerbosity;
+        // Condition variable segment.
+        std::condition_variable mCv;
+        std::mutex mCvMutex;
+        bool mLogging;
+        bool mWork;
+        int current_loop;
 
-            Resources();
+        // Context configuration.
+        std::mutex mConfigMutex;
+        bool mFilenames;
+        bool mFunctions;
+        std::unique_ptr<std::regex> mCategoryFilter;
+        std::unique_ptr<std::regex> mFilenameFilter;
+        std::unique_ptr<std::regex> mErrorStringFilter;
 
-            ~Resources();
-        };
+        std::atomic<Log::Kind> mVerbosity;
 
-        static struct Resources mResources;
+        Resources();
 
-        // Applies transformations to the entries compliant with the options selected (such as
-        // erasure of certain context information, or filtering by category. Returns false
-        // if the log entry is blacklisted.
-        static bool Preprocess(Entry&);
+        ~Resources();
+    };
 
-        static void LaunchThread();
+    static struct Resources mResources;
 
-        static void Run();
+    // Applies transformations to the entries compliant with the options selected (such as
+    // erasure of certain context information, or filtering by category. Returns false
+    // if the log entry is blacklisted.
+    static bool Preprocess(
+            Entry&);
 
-        static void GetTimestamp(std::string&);
+    static void LaunchThread();
+
+    static void Run();
+
+    static void GetTimestamp(
+            std::string&);
 };
 
 /**
@@ -191,40 +202,45 @@ class Log
  */
 class LogConsumer
 {
-    public:
-        virtual ~LogConsumer(){};
+public:
 
-        virtual void Consume(const Log::Entry&) = 0;
+    virtual ~LogConsumer()
+    {
+    }
 
-    protected:
-        void PrintTimestamp(
-                std::ostream& stream,
-                const Log::Entry&,
-                bool color) const;
+    virtual void Consume(
+            const Log::Entry&) = 0;
 
-        void PrintHeader(
-                std::ostream& stream,
-                const Log::Entry&,
-                bool color) const;
+protected:
 
-        void PrintContext(
-                std::ostream& stream,
-                const Log::Entry&,
-                bool color) const;
+    void PrintTimestamp(
+            std::ostream& stream,
+            const Log::Entry&,
+            bool color) const;
 
-        void PrintMessage(
-                std::ostream& stream,
-                const Log::Entry&,
-                bool color) const;
+    void PrintHeader(
+            std::ostream& stream,
+            const Log::Entry&,
+            bool color) const;
 
-        void PrintNewLine(
-                std::ostream& stream,
-                bool color) const;
+    void PrintContext(
+            std::ostream& stream,
+            const Log::Entry&,
+            bool color) const;
+
+    void PrintMessage(
+            std::ostream& stream,
+            const Log::Entry&,
+            bool color) const;
+
+    void PrintNewLine(
+            std::ostream& stream,
+            bool color) const;
 };
 
 #if defined(WIN32)
 #define __func__ __FUNCTION__
-#endif
+#endif // if defined(WIN32)
 
 #ifndef LOG_NO_ERROR
 #define logError_(cat, msg)                                                                          \
@@ -235,7 +251,7 @@ class LogConsumer
     }
 #else
 #define logError_(cat, msg)
-#endif
+#endif // ifndef LOG_NO_ERROR
 
 #ifndef LOG_NO_WARNING
 #define logWarning_(cat, msg)                                                                              \
@@ -249,7 +265,7 @@ class LogConsumer
     }
 #else
 #define logWarning_(cat, msg)
-#endif
+#endif // ifndef LOG_NO_WARNING
 
 #if !HAVE_LOG_NO_INFO
 #define logInfo_(cat, msg)                                                                              \
@@ -263,9 +279,9 @@ class LogConsumer
     }
 #else
 #define logInfo_(cat, msg)
-#endif
+#endif // if !HAVE_LOG_NO_INFO
 
 } // namespace fastrtps
 } // namespace eprosima
 
-#endif
+#endif // ifndef _FASTRTPS_LOG_LOG_H_

--- a/test/unittest/rtps/resources/timedevent/CMakeLists.txt
+++ b/test/unittest/rtps/resources/timedevent/CMakeLists.txt
@@ -27,6 +27,8 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEvent.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/ResourceEvent.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/TimedConditionVariable.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
             )
 


### PR DESCRIPTION
Backport of LOG_NO_INFO refactor to ros2-eloquent.

Locally I have tested the following cases:

* Build type Debug: Log INFO are printed.
* Build type Debug and LOG_NO_INFO=ON: Log INFO are not printed.
* Build type Release: Log INFO are not printed.
* Build type Release and LOG_NO_INFO=OFF: Log INFO are printed.