### PR TITLE
[10646] Fix various CMake issues

### DIFF
--- a/cmake/modules/FindAtomic.cmake
+++ b/cmake/modules/FindAtomic.cmake
@@ -49,7 +49,10 @@ set(OLD_CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
 # must locally change CMAKE_C_COMPILER_LOADED value to force the use of C++ compiler. Note that future changes in
 # CheckLibraryExists module may alter this workaround.
 set(CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS} ${FASTDDS_REQUIRED_FLAGS})
-set(CMAKE_C_COMPILER_LOADED 0)
+
+if(MSVC OR MSVC_IDE OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+    set(CMAKE_C_COMPILER_LOADED 0)
+endif()
 
 # Test linking without atomic
 check_cxx_source_compiles(

--- a/include/fastrtps/config.h.in
+++ b/include/fastrtps/config.h.in
@@ -22,6 +22,16 @@
 
 #define GEN_API_VER 1
 
+// C++20 support defines
+#ifndef HAVE_CXX20
+#define HAVE_CXX20 @HAVE_CXX20@
+#endif
+
+// C++17 support defines
+#ifndef HAVE_CXX17
+#define HAVE_CXX17 @HAVE_CXX17@
+#endif
+
 // C++14 support defines
 #ifndef HAVE_CXX14
 #define HAVE_CXX14 @HAVE_CXX14@

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -375,10 +375,11 @@ elseif(NOT EPROSIMA_INSTALLER)
     # make visual studio more gcc and clang like. Propagated to dependent targets.
     if(MSVC)
         # C4101 'identifier' : unreferenced local variable 
-        # C4555 expression has no effect; expected expression with side-effect 
         # C4189 'identifier' : local variable is initialized but not referenced
+        # C4555  expression has no effect; expected expression with side-effect
+        # C4715: 'Test': not all control paths return a value
         # C5038 data member 'member1' will be initialized after data member 'member2'
-        target_compile_options(${PROJECT_NAME} PUBLIC /w34101 /w34555 /w34189 /w35038)
+        target_compile_options(${PROJECT_NAME} PUBLIC /w34101 /w34555 /w34189 /w35038 /w34101)
     endif(MSVC)
 
     target_compile_definitions(${PROJECT_NAME} PRIVATE

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -379,7 +379,7 @@ elseif(NOT EPROSIMA_INSTALLER)
         # C4555  expression has no effect; expected expression with side-effect
         # C4715: 'Test': not all control paths return a value
         # C5038 data member 'member1' will be initialized after data member 'member2'
-        target_compile_options(${PROJECT_NAME} PUBLIC /w34101 /w34555 /w34189 /w35038 /w34101)
+        target_compile_options(${PROJECT_NAME} PUBLIC /w34101 /w34555 /w34189 /w35038 /w34715)
     endif(MSVC)
 
     target_compile_definitions(${PROJECT_NAME} PRIVATE


### PR DESCRIPTION
## Fix Fast-DDS build on raspbian buster
`FindAtomic.cmake` module relies on CMake module `CheckLibraryExists` to check if **libatomic.so** is present in the system.
This module implementation just checks that specific APIs in the given library can be successfully linked in a dummy source file.
If the module build reports any other error unrelated to the linker ability to find the APIs the wrongly module assumes the APIs are not available.
Raspbian buster g++ version arises an error (related with API signature redefinition) that gcc considers a warning. Thus in this OS the checks must be done using the C compiler. Note that in MSVC and Clang conversely the C++ compiler must be used to avoid unrelated errors.
## Update CMake config.h and windows warnings
Now if c++20 or c++17 standard is enforced a corresponding preprocessor macro is defined (as in C++14 and C++11 were).
A new windows warning is promoted to match clang warning level.
