### PR TITLE
Bump to Fast CDR <1.0.20> in Fast DDS <2.1.x> [10711]

### DIFF
--- a/fastrtps.repos
+++ b/fastrtps.repos
@@ -6,7 +6,7 @@ repositories:
     fastcdr:
         type: git
         url: https://github.com/eProsima/Fast-CDR.git
-        version: v1.0.16
+        version: v1.0.20
     fastrtps:
         type: git
         url: https://github.com/eProsima/Fast-DDS.git


### PR DESCRIPTION
`BuiltinDataSerializationTests` requires using the latest release for Fast CDR (1.0.20)