### PR TITLE
Solving reference counting mistake on DataWriterImpl use of TopicPayloadPool 

### DIFF
--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1480,9 +1480,23 @@ bool DataWriterImpl::release_payload_pool()
     assert(payload_pool_);
 
     loans_.reset();
+
+    bool result = true;
+
+    if (is_data_sharing_compatible_)
+    {
+        // No-op
+    }
+    else
+    {
+        PoolConfig config = PoolConfig::from_history_attributes(history_.m_att);
+        auto topic_pool = std::static_pointer_cast<ITopicPayloadPool>(payload_pool_);
+        result = topic_pool->release_history(config, false);
+    }
+
     payload_pool_.reset();
 
-    return true;
+    return result;
 }
 
 bool DataWriterImpl::add_loan(

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1462,11 +1462,7 @@ std::shared_ptr<IPayloadPool> DataWriterImpl::get_payload_pool()
         else
         {
             payload_pool_ = TopicPayloadPoolRegistry::get(topic_->get_name(), config);
-            if (!std::static_pointer_cast<ITopicPayloadPool>(payload_pool_)->reserve_history(config, false))
-            {
-                auto topic_pool = std::static_pointer_cast<ITopicPayloadPool>(payload_pool_);
-                TopicPayloadPoolRegistry::release(topic_pool);
-            }
+            std::static_pointer_cast<ITopicPayloadPool>(payload_pool_)->reserve_history(config, false);
         }
 
         // Prepare loans collection for plain types only
@@ -1484,23 +1480,9 @@ bool DataWriterImpl::release_payload_pool()
     assert(payload_pool_);
 
     loans_.reset();
-
-    bool result = true;
-
-    PoolConfig config = PoolConfig::from_history_attributes(history_.m_att);
-    if (is_data_sharing_compatible_)
-    {
-        // No-op
-    }
-    else
-    {
-        auto topic_pool = std::static_pointer_cast<ITopicPayloadPool>(payload_pool_);
-        result = topic_pool->release_history(config, false);
-        TopicPayloadPoolRegistry::release(topic_pool);
-    }
-
     payload_pool_.reset();
-    return result;
+
+    return true;
 }
 
 bool DataWriterImpl::add_loan(

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1462,7 +1462,10 @@ std::shared_ptr<IPayloadPool> DataWriterImpl::get_payload_pool()
         else
         {
             payload_pool_ = TopicPayloadPoolRegistry::get(topic_->get_name(), config);
-            std::static_pointer_cast<ITopicPayloadPool>(payload_pool_)->reserve_history(config, false);
+            if (!std::static_pointer_cast<ITopicPayloadPool>(payload_pool_)->reserve_history(config, false))
+            {
+                payload_pool_.reset();
+            }
         }
 
         // Prepare loans collection for plain types only

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1376,6 +1376,7 @@ void DataReaderImpl::release_payload_pool()
 
     PoolConfig config = PoolConfig::from_history_attributes(history_.m_att);
     payload_pool_->release_history(config, true);
+    payload_pool_.reset();
 }
 
 ReturnCode_t DataReaderImpl::check_datasharing_compatible(

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1376,8 +1376,6 @@ void DataReaderImpl::release_payload_pool()
 
     PoolConfig config = PoolConfig::from_history_attributes(history_.m_att);
     payload_pool_->release_history(config, true);
-
-    TopicPayloadPoolRegistry::release(payload_pool_);
 }
 
 ReturnCode_t DataReaderImpl::check_datasharing_compatible(

--- a/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.cpp
+++ b/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.cpp
@@ -111,7 +111,6 @@ PublisherImpl::~PublisherImpl()
     std::string topic_name = m_att.topic.getTopicName().to_string();
     PoolConfig pool_cfg = PoolConfig::from_history_attributes(m_history.m_att);
     payload_pool_->release_history(pool_cfg, false);
-    TopicPayloadPoolRegistry::release(payload_pool_);
 }
 
 bool PublisherImpl::create_new_change(

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberImpl.cpp
@@ -102,7 +102,6 @@ SubscriberImpl::~SubscriberImpl()
     std::string topic_name = m_att.topic.getTopicName().to_string();
     PoolConfig pool_cfg = PoolConfig::from_history_attributes(m_history.m_att);
     payload_pool_->release_history(pool_cfg, true);
-    TopicPayloadPoolRegistry::release(payload_pool_);
 }
 
 bool SubscriberImpl::wait_for_unread_samples(

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPUtils.hpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPUtils.hpp
@@ -68,7 +68,6 @@ public:
         {
             PoolConfig pool_cfg = PoolConfig::from_history_attributes(history_attr);
             pool->release_history(pool_cfg, is_reader);
-            TopicPayloadPoolRegistry::release(pool);
         }
     }
 

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPUtils.hpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPUtils.hpp
@@ -68,6 +68,7 @@ public:
         {
             PoolConfig pool_cfg = PoolConfig::from_history_attributes(history_attr);
             pool->release_history(pool_cfg, is_reader);
+            pool.reset();
         }
     }
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -152,7 +152,6 @@ PDP::~PDP()
         if (writer_payload_pool_)
         {
             writer_payload_pool_->release_history(cfg, false);
-            TopicPayloadPoolRegistry::release(writer_payload_pool_);
         }
     }
 
@@ -163,7 +162,6 @@ PDP::~PDP()
         if (reader_payload_pool_)
         {
             reader_payload_pool_->release_history(cfg, true);
-            TopicPayloadPoolRegistry::release(reader_payload_pool_);
         }
     }
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -279,6 +279,7 @@ bool PDPSimple::createPDPEndpoints()
         delete mp_listener;
         mp_listener = nullptr;
         reader_payload_pool_->release_history(reader_pool_cfg, true);
+        reader_payload_pool_.reset();
         return false;
     }
 
@@ -336,6 +337,7 @@ bool PDPSimple::createPDPEndpoints()
         delete mp_PDPWriterHistory;
         mp_PDPWriterHistory = nullptr;
         writer_payload_pool_->release_history(writer_pool_cfg, false);
+        writer_payload_pool_.reset();
         return false;
     }
     logInfo(RTPS_PDP, "SPDP Endpoints creation finished");

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -279,7 +279,6 @@ bool PDPSimple::createPDPEndpoints()
         delete mp_listener;
         mp_listener = nullptr;
         reader_payload_pool_->release_history(reader_pool_cfg, true);
-        TopicPayloadPoolRegistry::release(reader_payload_pool_);
         return false;
     }
 
@@ -337,7 +336,6 @@ bool PDPSimple::createPDPEndpoints()
         delete mp_PDPWriterHistory;
         mp_PDPWriterHistory = nullptr;
         writer_payload_pool_->release_history(writer_pool_cfg, false);
-        TopicPayloadPoolRegistry::release(writer_payload_pool_);
         return false;
     }
     logInfo(RTPS_PDP, "SPDP Endpoints creation finished");

--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -153,8 +153,6 @@ WLP::~WLP()
             delete mp_builtinWriterSecureHistory;
             secure_payload_pool_->release_history(swriter_pool_cfg, false);
         }
-
-        TopicPayloadPoolRegistry::release(secure_payload_pool_);
     }
 #endif // if HAVE_SECURITY
 
@@ -179,8 +177,6 @@ WLP::~WLP()
 
     delete pub_liveliness_manager_;
     delete sub_liveliness_manager_;
-
-    TopicPayloadPoolRegistry::release(payload_pool_);
 }
 
 bool WLP::initWL(

--- a/src/cpp/rtps/history/TopicPayloadPoolRegistry.cpp
+++ b/src/cpp/rtps/history/TopicPayloadPoolRegistry.cpp
@@ -35,18 +35,6 @@ std::shared_ptr<ITopicPayloadPool> TopicPayloadPoolRegistry::get(
     return detail::TopicPayloadPoolRegistry::instance().get(topic_name, config);
 }
 
-void TopicPayloadPoolRegistry::release(
-        std::shared_ptr<ITopicPayloadPool>& pool)
-{
-    auto topic_pool = std::static_pointer_cast<detail::TopicPayloadPoolProxy, IPayloadPool>(pool);
-    pool.reset();
-
-    if (topic_pool)
-    {
-        detail::TopicPayloadPoolRegistry::instance().release(topic_pool);
-    }
-}
-
 }  // namespace rtps
 }  // namespace fastrtps
 }  // namespace eprosima

--- a/src/cpp/rtps/history/TopicPayloadPoolRegistry.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPoolRegistry.hpp
@@ -38,9 +38,6 @@ public:
     static std::shared_ptr<ITopicPayloadPool> get(
             const std::string& topic_name,
             const BasicPoolConfig& config);
-
-    static void release(
-            std::shared_ptr<ITopicPayloadPool>& pool);
 };
 
 }  // namespace rtps

--- a/src/cpp/rtps/history/TopicPayloadPoolRegistry_impl/TopicPayloadPoolRegistryEntry.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPoolRegistry_impl/TopicPayloadPoolRegistryEntry.hpp
@@ -29,10 +29,10 @@ namespace detail {
 
 struct TopicPayloadPoolRegistryEntry
 {
-    std::shared_ptr<TopicPayloadPoolProxy> pool_for_preallocated;
-    std::shared_ptr<TopicPayloadPoolProxy> pool_for_preallocated_realloc;
-    std::shared_ptr<TopicPayloadPoolProxy> pool_for_dynamic;
-    std::shared_ptr<TopicPayloadPoolProxy> pool_for_dynamic_reusable;
+    std::weak_ptr<TopicPayloadPoolProxy> pool_for_preallocated;
+    std::weak_ptr<TopicPayloadPoolProxy> pool_for_preallocated_realloc;
+    std::weak_ptr<TopicPayloadPoolProxy> pool_for_dynamic;
+    std::weak_ptr<TopicPayloadPoolProxy> pool_for_dynamic_reusable;
 };
 
 }  // namespace detail

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -1018,8 +1018,6 @@ void SecurityManager::delete_participant_stateless_message_pool()
 
         PoolConfig reader_cfg = PoolConfig::from_history_attributes(participant_stateless_message_reader_hattr_);
         participant_stateless_message_pool_->release_history(reader_cfg, true);
-
-        TopicPayloadPoolRegistry::release(participant_stateless_message_pool_);
     }
 }
 
@@ -1167,7 +1165,6 @@ void SecurityManager::delete_participant_volatile_message_secure_pool()
         PoolConfig pool_cfg = PoolConfig::from_history_attributes(participant_volatile_message_secure_hattr_);
         participant_volatile_message_secure_pool_->release_history(pool_cfg, true);
         participant_volatile_message_secure_pool_->release_history(pool_cfg, false);
-        TopicPayloadPoolRegistry::release(participant_volatile_message_secure_pool_);
     }
 }
 

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -1018,6 +1018,8 @@ void SecurityManager::delete_participant_stateless_message_pool()
 
         PoolConfig reader_cfg = PoolConfig::from_history_attributes(participant_stateless_message_reader_hattr_);
         participant_stateless_message_pool_->release_history(reader_cfg, true);
+
+        participant_stateless_message_pool_.reset();
     }
 }
 
@@ -1165,6 +1167,7 @@ void SecurityManager::delete_participant_volatile_message_secure_pool()
         PoolConfig pool_cfg = PoolConfig::from_history_attributes(participant_volatile_message_secure_hattr_);
         participant_volatile_message_secure_pool_->release_history(pool_cfg, true);
         participant_volatile_message_secure_pool_->release_history(pool_cfg, false);
+        participant_volatile_message_secure_pool_.reset();
     }
 }
 

--- a/test/unittest/rtps/history/TopicPayloadPoolRegistryTests.cpp
+++ b/test/unittest/rtps/history/TopicPayloadPoolRegistryTests.cpp
@@ -51,8 +51,9 @@ TEST(TopicPayloadPoolRegistryTests, basic_checks)
     std::weak_ptr<ITopicPayloadPool> pool_wa = pool_a1;
     pool_a1.reset();
     pool_a2.reset();
+    pool_a3.reset();
     EXPECT_TRUE(pool_wa.expired());
 
     // Destructor should have been called a certain number of times
-    EXPECT_EQ(detail::TopicPayloadPoolProxy::DestructorHelper::instance().get(), 3u);
+    EXPECT_EQ(detail::TopicPayloadPoolProxy::DestructorHelper::instance().get(), 2u);
 }

--- a/test/unittest/rtps/history/TopicPayloadPoolRegistryTests.cpp
+++ b/test/unittest/rtps/history/TopicPayloadPoolRegistryTests.cpp
@@ -47,29 +47,11 @@ TEST(TopicPayloadPoolRegistryTests, basic_checks)
     // And be different from the other topic.
     EXPECT_NE(pool_b1, pool_a3);
 
-    // Releasing pointers should reset them
-    TopicPayloadPoolRegistry::release(pool_a1);
-    EXPECT_FALSE(pool_a1);
-    TopicPayloadPoolRegistry::release(pool_a2);
-    EXPECT_FALSE(pool_a2);
-    TopicPayloadPoolRegistry::release(pool_a3);
-    EXPECT_FALSE(pool_a3);
-    TopicPayloadPoolRegistry::release(pool_b1);
-    EXPECT_FALSE(pool_b1);
-    TopicPayloadPoolRegistry::release(pool_b2);
-    EXPECT_FALSE(pool_b2);
-
-    // Releasing twice should not throw
-    EXPECT_NO_THROW(TopicPayloadPoolRegistry::release(pool_a1));
-    EXPECT_FALSE(pool_a1);
-    EXPECT_NO_THROW(TopicPayloadPoolRegistry::release(pool_a2));
-    EXPECT_FALSE(pool_a2);
-    EXPECT_NO_THROW(TopicPayloadPoolRegistry::release(pool_a3));
-    EXPECT_FALSE(pool_a3);
-    EXPECT_NO_THROW(TopicPayloadPoolRegistry::release(pool_b1));
-    EXPECT_FALSE(pool_b1);
-    EXPECT_NO_THROW(TopicPayloadPoolRegistry::release(pool_b2));
-    EXPECT_FALSE(pool_b2);
+    // Releasing all references to a topic pool should automatically release the entry
+    std::weak_ptr<ITopicPayloadPool> pool_wa = pool_a1;
+    pool_a1.reset();
+    pool_a2.reset();
+    EXPECT_TRUE(pool_wa.expired());
 
     // Destructor should have been called a certain number of times
     EXPECT_EQ(detail::TopicPayloadPoolProxy::DestructorHelper::instance().get(), 3u);

--- a/test/unittest/rtps/security/CMakeLists.txt
+++ b/test/unittest/rtps/security/CMakeLists.txt
@@ -57,6 +57,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         if(WIN32)
             set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/SecurityHandshakeProcessTests.cpp PROPERTIES COMPILE_OPTIONS /bigobj)
             set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/SecurityValidationRemoteTests.cpp PROPERTIES COMPILE_OPTIONS /bigobj)
+            set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/SecurityInitializationTests.cpp PROPERTIES COMPILE_OPTIONS /bigobj)
         endif()
 
         target_compile_definitions(SecurityAuthentication PRIVATE FASTRTPS_NO_LIB


### PR DESCRIPTION
`TopicPayloadPoolRegistry` didn't rely on shared_ptr funcionality to reset the pool registry entries. Instead rely on a devoted `release` method that will check if the pool reference in the registry was the last one by doing:
```c++
if (pool.use_count() == 2)
```
The `DataWriterImpl::release_payload_pool` used:
```c++
auto topic_pool = std::static_pointer_cast<ITopicPayloadPool>(payload_pool_);
result = topic_pool->release_history(config, false);
TopicPayloadPoolRegistry::release(topic_pool);
```
were `topic_pool` construction increased the count to 3 preventing the actual reset of the pool entry. In order to avoid this sort of errors induced by local auxiliary variables now registry clean-up relies only on 'shared_ptr' reference tracking.