### PR TITLE
Fix fastrtps API test compilation [10480]

### DIFF
--- a/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
@@ -1207,8 +1207,8 @@ private:
             std::unique_lock<std::mutex> lock(mutex_);
 
             // Check order of changes.
-            ASSERT_LT(last_seq[info.instance_handle], info.sample_identity.sequence_number());
-            last_seq[info.instance_handle] = info.sample_identity.sequence_number();
+            ASSERT_LT(last_seq[info.iHandle], info.sample_identity.sequence_number());
+            last_seq[info.iHandle] = info.sample_identity.sequence_number();
 
             if (info.sampleKind == eprosima::fastrtps::rtps::ALIVE)
             {


### PR DESCRIPTION
eProsima/Fast-DDS#1732 introduced a regression on fastrtps API compilation. This PR corrects the compilation with `-DFASTRTPS_API_TESTS=ON`

Signed-off-by: EduPonz <eduardoponz@eprosima.com>