### PR TITLE
Expose get_unread_count on DataReader [10756]

### DIFF
--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -766,6 +766,15 @@ public:
             SampleInfo* info);
 
     /**
+     * Get the number of samples pending to be read.
+     * The number includes samples that may not yet be available to be read or taken by the user, due to samples
+     * being received out of order.
+     *
+     * @return the number of samples on the reader history that have never been read.
+     */
+    RTPS_DllAPI uint64_t get_unread_count() const;
+
+    /**
      * Get associated GUID.
      *
      * @return Associated GUID

--- a/src/cpp/fastdds/subscriber/DataReader.cpp
+++ b/src/cpp/fastdds/subscriber/DataReader.cpp
@@ -252,6 +252,11 @@ ReturnCode_t DataReader::get_first_untaken_info(
     return impl_->get_first_untaken_info(info);
 }
 
+uint64_t DataReader::get_unread_count() const
+{
+    return impl_->get_unread_count();
+}
+
 const GUID_t& DataReader::guid()
 {
     return impl_->guid();

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -657,6 +657,11 @@ ReturnCode_t DataReaderImpl::get_first_untaken_info(
     return ReturnCode_t::RETCODE_NO_DATA;
 }
 
+uint64_t DataReaderImpl::get_unread_count() const
+{
+    return reader_ ? reader_->get_unread_count() : 0;
+}
+
 const GUID_t& DataReaderImpl::guid() const
 {
     return reader_ ? reader_->getGuid() : c_Guid_Unknown;

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -194,6 +194,11 @@ public:
             SampleInfo* info);
 
     /**
+     * @return the number of samples pending to be read.
+     */
+    uint64_t get_unread_count() const;
+
+    /**
      * Get associated GUID
      * @return Associated GUID
      */

--- a/test/mock/rtps/RTPSReader/fastdds/rtps/reader/RTPSReader.h
+++ b/test/mock/rtps/RTPSReader/fastdds/rtps/reader/RTPSReader.h
@@ -93,6 +93,8 @@ public:
 
     MOCK_METHOD1(wait_for_unread_cache, bool (const eprosima::fastrtps::Duration_t& timeout));
 
+    MOCK_METHOD0(get_unread_count, uint64_t());
+
     // *INDENT-ON*
 
 

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -497,7 +497,7 @@ protected:
 
         create_entities(nullptr, reader_qos, subscriber_qos);
         EXPECT_FALSE(data_reader_->is_enabled());
-        EXPECT_EQ(0, data_reader_->get_unread_count());
+        EXPECT_EQ(0ull, data_reader_->get_unread_count());
 
         // Read / take operations should all return NOT_ENABLED
         basic_read_apis_check<DataType, DataSeq>(ReturnCode_t::RETCODE_NOT_ENABLED, data_reader_);
@@ -1205,6 +1205,7 @@ TEST_F(DataReaderTests, read_unread)
 {
     static const Duration_t time_to_wait(0, 100 * 1000 * 1000);
     static constexpr int32_t num_samples = 10;
+    static constexpr uint64_t num_samples_check = static_cast<uint64_t>(num_samples);
 
     const ReturnCode_t& ok_code = ReturnCode_t::RETCODE_OK;
     const ReturnCode_t& no_data_code = ReturnCode_t::RETCODE_NO_DATA;
@@ -1241,7 +1242,7 @@ TEST_F(DataReaderTests, read_unread)
 
     // There are unread samples, so wait_for_unread should be ok
     EXPECT_TRUE(data_reader_->wait_for_unread_message(time_to_wait));
-    EXPECT_EQ(num_samples, data_reader_->get_unread_count());
+    EXPECT_EQ(num_samples_check, data_reader_->get_unread_count());
 
     // Trying to get READ samples should return NO_DATA
     {
@@ -1271,7 +1272,7 @@ TEST_F(DataReaderTests, read_unread)
         SampleInfoSeq info_seq[6];
 
         // Current state: {R, N, N, N, N, N, N, N, N, N}
-        EXPECT_EQ(num_samples, data_reader_->get_unread_count());
+        EXPECT_EQ(num_samples_check, data_reader_->get_unread_count());
 
         // This should return the first sample
         EXPECT_EQ(ok_code, data_reader_->read(data_seq[0], info_seq[0], 1, NOT_READ_SAMPLE_STATE));
@@ -1279,7 +1280,7 @@ TEST_F(DataReaderTests, read_unread)
         check_sample_values(data_seq[0], "0");
 
         // Current state: {R, N, N, N, N, N, N, N, N, N}
-        EXPECT_EQ(num_samples - 1, data_reader_->get_unread_count());
+        EXPECT_EQ(num_samples_check - 1, data_reader_->get_unread_count());
 
         // This should return the first sample
         EXPECT_EQ(ok_code, data_reader_->read(data_seq[1], info_seq[1], 1, READ_SAMPLE_STATE));
@@ -1287,7 +1288,7 @@ TEST_F(DataReaderTests, read_unread)
         check_sample_values(data_seq[1], "0");
 
         // Current state: {R, N, N, N, N, N, N, N, N, N}
-        EXPECT_EQ(num_samples - 1, data_reader_->get_unread_count());
+        EXPECT_EQ(num_samples_check - 1, data_reader_->get_unread_count());
 
         // This should return the first sample
         EXPECT_EQ(ok_code, data_reader_->read(data_seq[2], info_seq[2], LENGTH_UNLIMITED, READ_SAMPLE_STATE));
@@ -1295,7 +1296,7 @@ TEST_F(DataReaderTests, read_unread)
         check_sample_values(data_seq[2], "0");
 
         // Current state: {R, N, N, N, N, N, N, N, N, N}
-        EXPECT_EQ(num_samples - 1, data_reader_->get_unread_count());
+        EXPECT_EQ(num_samples_check - 1, data_reader_->get_unread_count());
 
         // This should return the second sample
         EXPECT_EQ(ok_code, data_reader_->read(data_seq[3], info_seq[3], 1, NOT_READ_SAMPLE_STATE));
@@ -1303,7 +1304,7 @@ TEST_F(DataReaderTests, read_unread)
         check_sample_values(data_seq[3], "1");
 
         // Current state: {R, R, N, N, N, N, N, N, N, N}
-        EXPECT_EQ(num_samples - 2, data_reader_->get_unread_count());
+        EXPECT_EQ(num_samples_check - 2, data_reader_->get_unread_count());
 
         // This should return the first sample
         EXPECT_EQ(ok_code, data_reader_->read(data_seq[4], info_seq[4], 1, READ_SAMPLE_STATE));
@@ -1311,7 +1312,7 @@ TEST_F(DataReaderTests, read_unread)
         check_sample_values(data_seq[4], "0");
 
         // Current state: {R, R, N, N, N, N, N, N, N, N}
-        EXPECT_EQ(num_samples - 2, data_reader_->get_unread_count());
+        EXPECT_EQ(num_samples_check - 2, data_reader_->get_unread_count());
 
         // This should return the first and second samples
         EXPECT_EQ(ok_code, data_reader_->read(data_seq[5], info_seq[5], LENGTH_UNLIMITED, READ_SAMPLE_STATE));
@@ -1334,7 +1335,7 @@ TEST_F(DataReaderTests, read_unread)
         SampleInfoSeq info_seq[6];
 
         // Current state: {R, R, N, N, N, N, N, N, N, N}
-        EXPECT_EQ(num_samples - 2, data_reader_->get_unread_count());
+        EXPECT_EQ(num_samples_check - 2, data_reader_->get_unread_count());
 
         // This should return the third sample
         EXPECT_EQ(ok_code, data_reader_->take(data_seq[0], info_seq[0], 1, NOT_READ_SAMPLE_STATE));
@@ -1342,7 +1343,7 @@ TEST_F(DataReaderTests, read_unread)
         check_sample_values(data_seq[0], "2");
 
         // Current state: {R, R, /, N, N, N, N, N, N, N}
-        EXPECT_EQ(num_samples - 3, data_reader_->get_unread_count());
+        EXPECT_EQ(num_samples_check - 3, data_reader_->get_unread_count());
 
         // This should return the first sample
         EXPECT_EQ(ok_code, data_reader_->take(data_seq[1], info_seq[1], 1, READ_SAMPLE_STATE));
@@ -1350,7 +1351,7 @@ TEST_F(DataReaderTests, read_unread)
         check_sample_values(data_seq[1], "0");
 
         // Current state: {/, R, /, N, N, N, N, N, N, N}
-        EXPECT_EQ(num_samples - 3, data_reader_->get_unread_count());
+        EXPECT_EQ(num_samples_check - 3, data_reader_->get_unread_count());
 
         // This should return samples 2 and 4
         EXPECT_EQ(ok_code, data_reader_->take(data_seq[2], info_seq[2], 2));
@@ -1358,14 +1359,14 @@ TEST_F(DataReaderTests, read_unread)
         check_sample_values(data_seq[2], "13");
 
         // Current state: {/, /, /, /, N, N, N, N, N, N}
-        EXPECT_EQ(num_samples - 4, data_reader_->get_unread_count());
+        EXPECT_EQ(num_samples_check - 4, data_reader_->get_unread_count());
 
         // This should return no data
         EXPECT_EQ(no_data_code, data_reader_->take(data_seq[3], info_seq[3], LENGTH_UNLIMITED, READ_SAMPLE_STATE));
         check_collection(data_seq[3], true, 0, 0);
 
         // Current state: {/, /, /, /, N, N, N, N, N, N}
-        EXPECT_EQ(num_samples - 4, data_reader_->get_unread_count());
+        EXPECT_EQ(num_samples_check - 4, data_reader_->get_unread_count());
 
         // This should return samples 5 and 6
         EXPECT_EQ(ok_code, data_reader_->read(data_seq[3], info_seq[3], 2));
@@ -1373,7 +1374,7 @@ TEST_F(DataReaderTests, read_unread)
         check_sample_values(data_seq[3], "45");
 
         // Current state: {/, /, /, /, R, R, N, N, N, N}
-        EXPECT_EQ(num_samples - 6, data_reader_->get_unread_count());
+        EXPECT_EQ(num_samples_check - 6, data_reader_->get_unread_count());
 
         // This should return samples 7, ... num_samples
         EXPECT_EQ(ok_code, data_reader_->take(data_seq[4], info_seq[4], LENGTH_UNLIMITED, NOT_READ_SAMPLE_STATE));
@@ -1381,13 +1382,13 @@ TEST_F(DataReaderTests, read_unread)
         check_sample_values(data_seq[4], "6789");
 
         // Current state: {/, /, /, /, R, R, /, /, /, /}
-        EXPECT_EQ(num_samples - 10, data_reader_->get_unread_count());
+        EXPECT_EQ(num_samples_check - 10, data_reader_->get_unread_count());
 
         // There are not unread samples, so wait_for_unread should return false
         EXPECT_FALSE(data_reader_->wait_for_unread_message(time_to_wait));
 
         // Current state: {/, /, /, /, R, R, /, /, /, /}
-        EXPECT_EQ(num_samples - 10, data_reader_->get_unread_count());
+        EXPECT_EQ(num_samples_check - 10, data_reader_->get_unread_count());
 
         // Add a new sample to have a NOT_READ one
         data.message()[0] = 'A';
@@ -1397,7 +1398,7 @@ TEST_F(DataReaderTests, read_unread)
         EXPECT_TRUE(data_reader_->wait_for_unread_message(time_to_wait));
 
         // Current state: {/, /, /, /, R, R, /, /, /, /, N}
-        EXPECT_EQ(num_samples - 10 + 1, data_reader_->get_unread_count());
+        EXPECT_EQ(num_samples_check - 10 + 1, data_reader_->get_unread_count());
 
         // This should return samples 5, 6 and new
         EXPECT_EQ(ok_code, data_reader_->take(data_seq[5], info_seq[5]));
@@ -1405,7 +1406,7 @@ TEST_F(DataReaderTests, read_unread)
         check_sample_values(data_seq[5], "45A");
 
         // Current state: {/, /, /, /, /, /, /, /, /, /, /}
-        EXPECT_EQ(num_samples - 10 + 1 - 1, data_reader_->get_unread_count());
+        EXPECT_EQ(num_samples_check - 10 + 1 - 1, data_reader_->get_unread_count());
 
         // There are not unread samples, so wait_for_unread should return false
         EXPECT_FALSE(data_reader_->wait_for_unread_message(time_to_wait));

--- a/versions.md
+++ b/versions.md
@@ -1,6 +1,8 @@
 Forthcoming
 -----------
 
+* Added eprosima::fastdds::dds::DataReader::get_unread_count (ABI break)
+
 Version 2.2.0
 -------------
 


### PR DESCRIPTION
The old `Subscriber` API has a `get_unread_count` method. This PR adds the equivalent on DataReader along with checks for it on the DataReader unit tests.