### PR TITLE
[10787] Fix doxygen documentation

### DIFF
--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -583,7 +583,7 @@ public:
     /**
      * This operation checks whether or not the given handle represents an Entity that was created from the
      * DomainParticipant.
-     * @param handle InstanceHandle of the entity to look for.
+     * @param a_handle InstanceHandle of the entity to look for.
      * @param recursive The containment applies recursively. That is, it applies both to entities
      * (TopicDescription, Publisher, or Subscriber) created directly using the DomainParticipant as well as
      * entities created using a contained Publisher, or Subscriber as the factory, and so forth. (default: true)

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -520,7 +520,7 @@ public:
      * 
      * See the description on @ref loan_sample for how and when to call this method.
      * 
-     * @param [in][out] sample  Pointer to the previously loaned sample.
+     * @param [in,out] sample  Pointer to the previously loaned sample.
      * 
      * @return ReturnCode_t::RETCODE_ILLEGAL_OPERATION when the data type does not support loans.
      * @return ReturnCode_t::RETCODE_NOT_ENABLED if the writer has not been enabled.

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -201,10 +201,10 @@ public:
      * The @ref eprosima::fastdds::dds::SampleInfo::source_timestamp "source_timestamp" potentially affects the relative
      * order in which readers observe events from multiple writers. See the QoS policy
      * @ref eprosima::fastdds::dds::DataWriterQos::destination_order "DESTINATION_ORDER".
-     * 
+     *
      * This operation may block and return RETCODE_TIMEOUT under the same circumstances described for the @ref write
      * operation.
-     * 
+     *
      * This operation may return RETCODE_OUT_OF_RESOURCES under the same circumstances described for the
      * @ref write operation.
      *
@@ -237,10 +237,10 @@ public:
      * The @ref eprosima::fastdds::dds::SampleInfo::source_timestamp "source_timestamp" potentially affects the relative
      * order in which readers observe events from multiple writers. See the QoS policy
      * @ref eprosima::fastdds::dds::DataWriterQos::destination_order "DESTINATION_ORDER".
-     * 
+     *
      * The constraints on the values of the @c handle parameter and the corresponding error behavior are the same
      * specified for the @ref unregister_instance operation.
-     * 
+     *
      * This operation may block and return RETCODE_TIMEOUT under the same circumstances described for the write
      * operation
      *
@@ -416,13 +416,13 @@ public:
      * for the @ref eprosima::fastdds::dds::SampleInfo::source_timestamp "source_timestamp" that is made available to
      * DataReader objects by means of the @ref eprosima::fastdds::dds::SampleInfo::source_timestamp "source_timestamp"
      * attribute inside the SampleInfo.
-     * 
+     *
      * The constraints on the values of the @c handle parameter and the corresponding error behavior are the same
      * specified for the @ref dispose operation.
-     * 
+     *
      * This operation may return RETCODE_PRECONDITION_NOT_MET and RETCODE_BAD_PARAMETER under the same circumstances
      * described for the @ref dispose operation.
-     * 
+     *
      * This operation may return RETCODE_TIMEOUT and RETCODE_OUT_OF_RESOURCES under the same circumstances described
      * for the @ref write operation.
      *
@@ -517,11 +517,11 @@ public:
 
     /**
      * @brief Discards a loaned sample pointer.
-     * 
+     *
      * See the description on @ref loan_sample for how and when to call this method.
-     * 
+     *
      * @param [in,out] sample  Pointer to the previously loaned sample.
-     * 
+     *
      * @return ReturnCode_t::RETCODE_ILLEGAL_OPERATION when the data type does not support loans.
      * @return ReturnCode_t::RETCODE_NOT_ENABLED if the writer has not been enabled.
      * @return ReturnCode_t::RETCODE_BAD_PARAMETER if the pointer does not correspond to a loaned sample.

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -164,12 +164,12 @@ public:
 
     /** NOT YET IMPLEMENTED
      * @brief This operation performs the same function as write except that it also provides the value for the
-     * \ref eprosima::fastdds::dds::SampleInfo::source_timestamp "source_timestamp" that is made available to DataReader
-     * objects by means of the \ref eprosima::fastdds::dds::SampleInfo::source_timestamp attribute "source_timestamp"
+     * @ref eprosima::fastdds::dds::SampleInfo::source_timestamp "source_timestamp" that is made available to DataReader
+     * objects by means of the @ref eprosima::fastdds::dds::SampleInfo::source_timestamp attribute "source_timestamp"
      * inside the SampleInfo.
      * The constraints on the values of the @c handle parameter and the corresponding error behavior are the same
-     * specified for the \ref write operation. This operation may block and return RETCODE_TIMEOUT under the same
-     * circumstances described for the \ref write operation.
+     * specified for the @ref write operation. This operation may block and return RETCODE_TIMEOUT under the same
+     * circumstances described for the @ref write operation.
      * This operation may return RETCODE_OUT_OF_RESOURCES, RETCODE_PRECONDITION_NOT_MET or RETCODE_BAD_PARAMETER under
      * the same circumstances described for the write operation.
      *

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -164,11 +164,12 @@ public:
 
     /** NOT YET IMPLEMENTED
      * @brief This operation performs the same function as write except that it also provides the value for the
-     * @ref source_timestamp that is made available to DataReader objects by means of the @ref source_timestamp
-     * attribute inside the SampleInfo.
+     * \ref eprosima::fastdds::dds::SampleInfo::source_timestamp "source_timestamp" that is made available to DataReader
+     * objects by means of the \ref eprosima::fastdds::dds::SampleInfo::source_timestamp attribute "source_timestamp"
+     * inside the SampleInfo.
      * The constraints on the values of the @c handle parameter and the corresponding error behavior are the same
-     * specified for the @ref write operation. This operation may block and return RETCODE_TIMEOUT under the same
-     * circumstances described for the @ref write operation.
+     * specified for the \ref write operation. This operation may block and return RETCODE_TIMEOUT under the same
+     * circumstances described for the \ref write operation.
      * This operation may return RETCODE_OUT_OF_RESOURCES, RETCODE_PRECONDITION_NOT_MET or RETCODE_BAD_PARAMETER under
      * the same circumstances described for the write operation.
      *
@@ -196,10 +197,16 @@ public:
     /** NOT YET IMPLEMENTED
      * @brief This operation performs the same function as register_instance and can be used instead of
      * @ref register_instance in the cases where the application desires to specify the value for the
-     * @ref source_timestamp. The @ref source_timestamp potentially affects the relative order in which readers observe
-     * events from multiple writers. See the QoS policy @ref DESTINATION_ORDER. This operation may block and return
-     * RETCODE_TIMEOUT under the same circumstances described for the @ref write operation. This operation may return
-     * RETCODE_OUT_OF_RESOURCES under the same circumstances described for the @ref write operation.
+     * @ref eprosima::fastdds::dds::SampleInfo::source_timestamp "source_timestamp".
+     * The @ref eprosima::fastdds::dds::SampleInfo::source_timestamp "source_timestamp" potentially affects the relative
+     * order in which readers observe events from multiple writers. See the QoS policy
+     * @ref eprosima::fastdds::dds::DataWriterQos::destination_order "DESTINATION_ORDER".
+     * 
+     * This operation may block and return RETCODE_TIMEOUT under the same circumstances described for the @ref write
+     * operation.
+     * 
+     * This operation may return RETCODE_OUT_OF_RESOURCES under the same circumstances described for the
+     * @ref write operation.
      *
      * @param instance  Sample used to get the instance's key.
      * @param timestamp Time_t used to set the source_timestamp.
@@ -226,10 +233,14 @@ public:
     /** NOT YET IMPLEMENTED
      * @brief This operation performs the same function as @ref unregister_instance and can be used instead of
      * @ref unregister_instance in the cases where the application desires to specify the value for the
-     * @ref source_timestamp. The @ref source_timestamp potentially affects the relative order in which readers observe
-     * events from multiple writers. RETCODE_DESTINATION_ORDER).
+     * @ref eprosima::fastdds::dds::SampleInfo::source_timestamp "source_timestamp".
+     * The @ref eprosima::fastdds::dds::SampleInfo::source_timestamp "source_timestamp" potentially affects the relative
+     * order in which readers observe events from multiple writers. See the QoS policy
+     * @ref eprosima::fastdds::dds::DataWriterQos::destination_order "DESTINATION_ORDER".
+     * 
      * The constraints on the values of the @c handle parameter and the corresponding error behavior are the same
      * specified for the @ref unregister_instance operation.
+     * 
      * This operation may block and return RETCODE_TIMEOUT under the same circumstances described for the write
      * operation
      *
@@ -244,14 +255,15 @@ public:
             const fastrtps::rtps::Time_t& timestamp);
 
     /** NOT YET IMPLEMENTED
-     * This operation can be used to retrieve the instance key that corresponds to an @ref instance_handle.
-     * The operation will only fill the fields that form the key inside the @ref key_holder instance.
+     * This operation can be used to retrieve the instance key that corresponds to an
+     * @ref eprosima::fastdds::dds::Entity::instance_handle_ "instance_handle".
+     * The operation will only fill the fields that form the key inside the key_holder instance.
      *
-     * This operation may return BAD_PARAMETER if the InstanceHandle_t a_handle does not correspond to an existing
+     * This operation may return BAD_PARAMETER if the InstanceHandle_t handle does not correspond to an existing
      * data-object known to the DataWriter. If the implementation is not able to check invalid handles then the result
      * in this situation is unspecified.
      *
-     * @param[in,out] key
+     * @param[in,out] key_holder
      * @param[in] handle
      *
      * @return Any of the standard return codes.
@@ -401,12 +413,16 @@ public:
 
     /**
      * @brief This operation performs the same functions as @ref dispose except that the application provides the value
-     * for the @ref source_timestamp that is made available to DataReader objects by means of the @ref source_timestamp
+     * for the @ref eprosima::fastdds::dds::SampleInfo::source_timestamp "source_timestamp" that is made available to
+     * DataReader objects by means of the @ref eprosima::fastdds::dds::SampleInfo::source_timestamp "source_timestamp"
      * attribute inside the SampleInfo.
+     * 
      * The constraints on the values of the @c handle parameter and the corresponding error behavior are the same
      * specified for the @ref dispose operation.
+     * 
      * This operation may return RETCODE_PRECONDITION_NOT_MET and RETCODE_BAD_PARAMETER under the same circumstances
      * described for the @ref dispose operation.
+     * 
      * This operation may return RETCODE_TIMEOUT and RETCODE_OUT_OF_RESOURCES under the same circumstances described
      * for the @ref write operation.
      *
@@ -501,11 +517,11 @@ public:
 
     /**
      * @brief Discards a loaned sample pointer.
-     *
+     * 
      * See the description on @ref loan_sample for how and when to call this method.
-     *
+     * 
      * @param [in][out] sample  Pointer to the previously loaned sample.
-     *
+     * 
      * @return ReturnCode_t::RETCODE_ILLEGAL_OPERATION when the data type does not support loans.
      * @return ReturnCode_t::RETCODE_NOT_ENABLED if the writer has not been enabled.
      * @return ReturnCode_t::RETCODE_BAD_PARAMETER if the pointer does not correspond to a loaned sample.

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -170,7 +170,7 @@ public:
      *    is able to read samples belonging to different DataReader objects in a specific order.
      *
      * In any case, the relative order between the samples of one instance is consistent with the
-     * @ref DestinationOrderQosPolicy:
+     * @ref eprosima::fastdds::dds::DestinationOrderQosPolicy "DestinationOrderQosPolicy":
      *
      * - If @ref DestinationOrderQosPolicy::kind is @ref BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS, samples
      *   belonging to the same instances will appear in the relative order in which there were received (FIFO,
@@ -180,7 +180,8 @@ public:
      *   smaller values of source_timestamp ahead of the larger values).
      *
      * The actual number of samples returned depends on the information that has been received by the middleware
-     * as well as the @ref HistoryQosPolicy, @ref ResourceLimitsQosPolicy, and @ref ReaderResourceLimitsQos:
+     * as well as the @ref HistoryQosPolicy, @ref ResourceLimitsQosPolicy, and
+     * @ref eprosima::fastdds::dds::ReaderResourceLimitsQos "ReaderResourceLimitsQos":
      *
      * - In the case where the @ref HistoryQosPolicy::kind is KEEP_LAST_HISTORY_QOS, the call will return at most
      *   @ref HistoryQosPolicy::depth samples per instance.
@@ -290,14 +291,14 @@ public:
             InstanceStateMask instance_states = ANY_INSTANCE_STATE);
 
     /** NOT YET IMPLEMENTED
-     * This operation accesses via ‘read’ the samples that match the criteria specified in the @ref ReadCondition.
-     * This operation is especially useful in combination with @ref QueryCondition to filter data samples based on the
+     * This operation accesses via ‘read’ the samples that match the criteria specified in the ReadCondition.
+     * This operation is especially useful in combination with QueryCondition to filter data samples based on the
      * content.
      *
-     * The specified @ref ReadCondition must be attached to the DataReader; otherwise the operation will fail and return
+     * The specified ReadCondition must be attached to the DataReader; otherwise the operation will fail and return
      * RETCODE_PRECONDITION_NOT_MET.
      *
-     * In case the @ref ReadCondition is a ‘plain’ @ref ReadCondition and not the specialized @ref QueryCondition, the
+     * In case the ReadCondition is a ‘plain’ ReadCondition and not the specialized QueryCondition, the
      * operation is equivalent to calling read and passing as @c sample_states, @c view_states and @c instance_states
      * the value of the corresponding attributes in @c a_condition. Using this operation the application can avoid
      * repeating the same parameters specified when creating the ReadCondition.
@@ -332,7 +333,7 @@ public:
      * The DataReader will check that the sample belongs to the specified instance and otherwise it will not place
      * the sample in the returned collection.
      *
-     * The behavior of this operation follows the same rules as the @read operation regarding the pre-conditions and
+     * The behavior of this operation follows the same rules as the @ref read operation regarding the pre-conditions and
      * post-conditions for the @c data_values and @c sample_infos. Similar to @ref read, this operation may 'loan'
      * elements to the output collections, which must then be returned by means of @ref return_loan.
      *
@@ -398,7 +399,7 @@ public:
      * @ref NOT_ALIVE_NO_WRITERS_INSTANCE_STATE instance, returns the loan (at which point the instance information
      * may be removed, and thus the handle becomes invalid), and tries to read the next instance.
      *
-     * The behavior of this operation follows the same rules as the @read operation regarding the pre-conditions and
+     * The behavior of this operation follows the same rules as the @ref read operation regarding the pre-conditions and
      * post-conditions for the @c data_values and @c sample_infos. Similar to @ref read, this operation may 'loan'
      * elements to the output collections, which must then be returned by means of @ref return_loan.
      *
@@ -599,7 +600,7 @@ public:
      * Similar to the operation @ref read_next_instance, it is possible to call this operation with a
      * @c previous_handle that does not correspond to an instance currently managed by the DataReader.
      *
-     * The behavior of this operation follows the same rules as the @read operation regarding the pre-conditions and
+     * The behavior of this operation follows the same rules as the @ref read operation regarding the pre-conditions and
      * post-conditions for the @c data_values and @c sample_infos. Similar to @ref read, this operation may 'loan'
      * elements to the output collections, which must then be returned by means of @ref return_loan.
      *
@@ -631,7 +632,7 @@ public:
      * This operation accesses a collection of Data values from the DataReader. The behavior is identical to
      *  @ref read_next_instance except that all samples returned satisfy the specified condition. In other words, on
      * success all returned samples belong to the same instance, and the instance is the instance with ‘smallest’
-     *  @ref instance_handle among the ones that verify (a) @ref instance_handle >= @c previous_handle and (b) have
+     *  @c instance_handle among the ones that verify (a) @c instance_handle >= @c previous_handle and (b) have
      * samples for which the specified ReadCondition evaluates to TRUE.
      *
      * Similar to the operation @ref read_next_instance it is possible to call @ref read_next_instance_w_condition with
@@ -727,14 +728,14 @@ public:
             SampleInfoSeq& sample_infos);
 
     /** NOT YET IMPLEMENTED
-     * This operation can be used to retrieve the instance key that corresponds to an @ref instance_handle. The operation
-     * will only fill the fields that form the key inside the @ref key_holder instance.
+     * This operation can be used to retrieve the instance key that corresponds to an @c instance_handle. The operation
+     * will only fill the fields that form the key inside the key_holder instance.
      *
      * This operation may return BAD_PARAMETER if the InstanceHandle_t a_handle does not correspond to an existing
      * data-object known to the DataReader. If the implementation is not able to check invalid handles then the result
      * in this situation is unspecified.
      *
-     * @param[in,out] key
+     * @param[in,out] key_holder
      * @param[in] handle
      *
      * @return Any of the standard return codes.

--- a/include/fastdds/rtps/participant/RTPSParticipant.h
+++ b/include/fastdds/rtps/participant/RTPSParticipant.h
@@ -250,8 +250,8 @@ public:
             const WriterAttributes& writer_attributes);
 
     /**
-     * @brief Checks whether the writer has security attributes enabled
-     * @param writer_attributes Attributes of the writer as given to the RTPSParticipantImpl::create_writer
+     * @brief Checks whether the reader has security attributes enabled
+     * @param reader_attributes Attributes of the reader as given to the RTPSParticipantImpl::create_reader
      */
 
     bool is_security_enabled_for_reader(

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -116,7 +116,7 @@ public:
     /**
      * Discards a loaned sample pointer.
      *
-     * @param [in][out] sample  Pointer to the previously loaned sample.
+     * @param [in,out] sample  Pointer to the previously loaned sample.
      *
      * @return ReturnCode_t::RETCODE_ILLEGAL_OPERATION when the type does not support loans.
      * @return ReturnCode_t::RETCODE_BAD_PARAMETER if the pointer does not correspond to a loaned sample.


### PR DESCRIPTION
When building the doxygen documentation several warnings were issued due to current additions to the DataReader and DataWriter APIs. This PR solves those warnings with the following exception:

Doxygen issues this warning:

```
[workspace]/build/code/external/eprosima/src/fastdds/include/fastdds/rtps/attributes/ServerAttributes.h:74: warning: Found ';' while parsing initializer list! (doxygen could be confused by a macro call without semicolon)
```

This warning is caused by the `FASTDDS_DEPRECATED_UNTIL` macro and no easy solution have been found.

Labelled as `skip-ci` because this PR only modifies comments.