### PR TITLE
Use gather send [10657]

### DIFF
--- a/include/fastdds/rtps/messages/RTPSMessageCreator.h
+++ b/include/fastdds/rtps/messages/RTPSMessageCreator.h
@@ -156,7 +156,11 @@ public:
             TopicKind_t topicKind,
             const EntityId_t& readerId,
             bool expectsInlineQos,
-            InlineQosWriter* inlineQos);
+            InlineQosWriter* inlineQos,
+            bool copy_data,
+            octet*& pending_payload,
+            uint32_t& pending_size,
+            uint32_t& pending_padding);
 
     static bool addMessageGap(
             CDRMessage_t* msg,

--- a/include/fastdds/rtps/messages/RTPSMessageCreator.h
+++ b/include/fastdds/rtps/messages/RTPSMessageCreator.h
@@ -133,7 +133,11 @@ public:
             const EntityId_t& readerId,
             bool expectsInlineQos,
             InlineQosWriter* inlineQos,
-            bool* is_big_submessage);
+            bool& is_big_submessage,
+            bool copy_data,
+            octet*& pending_payload,
+            uint32_t& pending_size,
+            uint32_t& pending_padding);
 
     static bool addMessageDataFrag(
             CDRMessage_t* msg,

--- a/include/fastdds/rtps/messages/RTPSMessageGroup.h
+++ b/include/fastdds/rtps/messages/RTPSMessageGroup.h
@@ -52,7 +52,9 @@ public:
     public:
 
         timeout()
-            : std::runtime_error("timeout") {}
+            : std::runtime_error("timeout")
+        {
+        }
 
         virtual ~timeout() = default;
     };
@@ -70,7 +72,7 @@ public:
             Endpoint* endpoint,
             const RTPSMessageSenderInterface& msg_sender,
             std::chrono::steady_clock::time_point max_blocking_time_point =
-                std::chrono::steady_clock::now() + std::chrono::hours(24));
+            std::chrono::steady_clock::now() + std::chrono::hours(24));
 
     ~RTPSMessageGroup() noexcept(false);
 
@@ -167,8 +169,8 @@ public:
             int32_t count);
 
     inline uint32_t get_current_bytes_processed() const
-    { 
-        return currentBytesSent_ + full_msg_->length; 
+    {
+        return currentBytesSent_ + full_msg_->length;
     }
 
     /**
@@ -245,10 +247,10 @@ private:
     RTPSParticipantImpl* participant_;
 
 #if HAVE_SECURITY
-    
+
     CDRMessage_t* encrypt_msg_;
-    
-#endif
+
+#endif // if HAVE_SECURITY
 
     std::chrono::steady_clock::time_point max_blocking_time_point_;
 
@@ -263,5 +265,5 @@ private:
 } /* namespace fastrtps */
 } /* namespace eprosima */
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif /* _FASTDDS_RTPS_RTPSMESSAGEGROUP_H_ */

--- a/include/fastdds/rtps/messages/RTPSMessageGroup.h
+++ b/include/fastdds/rtps/messages/RTPSMessageGroup.h
@@ -192,6 +192,8 @@ private:
     static constexpr uint32_t data_frag_header_size_ = 28;
     static constexpr uint32_t max_inline_qos_size_ = 32;
 
+    void append_pending_payload();
+
     void reset_to_header();
 
     void flush();
@@ -251,6 +253,10 @@ private:
     std::chrono::steady_clock::time_point max_blocking_time_point_;
 
     std::unique_ptr<RTPSMessageGroup_t> send_buffer_;
+
+    octet* pending_data_ = nullptr;
+    uint32_t pending_data_size_ = 0;
+    uint32_t pending_padding_ = 0;
 };
 
 } /* namespace rtps */

--- a/include/fastdds/rtps/messages/RTPSMessageSenderInterface.hpp
+++ b/include/fastdds/rtps/messages/RTPSMessageSenderInterface.hpp
@@ -83,7 +83,7 @@ public:
      * @param max_blocking_time_point Future timepoint where blocking send should end.
      */
     virtual bool send(
-            const NetworkBuffer* message,
+            const NetworkBuffer* buffers,
             size_t num_buffers,
             uint32_t total_bytes,
             std::chrono::steady_clock::time_point& max_blocking_time_point) const = 0;

--- a/include/fastdds/rtps/messages/RTPSMessageSenderInterface.hpp
+++ b/include/fastdds/rtps/messages/RTPSMessageSenderInterface.hpp
@@ -77,7 +77,9 @@ class RTPSMessageSenderInterface
         /**
          * Send a message through this interface.
          *
-         * @param message Pointer to the buffer with the message already serialized.
+         * @param buffers Array of buffers to gather.
+         * @param num_buffers Number of elements on @c buffers.
+         * @param total_bytes Total size of the raw data. Should be equal to the sum of the @c length field of all buffers.
          * @param max_blocking_time_point Future timepoint where blocking send should end.
          */
         virtual bool send(
@@ -85,20 +87,6 @@ class RTPSMessageSenderInterface
                 size_t num_buffers,
                 uint32_t total_bytes,
                 std::chrono::steady_clock::time_point& max_blocking_time_point) const = 0;
-
-        /**
-         * Send a message through this interface.
-         *
-         * @param message Pointer to the buffer with the message already serialized.
-         * @param max_blocking_time_point Future timepoint where blocking send should end.
-         */
-        bool send(
-                CDRMessage_t* message,
-                std::chrono::steady_clock::time_point& max_blocking_time_point) const
-        {
-            NetworkBuffer buffer{ message->buffer, message->length };
-            return send(&buffer, 1, message->length, max_blocking_time_point);
-        }
 };
 
 } /* namespace rtps */

--- a/include/fastdds/rtps/messages/RTPSMessageSenderInterface.hpp
+++ b/include/fastdds/rtps/messages/RTPSMessageSenderInterface.hpp
@@ -38,61 +38,61 @@ namespace rtps {
  */
 class RTPSMessageSenderInterface
 {
-    public:
+public:
 
-        using NetworkBuffer = eprosima::fastdds::rtps::NetworkBuffer;
+    using NetworkBuffer = eprosima::fastdds::rtps::NetworkBuffer;
 
-        virtual ~RTPSMessageSenderInterface() = default;
+    virtual ~RTPSMessageSenderInterface() = default;
 
-        /**
-         * Check if the destinations managed by this sender interface have changed.
-         *
-         * @return true if destinations have changed, false otherwise.
-         */
-        virtual bool destinations_have_changed() const = 0;
+    /**
+     * Check if the destinations managed by this sender interface have changed.
+     *
+     * @return true if destinations have changed, false otherwise.
+     */
+    virtual bool destinations_have_changed() const = 0;
 
-        /**
-         * Get a GUID prefix representing all destinations.
-         *
-         * @return When all the destinations share the same prefix (i.e. belong to the same participant)
-         * that prefix is returned. When there are no destinations, or they belong to different
-         * participants, c_GuidPrefix_Unknown is returned.
-         */
-        virtual GuidPrefix_t destination_guid_prefix() const = 0;
+    /**
+     * Get a GUID prefix representing all destinations.
+     *
+     * @return When all the destinations share the same prefix (i.e. belong to the same participant)
+     * that prefix is returned. When there are no destinations, or they belong to different
+     * participants, c_GuidPrefix_Unknown is returned.
+     */
+    virtual GuidPrefix_t destination_guid_prefix() const = 0;
 
-        /**
-         * Get the GUID prefix of all the destination participants.
-         *
-         * @return a const reference to a vector with the GUID prefix of all destination participants.
-         */
-        virtual const std::vector<GuidPrefix_t>& remote_participants() const = 0;
+    /**
+     * Get the GUID prefix of all the destination participants.
+     *
+     * @return a const reference to a vector with the GUID prefix of all destination participants.
+     */
+    virtual const std::vector<GuidPrefix_t>& remote_participants() const = 0;
 
-        /**
-         * Get the GUID of all destinations.
-         *
-         * @return a const reference to a vector with the GUID of all destinations.
-         */
-        virtual const std::vector<GUID_t>& remote_guids() const = 0;
+    /**
+     * Get the GUID of all destinations.
+     *
+     * @return a const reference to a vector with the GUID of all destinations.
+     */
+    virtual const std::vector<GUID_t>& remote_guids() const = 0;
 
-        /**
-         * Send a message through this interface.
-         *
-         * @param buffers Array of buffers to gather.
-         * @param num_buffers Number of elements on @c buffers.
-         * @param total_bytes Total size of the raw data. Should be equal to the sum of the @c length field of all buffers.
-         * @param max_blocking_time_point Future timepoint where blocking send should end.
-         */
-        virtual bool send(
-                const NetworkBuffer* message,
-                size_t num_buffers,
-                uint32_t total_bytes,
-                std::chrono::steady_clock::time_point& max_blocking_time_point) const = 0;
+    /**
+     * Send a message through this interface.
+     *
+     * @param buffers Array of buffers to gather.
+     * @param num_buffers Number of elements on @c buffers.
+     * @param total_bytes Total size of the raw data. Should be equal to the sum of the @c length field of all buffers.
+     * @param max_blocking_time_point Future timepoint where blocking send should end.
+     */
+    virtual bool send(
+            const NetworkBuffer* message,
+            size_t num_buffers,
+            uint32_t total_bytes,
+            std::chrono::steady_clock::time_point& max_blocking_time_point) const = 0;
 };
 
 } /* namespace rtps */
 } /* namespace fastrtps */
 } /* namespace eprosima */
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 #endif /* _FASTDDS_RTPS_MESSAGES_RTPSMESSAGESENDERINTERFACE_HPP_ */

--- a/include/fastdds/rtps/messages/RTPSMessageSenderInterface.hpp
+++ b/include/fastdds/rtps/messages/RTPSMessageSenderInterface.hpp
@@ -22,8 +22,9 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
-#include <fastdds/rtps/messages/CDRMessage.h>
 #include <fastdds/rtps/common/Guid.h>
+#include <fastdds/rtps/messages/CDRMessage.h>
+#include <fastdds/rtps/network/NetworkBuffer.hpp>
 
 #include <vector>
 
@@ -38,6 +39,8 @@ namespace rtps {
 class RTPSMessageSenderInterface
 {
     public:
+
+        using NetworkBuffer = eprosima::fastdds::rtps::NetworkBuffer;
 
         virtual ~RTPSMessageSenderInterface() = default;
 
@@ -78,8 +81,24 @@ class RTPSMessageSenderInterface
          * @param max_blocking_time_point Future timepoint where blocking send should end.
          */
         virtual bool send(
-                CDRMessage_t* message,
+                const NetworkBuffer* message,
+                size_t num_buffers,
+                uint32_t total_bytes,
                 std::chrono::steady_clock::time_point& max_blocking_time_point) const = 0;
+
+        /**
+         * Send a message through this interface.
+         *
+         * @param message Pointer to the buffer with the message already serialized.
+         * @param max_blocking_time_point Future timepoint where blocking send should end.
+         */
+        bool send(
+                CDRMessage_t* message,
+                std::chrono::steady_clock::time_point& max_blocking_time_point) const
+        {
+            NetworkBuffer buffer{ message->buffer, message->length };
+            return send(&buffer, 1, message->length, max_blocking_time_point);
+        }
 };
 
 } /* namespace rtps */

--- a/include/fastdds/rtps/network/NetworkBuffer.hpp
+++ b/include/fastdds/rtps/network/NetworkBuffer.hpp
@@ -16,8 +16,8 @@
  * @file NetworkBuffer.hpp
  */
 
-#ifndef FASTDDS_RTPS_NETWORK_NETWORKBUFFER_HPP
-#define FASTDDS_RTPS_NETWORK_NETWORKBUFFER_HPP
+#ifndef _FASTDDS_RTPS_NETWORK_NETWORKBUFFER_HPP
+#define _FASTDDS_RTPS_NETWORK_NETWORKBUFFER_HPP
 
 #include <cstdint>  // uint32_t
 #include <cstdlib>  // size_t
@@ -42,4 +42,4 @@ struct NetworkBuffer final
 }  // namespace fastdds
 }  // namespace eprosima
 
-#endif  // FASTDDS_RTPS_NETWORK_NETWORKBUFFER_HPP
+#endif  // _FASTDDS_RTPS_NETWORK_NETWORKBUFFER_HPP

--- a/include/fastdds/rtps/network/NetworkBuffer.hpp
+++ b/include/fastdds/rtps/network/NetworkBuffer.hpp
@@ -33,9 +33,9 @@ namespace rtps {
 struct NetworkBuffer final
 {
     //! Pointer to the buffer where the data is stored.
-    const void* buffer = nullptr;
+    const void* buffer;
     //! Number of bytes to use starting at @c buffer.
-    uint32_t length = 0;
+    uint32_t length;
 };
 
 }  // namespace rtps

--- a/include/fastdds/rtps/network/NetworkBuffer.hpp
+++ b/include/fastdds/rtps/network/NetworkBuffer.hpp
@@ -27,13 +27,14 @@ namespace fastdds {
 namespace rtps {
 
 /**
- * Mimicks C struct iovec
+ * A slice of data to be sent to one or more transports.
+ * An RTPS datagram is made up of one or more NetworkBuffer instances.
  */
 struct NetworkBuffer final
 {
     //! Pointer to the buffer where the data is stored.
     const void* buffer = nullptr;
-    //! Number of bytes
+    //! Number of bytes to use starting at @c buffer.
     uint32_t length = 0;
 };
 

--- a/include/fastdds/rtps/network/NetworkBuffer.hpp
+++ b/include/fastdds/rtps/network/NetworkBuffer.hpp
@@ -1,0 +1,44 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file NetworkBuffer.hpp
+ */
+
+#ifndef FASTDDS_RTPS_NETWORK_NETWORKBUFFER_HPP
+#define FASTDDS_RTPS_NETWORK_NETWORKBUFFER_HPP
+
+#include <cstdint>  // uint32_t
+#include <cstdlib>  // size_t
+
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+
+/**
+ * Mimicks C struct iovec
+ */
+struct NetworkBuffer final
+{
+    //! Pointer to the buffer where the data is stored.
+    const void* buffer = nullptr;
+    //! Number of bytes
+    uint32_t length = 0;
+};
+
+}  // namespace rtps
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif  // FASTDDS_RTPS_NETWORK_NETWORKBUFFER_HPP

--- a/include/fastdds/rtps/network/SenderResource.h
+++ b/include/fastdds/rtps/network/SenderResource.h
@@ -38,6 +38,15 @@ public:
 
     using NetworkBuffer = eprosima::fastdds::rtps::NetworkBuffer;
 
+    /* The maximum number of buffers that will be sent on a single send call.
+     * We are currently supporting 3 buffers, due to the way RTPSMessageGroup works.
+     * Only the last DATA / DATA_FRAG on the datagram may be back-referenced, so there will be at most 3 buffers used:
+     * - Buffer with RTPS header + other submessages + DATA / DATA_FRAG header
+     * - Buffer pointing to history cache payload
+     * - Buffer with padding of up to 3 bytes
+     */
+    static constexpr size_t max_required_buffers = 3;
+
     /**
      * Sends to a destination locator, through the channel managed by this resource.
      * @param data Pointer to the contiguous data buffer.

--- a/include/fastdds/rtps/network/SenderResource.h
+++ b/include/fastdds/rtps/network/SenderResource.h
@@ -16,7 +16,6 @@
 #define _FASTDDS_RTPS_SENDER_RESOURCE_H
 
 #include <functional>
-#include <vector>
 #include <chrono>
 
 #include <fastdds/rtps/common/Locator.h>
@@ -25,9 +24,6 @@
 namespace eprosima {
 namespace fastrtps {
 namespace rtps {
-
-class RTPSParticipantImpl;
-class MessageReceiver;
 
 /**
  * RAII object that encapsulates the Send operation over one chanel in an unknown transport.

--- a/include/fastdds/rtps/network/SenderResource.h
+++ b/include/fastdds/rtps/network/SenderResource.h
@@ -20,6 +20,7 @@
 #include <chrono>
 
 #include <fastdds/rtps/common/Locator.h>
+#include <fastdds/rtps/network/NetworkBuffer.hpp>
 
 namespace eprosima {
 namespace fastrtps {
@@ -38,6 +39,8 @@ class MessageReceiver;
 class SenderResource
 {
 public:
+
+    using NetworkBuffer = eprosima::fastdds::rtps::NetworkBuffer;
 
     /**
      * Sends to a destination locator, through the channel managed by this resource.
@@ -58,10 +61,13 @@ public:
     {
         bool returned_value = false;
 
+        NetworkBuffer buf{ data, dataLength };
+
         if (send_lambda_)
         {
-            returned_value = send_lambda_(data, dataLength, destination_locators_begin, destination_locators_end,
-                            max_blocking_time_point);
+            returned_value =
+                    send_lambda_(&buf, 1, dataLength,
+                            destination_locators_begin, destination_locators_end, max_blocking_time_point);
         }
 
         return returned_value;
@@ -108,17 +114,18 @@ protected:
 
     std::function<void()> clean_up;
     std::function<bool(
-                const octet*,
-                uint32_t,
+                const NetworkBuffer* buffers,
+                size_t num_buffers,
+                uint32_t total_bytes,
                 LocatorsIterator* destination_locators_begin,
                 LocatorsIterator* destination_locators_end,
                 const std::chrono::steady_clock::time_point&)> send_lambda_;
 
 private:
 
-    SenderResource()                                 = delete;
+    SenderResource() = delete;
     SenderResource(
-            const SenderResource&)            = delete;
+            const SenderResource&) = delete;
     SenderResource& operator =(
             const SenderResource&) = delete;
 };

--- a/include/fastdds/rtps/network/SenderResource.h
+++ b/include/fastdds/rtps/network/SenderResource.h
@@ -57,14 +57,14 @@ public:
         if (send_lambda_ && !send_buffers_lambda_)
         {
             logWarning(RTPS, "The usage of send_lambda_ on SenderResource has been deprecated."
-                << std::endl << "Please implement send_buffers_lambda_ instead.");
+                    << std::endl << "Please implement send_buffers_lambda_ instead.");
             return send_lambda_(data, data_size,
                            destination_locators_begin, destination_locators_end, max_blocking_time_point);
         }
 
         NetworkBuffer buf{ data, data_size };
         return send(&buf, 1, data_size,
-            destination_locators_begin, destination_locators_end, max_blocking_time_point);
+                       destination_locators_begin, destination_locators_end, max_blocking_time_point);
     }
 
     /**
@@ -89,14 +89,14 @@ public:
         if (send_buffers_lambda_)
         {
             return send_buffers_lambda_(buffers, num_buffers, total_bytes,
-                            destination_locators_begin, destination_locators_end, max_blocking_time_point);
+                           destination_locators_begin, destination_locators_end, max_blocking_time_point);
         }
 
         if (send_lambda_)
         {
             send_lambda_ = nullptr;
             logError(RTPS, "The usage of send_lambda_ on SenderResource has been deprecated."
-                << std::endl << "Please implement send_buffers_lambda_ instead.");
+                    << std::endl << "Please implement send_buffers_lambda_ instead.");
         }
 
         return false;

--- a/include/fastdds/rtps/reader/StatefulReader.h
+++ b/include/fastdds/rtps/reader/StatefulReader.h
@@ -260,13 +260,15 @@ public:
             const RTPSMessageSenderInterface& sender,
             bool heartbeat_was_final);
 
-    /**
-     * Use the participant of this reader to send a message to certain locator.
-     * @param message Message to be sent.
-     * @param locators_begin Destination locators iterator begin.
-     * @param locators_end Destination locators iterator end.
-     * @param max_blocking_time_point Future time point where any blocking should end.
-     */
+     /**
+      * Use the participant of this reader to send a message to certain locator.
+      * @param buffers Array of buffers to gather.
+      * @param num_buffers Number of elements on @c buffers.
+      * @param total_bytes Total size of the raw data. Should be equal to the sum of the @c length field of all buffers.
+      * @param locators_begin Destination locators iterator begin.
+      * @param locators_end Destination locators iterator end.
+      * @param max_blocking_time_point Future time point where any blocking should end.
+      */
     bool send_sync_nts(
             const RTPSMessageSenderInterface::NetworkBuffer* buffers,
             size_t num_buffers,

--- a/include/fastdds/rtps/reader/StatefulReader.h
+++ b/include/fastdds/rtps/reader/StatefulReader.h
@@ -268,7 +268,9 @@ public:
      * @param max_blocking_time_point Future time point where any blocking should end.
      */
     bool send_sync_nts(
-            CDRMessage_t* message,
+            const RTPSMessageSenderInterface::NetworkBuffer* buffers,
+            size_t num_buffers,
+            uint32_t total_bytes,
             const Locators& locators_begin,
             const Locators& locators_end,
             std::chrono::steady_clock::time_point& max_blocking_time_point);

--- a/include/fastdds/rtps/reader/StatefulReader.h
+++ b/include/fastdds/rtps/reader/StatefulReader.h
@@ -260,15 +260,15 @@ public:
             const RTPSMessageSenderInterface& sender,
             bool heartbeat_was_final);
 
-     /**
-      * Use the participant of this reader to send a message to certain locator.
-      * @param buffers Array of buffers to gather.
-      * @param num_buffers Number of elements on @c buffers.
-      * @param total_bytes Total size of the raw data. Should be equal to the sum of the @c length field of all buffers.
-      * @param locators_begin Destination locators iterator begin.
-      * @param locators_end Destination locators iterator end.
-      * @param max_blocking_time_point Future time point where any blocking should end.
-      */
+    /**
+     * Use the participant of this reader to send a message to certain locator.
+     * @param buffers Array of buffers to gather.
+     * @param num_buffers Number of elements on @c buffers.
+     * @param total_bytes Total size of the raw data. Should be equal to the sum of the @c length field of all buffers.
+     * @param locators_begin Destination locators iterator begin.
+     * @param locators_end Destination locators iterator end.
+     * @param max_blocking_time_point Future time point where any blocking should end.
+     */
     bool send_sync_nts(
             const RTPSMessageSenderInterface::NetworkBuffer* buffers,
             size_t num_buffers,

--- a/include/fastdds/rtps/transport/TransportInterface.h
+++ b/include/fastdds/rtps/transport/TransportInterface.h
@@ -20,9 +20,9 @@
 #include <fastdds/rtps/common/Locator.h>
 #include <fastdds/rtps/common/LocatorSelector.hpp>
 #include <fastdds/rtps/common/PortParameters.h>
+#include <fastdds/rtps/network/SenderResource.h>
 #include <fastdds/rtps/transport/TransportDescriptorInterface.h>
 #include <fastdds/rtps/transport/TransportReceiverInterface.h>
-#include <fastdds/rtps/network/SenderResource.h>
 
 namespace eprosima {
 namespace fastdds {
@@ -51,6 +51,9 @@ using SendResourceList = std::vector<std::unique_ptr<fastrtps::rtps::SenderResou
 class TransportInterface
 {
 public:
+
+    using SenderResource = eprosima::fastrtps::rtps::SenderResource;
+    static constexpr size_t max_required_buffers = SenderResource::max_required_buffers;
 
     /**
      * Aside from the API defined here, an user-defined Transport must define a descriptor data type and a constructor that

--- a/include/fastdds/rtps/writer/RTPSWriter.h
+++ b/include/fastdds/rtps/writer/RTPSWriter.h
@@ -428,7 +428,9 @@ public:
     /**
      * Send a message through this interface.
      *
-     * @param message Pointer to the buffer with the message already serialized.
+     * @param buffers Array of buffers to gather.
+     * @param num_buffers Number of elements on @c buffers.
+     * @param total_bytes Total size of the raw data. Should be equal to the sum of the @c length field of all buffers.
      * @param max_blocking_time_point Future timepoint where blocking send should end.
      */
     bool send(

--- a/include/fastdds/rtps/writer/RTPSWriter.h
+++ b/include/fastdds/rtps/writer/RTPSWriter.h
@@ -432,7 +432,9 @@ public:
      * @param max_blocking_time_point Future timepoint where blocking send should end.
      */
     bool send(
-            CDRMessage_t* message,
+            const RTPSMessageSenderInterface::NetworkBuffer* buffers,
+            size_t num_buffers,
+            uint32_t total_bytes,
             std::chrono::steady_clock::time_point& max_blocking_time_point) const override;
 
     /**

--- a/include/fastdds/rtps/writer/ReaderLocator.h
+++ b/include/fastdds/rtps/writer/ReaderLocator.h
@@ -183,7 +183,9 @@ public:
      * @param max_blocking_time_point Future timepoint where blocking send should end.
      */
     bool send(
-            CDRMessage_t* message,
+            const RTPSMessageSenderInterface::NetworkBuffer* buffers,
+            size_t num_buffers,
+            uint32_t total_bytes,
             std::chrono::steady_clock::time_point& max_blocking_time_point) const override;
 
     /**

--- a/include/fastdds/rtps/writer/ReaderLocator.h
+++ b/include/fastdds/rtps/writer/ReaderLocator.h
@@ -179,7 +179,9 @@ public:
     /**
      * Send a message through this interface.
      *
-     * @param message Pointer to the buffer with the message already serialized.
+     * @param buffers Array of buffers to gather.
+     * @param num_buffers Number of elements on @c buffers.
+     * @param total_bytes Total size of the raw data. Should be equal to the sum of the @c length field of all buffers.
      * @param max_blocking_time_point Future timepoint where blocking send should end.
      */
     bool send(

--- a/include/fastdds/rtps/writer/StatelessWriter.h
+++ b/include/fastdds/rtps/writer/StatelessWriter.h
@@ -165,7 +165,9 @@ public:
      * @param max_blocking_time_point Future timepoint where blocking send should end.
      */
     bool send(
-            CDRMessage_t* message,
+            const RTPSMessageSenderInterface::NetworkBuffer* buffers,
+            size_t num_buffers,
+            uint32_t total_bytes,
             std::chrono::steady_clock::time_point& max_blocking_time_point) const override;
 
     /**

--- a/include/fastdds/rtps/writer/StatelessWriter.h
+++ b/include/fastdds/rtps/writer/StatelessWriter.h
@@ -161,7 +161,9 @@ public:
     /**
      * Send a message through this interface.
      *
-     * @param message Pointer to the buffer with the message already serialized.
+     * @param buffers Array of buffers to gather.
+     * @param num_buffers Number of elements on @c buffers.
+     * @param total_bytes Total size of the raw data. Should be equal to the sum of the @c length field of all buffers.
      * @param max_blocking_time_point Future timepoint where blocking send should end.
      */
     bool send(

--- a/src/cpp/rtps/builtin/discovery/participant/DirectMessageSender.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/DirectMessageSender.cpp
@@ -95,10 +95,13 @@ const std::vector<GUID_t>& DirectMessageSender::remote_guids() const
  * @param max_blocking_time_point Future timepoint where blocking send should end.
  */
 bool DirectMessageSender::send(
-        CDRMessage_t* message,
+        const RTPSMessageSenderInterface::NetworkBuffer* buffers,
+        size_t num_buffers,
+        uint32_t total_bytes,
         std::chrono::steady_clock::time_point& max_blocking_time_point) const
 {
-    return participant_->sendSync(message, Locators(locators_->begin()), Locators(locators_->end()), max_blocking_time_point);
+    return participant_->sendSync(buffers, num_buffers, total_bytes,
+                   Locators(locators_->begin()), Locators(locators_->end()), max_blocking_time_point);
 }
 
 } /* namespace rtps */

--- a/src/cpp/rtps/builtin/discovery/participant/DirectMessageSender.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/DirectMessageSender.cpp
@@ -39,7 +39,7 @@ DirectMessageSender::DirectMessageSender(
     for (const GUID_t& guid : *guids)
     {
         if (std::find(participant_guids_.begin(), participant_guids_.end(), guid.guidPrefix) ==
-            participant_guids_.end())
+                participant_guids_.end())
         {
             participant_guids_.push_back(guid.guidPrefix);
         }

--- a/src/cpp/rtps/builtin/discovery/participant/DirectMessageSender.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/DirectMessageSender.cpp
@@ -91,7 +91,9 @@ const std::vector<GUID_t>& DirectMessageSender::remote_guids() const
 /**
  * Send a message through this interface.
  *
- * @param message Pointer to the buffer with the message already serialized.
+ * @param buffers Array of buffers to gather.
+ * @param num_buffers Number of elements on @c buffers.
+ * @param total_bytes Total size of the raw data. Should be equal to the sum of the @c length field of all buffers.
  * @param max_blocking_time_point Future timepoint where blocking send should end.
  */
 bool DirectMessageSender::send(

--- a/src/cpp/rtps/builtin/discovery/participant/DirectMessageSender.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/DirectMessageSender.hpp
@@ -36,54 +36,55 @@ class RTPSParticipantImpl;
  */
 class DirectMessageSender : public RTPSMessageSenderInterface
 {
-public:
+    public:
+        DirectMessageSender(
+                RTPSParticipantImpl* participant,
+                std::vector<GUID_t>* guids,
+                LocatorList_t* locators);
 
-    DirectMessageSender(
-            RTPSParticipantImpl* participant,
-            std::vector<GUID_t>* guids,
-            LocatorList_t* locators);
+        virtual ~DirectMessageSender() override = default;
 
-    virtual ~DirectMessageSender() override = default;
+        /**
+         * Check if the destinations managed by this sender interface have changed.
+         *
+         * @return true if destinations have changed, false otherwise.
+         */
+        virtual bool destinations_have_changed() const override;
 
-    /**
-     * Check if the destinations managed by this sender interface have changed.
-     *
-     * @return true if destinations have changed, false otherwise.
-     */
-    virtual bool destinations_have_changed() const override;
+        /**
+         * Get a GUID prefix representing all destinations.
+         *
+         * @return When all the destinations share the same prefix (i.e. belong to the same participant)
+         * that prefix is returned. When there are no destinations, or they belong to different
+         * participants, c_GuidPrefix_Unknown is returned.
+         */
+        virtual GuidPrefix_t destination_guid_prefix() const override;
 
-    /**
-     * Get a GUID prefix representing all destinations.
-     *
-     * @return When all the destinations share the same prefix (i.e. belong to the same participant)
-     * that prefix is returned. When there are no destinations, or they belong to different
-     * participants, c_GuidPrefix_Unknown is returned.
-     */
-    virtual GuidPrefix_t destination_guid_prefix() const override;
+        /**
+         * Get the GUID prefix of all the destination participants.
+         *
+         * @return a const reference to a vector with the GUID prefix of all destination participants.
+         */
+        virtual const std::vector<GuidPrefix_t>& remote_participants() const override;
 
-    /**
-     * Get the GUID prefix of all the destination participants.
-     *
-     * @return a const reference to a vector with the GUID prefix of all destination participants.
-     */
-    virtual const std::vector<GuidPrefix_t>& remote_participants() const override;
+        /**
+         * Get the GUID of all destinations.
+         *
+         * @return a const reference to a vector with the GUID of all destinations.
+         */
+        virtual const std::vector<GUID_t>& remote_guids() const override;
 
-    /**
-     * Get the GUID of all destinations.
-     *
-     * @return a const reference to a vector with the GUID of all destinations.
-     */
-    virtual const std::vector<GUID_t>& remote_guids() const override;
-
-    /**
-     * Send a message through this interface.
-     *
-     * @param message Pointer to the buffer with the message already serialized.
-     * @param max_blocking_time_point Future timepoint where blocking send should end.
-     */
-    virtual bool send(
-            CDRMessage_t* message,
-            std::chrono::steady_clock::time_point& max_blocking_time_point) const override;
+        /**
+         * Send a message through this interface.
+         *
+         * @param message Pointer to the buffer with the message already serialized.
+         * @param max_blocking_time_point Future timepoint where blocking send should end.
+         */
+        virtual bool send(
+                const RTPSMessageSenderInterface::NetworkBuffer* buffers,
+                size_t num_buffers,
+                uint32_t total_bytes,
+                std::chrono::steady_clock::time_point& max_blocking_time_point) const override;
 
 private:
 

--- a/src/cpp/rtps/builtin/discovery/participant/DirectMessageSender.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/DirectMessageSender.hpp
@@ -78,7 +78,9 @@ public:
     /**
      * Send a message through this interface.
      *
-     * @param message Pointer to the buffer with the message already serialized.
+     * @param buffers Array of buffers to gather.
+     * @param num_buffers Number of elements on @c buffers.
+     * @param total_bytes Total size of the raw data. Should be equal to the sum of the @c length field of all buffers.
      * @param max_blocking_time_point Future timepoint where blocking send should end.
      */
     virtual bool send(

--- a/src/cpp/rtps/builtin/discovery/participant/DirectMessageSender.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/DirectMessageSender.hpp
@@ -36,55 +36,56 @@ class RTPSParticipantImpl;
  */
 class DirectMessageSender : public RTPSMessageSenderInterface
 {
-    public:
-        DirectMessageSender(
-                RTPSParticipantImpl* participant,
-                std::vector<GUID_t>* guids,
-                LocatorList_t* locators);
+public:
 
-        virtual ~DirectMessageSender() override = default;
+    DirectMessageSender(
+            RTPSParticipantImpl* participant,
+            std::vector<GUID_t>* guids,
+            LocatorList_t* locators);
 
-        /**
-         * Check if the destinations managed by this sender interface have changed.
-         *
-         * @return true if destinations have changed, false otherwise.
-         */
-        virtual bool destinations_have_changed() const override;
+    virtual ~DirectMessageSender() override = default;
 
-        /**
-         * Get a GUID prefix representing all destinations.
-         *
-         * @return When all the destinations share the same prefix (i.e. belong to the same participant)
-         * that prefix is returned. When there are no destinations, or they belong to different
-         * participants, c_GuidPrefix_Unknown is returned.
-         */
-        virtual GuidPrefix_t destination_guid_prefix() const override;
+    /**
+     * Check if the destinations managed by this sender interface have changed.
+     *
+     * @return true if destinations have changed, false otherwise.
+     */
+    virtual bool destinations_have_changed() const override;
 
-        /**
-         * Get the GUID prefix of all the destination participants.
-         *
-         * @return a const reference to a vector with the GUID prefix of all destination participants.
-         */
-        virtual const std::vector<GuidPrefix_t>& remote_participants() const override;
+    /**
+     * Get a GUID prefix representing all destinations.
+     *
+     * @return When all the destinations share the same prefix (i.e. belong to the same participant)
+     * that prefix is returned. When there are no destinations, or they belong to different
+     * participants, c_GuidPrefix_Unknown is returned.
+     */
+    virtual GuidPrefix_t destination_guid_prefix() const override;
 
-        /**
-         * Get the GUID of all destinations.
-         *
-         * @return a const reference to a vector with the GUID of all destinations.
-         */
-        virtual const std::vector<GUID_t>& remote_guids() const override;
+    /**
+     * Get the GUID prefix of all the destination participants.
+     *
+     * @return a const reference to a vector with the GUID prefix of all destination participants.
+     */
+    virtual const std::vector<GuidPrefix_t>& remote_participants() const override;
 
-        /**
-         * Send a message through this interface.
-         *
-         * @param message Pointer to the buffer with the message already serialized.
-         * @param max_blocking_time_point Future timepoint where blocking send should end.
-         */
-        virtual bool send(
-                const RTPSMessageSenderInterface::NetworkBuffer* buffers,
-                size_t num_buffers,
-                uint32_t total_bytes,
-                std::chrono::steady_clock::time_point& max_blocking_time_point) const override;
+    /**
+     * Get the GUID of all destinations.
+     *
+     * @return a const reference to a vector with the GUID of all destinations.
+     */
+    virtual const std::vector<GUID_t>& remote_guids() const override;
+
+    /**
+     * Send a message through this interface.
+     *
+     * @param message Pointer to the buffer with the message already serialized.
+     * @param max_blocking_time_point Future timepoint where blocking send should end.
+     */
+    virtual bool send(
+            const RTPSMessageSenderInterface::NetworkBuffer* buffers,
+            size_t num_buffers,
+            uint32_t total_bytes,
+            std::chrono::steady_clock::time_point& max_blocking_time_point) const override;
 
 private:
 

--- a/src/cpp/rtps/messages/RTPSMessageGroup.cpp
+++ b/src/cpp/rtps/messages/RTPSMessageGroup.cpp
@@ -255,7 +255,7 @@ void RTPSMessageGroup::send()
         {
             throw timeout();
         }
-        currentBytesSent_ += msgToSend->length;
+        currentBytesSent_ += total_bytes;
     }
 }
 

--- a/src/cpp/rtps/messages/RTPSMessageGroup.cpp
+++ b/src/cpp/rtps/messages/RTPSMessageGroup.cpp
@@ -250,7 +250,7 @@ void RTPSMessageGroup::send()
             pending_data_size_ = 0;
             pending_padding_ = 0;
         }
-        
+
         if (!sender_.send(buffers, num_buffers, total_bytes, max_blocking_time_point_))
         {
             throw timeout();
@@ -326,7 +326,7 @@ bool RTPSMessageGroup::add_info_dst_in_buffer(
 {
 #if HAVE_SECURITY
     // Add INFO_SRC when we are at the beginning of the message and RTPS protection is enabled
-    if ( (full_msg_->length == RTPSMESSAGE_HEADER_SIZE) &&
+    if ((full_msg_->length == RTPSMESSAGE_HEADER_SIZE) &&
             participant_->security_attributes().is_rtps_protected && endpoint_->supports_rtps_protection())
     {
         RTPSMessageCreator::addSubmessageInfoSRC(buffer, c_ProtocolVersion, c_VendorId_eProsima,

--- a/src/cpp/rtps/messages/RTPSMessageGroup.cpp
+++ b/src/cpp/rtps/messages/RTPSMessageGroup.cpp
@@ -268,9 +268,12 @@ bool RTPSMessageGroup::insert_submessage(
         const GuidPrefix_t& destination_guid_prefix,
         bool is_big_submessage)
 {
-    if (!CDRMessage::appendMsg(full_msg_, submessage_msg_))
+    uint32_t total_size = submessage_msg_->length + pending_data_size_ + pending_padding_;
+    if (full_msg_->pos + total_size > full_msg_->max_size)
     {
-        // Retry
+        octet* backup = pending_data_;
+        pending_data_ = nullptr;
+
         flush();
 
         current_dst_ = c_GuidPrefix_Unknown;
@@ -281,11 +284,13 @@ bool RTPSMessageGroup::insert_submessage(
             return false;
         }
 
-        if (!CDRMessage::appendMsg(full_msg_, submessage_msg_))
-        {
-            logError(RTPS_WRITER, "Cannot add RTPS submesage to the CDRMessage. Buffer too small");
-            return false;
-        }
+        pending_data_ = backup;
+    }
+
+    if (!CDRMessage::appendMsg(full_msg_, submessage_msg_))
+    {
+        logError(RTPS_WRITER, "Cannot add RTPS submesage to the CDRMessage. Buffer too small");
+        return false;
     }
 
     // Messages with a submessage bigger than 64KB cannot have more submessages and should be flushed

--- a/src/cpp/rtps/messages/submessages/DataMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/DataMsg.hpp
@@ -246,12 +246,6 @@ bool RTPSMessageCreator::addSubmessageData(
         msg->pos += align;
     }
 
-    //if(align > 0)
-    {
-        //submsgElem.pos += align;
-        //submsgElem.length += align;
-    }
-
     uint32_t size32 = msg->pos - position_size_count_size;
     if (size32 <= std::numeric_limits<uint16_t>::max())
     {

--- a/src/cpp/rtps/messages/submessages/DataMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/DataMsg.hpp
@@ -196,7 +196,8 @@ bool RTPSMessageCreator::addSubmessageData(
     {
         if (copy_data)
         {
-            added_no_error &= CDRMessage::addData(msg, change->serializedPayload.data, change->serializedPayload.length);
+            added_no_error &=
+                    CDRMessage::addData(msg, change->serializedPayload.data, change->serializedPayload.length);
         }
         else if (msg->pos + change->serializedPayload.length > msg->max_size)
         {

--- a/src/cpp/rtps/messages/submessages/DataMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/DataMsg.hpp
@@ -310,8 +310,11 @@ bool RTPSMessageCreator::addMessageDataFrag(
     payload.data = change->serializedPayload.data + fragment_start;
     payload.length = fragment_size;
 
+    octet* pending_payload = nullptr;
+    uint32_t pending_size = 0;
+    uint32_t pending_padding = 0;
     RTPSMessageCreator::addSubmessageDataFrag(msg, change, fragment_number, payload,
-            topicKind, readerId, expectsInlineQos, inlineQos);
+            topicKind, readerId, expectsInlineQos, inlineQos, false, pending_payload, pending_size, pending_padding);
 
     payload.data = NULL;
 
@@ -327,8 +330,17 @@ bool RTPSMessageCreator::addSubmessageDataFrag(
         TopicKind_t topicKind,
         const EntityId_t& readerId,
         bool expectsInlineQos,
-        InlineQosWriter* inlineQos)
+        InlineQosWriter* inlineQos,
+        bool copy_data,
+        octet*& pending_payload,
+        uint32_t& pending_size,
+        uint32_t& pending_padding)
 {
+    // Initialize output parameters
+    pending_payload = nullptr;
+    pending_size = 0;
+    pending_padding = 0;
+
     octet flags = 0x0;
     //Find out flags
     bool keyFlag = false;
@@ -460,7 +472,20 @@ bool RTPSMessageCreator::addSubmessageDataFrag(
     //Add Serialized Payload XXX TODO
     if (!keyFlag) // keyflag = 0 means that the serializedPayload SubmessageElement contains the serialized Data
     {
-        added_no_error &= CDRMessage::addData(msg, payload.data, payload.length);
+        if (copy_data)
+        {
+            added_no_error &= CDRMessage::addData(msg, payload.data, payload.length);
+        }
+        else if (msg->pos + payload.length > msg->max_size)
+        {
+            return false;
+        }
+        else
+        {
+            pending_payload = payload.data;
+            pending_size = payload.length;
+            msg->pos += pending_size;
+        }
     }
     else
     {
@@ -484,9 +509,21 @@ bool RTPSMessageCreator::addSubmessageDataFrag(
     // TODO(Ricardo) This should be on cachechange.
     // Align submessage to rtps alignment (4).
     submessage_size = uint16_t(msg->pos - position_size_count_size);
-    for (; submessage_size& 3; ++submessage_size)
+    for (; 0 != (submessage_size & 3); ++submessage_size)
     {
-        added_no_error &= CDRMessage::addOctet(msg, 0);
+        if (copy_data)
+        {
+            added_no_error &= CDRMessage::addOctet(msg, 0);
+        }
+        else
+        {
+            ++pending_padding;
+        }
+    }
+
+    if (!copy_data)
+    {
+        msg->pos -= pending_size;
     }
 
     //TODO(Ricardo) Improve.

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -284,26 +284,6 @@ public:
         return ret_code;
     }
 
-    /**
-     * Send a message to several locations
-     * @param msg Message to send.
-     * @param destination_locators_begin Iterator at the first destination locator.
-     * @param destination_locators_end Iterator at the end destination locator.
-     * @param max_blocking_time_point execution time limit timepoint.
-     * @return true if at least one locator has been sent.
-     */
-    template<class LocatorIteratorT>
-    bool sendSync(
-            CDRMessage_t* msg,
-            const LocatorIteratorT& destination_locators_begin,
-            const LocatorIteratorT& destination_locators_end,
-            std::chrono::steady_clock::time_point& max_blocking_time_point)
-    {
-        SenderResource::NetworkBuffer buffer{ msg->buffer, msg->length };
-        return sendSync(&buffer, 1, msg->length, destination_locators_begin, destination_locators_end,
-            max_blocking_time_point);
-    }
-
     //!Get the participant Mutex
     std::recursive_mutex* getParticipantMutex() const
     {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -268,11 +268,12 @@ public:
         {
             ret_code = true;
 
+            SenderResource::NetworkBuffer buffer{ msg->buffer, msg->length };
             for (auto& send_resource : send_resource_list_)
             {
                 LocatorIteratorT locators_begin = destination_locators_begin;
                 LocatorIteratorT locators_end = destination_locators_end;
-                send_resource->send(msg->buffer, msg->length, &locators_begin, &locators_end,
+                send_resource->send(&buffer, 1, msg->length, &locators_begin, &locators_end,
                         max_blocking_time_point);
             }
         }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -248,6 +248,44 @@ public:
 
     /**
      * Send a message to several locations
+     * @param buffers Array of buffers to gather.
+     * @param num_buffers Number of elements on @c buffers.
+     * @param total_bytes Total size of the raw data. Should be equal to the sum of the @c length field of all buffers.
+     * @param destination_locators_begin Iterator at the first destination locator.
+     * @param destination_locators_end Iterator at the end destination locator.
+     * @param max_blocking_time_point execution time limit timepoint.
+     * @return true if at least one locator has been sent.
+     */
+    template<class LocatorIteratorT>
+    bool sendSync(
+            const SenderResource::NetworkBuffer* buffers,
+            size_t num_buffers,
+            uint32_t total_bytes,
+            const LocatorIteratorT& destination_locators_begin,
+            const LocatorIteratorT& destination_locators_end,
+            std::chrono::steady_clock::time_point& max_blocking_time_point)
+    {
+        bool ret_code = false;
+        std::unique_lock<std::timed_mutex> lock(m_send_resources_mutex_, std::defer_lock);
+
+        if (lock.try_lock_until(max_blocking_time_point))
+        {
+            ret_code = true;
+
+            for (auto& send_resource : send_resource_list_)
+            {
+                LocatorIteratorT locators_begin = destination_locators_begin;
+                LocatorIteratorT locators_end = destination_locators_end;
+                send_resource->send(buffers, num_buffers, total_bytes, &locators_begin, &locators_end,
+                        max_blocking_time_point);
+            }
+        }
+
+        return ret_code;
+    }
+
+    /**
+     * Send a message to several locations
      * @param msg Message to send.
      * @param destination_locators_begin Iterator at the first destination locator.
      * @param destination_locators_end Iterator at the end destination locator.
@@ -261,24 +299,9 @@ public:
             const LocatorIteratorT& destination_locators_end,
             std::chrono::steady_clock::time_point& max_blocking_time_point)
     {
-        bool ret_code = false;
-        std::unique_lock<std::timed_mutex> lock(m_send_resources_mutex_, std::defer_lock);
-
-        if (lock.try_lock_until(max_blocking_time_point))
-        {
-            ret_code = true;
-
-            SenderResource::NetworkBuffer buffer{ msg->buffer, msg->length };
-            for (auto& send_resource : send_resource_list_)
-            {
-                LocatorIteratorT locators_begin = destination_locators_begin;
-                LocatorIteratorT locators_end = destination_locators_end;
-                send_resource->send(&buffer, 1, msg->length, &locators_begin, &locators_end,
-                        max_blocking_time_point);
-            }
-        }
-
-        return ret_code;
+        SenderResource::NetworkBuffer buffer{ msg->buffer, msg->length };
+        return sendSync(&buffer, 1, msg->length, destination_locators_begin, destination_locators_end,
+            max_blocking_time_point);
     }
 
     //!Get the participant Mutex

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -1266,10 +1266,13 @@ void StatefulReader::send_acknack(
 }
 
 bool StatefulReader::send_sync_nts(
-        CDRMessage_t* message,
+        const RTPSMessageSenderInterface::NetworkBuffer* buffers,
+        size_t num_buffers,
+        uint32_t total_bytes,
         const Locators& locators_begin,
         const Locators& locators_end,
         std::chrono::steady_clock::time_point& max_blocking_time_point)
 {
-    return mp_RTPSParticipant->sendSync(message, locators_begin, locators_end, max_blocking_time_point);
+    return mp_RTPSParticipant->sendSync(buffers, num_buffers, total_bytes,
+                   locators_begin, locators_end, max_blocking_time_point);
 }

--- a/src/cpp/rtps/reader/WriterProxy.cpp
+++ b/src/cpp/rtps/reader/WriterProxy.cpp
@@ -578,7 +578,9 @@ void WriterProxy::update_heartbeat_response_interval(
 }
 
 bool WriterProxy::send(
-        CDRMessage_t* message,
+        const RTPSMessageSenderInterface::NetworkBuffer* buffers,
+        size_t num_buffers,
+        uint32_t total_bytes,
         std::chrono::steady_clock::time_point& max_blocking_time_point) const
 {
     if (is_on_same_process_)
@@ -588,7 +590,7 @@ bool WriterProxy::send(
 
     const ResourceLimitedVector<Locator_t>& remote_locators = remote_locators_shrinked();
 
-    return reader_->send_sync_nts(message,
+    return reader_->send_sync_nts(buffers, num_buffers, total_bytes,
                    Locators(remote_locators.begin()),
                    Locators(remote_locators.end()),
                    max_blocking_time_point);

--- a/src/cpp/rtps/reader/WriterProxy.h
+++ b/src/cpp/rtps/reader/WriterProxy.h
@@ -320,7 +320,9 @@ public:
     /**
      * Send a message through this interface.
      *
-     * @param message Pointer to the buffer with the message already serialized.
+     * @param buffers Array of buffers to gather.
+     * @param num_buffers Number of elements on @c buffers.
+     * @param total_bytes Total size of the raw data. Should be equal to the sum of the @c length field of all buffers.
      * @param max_blocking_time_point Future timepoint where blocking send should end.
      */
     virtual bool send(

--- a/src/cpp/rtps/reader/WriterProxy.h
+++ b/src/cpp/rtps/reader/WriterProxy.h
@@ -324,7 +324,9 @@ public:
      * @param max_blocking_time_point Future timepoint where blocking send should end.
      */
     virtual bool send(
-            CDRMessage_t* message,
+            const RTPSMessageSenderInterface::NetworkBuffer* buffers,
+            size_t num_buffers,
+            uint32_t total_bytes,
             std::chrono::steady_clock::time_point& max_blocking_time_point) const override;
 
     bool is_on_same_process() const

--- a/src/cpp/rtps/transport/TCPChannelResource.h
+++ b/src/cpp/rtps/transport/TCPChannelResource.h
@@ -16,9 +16,12 @@
 #define _FASTDDS_TCP_CHANNEL_RESOURCE_BASE_
 
 #include <asio.hpp>
+
+#include <fastdds/rtps/common/Locator.h>
+#include <fastdds/rtps/network/SenderResource.h>
 #include <fastdds/rtps/transport/TCPTransportDescriptor.h>
 #include <fastdds/rtps/transport/TransportReceiverInterface.h>
-#include <fastdds/rtps/common/Locator.h>
+
 #include <rtps/transport/ChannelResource.h>
 #include <rtps/transport/tcp/RTCPMessageManager.h>
 
@@ -44,6 +47,9 @@ class TCPChannelResource : public ChannelResource
 {
 
 protected:
+
+    using SenderResource = eprosima::fastrtps::rtps::SenderResource;
+    static constexpr size_t max_required_buffers = SenderResource::max_required_buffers;
 
     enum TCPConnectionType
     {
@@ -130,7 +136,7 @@ public:
             size_t data_size,
             asio::error_code& ec)
     {
-        std::array<asio::const_buffer, 3> buffers;
+        std::array<asio::const_buffer, max_required_buffers> buffers;
         buffers[0] = { data, data_size };
         return send(header, header_size, buffers, ec);
     }
@@ -138,7 +144,7 @@ public:
     virtual size_t send(
             const fastrtps::rtps::octet* header,
             size_t header_size,
-            const std::array<asio::const_buffer, 3>& send_buffers,
+            const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
             asio::error_code& ec) = 0;
 
     virtual asio::ip::tcp::endpoint remote_endpoint() const = 0;

--- a/src/cpp/rtps/transport/TCPChannelResource.h
+++ b/src/cpp/rtps/transport/TCPChannelResource.h
@@ -123,11 +123,22 @@ public:
             std::size_t size,
             asio::error_code& ec) = 0;
 
+    size_t send(
+            const fastrtps::rtps::octet* header,
+            size_t header_size,
+            const fastrtps::rtps::octet* data,
+            size_t data_size,
+            asio::error_code& ec)
+    {
+        std::array<asio::const_buffer, 3> buffers;
+        buffers[0] = { data, data_size };
+        return send(header, header_size, buffers, ec);
+    }
+
     virtual size_t send(
             const fastrtps::rtps::octet* header,
             size_t header_size,
-            const fastrtps::rtps::octet* buffer,
-            size_t size,
+            const std::array<asio::const_buffer, 3>& send_buffers,
             asio::error_code& ec) = 0;
 
     virtual asio::ip::tcp::endpoint remote_endpoint() const = 0;

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
@@ -147,8 +147,7 @@ uint32_t TCPChannelResourceBasic::read(
 size_t TCPChannelResourceBasic::send(
         const octet* header,
         size_t header_size,
-        const octet* data,
-        size_t size,
+        const std::array<asio::const_buffer, 3>& send_buffers,
         asio::error_code& ec)
 {
     size_t bytes_sent = 0;
@@ -157,14 +156,17 @@ size_t TCPChannelResourceBasic::send(
     {
         if (header_size > 0)
         {
-            std::array<asio::const_buffer, 2> buffers;
+            std::array<asio::const_buffer, 4> buffers;
             buffers[0] = asio::buffer(header, header_size);
-            buffers[1] = asio::buffer(data, size);
+            for (size_t i = 0; i < 3; ++i)
+            {
+                buffers[i + 1] = send_buffers[i];
+            }
             bytes_sent = asio::write(*socket_.get(), buffers, ec);
         }
         else
         {
-            bytes_sent = asio::write(*socket_.get(), asio::buffer(data, size), ec);
+            bytes_sent = asio::write(*socket_.get(), send_buffers, ec);
         }
     }
 

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
@@ -158,15 +158,19 @@ size_t TCPChannelResourceBasic::send(
         {
             std::array<asio::const_buffer, max_required_buffers + 1> buffers;
             buffers[0] = asio::buffer(header, header_size);
+            size_t n = 1;
             for (size_t i = 0; i < max_required_buffers; ++i)
             {
-                buffers[i + 1] = send_buffers[i];
+                if (send_buffers[i].size())
+                {
+                    buffers[n++] = send_buffers[i];
+                }
             }
-            bytes_sent = asio::write(*socket_.get(), buffers, ec);
+            bytes_sent = socket_->send(buffers, 0, ec);
         }
         else
         {
-            bytes_sent = asio::write(*socket_.get(), send_buffers, ec);
+            bytes_sent = socket_->send(send_buffers, 0, ec);
         }
     }
 

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
@@ -147,7 +147,7 @@ uint32_t TCPChannelResourceBasic::read(
 size_t TCPChannelResourceBasic::send(
         const octet* header,
         size_t header_size,
-        const std::array<asio::const_buffer, 3>& send_buffers,
+        const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
         asio::error_code& ec)
 {
     size_t bytes_sent = 0;
@@ -156,7 +156,7 @@ size_t TCPChannelResourceBasic::send(
     {
         if (header_size > 0)
         {
-            std::array<asio::const_buffer, 4> buffers;
+            std::array<asio::const_buffer, max_required_buffers + 1> buffers;
             buffers[0] = asio::buffer(header, header_size);
             for (size_t i = 0; i < 3; ++i)
             {

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
@@ -158,7 +158,7 @@ size_t TCPChannelResourceBasic::send(
         {
             std::array<asio::const_buffer, max_required_buffers + 1> buffers;
             buffers[0] = asio::buffer(header, header_size);
-            for (size_t i = 0; i < 3; ++i)
+            for (size_t i = 0; i < max_required_buffers; ++i)
             {
                 buffers[i + 1] = send_buffers[i];
             }

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.h
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.h
@@ -58,7 +58,7 @@ public:
     size_t send(
             const fastrtps::rtps::octet* header,
             size_t header_size,
-            const std::array<asio::const_buffer, 3>& send_buffers,
+            const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
             asio::error_code& ec) override;
 
     asio::ip::tcp::endpoint remote_endpoint() const override;

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.h
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.h
@@ -58,8 +58,7 @@ public:
     size_t send(
             const fastrtps::rtps::octet* header,
             size_t header_size,
-            const fastrtps::rtps::octet* data,
-            size_t size,
+            const std::array<asio::const_buffer, 3>& send_buffers,
             asio::error_code& ec) override;
 
     asio::ip::tcp::endpoint remote_endpoint() const override;

--- a/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
@@ -199,8 +199,7 @@ uint32_t TCPChannelResourceSecure::read(
 size_t TCPChannelResourceSecure::send(
         const octet* header,
         size_t header_size,
-        const octet* data,
-        size_t size,
+        const std::array<asio::const_buffer, 3>& send_buffers,
         asio::error_code& ec)
 {
     size_t bytes_sent = 0;
@@ -212,7 +211,13 @@ size_t TCPChannelResourceSecure::send(
         {
             buffers.push_back(asio::buffer(header, header_size));
         }
-        buffers.push_back(asio::buffer(data, size));
+        for (size_t i = 0; i < 3; ++i)
+        {
+            if (send_buffers[i].size())
+            {
+                buffers.push_back(send_buffers[i]);
+            }
+        }
 
         // Work around meanwhile
         std::promise<size_t> write_bytes_promise;

--- a/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
@@ -228,7 +228,7 @@ size_t TCPChannelResourceSecure::send(
                 {
                     if (socket->lowest_layer().is_open())
                     {
-                        socket->async_send(buffers,
+                        socket->async_write_some(buffers,
                         [&, socket](const std::error_code& error, size_t bytes_transferred)
                         {
                             ec = error;

--- a/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
@@ -199,7 +199,7 @@ uint32_t TCPChannelResourceSecure::read(
 size_t TCPChannelResourceSecure::send(
         const octet* header,
         size_t header_size,
-        const std::array<asio::const_buffer, 3>& send_buffers,
+        const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
         asio::error_code& ec)
 {
     size_t bytes_sent = 0;
@@ -211,7 +211,7 @@ size_t TCPChannelResourceSecure::send(
         {
             buffers.push_back(asio::buffer(header, header_size));
         }
-        for (size_t i = 0; i < 3; ++i)
+        for (size_t i = 0; i < max_required_buffers; ++i)
         {
             if (send_buffers[i].size())
             {

--- a/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
@@ -228,8 +228,8 @@ size_t TCPChannelResourceSecure::send(
                 {
                     if (socket->lowest_layer().is_open())
                     {
-                        asio::async_write(*socket, buffers,
-                        [&, socket](const std::error_code& error, const size_t& bytes_transferred)
+                        socket->async_send(buffers,
+                        [&, socket](const std::error_code& error, size_t bytes_transferred)
                         {
                             ec = error;
 

--- a/src/cpp/rtps/transport/TCPChannelResourceSecure.h
+++ b/src/cpp/rtps/transport/TCPChannelResourceSecure.h
@@ -59,8 +59,7 @@ public:
     size_t send(
             const fastrtps::rtps::octet* header,
             size_t header_size,
-            const fastrtps::rtps::octet* data,
-            size_t size,
+            const std::array<asio::const_buffer, 3>& send_buffers,
             asio::error_code& ec) override;
 
     asio::ip::tcp::endpoint remote_endpoint() const override;

--- a/src/cpp/rtps/transport/TCPChannelResourceSecure.h
+++ b/src/cpp/rtps/transport/TCPChannelResourceSecure.h
@@ -59,7 +59,7 @@ public:
     size_t send(
             const fastrtps::rtps::octet* header,
             size_t header_size,
-            const std::array<asio::const_buffer, 3>& send_buffers,
+            const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
             asio::error_code& ec) override;
 
     asio::ip::tcp::endpoint remote_endpoint() const override;

--- a/src/cpp/rtps/transport/TCPSenderResource.hpp
+++ b/src/cpp/rtps/transport/TCPSenderResource.hpp
@@ -49,9 +49,9 @@ public:
             fastrtps::rtps::LocatorsIterator* destination_locators_end,
             const std::chrono::steady_clock::time_point&) -> bool
                 {
-                    assert(num_buffers < 4);
+                    assert(num_buffers <= max_required_buffers);
 
-                    std::array<asio::const_buffer, 3> asio_buffers;
+                    std::array<asio::const_buffer, max_required_buffers> asio_buffers;
                     uint32_t total_size = 0;
                     for (size_t i = 0; i < num_buffers; ++i)
                     {

--- a/src/cpp/rtps/transport/TCPSenderResource.hpp
+++ b/src/cpp/rtps/transport/TCPSenderResource.hpp
@@ -41,7 +41,7 @@ public:
                     transport.CloseOutputChannel(channel_);
                 };
 
-        send_lambda_ = [this, &transport](
+        send_buffers_lambda_ = [this, &transport](
             const NetworkBuffer* buffers,
             size_t num_buffers,
             uint32_t total_bytes,

--- a/src/cpp/rtps/transport/TCPSenderResource.hpp
+++ b/src/cpp/rtps/transport/TCPSenderResource.hpp
@@ -52,14 +52,14 @@ public:
                     assert(num_buffers <= max_required_buffers);
 
                     std::array<asio::const_buffer, max_required_buffers> asio_buffers;
-                    uint32_t total_size = 0;
+                    uint32_t total_num_bytes = 0;
                     for (size_t i = 0; i < num_buffers; ++i)
                     {
                         asio_buffers[i] = { buffers[i].buffer, buffers[i].length };
-                        total_size += buffers[i].length;
+                        total_num_bytes += buffers[i].length;
                     }
 
-                    assert(total_size == total_bytes);
+                    assert(total_num_bytes == total_bytes);
                     return transport.send(asio_buffers, total_bytes, channel_, destination_locators_begin,
                                    destination_locators_end);
                 };

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -240,7 +240,7 @@ bool TCPTransportInterface::check_crc(
 
 void TCPTransportInterface::calculate_crc(
         TCPHeader& header,
-        const std::array<asio::const_buffer, 3>& send_buffers) const
+        const std::array<asio::const_buffer, max_required_buffers>& send_buffers) const
 {
     uint32_t crc(0);
     for (const asio::const_buffer& buf : send_buffers)
@@ -330,7 +330,7 @@ bool TCPTransportInterface::create_acceptor_socket(
 
 void TCPTransportInterface::fill_rtcp_header(
         TCPHeader& header,
-        const std::array<asio::const_buffer, 3>& send_buffers,
+        const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
         uint32_t total_bytes,
         uint16_t logical_port) const
 {
@@ -1030,7 +1030,7 @@ bool TCPTransportInterface::Receive(
 }
 
 bool TCPTransportInterface::send(
-        const std::array<asio::const_buffer, 3>& send_buffers,
+        const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
         uint32_t total_bytes,
         std::shared_ptr<TCPChannelResource>& channel,
         fastrtps::rtps::LocatorsIterator* destination_locators_begin,
@@ -1054,7 +1054,7 @@ bool TCPTransportInterface::send(
 }
 
 bool TCPTransportInterface::send(
-        const std::array<asio::const_buffer, 3>& send_buffers,
+        const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
         uint32_t total_bytes,
         std::shared_ptr<TCPChannelResource>& channel,
         const Locator& remote_locator)

--- a/src/cpp/rtps/transport/TCPTransportInterface.h
+++ b/src/cpp/rtps/transport/TCPTransportInterface.h
@@ -117,11 +117,11 @@ protected:
 
     void calculate_crc(
             TCPHeader& header,
-            const std::array<asio::const_buffer, 3>& send_buffers) const;
+            const std::array<asio::const_buffer, max_required_buffers>& send_buffers) const;
 
     void fill_rtcp_header(
             TCPHeader& header,
-            const std::array<asio::const_buffer, 3>& send_buffers,
+            const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
             uint32_t total_bytes,
             uint16_t logical_port) const;
 
@@ -182,7 +182,7 @@ protected:
      * Send a buffer to a destination
      */
     bool send(
-            const std::array<asio::const_buffer, 3>& send_buffers,
+            const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
             uint32_t total_bytes,
             std::shared_ptr<TCPChannelResource>& channel,
             const Locator& remote_locator);
@@ -325,7 +325,7 @@ public:
      * so should not be reuse.
      */
     bool send(
-            const std::array<asio::const_buffer, 3>& send_buffers,
+            const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
             uint32_t total_bytes,
             std::shared_ptr<TCPChannelResource>& channel,
             fastrtps::rtps::LocatorsIterator* destination_locators_begin,

--- a/src/cpp/rtps/transport/TCPTransportInterface.h
+++ b/src/cpp/rtps/transport/TCPTransportInterface.h
@@ -117,13 +117,12 @@ protected:
 
     void calculate_crc(
             TCPHeader& header,
-            const fastrtps::rtps::octet* data,
-            uint32_t size) const;
+            const std::array<asio::const_buffer, 3>& send_buffers) const;
 
     void fill_rtcp_header(
             TCPHeader& header,
-            const fastrtps::rtps::octet* send_buffer,
-            uint32_t send_buffer_size,
+            const std::array<asio::const_buffer, 3>& send_buffers,
+            uint32_t total_bytes,
             uint16_t logical_port) const;
 
     //! Closes the given p_channel_resource and unbind it from every resource.
@@ -183,8 +182,8 @@ protected:
      * Send a buffer to a destination
      */
     bool send(
-            const fastrtps::rtps::octet* send_buffer,
-            uint32_t send_buffer_size,
+            const std::array<asio::const_buffer, 3>& send_buffers,
+            uint32_t total_bytes,
             std::shared_ptr<TCPChannelResource>& channel,
             const Locator& remote_locator);
 
@@ -326,8 +325,8 @@ public:
      * so should not be reuse.
      */
     bool send(
-            const fastrtps::rtps::octet* send_buffer,
-            uint32_t send_buffer_size,
+            const std::array<asio::const_buffer, 3>& send_buffers,
+            uint32_t total_bytes,
             std::shared_ptr<TCPChannelResource>& channel,
             fastrtps::rtps::LocatorsIterator* destination_locators_begin,
             fastrtps::rtps::LocatorsIterator* destination_locators_end);

--- a/src/cpp/rtps/transport/TCPTransportInterface.h
+++ b/src/cpp/rtps/transport/TCPTransportInterface.h
@@ -315,8 +315,8 @@ public:
 
     /**
      * Blocking Send through the specified channel.
-     * @param send_buffer Slice into the raw data to send.
-     * @param send_buffer_size Size of the raw data. It will be used as a bounds check for the previous argument.
+     * @param send_buffers Slices of raw data to send.
+     * @param total_bytes Total number of bytes to send. It will be used as a bounds check for the previous argument.
      * It must not exceed the send_buffer_size fed to this class during construction.
      * @param channel channel we're sending from.
      * @param destination_locators_begin pointer to destination locators iterator begin, the iterator can be advanced inside this fuction

--- a/src/cpp/rtps/transport/UDPSenderResource.hpp
+++ b/src/cpp/rtps/transport/UDPSenderResource.hpp
@@ -51,9 +51,9 @@ public:
             fastrtps::rtps::LocatorsIterator* destination_locators_end,
             const std::chrono::steady_clock::time_point& max_blocking_time_point) -> bool
                 {
-                    assert(num_buffers < 4);
+                    assert(num_buffers <= max_required_buffers);
 
-                    std::array<asio::const_buffer, 3> asio_buffers;
+                    std::array<asio::const_buffer, max_required_buffers> asio_buffers;
                     uint32_t total_size = 0;
                     for (size_t i = 0; i < num_buffers; ++i)
                     {

--- a/src/cpp/rtps/transport/UDPSenderResource.hpp
+++ b/src/cpp/rtps/transport/UDPSenderResource.hpp
@@ -44,13 +44,25 @@ public:
                 };
 
         send_lambda_ = [this, &transport](
-            const fastrtps::rtps::octet* data,
-            uint32_t dataSize,
+            const NetworkBuffer* buffers,
+            size_t num_buffers,
+            uint32_t total_bytes,
             fastrtps::rtps::LocatorsIterator* destination_locators_begin,
             fastrtps::rtps::LocatorsIterator* destination_locators_end,
             const std::chrono::steady_clock::time_point& max_blocking_time_point) -> bool
                 {
-                    return transport.send(data, dataSize, socket_, destination_locators_begin,
+                    assert(num_buffers < 4);
+
+                    std::array<asio::const_buffer, 3> asio_buffers;
+                    uint32_t total_size = 0;
+                    for (size_t i = 0; i < num_buffers; ++i)
+                    {
+                        asio_buffers[i] = { buffers[i].buffer, buffers[i].length };
+                        total_size += buffers[i].length;
+                    }
+
+                    assert(total_size == total_bytes);
+                    return transport.send(asio_buffers, total_bytes, socket_, destination_locators_begin,
                                    destination_locators_end, only_multicast_purpose_, max_blocking_time_point);
                 };
     }

--- a/src/cpp/rtps/transport/UDPSenderResource.hpp
+++ b/src/cpp/rtps/transport/UDPSenderResource.hpp
@@ -43,7 +43,7 @@ public:
                     transport.CloseOutputChannel(socket_);
                 };
 
-        send_lambda_ = [this, &transport](
+        send_buffers_lambda_ = [this, &transport](
             const NetworkBuffer* buffers,
             size_t num_buffers,
             uint32_t total_bytes,

--- a/src/cpp/rtps/transport/UDPSenderResource.hpp
+++ b/src/cpp/rtps/transport/UDPSenderResource.hpp
@@ -54,14 +54,14 @@ public:
                     assert(num_buffers <= max_required_buffers);
 
                     std::array<asio::const_buffer, max_required_buffers> asio_buffers;
-                    uint32_t total_size = 0;
+                    uint32_t total_num_bytes = 0;
                     for (size_t i = 0; i < num_buffers; ++i)
                     {
                         asio_buffers[i] = { buffers[i].buffer, buffers[i].length };
-                        total_size += buffers[i].length;
+                        total_num_bytes += buffers[i].length;
                     }
 
-                    assert(total_size == total_bytes);
+                    assert(total_num_bytes == total_bytes);
                     return transport.send(asio_buffers, total_bytes, socket_, destination_locators_begin,
                                    destination_locators_end, only_multicast_purpose_, max_blocking_time_point);
                 };

--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -460,7 +460,7 @@ bool UDPTransportInterface::transform_remote_locator(
 }
 
 bool UDPTransportInterface::send(
-        const octet* send_buffer,
+        const std::array<asio::const_buffer, 3>& send_buffer,
         uint32_t send_buffer_size,
         eProsimaUDPSocket& socket,
         fastrtps::rtps::LocatorsIterator* destination_locators_begin,
@@ -494,8 +494,8 @@ bool UDPTransportInterface::send(
 }
 
 bool UDPTransportInterface::send(
-        const octet* send_buffer,
-        uint32_t send_buffer_size,
+        const std::array<asio::const_buffer, 3>& send_buffer,
+        size_t send_buffer_size,
         eProsimaUDPSocket& socket,
         const Locator& remote_locator,
         bool only_multicast_purpose,
@@ -527,8 +527,7 @@ bool UDPTransportInterface::send(
 #endif // ifndef _WIN32
 
             asio::error_code ec;
-            bytesSent = getSocketPtr(socket)->send_to(asio::buffer(send_buffer,
-                            send_buffer_size), destinationEndpoint, 0, ec);
+            bytesSent = getSocketPtr(socket)->send_to(send_buffer, destinationEndpoint, 0, ec);
             if (!!ec)
             {
                 if ((ec.value() == asio::error::would_block) ||

--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -460,8 +460,8 @@ bool UDPTransportInterface::transform_remote_locator(
 }
 
 bool UDPTransportInterface::send(
-        const std::array<asio::const_buffer, max_required_buffers>& send_buffer,
-        uint32_t send_buffer_size,
+        const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
+        uint32_t total_bytes,
         eProsimaUDPSocket& socket,
         fastrtps::rtps::LocatorsIterator* destination_locators_begin,
         fastrtps::rtps::LocatorsIterator* destination_locators_end,
@@ -479,8 +479,8 @@ bool UDPTransportInterface::send(
     {
         if (IsLocatorSupported(*it))
         {
-            ret &= send(send_buffer,
-                            send_buffer_size,
+            ret &= send(send_buffers,
+                            total_bytes,
                             socket,
                             *it,
                             only_multicast_purpose,
@@ -494,14 +494,14 @@ bool UDPTransportInterface::send(
 }
 
 bool UDPTransportInterface::send(
-        const std::array<asio::const_buffer, max_required_buffers>& send_buffer,
-        size_t send_buffer_size,
+        const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
+        uint32_t total_bytes,
         eProsimaUDPSocket& socket,
         const Locator& remote_locator,
         bool only_multicast_purpose,
         const std::chrono::microseconds& timeout)
 {
-    if (send_buffer_size > configuration()->sendBufferSize)
+    if (total_bytes > configuration()->sendBufferSize)
     {
         return false;
     }
@@ -527,7 +527,7 @@ bool UDPTransportInterface::send(
 #endif // ifndef _WIN32
 
             asio::error_code ec;
-            bytesSent = getSocketPtr(socket)->send_to(send_buffer, destinationEndpoint, 0, ec);
+            bytesSent = getSocketPtr(socket)->send_to(send_buffers, destinationEndpoint, 0, ec);
             if (!!ec)
             {
                 if ((ec.value() == asio::error::would_block) ||

--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -460,7 +460,7 @@ bool UDPTransportInterface::transform_remote_locator(
 }
 
 bool UDPTransportInterface::send(
-        const std::array<asio::const_buffer, 3>& send_buffer,
+        const std::array<asio::const_buffer, max_required_buffers>& send_buffer,
         uint32_t send_buffer_size,
         eProsimaUDPSocket& socket,
         fastrtps::rtps::LocatorsIterator* destination_locators_begin,
@@ -494,7 +494,7 @@ bool UDPTransportInterface::send(
 }
 
 bool UDPTransportInterface::send(
-        const std::array<asio::const_buffer, 3>& send_buffer,
+        const std::array<asio::const_buffer, max_required_buffers>& send_buffer,
         size_t send_buffer_size,
         eProsimaUDPSocket& socket,
         const Locator& remote_locator,

--- a/src/cpp/rtps/transport/UDPTransportInterface.h
+++ b/src/cpp/rtps/transport/UDPTransportInterface.h
@@ -98,8 +98,8 @@ public:
     /**
      * Blocking Send through the specified channel. In both modes, using a localLocator of 0.0.0.0 will
      * send through all whitelisted interfaces provided the channel is open.
-     * @param send_buffer Slice into the raw data to send.
-     * @param send_buffer_size Size of the raw data. It will be used as a bounds check for the previous argument.
+     * @param send_buffers Slice into the raw data to send.
+     * @param total_bytes Size of the raw data. It will be used as a bounds check for the previous argument.
      * It must not exceed the send_buffer_size fed to this class during construction.
      * @param socket channel we're sending from.
      * @param destination_locators_begin pointer to destination locators iterator begin, the iterator can be advanced inside this fuction
@@ -110,8 +110,8 @@ public:
      * @param max_blocking_time_point maximum blocking time.
      */
     virtual bool send(
-            const std::array<asio::const_buffer, max_required_buffers>& send_buffer,
-            uint32_t send_buffer_size,
+            const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
+            uint32_t total_bytes,
             eProsimaUDPSocket& socket,
             fastrtps::rtps::LocatorsIterator* destination_locators_begin,
             fastrtps::rtps::LocatorsIterator* destination_locators_end,
@@ -250,8 +250,8 @@ protected:
      * Send a buffer to a destination
      */
     bool send(
-            const std::array<asio::const_buffer, max_required_buffers>& send_buffer,
-            size_t send_buffer_size,
+            const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
+            uint32_t total_bytes,
             eProsimaUDPSocket& socket,
             const Locator& remote_locator,
             bool only_multicast_purpose,

--- a/src/cpp/rtps/transport/UDPTransportInterface.h
+++ b/src/cpp/rtps/transport/UDPTransportInterface.h
@@ -110,7 +110,7 @@ public:
      * @param max_blocking_time_point maximum blocking time.
      */
     virtual bool send(
-            const std::array<asio::const_buffer, 3>& send_buffer,
+            const std::array<asio::const_buffer, max_required_buffers>& send_buffer,
             uint32_t send_buffer_size,
             eProsimaUDPSocket& socket,
             fastrtps::rtps::LocatorsIterator* destination_locators_begin,
@@ -250,7 +250,7 @@ protected:
      * Send a buffer to a destination
      */
     bool send(
-            const std::array<asio::const_buffer, 3>& send_buffer,
+            const std::array<asio::const_buffer, max_required_buffers>& send_buffer,
             size_t send_buffer_size,
             eProsimaUDPSocket& socket,
             const Locator& remote_locator,

--- a/src/cpp/rtps/transport/UDPTransportInterface.h
+++ b/src/cpp/rtps/transport/UDPTransportInterface.h
@@ -110,7 +110,7 @@ public:
      * @param max_blocking_time_point maximum blocking time.
      */
     virtual bool send(
-            const fastrtps::rtps::octet* send_buffer,
+            const std::array<asio::const_buffer, 3>& send_buffer,
             uint32_t send_buffer_size,
             eProsimaUDPSocket& socket,
             fastrtps::rtps::LocatorsIterator* destination_locators_begin,
@@ -250,8 +250,8 @@ protected:
      * Send a buffer to a destination
      */
     bool send(
-            const fastrtps::rtps::octet* send_buffer,
-            uint32_t send_buffer_size,
+            const std::array<asio::const_buffer, 3>& send_buffer,
+            size_t send_buffer_size,
             eProsimaUDPSocket& socket,
             const Locator& remote_locator,
             bool only_multicast_purpose,

--- a/src/cpp/rtps/transport/shared_mem/SharedMemSenderResource.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemSenderResource.hpp
@@ -37,13 +37,15 @@ public:
                 };
 
         send_lambda_ = [&transport](
-            const fastrtps::rtps::octet* data,
-            uint32_t dataSize,
+            const NetworkBuffer* buffers,
+            size_t num_buffers,
+            uint32_t total_bytes,
             fastrtps::rtps::LocatorsIterator* destination_locators_begin,
             fastrtps::rtps::LocatorsIterator* destination_locators_end,
             const std::chrono::steady_clock::time_point& max_blocking_time_point) -> bool
                 {
-                    return transport.send(data, dataSize, destination_locators_begin, destination_locators_end,
+                    return transport.send(buffers, num_buffers, total_bytes,
+                                   destination_locators_begin, destination_locators_end,
                                    max_blocking_time_point);
                 };
 

--- a/src/cpp/rtps/transport/shared_mem/SharedMemSenderResource.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemSenderResource.hpp
@@ -36,7 +36,7 @@ public:
                     // No cleanup is required
                 };
 
-        send_lambda_ = [&transport](
+        send_buffers_lambda_ = [&transport](
             const NetworkBuffer* buffers,
             size_t num_buffers,
             uint32_t total_bytes,

--- a/src/cpp/rtps/transport/shared_mem/SharedMemSenderResource.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemSenderResource.hpp
@@ -44,6 +44,7 @@ public:
             fastrtps::rtps::LocatorsIterator* destination_locators_end,
             const std::chrono::steady_clock::time_point& max_blocking_time_point) -> bool
                 {
+                    assert(num_buffers <= max_required_buffers);
                     return transport.send(buffers, num_buffers, total_bytes,
                                    destination_locators_begin, destination_locators_end,
                                    max_blocking_time_point);

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
@@ -386,21 +386,6 @@ bool SharedMemTransport::transform_remote_locator(
     return false;
 }
 
-std::shared_ptr<SharedMemManager::Buffer> SharedMemTransport::copy_to_shared_buffer(
-        const octet* send_buffer,
-        uint32_t send_buffer_size,
-        const std::chrono::steady_clock::time_point& max_blocking_time_point)
-{
-    assert(shared_mem_segment_);
-
-    std::shared_ptr<SharedMemManager::Buffer> shared_buffer =
-            shared_mem_segment_->alloc_buffer(send_buffer_size, max_blocking_time_point);
-
-    memcpy(shared_buffer->data(), send_buffer, send_buffer_size);
-
-    return shared_buffer;
-}
-
 bool SharedMemTransport::send(
         const NetworkBuffer* buffers,
         size_t num_buffers,

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransport.h
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransport.h
@@ -135,19 +135,19 @@ public:
             uint32_t unicast_port) const override;
 
     /**
-     * Blocking Send through the specified channel. In both modes, using a localLocator of 0.0.0.0 will
-     * send through all whitelisted interfaces provided the channel is open.
-     * @param send_buffer Slice into the raw data to send.
-     * @param send_buffer_size Size of the raw data. It will be used as a bounds check for the previous argument.
-     * It must not exceed the send_buffer_size fed to this class during construction.
-     * @param socket channel we're sending from.
-     * @param remote_locator Locator describing the remote destination we're sending to.
-     * @param only_multicast_purpose
-     * @param timeout Maximum time this function will block
+     * Blocking Send to a list of destinations.
+     * @param buffers Array of buffers to gather.
+     * @param num_buffers Number of elements on @c buffers.
+     * @param total_bytes Total size of the raw data. Should be equal to the sum of the @c length field of all
+     * buffers. It must not exceed the send_buffer_size fed to this class during construction.
+     * @param destination_locators_begin Beginning iterator for the list of destinations.
+     * @param destination_locators_end Ending iterator for the list of destinations.
+     * @param timeout Maximum time this function will block.
      */
     virtual bool send(
-            const fastrtps::rtps::octet* send_buffer,
-            uint32_t send_buffer_size,
+            const NetworkBuffer* buffers,
+            size_t num_buffers,
+            uint32_t total_bytes,
             fastrtps::rtps::LocatorsIterator* destination_locators_begin,
             fastrtps::rtps::LocatorsIterator* destination_locators_end,
             const std::chrono::steady_clock::time_point& max_blocking_time_point);

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransport.h
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransport.h
@@ -138,8 +138,8 @@ public:
      * Blocking Send to a list of destinations.
      * @param buffers Array of buffers to gather.
      * @param num_buffers Number of elements on @c buffers.
-     * @param total_bytes Total size of the raw data. Should be equal to the sum of the @c length field of all
-     * buffers. It must not exceed the send_buffer_size fed to this class during construction.
+     * @param total_bytes Total size of the raw data. Should be equal to the sum of the @c length field of all buffers.
+     *                    It must not exceed the value returned by configuration()->segment_size().
      * @param destination_locators_begin Beginning iterator for the list of destinations.
      * @param destination_locators_end Ending iterator for the list of destinations.
      * @param timeout Maximum time this function will block.

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransport.h
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransport.h
@@ -237,11 +237,6 @@ protected:
 
 private:
 
-    std::shared_ptr<SharedMemManager::Buffer> copy_to_shared_buffer(
-            const fastrtps::rtps::octet* send_buffer,
-            uint32_t send_buffer_size,
-            const std::chrono::steady_clock::time_point& max_blocking_time_point);
-
     bool send(
             const std::shared_ptr<SharedMemManager::Buffer>& buffer,
             const Locator& remote_locator);

--- a/src/cpp/rtps/transport/shared_mem/test_SharedMemTransport.cpp
+++ b/src/cpp/rtps/transport/shared_mem/test_SharedMemTransport.cpp
@@ -49,18 +49,19 @@ TransportInterface* test_SharedMemTransportDescriptor::create_transport() const
 }
 
 bool test_SharedMemTransport::send(
-        const fastrtps::rtps::octet* send_buffer,
-        uint32_t send_buffer_size,
+        const NetworkBuffer* buffers,
+        size_t num_buffers,
+        uint32_t total_bytes,
         fastrtps::rtps::LocatorsIterator* destination_locators_begin,
         fastrtps::rtps::LocatorsIterator* destination_locators_end,
         const std::chrono::steady_clock::time_point& max_blocking_time_point)
 {
-    if (send_buffer_size >= big_buffer_size_)
+    if (total_bytes >= big_buffer_size_)
     {
         (*big_buffer_size_send_count_)++;
     }
 
-    return SharedMemTransport::send(send_buffer, send_buffer_size, destination_locators_begin,
+    return SharedMemTransport::send(buffers, num_buffers, total_bytes, destination_locators_begin,
                    destination_locators_end, max_blocking_time_point);
 }
 

--- a/src/cpp/rtps/transport/shared_mem/test_SharedMemTransport.h
+++ b/src/cpp/rtps/transport/shared_mem/test_SharedMemTransport.h
@@ -30,8 +30,9 @@ public:
             const test_SharedMemTransportDescriptor&);
 
     bool send(
-            const fastrtps::rtps::octet* send_buffer,
-            uint32_t send_buffer_size,
+            const NetworkBuffer* buffers,
+            size_t num_buffers,
+            uint32_t total_bytes,
             fastrtps::rtps::LocatorsIterator* destination_locators_begin,
             fastrtps::rtps::LocatorsIterator* destination_locators_end,
             const std::chrono::steady_clock::time_point& max_blocking_time_point) override;

--- a/src/cpp/rtps/transport/test_UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.cpp
@@ -259,7 +259,7 @@ bool test_UDPv4Transport::packet_should_drop(
     for (size_t i = 0; i < max_required_buffers; ++i)
     {
         memcpy(&cdrMessage.buffer[n_bytes], send_buffers[i].data(), send_buffers[i].size());
-        n_bytes += send_buffers.size();
+        n_bytes += send_buffers[i].size();
     }
     assert(total_bytes == n_bytes);
     cdrMessage.length = total_bytes;

--- a/src/cpp/rtps/transport/test_UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.cpp
@@ -154,7 +154,7 @@ void test_UDPv4Transport::get_ips(
 }
 
 bool test_UDPv4Transport::send(
-        const std::array<asio::const_buffer, 3>& send_buffer,
+        const std::array<asio::const_buffer, max_required_buffers>& send_buffer,
         uint32_t send_buffer_size,
         eProsimaUDPSocket& socket,
         fastrtps::rtps::LocatorsIterator* destination_locators_begin,
@@ -192,7 +192,7 @@ bool test_UDPv4Transport::send(
 }
 
 bool test_UDPv4Transport::send(
-        const std::array<asio::const_buffer, 3>& send_buffers,
+        const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
         uint32_t total_bytes,
         eProsimaUDPSocket& socket,
         const Locator& remote_locator,
@@ -246,7 +246,7 @@ static bool ReadSubmessageHeader(
 }
 
 bool test_UDPv4Transport::packet_should_drop(
-        const std::array<asio::const_buffer, 3>& send_buffer,
+        const std::array<asio::const_buffer, max_required_buffers>& send_buffer,
         uint32_t send_buffer_size)
 {
     if (test_UDPv4Transport_ShutdownAllNetwork)
@@ -255,7 +255,7 @@ bool test_UDPv4Transport::packet_should_drop(
     }
 
     CDRMessage_t cdrMessage(send_buffer_size);
-    for (size_t i = 0; i < 3; ++i)
+    for (size_t i = 0; i < max_required_buffers; ++i)
     {
         memcpy(cdrMessage.buffer, send_buffer[i].data(), send_buffer[i].size());
     }

--- a/src/cpp/rtps/transport/test_UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.cpp
@@ -201,7 +201,7 @@ bool test_UDPv4Transport::send(
 {
     if (packet_should_drop(send_buffers, total_bytes))
     {
-        log_drop(static_cast<const octet*>(send_buffers[0].data()), total_bytes);
+        log_drop(send_buffers, total_bytes);
         return true;
     }
     else
@@ -413,13 +413,20 @@ bool test_UDPv4Transport::packet_should_drop(
 }
 
 bool test_UDPv4Transport::log_drop(
-        const octet* buffer,
-        uint32_t size)
+        const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
+        uint32_t total_bytes)
 {
     if (test_UDPv4Transport_DropLog.size() < test_UDPv4Transport_DropLogLength)
     {
         vector<octet> message;
-        message.assign(buffer, buffer + size);
+        for (const auto& buf : send_buffers)
+        {
+            if (buf.size())
+            {
+                auto byte_data = static_cast<const octet*>(buf.data());
+                message.insert(message.end(), byte_data, byte_data + buf.size());
+            }
+        }
         test_UDPv4Transport_DropLog.push_back(message);
         return true;
     }

--- a/src/cpp/rtps/transport/test_UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.cpp
@@ -201,7 +201,7 @@ bool test_UDPv4Transport::send(
 {
     if (packet_should_drop(send_buffers, total_bytes))
     {
-        log_drop(send_buffers, total_bytes);
+        log_drop(send_buffers);
         return true;
     }
     else
@@ -413,8 +413,7 @@ bool test_UDPv4Transport::packet_should_drop(
 }
 
 bool test_UDPv4Transport::log_drop(
-        const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
-        uint32_t total_bytes)
+        const std::array<asio::const_buffer, max_required_buffers>& send_buffers)
 {
     if (test_UDPv4Transport_DropLog.size() < test_UDPv4Transport_DropLogLength)
     {

--- a/src/cpp/rtps/transport/test_UDPv4Transport.h
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.h
@@ -41,8 +41,8 @@ public:
             const test_UDPv4TransportDescriptor& descriptor);
 
     virtual bool send(
-            const std::array<asio::const_buffer, max_required_buffers>& send_buffer,
-            uint32_t send_buffer_size,
+            const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
+            uint32_t total_bytes,
             eProsimaUDPSocket& socket,
             fastrtps::rtps::LocatorsIterator* destination_locators_begin,
             fastrtps::rtps::LocatorsIterator* destination_locators_end,

--- a/src/cpp/rtps/transport/test_UDPv4Transport.h
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.h
@@ -98,8 +98,7 @@ private:
 
 
     bool log_drop(
-            const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
-            uint32_t total_bytes);
+            const std::array<asio::const_buffer, max_required_buffers>& send_buffers);
     bool packet_should_drop(
             const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
             uint32_t total_bytes);

--- a/src/cpp/rtps/transport/test_UDPv4Transport.h
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.h
@@ -41,7 +41,7 @@ public:
             const test_UDPv4TransportDescriptor& descriptor);
 
     virtual bool send(
-            const fastrtps::rtps::octet* send_buffer,
+            const std::array<asio::const_buffer, 3>& send_buffer,
             uint32_t send_buffer_size,
             eProsimaUDPSocket& socket,
             fastrtps::rtps::LocatorsIterator* destination_locators_begin,
@@ -101,15 +101,15 @@ private:
             const fastrtps::rtps::octet* buffer,
             uint32_t size);
     bool packet_should_drop(
-            const fastrtps::rtps::octet* send_buffer,
-            uint32_t send_buffer_size);
+            const std::array<asio::const_buffer, 3>& send_buffers,
+            uint32_t total_bytes);
     bool random_chance_drop();
     bool should_be_dropped(
             PercentageData* percentage);
 
     bool send(
-            const fastrtps::rtps::octet* send_buffer,
-            uint32_t send_buffer_size,
+            const std::array<asio::const_buffer, 3>& send_buffers,
+            uint32_t total_bytes,
             eProsimaUDPSocket& socket,
             const Locator& remote_locator,
             bool only_multicast_purpose,

--- a/src/cpp/rtps/transport/test_UDPv4Transport.h
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.h
@@ -41,7 +41,7 @@ public:
             const test_UDPv4TransportDescriptor& descriptor);
 
     virtual bool send(
-            const std::array<asio::const_buffer, 3>& send_buffer,
+            const std::array<asio::const_buffer, max_required_buffers>& send_buffer,
             uint32_t send_buffer_size,
             eProsimaUDPSocket& socket,
             fastrtps::rtps::LocatorsIterator* destination_locators_begin,
@@ -101,14 +101,14 @@ private:
             const fastrtps::rtps::octet* buffer,
             uint32_t size);
     bool packet_should_drop(
-            const std::array<asio::const_buffer, 3>& send_buffers,
+            const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
             uint32_t total_bytes);
     bool random_chance_drop();
     bool should_be_dropped(
             PercentageData* percentage);
 
     bool send(
-            const std::array<asio::const_buffer, 3>& send_buffers,
+            const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
             uint32_t total_bytes,
             eProsimaUDPSocket& socket,
             const Locator& remote_locator,

--- a/src/cpp/rtps/transport/test_UDPv4Transport.h
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.h
@@ -98,8 +98,8 @@ private:
 
 
     bool log_drop(
-            const fastrtps::rtps::octet* buffer,
-            uint32_t size);
+            const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
+            uint32_t total_bytes);
     bool packet_should_drop(
             const std::array<asio::const_buffer, max_required_buffers>& send_buffers,
             uint32_t total_bytes);

--- a/src/cpp/rtps/writer/RTPSWriter.cpp
+++ b/src/cpp/rtps/writer/RTPSWriter.cpp
@@ -354,13 +354,16 @@ const std::vector<GUID_t>& RTPSWriter::remote_guids() const
 }
 
 bool RTPSWriter::send(
-        CDRMessage_t* message,
+        const RTPSMessageSenderInterface::NetworkBuffer* buffers,
+        size_t num_buffers,
+        uint32_t total_bytes,
         std::chrono::steady_clock::time_point& max_blocking_time_point) const
 {
     RTPSParticipantImpl* participant = getRTPSParticipant();
 
     return locator_selector_.selected_size() == 0 ||
-           participant->sendSync(message, locator_selector_.begin(), locator_selector_.end(), max_blocking_time_point);
+           participant->sendSync(buffers, num_buffers, total_bytes,
+                   locator_selector_.begin(), locator_selector_.end(), max_blocking_time_point);
 }
 
 const LivelinessQosPolicyKind& RTPSWriter::get_liveliness_kind() const

--- a/src/cpp/rtps/writer/ReaderLocator.cpp
+++ b/src/cpp/rtps/writer/ReaderLocator.cpp
@@ -161,20 +161,24 @@ void ReaderLocator::stop()
 }
 
 bool ReaderLocator::send(
-        CDRMessage_t* message,
+        const RTPSMessageSenderInterface::NetworkBuffer* buffers,
+        size_t num_buffers,
+        uint32_t total_bytes,
         std::chrono::steady_clock::time_point& max_blocking_time_point) const
 {
     if (locator_info_.remote_guid != c_Guid_Unknown && !is_local_reader_)
     {
         if (locator_info_.unicast.size() > 0)
         {
-            return participant_owner_->sendSync(message, Locators(locator_info_.unicast.begin()),
-                           Locators(locator_info_.unicast.end()), max_blocking_time_point);
+            return participant_owner_->sendSync(buffers, num_buffers, total_bytes,
+                           Locators(locator_info_.unicast.begin()), Locators(locator_info_.unicast.end()),
+                           max_blocking_time_point);
         }
         else
         {
-            return participant_owner_->sendSync(message, Locators(locator_info_.multicast.begin()),
-                           Locators(locator_info_.multicast.end()), max_blocking_time_point);
+            return participant_owner_->sendSync(buffers, num_buffers, total_bytes,
+                           Locators(locator_info_.multicast.begin()), Locators(locator_info_.multicast.end()),
+                           max_blocking_time_point);
         }
     }
 

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -1074,18 +1074,20 @@ void StatelessWriter::add_flow_controller(
 }
 
 bool StatelessWriter::send(
-        CDRMessage_t* message,
+        const RTPSMessageSenderInterface::NetworkBuffer* buffers,
+        size_t num_buffers,
+        uint32_t total_bytes,
         std::chrono::steady_clock::time_point& max_blocking_time_point) const
 {
-    if (!RTPSWriter::send(message, max_blocking_time_point))
+    if (!RTPSWriter::send(buffers, num_buffers, total_bytes, max_blocking_time_point))
     {
         return false;
     }
 
     return ignore_fixed_locators_ ||
            fixed_locators_.empty() ||
-           mp_RTPSParticipant->sendSync(message, Locators(fixed_locators_.begin()), Locators(
-                       fixed_locators_.end()), max_blocking_time_point);
+           mp_RTPSParticipant->sendSync(buffers, num_buffers, total_bytes,
+                   Locators(fixed_locators_.begin()), Locators(fixed_locators_.end()), max_blocking_time_point);
 }
 
 } /* namespace rtps */

--- a/test/blackbox/common/BlackboxTestsPubSubFragments.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubFragments.cpp
@@ -134,7 +134,7 @@ protected:
 
         reader.startReception(data);
         // Send data
-        writer.send(data, reliable ? 0u : 10u);
+        writer.send(data, reliable ? 0u : 30u);
         ASSERT_TRUE(data.empty());
 
         // Block reader until reception finished or timeout.

--- a/test/mock/rtps/ReaderLocator/fastdds/rtps/writer/ReaderLocator.h
+++ b/test/mock/rtps/ReaderLocator/fastdds/rtps/writer/ReaderLocator.h
@@ -187,7 +187,9 @@ public:
      * @param max_blocking_time_point Future timepoint where blocking send should end.
      */
     bool send(
-            CDRMessage_t* /*message*/,
+            const RTPSMessageSenderInterface::NetworkBuffer* /*buffers*/,
+            size_t /*num_buffers*/,
+            uint32_t /*total_bytes*/,
             std::chrono::steady_clock::time_point& /*max_blocking_time_point*/) const override
     {
         return true;

--- a/test/mock/rtps/ReaderLocator/fastdds/rtps/writer/ReaderLocator.h
+++ b/test/mock/rtps/ReaderLocator/fastdds/rtps/writer/ReaderLocator.h
@@ -183,7 +183,9 @@ public:
     /**
      * Send a message through this interface.
      *
-     * @param message Pointer to the buffer with the message already serialized.
+     * @param buffers Array of buffers to gather.
+     * @param num_buffers Number of elements on @c buffers.
+     * @param total_bytes Total size of the raw data. Should be equal to the sum of the @c length field of all buffers.
      * @param max_blocking_time_point Future timepoint where blocking send should end.
      */
     bool send(

--- a/test/mock/rtps/StatefulReader/fastdds/rtps/reader/StatefulReader.h
+++ b/test/mock/rtps/StatefulReader/fastdds/rtps/reader/StatefulReader.h
@@ -29,6 +29,8 @@ class RTPSMessageSenderInterface;
 class RTPSParticipantImpl;
 struct CDRMessage_t;
 
+using NetworkBuffer = eprosima::fastdds::rtps::NetworkBuffer;
+
 class StatefulReader : public RTPSReader
 {
 public:
@@ -98,7 +100,9 @@ public:
     }
 
     bool send_sync_nts(
-            CDRMessage_t* /*message*/,
+            const NetworkBuffer* /*buffers*/,
+            size_t /*num_buffers*/,
+            uint32_t /*total_bytes*/,
             const LocatorsIterator& /*destination_locators_begin*/,
             const LocatorsIterator& /*destination_locators_end*/,
             std::chrono::steady_clock::time_point& /*max_blocking_time_point*/)


### PR DESCRIPTION
This PR extends the transport interface to avoid copying user data when encapsulating the serialized payload into the RTPS datagram.