### PR TITLE
Fix singleton destruction order <master> [10533]

### DIFF
--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -32,6 +32,8 @@
 #include <fastrtps/types/DynamicDataFactory.h>
 #include <fastrtps/types/TypeObjectFactory.h>
 
+#include <rtps/history/TopicPayloadPoolRegistry.hpp>
+
 using namespace eprosima::fastrtps::xmlparser;
 
 using eprosima::fastrtps::ParticipantAttributes;
@@ -97,6 +99,10 @@ DomainParticipantFactory::~DomainParticipantFactory()
 
 DomainParticipantFactory* DomainParticipantFactory::get_instance()
 {
+    // Keep a reference to the topic payload pool to avoid it to be destroyed before our own instance
+    using pool_registry_ref = eprosima::fastrtps::rtps::TopicPayloadPoolRegistry::reference;
+    static pool_registry_ref topic_pool_registry = eprosima::fastrtps::rtps::TopicPayloadPoolRegistry::instance();
+
     static DomainParticipantFactory instance;
     return &instance;
 }

--- a/src/cpp/rtps/history/TopicPayloadPoolRegistry.cpp
+++ b/src/cpp/rtps/history/TopicPayloadPoolRegistry.cpp
@@ -28,11 +28,16 @@ namespace eprosima {
 namespace fastrtps {
 namespace rtps {
 
+const TopicPayloadPoolRegistry::reference& TopicPayloadPoolRegistry::instance()
+{
+    return detail::TopicPayloadPoolRegistry::instance();
+}
+
 std::shared_ptr<ITopicPayloadPool> TopicPayloadPoolRegistry::get(
         const std::string& topic_name,
         const BasicPoolConfig& config)
 {
-    return detail::TopicPayloadPoolRegistry::instance().get(topic_name, config);
+    return detail::TopicPayloadPoolRegistry::instance()->get(topic_name, config);
 }
 
 }  // namespace rtps

--- a/src/cpp/rtps/history/TopicPayloadPoolRegistry.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPoolRegistry.hpp
@@ -31,8 +31,8 @@ namespace fastrtps {
 namespace rtps {
 
 namespace detail {
-    class TopicPayloadPoolRegistry;
-}
+class TopicPayloadPoolRegistry;
+} // namespace detail
 
 class TopicPayloadPoolRegistry
 {

--- a/src/cpp/rtps/history/TopicPayloadPoolRegistry.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPoolRegistry.hpp
@@ -30,10 +30,18 @@ namespace eprosima {
 namespace fastrtps {
 namespace rtps {
 
+namespace detail {
+    class TopicPayloadPoolRegistry;
+}
+
 class TopicPayloadPoolRegistry
 {
 
 public:
+
+    using reference = std::shared_ptr<detail::TopicPayloadPoolRegistry>;
+
+    static const reference& instance();
 
     static std::shared_ptr<ITopicPayloadPool> get(
             const std::string& topic_name,

--- a/src/cpp/rtps/history/TopicPayloadPoolRegistry_impl/TopicPayloadPoolRegistry.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPoolRegistry_impl/TopicPayloadPoolRegistry.hpp
@@ -37,12 +37,10 @@ private:
 
 public:
 
-    ~TopicPayloadPoolRegistry() = default;
-
     /// @return reference to singleton instance
-    static TopicPayloadPoolRegistry& instance()
+    static const std::shared_ptr<TopicPayloadPoolRegistry>& instance()
     {
-        static TopicPayloadPoolRegistry pool_registry_instance;
+        static auto pool_registry_instance = std::shared_ptr<TopicPayloadPoolRegistry>(new TopicPayloadPoolRegistry());
         return pool_registry_instance;
     }
 

--- a/src/cpp/rtps/history/TopicPayloadPoolRegistry_impl/TopicPayloadPoolRegistry.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPoolRegistry_impl/TopicPayloadPoolRegistry.hpp
@@ -40,7 +40,7 @@ public:
     /// @return reference to singleton instance
     static const std::shared_ptr<TopicPayloadPoolRegistry>& instance()
     {
-        static auto pool_registry_instance = std::shared_ptr<TopicPayloadPoolRegistry>(new TopicPayloadPoolRegistry());
+        static std::shared_ptr<TopicPayloadPoolRegistry> pool_registry_instance(new TopicPayloadPoolRegistry());
         return pool_registry_instance;
     }
 

--- a/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
@@ -166,7 +166,7 @@ public:
 
             static const std::shared_ptr<WatchTask>& get()
             {
-                static auto watch_task_instance = std::shared_ptr<WatchTask>(new WatchTask());
+                static std::shared_ptr<WatchTask> watch_task_instance(new WatchTask());
                 return watch_task_instance;
             }
 

--- a/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
@@ -203,7 +203,7 @@ public:
 
             }
 
-            ~WatchTask()
+            virtual ~WatchTask()
             {
                 shared_mem_watchdog_->remove_task(this);
             }

--- a/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
@@ -1003,7 +1003,7 @@ private:
 
             static std::shared_ptr<WatchTask>& get()
             {
-                static auto watch_task_instance = std::shared_ptr<WatchTask>(new WatchTask());
+                static std::shared_ptr<WatchTask> watch_task_instance(new WatchTask());
                 return watch_task_instance;
             }
 

--- a/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
@@ -1025,7 +1025,7 @@ private:
                 to_remove_.push_back(segment);
             }
 
-            ~WatchTask()
+            virtual ~WatchTask()
             {
                 shared_mem_watchdog_->remove_task(this);
             }

--- a/src/cpp/utils/shared_memory/SharedMemWatchdog.hpp
+++ b/src/cpp/utils/shared_memory/SharedMemWatchdog.hpp
@@ -42,7 +42,7 @@ public:
 
     static std::shared_ptr<SharedMemWatchdog>& get()
     {
-        static auto watch_dog_instance = std::shared_ptr<SharedMemWatchdog>(new SharedMemWatchdog());
+        static std::shared_ptr<SharedMemWatchdog> watch_dog_instance(new SharedMemWatchdog());
         return watch_dog_instance;
     }
 

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -506,6 +506,25 @@ TEST(DataWriterTests, SetListener)
     ASSERT_TRUE(DomainParticipantFactory::get_instance()->delete_participant(participant) == ReturnCode_t::RETCODE_OK);
 }
 
+TEST(DataWriterTests, TerminateWithoutDestroyingWriter)
+{
+    DomainParticipant* participant =
+            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
+
+    Publisher* publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT);
+    ASSERT_NE(publisher, nullptr);
+
+    TypeSupport type(new TopicDataTypeMock());
+    type.register_type(participant);
+
+    Topic* topic = participant->create_topic("footopic", type.get_type_name(), TOPIC_QOS_DEFAULT);
+    ASSERT_NE(topic, nullptr);
+
+    DataWriter* datawriter = publisher->create_datawriter(topic, DATAWRITER_QOS_DEFAULT);
+    ASSERT_NE(datawriter, nullptr);
+}
+
 struct LoanableType
 {
     static constexpr uint32_t initialization_value()

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -77,6 +77,11 @@ public:
 
     void TearDown() override
     {
+        if (!destroy_entities_)
+        {
+            return;
+        }
+
         if (data_writer_)
         {
             ASSERT_EQ(publisher_->delete_datawriter(data_writer_), ReturnCode_t::RETCODE_OK);
@@ -528,6 +533,7 @@ protected:
     DataReader* data_reader_ = nullptr;
     DataWriter* data_writer_ = nullptr;
     TypeSupport type_;
+    bool destroy_entities_ = true;
 
     InstanceHandle_t handle_ok_ = HANDLE_NIL;
     InstanceHandle_t handle_wrong_ = HANDLE_NIL;
@@ -1270,6 +1276,27 @@ TEST_F(DataReaderTests, read_unread)
             EXPECT_EQ(ok_code, data_reader_->return_loan(data_seq[i], info_seq[i]));
         }
     }
+}
+
+TEST_F(DataReaderTests, TerminateWithoutDestroyingReader)
+{
+    destroy_entities_ = false;
+
+    DomainParticipant* participant =
+            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
+
+    Subscriber* subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
+
+    TypeSupport type(new FooTypeSupport());
+    type.register_type(participant);
+
+    Topic* topic = participant->create_topic("footopic", type.get_type_name(), TOPIC_QOS_DEFAULT);
+    ASSERT_NE(topic, nullptr);
+
+    DataReader* datareader = subscriber->create_datareader(topic, DATAREADER_QOS_DEFAULT);
+    ASSERT_NE(datareader, nullptr);
 }
 
 void set_listener_test (

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -1281,22 +1281,7 @@ TEST_F(DataReaderTests, read_unread)
 TEST_F(DataReaderTests, TerminateWithoutDestroyingReader)
 {
     destroy_entities_ = false;
-
-    DomainParticipant* participant =
-            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
-    ASSERT_NE(participant, nullptr);
-
-    Subscriber* subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
-    ASSERT_NE(participant, nullptr);
-
-    TypeSupport type(new FooTypeSupport());
-    type.register_type(participant);
-
-    Topic* topic = participant->create_topic("footopic", type.get_type_name(), TOPIC_QOS_DEFAULT);
-    ASSERT_NE(topic, nullptr);
-
-    DataReader* datareader = subscriber->create_datareader(topic, DATAREADER_QOS_DEFAULT);
-    ASSERT_NE(datareader, nullptr);
+    create_entities();
 }
 
 void set_listener_test (


### PR DESCRIPTION
These singletons are used on the destruction of certain classes.
In order to avoid these singletons to be already destructed,
these classes keep a shared_pointer to an instance to the singleton.
This ensures that the singleton is destructed AFTER the class instance.
