### PR TITLE
Remove dependency between DataWriter tables in persistent writers [10500]

### DIFF
--- a/src/cpp/rtps/persistence/SQLite3PersistenceServiceStatements.h
+++ b/src/cpp/rtps/persistence/SQLite3PersistenceServiceStatements.h
@@ -36,9 +36,7 @@ public:
             "seq_num INTEGER CHECK(seq_num > 0),"
             "instance BLOB CHECK(length(instance)=16),"
             "payload BLOB,"
-            "PRIMARY KEY(guid, seq_num DESC),"
-            "FOREIGN KEY (guid)"
-            "    REFERENCES writers_states(guid)";
+            "PRIMARY KEY(guid, seq_num DESC)";
 
     static constexpr const char* const readers_table =
             "guid text,"


### PR DESCRIPTION
The `writer_histories` table defines the DataWriter GUID of the `writer_states` table as a foreign key. This implies that when the `writer_states` table is updated a lookup is performed on the `writer_histories` table to maintain consistency between tables. This results in an increased write time in the `writer_states` table as the size of the `writer_histories` table increases. Since the GUID value in the `writer_states` table is never changed, it is not necessary to maintain this consistency.