### PR TITLE
Set client known as remote to local if is pinging server [10548]

### DIFF
--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -563,141 +563,215 @@ void DiscoveryDataBase::create_participant_from_change_(
     // The participant was already known in the database
     if (participant_it != participants_.end())
     {
-        // Only update database if the change is newer than the one we already have
-        if (ch->write_params.sample_identity().sequence_number() >
-                participant_it->second.change()->write_params.sample_identity().sequence_number())
-        {
-            logInfo(DISCOVERY_DATABASE, "Participant already known with newer sequence number");
-
-            // The change could be newer and at the same time not being an update.
-            // This happens with DATAs coming from servers, since they take their own DATAs in and out frequently,
-            // so the sequence number in `write_params` changes.
-            // To account for that, we discard the DATA if the payload is exactly the same as what we have.
-            if (!(ch->serializedPayload == participant_it->second.change()->serializedPayload))
-            {
-                logInfo(DISCOVERY_DATABASE, "Participant updating. Marking old change to release");
-                // Update participant's change in the database, set all relevant participants ACK status to 0, and add
-                // old change to changes_to_release_.
-                update_change_and_unmatch_(ch, participant_it->second);
-
-                // If it is an update of our own server, is already in history
-                // Else, it needs to be sent in case it has unacked participants
-                if (change_guid.guidPrefix != server_guid_prefix_ &&
-                        !participant_it->second.is_acked_by_all())
-                {
-                    new_updates_++;
-                    add_pdp_to_send_(ch);
-                }
-            }
-        }
-        // if the cache is not new we have to release it, because it is repeated or outdated
-        else
-        {
-            // if the change is the same that we already have, we update the ack list. This is because we have
-            //  received the data from two servers, so we have to set that both of them already know this data
-            if (ch->write_params.sample_identity().sequence_number() ==
-                    participant_it->second.change()->write_params.sample_identity().sequence_number())
-            {
-                participant_it->second.add_or_update_ack_participant(ch->writerGUID.guidPrefix, true);
-            }
-
-            // we release it if it's the same or if it is lower
-            changes_to_release_.push_back(ch);
-        }
+        update_participant_from_change_(participant_it->second, ch, change_data);
     }
 
     // New participant
     else
     {
-        DiscoveryParticipantInfo part(ch, server_guid_prefix_, change_data);
-        std::pair<std::map<eprosima::fastrtps::rtps::GuidPrefix_t, DiscoveryParticipantInfo>::iterator, bool> ret =
-                participants_.insert(std::make_pair(change_guid.guidPrefix, part));
-        // If insert was successful
-        if (ret.second)
+        create_new_participant_from_change_(ch, change_data);
+    }
+}
+
+void DiscoveryDataBase::match_new_server_(
+        eprosima::fastrtps::rtps::GuidPrefix_t& participant_prefix)
+{
+    // Send Our DATA(p) to the new participant
+    // If this is not done, our data could be skip afterwards because a gap sent in newer DATA(p)s
+    //  so the new participant could never receive out data
+    auto our_data_it = participants_.find(server_guid_prefix_);
+    assert(our_data_it != participants_.end());
+    add_pdp_to_send_(our_data_it->second.change());
+
+    // Create virtual endpoints
+    create_virtual_endpoints_(participant_prefix);
+}
+
+void DiscoveryDataBase::create_virtual_endpoints_(
+        eprosima::fastrtps::rtps::GuidPrefix_t& participant_prefix)
+{
+    logInfo(DISCOVERY_DATABASE, "Creating virtual entities for " << participant_prefix);
+    /* Create virtual writer */
+    // Create a GUID for the virtual writer from the local server GUID prefix and the virtual writer entity
+    // ID.
+    fastrtps::rtps::GUID_t virtual_writer_guid(participant_prefix,
+            fastrtps::rtps::ds_server_virtual_writer);
+    // Create a populate the Cache Change with the necessary information.
+    fastrtps::rtps::CacheChange_t* virtual_writer_change = new fastrtps::rtps::CacheChange_t();
+    virtual_writer_change->kind = fastrtps::rtps::ChangeKind_t::ALIVE;
+    virtual_writer_change->writerGUID.guidPrefix = participant_prefix;
+    virtual_writer_change->writerGUID.entityId = fastrtps::rtps::ds_server_virtual_writer;
+    virtual_writer_change->instanceHandle = fastrtps::rtps::InstanceHandle_t(virtual_writer_guid);
+    // Populate sample identity
+    fastrtps::rtps::SampleIdentity virtual_writer_sample_id;
+    virtual_writer_sample_id.writer_guid(virtual_writer_guid);
+    virtual_writer_sample_id.sequence_number(eprosima::fastrtps::rtps::SequenceNumber_t(0));
+    // Set write params
+    eprosima::fastrtps::rtps::WriteParams virtual_writer_writer_params;
+    virtual_writer_writer_params.sample_identity(virtual_writer_sample_id);
+    virtual_writer_writer_params.related_sample_identity(virtual_writer_sample_id);
+    virtual_writer_change->write_params = std::move(virtual_writer_writer_params);
+    // Create the virtual writer
+    create_writers_from_change_(virtual_writer_change, virtual_topic_);
+
+    /* Create virtual reader */
+    // Create a GUID for the virtual reader from the local server GUID prefix and the virtual reader entity
+    // ID.
+    fastrtps::rtps::GUID_t virtual_reader_guid(participant_prefix,
+            fastrtps::rtps::ds_server_virtual_reader);
+    // Create a populate the Cache Change with the necessary information.
+    fastrtps::rtps::CacheChange_t* virtual_reader_change = new fastrtps::rtps::CacheChange_t();
+    virtual_reader_change->kind = fastrtps::rtps::ChangeKind_t::ALIVE;
+    virtual_reader_change->writerGUID.guidPrefix = participant_prefix;
+    virtual_reader_change->writerGUID.entityId = fastrtps::rtps::ds_server_virtual_reader;
+    virtual_reader_change->instanceHandle = fastrtps::rtps::InstanceHandle_t(virtual_reader_guid);
+    // Populate sample identity
+    fastrtps::rtps::SampleIdentity virtual_reader_sample_id;
+    virtual_reader_sample_id.writer_guid(virtual_reader_guid);
+    virtual_reader_sample_id.sequence_number(eprosima::fastrtps::rtps::SequenceNumber_t(0));
+    // Set write params
+    eprosima::fastrtps::rtps::WriteParams virtual_reader_writer_params;
+    virtual_reader_writer_params.sample_identity(virtual_reader_sample_id);
+    virtual_reader_writer_params.related_sample_identity(virtual_reader_sample_id);
+    virtual_reader_change->write_params = std::move(virtual_reader_writer_params);
+    // Create the virtual reader
+    create_readers_from_change_(virtual_reader_change, virtual_topic_);
+}
+
+bool DiscoveryDataBase::participant_data_has_changed_(
+        const DiscoveryParticipantInfo& participant_info,
+        const DiscoveryParticipantChangeData& new_change_data)
+{
+    return !(participant_info.is_local() == new_change_data.is_local() &&
+        participant_info.is_client() == new_change_data.is_client());
+}
+
+void DiscoveryDataBase::create_new_participant_from_change_(
+        eprosima::fastrtps::rtps::CacheChange_t* ch,
+        const DiscoveryParticipantChangeData& change_data)
+{
+    fastrtps::rtps::GUID_t change_guid = guid_from_change(ch);
+
+    DiscoveryParticipantInfo part(ch, server_guid_prefix_, change_data);
+    std::pair<std::map<eprosima::fastrtps::rtps::GuidPrefix_t, DiscoveryParticipantInfo>::iterator, bool> ret =
+            participants_.insert(std::make_pair(change_guid.guidPrefix, part));
+    // If insert was successful
+    if (ret.second)
+    {
+        // New participant found
+        new_updates_++;
+
+        logInfo(DISCOVERY_DATABASE, "New participant added: " << change_guid.guidPrefix);
+
+        // Manually set to 1 the relevant participants ACK status of the participant that sent the change. This way,
+        // we avoid backprogation of the data.
+        ret.first->second.add_or_update_ack_participant(ch->writerGUID.guidPrefix, true);
+
+        // If the DATA(p) it's from this server, it is already in history and we do nothing here
+        if (change_guid.guidPrefix != server_guid_prefix_)
         {
-            // New participant found
-            new_updates_++;
+            // If the participant is a new participant, mark that not everyone has ACKed this server's DATA(p)
+            // TODO if the new participant is a server it may be that our DATA(p) is already acked because he is
+            //  our server and we have pinged it. But also if we are its server it could be the case that
+            //  our DATA(p) is not acked even when it is our server. Solution: see in PDPServer how the change has
+            //  arrived, if because our ping or because their DATA(p). MINOR PROBLEM
+            server_acked_by_all(false);
+        }
 
-            logInfo(DISCOVERY_DATABASE, "New participant added: " << change_guid.guidPrefix);
+        // If it is local and server we have to create virtual endpoints, except for our own server
+        if (change_guid.guidPrefix != server_guid_prefix_ &&
+                !ret.first->second.is_client() && ret.first->second.is_local())
+        {
+            // Match new server and create virtual endpoints
+            match_new_server_(change_guid.guidPrefix);
+        }
+    }
+    else
+    {
+        logError(DISCOVERY_DATABASE, "Failed adding new participant " << change_guid.guidPrefix);
+    }
+}
 
-            // Manually set to 1 the relevant participants ACK status of the participant that sent the change. This way,
-            // we avoid backprogation of the data.
-            ret.first->second.add_or_update_ack_participant(ch->writerGUID.guidPrefix, true);
+void DiscoveryDataBase::update_participant_from_change_(
+        DiscoveryParticipantInfo& participant_info,
+        eprosima::fastrtps::rtps::CacheChange_t* ch,
+        const DiscoveryParticipantChangeData& change_data)
+{
+    fastrtps::rtps::GUID_t change_guid = guid_from_change(ch);
 
-            // If the DATA(p) it's from this server, it is already in history and we do nothing here
-            if (change_guid.guidPrefix != server_guid_prefix_)
-            {
-                // If the participant is a new participant, mark that not everyone has ACKed this server's DATA(p)
-                // TODO if the new participant is a server it may be that our DATA(p) is already acked because he is
-                //  our server and we have pinged it. But also if we are its server it could be the case that
-                //  our DATA(p) is not acked even when it is our server. Solution: see in PDPServer how the change has
-                //  arrived, if because our ping or because their DATA(p). MINOR PROBLEM
-                server_acked_by_all(false);
-            }
+    // Specific case when a Data(P) from an entity A known as remote comes from the very entity A (we have
+    // the Data(P) because of other server B, but now it arrives from A itself)
+    // The entity A changes to local
+    // Must be local data, or else it is a remote endpoint and should not be changed
+    if (change_guid.guidPrefix != server_guid_prefix_ && change_data.is_local() &&
+        DiscoveryDataBase::participant_data_has_changed_(participant_info, change_data))
+    {
+        // If the participant changes to server local, virtual endpoints must be added
+        // If it is local and server the only possibility is it was a remote server and it must be converted to local
+        if (!change_data.is_client())
+        {
+            match_new_server_(change_guid.guidPrefix);
+        }
 
-            // If it is local and server we have to create virtual endpoints, except for our own server
+        // Update the change data
+        participant_info.participant_change_data(change_data);
+
+        // Update change
+        update_change_and_unmatch_(ch, participant_info);
+
+        // Treat as a new participant found
+        new_updates_++;
+        server_acked_by_all(false);
+
+        // It is possible that this Data(P) is in our history if it has not been acked by all
+        // In this case we have to resent it with the new update
+        if (!participant_info.is_acked_by_all())
+        {
+            add_pdp_to_send_(ch);
+        }
+    }
+
+    // Only update database if the change is newer than the one we already have
+    else if (ch->write_params.sample_identity().sequence_number() >
+            participant_info.change()->write_params.sample_identity().sequence_number())
+    {
+        logInfo(DISCOVERY_DATABASE, "Participant already known with newer sequence number");
+
+        // The change could be newer and at the same time not being an update.
+        // This happens with DATAs coming from servers, since they take their own DATAs in and out frequently,
+        // so the sequence number in `write_params` changes.
+        // To account for that, we discard the DATA if the payload is exactly the same as what we have.
+        if (!(ch->serializedPayload == participant_info.change()->serializedPayload))
+        {
+            logInfo(DISCOVERY_DATABASE, "Participant updating. Marking old change to release");
+            // Update participant's change in the database, set all relevant participants ACK status to 0, and add
+            // old change to changes_to_release_.
+            update_change_and_unmatch_(ch, participant_info);
+
+            // If it is an update of our own server, is already in history
+            // Else, it needs to be sent in case it has unacked participants
             if (change_guid.guidPrefix != server_guid_prefix_ &&
-                    !ret.first->second.is_client() && ret.first->second.is_local())
+                    !participant_info.is_acked_by_all())
             {
-                // Send Our DATA(p) to the new participant
-                // If this is not done, our data could be skip afterwards because a gap sent in newer DATA(p)s
-                //  so the new participant could never receive out data
-                auto our_data_it = participants_.find(server_guid_prefix_);
-                assert(our_data_it != participants_.end());
-                add_pdp_to_send_(our_data_it->second.change());
-
-                logInfo(DISCOVERY_DATABASE, "Creating virtual entities for " << change_guid.guidPrefix);
-                /* Create virtual writer */
-                // Create a GUID for the virtual writer from the local server GUID prefix and the virtual writer entity
-                // ID.
-                fastrtps::rtps::GUID_t virtual_writer_guid(change_guid.guidPrefix,
-                        fastrtps::rtps::ds_server_virtual_writer);
-                // Create a populate the Cache Change with the necessary information.
-                fastrtps::rtps::CacheChange_t* virtual_writer_change = new fastrtps::rtps::CacheChange_t();
-                virtual_writer_change->kind = fastrtps::rtps::ChangeKind_t::ALIVE;
-                virtual_writer_change->writerGUID.guidPrefix = ch->writerGUID.guidPrefix;
-                virtual_writer_change->writerGUID.entityId = fastrtps::rtps::ds_server_virtual_writer;
-                virtual_writer_change->instanceHandle = fastrtps::rtps::InstanceHandle_t(virtual_writer_guid);
-                // Populate sample identity
-                fastrtps::rtps::SampleIdentity virtual_writer_sample_id;
-                virtual_writer_sample_id.writer_guid(virtual_writer_guid);
-                virtual_writer_sample_id.sequence_number(eprosima::fastrtps::rtps::SequenceNumber_t(0));
-                // Set write params
-                eprosima::fastrtps::rtps::WriteParams virtual_writer_writer_params;
-                virtual_writer_writer_params.sample_identity(virtual_writer_sample_id);
-                virtual_writer_writer_params.related_sample_identity(virtual_writer_sample_id);
-                virtual_writer_change->write_params = std::move(virtual_writer_writer_params);
-                // Create the virtual writer
-                create_writers_from_change_(virtual_writer_change, virtual_topic_);
-
-                /* Create virtual reader */
-                // Create a GUID for the virtual reader from the local server GUID prefix and the virtual reader entity
-                // ID.
-                fastrtps::rtps::GUID_t virtual_reader_guid(change_guid.guidPrefix,
-                        fastrtps::rtps::ds_server_virtual_reader);
-                // Create a populate the Cache Change with the necessary information.
-                fastrtps::rtps::CacheChange_t* virtual_reader_change = new fastrtps::rtps::CacheChange_t();
-                virtual_reader_change->kind = fastrtps::rtps::ChangeKind_t::ALIVE;
-                virtual_reader_change->writerGUID.guidPrefix = ch->writerGUID.guidPrefix;
-                virtual_reader_change->writerGUID.entityId = fastrtps::rtps::ds_server_virtual_reader;
-                virtual_reader_change->instanceHandle = fastrtps::rtps::InstanceHandle_t(virtual_reader_guid);
-                // Populate sample identity
-                fastrtps::rtps::SampleIdentity virtual_reader_sample_id;
-                virtual_reader_sample_id.writer_guid(virtual_reader_guid);
-                virtual_reader_sample_id.sequence_number(eprosima::fastrtps::rtps::SequenceNumber_t(0));
-                // Set write params
-                eprosima::fastrtps::rtps::WriteParams virtual_reader_writer_params;
-                virtual_reader_writer_params.sample_identity(virtual_reader_sample_id);
-                virtual_reader_writer_params.related_sample_identity(virtual_reader_sample_id);
-                virtual_reader_change->write_params = std::move(virtual_reader_writer_params);
-                // Create the virtual reader
-                create_readers_from_change_(virtual_reader_change, virtual_topic_);
+                new_updates_++;
+                add_pdp_to_send_(ch);
             }
         }
-        else
+    }
+
+    // if the cache is not new we have to release it, because it is repeated or outdated
+    else
+    {
+        // if the change is the same that we already have, we update the ack list. This is because we have
+        //  received the data from two servers, so we have to set that both of them already know this data
+        if (ch->write_params.sample_identity().sequence_number() ==
+                participant_info.change()->write_params.sample_identity().sequence_number())
         {
-            logError(DISCOVERY_DATABASE, "Failed adding new participant " << change_guid.guidPrefix);
+            participant_info.add_or_update_ack_participant(ch->writerGUID.guidPrefix, true);
         }
+
+        // we release it if it's the same or if it is lower
+        changes_to_release_.push_back(ch);
     }
 }
 

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -2510,6 +2510,16 @@ void DiscoveryDataBase::persistence_enable(
     backup_file_.open(backup_file_name_, std::ios::app);
 }
 
+bool DiscoveryDataBase::is_participant_local(const eprosima::fastrtps::rtps::GuidPrefix_t& participant_prefix)
+{
+    auto pit = participants_.find(participant_prefix);
+    if (pit != participants_.end())
+    {
+        return pit->second.is_local();
+    }
+    return false; // In case it does not exist
+}
+
 } // namespace ddb
 } // namespace rtps
 } // namespace fastdds

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -643,7 +643,7 @@ bool DiscoveryDataBase::participant_data_has_changed_(
         const DiscoveryParticipantChangeData& new_change_data)
 {
     return !(participant_info.is_local() == new_change_data.is_local() &&
-        participant_info.is_client() == new_change_data.is_client());
+           participant_info.is_client() == new_change_data.is_client());
 }
 
 void DiscoveryDataBase::create_new_participant_from_change_(
@@ -704,7 +704,7 @@ void DiscoveryDataBase::update_participant_from_change_(
     // The entity A changes to local
     // Must be local data, or else it is a remote endpoint and should not be changed
     if (change_guid.guidPrefix != server_guid_prefix_ && change_data.is_local() &&
-        DiscoveryDataBase::participant_data_has_changed_(participant_info, change_data))
+            DiscoveryDataBase::participant_data_has_changed_(participant_info, change_data))
     {
         // If the participant changes to server local, virtual endpoints must be added
         // If it is local and server the only possibility is it was a remote server and it must be converted to local
@@ -2584,7 +2584,8 @@ void DiscoveryDataBase::persistence_enable(
     backup_file_.open(backup_file_name_, std::ios::app);
 }
 
-bool DiscoveryDataBase::is_participant_local(const eprosima::fastrtps::rtps::GuidPrefix_t& participant_prefix)
+bool DiscoveryDataBase::is_participant_local(
+        const eprosima::fastrtps::rtps::GuidPrefix_t& participant_prefix)
 {
     auto pit = participants_.find(participant_prefix);
     if (pit != participants_.end())

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
@@ -339,7 +339,8 @@ public:
     }
 
     // Check if an participant is stored as local. If the participant does not exist, it returns false
-    bool is_participant_local(const eprosima::fastrtps::rtps::GuidPrefix_t& participant_prefix);
+    bool is_participant_local(
+            const eprosima::fastrtps::rtps::GuidPrefix_t& participant_prefix);
 
 protected:
 

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
@@ -380,6 +380,27 @@ protected:
             eprosima::fastrtps::rtps::CacheChange_t* ch,
             const std::string& topic_name);
 
+    // Functions related with create_participant_from_change_
+
+    void match_new_server_(
+            eprosima::fastrtps::rtps::GuidPrefix_t& participant_prefix);
+
+    void create_virtual_endpoints_(
+            eprosima::fastrtps::rtps::GuidPrefix_t& participant_prefix);
+
+    static bool participant_data_has_changed_(
+            const DiscoveryParticipantInfo& participant_info,
+            const DiscoveryParticipantChangeData& new_change_data);
+
+    void create_new_participant_from_change_(
+            eprosima::fastrtps::rtps::CacheChange_t* ch,
+            const DiscoveryParticipantChangeData& change_data);
+
+    void update_participant_from_change_(
+            DiscoveryParticipantInfo& participant_info,
+            eprosima::fastrtps::rtps::CacheChange_t* ch,
+            const DiscoveryParticipantChangeData& change_data);
+
     // change ack relevants and matched between entities participants and endpoints
     void match_writer_reader_(
             const eprosima::fastrtps::rtps::GUID_t& writer_guid,

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
@@ -326,15 +326,20 @@ public:
         data_queues_mutex_.unlock();
     }
 
+    // Return string with virtual topic default name
     std::string virtual_topic() const
     {
         return virtual_topic_;
     }
 
+    // Return number of updated entities since last call to this same function
     int updates_since_last_checked()
     {
         return new_updates_.exchange(0);
     }
+
+    // Check if an participant is stored as local. If the participant does not exist, it returns false
+    bool is_participant_local(const eprosima::fastrtps::rtps::GuidPrefix_t& participant_prefix);
 
 protected:
 

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryParticipantInfo.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryParticipantInfo.hpp
@@ -90,14 +90,19 @@ public:
     void remove_writer(
             const eprosima::fastrtps::rtps::GUID_t& guid);
 
-    bool is_client()
+    bool is_client() const
     {
         return participant_change_data_.is_client();
     }
 
-    bool is_local()
+    bool is_local() const
     {
         return participant_change_data_.is_local();
+    }
+
+    void participant_change_data(const DiscoveryParticipantChangeData& new_participant_change_data)
+    {
+        participant_change_data_ = new_participant_change_data;
     }
 
     bool is_external()

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryParticipantInfo.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryParticipantInfo.hpp
@@ -100,7 +100,8 @@ public:
         return participant_change_data_.is_local();
     }
 
-    void participant_change_data(const DiscoveryParticipantChangeData& new_participant_change_data)
+    void participant_change_data(
+            const DiscoveryParticipantChangeData& new_participant_change_data)
     {
         participant_change_data_ = new_participant_change_data;
     }

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners.cpp
@@ -72,6 +72,13 @@ void EDPServerPUBListener::onNewCacheChangeAdded(
     GUID_t auxGUID = iHandle2GUID(change->instanceHandle);
     ReaderHistory* reader_history = sedp_->publications_reader_.second;
 
+    // Related_sample_identity could be lost in message delivered, so we set as sample_identity
+    // An empty related_sample_identity could lead into an empty sample_identity when resending this msg
+    if (change->write_params.related_sample_identity() == SampleIdentity::unknown())
+    {
+        change->write_params.related_sample_identity(change->write_params.sample_identity());
+    }
+
     // String to store the topic of the writer
     std::string topic_name = "";
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
@@ -221,10 +221,20 @@ void PDPServerListener::onNewCacheChangeAdded(
             //  another entity (server).
             // is_local means that the server is connected (or will be) with this entity directly
             bool is_local = true;
+
+            // In case a new changes arrives from a local entity, but the ParticipantProxyData already exists
+            //  because we know it from other server
+            bool was_local = true;
+
             // If the instance handle is different from the writer GUID, then the change has been relayed
             if (iHandle2GUID(change->instanceHandle).guidPrefix != change->writerGUID.guidPrefix)
             {
                 is_local = false;
+            }
+            else
+            {
+                // We already know that the writer and the entity are the same, so we can use writerGUID
+                was_local = pdp_server()->discovery_db().is_participant_local(change->writerGUID.guidPrefix);
             }
 
             if (!pdp_server()->discovery_db().backup_in_progress())
@@ -262,7 +272,6 @@ void PDPServerListener::onNewCacheChangeAdded(
                 // Release the unique pointer, not the change in the pool
                 change.release();
             }
-
 
             // At this point we can release reader lock.
             reader->getMutex().unlock();
@@ -303,6 +312,14 @@ void PDPServerListener::onNewCacheChangeAdded(
                 {
                     pdp_server()->assignRemoteEndpoints(pdata);
                 }
+            }
+            // Case ParticipantProxyData already exists but was known remotly and now must be local
+            else if (is_local && !was_local)
+            {
+                // Realease PDP mutex
+                lock.unlock();
+
+                pdp_server()->assignRemoteEndpoints(pdata);
             }
             // Updated participant information case
             else


### PR DESCRIPTION
Test cases to test this bug: https://github.com/eProsima/Discovery-Server/pull/23.
Discovery server test cases: 28, 30.

When a server already knows a client by other server (remotely) and this client is pinging such server, this server never replies as this Data(P) was checked as known (the ParticipantProxyData already existed).