### PR TITLE
Move RTPSDomain mutex lock to callers of find_local_participant [10843]

### DIFF
--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -434,12 +434,13 @@ RTPSParticipantImpl* RTPSDomainImpl::find_local_participant(
 RTPSReader* RTPSDomainImpl::find_local_reader(
         const GUID_t& reader_guid)
 {
-    std::lock_guard<std::mutex> guard(RTPSDomain::m_mutex);
+    std::unique_lock<std::mutex> lock(RTPSDomain::m_mutex);
     for (const RTPSDomain::t_p_RTPSParticipant& participant : RTPSDomain::m_RTPSParticipants)
     {
         if (participant.second->getGuid().guidPrefix == reader_guid.guidPrefix)
         {
             // Participant found, forward the query
+            lock.unlock();
             return participant.second->find_local_reader(reader_guid);
         }
     }
@@ -450,12 +451,13 @@ RTPSReader* RTPSDomainImpl::find_local_reader(
 RTPSWriter* RTPSDomainImpl::find_local_writer(
         const GUID_t& writer_guid)
 {
-    std::lock_guard<std::mutex> guard(RTPSDomain::m_mutex);
+    std::unique_lock<std::mutex> lock(RTPSDomain::m_mutex);
     for (const RTPSDomain::t_p_RTPSParticipant& participant : RTPSDomain::m_RTPSParticipants)
     {
         if (participant.second->getGuid().guidPrefix == writer_guid.guidPrefix)
         {
             // Participant found, forward the query
+            lock.unlock();
             return participant.second->find_local_writer(writer_guid);
         }
     }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -975,10 +975,7 @@ bool RTPSParticipantImpl::createReader(
 RTPSReader* RTPSParticipantImpl::find_local_reader(
         const GUID_t& reader_guid)
 {
-    // As this is only called from RTPSDomainImpl::find_local_reader, and it has
-    // the domain mutex taken, there is no need to take the participant mutex
-    // std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
-
+    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
     for (auto reader : m_allReaderList)
     {
         if (reader->getGuid() == reader_guid)
@@ -993,10 +990,7 @@ RTPSReader* RTPSParticipantImpl::find_local_reader(
 RTPSWriter* RTPSParticipantImpl::find_local_writer(
         const GUID_t& writer_guid)
 {
-    // As this is only called from RTPSDomainImpl::find_local_reader, and it has
-    // the domain mutex taken, there is no need to take the participant mutex
-    // std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
-
+    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
     for (auto writer : m_allWriterList)
     {
         if (writer->getGuid() == writer_guid)

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -690,7 +690,7 @@ bool StatefulWriter::intraprocess_heartbeat(
     bool returned_value = false;
 
     std::lock_guard<RecursiveTimedMutex> guardW(mp_mutex);
-    RTPSReader* reader = RTPSDomainImpl::find_local_reader(reader_proxy->guid());
+    RTPSReader* reader = reader_proxy->local_reader();
 
     if (reader)
     {

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -529,6 +529,23 @@ public:
         return *this;
     }
 
+    PubSubParticipant& initial_heartbeat_delay(
+            int32_t sec,
+            uint32_t nanosec)
+    {
+        datawriter_qos_.reliable_writer_qos().times.initialHeartbeatDelay.seconds = sec;
+        datawriter_qos_.reliable_writer_qos().times.initialHeartbeatDelay.nanosec = nanosec;
+        return *this;
+    }
+
+    PubSubParticipant& durability(
+            const eprosima::fastdds::dds::DurabilityQosPolicyKind kind)
+    {
+        datawriter_qos_.durability().kind = kind;
+        datareader_qos_.durability().kind = kind;
+        return *this;
+    }
+
     PubSubParticipant& reliability(
             const eprosima::fastdds::dds::ReliabilityQosPolicyKind kind)
     {

--- a/test/blackbox/api/fastrtps_deprecated/PubSubParticipant.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubParticipant.hpp
@@ -443,6 +443,23 @@ public:
         return *this;
     }
 
+    PubSubParticipant& initial_heartbeat_delay(
+            int32_t sec,
+            uint32_t nanosec)
+    {
+        publisher_attr_.times.initialHeartbeatDelay.seconds = sec;
+        publisher_attr_.times.initialHeartbeatDelay.nanosec = nanosec;
+        return *this;
+    }
+
+    PubSubParticipant& durability(
+            const eprosima::fastdds::dds::DurabilityQosPolicyKind kind)
+    {
+        publisher_attr_.qos.m_durability.kind = kind;
+        subscriber_attr_.qos.m_durability.kind = kind;
+        return *this;
+    }
+
     PubSubParticipant& reliability(
             const ReliabilityQosPolicyKind kind)
     {


### PR DESCRIPTION
This prevents the race detected on #1819 by ensuring that the `RTPSDomain` mutex is taken when a new entry is added to `RTPSParticipant::m_allReaderList` or `RTPSParticipant::m_allWriterList`