### PR TITLE
[10645 ] Fixing performance latency test build without security

### DIFF
--- a/test/performance/latency/LatencyTestSubscriber.cpp
+++ b/test/performance/latency/LatencyTestSubscriber.cpp
@@ -605,7 +605,7 @@ void LatencyTestSubscriber::run()
 bool LatencyTestSubscriber::test(
         uint32_t datasize)
 {
-    logInfo(LatencyTest, "Preparing test with data size: " << datasize + 4);
+    logInfo(LatencyTest, "Preparing test with data size: " << datasize );
 
     // Wait for the Publisher READY command
     // Assures that LatencyTestSubscriber|Publisher data endpoints creation and
@@ -672,7 +672,7 @@ bool LatencyTestSubscriber::test(
         return false;
     }
 
-    logInfo(LatencyTest, "Testing with data size: " << datasize + 4);
+    logInfo(LatencyTest, "Testing with data size: " << datasize);
 
     // Wait for the STOP or STOP_ERROR commands
     wait_for_command(
@@ -681,7 +681,7 @@ bool LatencyTestSubscriber::test(
             return command_msg_count_ != 0;
         });
 
-    logInfo(LatencyTest, "TEST OF SIZE: " << datasize + 4 << " ENDS");
+    logInfo(LatencyTest, "TEST OF SIZE: " << datasize << " ENDS");
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
     if (dynamic_types_)

--- a/test/performance/latency/main_LatencyTest.cpp
+++ b/test/performance/latency/main_LatencyTest.cpp
@@ -470,20 +470,26 @@ int main(
         }
     }
 
+#if HAVE_SECURITY
     // Check parameters validity
-    if (use_security && test_agent == TestAgent::BOTH)
+    if (use_security)
     {
-        logError(LatencyTest, "Intra-process delivery NOT supported with security");
-        return 1;
+        if (test_agent == TestAgent::BOTH)
+        {
+            logError(LatencyTest, "Intra-process delivery NOT supported with security");
+            return 1;
+        }
+        else if (data_sharing)
+        {
+            logError(LatencyTest, "Sharing sample APIs NOT supported with RTPS encryption");
+            return 1;
+        }
     }
-    else if ((data_sharing || data_loans) && dynamic_types)
+#endif // if HAVE_SECURITY
+
+    if ((data_sharing || data_loans) && dynamic_types)
     {
         logError(LatencyTest, "Sharing sample APIs NOT supported with dynamic types");
-        return 1;
-    }
-    else if ( data_sharing && use_security )
-    {
-        logError(LatencyTest, "Sharing sample APIs NOT supported with RTPS encryption");
         return 1;
     }
 


### PR DESCRIPTION
Parameter validation didn't take into account that some flags were not present in non-security sources.