### PR TITLE
Provide an alternative path for robustlock files under QNX <2.2.x>

### DIFF
--- a/src/cpp/rtps/DataSharing/DataSharingPayloadPool.hpp
+++ b/src/cpp/rtps/DataSharing/DataSharingPayloadPool.hpp
@@ -23,7 +23,7 @@
 #include <fastdds/rtps/history/IPayloadPool.h>
 #include <fastdds/dds/log/Log.hpp>
 #include <rtps/history/PoolConfig.h>
-#include <utils/shared_memory/RobustExclusiveLock.hpp>
+#include <utils/shared_memory/SharedDir.hpp>
 #include <utils/shared_memory/SharedMemSegment.hpp>
 
 #include <memory>

--- a/src/cpp/utils/shared_memory/RobustExclusiveLock.hpp
+++ b/src/cpp/utils/shared_memory/RobustExclusiveLock.hpp
@@ -50,7 +50,7 @@ public:
             const std::string& name,
             bool* was_lock_created)
     {
-        auto file_path = SharedDir::get_file_path(name);
+        auto file_path = SharedDir::get_lock_path(name);
 
         if ((fd_ = open_and_lock_file(file_path, was_lock_created)) == -1)
         {
@@ -70,7 +70,7 @@ public:
     {
         bool was_lock_created;
 
-        auto file_path = SharedDir::get_file_path(name);
+        auto file_path = SharedDir::get_lock_path(name);
 
         if ((fd_ = open_and_lock_file(file_path, &was_lock_created)) == -1)
         {
@@ -89,7 +89,7 @@ public:
     {
         bool was_lock_created;
 
-        auto file_path = SharedDir::get_file_path(name);
+        auto file_path = SharedDir::get_lock_path(name);
 
         int fd;
         if ((fd = open_and_lock_file(file_path, &was_lock_created)) == -1)
@@ -117,7 +117,7 @@ public:
     static bool remove(
             const std::string& name)
     {
-        return 0 == std::remove(SharedDir::get_file_path(name).c_str());
+        return 0 == std::remove(SharedDir::get_lock_path(name).c_str());
     }
 
 private:
@@ -159,9 +159,9 @@ private:
     {
         _close(fd);
 
-        if (0 != std::remove(SharedDir::get_file_path(name).c_str()))
+        if (0 != std::remove(SharedDir::get_lock_path(name).c_str()))
         {
-            logWarning(RTPS_TRANSPORT_SHM, "Failed to remove " << SharedDir::get_file_path(name));
+            logWarning(RTPS_TRANSPORT_SHM, "Failed to remove " << SharedDir::get_lock_path(name));
         }
     }
 
@@ -205,9 +205,9 @@ private:
         flock(fd, LOCK_UN | LOCK_NB);
         close(fd);
 
-        if (0 != std::remove(SharedDir::get_file_path(name).c_str()))
+        if (0 != std::remove(SharedDir::get_lock_path(name).c_str()))
         {
-            logWarning(RTPS_TRANSPORT_SHM, "Failed to remove " << SharedDir::get_file_path(name));
+            logWarning(RTPS_TRANSPORT_SHM, "Failed to remove " << SharedDir::get_lock_path(name));
         }
     }
 

--- a/src/cpp/utils/shared_memory/RobustSharedLock.hpp
+++ b/src/cpp/utils/shared_memory/RobustSharedLock.hpp
@@ -51,7 +51,7 @@ public:
             bool* was_lock_created,
             bool* was_lock_released)
     {
-        auto file_path = SharedDir::get_file_path(name);
+        auto file_path = SharedDir::get_lock_path(name);
 
         fd_ = open_and_lock_file(file_path, was_lock_created, was_lock_released);
 
@@ -68,7 +68,7 @@ public:
     {
         bool was_lock_created;
 
-        auto file_path = SharedDir::get_file_path(name);
+        auto file_path = SharedDir::get_lock_path(name);
 
         fd_ = open_and_lock_file(file_path, &was_lock_created, nullptr);
 
@@ -91,7 +91,7 @@ public:
     static bool is_locked(
             const std::string& name)
     {
-        return test_lock(SharedDir::get_file_path(name)) == LockStatus::LOCKED;
+        return test_lock(SharedDir::get_lock_path(name)) == LockStatus::LOCKED;
     }
 
     /**
@@ -102,7 +102,7 @@ public:
     static bool remove(
             const std::string& name)
     {
-        return 0 == std::remove(SharedDir::get_file_path(name).c_str());
+        return 0 == std::remove(SharedDir::get_lock_path(name).c_str());
     }
 
 private:
@@ -185,7 +185,7 @@ private:
     {
         _close(fd_);
 
-        test_lock(SharedDir::get_file_path(name_), true);
+        test_lock(SharedDir::get_lock_path(name_), true);
     }
 
     static LockStatus test_lock(
@@ -280,7 +280,7 @@ private:
         flock(fd_, LOCK_UN | LOCK_NB);
         close(fd_);
 
-        test_lock(SharedDir::get_file_path(name_), true);
+        test_lock(SharedDir::get_lock_path(name_), true);
     }
 
     static LockStatus test_lock(

--- a/src/cpp/utils/shared_memory/SharedDir.hpp
+++ b/src/cpp/utils/shared_memory/SharedDir.hpp
@@ -18,6 +18,12 @@
 #include <boostconfig.hpp>
 #include <boost/interprocess/detail/shared_dir_helpers.hpp>
 
+#ifdef __QNXNTO__
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <errno.h>
+#endif  // __QNXNTO__
+
 namespace eprosima {
 namespace fastdds {
 namespace rtps {
@@ -65,6 +71,38 @@ public:
         std::string path;
         get_default_shared_dir(path);
         return path + "/" + filename;
+    }
+
+    static std::string get_lock_path(
+            const std::string& filename)
+    {
+#ifdef __QNXNTO__
+        static const char defaultdir[] = "/var/lock";
+        struct stat buf;
+        // check directory status
+        if (stat(defaultdir, &buf) != 0)
+        {
+            // directory not found, create it
+            if (errno == ENOENT)
+            {
+                mkdir(defaultdir, 0777);
+            }
+            // if another error then throw exception
+            else
+            {
+                std::string err("get_file_path() ");
+                err = err + strerror(errno);
+                throw std::runtime_error(err);
+            }
+        }
+        else
+        {
+            // directory exists do nothing
+        }
+        return (std::string(defaultdir) + "/" + filename);
+#else
+        return SharedDir::get_file_path(filename);
+#endif  // __QNXNTO__
     }
 
 };


### PR DESCRIPTION
This is a port of #1776 to 2.2.x