### PR TITLE
Bugfix/intraprocess datasharing [10845]

### DIFF
--- a/include/fastdds/dds/topic/TypeSupport.hpp
+++ b/include/fastdds/dds/topic/TypeSupport.hpp
@@ -138,10 +138,7 @@ public:
      */
     RTPS_DllAPI virtual bool serialize(
             void* data,
-            fastrtps::rtps::SerializedPayload_t* payload)
-    {
-        return get()->serialize(data, payload);
-    }
+            fastrtps::rtps::SerializedPayload_t* payload);
 
     /**
      * @brief Deserializes the data
@@ -151,10 +148,7 @@ public:
      */
     RTPS_DllAPI virtual bool deserialize(
             fastrtps::rtps::SerializedPayload_t* payload,
-            void* data)
-    {
-        return get()->deserialize(payload, data);
-    }
+            void* data);
 
     /**
      * @brief Getter for the SerializedSizeProvider

--- a/include/fastdds/rtps/reader/StatefulReader.h
+++ b/include/fastdds/rtps/reader/StatefulReader.h
@@ -225,7 +225,7 @@ public:
      */
     inline size_t getMatchedWritersSize() const
     {
-        return matched_writers_.size() + matched_datasharing_writers_.size();
+        return matched_writers_.size();
     }
 
     /*!
@@ -356,8 +356,6 @@ private:
     bool disable_positive_acks_;
     //! False when being destroyed
     bool is_alive_;
-    //! Vector containing pointers to the active DataSharing WriterProxies.
-    ResourceLimitedVector<WriterProxy*> matched_datasharing_writers_;
 };
 
 } /* namespace rtps */

--- a/include/fastdds/rtps/reader/StatelessReader.h
+++ b/include/fastdds/rtps/reader/StatelessReader.h
@@ -258,6 +258,7 @@ private:
         GUID_t persistence_guid;
         bool has_manual_topic_liveliness = false;
         CacheChange_t* fragmented_change = nullptr;
+        bool is_datasharing = false;
     };
 
     bool acceptMsgFrom(

--- a/include/fastdds/rtps/writer/RTPSWriter.h
+++ b/include/fastdds/rtps/writer/RTPSWriter.h
@@ -440,13 +440,6 @@ public:
      */
     bool is_datasharing_compatible() const;
 
-    /**
-     * @param source_timestamp the timestamp of the payload we want to recycle
-     * @return whether a payload with the given source timestamp can be reused for a new change
-     */
-    virtual bool is_datasharing_payload_reusable(
-            const Time_t& source_timestamp) const = 0;
-
 protected:
 
     //!Is the data sent directly or announced by HB and THEN sent to the ones who ask for it?.

--- a/include/fastdds/rtps/writer/StatefulWriter.h
+++ b/include/fastdds/rtps/writer/StatefulWriter.h
@@ -381,13 +381,6 @@ public:
      */
     const fastdds::rtps::IReaderDataFilter* reader_data_filter() const;
 
-    /**
-     * @param source_timestamp the timestamp of the payload we want to recycle
-     * @return whether a payload with the given source timestamp can be reused for a new change
-     */
-    bool is_datasharing_payload_reusable(
-            const Time_t& source_timestamp) const override;
-
 private:
 
     bool is_acked_by_all(

--- a/include/fastdds/rtps/writer/StatelessWriter.h
+++ b/include/fastdds/rtps/writer/StatelessWriter.h
@@ -180,13 +180,6 @@ public:
                + matched_datasharing_readers_.size();
     }
 
-    /**
-     * @param source_timestamp the timestamp of the payload we want to recycle
-     * @return whether a payload with the given source timestamp can be reused for a new change
-     */
-    bool is_datasharing_payload_reusable(
-            const Time_t& source_timestamp) const override;
-
 private:
 
     void init(

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -686,7 +686,7 @@ ReturnCode_t DataWriterImpl::perform_create_new_change(
     bool was_loaned = check_and_remove_loan(data, payload);
     if (!was_loaned)
     {
-        if (!get_free_payload_from_pool(type_->getSerializedSizeProvider(data), payload, max_blocking_time))
+        if (!get_free_payload_from_pool(type_->getSerializedSizeProvider(data), payload))
         {
             return ReturnCode_t::RETCODE_OUT_OF_RESOURCES;
         }

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -464,46 +464,6 @@ protected:
     template<typename SizeFunctor>
     bool get_free_payload_from_pool(
             const SizeFunctor& size_getter,
-            PayloadInfo_t& payload,
-            const std::chrono::time_point<std::chrono::steady_clock>& max_blocking_time)
-    {
-        CacheChange_t change;
-        if (!payload_pool_)
-        {
-            return false;
-        }
-
-        uint32_t size = fixed_payload_size_ ? fixed_payload_size_ : size_getter();
-        if (is_data_sharing_compatible_)
-        {
-            auto pool = std::dynamic_pointer_cast<eprosima::fastrtps::rtps::DataSharingPayloadPool>(payload_pool_);
-            assert (pool != nullptr);
-
-            bool payload_reserved = pool->wait_until(max_blocking_time,
-                            [&]()
-                            {
-                                return pool->get_payload(size, change);
-                            });
-            if (!payload_reserved)
-            {
-                return false;
-            }
-        }
-        else
-        {
-            if (!payload_pool_->get_payload(size, change))
-            {
-                return false;
-            }
-        }
-
-        payload.move_from_change(change);
-        return true;
-    }
-
-    template<typename SizeFunctor>
-    bool get_free_payload_from_pool(
-            const SizeFunctor& size_getter,
             PayloadInfo_t& payload)
     {
         CacheChange_t change;

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
@@ -192,6 +192,9 @@ struct ReadTakeCommand
                 sample_infos_[slot].sample_rank = n;
                 ++n;
             }
+
+            // Mark that some data is available
+            return_value_ = ReturnCode_t::RETCODE_OK;
         }
 
         next_instance();
@@ -292,9 +295,6 @@ private:
             --remaining_samples_;
             ret_val = true;
         }
-
-        // Mark that some data is available
-        return_value_ = ReturnCode_t::RETCODE_OK;
 
         // Finish when there are no remaining samples
         finished_ = (remaining_samples_ == 0);

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
@@ -84,7 +84,11 @@ struct ReadTakeCommand
         assert(0 <= remaining_samples_);
 
         current_slot_ = data_values_.length();
-        finished_ = nullptr == instance.second;
+        finished_ = nullptr == instance.second || remaining_samples_ == 0;
+        if (remaining_samples_ == 0)
+        {
+            return_value_ = ReturnCode_t::RETCODE_OK;
+        }
     }
 
     ~ReadTakeCommand()
@@ -100,6 +104,13 @@ struct ReadTakeCommand
     bool add_instance(
             bool take_samples)
     {
+        // Shortcut for null size requests
+        if (0 == remaining_samples_ && ReturnCode_t::RETCODE_NO_DATA == return_value_)
+        {
+            return_value_ = ReturnCode_t::RETCODE_OK;
+            return false;
+        }
+
         // Advance to the first instance with a valid state
         if (!go_to_first_valid_instance())
         {

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
@@ -380,19 +380,13 @@ private:
             WriterProxy* wp)
     {
         bool is_valid = true;
-        if (has_ownership)                          //< On loans the user must check the validity anyways
+        if (has_ownership)  //< On loans the user must check the validity anyways
         {
-            if (wp                                  //< On reliable we can use the wp (efficiency)
-                && wp->is_datasharing_writer())     //< This check only has sense on datasharing
+            DataSharingPayloadPool* pool = dynamic_cast<DataSharingPayloadPool*>(change->payload_owner());
+            if (pool)
             {
                 //Check if the payload is dirty
-                is_valid = DataSharingPayloadPool::check_sequence_number(
-                        change->serializedPayload.data, change->sequenceNumber);
-            }
-            else
-            {
-                //Check if the payload is dirty
-                is_valid = reader_->is_sample_valid(change->serializedPayload.data, change->writerGUID, change->sequenceNumber);
+                is_valid = pool->is_sample_valid(*change);
             }
         }
 

--- a/src/cpp/fastdds/topic/TypeSupport.cpp
+++ b/src/cpp/fastdds/topic/TypeSupport.cpp
@@ -51,7 +51,7 @@ bool TypeSupport::serialize(
     {
         result = get()->serialize(data, payload);
     }
-    catch (eprosima::fastcdr::exception::Exception& e)
+    catch (eprosima::fastcdr::exception::Exception&)
     {
         result = false;
     }
@@ -68,7 +68,7 @@ bool TypeSupport::deserialize(
     {
         result = get()->deserialize(payload, data);
     }
-    catch (eprosima::fastcdr::exception::Exception& e)
+    catch (eprosima::fastcdr::exception::Exception&)
     {
         result = false;
     }

--- a/src/cpp/fastdds/topic/TypeSupport.cpp
+++ b/src/cpp/fastdds/topic/TypeSupport.cpp
@@ -72,7 +72,7 @@ bool TypeSupport::deserialize(
     {
         result = false;
     }
-    
+
     return result;
 }
 

--- a/src/cpp/fastdds/topic/TypeSupport.cpp
+++ b/src/cpp/fastdds/topic/TypeSupport.cpp
@@ -20,6 +20,9 @@
 #include <fastdds/dds/topic/TypeSupport.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 
+#include <fastcdr/exceptions/Exception.h>
+
+
 namespace eprosima {
 namespace fastdds {
 namespace dds {
@@ -37,6 +40,34 @@ ReturnCode_t TypeSupport::register_type(
         DomainParticipant* participant) const
 {
     return participant->register_type(*this, get_type_name());
+}
+
+bool TypeSupport::serialize(
+        void* data,
+        fastrtps::rtps::SerializedPayload_t* payload)
+{
+    try
+    {
+        return get()->serialize(data, payload);
+    }
+    catch (eprosima::fastcdr::exception::Exception& e)
+    {
+        return false;
+    }
+}
+
+bool TypeSupport::deserialize(
+        fastrtps::rtps::SerializedPayload_t* payload,
+        void* data)
+{
+    try
+    {
+        return get()->deserialize(payload, data);
+    }
+    catch (eprosima::fastcdr::exception::Exception& e)
+    {
+        return false;
+    }
 }
 
 }  // namespace dds

--- a/src/cpp/fastdds/topic/TypeSupport.cpp
+++ b/src/cpp/fastdds/topic/TypeSupport.cpp
@@ -46,28 +46,34 @@ bool TypeSupport::serialize(
         void* data,
         fastrtps::rtps::SerializedPayload_t* payload)
 {
+    bool result = false;
     try
     {
-        return get()->serialize(data, payload);
+        result = get()->serialize(data, payload);
     }
     catch (eprosima::fastcdr::exception::Exception& e)
     {
-        return false;
+        result = false;
     }
+
+    return result;
 }
 
 bool TypeSupport::deserialize(
         fastrtps::rtps::SerializedPayload_t* payload,
         void* data)
 {
+    bool result = false;
     try
     {
-        return get()->deserialize(payload, data);
+        result = get()->deserialize(payload, data);
     }
     catch (eprosima::fastcdr::exception::Exception& e)
     {
-        return false;
+        result = false;
     }
+    
+    return result;
 }
 
 }  // namespace dds

--- a/src/cpp/rtps/DataSharing/DataSharingListener.cpp
+++ b/src/cpp/rtps/DataSharing/DataSharingListener.cpp
@@ -284,6 +284,24 @@ void DataSharingListener::change_added_with_timestamp(
     }
 }
 
+
+std::shared_ptr<ReaderPool> DataSharingListener::get_pool_for_writer(
+        const GUID_t& writer_guid)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = std::find_if(writer_pools_.begin(), writer_pools_.end(),
+                    [&writer_guid](const WriterInfo& info)
+                    {
+                        return info.pool->writer() == writer_guid;
+                    }
+                    );
+    if (it != writer_pools_.end())
+    {
+        return it->pool;
+    }
+    return std::shared_ptr<ReaderPool>(nullptr);
+}
+
 }  // namespace rtps
 }  // namespace fastrtps
 }  // namespace eprosima

--- a/src/cpp/rtps/DataSharing/DataSharingListener.cpp
+++ b/src/cpp/rtps/DataSharing/DataSharingListener.cpp
@@ -257,34 +257,6 @@ void DataSharingListener::notify(
     }
 }
 
-void DataSharingListener::change_removed_with_timestamp(
-        int64_t timestamp)
-{
-    // This method should be called from the RTPSReader,
-    // then, the reader's lock is protecting the concurrency on the value updates.
-    if (timestamp > notification_->notification_->ack_timestamp.load())
-    {
-        notification_->notification_->ack_timestamp.store(timestamp);
-        for (auto it = writer_pools_.begin(); it != writer_pools_.end(); ++it)
-        {
-            // Notify all writers in case any is waiting for a recyclable payload
-            it->pool->notify();
-        }
-    }
-}
-
-void DataSharingListener::change_added_with_timestamp(
-        int64_t timestamp)
-{
-    // This method should be called from the RTPSReader,
-    // then, the reader's lock is protecting the concurrency on the value updates.
-    if (timestamp < notification_->notification_->ack_timestamp.load())
-    {
-        notification_->notification_->ack_timestamp.store(timestamp);
-    }
-}
-
-
 std::shared_ptr<ReaderPool> DataSharingListener::get_pool_for_writer(
         const GUID_t& writer_guid)
 {

--- a/src/cpp/rtps/DataSharing/DataSharingListener.hpp
+++ b/src/cpp/rtps/DataSharing/DataSharingListener.hpp
@@ -22,7 +22,6 @@
 #include <fastdds/dds/log/Log.hpp>
 #include <rtps/DataSharing/IDataSharingListener.hpp>
 #include <rtps/DataSharing/DataSharingNotification.hpp>
-#include <rtps/DataSharing/DataSharingPayloadPool.hpp>
 #include <rtps/DataSharing/ReaderPool.hpp>
 #include <fastrtps/utils/collections/ResourceLimitedVector.hpp>
 
@@ -82,6 +81,9 @@ public:
 
     void change_added_with_timestamp(
             int64_t timestamp) override;
+
+    std::shared_ptr<ReaderPool> get_pool_for_writer(
+            const GUID_t& writer_guid) override;
 
 protected:
 

--- a/src/cpp/rtps/DataSharing/DataSharingListener.hpp
+++ b/src/cpp/rtps/DataSharing/DataSharingListener.hpp
@@ -76,12 +76,6 @@ public:
     void notify(
             bool same_thread) override;
 
-    void change_removed_with_timestamp(
-            int64_t timestamp) override;
-
-    void change_added_with_timestamp(
-            int64_t timestamp) override;
-
     std::shared_ptr<ReaderPool> get_pool_for_writer(
             const GUID_t& writer_guid) override;
 

--- a/src/cpp/rtps/DataSharing/DataSharingNotification.cpp
+++ b/src/cpp/rtps/DataSharing/DataSharingNotification.cpp
@@ -98,9 +98,6 @@ bool DataSharingNotification::create_and_init_notification(
         // Alloc and initialize the Node
         notification_ = segment_->get().construct<Notification>("notification_node")();
         notification_->new_data.store(false);
-        Time_t now;
-        Time_t::now(now);
-        notification_->ack_timestamp.store(now.to_ns());
     }
     catch (std::exception& e)
     {

--- a/src/cpp/rtps/DataSharing/DataSharingNotification.hpp
+++ b/src/cpp/rtps/DataSharing/DataSharingNotification.hpp
@@ -101,9 +101,6 @@ protected:
 
         //! New data available
         std::atomic<bool> new_data;
-
-        //! Timestamp of the reader's first sample NOT ack'd
-        std::atomic<int64_t> ack_timestamp;
     };
 #pragma warning(pop)
 

--- a/src/cpp/rtps/DataSharing/DataSharingNotification.hpp
+++ b/src/cpp/rtps/DataSharing/DataSharingNotification.hpp
@@ -53,7 +53,9 @@ public:
      */
     inline void notify()
     {
+        std::unique_lock<Segment::mutex> lock(notification_->notification_mutex);
         notification_->new_data.store(true);
+        lock.unlock();
         notification_->notification_cv.notify_all();
     }
 

--- a/src/cpp/rtps/DataSharing/DataSharingNotifier.hpp
+++ b/src/cpp/rtps/DataSharing/DataSharingNotifier.hpp
@@ -84,14 +84,6 @@ public:
         }
     }
 
-    /**
-     * @return the ACK'd timestamp
-     */
-    int64_t ack_timestamp() const override
-    {
-        return shared_notification_->notification_->ack_timestamp.load();
-    }
-
 protected:
 
     std::shared_ptr<DataSharingNotification> shared_notification_;

--- a/src/cpp/rtps/DataSharing/DataSharingPayloadPool.cpp
+++ b/src/cpp/rtps/DataSharing/DataSharingPayloadPool.cpp
@@ -87,7 +87,6 @@ bool DataSharingPayloadPool::is_sample_valid(
     return check_sequence_number(change.serializedPayload.data, change.sequenceNumber);
 }
 
-
 std::shared_ptr<DataSharingPayloadPool> DataSharingPayloadPool::get_reader_pool(
         bool is_reader_volatile)
 {

--- a/src/cpp/rtps/DataSharing/DataSharingPayloadPool.cpp
+++ b/src/cpp/rtps/DataSharing/DataSharingPayloadPool.cpp
@@ -81,12 +81,6 @@ bool DataSharingPayloadPool::check_sequence_number(
     return (PayloadNode::get_from_data(data)->sequence_number() == sn);
 }
 
-DataSharingPayloadPool::sharable_mutex& DataSharingPayloadPool::shared_mutex(
-        octet* data)
-{
-    return PayloadNode::get_from_data(data)->mutex();
-}
-
 std::shared_ptr<DataSharingPayloadPool> DataSharingPayloadPool::get_reader_pool(
         bool is_reader_volatile)
 {
@@ -102,15 +96,6 @@ std::shared_ptr<DataSharingPayloadPool> DataSharingPayloadPool::get_writer_pool(
     return std::make_shared<WriterPool>(
         config.maximum_size,
         config.payload_initial_size);
-}
-
-/**
- * Notifies to the writer
- */
-void DataSharingPayloadPool::notify()
-{
-    logInfo(RTPS_READER, "Notifying writer " << writer());
-    descriptor_->notification_cv.notify_all();
 }
 
 }  // namespace rtps

--- a/src/cpp/rtps/DataSharing/DataSharingPayloadPool.cpp
+++ b/src/cpp/rtps/DataSharing/DataSharingPayloadPool.cpp
@@ -81,6 +81,13 @@ bool DataSharingPayloadPool::check_sequence_number(
     return (PayloadNode::get_from_data(data)->sequence_number() == sn);
 }
 
+bool DataSharingPayloadPool::is_sample_valid(
+        const CacheChange_t& change) const
+{
+    return check_sequence_number(change.serializedPayload.data, change.sequenceNumber);
+}
+
+
 std::shared_ptr<DataSharingPayloadPool> DataSharingPayloadPool::get_reader_pool(
         bool is_reader_volatile)
 {

--- a/src/cpp/rtps/DataSharing/DataSharingPayloadPool.hpp
+++ b/src/cpp/rtps/DataSharing/DataSharingPayloadPool.hpp
@@ -130,6 +130,9 @@ public:
             const octet* data,
             const SequenceNumber_t& sn);
 
+    bool is_sample_valid(
+            const CacheChange_t& change) const;
+
 protected:
 
 #pragma warning(push)

--- a/src/cpp/rtps/DataSharing/IDataSharingListener.hpp
+++ b/src/cpp/rtps/DataSharing/IDataSharingListener.hpp
@@ -99,22 +99,6 @@ public:
             bool same_thread) = 0;
 
     /**
-     * Updates the ACK'd timestamp of the notification due to a change read/removed from the history
-     *
-     * @param timestamp the source timestamp of the change
-     */
-    virtual void change_removed_with_timestamp(
-            int64_t timestamp) = 0;
-
-    /**
-     * Updates the ACK'd timestamp of the notification due to a new change added to the history
-     *
-     * @param timestamp the source timestamp of the added change
-     */
-    virtual void change_added_with_timestamp(
-            int64_t timestamp) = 0;
-
-    /**
      * Returns the local datasharing pool for the specified remote writer
      *
      * @param writer_guid The GUID of the remote writer

--- a/src/cpp/rtps/DataSharing/IDataSharingListener.hpp
+++ b/src/cpp/rtps/DataSharing/IDataSharingListener.hpp
@@ -21,7 +21,7 @@
 
 #include <fastdds/dds/log/Log.hpp>
 #include <rtps/DataSharing/DataSharingNotification.hpp>
-#include <rtps/DataSharing/DataSharingPayloadPool.hpp>
+#include <rtps/DataSharing/ReaderPool.hpp>
 #include <fastrtps/utils/collections/ResourceLimitedVector.hpp>
 
 #include <memory>
@@ -113,6 +113,15 @@ public:
      */
     virtual void change_added_with_timestamp(
             int64_t timestamp) = 0;
+
+    /**
+     * Returns the local datasharing pool for the specified remote writer
+     *
+     * @param writer_guid The GUID of the remote writer
+     * @return the local pool for the given writer or null if the writer is not being listened
+     */
+    virtual std::shared_ptr<ReaderPool> get_pool_for_writer(
+            const GUID_t& writer_guid) = 0;
 
 };
 

--- a/src/cpp/rtps/DataSharing/IDataSharingNotifier.hpp
+++ b/src/cpp/rtps/DataSharing/IDataSharingNotifier.hpp
@@ -57,10 +57,6 @@ public:
      */
     virtual void notify() = 0;
 
-    /**
-     * @return the ACK'd timestamp
-     */
-    virtual int64_t ack_timestamp() const = 0;
 };
 
 

--- a/src/cpp/rtps/DataSharing/ReaderPool.hpp
+++ b/src/cpp/rtps/DataSharing/ReaderPool.hpp
@@ -64,7 +64,7 @@ public:
             return true;
         }
 
-        //If owner is not this, then it must be an intraprocess datasharing writer 
+        //If owner is not this, then it must be an intraprocess datasharing writer
         PayloadNode* payload = PayloadNode::get_from_data(data.data);
         read_from_shared_history(cache_change, payload);
         return true;

--- a/src/cpp/rtps/DataSharing/ReaderPool.hpp
+++ b/src/cpp/rtps/DataSharing/ReaderPool.hpp
@@ -64,7 +64,7 @@ public:
             return true;
         }
 
-        //If owner is not this, then it must be an intraprocess datasharing writer
+        // If owner is not this, then it must be an intraprocess datasharing writer
         PayloadNode* payload = PayloadNode::get_from_data(data.data);
         read_from_shared_history(cache_change, payload);
         return true;
@@ -85,7 +85,7 @@ public:
         segment_id_ = writer_guid;
         segment_name_ = generate_segment_name(shared_dir, writer_guid);
 
-        //Open the segment
+        // Open the segment
         try
         {
             segment_ = std::unique_ptr<fastdds::rtps::SharedMemSegment>(

--- a/src/cpp/rtps/DataSharing/ReaderPool.hpp
+++ b/src/cpp/rtps/DataSharing/ReaderPool.hpp
@@ -65,6 +65,7 @@ public:
         }
 
         // If owner is not this, then it must be an intraprocess datasharing writer
+        assert(nullptr != dynamic_cast<DataSharingPayloadPool*>(data_owner));
         PayloadNode* payload = PayloadNode::get_from_data(data.data);
         read_from_shared_history(cache_change, payload);
         return true;

--- a/src/cpp/rtps/DataSharing/WriterPool.hpp
+++ b/src/cpp/rtps/DataSharing/WriterPool.hpp
@@ -247,7 +247,6 @@ public:
 
         // Fill the payload metadata with the change info
         PayloadNode* node = PayloadNode::get_from_data(cache_change->serializedPayload.data);
-        node->sequence_number(cache_change->sequenceNumber);
         node->status(ALIVE);
         node->data_length(cache_change->serializedPayload.length);
         node->source_timestamp(cache_change->sourceTimestamp);
@@ -257,6 +256,9 @@ public:
         {
             node->related_sample_identity(cache_change->write_params.related_sample_identity());
         }
+
+        // Set the sequence number last, it signals the data is ready
+        node->sequence_number(cache_change->sequenceNumber);
 
         // Add it to the history
         history_[static_cast<uint32_t>(descriptor_->notified_end)] = segment_->get_offset_from_address(node);

--- a/src/cpp/rtps/DataSharing/WriterPool.hpp
+++ b/src/cpp/rtps/DataSharing/WriterPool.hpp
@@ -65,22 +65,8 @@ public:
             return false;
         }
 
-        // Look for a free payload that is recyclable
-        PayloadNode* payload = nullptr;
-        for (auto it = free_payloads_.begin(); it != free_payloads_.end(); ++it)
-        {
-            if (writer_->is_datasharing_payload_reusable((*it)->source_timestamp()))
-            {
-                payload = *it;
-                free_payloads_.erase(it);
-                break;
-            }
-        }
-        if (payload == nullptr)
-        {
-            return false;
-        }
-
+        PayloadNode* payload = free_payloads_.front();
+        free_payloads_.pop_front();
         payload->mutex().lock();
         // Reset all the metadata to signal the reader that the payload is dirty
         payload->reset();

--- a/src/cpp/rtps/DataSharing/WriterPool.hpp
+++ b/src/cpp/rtps/DataSharing/WriterPool.hpp
@@ -67,11 +67,8 @@ public:
 
         PayloadNode* payload = free_payloads_.front();
         free_payloads_.pop_front();
-        payload->mutex().lock();
         // Reset all the metadata to signal the reader that the payload is dirty
         payload->reset();
-        // Now we can unlock
-        payload->mutex().unlock();
 
         cache_change.serializedPayload.data = payload->data();
         cache_change.serializedPayload.max_size = max_data_size_;

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -452,7 +452,7 @@ bool StatefulReader::processDataMsg(
 
             if (is_datasharing_compatible_ && datasharing_listener_->writer_is_matched(change->writerGUID))
             {
-                //We may receive the change from the listener (with owner a ReaderPool) or intraprocess (with owner a WriterPool)
+                // We may receive the change from the listener (with owner a ReaderPool) or intraprocess (with owner a WriterPool)
                 ReaderPool* datasharing_pool = dynamic_cast<ReaderPool*>(payload_owner);
                 if (!datasharing_pool)
                 {

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -1136,22 +1136,16 @@ void StatefulReader::change_read_by_user(
                         //There are earlier changes not read yet. Do not send ACK.
                         return;
                     }
-                    acknack_count_++;
-                    RTPSMessageGroup group(getRTPSParticipant(), this, *writer);
                     SequenceNumberSet_t sns((*it)->sequenceNumber);
-                    group.add_acknack(sns, acknack_count_, false);
-                    logInfo(RTPS_READER, "Sending datasharing ACK for SN " << (*it)->sequenceNumber - 1);
+                    send_acknack(writer, sns, *writer, false);
                     return;
                 }
             }
         }
 
         // Must ACK all in the writer
-        acknack_count_++;
-        RTPSMessageGroup group(getRTPSParticipant(), this, *writer);
         SequenceNumberSet_t sns(writer->available_changes_max() + 1);
-        group.add_acknack(sns, acknack_count_, false);
-        logInfo(RTPS_READER, "Sending datasharing ACK for last SN " << writer->available_changes_max());
+        send_acknack(writer, sns, *writer, false);
     }
 }
 
@@ -1208,6 +1202,8 @@ void StatefulReader::send_acknack(
         return;
     }
 
+    // ACKNACK for datasharing writers is done for changes with status READ, not on reception
+    // This is handled in change_read_by_user
     if (writer->is_datasharing_writer())
     {
         return;

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -405,10 +405,10 @@ bool StatelessReader::processDataMsg(
         IPayloadPool* payload_owner = change->payload_owner();
 
         bool is_datasharing = std::any_of(matched_writers_.begin(), matched_writers_.end(),
-                   [&change](const RemoteWriterInfo_t& writer)
-                   {
-                       return (writer.guid == change->writerGUID) && (writer.is_datasharing);
-                   });
+                        [&change](const RemoteWriterInfo_t& writer)
+                        {
+                            return (writer.guid == change->writerGUID) && (writer.is_datasharing);
+                        });
 
         if (is_datasharing)
         {

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -254,14 +254,6 @@ bool StatelessReader::change_received(
             update_last_notified(change->writerGUID, change->sequenceNumber);
             ++total_unread_;
 
-            ReaderPool* datasharing_pool = dynamic_cast<ReaderPool*>(change->payload_owner());
-            if (datasharing_pool)
-            {
-                // Change was added to the history. May need to update datasharing ACK timestamp
-                // because we can receive changes in a different order (due to processing of writers or late-joiners)
-                datasharing_listener_->change_added_with_timestamp(change->sourceTimestamp.to_ns());
-            }
-
             if (getListener() != nullptr)
             {
                 getListener()->onNewCacheChangeAdded(this, change);

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -128,21 +128,23 @@ bool StatelessReader::matched_writer_add(
         }
     }
 
+    RemoteWriterInfo_t info;
+    info.guid = wdata.guid();
+    info.persistence_guid = wdata.persistence_guid();
+    info.has_manual_topic_liveliness = (MANUAL_BY_TOPIC_LIVELINESS_QOS == wdata.m_qos.m_liveliness.kind);
+
+    // Remote data-sharing writers are always checked via datasharing_listener_
     if (!is_datasharing || is_same_process)
     {
-        RemoteWriterInfo_t info;
-        info.guid = wdata.guid();
-        info.persistence_guid = wdata.persistence_guid();
-        info.has_manual_topic_liveliness = (MANUAL_BY_TOPIC_LIVELINESS_QOS == wdata.m_qos.m_liveliness.kind);
         if (matched_writers_.emplace_back(info) == nullptr)
         {
             logWarning(RTPS_READER, "No space to add writer " << wdata.guid() << " to reader " << m_guid);
             return false;
         }
-
-        add_persistence_guid(info.guid, info.persistence_guid);
         logInfo(RTPS_READER, "Writer " << wdata.guid() << " added to reader " << m_guid);
     }
+
+    add_persistence_guid(info.guid, info.persistence_guid);
 
     m_acceptMessagesFromUnkownWriters = false;
 

--- a/src/cpp/rtps/reader/WriterProxy.cpp
+++ b/src/cpp/rtps/reader/WriterProxy.cpp
@@ -87,6 +87,7 @@ WriterProxy::WriterProxy(
     , ownership_strength_(0)
     , liveliness_kind_(AUTOMATIC_LIVELINESS_QOS)
     , locators_entry_(loc_alloc.max_unicast_locators, loc_alloc.max_multicast_locators)
+    , is_datasharing_writer_(false)
 {
     //Create Events
     ResourceEvent& event_manager = reader_->getRTPSParticipant()->getEventResource();

--- a/src/cpp/rtps/reader/WriterProxy.cpp
+++ b/src/cpp/rtps/reader/WriterProxy.cpp
@@ -112,6 +112,14 @@ void WriterProxy::start(
         const WriterProxyData& attributes,
         const SequenceNumber_t& initial_sequence)
 {
+    start(attributes, initial_sequence, false);
+}
+
+void WriterProxy::start(
+        const WriterProxyData& attributes,
+        const SequenceNumber_t& initial_sequence,
+        bool is_datasharing)
+{
 #ifdef SHOULD_DEBUG_LINUX
     assert(get_mutex_owner() == get_thread_id());
 #endif // SHOULD_DEBUG_LINUX
@@ -129,7 +137,7 @@ void WriterProxy::start(
     liveliness_kind_ = attributes.m_qos.m_liveliness.kind;
     locators_entry_.unicast = attributes.remote_locators().unicast;
     locators_entry_.multicast = attributes.remote_locators().multicast;
-
+    is_datasharing_writer_ = is_datasharing;
     initial_acknack_->restart_timer();
     loaded_from_storage(initial_sequence);
 }

--- a/src/cpp/rtps/reader/WriterProxy.h
+++ b/src/cpp/rtps/reader/WriterProxy.h
@@ -368,7 +368,7 @@ private:
     bool is_alive_;
 
     using pool_allocator_t =
-                    foonathan::memory::memory_pool<foonathan::memory::node_pool, foonathan::memory::heap_allocator>;
+            foonathan::memory::memory_pool<foonathan::memory::node_pool, foonathan::memory::heap_allocator>;
 
     //! Memory pool allocator for changes_received_
     pool_allocator_t changes_pool_;
@@ -403,12 +403,12 @@ private:
     int get_mutex_owner() const;
 
     int get_thread_id() const;
-#endif
+#endif // if !defined(NDEBUG) && defined(FASTRTPS_SOURCE) && defined(__linux__)
 };
 
 } /* namespace rtps */
 } /* namespace fastrtps */
 } /* namespace eprosima */
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif /* FASTRTPS_RTPS_READER_WRITERPROXY_H_ */

--- a/src/cpp/rtps/reader/WriterProxy.h
+++ b/src/cpp/rtps/reader/WriterProxy.h
@@ -81,6 +81,17 @@ public:
             const SequenceNumber_t& initial_sequence);
 
     /**
+     * Activate this proxy associating it to a remote writer.
+     * @param attributes WriterProxyData of the writer for which to keep state.
+     * @param initial_sequence Sequence number of last acknowledged change.
+     * @param is_datasharing Whether the writer is datasharing with us or not.
+     */
+    void start(
+            const WriterProxyData& attributes,
+            const SequenceNumber_t& initial_sequence,
+            bool is_datasharing);
+
+    /**
      * Update information on the remote writer.
      * @param attributes WriterProxyData with updated information of the writer.
      */
@@ -321,6 +332,11 @@ public:
         return is_on_same_process_;
     }
 
+    bool is_datasharing_writer() const
+    {
+        return is_datasharing_writer_;
+    }
+
 private:
 
     /**
@@ -378,6 +394,8 @@ private:
     GUID_t persistence_guid_;
     //! Taken from proxy data
     LocatorSelectorEntry locators_entry_;
+    //! Is the writer datasharing
+    bool is_datasharing_writer_;
 
     using ChangeIterator = decltype(changes_received_)::iterator;
 

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -2575,19 +2575,6 @@ const fastdds::rtps::IReaderDataFilter* StatefulWriter::reader_data_filter() con
     return reader_data_filter_;
 }
 
-bool StatefulWriter::is_datasharing_payload_reusable(
-        const Time_t& source_timestamp) const
-{
-    for (const ReaderProxy* reader : matched_datasharing_readers_)
-    {
-        if (reader->datasharing_notifier()->ack_timestamp() <= source_timestamp.to_ns())
-        {
-            return false;
-        }
-    }
-    return true;
-}
-
 }  // namespace rtps
 }  // namespace fastrtps
 }  // namespace eprosima

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1556,7 +1556,7 @@ bool StatefulWriter::matched_reader_add(
     {
         matched_local_readers_.push_back(rp);
         logInfo(RTPS_WRITER, "Adding reader " << rdata.guid() << " to " << this->m_guid.entityId
-                                                << " as local reader");
+                                              << " as local reader");
     }
     else
     {
@@ -1564,7 +1564,7 @@ bool StatefulWriter::matched_reader_add(
         {
             matched_datasharing_readers_.push_back(rp);
             logInfo(RTPS_WRITER, "Adding reader " << rdata.guid() << " to " << this->m_guid.entityId
-                                                << " as data sharing");
+                                                  << " as data sharing");
         }
         else
         {

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1552,19 +1552,19 @@ bool StatefulWriter::matched_reader_add(
     rp->start(rdata, is_datasharing_compatible_with(rdata));
     locator_selector_.add_entry(rp->locator_selector_entry());
 
-    if (rp->is_datasharing_reader())
+    if (rp->is_local_reader())
     {
-        matched_datasharing_readers_.push_back(rp);
+        matched_local_readers_.push_back(rp);
         logInfo(RTPS_WRITER, "Adding reader " << rdata.guid() << " to " << this->m_guid.entityId
-                                              << " as data sharing");
+                                                << " as local reader");
     }
     else
     {
-        if (rp->is_local_reader())
+        if (rp->is_datasharing_reader())
         {
-            matched_local_readers_.push_back(rp);
+            matched_datasharing_readers_.push_back(rp);
             logInfo(RTPS_WRITER, "Adding reader " << rdata.guid() << " to " << this->m_guid.entityId
-                                                  << " as local reader");
+                                                << " as data sharing");
         }
         else
         {

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -920,7 +920,7 @@ bool StatelessWriter::matched_reader_add(
     locator_selector_.add_entry(new_reader->locator_selector_entry());
 
     // Datasharing readers handle transient history themselves
-    if (!new_reader->is_datasharing_reader() &&
+    if ((!new_reader->is_datasharing_reader() || new_reader->is_local_reader()) &&
             mp_history->getHistorySize() > 0 &&
             data.m_qos.m_durability.kind >= TRANSIENT_LOCAL_DURABILITY_QOS)
     {
@@ -934,17 +934,17 @@ bool StatelessWriter::matched_reader_add(
         mp_RTPSParticipant->async_thread().wake_up(this);
     }
 
-    if (new_reader->is_datasharing_reader())
-    {
-        matched_datasharing_readers_.push_back(std::move(new_reader));
-        logInfo(RTPS_WRITER, "Adding reader " << data.guid() << " to " << this->m_guid.entityId
-                                              << " as data sharing");
-    }
-    else if (new_reader->is_local_reader())
+    if (new_reader->is_local_reader())
     {
         matched_local_readers_.push_back(std::move(new_reader));
         logInfo(RTPS_WRITER, "Adding reader " << data.guid() << " to " << this->m_guid.entityId
                                               << " as local reader");
+    }
+    else if (new_reader->is_datasharing_reader())
+    {
+        matched_datasharing_readers_.push_back(std::move(new_reader));
+        logInfo(RTPS_WRITER, "Adding reader " << data.guid() << " to " << this->m_guid.entityId
+                                              << " as data sharing");
     }
     else
     {

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -919,7 +919,7 @@ bool StatelessWriter::matched_reader_add(
 
     locator_selector_.add_entry(new_reader->locator_selector_entry());
 
-    // Local datasharing readers handle transient history themselves
+    // Remote datasharing readers handle transient history themselves
     if ((!new_reader->is_datasharing_reader() || new_reader->is_local_reader()) &&
             mp_history->getHistorySize() > 0 &&
             data.m_qos.m_durability.kind >= TRANSIENT_LOCAL_DURABILITY_QOS)

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -1088,19 +1088,6 @@ bool StatelessWriter::send(
                        fixed_locators_.end()), max_blocking_time_point);
 }
 
-bool StatelessWriter::is_datasharing_payload_reusable(
-        const Time_t& source_timestamp) const
-{
-    for (const std::unique_ptr<ReaderLocator>& reader : matched_datasharing_readers_)
-    {
-        if (reader->datasharing_notifier()->ack_timestamp() <= source_timestamp.to_ns())
-        {
-            return false;
-        }
-    }
-    return true;
-}
-
 } /* namespace rtps */
 } /* namespace fastrtps */
 } /* namespace eprosima */

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -919,7 +919,7 @@ bool StatelessWriter::matched_reader_add(
 
     locator_selector_.add_entry(new_reader->locator_selector_entry());
 
-    // Datasharing readers handle transient history themselves
+    // Local datasharing readers handle transient history themselves
     if ((!new_reader->is_datasharing_reader() || new_reader->is_local_reader()) &&
             mp_history->getHistorySize() > 0 &&
             data.m_qos.m_durability.kind >= TRANSIENT_LOCAL_DURABILITY_QOS)

--- a/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
@@ -454,6 +454,13 @@ TEST_P(PubSubHistory, PubSubAsReliableMultithreadKeepLast1)
 
     ASSERT_TRUE(reader.isInitialized());
 
+    if (enable_datasharing)
+    {
+        // on datasharing we need to give time to the reader to process the data
+        // before reusing it
+        writer.resource_limits_extra_samples(100);
+    }
+
     writer.history_depth(1).init();
 
     ASSERT_TRUE(writer.isInitialized());

--- a/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
@@ -458,7 +458,7 @@ TEST_P(PubSubHistory, PubSubAsReliableMultithreadKeepLast1)
     {
         // on datasharing we need to give time to the reader to process the data
         // before reusing it
-        writer.resource_limits_extra_samples(100);
+        writer.resource_limits_extra_samples(200);
     }
 
     writer.history_depth(1).init();

--- a/test/blackbox/common/DDSBlackboxTestsDataSharing.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataSharing.cpp
@@ -217,7 +217,7 @@ TEST(DDSDataSharing, ReliableDirtyPayloads)
         ASSERT_EQ(valid_data.front(), data);
         valid_data.pop_front();
     }
-        ASSERT_TRUE(valid_data.empty());
+    ASSERT_TRUE(valid_data.empty());
 }
 
 TEST(DDSDataSharing, DataSharingWriter_DifferentDomainReaders)

--- a/test/blackbox/common/DDSBlackboxTestsDataSharing.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataSharing.cpp
@@ -212,9 +212,9 @@ TEST(DDSDataSharing, ReliableDirtyPayloads)
     // Doing a second read on the same history, the application will see only the last samples
     while (!valid_data.empty())
     {
-        FixedSized data;
-        ASSERT_TRUE(read_reader.take_first_data(&data));
-        ASSERT_EQ(valid_data.front(), data);
+        FixedSized value;
+        ASSERT_TRUE(read_reader.take_first_data(&value));
+        ASSERT_EQ(valid_data.front(), value);
         valid_data.pop_front();
     }
     ASSERT_TRUE(valid_data.empty());

--- a/test/mock/rtps/DataSharingPayloadPool/rtps/DataSharing/DataSharingPayloadPool.hpp
+++ b/test/mock/rtps/DataSharingPayloadPool/rtps/DataSharing/DataSharingPayloadPool.hpp
@@ -159,7 +159,6 @@ public:
         return true;
     }
 
-
 protected:
 
     GUID_t writer_guid_;

--- a/test/mock/rtps/DataSharingPayloadPool/rtps/DataSharing/DataSharingPayloadPool.hpp
+++ b/test/mock/rtps/DataSharingPayloadPool/rtps/DataSharing/DataSharingPayloadPool.hpp
@@ -153,8 +153,12 @@ public:
         return true;
     }
 
+    bool is_sample_valid(
+            const CacheChange_t& /*change*/) const
     {
+        return true;
     }
+
 
 protected:
 

--- a/test/mock/rtps/DataSharingPayloadPool/rtps/DataSharing/DataSharingPayloadPool.hpp
+++ b/test/mock/rtps/DataSharingPayloadPool/rtps/DataSharing/DataSharingPayloadPool.hpp
@@ -153,12 +153,7 @@ public:
         return true;
     }
 
-    template<typename ConditionFunctor>
-    bool wait_until(
-            const std::chrono::time_point<std::chrono::steady_clock>& /*max_blocking_time*/,
-            const ConditionFunctor& condition)
     {
-        return condition();
     }
 
 protected:

--- a/test/mock/rtps/DataSharingPayloadPool/rtps/DataSharing/ReaderPool.hpp
+++ b/test/mock/rtps/DataSharingPayloadPool/rtps/DataSharing/ReaderPool.hpp
@@ -1,0 +1,40 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file ReaderPool.hpp
+ */
+
+#ifndef RTPS_DATASHARING_READERPOOL_HPP
+#define RTPS_DATASHARING_READERPOOL_HPP
+
+#include <rtps/DataSharing/DataSharingPayloadPool.hpp>
+
+#include <memory>
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+
+class ReaderPool : public DataSharingPayloadPool
+{
+
+
+};
+
+}  // namespace rtps
+}  // namespace fastrtps
+}  // namespace eprosima
+
+#endif  // RTPS_DATASHARING_DATASHARINGPAYLOADPOOLIMPL_READERPOOL_HPP

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -1546,7 +1546,7 @@ TEST_F(DataReaderTests, Deserialization_errors)
 
             // This should return samples 0, 2, 4, 6, and 8
             EXPECT_EQ(ok_code, data_reader_->read(data_seq, info_seq, num_samples));
-            check_collection(data_seq, true, num_samples, 5);
+            check_collection(data_seq, true, num_samples, num_samples / 2);
             check_sample_values(data_seq, "02468");
         }
 
@@ -1567,7 +1567,7 @@ TEST_F(DataReaderTests, Deserialization_errors)
 
             // This should return samples 0, 2, 4, 6, and 8 (just for cleaning)
             EXPECT_EQ(ok_code, data_reader_->take(data_seq, info_seq, num_samples, READ_SAMPLE_STATE));
-            check_collection(data_seq, true, num_samples, 5);
+            check_collection(data_seq, true, num_samples, num_samples / 2);
             check_sample_values(data_seq, "02468");
         }
     }
@@ -1593,7 +1593,7 @@ TEST_F(DataReaderTests, Deserialization_errors)
 
             // This should return samples 0 to 9
             EXPECT_EQ(ok_code, data_reader_->read(data_seq, info_seq, num_samples));
-            check_collection(data_seq, false, num_samples, 10);
+            check_collection(data_seq, false, num_samples, num_samples);
             check_sample_values(data_seq, "0123456789");
             EXPECT_EQ(ok_code, data_reader_->return_loan(data_seq, info_seq));
         }

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -1498,7 +1498,7 @@ public:
 TEST_F(DataReaderTests, Deserialization_errors)
 {
     type_.reset(new FailingFooTypeSupport());
-    
+
     static const Duration_t time_to_wait(0, 100 * 1000 * 1000);
     static constexpr int32_t num_samples = 10;
 


### PR DESCRIPTION
This pull request solves the issues found when intraprocess and datasharing are mixed.

- Removes the ACK for reusability of the payloads: Any payload that is not on the writer's history can be reused anytime
  - This means that best effort behaves as such, but also that the reader may never catch up with the writer
- Removes the notification back to the writer when a payload has been marked as reusable
- Removes the payload locks related to the serialization. Instead, the sanity of the payload is checked before and after the deserialization