### PR TITLE
Extend endpoint QoS with new unique locators request feature [10496]

### DIFF
--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1314,6 +1314,11 @@ ReturnCode_t DataWriterImpl::check_qos(
         logError(RTPS_QOS_CHECK, "BY SOURCE TIMESTAMP DestinationOrder not supported");
         return ReturnCode_t::RETCODE_UNSUPPORTED;
     }
+    if (nullptr != PropertyPolicyHelper::find_property(qos.properties(), "fastdds.unique_network_flows"))
+    {
+        logError(RTPS_QOS_CHECK, "Unique network flows not supported on writers");
+        return ReturnCode_t::RETCODE_UNSUPPORTED;
+    }
     if (qos.reliability().kind == BEST_EFFORT_RELIABILITY_QOS && qos.ownership().kind == EXCLUSIVE_OWNERSHIP_QOS)
     {
         logError(RTPS_QOS_CHECK, "BEST_EFFORT incompatible with EXCLUSIVE ownership");

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -99,8 +99,7 @@ static bool collections_have_same_properties(
 static bool qos_has_unique_network_request(
         const DataReaderQos& qos)
 {
-    const std::string* value = PropertyPolicyHelper::find_property(qos.properties(), "fastdds.unique_network_flows");
-    return value && !value->empty();
+    return nullptr != PropertyPolicyHelper::find_property(qos.properties(), "fastdds.unique_network_flows");
 }
 
 static bool qos_has_specific_locators(

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -979,32 +979,6 @@ bool DataReaderImpl::lifespan_expired()
     return false;
 }
 
-/* TODO
-   bool DataReaderImpl::read(
-        std::vector<void *>& data_values,
-        std::vector<SampleInfo_t>& sample_infos,
-        uint32_t max_samples)
-   {
-    (void)data_values;
-    (void)sample_infos;
-    (void)max_samples;
-    // TODO Implement
-    return false;
-   }
-
-   bool DataReaderImpl::take(
-        std::vector<void *>& data_values,
-        std::vector<SampleInfo_t>& sample_infos,
-        uint32_t max_samples)
-   {
-    (void)data_values;
-    (void)sample_infos;
-    (void)max_samples;
-    // TODO Implement
-    return false;
-   }
- */
-
 ReturnCode_t DataReaderImpl::set_listener(
         DataReaderListener* listener)
 {

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -96,6 +96,22 @@ static bool collections_have_same_properties(
            (data_values.length() == sample_infos.length()));
 }
 
+static bool qos_has_unique_network_request(
+        const DataReaderQos& qos)
+{
+    const std::string* value = PropertyPolicyHelper::find_property(qos.properties(), "fastdds.unique_network_flows");
+    return value && !value->empty();
+}
+
+static bool qos_has_specific_locators(
+        const DataReaderQos& qos)
+{
+    const RTPSEndpointQos& endpoint = qos.endpoint();
+    return !endpoint.unicast_locator_list.empty() ||
+           !endpoint.multicast_locator_list.empty() ||
+           !endpoint.remote_locator_list.empty();
+}
+
 DataReaderImpl::DataReaderImpl(
         SubscriberImpl* s,
         TypeSupport& type,
@@ -1143,6 +1159,11 @@ ReturnCode_t DataReaderImpl::check_qos (
         logError(DDS_QOS_CHECK, "max_samples_per_read should be strictly possitive");
         return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
     }
+    if (qos_has_unique_network_request(qos) && qos_has_specific_locators(qos))
+    {
+        logError(DDS_QOS_CHECK, "unique_network_request cannot be set along specific locators");
+        return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
+    }
     return ReturnCode_t::RETCODE_OK;
 }
 
@@ -1209,6 +1230,12 @@ bool DataReaderImpl::can_qos_be_updated(
     {
         updatable = false;
         logWarning(RTPS_QOS_CHECK, "Data sharing configuration cannot be changed after the creation of a DataReader.");
+    }
+    if (qos_has_unique_network_request(to) != qos_has_unique_network_request(from))
+    {
+        updatable = false;
+        logWarning(RTPS_QOS_CHECK,
+                "Unique network flows request cannot be changed after the creation of a DataReader.");
     }
     return updatable;
 }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -558,6 +558,13 @@ bool RTPSParticipantImpl::create_writer(
         return false;
     }
 
+    // Check for unique_network_flows feature
+    if (nullptr != PropertyPolicyHelper::find_property(param.endpoint.properties, "fastdds.unique_network_flows"))
+    {
+        logError(RTPS_PARTICIPANT, "Unique network flows not supported on writers");
+        return false;
+    }
+
     // Special case for DiscoveryProtocol::BACKUP, which abuses persistence guid
     GUID_t former_persistence_guid = param.endpoint.persistence_guid;
     if (param.endpoint.persistence_guid == c_Guid_Unknown)
@@ -665,6 +672,13 @@ bool RTPSParticipantImpl::create_reader(
     EntityId_t entId;
     if (!preprocess_endpoint_attributes<READER, 0x04, 0x07>(entity_id, param.endpoint, entId))
     {
+        return false;
+    }
+
+    // Check for unique_network_flows feature
+    if (nullptr != PropertyPolicyHelper::find_property(param.endpoint.properties, "fastdds.unique_network_flows"))
+    {
+        logError(RTPS_PARTICIPANT, "Unique network flows not supported on readers");
         return false;
     }
 

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -969,14 +969,14 @@ public:
     }
 
     PubSubReader& property_policy(
-            const eprosima::fastrtps::rtps::PropertyPolicy property_policy)
+            const eprosima::fastrtps::rtps::PropertyPolicy& property_policy)
     {
         participant_qos_.properties() = property_policy;
         return *this;
     }
 
     PubSubReader& entity_property_policy(
-            const eprosima::fastrtps::rtps::PropertyPolicy property_policy)
+            const eprosima::fastrtps::rtps::PropertyPolicy& property_policy)
     {
         datareader_qos_.properties() = property_policy;
         return *this;

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -983,14 +983,14 @@ public:
     }
 
     PubSubWriter& property_policy(
-            const eprosima::fastrtps::rtps::PropertyPolicy property_policy)
+            const eprosima::fastrtps::rtps::PropertyPolicy& property_policy)
     {
         participant_qos_.properties() = property_policy;
         return *this;
     }
 
     PubSubWriter& entity_property_policy(
-            const eprosima::fastrtps::rtps::PropertyPolicy property_policy)
+            const eprosima::fastrtps::rtps::PropertyPolicy& property_policy)
     {
         datawriter_qos_.properties() = property_policy;
         return *this;

--- a/test/blackbox/common/BlackboxTestsNetworkConf.cpp
+++ b/test/blackbox/common/BlackboxTestsNetworkConf.cpp
@@ -45,6 +45,32 @@ static void GetIP4s(
             });
 }
 
+TEST(Blackbox, pub_unique_network_flows)
+{
+    PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+
+    PropertyPolicy properties;
+    properties.properties().emplace_back("fastdds.unique_network_flows", "");
+
+    writer.entity_property_policy(properties).init();
+
+    // Creation should fail as feature is not implemented for writers
+    EXPECT_FALSE(writer.isInitialized());
+}
+
+TEST(Blackbox, sub_unique_network_flows)
+{
+    PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
+
+    PropertyPolicy properties;
+    properties.properties().emplace_back("fastdds.unique_network_flows", "");
+
+    reader.entity_property_policy(properties).init();
+
+    // Creation should fail as feature is not implemented for readers
+    EXPECT_FALSE(reader.isInitialized());
+}
+
 //Verify that outLocatorList is used to select the desired output channel
 TEST(BlackBox, PubSubOutLocatorSelection)
 {

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -358,6 +358,10 @@ TEST(DataWriterTests, InvalidQos)
     ASSERT_TRUE(datawriter->set_qos(qos) == ReturnCode_t::RETCODE_UNSUPPORTED);
 
     qos = DATAWRITER_QOS_DEFAULT;
+    qos.properties().properties().emplace_back("fastdds.unique_network_flows", "");
+    ASSERT_TRUE(datawriter->set_qos(qos) == ReturnCode_t::RETCODE_UNSUPPORTED);
+
+    qos = DATAWRITER_QOS_DEFAULT;
     qos.reliability().kind = BEST_EFFORT_RELIABILITY_QOS;
     qos.ownership().kind = EXCLUSIVE_OWNERSHIP_QOS;
     ASSERT_TRUE(datawriter->set_qos(qos) == ReturnCode_t::RETCODE_INCONSISTENT_POLICY);

--- a/test/unittest/dds/status/CMakeLists.txt
+++ b/test/unittest/dds/status/CMakeLists.txt
@@ -50,6 +50,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/FileConsumer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/PropertyPolicy.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/flowcontrol/ThroughputControllerDescriptor.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/history/TopicPayloadPool.cpp

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -46,6 +46,8 @@
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 #include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
 
+#include <fastdds/rtps/common/Locator.h>
+
 #include "./FooBoundedType.hpp"
 #include "./FooBoundedTypeSupport.hpp"
 
@@ -533,6 +535,108 @@ protected:
     InstanceHandle_t handle_wrong_ = HANDLE_NIL;
 
 };
+
+TEST_F(DataReaderTests, InvalidQos)
+{
+    DataReaderQos qos;
+
+    create_entities();
+
+    ASSERT_TRUE(data_reader_->is_enabled());
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, data_reader_->get_qos(qos));
+    ASSERT_EQ(qos, DATAREADER_QOS_DEFAULT);
+
+    /* Unsupported QoS */
+    const ReturnCode_t unsupported_code = ReturnCode_t::RETCODE_UNSUPPORTED;
+
+    qos = DATAREADER_QOS_DEFAULT;
+    qos.durability().kind = PERSISTENT_DURABILITY_QOS;
+    EXPECT_EQ(unsupported_code, data_reader_->set_qos(qos));
+
+    qos = DATAREADER_QOS_DEFAULT;
+    qos.destination_order().kind = BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS;
+    EXPECT_EQ(unsupported_code, data_reader_->set_qos(qos));
+
+    /* Inconsistent QoS */
+    const ReturnCode_t inconsistent_code = ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
+
+    qos = DATAREADER_QOS_DEFAULT;
+    qos.reliability().kind = BEST_EFFORT_RELIABILITY_QOS;
+    qos.ownership().kind = EXCLUSIVE_OWNERSHIP_QOS;
+    EXPECT_EQ(inconsistent_code, data_reader_->set_qos(qos));
+
+    qos = DATAREADER_QOS_DEFAULT;
+    qos.reader_resource_limits().max_samples_per_read = -1;
+    EXPECT_EQ(inconsistent_code, data_reader_->set_qos(qos));
+
+    qos = DATAREADER_QOS_DEFAULT;
+    eprosima::fastrtps::rtps::Locator_t locator;
+    qos.endpoint().unicast_locator_list.push_back(locator);
+    qos.properties().properties().emplace_back("fastdds.unique_network_flows", "");
+    EXPECT_EQ(inconsistent_code, data_reader_->set_qos(qos));
+
+    qos = DATAREADER_QOS_DEFAULT;
+    qos.endpoint().multicast_locator_list.push_back(locator);
+    qos.properties().properties().emplace_back("fastdds.unique_network_flows", "");
+    EXPECT_EQ(inconsistent_code, data_reader_->set_qos(qos));
+
+    qos = DATAREADER_QOS_DEFAULT;
+    qos.endpoint().remote_locator_list.push_back(locator);
+    qos.properties().properties().emplace_back("fastdds.unique_network_flows", "");
+    EXPECT_EQ(inconsistent_code, data_reader_->set_qos(qos));
+
+    /* Inmutable QoS */
+    const ReturnCode_t inmutable_code = ReturnCode_t::RETCODE_IMMUTABLE_POLICY;
+
+    qos = DATAREADER_QOS_DEFAULT;
+    qos.resource_limits().max_samples++;
+    EXPECT_EQ(inmutable_code, data_reader_->set_qos(qos));
+
+    qos = DATAREADER_QOS_DEFAULT;
+    qos.history().kind = KEEP_ALL_HISTORY_QOS;
+    EXPECT_EQ(inmutable_code, data_reader_->set_qos(qos));
+
+    qos = DATAREADER_QOS_DEFAULT;
+    qos.history().depth++;
+    EXPECT_EQ(inmutable_code, data_reader_->set_qos(qos));
+
+    qos = DATAREADER_QOS_DEFAULT;
+    qos.durability().kind = TRANSIENT_LOCAL_DURABILITY_QOS;
+    EXPECT_EQ(inmutable_code, data_reader_->set_qos(qos));
+
+    qos = DATAREADER_QOS_DEFAULT;
+    qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
+    EXPECT_EQ(inmutable_code, data_reader_->set_qos(qos));
+
+    qos = DATAREADER_QOS_DEFAULT;
+    qos.liveliness().kind = MANUAL_BY_PARTICIPANT_LIVELINESS_QOS;
+    EXPECT_EQ(inmutable_code, data_reader_->set_qos(qos));
+
+    qos = DATAREADER_QOS_DEFAULT;
+    qos.liveliness().lease_duration.seconds = -131;
+    EXPECT_EQ(inmutable_code, data_reader_->set_qos(qos));
+
+    qos = DATAREADER_QOS_DEFAULT;
+    qos.liveliness().announcement_period.seconds = -131;
+    EXPECT_EQ(inmutable_code, data_reader_->set_qos(qos));
+
+    qos = DATAREADER_QOS_DEFAULT;
+    qos.reader_resource_limits().matched_publisher_allocation.initial++;
+    EXPECT_EQ(inmutable_code, data_reader_->set_qos(qos));
+
+    qos = DATAREADER_QOS_DEFAULT;
+    qos.data_sharing().off();
+    EXPECT_EQ(inmutable_code, data_reader_->set_qos(qos));
+
+    qos = DATAREADER_QOS_DEFAULT;
+    uint16_t datasharing_domain = 131u;
+    qos.data_sharing().add_domain_id(datasharing_domain);
+    EXPECT_EQ(inmutable_code, data_reader_->set_qos(qos));
+
+    qos = DATAREADER_QOS_DEFAULT;
+    qos.properties().properties().emplace_back("fastdds.unique_network_flows", "");
+    EXPECT_EQ(inmutable_code, data_reader_->set_qos(qos));
+}
 
 /**
  * This test checks all variants of read / take in several situations for a keyed plain type.


### PR DESCRIPTION
* Adding `fastdds.unique_network_flows` property interpretation on QoS
* Adding tests that fail on creation of endpoints requesting the new feature
* (Bonus) Additional invalid qos tests for DataReader