### PR TITLE
clean reader history on performance tests 

### DIFF
--- a/test/performance/throughput/ThroughputSubscriber.cpp
+++ b/test/performance/throughput/ThroughputSubscriber.cpp
@@ -598,8 +598,23 @@ int ThroughputSubscriber::process_message()
                     data_size_ = command.m_size;
                     demand_ = command.m_demand;
 
-                    ThroughputCommandType command_sample(BEGIN);
+                    SampleInfoSeq infos;
+                    LoanableSequence<ThroughputType> data_seq;
+
+                    // Consume history
+                    while (data_reader_->wait_for_unread_message({0, 1000000}))
+                    {
+                        while (ReturnCode_t::RETCODE_OK == data_reader_->take(data_seq, infos))
+                        {
+                            if (ReturnCode_t::RETCODE_OK != data_reader_->return_loan(data_seq, infos))
+                            {
+                                logInfo(ThroughputTest, "Problem returning loan");
+		            }
+                        }
+                    }
                     data_reader_listener_.reset();
+
+                    ThroughputCommandType command_sample(BEGIN);
                     command_writer_->write(&command_sample);
                     break;
                 }

--- a/test/performance/throughput/ThroughputSubscriber.cpp
+++ b/test/performance/throughput/ThroughputSubscriber.cpp
@@ -106,17 +106,17 @@ void ThroughputSubscriber::DataReaderListener::on_data_available(
         for (int32_t i = 0; i < size; ++i)
         {
             uint32_t seq_num = std::max(data_seq[i].seqnum, last_seq_num);
-	    if (sub.data_sharing_ && seq_num > last_seq_num + 1)
+            if (sub.data_sharing_ && seq_num > last_seq_num + 1)
             {
-		if (!reader->is_sample_valid(&data_seq[i], &infos[i]))
-		{
-		    // This was overridden. Counts as a loss
-		    ++lost_samples_;
-		    ++last_seq_num;
-		    continue;
-		}
-	    }
-	    last_seq_num = seq_num;
+                if (!reader->is_sample_valid(&data_seq[i], &infos[i]))
+                {
+                    // This was overridden. Counts as a loss
+                    ++lost_samples_;
+                    ++last_seq_num;
+                    continue;
+                }
+            }
+            last_seq_num = seq_num;
         }
 
         if ((last_seq_num_ + size) < last_seq_num)
@@ -609,7 +609,7 @@ int ThroughputSubscriber::process_message()
                             if (ReturnCode_t::RETCODE_OK != data_reader_->return_loan(data_seq, infos))
                             {
                                 logInfo(ThroughputTest, "Problem returning loan");
-		            }
+                            }
                         }
                     }
                     data_reader_listener_.reset();


### PR DESCRIPTION
This PR:
* Makes sure that the reader history is empty when a new test is recycling the same reader
* Considers data-sharing overrides as a lost sample