### PR TITLE
Fix read_next_sample and take_next_sample [10480]

### DIFF
--- a/include/fastdds/dds/core/UserAllocatedSequence.hpp
+++ b/include/fastdds/dds/core/UserAllocatedSequence.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/fastdds/dds/core/UserAllocatedSequence.hpp
+++ b/include/fastdds/dds/core/UserAllocatedSequence.hpp
@@ -93,6 +93,7 @@ protected:
             throw std::bad_alloc();
         }
     }
+
 };
 
 } // namespace dds

--- a/include/fastdds/dds/core/UserAllocatedSequence.hpp
+++ b/include/fastdds/dds/core/UserAllocatedSequence.hpp
@@ -1,0 +1,102 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file UserAllocatedSequence.hpp
+ */
+
+#ifndef _FASTDDS_DDS_CORE_USERALLOCATEDSEQUENCE_HPP_
+#define _FASTDDS_DDS_CORE_USERALLOCATEDSEQUENCE_HPP_
+
+#include <cassert>
+#include <cstdint>
+#include <stdexcept>
+
+#include <fastdds/dds/core/LoanableCollection.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+
+/**
+ * A collection of generic opaque pointers allocated by the user.
+ *
+ * This kind of collection would always return @c true for @c has_ownership(),
+ * and thus would not be able to receive loans.
+ * It would also have an inmutable @c maximum(), so it would not allow @c length() to grow beyond the maximum
+ * value indicated on construction.
+ */
+struct UserAllocatedSequence : public LoanableCollection
+{
+    using size_type = LoanableCollection::size_type;
+    using element_type = LoanableCollection::element_type;
+
+    /**
+     * Construct a UserAllocatedSequence.
+     *
+     * @param [in] items      Pointer to the beginning of an array of @c num_items opaque pointers.
+     * @param [in] num_items  Number of opaque pointers in @c items.
+     *
+     * @post buffer() == items
+     * @post has_ownership() == true
+     * @post length() == 0
+     * @post maximum() == num_items
+     */
+    UserAllocatedSequence(
+            element_type* items,
+            size_type num_items)
+    {
+        has_ownership_ = true;
+        maximum_ = num_items;
+        length_ = 0;
+        elements_ = items;
+    }
+
+    ~UserAllocatedSequence() = default;
+
+    // Non-copyable
+    UserAllocatedSequence(
+            const UserAllocatedSequence&) = delete;
+    UserAllocatedSequence& operator = (
+            const UserAllocatedSequence&) = delete;
+
+    // Non-moveable
+    UserAllocatedSequence(
+            UserAllocatedSequence&&) = delete;
+    UserAllocatedSequence& operator = (
+            UserAllocatedSequence&&) = delete;
+
+protected:
+
+    using LoanableCollection::maximum_;
+    using LoanableCollection::length_;
+    using LoanableCollection::elements_;
+    using LoanableCollection::has_ownership_;
+
+    void resize(
+            size_type new_length) override
+    {
+        // This kind of collection cannot grow above its stack-allocated size
+        if (new_length > maximum_)
+        {
+            throw std::bad_alloc();
+        }
+    }
+};
+
+} // namespace dds
+} // namespace fastdds
+} // namespace eprosima
+
+#endif // _FASTDDS_DDS_CORE_USERALLOCATEDSEQUENCE_HPP_

--- a/include/fastdds/rtps/history/ReaderHistory.h
+++ b/include/fastdds/rtps/history/ReaderHistory.h
@@ -126,6 +126,9 @@ protected:
     RTPS_DllAPI void do_release_cache(
             CacheChange_t* ch) override;
 
+    iterator get_first_change_with_minimum_ts(
+            const Time_t timestamp);
+
     //!Pointer to the reader
     RTPSReader* mp_reader;
 

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -402,6 +402,11 @@ protected:
             bool single_instance,
             bool should_take);
 
+    ReturnCode_t read_or_take_next_sample(
+            void* data,
+            SampleInfo* info,
+            bool should_take);
+
     /**
      * @brief A method called when a new cache change is added
      * @param change The cache change that has been added

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/DataReaderLoanManager.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/DataReaderLoanManager.hpp
@@ -23,7 +23,7 @@
 #include <cassert>
 
 #include <fastdds/dds/core/LoanableCollection.hpp>
-#include <fastdds/dds/core/LoanableSequence.hpp>
+#include <fastdds/dds/core/LoanableTypedCollection.hpp>
 #include <fastdds/dds/subscriber/SampleInfo.hpp>
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 
@@ -38,7 +38,7 @@ namespace detail {
 
 struct DataReaderLoanManager
 {
-    using SampleInfoSeq = LoanableSequence<SampleInfo>;
+    using SampleInfoSeq = LoanableTypedCollection<SampleInfo>;
     using ReturnCode_t = eprosima::fastrtps::types::ReturnCode_t;
 
     explicit DataReaderLoanManager(

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
@@ -23,7 +23,7 @@
 #include <cstdint>
 
 #include <fastdds/dds/core/LoanableCollection.hpp>
-#include <fastdds/dds/core/LoanableSequence.hpp>
+#include <fastdds/dds/core/LoanableTypedCollection.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
 #include <fastdds/dds/subscriber/SampleInfo.hpp>
 
@@ -51,7 +51,7 @@ struct ReadTakeCommand
     using CacheChange_t = eprosima::fastrtps::rtps::CacheChange_t;
     using RTPSReader = eprosima::fastrtps::rtps::RTPSReader;
     using WriterProxy = eprosima::fastrtps::rtps::WriterProxy;
-    using SampleInfoSeq = LoanableSequence<SampleInfo>;
+    using SampleInfoSeq = LoanableTypedCollection<SampleInfo>;
 
     ReadTakeCommand(
             DataReaderImpl& reader,

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -693,7 +693,7 @@ public:
             return eprosima::fastrtps::rtps::SequenceNumber_t();
         }
 
-        using pair_type = decltype(last_seq)::value_type;
+        using pair_type = typename decltype(last_seq)::value_type;
         auto seq_comp = [](const pair_type& v1, const pair_type& v2) -> bool
                 {
                     return v1.second < v2.second;

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -413,7 +413,7 @@ public:
         total_msgs_ = msgs;
         number_samples_expected_ = total_msgs_.size();
         current_processed_count_ = 0;
-        last_seq = eprosima::fastrtps::rtps::SequenceNumber_t();
+        last_seq.clear();
         mutex_.unlock();
 
         bool ret = false;
@@ -424,7 +424,7 @@ public:
         while (ret);
 
         receiving_.store(true);
-        return last_seq;
+        return get_last_sequence_received();
     }
 
     void stopReception()
@@ -463,7 +463,7 @@ public:
     {
         block([this, seq]() -> bool
                 {
-                    return last_seq == seq;
+                    return get_last_sequence_received() == seq;
                 });
     }
 
@@ -688,7 +688,17 @@ public:
 
     eprosima::fastrtps::rtps::SequenceNumber_t get_last_sequence_received()
     {
-        return last_seq;
+        if (last_seq.empty())
+        {
+            return eprosima::fastrtps::rtps::SequenceNumber_t();
+        }
+
+        using pair_type = decltype(last_seq)::value_type;
+        auto seq_comp = [](const pair_type& v1, const pair_type& v2) -> bool
+        {
+            return v1.second < v2.second;
+        };
+        return std::max_element(last_seq.cbegin(), last_seq.cend(), seq_comp)->second;
     }
 
     PubSubReader& deactivate_status_listener(
@@ -1402,8 +1412,8 @@ private:
             std::unique_lock<std::mutex> lock(mutex_);
 
             // Check order of changes.
-            ASSERT_LT(last_seq, info.sample_identity.sequence_number());
-            last_seq = info.sample_identity.sequence_number();
+            ASSERT_LT(last_seq[info.instance_handle], info.sample_identity.sequence_number());
+            last_seq[info.instance_handle] = info.sample_identity.sequence_number();
 
             if (info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
             {
@@ -1487,7 +1497,7 @@ private:
     unsigned int participant_matched_;
     std::atomic<bool> receiving_;
     eprosima::fastdds::dds::TypeSupport type_;
-    eprosima::fastrtps::rtps::SequenceNumber_t last_seq;
+    std::map<eprosima::fastrtps::rtps::InstanceHandle_t, eprosima::fastrtps::rtps::SequenceNumber_t> last_seq;
     size_t current_processed_count_;
     size_t number_samples_expected_;
     bool discovery_result_;

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -509,10 +509,10 @@ public:
 
         ReturnCode_t success =
                 datareader_->read(data_seq, info_seq,
-                eprosima::fastdds::dds::LENGTH_UNLIMITED,
-                eprosima::fastdds::dds::ANY_SAMPLE_STATE,
-                eprosima::fastdds::dds::ANY_VIEW_STATE,
-                eprosima::fastdds::dds::ANY_INSTANCE_STATE);
+                        eprosima::fastdds::dds::LENGTH_UNLIMITED,
+                        eprosima::fastdds::dds::ANY_SAMPLE_STATE,
+                        eprosima::fastdds::dds::ANY_VIEW_STATE,
+                        eprosima::fastdds::dds::ANY_INSTANCE_STATE);
 
         if (ReturnCode_t::RETCODE_OK == success)
         {
@@ -526,7 +526,6 @@ public:
                 }
             }
             ASSERT_TRUE(expected_messages.empty());
-         
             datareader_->return_loan(data_seq, info_seq);
         }
     }
@@ -696,9 +695,9 @@ public:
 
         using pair_type = decltype(last_seq)::value_type;
         auto seq_comp = [](const pair_type& v1, const pair_type& v2) -> bool
-        {
-            return v1.second < v2.second;
-        };
+                {
+                    return v1.second < v2.second;
+                };
         return std::max_element(last_seq.cbegin(), last_seq.cend(), seq_comp)->second;
     }
 
@@ -1286,7 +1285,7 @@ public:
         collection::element_type buf[1] = { data };
         collection data_seq(buf, 1);
         info_seq_type info_seq(1);
-        
+
         if (ReturnCode_t::RETCODE_OK == datareader_->take(data_seq, info_seq))
         {
             current_processed_count_++;

--- a/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
@@ -1104,6 +1104,12 @@ public:
         onEndpointDiscovery_ = f;
     }
 
+    bool take_first_data(
+            void* data)
+    {
+        return takeNextData(data);
+    }
+
     bool takeNextData(
             void* data)
     {

--- a/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
@@ -565,7 +565,7 @@ public:
             return eprosima::fastrtps::rtps::SequenceNumber_t();
         }
 
-        using pair_type = decltype(last_seq)::value_type;
+        using pair_type = typename decltype(last_seq)::value_type;
         auto seq_comp = [](const pair_type& v1, const pair_type& v2) -> bool
                 {
                     return v1.second < v2.second;

--- a/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
@@ -567,9 +567,9 @@ public:
 
         using pair_type = decltype(last_seq)::value_type;
         auto seq_comp = [](const pair_type& v1, const pair_type& v2) -> bool
-        {
-            return v1.second < v2.second;
-        };
+                {
+                    return v1.second < v2.second;
+                };
         return std::max_element(last_seq.cbegin(), last_seq.cend(), seq_comp)->second;
     }
 

--- a/test/blackbox/common/BlackboxTestsLifespanQoS.cpp
+++ b/test/blackbox/common/BlackboxTestsLifespanQoS.cpp
@@ -124,9 +124,9 @@ TEST_P(LifespanQos, LongLifespan)
 
     // On the reader side we should be able to take the data
     HelloWorldType::type msg;
-    EXPECT_EQ(reader.takeNextData(&msg), true);
-    EXPECT_EQ(reader.takeNextData(&msg), true);
-    EXPECT_EQ(reader.takeNextData(&msg), true);
+    EXPECT_EQ(reader.take_first_data(&msg), true);
+    EXPECT_EQ(reader.take_first_data(&msg), true);
+    EXPECT_EQ(reader.take_first_data(&msg), true);
 }
 
 TEST_P(LifespanQos, ShortLifespan)
@@ -171,9 +171,9 @@ TEST_P(LifespanQos, ShortLifespan)
 
     // On the reader side we should not be able to take the data
     HelloWorldType::type msg;
-    EXPECT_EQ(reader.takeNextData(&msg), false);
-    EXPECT_EQ(reader.takeNextData(&msg), false);
-    EXPECT_EQ(reader.takeNextData(&msg), false);
+    EXPECT_EQ(reader.take_first_data(&msg), false);
+    EXPECT_EQ(reader.take_first_data(&msg), false);
+    EXPECT_EQ(reader.take_first_data(&msg), false);
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P

--- a/test/blackbox/common/BlackboxTestsLifespanQoS.cpp
+++ b/test/blackbox/common/BlackboxTestsLifespanQoS.cpp
@@ -124,9 +124,10 @@ TEST_P(LifespanQos, LongLifespan)
 
     // On the reader side we should be able to take the data
     HelloWorldType::type msg;
-    EXPECT_EQ(reader.take_first_data(&msg), true);
-    EXPECT_EQ(reader.take_first_data(&msg), true);
-    EXPECT_EQ(reader.take_first_data(&msg), true);
+    for (uint32_t i = 0; i < writer_samples; ++i)
+    {
+        EXPECT_EQ(reader.take_first_data(&msg), true);
+    }
 }
 
 TEST_P(LifespanQos, ShortLifespan)
@@ -171,9 +172,10 @@ TEST_P(LifespanQos, ShortLifespan)
 
     // On the reader side we should not be able to take the data
     HelloWorldType::type msg;
-    EXPECT_EQ(reader.take_first_data(&msg), false);
-    EXPECT_EQ(reader.take_first_data(&msg), false);
-    EXPECT_EQ(reader.take_first_data(&msg), false);
+    for (uint32_t i = 0; i < writer_samples; ++i)
+    {
+        EXPECT_EQ(reader.take_first_data(&msg), false);
+    }
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P
@@ -201,4 +203,3 @@ GTEST_INSTANTIATE_TEST_MACRO(LifespanQos,
             }
 
         });
-

--- a/test/blackbox/common/DDSBlackboxTestsDataSharing.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataSharing.cpp
@@ -116,6 +116,9 @@ TEST(DDSDataSharing, TransientReader)
 
 TEST(DDSDataSharing, BestEffortDirtyPayloads)
 {
+    // The writer's pool is smaller than the reader history.
+    // The number of samples is larger than the pool size, so some payloads get rused
+    // leaving dirty payloads in the reader
     PubSubReader<FixedSizedType> read_reader(TEST_TOPIC_NAME, false);
     PubSubWriter<FixedSizedType> writer(TEST_TOPIC_NAME);
 
@@ -144,13 +147,11 @@ TEST(DDSDataSharing, BestEffortDirtyPayloads)
     writer.wait_discovery();
     read_reader.wait_discovery();
 
-    // Send the data to fill the history and overwrite old changes
-    // The reader will receive all changes but the application will see only the last ones
     std::list<FixedSized> data = default_fixed_sized_data_generator(writer_sent_data);
-    std::list<FixedSized> received_data;
+    std::list<FixedSized> data_in_history;
     auto data_it = data.begin();
     std::advance(data_it, writer_sent_data - writer_history_depth - 1);
-    std::copy(data_it, data.end(), std::back_inserter(received_data));
+    std::copy(data_it, data.end(), std::back_inserter(data_in_history));
 
     // Send the data to fill the history and overwrite old changes
     // The reader will receive and process all changes so that the writer can reuse them,
@@ -161,17 +162,14 @@ TEST(DDSDataSharing, BestEffortDirtyPayloads)
     read_reader.block_for_all();
 
     // Doing a second read on the same history, the application will see only the last samples
-    read_reader.startReception(received_data);
-    FixedSizedType::type value;
-    while (read_reader.takeNextData ((void*)&value))
-    {
-        default_receive_print<FixedSizedType::type>(value);
-    }
-    read_reader.block_for_all();
+    read_reader.check_history_content(data_in_history);
 }
 
 TEST(DDSDataSharing, ReliableDirtyPayloads)
 {
+    // The writer's pool is smaller than the reader history.
+    // The number of samples is larger than the pool size, so some payloads get rused
+    // leaving dirty payloads in the reader
     PubSubReader<FixedSizedType> read_reader(TEST_TOPIC_NAME, false);
     PubSubWriter<FixedSizedType> writer(TEST_TOPIC_NAME);
 
@@ -200,13 +198,11 @@ TEST(DDSDataSharing, ReliableDirtyPayloads)
     writer.wait_discovery();
     read_reader.wait_discovery();
 
-    // Send the data to fill the history and overwrite old changes
-    // The reader will receive all changes but the application will see only the last ones
     std::list<FixedSized> data = default_fixed_sized_data_generator(writer_sent_data);
-    std::list<FixedSized> received_data;
+    std::list<FixedSized> data_in_history;
     auto data_it = data.begin();
     std::advance(data_it, writer_sent_data - writer_history_depth - 1);
-    std::copy(data_it, data.end(), std::back_inserter(received_data));
+    std::copy(data_it, data.end(), std::back_inserter(data_in_history));
 
     // Send the data to fill the history and overwrite old changes
     // The reader will receive and process all changes so that the writer can reuse them,
@@ -217,13 +213,7 @@ TEST(DDSDataSharing, ReliableDirtyPayloads)
     read_reader.block_for_all();
 
     // Doing a second read on the same history, the application will see only the last samples
-    read_reader.startReception(received_data);
-    FixedSizedType::type value;
-    while (read_reader.takeNextData ((void*)&value))
-    {
-        default_receive_print<FixedSizedType::type>(value);
-    }
-    read_reader.block_for_all();
+    read_reader.check_history_content(data_in_history);
 }
 
 TEST(DDSDataSharing, DataSharingWriter_DifferentDomainReaders)

--- a/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
+++ b/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
@@ -120,6 +120,7 @@ protected:
     {
         return m_changes.end();
     }
+
 };
 
 } // namespace rtps

--- a/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
+++ b/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
@@ -114,6 +114,12 @@ protected:
     std::mutex samples_number_mutex_;
     unsigned int samples_number_;
     SequenceNumber_t last_sequence_number_;
+
+    iterator get_first_change_with_minimum_ts(
+            const Time_t& /* timestamp */)
+    {
+        return m_changes.end();
+    }
 };
 
 } // namespace rtps

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -358,7 +358,6 @@ protected:
             DataType data;
             SampleInfo info;
 
-            EXPECT_EQ(code, data_reader->read_next_sample(&data, &info));
             EXPECT_EQ(code, data_reader->take_next_sample(&data, &info));
             if (ReturnCode_t::RETCODE_OK == code)
             {
@@ -366,6 +365,7 @@ protected:
                 data_writer_->write(&data);
                 data_reader->wait_for_unread_message(time_to_wait);
             }
+            EXPECT_EQ(code, data_reader->read_next_sample(&data, &info));
         }
 
         // Return code when requesting a bad instance

--- a/test/unittest/dds/subscriber/FooType.hpp
+++ b/test/unittest/dds/subscriber/FooType.hpp
@@ -85,6 +85,12 @@ public:
         scdr << index_;
     }
 
+    inline bool operator ==(
+            const FooType& other) const
+    {
+        return (index_ == other.index_) && (message_ == other.message_);
+    }
+
 private:
 
     uint32_t index_ = 0;


### PR DESCRIPTION
This PR adds new checks to `DataReaderTests.read_unread` and fixes the behavior of  `read_next_sample` and `take_next_sample`.

Depends on #1731 