### PR TITLE
Fix build issues when windows.h is included before Fast DDS headers [10521]

### DIFF
--- a/include/fastdds/rtps/attributes/RTPSParticipantAllocationAttributes.hpp
+++ b/include/fastdds/rtps/attributes/RTPSParticipantAllocationAttributes.hpp
@@ -156,7 +156,7 @@ private:
     ResourceLimitedContainerConfig total_endpoints(
             const ResourceLimitedContainerConfig& endpoints) const
     {
-        constexpr size_t max = std::numeric_limits<size_t>::max();
+        constexpr size_t max = (std::numeric_limits<size_t>::max)();
         size_t initial;
         size_t maximum;
         size_t increment;
@@ -164,7 +164,7 @@ private:
         initial = participants.initial * endpoints.initial;
         maximum = (participants.maximum == max || endpoints.maximum == max)
                 ? max : participants.maximum * endpoints.maximum;
-        increment = std::max(participants.increment, endpoints.increment);
+        increment = (std::max)(participants.increment, endpoints.increment);
 
         return { initial, maximum, increment };
     }

--- a/include/fastdds/rtps/common/CacheChange.h
+++ b/include/fastdds/rtps/common/CacheChange.h
@@ -406,6 +406,4 @@ private:
 } // namespace fastrtps
 } // namespace eprosima
 
-#include <fastdds/rtps/writer/ChangeForReader.h>
-
 #endif /* _FASTDDS_RTPS_CACHECHANGE_H_ */

--- a/include/fastdds/rtps/common/CacheChange.h
+++ b/include/fastdds/rtps/common/CacheChange.h
@@ -19,33 +19,21 @@
 #ifndef _FASTDDS_RTPS_CACHECHANGE_H_
 #define _FASTDDS_RTPS_CACHECHANGE_H_
 
-#include <fastdds/rtps/common/Types.h>
-#include <fastdds/rtps/common/WriteParams.h>
+#include <cassert>
+
+#include <fastdds/rtps/common/ChangeKind_t.hpp>
+#include <fastdds/rtps/common/FragmentNumber.h>
+#include <fastdds/rtps/common/InstanceHandle.h>
 #include <fastdds/rtps/common/SerializedPayload.h>
 #include <fastdds/rtps/common/Time_t.h>
-#include <fastdds/rtps/common/InstanceHandle.h>
-#include <fastdds/rtps/common/FragmentNumber.h>
-
-#include <cassert>
+#include <fastdds/rtps/common/Types.h>
+#include <fastdds/rtps/common/WriteParams.h>
 
 #include <fastdds/rtps/history/IPayloadPool.h>
 
 namespace eprosima {
 namespace fastrtps {
 namespace rtps {
-
-
-/**
- * @enum ChangeKind_t, different types of CacheChange_t.
- * @ingroup COMMON_MODULE
- */
-enum RTPS_DllAPI ChangeKind_t
-{
-    ALIVE,                            //!< ALIVE
-    NOT_ALIVE_DISPOSED,               //!< NOT_ALIVE_DISPOSED
-    NOT_ALIVE_UNREGISTERED,           //!< NOT_ALIVE_UNREGISTERED
-    NOT_ALIVE_DISPOSED_UNREGISTERED   //!< NOT_ALIVE_DISPOSED_UNREGISTERED
-};
 
 /**
  * Structure CacheChange_t, contains information on a specific CacheChange.

--- a/include/fastdds/rtps/common/ChangeKind_t.hpp
+++ b/include/fastdds/rtps/common/ChangeKind_t.hpp
@@ -1,0 +1,44 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file ChangeKind_t.hpp
+ */
+
+#ifndef _FASTDDS_RTPS_COMMON_CHANGEKINDT_HPP_
+#define _FASTDDS_RTPS_COMMON_CHANGEKINDT_HPP_
+
+#include <fastrtps/fastrtps_dll.h>
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+
+/**
+ * @enum ChangeKind_t, different types of CacheChange_t.
+ * @ingroup COMMON_MODULE
+ */
+enum RTPS_DllAPI ChangeKind_t
+{
+    ALIVE,                            //!< ALIVE
+    NOT_ALIVE_DISPOSED,               //!< NOT_ALIVE_DISPOSED
+    NOT_ALIVE_UNREGISTERED,           //!< NOT_ALIVE_UNREGISTERED
+    NOT_ALIVE_DISPOSED_UNREGISTERED   //!< NOT_ALIVE_DISPOSED_UNREGISTERED
+};
+
+} // namespace rtps
+} // namespace fastrtps
+} // namespace eprosima
+
+#endif /* _FASTDDS_RTPS_COMMON_CHANGEKINDT_HPP_ */

--- a/include/fastdds/rtps/common/LocatorSelector.hpp
+++ b/include/fastdds/rtps/common/LocatorSelector.hpp
@@ -351,7 +351,7 @@ public:
                 Position index_pos)
             : locator_selector_(locator_selector)
         {
-            current_ = {std::numeric_limits<size_t>::max(), 0, true, nullptr};
+            current_ = {(std::numeric_limits<size_t>::max)(), 0, true, nullptr};
 
             if (index_pos == Position::Begin)
             {

--- a/include/fastrtps/subscriber/SampleInfo.h
+++ b/include/fastrtps/subscriber/SampleInfo.h
@@ -21,11 +21,12 @@
 
 #include <cstdint>
 
-#include <fastrtps/fastrtps_dll.h>
-
-#include <fastdds/rtps/common/Time_t.h>
+#include <fastdds/rtps/common/ChangeKind_t.hpp>
 #include <fastdds/rtps/common/InstanceHandle.h>
-#include <fastdds/rtps/common/CacheChange.h>
+#include <fastdds/rtps/common/SampleIdentity.h>
+#include <fastdds/rtps/common/Time_t.h>
+
+#include <fastrtps/fastrtps_dll.h>
 
 namespace eprosima {
 namespace fastrtps {

--- a/include/fastrtps/types/AnnotationParameterValue.h
+++ b/include/fastrtps/types/AnnotationParameterValue.h
@@ -22,6 +22,22 @@
 #ifndef _ANNOTATIONPARAMETERVALUE_H_
 #define _ANNOTATIONPARAMETERVALUE_H_
 
+#if _MSC_VER
+
+#if defined(max)
+#pragma push_macro("max")
+#undef max
+#define FASTDDS_RESTORE_MAX
+#endif // defined(max)
+
+#if defined(min)
+#pragma push_macro("min")
+#undef min
+#define FASTDDS_RESTORE_MIN
+#endif // defined(min)
+
+#endif // if _MSC_VER
+
 #include <fastrtps/types/TypesBase.h>
 #include <fastrtps/types/TypeIdentifier.h>
 #include <fastrtps/utils/string_convert.hpp>
@@ -1348,5 +1364,19 @@ private:
 } // namespace types
 } // namespace fastrtps
 } // namespace eprosima
+
+#if _MSC_VER
+
+#if defined(FASTDDS_RESTORE_MIN)
+#pragma pop_macro("min")
+#undef FASTDDS_RESTORE_MIN
+#endif // defined(FASTDDS_RESTORE_MIN)
+
+#if defined(FASTDDS_RESTORE_MAX)
+#pragma pop_macro("max")
+#undef FASTDDS_RESTORE_MAX
+#endif // defined(FASTDDS_RESTORE_MAX)
+
+#endif // if _MSC_VER
 
 #endif // _ANNOTATIONPARAMETERVALUE_H_

--- a/include/fastrtps/utils/collections/ResourceLimitedContainerConfig.hpp
+++ b/include/fastrtps/utils/collections/ResourceLimitedContainerConfig.hpp
@@ -35,7 +35,7 @@ struct ResourceLimitedContainerConfig
 
     ResourceLimitedContainerConfig(
             size_t ini = 0, 
-            size_t max = std::numeric_limits<size_t>::max(),
+            size_t max = (std::numeric_limits<size_t>::max)(),
             size_t inc = 1u)
         : initial(ini)
         , maximum(max)
@@ -46,7 +46,7 @@ struct ResourceLimitedContainerConfig
     //! Number of elements to be preallocated in the collection.
     size_t initial = 0;
     //! Maximum number of elements allowed in the collection.
-    size_t maximum = std::numeric_limits<size_t>::max();
+    size_t maximum = (std::numeric_limits<size_t>::max)();
     //! Number of items to add when capacity limit is reached.
     size_t increment = 1u;
 
@@ -67,7 +67,7 @@ struct ResourceLimitedContainerConfig
      */
     inline static ResourceLimitedContainerConfig dynamic_allocation_configuration(size_t increment = 1u)
     {
-        return ResourceLimitedContainerConfig(0u, std::numeric_limits<size_t>::max(), increment ? increment : 1u);
+        return ResourceLimitedContainerConfig(0u, (std::numeric_limits<size_t>::max)(), increment ? increment : 1u);
     }
 };
 

--- a/include/fastrtps/utils/collections/ResourceLimitedContainerConfig.hpp
+++ b/include/fastrtps/utils/collections/ResourceLimitedContainerConfig.hpp
@@ -34,7 +34,7 @@ struct ResourceLimitedContainerConfig
 {
 
     ResourceLimitedContainerConfig(
-            size_t ini = 0, 
+            size_t ini = 0,
             size_t max = (std::numeric_limits<size_t>::max)(),
             size_t inc = 1u)
         : initial(ini)
@@ -55,7 +55,8 @@ struct ResourceLimitedContainerConfig
      * @param size Number of elements to allocate.
      * @return Resource limits configuration.
      */
-    inline static ResourceLimitedContainerConfig fixed_size_configuration(size_t size)
+    inline static ResourceLimitedContainerConfig fixed_size_configuration(
+            size_t size)
     {
         return ResourceLimitedContainerConfig(size, size, 0u);
     }
@@ -65,14 +66,16 @@ struct ResourceLimitedContainerConfig
      * @param increment Number of new elements to allocate when increasing the capacity of the collection.
      * @return Resource limits configuration.
      */
-    inline static ResourceLimitedContainerConfig dynamic_allocation_configuration(size_t increment = 1u)
+    inline static ResourceLimitedContainerConfig dynamic_allocation_configuration(
+            size_t increment = 1u)
     {
         return ResourceLimitedContainerConfig(0u, (std::numeric_limits<size_t>::max)(), increment ? increment : 1u);
     }
+
 };
 
 inline bool operator == (
-        const ResourceLimitedContainerConfig& lhs, 
+        const ResourceLimitedContainerConfig& lhs,
         const ResourceLimitedContainerConfig& rhs)
 {
     return

--- a/include/fastrtps/utils/collections/ResourceLimitedVector.hpp
+++ b/include/fastrtps/utils/collections/ResourceLimitedVector.hpp
@@ -258,7 +258,7 @@ public:
             InputIterator last)
     {
         size_type n = static_cast<size_type>(std::distance(first, last));
-        n = std::min(n, configuration_.maximum);
+        n = (std::min)(n, configuration_.maximum);
         InputIterator value = first;
         std::advance(value, n);
         collection_.assign(first, value);
@@ -278,7 +278,7 @@ public:
             size_type n,
             const value_type& val)
     {
-        n = std::min(n, configuration_.maximum);
+        n = (std::min)(n, configuration_.maximum);
         collection_.assign(n, val);
     }
 
@@ -296,7 +296,7 @@ public:
     void assign(
             std::initializer_list<value_type> il)
     {
-        size_type n = std::min(il.size(), configuration_.maximum);
+        size_type n = (std::min)(il.size(), configuration_.maximum);
         collection_.assign(il.begin(), il.begin() + n);
     }
 
@@ -426,7 +426,7 @@ public:
 
     size_type max_size() const noexcept
     {
-        return std::min(configuration_.maximum, collection_.max_size());
+        return (std::min)(configuration_.maximum, collection_.max_size());
     }
 
     void clear()
@@ -500,7 +500,7 @@ protected:
                 // increase collection capacity
                 assert(configuration_.increment > 0);
                 cap += configuration_.increment;
-                cap = std::min(cap, configuration_.maximum);
+                cap = (std::min)(cap, configuration_.maximum);
                 collection_.reserve(cap);
             }
             else

--- a/include/fastrtps/utils/fixed_size_bitmap.hpp
+++ b/include/fastrtps/utils/fixed_size_bitmap.hpp
@@ -27,6 +27,19 @@
 
 #if _MSC_VER
 #include <intrin.h>
+
+#if defined(max)
+#pragma push_macro("max")
+#undef max
+#define FASTDDS_RESTORE_MAX
+#endif // defined(max)
+
+#if defined(min)
+#pragma push_macro("min")
+#undef min
+#define FASTDDS_RESTORE_MIN
+#endif // defined(min)
+
 #endif // if _MSC_VER
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
@@ -573,5 +586,19 @@ private:
 }   // namespace eprosima
 
 #endif   // DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+
+#if _MSC_VER
+
+#if defined(FASTDDS_RESTORE_MIN)
+#pragma pop_macro("min")
+#undef FASTDDS_RESTORE_MIN
+#endif // defined(FASTDDS_RESTORE_MIN)
+
+#if defined(FASTDDS_RESTORE_MAX)
+#pragma pop_macro("max")
+#undef FASTDDS_RESTORE_MAX
+#endif // defined(FASTDDS_RESTORE_MAX)
+
+#endif // if _MSC_VER
 
 #endif   // FASTRTPS_UTILS_FIXED_SIZE_BITMAP_HPP_

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -20,6 +20,17 @@
 #ifndef _TEST_BLACKBOX_PUBSUBREADER_HPP_
 #define _TEST_BLACKBOX_PUBSUBREADER_HPP_
 
+#include <string>
+#include <list>
+#include <atomic>
+#include <condition_variable>
+#include <asio.hpp>
+#include <gtest/gtest.h>
+
+#if _MSC_VER
+#include <Windows.h>
+#endif // _MSC_VER
+
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/DomainParticipantListener.hpp>
@@ -36,13 +47,6 @@
 #include <fastrtps/xmlparser/XMLTree.h>
 #include <fastrtps/utils/IPLocator.h>
 #include <fastrtps/transport/UDPv4TransportDescriptor.h>
-
-#include <string>
-#include <list>
-#include <atomic>
-#include <condition_variable>
-#include <asio.hpp>
-#include <gtest/gtest.h>
 
 using DomainParticipantFactory = eprosima::fastdds::dds::DomainParticipantFactory;
 using eprosima::fastrtps::rtps::IPLocator;

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -20,6 +20,18 @@
 #ifndef _TEST_BLACKBOX_PUBSUBWRITER_HPP_
 #define _TEST_BLACKBOX_PUBSUBWRITER_HPP_
 
+#include <string>
+#include <list>
+#include <map>
+#include <condition_variable>
+#include <asio.hpp>
+#include <gtest/gtest.h>
+#include <thread>
+
+#if _MSC_VER
+#include <Windows.h>
+#endif // _MSC_VER
+
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/DomainParticipantListener.hpp>
@@ -34,13 +46,6 @@
 #include <fastrtps/xmlparser/XMLTree.h>
 #include <fastrtps/utils/IPLocator.h>
 #include <fastrtps/transport/UDPv4TransportDescriptor.h>
-#include <string>
-#include <list>
-#include <map>
-#include <condition_variable>
-#include <asio.hpp>
-#include <gtest/gtest.h>
-#include <thread>
 
 using DomainParticipantFactory = eprosima::fastdds::dds::DomainParticipantFactory;
 using eprosima::fastrtps::rtps::IPLocator;


### PR DESCRIPTION
This PR fixes some build errors when `#include <Windows.h>` is present before including Fast DDS header files.