### PR TITLE
Introduce new LoanableTypedCollection interface [10479]

### DIFF
--- a/include/fastdds/dds/core/LoanableSequence.hpp
+++ b/include/fastdds/dds/core/LoanableSequence.hpp
@@ -62,6 +62,9 @@ class LoanableSequence : public LoanableTypedCollection<T>
 {
 public:
 
+    using size_type = LoanableCollection::size_type;
+    using element_type = LoanableCollection::element_type;
+
     /**
      * Default constructor.
      *
@@ -169,6 +172,13 @@ public:
 
         return *this;
     }
+
+protected:
+
+    using LoanableCollection::maximum_;
+    using LoanableCollection::length_;
+    using LoanableCollection::elements_;
+    using LoanableCollection::has_ownership_;
 
 private:
 

--- a/include/fastdds/dds/core/LoanableSequence.hpp
+++ b/include/fastdds/dds/core/LoanableSequence.hpp
@@ -163,7 +163,7 @@ public:
             release();
         }
 
-        length(other.length());
+        LoanableCollection::length(other.length());
         const element_type* other_buf = other.buffer();
         for (size_type n = 0; n < length_; ++n)
         {

--- a/include/fastdds/dds/core/LoanableSequence.hpp
+++ b/include/fastdds/dds/core/LoanableSequence.hpp
@@ -23,7 +23,7 @@
 #include <cstdint>
 #include <vector>
 
-#include <fastdds/dds/core/LoanableCollection.hpp>
+#include <fastdds/dds/core/LoanableTypedCollection.hpp>
 #include <fastdds/dds/log/Log.hpp>
 
 namespace eprosima {
@@ -58,7 +58,7 @@ namespace dds {
  *     @li A sequence with a zero maximum always has has_ownership == true
  */
 template<typename T>
-class LoanableSequence : public LoanableCollection
+class LoanableSequence : public LoanableTypedCollection<T>
 {
 public:
 
@@ -168,57 +168,6 @@ public:
         }
 
         return *this;
-    }
-
-    /**
-     * Set an element of the sequence.
-     *
-     * This is the operator that is invoked when the application indexes into a @em non-const sequence:
-     * @code{.cpp}
-     * element = sequence[n];
-     * sequence[n] = element;
-     * @endcode
-     *
-     * Note that a @em reference to the element is returned (and not a copy)
-     *
-     * @param [in] n index of element to access, must be >= 0 and less than length().
-     *
-     * @return a reference to the element at position @c n
-     */
-    T& operator [](
-            size_type n)
-    {
-        if (n >= length_)
-        {
-            throw std::out_of_range("");
-        }
-
-        return *static_cast<T*>(elements_[n]);
-    }
-
-    /**
-     * Get an element of the sequence.
-     *
-     * This is the operator that is invoked when the application indexes into a @em const sequence:
-     * @code{.cpp}
-     * element = sequence[n];
-     * @endcode
-     *
-     * Note that a @em reference to the element is returned (and not a copy)
-     *
-     * @param [in] n index of element to access, must be >= 0 and less than length().
-     *
-     * @return a const reference to the element at position @n
-     */
-    const T& operator [](
-            size_type n) const
-    {
-        if (n >= length_)
-        {
-            throw std::out_of_range("");
-        }
-
-        return *static_cast<const T*>(elements_[n]);
     }
 
 private:

--- a/include/fastdds/dds/core/LoanableTypedCollection.hpp
+++ b/include/fastdds/dds/core/LoanableTypedCollection.hpp
@@ -1,0 +1,99 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file LoanableTypedCollection.hpp
+ */
+
+#ifndef _FASTDDS_DDS_CORE_LOANABLETYPEDCOLLECTION_HPP_
+#define _FASTDDS_DDS_CORE_LOANABLETYPEDCOLLECTION_HPP_
+
+#include <cassert>
+#include <cstdint>
+#include <stdexcept>
+
+#include <fastdds/dds/core/LoanableCollection.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+
+/**
+ * A type-safe accessible collection of generic opaque pointers that can receive the buffer from outside (loan).
+ *
+ * This is an abstract class. See @ref LoanableSequence for details.
+ */
+template<typename T>
+class LoanableTypedCollection : public LoanableCollection
+{
+public:
+
+    /**
+     * Set an element of the sequence.
+     *
+     * This is the operator that is invoked when the application indexes into a @em non-const sequence:
+     * @code{.cpp}
+     * element = sequence[n];
+     * sequence[n] = element;
+     * @endcode
+     *
+     * Note that a @em reference to the element is returned (and not a copy)
+     *
+     * @param [in] n index of element to access, must be >= 0 and less than length().
+     *
+     * @return a reference to the element at position @c n
+     */
+    T& operator [](
+            size_type n)
+    {
+        if (n >= length_)
+        {
+            throw std::out_of_range("");
+        }
+
+        return *static_cast<T*>(elements_[n]);
+    }
+
+    /**
+     * Get an element of the sequence.
+     *
+     * This is the operator that is invoked when the application indexes into a @em const sequence:
+     * @code{.cpp}
+     * element = sequence[n];
+     * @endcode
+     *
+     * Note that a @em reference to the element is returned (and not a copy)
+     *
+     * @param [in] n index of element to access, must be >= 0 and less than length().
+     *
+     * @return a const reference to the element at position @n
+     */
+    const T& operator [](
+            size_type n) const
+    {
+        if (n >= length_)
+        {
+            throw std::out_of_range("");
+        }
+
+        return *static_cast<const T*>(elements_[n]);
+    }
+
+};
+
+} // namespace dds
+} // namespace fastdds
+} // namespace eprosima
+
+#endif // _FASTDDS_DDS_CORE_LOANABLETYPEDCOLLECTION_HPP_

--- a/include/fastdds/dds/core/StackAllocatedSequence.hpp
+++ b/include/fastdds/dds/core/StackAllocatedSequence.hpp
@@ -37,6 +37,9 @@ namespace dds {
 template<typename T, LoanableCollection::size_type num_items>
 struct StackAllocatedSequence : public LoanableTypedCollection<T>
 {
+    using size_type = LoanableCollection::size_type;
+    using element_type = LoanableCollection::element_type;
+
     StackAllocatedSequence()
     {
         has_ownership_ = true;
@@ -60,6 +63,11 @@ struct StackAllocatedSequence : public LoanableTypedCollection<T>
             StackAllocatedSequence&&) = delete;
 
 protected:
+
+    using LoanableCollection::maximum_;
+    using LoanableCollection::length_;
+    using LoanableCollection::elements_;
+    using LoanableCollection::has_ownership_;
 
     void resize(
             LoanableCollection::size_type new_length) override

--- a/include/fastdds/dds/core/StackAllocatedSequence.hpp
+++ b/include/fastdds/dds/core/StackAllocatedSequence.hpp
@@ -25,7 +25,7 @@
 #include <stdexcept>
 
 #include <fastdds/dds/core/LoanableArray.hpp>
-#include <fastdds/dds/core/LoanableCollection.hpp>
+#include <fastdds/dds/core/LoanableTypedCollection.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -35,7 +35,7 @@ namespace dds {
  * A type-safe, ordered collection of elements allocated on the stack.
  */
 template<typename T, LoanableCollection::size_type num_items>
-struct StackAllocatedSequence : public LoanableCollection
+struct StackAllocatedSequence : public LoanableTypedCollection<T>
 {
     StackAllocatedSequence()
     {
@@ -58,57 +58,6 @@ struct StackAllocatedSequence : public LoanableCollection
             StackAllocatedSequence&&) = delete;
     StackAllocatedSequence& operator = (
             StackAllocatedSequence&&) = delete;
-
-    /**
-     * Set an element of the sequence.
-     *
-     * This is the operator that is invoked when the application indexes into a @em non-const sequence:
-     * @code{.cpp}
-     * element = sequence[n];
-     * sequence[n] = element;
-     * @endcode
-     *
-     * Note that a @em reference to the element is returned (and not a copy)
-     *
-     * @param [in] n index of element to access, must be >= 0 and less than length().
-     *
-     * @return a reference to the element at position @c n
-     */
-    T& operator [](
-            size_type n)
-    {
-        if (n >= length_)
-        {
-            throw std::out_of_range("");
-        }
-
-        return *static_cast<T*>(elements_[n]);
-    }
-
-    /**
-     * Get an element of the sequence.
-     *
-     * This is the operator that is invoked when the application indexes into a @em const sequence:
-     * @code{.cpp}
-     * element = sequence[n];
-     * @endcode
-     *
-     * Note that a @em reference to the element is returned (and not a copy)
-     *
-     * @param [in] n index of element to access, must be >= 0 and less than length().
-     *
-     * @return a const reference to the element at position @n
-     */
-    const T& operator [](
-            size_type n) const
-    {
-        if (n >= length_)
-        {
-            throw std::out_of_range("");
-        }
-
-        return *static_cast<const T*>(elements_[n]);
-    }
 
 protected:
 


### PR DESCRIPTION
Joining code duplicated on `LoanableSequence` and `StackAllocatedSequence`.

This would allow using `LoanableTypedCollection<T>` when we implement type-safe readers and writers, as well as using a `StackAllocatedSequence<SampleInfo>` on internal code where we now use a `SampleInfoSeq`