### PR TITLE
Stop listener thread on reader destructor <master> [10618]

### DIFF
--- a/src/cpp/rtps/reader/RTPSReader.cpp
+++ b/src/cpp/rtps/reader/RTPSReader.cpp
@@ -125,6 +125,10 @@ void RTPSReader::init(
                     att.endpoint.data_sharing_configuration().shm_directory(),
                     att.matched_writers_allocation,
                     this));
+
+        // We can start the listener here, as no writer can be matched already,
+        // so no notification will occur until the the non-virtual instance is constructed.
+        // But we need to stop the listener in the non-virtual instance destructor.
         datasharing_listener_->start();
     }
 

--- a/src/cpp/rtps/reader/RTPSReader.cpp
+++ b/src/cpp/rtps/reader/RTPSReader.cpp
@@ -127,7 +127,7 @@ void RTPSReader::init(
                     this));
 
         // We can start the listener here, as no writer can be matched already,
-        // so no notification will occur until the the non-virtual instance is constructed.
+        // so no notification will occur until the non-virtual instance is constructed.
         // But we need to stop the listener in the non-virtual instance destructor.
         datasharing_listener_->start();
     }

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -55,6 +55,13 @@ StatefulReader::~StatefulReader()
         is_alive_ = false;
     }
 
+    // Datasharing listener must be stopped to avoid processing notifications
+    // while the reader is being destroyed
+    if (is_datasharing_compatible_)
+    {
+        datasharing_listener_->stop();
+    }
+
     for (WriterProxy* writer : matched_writers_)
     {
         delete(writer);

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -41,6 +41,13 @@ using namespace eprosima::fastrtps::rtps;
 StatelessReader::~StatelessReader()
 {
     logInfo(RTPS_READER, "Removing reader " << m_guid);
+
+    // Datasharing listener must be stopped to avoid processing notifications
+    // while the reader is being destroyed
+    if (is_datasharing_compatible_)
+    {
+        datasharing_listener_->stop();
+    }
 }
 
 StatelessReader::StatelessReader(


### PR DESCRIPTION
The listener thread is not being stopped when the reader is dismissed. This can lead to problems if the listener processes a notification while the reader is being destroyed, as it may end up calling methods already removed from the vtable.