### PR TITLE
Add more verbosity to discovery CLI [10611]

### DIFF
--- a/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h
+++ b/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h
@@ -37,14 +37,14 @@ namespace eprosima {
 
 namespace fastdds {
 
-namespace rtps
-{
+namespace rtps {
 
 /**
  * Struct to define participant types to set participant type parameter property
  *@ingroup DISCOVERY_MODULE
  */
-struct ParticipantType {
+struct ParticipantType
+{
     static constexpr const char* SIMPLE = "SIMPLE";
     static constexpr const char* SERVER = "SERVER";
     static constexpr const char* CLIENT = "CLIENT";
@@ -95,26 +95,26 @@ inline std::ostream& operator <<(
 {
     switch (discovery_protocol)
     {
-    case DiscoveryProtocol::NONE:
-        output << fastdds::rtps::ParticipantType::NONE;
-        break;
-    case DiscoveryProtocol::SIMPLE:
-        output << fastdds::rtps::ParticipantType::SIMPLE;
-        break;
-    case DiscoveryProtocol::EXTERNAL:
-        output << fastdds::rtps::ParticipantType::EXTERNAL;
-        break;
-    case DiscoveryProtocol::CLIENT:
-        output << fastdds::rtps::ParticipantType::CLIENT;
-        break;
-    case DiscoveryProtocol::SERVER:
-        output << fastdds::rtps::ParticipantType::SERVER;
-        break;
-    case DiscoveryProtocol::BACKUP:
-        output << fastdds::rtps::ParticipantType::BACKUP;
-        break;
-    default:
-        output << fastdds::rtps::ParticipantType::UNKNOWN;
+        case DiscoveryProtocol::NONE:
+            output << fastdds::rtps::ParticipantType::NONE;
+            break;
+        case DiscoveryProtocol::SIMPLE:
+            output << fastdds::rtps::ParticipantType::SIMPLE;
+            break;
+        case DiscoveryProtocol::EXTERNAL:
+            output << fastdds::rtps::ParticipantType::EXTERNAL;
+            break;
+        case DiscoveryProtocol::CLIENT:
+            output << fastdds::rtps::ParticipantType::CLIENT;
+            break;
+        case DiscoveryProtocol::SERVER:
+            output << fastdds::rtps::ParticipantType::SERVER;
+            break;
+        case DiscoveryProtocol::BACKUP:
+            output << fastdds::rtps::ParticipantType::BACKUP;
+            break;
+        default:
+            output << fastdds::rtps::ParticipantType::UNKNOWN;
     }
     return output;
 }

--- a/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h
+++ b/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h
@@ -34,6 +34,29 @@
 #include <sstream>
 
 namespace eprosima {
+
+namespace fastdds {
+
+namespace rtps
+{
+
+/**
+ * Struct to define participant types to set participant type parameter property
+ *@ingroup DISCOVERY_MODULE
+ */
+struct ParticipantType {
+    static constexpr const char* SIMPLE = "SIMPLE";
+    static constexpr const char* SERVER = "SERVER";
+    static constexpr const char* CLIENT = "CLIENT";
+    static constexpr const char* BACKUP = "BACKUP";
+    static constexpr const char* NONE = "NONE";
+    static constexpr const char* EXTERNAL = "EXTERNAL";
+    static constexpr const char* UNKNOWN = "UNKNOWN";
+};
+
+} /* namespace rtps */
+} /* namespace fastdds */
+
 namespace fastrtps {
 namespace rtps {
 
@@ -65,6 +88,36 @@ typedef enum DiscoveryProtocol
                  Discovery operation persist on a file (discovery handshake wouldn't repeat if shutdown). */
 
 } DiscoveryProtocol_t;
+
+inline std::ostream& operator <<(
+        std::ostream& output,
+        const DiscoveryProtocol& discovery_protocol)
+{
+    switch (discovery_protocol)
+    {
+    case DiscoveryProtocol::NONE:
+        output << fastdds::rtps::ParticipantType::NONE;
+        break;
+    case DiscoveryProtocol::SIMPLE:
+        output << fastdds::rtps::ParticipantType::SIMPLE;
+        break;
+    case DiscoveryProtocol::EXTERNAL:
+        output << fastdds::rtps::ParticipantType::EXTERNAL;
+        break;
+    case DiscoveryProtocol::CLIENT:
+        output << fastdds::rtps::ParticipantType::CLIENT;
+        break;
+    case DiscoveryProtocol::SERVER:
+        output << fastdds::rtps::ParticipantType::SERVER;
+        break;
+    case DiscoveryProtocol::BACKUP:
+        output << fastdds::rtps::ParticipantType::BACKUP;
+        break;
+    default:
+        output << fastdds::rtps::ParticipantType::UNKNOWN;
+    }
+    return output;
+}
 
 //!Filtering flags when discovering participants
 typedef enum ParticipantFilteringFlags : uint32_t

--- a/include/fastdds/rtps/attributes/ServerAttributes.h
+++ b/include/fastdds/rtps/attributes/ServerAttributes.h
@@ -106,13 +106,13 @@ typedef std::list<RemoteServerAttributes> RemoteServerList_t;
 // port use if the ros environment variable doesn't specified one
 constexpr uint16_t DEFAULT_ROS2_SERVER_PORT = 11811;
 // default server base guidPrefix
-const char* const DEFAULT_ROS2_SERVER_GUIDPREFIX = "44.49.53.43.53.45.52.56.45.52.5F.30";
+const char* const DEFAULT_ROS2_SERVER_GUIDPREFIX = "44.53.00.5f.45.50.52.4f.53.49.4d.41";
 
 /**
  * Retrieves a ; separated list of locators from an environment variable and
  * populates a RemoteServerList_t mapping list position to default guid.
  * @param list servers listening locator list provided.
- * @param attributes referenct to a RemoteServerList_t to populate.
+ * @param attributes reference to a RemoteServerList_t to populate.
  * @return true if parsing succeeds
  */
 RTPS_DllAPI bool load_environment_server_info(

--- a/include/fastdds/rtps/builtin/discovery/participant/PDP.h
+++ b/include/fastdds/rtps/builtin/discovery/participant/PDP.h
@@ -39,18 +39,6 @@ namespace rtps {
 
 class PDPServerListener;
 
-/**
- * Struct to define participant types to set participant type parameter property
- *@ingroup DISCOVERY_MODULE
- */
-struct ParticipantType
-{
-    static const char SIMPLE[];
-    static const char SERVER[];
-    static const char CLIENT[];
-    static const char BACKUP[];
-};
-
 } // namespace rtps
 } // namespace fastdds
 

--- a/include/fastdds/rtps/common/GuidPrefix_t.hpp
+++ b/include/fastdds/rtps/common/GuidPrefix_t.hpp
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <cstring>
 #include <sstream>
+#include <iomanip>
 
 namespace eprosima {
 namespace fastrtps {
@@ -93,11 +94,12 @@ inline std::ostream& operator <<(
         const GuidPrefix_t& guiP)
 {
     output << std::hex;
+    output.fill('0');
     for (uint8_t i = 0; i < 11; ++i)
     {
-        output << (int)guiP.value[i] << ".";
+        output << std::setw(2) << (int)guiP.value[i] << ".";
     }
-    output << (int)guiP.value[11];
+    output << std::setw(2) << (int)guiP.value[11];
     return output << std::dec;
 }
 

--- a/include/fastdds/rtps/common/GuidPrefix_t.hpp
+++ b/include/fastdds/rtps/common/GuidPrefix_t.hpp
@@ -94,13 +94,14 @@ inline std::ostream& operator <<(
         const GuidPrefix_t& guiP)
 {
     output << std::hex;
-    output.fill('0');
+    char old_fill = output.fill('0');
     for (uint8_t i = 0; i < 11; ++i)
     {
         output << std::setw(2) << (int)guiP.value[i] << ".";
     }
     output << std::setw(2) << (int)guiP.value[11];
     return output << std::dec;
+    output.fill(old_fill);
 }
 
 inline std::istream& operator >>(

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -64,18 +64,6 @@
 #include <chrono>
 
 namespace eprosima {
-namespace fastdds {
-namespace rtps {
-
-// Values for participant type parameter property
-const char ParticipantType::SIMPLE[] = "SIMPLE";
-const char ParticipantType::SERVER[] = "SERVER";
-const char ParticipantType::CLIENT[] = "CLIENT";
-const char ParticipantType::BACKUP[] = "BACKUP";
-
-} // namespace rtps
-} // namespace fastdds
-
 namespace fastrtps {
 namespace rtps {
 
@@ -352,6 +340,12 @@ void PDP::initializeParticipantProxyData(
         participant_data->plugin_security_attributes_ = 0UL;
     }
 #endif // if HAVE_SECURITY
+
+    // Set participant type property
+    std::stringstream participant_type;
+    participant_type << mp_RTPSParticipant->getAttributes().builtin.discovery_config.discoveryProtocol;
+    participant_data->m_properties.push_back(std::pair<std::string,
+            std::string>({fastdds::dds::parameter_property_participant_type, participant_type.str()}));
 }
 
 bool PDP::initPDP(

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -90,9 +90,7 @@ void PDPClient::initializeParticipantProxyData(
         participant_data->m_availableBuiltinEndpoints |= DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER;
     }
 
-    // Set participant type and discovery server version properties
-    participant_data->m_properties.push_back(std::pair<std::string,
-            std::string>({fastdds::dds::parameter_property_participant_type, fastdds::rtps::ParticipantType::CLIENT}));
+    // Set discovery server version property
     participant_data->m_properties.push_back(std::pair<std::string,
             std::string>({fastdds::dds::parameter_property_ds_version,
                           fastdds::dds::parameter_property_current_ds_version}));
@@ -716,8 +714,8 @@ bool get_server_client_default_guidPrefix(
             && id < 256
             && std::istringstream(DEFAULT_ROS2_SERVER_GUIDPREFIX) >> guid)
     {
-        // Last octet denotes the default server id but to ease debugging it starts on char '0' = 48
-        guid.value[11] = static_cast<octet>((48 + id) % 256);
+        // Third octet denotes the server id
+        guid.value[2] = static_cast<octet>(id);
 
         return true;
     }

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -373,10 +373,7 @@ void PDPServer::initializeParticipantProxyData(
         logWarning(RTPS_PDP_SERVER, "SERVER or BACKUP PDP requires always all EDP endpoints creation.");
     }
 
-    // Set participant type and discovery server version properties
-    participant_data->m_properties.push_back(
-        std::pair<std::string, std::string>(
-            {dds::parameter_property_participant_type, ParticipantType::SERVER}));
+    // Set discovery server version property
     participant_data->m_properties.push_back(
         std::pair<std::string,
         std::string>({dds::parameter_property_ds_version, dds::parameter_property_current_ds_version}));

--- a/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
@@ -506,8 +506,8 @@ TEST_P(PubSubBasic, ReceivedPropertiesDataWithinSizeLimit)
     LocatorBuffer.port = static_cast<uint16_t>(MULTICAST_PORT_RANDOM_NUMBER);
     ReaderMulticastLocators.push_back(LocatorBuffer);
 
-    //Expected properties have exactly size 52
-    reader.properties_max_size(52).
+    //Expected properties have exactly size 92
+    reader.properties_max_size(92).
             static_discovery("PubSubReader.xml").
             unicastLocatorList(ReaderUnicastLocators).multicastLocatorList(ReaderMulticastLocators).
             setSubscriberIDs(3,
@@ -603,7 +603,7 @@ TEST_P(PubSubBasic, ReceivedPropertiesDataExceedsSizeLimit)
     LocatorBuffer.port = static_cast<uint16_t>(MULTICAST_PORT_RANDOM_NUMBER);
     ReaderMulticastLocators.push_back(LocatorBuffer);
 
-    //Expected properties have size 52
+    //Expected properties have size 92
     reader.properties_max_size(50)
             .static_discovery("PubSubReader.xml")
             .unicastLocatorList(ReaderUnicastLocators).multicastLocatorList(ReaderMulticastLocators)

--- a/test/blackbox/common/RTPSBlackboxTestsPersistenceGuid.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsPersistenceGuid.cpp
@@ -211,7 +211,7 @@ TEST_P(PersistenceGuid, CheckPrevalenceBetweenManualAndPropertyConfiguration)
 
     // Check if there is one entry in the writers database table with the stated persistence guid
     result1 =
-            system("python check_guid.py \"persistence.db\" \"writers_histories\" \"0.0.0.0.0.0.0.0.0.0.0.1|0.0.0.1\"");
+            system("python check_guid.py \"persistence.db\" \"writers_histories\" \"00.00.00.00.00.00.00.00.00.00.00.01|0.0.0.1\"");
     ASSERT_EQ(result1, 1);
 
     // Check if that there is no entry in the readers database table with the stated persistence guid
@@ -220,7 +220,7 @@ TEST_P(PersistenceGuid, CheckPrevalenceBetweenManualAndPropertyConfiguration)
     ASSERT_EQ(result2, 0);
 
     // Check if there is one entry in the readers database table with the stated persistence guid
-    result2 = system("python check_guid.py \"persistence.db\" \"readers\" \"0.0.0.0.0.0.0.0.0.0.0.2|0.0.0.1\"");
+    result2 = system("python check_guid.py \"persistence.db\" \"readers\" \"00.00.00.00.00.00.00.00.00.00.00.02|0.0.0.1\"");
     ASSERT_EQ(result2, 1);
 #else
 
@@ -230,7 +230,7 @@ TEST_P(PersistenceGuid, CheckPrevalenceBetweenManualAndPropertyConfiguration)
     ASSERT_EQ((result1 >> 8), 0);
 
     // Check if there is one entry in the writers database table with the stated persistence guid
-    result1 = system("python3 check_guid.py 'persistence.db' 'writers_histories' '0.0.0.0.0.0.0.0.0.0.0.1|0.0.0.1'");
+    result1 = system("python3 check_guid.py 'persistence.db' 'writers_histories' '00.00.00.00.00.00.00.00.00.00.00.01|0.0.0.1'");
     ASSERT_EQ((result1 >> 8), 1);
 
     // Check if that there is no entry in the readers database table with the stated persistence guid
@@ -239,7 +239,7 @@ TEST_P(PersistenceGuid, CheckPrevalenceBetweenManualAndPropertyConfiguration)
     ASSERT_EQ((result2 >> 8), 0);
 
     // Check if there is one entry in the readers database table with the stated persistence guid
-    result2 = system("python3 check_guid.py 'persistence.db' 'readers' '0.0.0.0.0.0.0.0.0.0.0.2|0.0.0.1'");
+    result2 = system("python3 check_guid.py 'persistence.db' 'readers' '00.00.00.00.00.00.00.00.00.00.00.02|0.0.0.1'");
     ASSERT_EQ((result2 >> 8), 1);
 #endif // WIN32
 }

--- a/test/blackbox/common/RTPSBlackboxTestsPersistenceGuid.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsPersistenceGuid.cpp
@@ -211,7 +211,8 @@ TEST_P(PersistenceGuid, CheckPrevalenceBetweenManualAndPropertyConfiguration)
 
     // Check if there is one entry in the writers database table with the stated persistence guid
     result1 =
-            system("python check_guid.py \"persistence.db\" \"writers_histories\" \"00.00.00.00.00.00.00.00.00.00.00.01|0.0.0.1\"");
+            system(
+        "python check_guid.py \"persistence.db\" \"writers_histories\" \"00.00.00.00.00.00.00.00.00.00.00.01|0.0.0.1\"");
     ASSERT_EQ(result1, 1);
 
     // Check if that there is no entry in the readers database table with the stated persistence guid
@@ -220,7 +221,8 @@ TEST_P(PersistenceGuid, CheckPrevalenceBetweenManualAndPropertyConfiguration)
     ASSERT_EQ(result2, 0);
 
     // Check if there is one entry in the readers database table with the stated persistence guid
-    result2 = system("python check_guid.py \"persistence.db\" \"readers\" \"00.00.00.00.00.00.00.00.00.00.00.02|0.0.0.1\"");
+    result2 = system(
+        "python check_guid.py \"persistence.db\" \"readers\" \"00.00.00.00.00.00.00.00.00.00.00.02|0.0.0.1\"");
     ASSERT_EQ(result2, 1);
 #else
 
@@ -230,7 +232,8 @@ TEST_P(PersistenceGuid, CheckPrevalenceBetweenManualAndPropertyConfiguration)
     ASSERT_EQ((result1 >> 8), 0);
 
     // Check if there is one entry in the writers database table with the stated persistence guid
-    result1 = system("python3 check_guid.py 'persistence.db' 'writers_histories' '00.00.00.00.00.00.00.00.00.00.00.01|0.0.0.1'");
+    result1 = system(
+        "python3 check_guid.py 'persistence.db' 'writers_histories' '00.00.00.00.00.00.00.00.00.00.00.01|0.0.0.1'");
     ASSERT_EQ((result1 >> 8), 1);
 
     // Check if that there is no entry in the readers database table with the stated persistence guid

--- a/test/blackbox/utils/check_guid.py
+++ b/test/blackbox/utils/check_guid.py
@@ -15,13 +15,13 @@
 import sqlite3
 import sys
 
-""" 
+"""
 Return the number of apparitions of a guid, on a specific table and database.
 
-It takes three arguments: 
+It takes three arguments:
     * database_name: The filename of the database
     * table_name: The name of the table within the database
-    * check_guid: The guid of the entity that you want to look for in the 
+    * check_guid: The guid of the entity that you want to look for in the
       stated table and database.
 
 """

--- a/tools/fds/server.cpp
+++ b/tools/fds/server.cpp
@@ -27,6 +27,7 @@
 #include <csignal>
 
 #include <fastrtps/Domain.h>
+#include <fastrtps/participant/Participant.h>
 #include <fastdds/dds/log/Log.hpp>
 
 using namespace eprosima;
@@ -99,6 +100,7 @@ int main (
     // Retrieve server Id: is mandatory and only specified once
     // Note there is a specific cast to pointer if the Option is valid
     option::Option* pOp = options[SERVERID];
+    int server_id;
 
     if ( nullptr == pOp )
     {
@@ -112,7 +114,6 @@ int main (
     }
     else
     {
-        int server_id;
         stringstream is;
         is << pOp->arg;
 
@@ -224,7 +225,13 @@ int main (
 
         // handle signal SIGINT for every thread
         signal(SIGINT, sigint_handler);
-        cout << endl << "\n### Server is running ###" << endl;
+
+        // Print running server attributes
+        cout << "### Server is running ###" << endl;
+        cout << "  Server ID:          " << server_id << endl;
+        cout << "  Server GUID prefix: " << pServer->getGuid().guidPrefix << endl;
+        cout << "  Server Address:     " << locator << endl;
+        cout << "  Participant Type    " << rtps.builtin.discovery_config.discoveryProtocol << endl;
 
         g_signal_cv.wait(lock, []
                 {


### PR DESCRIPTION
This PR adds more verbosity to the stdout of the `fastdds discovery` command. Example:

```
### Server is running ###
  Server ID:          0
  Server GUID prefix: 44.53.00.5f.45.50.52.4f.53.49.4d.41
  Server Address:     UDPv4:[127.0.0.1]:11811
  Participant Type    SERVER
### Server shut down ###
```

This way, creating an XML file for CLIENTS connecting to the SERVER is easier, since the prefix is clearly stated. For doing this, a `<<` operator has been added for the `DiscoveryProtocol` enum. Furthermore, the `<<` operator for the `GuidPrefix` has been enhanced, so that the bytes are always showed as two digits, adding a preceding 0 if necessary.

It is important to note the the default GUID prefix for the server has changed. The following schema is applied now:

* `44.53.<server_id>.5f.45.50.52.4f.53.49.4d.41`, which translated into ASCII as `DS<id_in_hex>_EPROSIMA`.

Finally, the participant type property has been added to the `SIMPLE` participant's DATA(p)s
