### PR TITLE
provide an alternative path for robustlock files under QNX

### DIFF
--- a/src/cpp/rtps/transport/shared_mem/RobustLock.hpp
+++ b/src/cpp/rtps/transport/shared_mem/RobustLock.hpp
@@ -22,7 +22,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <errno.h>
-#endif
+#endif  // __QNXNTO__
 
 namespace eprosima {
 namespace fastdds {
@@ -51,38 +51,45 @@ public:
     static std::string get_file_path(
             const std::string& filename)
     {
-        
+
 #ifdef __QNXNTO__
-	static const char defaultdir[] = "/var/lock";
+        static const char defaultdir[] = "/var/lock";
         struct stat buf;
         // check directory status
-        if (stat(defaultdir, &buf) != 0){
+        if (stat(defaultdir, &buf) != 0)
+	{
             // directory not found, create it
-            if(errno == ENOENT){
+            if(errno == ENOENT)
+	    {
                 mkdir(defaultdir, 0777);
             }
             // if another error then throw exception
-            else{
+            else
+	    {
                 std::string err("get_file_path() ");
                 err = err + strerror(errno);
                 throw std::runtime_error(err);
             }
         }
-        else{
+        else
+	{
             // directory exists do nothing
         }
 #else
         // Default value from: glibc-2.29/sysdeps/unix/sysv/linux/shm-directory.c
         static const char defaultdir[] = "/dev/shm/";
-#endif
+#endif  // __QNXNTO__
+
         std::string filepath;
+
         #if defined(BOOST_INTERPROCESS_FILESYSTEM_BASED_POSIX_SHARED_MEMORY)
         const bool add_leading_slash = false;
         #elif defined(BOOST_INTERPROCESS_RUNTIME_FILESYSTEM_BASED_POSIX_SHARED_MEMORY)
         const bool add_leading_slash = !boost::interprocess::shared_memory_object_detail::use_filesystem_based_posix();
         #else
         const bool add_leading_slash = true;
-        #endif
+        #endif  // Platform dependent leading slash
+
         if (add_leading_slash)
         {
             boost::interprocess::ipcdetail::add_leading_slash(filename.c_str(), filepath);
@@ -93,7 +100,8 @@ public:
         }
         return defaultdir + filepath;
     }
-#endif
+#endif  // !defined(BOOST_INTERPROCESS_POSIX_SHARED_MEMORY_OBJECTS)
+
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/transport/shared_mem/RobustLock.hpp
+++ b/src/cpp/rtps/transport/shared_mem/RobustLock.hpp
@@ -57,22 +57,22 @@ public:
         struct stat buf;
         // check directory status
         if (stat(defaultdir, &buf) != 0)
-	{
+        {
             // directory not found, create it
             if(errno == ENOENT)
-	    {
+            {
                 mkdir(defaultdir, 0777);
             }
             // if another error then throw exception
             else
-	    {
+            {
                 std::string err("get_file_path() ");
                 err = err + strerror(errno);
                 throw std::runtime_error(err);
             }
         }
         else
-	{
+        {
             // directory exists do nothing
         }
 #else
@@ -100,6 +100,7 @@ public:
         }
         return defaultdir + filepath;
     }
+
 #endif  // !defined(BOOST_INTERPROCESS_POSIX_SHARED_MEMORY_OBJECTS)
 
 };

--- a/src/cpp/rtps/transport/shared_mem/RobustLock.hpp
+++ b/src/cpp/rtps/transport/shared_mem/RobustLock.hpp
@@ -59,7 +59,7 @@ public:
         if (stat(defaultdir, &buf) != 0)
         {
             // directory not found, create it
-            if(errno == ENOENT)
+            if (errno == ENOENT)
             {
                 mkdir(defaultdir, 0777);
             }


### PR DESCRIPTION
fixes #1766 in 2.1.x
The robust lock path is changed from /dev/shmem to /var/lock as discussed with @IkerLuengo 
First we check if the directory /var/lock exists then mkdir it if it does not then proceed with the normal procedure of creating the locked file.

if PR is approved please cherry pick to 2.0.x as well, thank you.