### PR TITLE
Fix <2.0.x> build and bump Fast CDR to <1.0.20> [10710]

### DIFF
--- a/fastrtps.repos
+++ b/fastrtps.repos
@@ -6,7 +6,7 @@ repositories:
     fastcdr:
         type: git
         url: https://github.com/eProsima/Fast-CDR.git
-        version: v1.0.16
+        version: v1.0.20
     fastrtps:
         type: git
         url: https://github.com/eProsima/Fast-RTPS.git

--- a/test/unittest/rtps/builtin/CMakeLists.txt
+++ b/test/unittest/rtps/builtin/CMakeLists.txt
@@ -22,9 +22,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
 
         set(BUILTIN_DATA_SERIALIZATION_TESTS_SOURCE BuiltinDataSerializationTests.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
-            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
-            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
 
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/policy/ParameterList.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/publisher/qos/WriterQos.cpp
@@ -60,7 +58,6 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPFinder.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPLocator.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/md5.cpp
-            ${PROJECT_SOURCE_DIR}/src/cpp/utils/string_convert.cpp
             )
 
         if(WIN32)


### PR DESCRIPTION
Building <2.0.x> with the tests enabled failed due to source files being missed. This PR removes these files from the CMakeLists.txt.

Also, it bumps the Fast CDR version to <1.0.20> because `BuiltinDataSerializationTests` only pass with at least this release.