### PR TITLE
Change SOVERSION to <major>.<minor> [10489]

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -368,7 +368,7 @@ elseif(NOT EPROSIMA_INSTALLER)
     #Create library
     add_library(${PROJECT_NAME} ${${PROJECT_NAME}_source_files})
     set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${PROJECT_VERSION})
-    set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR})
+    set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR})
 
     option(INTERNAL_DEBUG "Activate developer debug messages" OFF)
 


### PR DESCRIPTION
This will solve #1722
SOVERSION should be bumped on every release that breaks ABI. Although not every minor release breaks ABI, it does in many cases in our product. Therefore, we find less error prone if we automatize the bumping of the SOVERSION, even if that means we end up generating a different library name on some backward compatible releases.