### PR TITLE
[10700] Add FASTDDS_INSTRUMENTATION CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,6 +335,15 @@ if(EPROSIMA_BUILD AND IS_TOP_LEVEL)
 endif()
 
 ###############################################################################
+# Fast DDS instrumentation tool default setup
+###############################################################################
+option(FASTDDS_INSTRUMENTATION "Enable Fast DDS instrumentation" OFF)
+
+if (FASTDDS_INSTRUMENTATION)
+    set(HAVE_FASTDDS_INSTRUMENTATION 1)
+endif()
+
+###############################################################################
 # Compile library.
 ###############################################################################
 add_subdirectory(src/cpp)

--- a/include/fastrtps/config.h.in
+++ b/include/fastrtps/config.h.in
@@ -107,6 +107,11 @@
 #define HAVE_LOG_NO_ERROR @HAVE_LOG_NO_ERROR@
 #endif
 
+// Instrumentation
+#ifndef HAVE_FASTDDS_INSTRUMENTATION
+#define HAVE_FASTDDS_INSTRUMENTATION @HAVE_FASTDDS_INSTRUMENTATION@
+#endif
+
 // Deprecated macro
 #if __cplusplus >= 201402L
 #define FASTRTPS_DEPRECATED(msg) [[ deprecated(msg) ]]

--- a/versions.md
+++ b/versions.md
@@ -1,6 +1,8 @@
 Forthcoming
 -----------
 
+* New Fast DDS Instrumentation module (implies ABI break)
+
 Version 2.2.0
 -------------
 


### PR DESCRIPTION
New instrumentation tool requires a CMake option that enables the building of the specific code implemented for this tool to prevent taxing the performance.

Here the [related documentation PR](https://github.com/eProsima/Fast-DDS-docs/pull/239).

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>