### PR TITLE
[10700] Add FASTDDS_STATISTICS CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,13 +335,9 @@ if(EPROSIMA_BUILD AND IS_TOP_LEVEL)
 endif()
 
 ###############################################################################
-# Fast DDS instrumentation tool default setup
+# Fast DDS statistics tool default setup
 ###############################################################################
-option(FASTDDS_INSTRUMENTATION "Enable Fast DDS instrumentation" OFF)
-
-if (FASTDDS_INSTRUMENTATION)
-    set(HAVE_FASTDDS_INSTRUMENTATION 1)
-endif()
+option(FASTDDS_STATISTICS "Enable Fast DDS Statistics Module" OFF)
 
 ###############################################################################
 # Compile library.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,6 +335,15 @@ if(EPROSIMA_BUILD AND IS_TOP_LEVEL)
 endif()
 
 ###############################################################################
+# Fast DDS instrumentation tool default setup
+###############################################################################
+option(FASTDDS_INSTRUMENTATION "Enable Fast DDS instrumentation" OFF)
+
+if (FASTDDS_INSTRUMENTATION)
+    set(HAVE_FASTDDS_INSTRUMENTATION 1)
+endif()
+
+###############################################################################
 # Compile library.
 ###############################################################################
 add_subdirectory(src/cpp)

--- a/include/fastrtps/config.h.in
+++ b/include/fastrtps/config.h.in
@@ -107,10 +107,8 @@
 #define HAVE_LOG_NO_ERROR @HAVE_LOG_NO_ERROR@
 #endif
 
-// Instrumentation
-#ifndef HAVE_FASTDDS_INSTRUMENTATION
-#define HAVE_FASTDDS_INSTRUMENTATION @HAVE_FASTDDS_INSTRUMENTATION@
-#endif
+// Statistics
+#cmakedefine FASTDDS_STATISTICS
 
 // Deprecated macro
 #if __cplusplus >= 201402L

--- a/include/fastrtps/config.h.in
+++ b/include/fastrtps/config.h.in
@@ -107,6 +107,11 @@
 #define HAVE_LOG_NO_ERROR @HAVE_LOG_NO_ERROR@
 #endif
 
+// Instrumentation
+#ifndef HAVE_FASTDDS_INSTRUMENTATION
+#define HAVE_FASTDDS_INSTRUMENTATION @HAVE_FASTDDS_INSTRUMENTATION@
+#endif
+
 // Deprecated macro
 #if __cplusplus >= 201402L
 #define FASTRTPS_DEPRECATED(msg) [[ deprecated(msg) ]]

--- a/versions.md
+++ b/versions.md
@@ -1,7 +1,7 @@
 Forthcoming
 -----------
 
-* New Fast DDS Statistics module (implies ABI break)
+* New Fast DDS Statistics module
 
 Version 2.2.0
 -------------

--- a/versions.md
+++ b/versions.md
@@ -1,7 +1,7 @@
 Forthcoming
 -----------
 
-* New Fast DDS Instrumentation module (implies ABI break)
+* New Fast DDS Statistics module (implies ABI break)
 
 Version 2.2.0
 -------------

--- a/versions.md
+++ b/versions.md
@@ -1,6 +1,8 @@
 Forthcoming
 -----------
 
+* New Fast DDS Instrumentation module (implies ABI break)
+
 Version 2.2.0
 -------------
 


### PR DESCRIPTION
New Statistics tool requires a CMake option that enables the building of the specific code implemented for this tool to prevent taxing the performance.

Here the [related documentation PR](https://github.com/eProsima/Fast-DDS-docs/pull/241).

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>