### PR TITLE
[10637] Restore smart default logging for multiconfig generators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,18 +282,30 @@ endif()
 # Log Info default setup
 ###############################################################################
 
+include(CMakeDependentOption)
+
+set(LOG_NO_INFO_HELP "\
+Do not compile Info Log level. For the sake of efficiency non-debug \
+configs do not log info messages unless the option ENFORCE_LOG_INFO \
+is set to on.")
 if(CMAKE_BUILD_TYPE MATCHES "^([Dd][Ee][Bb][Uu][Gg])$"  # single config generator
    OR ("Debug" IN_LIST CMAKE_CONFIGURATION_TYPES))      # multi config generator
-    option(LOG_NO_INFO "Do not compile Info Log level" OFF)
+    option(LOG_NO_INFO ${LOG_NO_INFO_HELP} OFF)
 else()
-    option(LOG_NO_INFO "Do not compile Info Log level" ON)
+    option(LOG_NO_INFO ${LOG_NO_INFO_HELP} ON)
 endif()
-
-option(ENFORCE_LOG_INFO "The LOG_NO_INFO option must be followed regardless of configuration" OFF)
+unset(LOG_NO_INFO_HELP)
 
 option(LOG_NO_WARNING "Do not compile Warning Log level" OFF)
 
 option(LOG_NO_ERROR "Do not compile Error Log level" OFF)
+
+cmake_dependent_option(
+    ENFORCE_LOG_INFO
+    "The LOG_NO_INFO option must be enforced regardless of selected configuration"
+    OFF
+    "NOT LOG_NO_INFO"
+    OFF)
 
 if(LOG_NO_INFO)
     set(HAVE_LOG_NO_INFO 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,7 +286,7 @@ include(CMakeDependentOption)
 
 set(LOG_NO_INFO_HELP "\
 Do not compile Info Log level. For the sake of efficiency non-debug \
-configs do not log info messages unless the option ENFORCE_LOG_INFO \
+configs do not log info messages unless the option FASTDDS_ENFORCE_LOG_INFO \
 is set to on.")
 if(CMAKE_BUILD_TYPE MATCHES "^([Dd][Ee][Bb][Uu][Gg])$"  # single config generator
    OR ("Debug" IN_LIST CMAKE_CONFIGURATION_TYPES))      # multi config generator
@@ -301,7 +301,7 @@ option(LOG_NO_WARNING "Do not compile Warning Log level" OFF)
 option(LOG_NO_ERROR "Do not compile Error Log level" OFF)
 
 cmake_dependent_option(
-    ENFORCE_LOG_INFO
+    FASTDDS_ENFORCE_LOG_INFO
     "The LOG_NO_INFO option must be enforced regardless of selected configuration"
     OFF
     "NOT LOG_NO_INFO"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,11 +281,15 @@ endif()
 ###############################################################################
 # Log Info default setup
 ###############################################################################
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+
+if(CMAKE_BUILD_TYPE MATCHES "^([Dd][Ee][Bb][Uu][Gg])$"  # single config generator
+   OR ("Debug" IN_LIST CMAKE_CONFIGURATION_TYPES))      # multi config generator
     option(LOG_NO_INFO "Do not compile Info Log level" OFF)
 else()
     option(LOG_NO_INFO "Do not compile Info Log level" ON)
 endif()
+
+option(ENFORCE_LOG_INFO "The LOG_NO_INFO option must be followed regardless of configuration" OFF)
 
 option(LOG_NO_WARNING "Do not compile Warning Log level" OFF)
 

--- a/include/fastdds/dds/log/Log.hpp
+++ b/include/fastdds/dds/log/Log.hpp
@@ -288,7 +288,9 @@ protected:
 #define logWarning_(cat, msg)
 #endif // ifndef LOG_NO_WARNING
 
-#if !HAVE_LOG_NO_INFO
+// Allow multiconfig platforms like windows to disable info queueing on Release and other non-debug configs
+#if !HAVE_LOG_NO_INFO &&  \
+    ( defined(ENFORCE_LOG_INFO) || (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG)) && (defined(_DEBUG) || defined(__DEBUG)))
 #define logInfo_(cat, msg)                                                                              \
     {                                                                                                   \
         using namespace eprosima::fastdds::dds;                                                         \

--- a/include/fastdds/dds/log/Log.hpp
+++ b/include/fastdds/dds/log/Log.hpp
@@ -290,7 +290,7 @@ protected:
 
 // Allow multiconfig platforms like windows to disable info queueing on Release and other non-debug configs
 #if !HAVE_LOG_NO_INFO &&  \
-    ( defined(ENFORCE_LOG_INFO) || \
+    (defined(FASTDDS_ENFORCE_LOG_INFO) || \
     ((defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG)) && (defined(_DEBUG) || defined(__DEBUG))))
 #define logInfo_(cat, msg)                                                                              \
     {                                                                                                   \

--- a/include/fastdds/dds/log/Log.hpp
+++ b/include/fastdds/dds/log/Log.hpp
@@ -290,7 +290,8 @@ protected:
 
 // Allow multiconfig platforms like windows to disable info queueing on Release and other non-debug configs
 #if !HAVE_LOG_NO_INFO &&  \
-    ( defined(ENFORCE_LOG_INFO) || (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG)) && (defined(_DEBUG) || defined(__DEBUG)))
+    ( defined(ENFORCE_LOG_INFO) || \
+    ((defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG)) && (defined(_DEBUG) || defined(__DEBUG))))
 #define logInfo_(cat, msg)                                                                              \
     {                                                                                                   \
         using namespace eprosima::fastdds::dds;                                                         \

--- a/include/fastrtps/config.h.in
+++ b/include/fastrtps/config.h.in
@@ -82,7 +82,7 @@
 /* Log Macros */
 
 // Log Info
-#cmakedefine ENFORCE_LOG_INFO
+#cmakedefine FASTDDS_ENFORCE_LOG_INFO
 #ifndef HAVE_LOG_NO_INFO
 #define HAVE_LOG_NO_INFO @HAVE_LOG_NO_INFO@
 #endif

--- a/include/fastrtps/config.h.in
+++ b/include/fastrtps/config.h.in
@@ -82,6 +82,7 @@
 /* Log Macros */
 
 // Log Info
+#cmakedefine ENFORCE_LOG_INFO
 #ifndef HAVE_LOG_NO_INFO
 #define HAVE_LOG_NO_INFO @HAVE_LOG_NO_INFO@
 #endif

--- a/test/unittest/logging/LogTests.cpp
+++ b/test/unittest/logging/LogTests.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 //
 
+#define ENFORCE_LOG_INFO
+
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/dds/log/OStreamConsumer.hpp>
 #include <fastdds/dds/log/StdoutConsumer.hpp>

--- a/test/unittest/logging/LogTests.cpp
+++ b/test/unittest/logging/LogTests.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-#define ENFORCE_LOG_INFO
+#define FASTDDS_ENFORCE_LOG_INFO
 
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/dds/log/OStreamConsumer.hpp>

--- a/test/unittest/logging/log_macros/LogMacrosAllActiveTests.cpp
+++ b/test/unittest/logging/log_macros/LogMacrosAllActiveTests.cpp
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-#define ENFORCE_LOG_INFO
+#define FASTDDS_ENFORCE_LOG_INFO
 #ifdef HAVE_LOG_NO_INFO
 #undef HAVE_LOG_NO_INFO
 #endif // HAVE_LOG_NO_INFO

--- a/test/unittest/logging/log_macros/LogMacrosAllActiveTests.cpp
+++ b/test/unittest/logging/log_macros/LogMacrosAllActiveTests.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+#define ENFORCE_LOG_INFO
 #ifdef HAVE_LOG_NO_INFO
 #undef HAVE_LOG_NO_INFO
 #endif // HAVE_LOG_NO_INFO

--- a/test/unittest/logging/log_macros/LogMacrosDefaultTests.cpp
+++ b/test/unittest/logging/log_macros/LogMacrosDefaultTests.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+#define ENFORCE_LOG_INFO
 #include <fastdds/dds/log/Log.hpp>
 #include "LogMacros.hpp"
 #include <gtest/gtest.h>

--- a/test/unittest/logging/log_macros/LogMacrosDefaultTests.cpp
+++ b/test/unittest/logging/log_macros/LogMacrosDefaultTests.cpp
@@ -14,7 +14,6 @@
 // limitations under the License.
 //
 
-#define ENFORCE_LOG_INFO
 #include <fastdds/dds/log/Log.hpp>
 #include "LogMacros.hpp"
 #include <gtest/gtest.h>

--- a/test/unittest/logging/log_macros/LogMacrosInternalDebugOffTests.cpp
+++ b/test/unittest/logging/log_macros/LogMacrosInternalDebugOffTests.cpp
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-#define ENFORCE_LOG_INFO
+#define FASTDDS_ENFORCE_LOG_INFO
 #ifdef HAVE_LOG_NO_INFO
 #undef HAVE_LOG_NO_INFO
 #endif // HAVE_LOG_NO_INFO

--- a/test/unittest/logging/log_macros/LogMacrosInternalDebugOffTests.cpp
+++ b/test/unittest/logging/log_macros/LogMacrosInternalDebugOffTests.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+#define ENFORCE_LOG_INFO
 #ifdef HAVE_LOG_NO_INFO
 #undef HAVE_LOG_NO_INFO
 #endif // HAVE_LOG_NO_INFO

--- a/test/unittest/logging/log_macros/LogMacrosNoErrorTests.cpp
+++ b/test/unittest/logging/log_macros/LogMacrosNoErrorTests.cpp
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-#define ENFORCE_LOG_INFO
+#define FASTDDS_ENFORCE_LOG_INFO
 #ifdef HAVE_LOG_NO_INFO
 #undef HAVE_LOG_NO_INFO
 #endif // HAVE_LOG_NO_INFO

--- a/test/unittest/logging/log_macros/LogMacrosNoErrorTests.cpp
+++ b/test/unittest/logging/log_macros/LogMacrosNoErrorTests.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+#define ENFORCE_LOG_INFO
 #ifdef HAVE_LOG_NO_INFO
 #undef HAVE_LOG_NO_INFO
 #endif // HAVE_LOG_NO_INFO

--- a/test/unittest/logging/log_macros/LogMacrosNoInfoTests.cpp
+++ b/test/unittest/logging/log_macros/LogMacrosNoInfoTests.cpp
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-#define ENFORCE_LOG_INFO
+#define FASTDDS_ENFORCE_LOG_INFO
 #ifdef HAVE_LOG_NO_INFO
 #undef HAVE_LOG_NO_INFO
 #endif // HAVE_LOG_NO_INFO

--- a/test/unittest/logging/log_macros/LogMacrosNoInfoTests.cpp
+++ b/test/unittest/logging/log_macros/LogMacrosNoInfoTests.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+#define ENFORCE_LOG_INFO
 #ifdef HAVE_LOG_NO_INFO
 #undef HAVE_LOG_NO_INFO
 #endif // HAVE_LOG_NO_INFO

--- a/test/unittest/logging/log_macros/LogMacrosNoWarningTests.cpp
+++ b/test/unittest/logging/log_macros/LogMacrosNoWarningTests.cpp
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-#define ENFORCE_LOG_INFO
+#define FASTDDS_ENFORCE_LOG_INFO
 #ifdef HAVE_LOG_NO_INFO
 #undef HAVE_LOG_NO_INFO
 #endif // HAVE_LOG_NO_INFO

--- a/test/unittest/logging/log_macros/LogMacrosNoWarningTests.cpp
+++ b/test/unittest/logging/log_macros/LogMacrosNoWarningTests.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+#define ENFORCE_LOG_INFO
 #ifdef HAVE_LOG_NO_INFO
 #undef HAVE_LOG_NO_INFO
 #endif // HAVE_LOG_NO_INFO


### PR DESCRIPTION
Prior to #1679 the default library behavior was:
- if not using **INTERNAL_DEBUG** never queue infos.
- if using **INTERNAL_DEBUG** on Debug config infos are queued but other configs don't queue them.
- if user defines **LOG_NO_INFO** no infos are queued regardless config or cmake options. 

For multiconfig generators like MSVC this was optimal because Release builds never queued infos and Debug builds may do it or not depending on **INTERNAL_DEBUG** or **LOG_NO_INFO** settings.

In order to allow testing to rely on logging regardless of configuration #1679 introduced new CMake options (**LOG_NO_INFO**, **LOG_NO_WARNING**, **LOG_NO_ERROR**). 

In order to enable info logging on debug builds **LOG_NO_INFO** option was set if **CMAKE_BUILD_TYPE** was debug.  Unfortunately this broke multiconfig generators usual behaviour because:
- they don't use **CMAKE_BUILD_TYPE** to specify the config (but is specified in a second build step by CMake cli).
- Fast-DDS defaults to **CMAKE_BUILD_TYPE=Release** if the variable is not provided.
thus: 
- multiconfig build never log infos by default.
- if logging was enforced by using **LOG_NO_INFO=OFF** then ALL configurations log ruining performance in Release.

To solve this issue:
 - **LOG_NO_INFO** falls back to its previous behavior. If option **LOG_NO_INFO=OFF** it doesn't force all configs to log infos but only debug if **INTERNAL_DEBUG=ON**.
 - **LOG_NO_INFO** fulfillment can be enforced using a new option **FASTDDS_ENFORCE_LOG_INFO**. This reproduces #1679 option behavior and can be used for testing purposes.
