### PR TITLE
[10879] Refactor `types::ReturnCode_t` to make it switch friendly

### DIFF
--- a/include/fastrtps/types/TypesBase.h
+++ b/include/fastrtps/types/TypesBase.h
@@ -226,12 +226,12 @@ public:
 
     explicit operator bool() = delete;
 
-    uint32_t operator ()()
+    uint32_t operator ()() const
     {
         return value_;
     }
 
-    bool operator !()
+    bool operator !() const
     {
         return value_ != 0;
     }

--- a/include/fastrtps/types/TypesBase.h
+++ b/include/fastrtps/types/TypesBase.h
@@ -182,7 +182,7 @@ const uint16_t MemberFlagMinimalMask = 0x003f;
  * @brief This class represents the enumeration ReturnCode_t.
  */
 
-class ReturnCode_t
+class RTPS_DllAPI ReturnCode_t
 {
     uint32_t value_;
 
@@ -205,6 +205,11 @@ public:
         RETCODE_ILLEGAL_OPERATION = 12,
         RETCODE_NOT_ALLOWED_BY_SECURITY = 13
     };
+
+    ReturnCode_t()
+        : value_(RETCODE_OK)
+    {
+    }
 
     ReturnCode_t(
             uint32_t e)

--- a/include/fastrtps/types/TypesBase.h
+++ b/include/fastrtps/types/TypesBase.h
@@ -23,6 +23,7 @@
 #include <cctype>
 #include <algorithm>
 #include <memory>
+#include <type_traits>
 
 namespace eprosima {
 namespace fastdds {
@@ -180,54 +181,35 @@ const uint16_t MemberFlagMinimalMask = 0x003f;
 /*!
  * @brief This class represents the enumeration ReturnCode_t.
  */
-/*
-   enum ReturnCode_t : uint32_t
-   {
-    RETCODE_OK = 0,
-    RETCODE_ERROR = 1,
-    RETCODE_UNSUPPORTED = 2,
-    RETCODE_BAD_PARAMETER = 3,
-    RETCODE_PRECONDITION_NOT_MET = 4,
-    RETCODE_OUT_OF_RESOURCES = 5,
-    RETCODE_NOT_ENABLED = 6,
-    RETCODE_IMMUTABLE_POLICY = 7,
-    RETCODE_INCONSISTENT_POLICY = 8,
-    RETCODE_ALREADY_DELETED = 9,
-    RETCODE_TIMEOUT = 10,
-    RETCODE_NO_DATA = 11,
-    RETCODE_ILLEGAL_OPERATION = 12
-   };
- */
-class ReturnCode_t;
 
-class RTPS_DllAPI ReturnCode_t
+class ReturnCode_t
 {
+    uint32_t value_;
+
 public:
 
-    ReturnCode_t(
-            uint32_t value)
+    enum
     {
-        value_ = value;
-    }
+        RETCODE_OK = 0,
+        RETCODE_ERROR = 1,
+        RETCODE_UNSUPPORTED = 2,
+        RETCODE_BAD_PARAMETER = 3,
+        RETCODE_PRECONDITION_NOT_MET = 4,
+        RETCODE_OUT_OF_RESOURCES = 5,
+        RETCODE_NOT_ENABLED = 6,
+        RETCODE_IMMUTABLE_POLICY = 7,
+        RETCODE_INCONSISTENT_POLICY = 8,
+        RETCODE_ALREADY_DELETED = 9,
+        RETCODE_TIMEOUT = 10,
+        RETCODE_NO_DATA = 11,
+        RETCODE_ILLEGAL_OPERATION = 12,
+        RETCODE_NOT_ALLOWED_BY_SECURITY = 13
+    };
 
     ReturnCode_t(
-            const ReturnCode_t& code)
+            uint32_t e)
     {
-        value_ = code.value_;
-    }
-
-    explicit operator bool() = delete;
-
-    bool operator !() const
-    {
-        return value_ != ReturnCode_t::RETCODE_OK.value_;
-    }
-
-    ReturnCode_t& operator =(
-            const ReturnCode_t& c)
-    {
-        value_ = c.value_;
-        return *this;
+        value_ = e;
     }
 
     bool operator ==(
@@ -242,32 +224,33 @@ public:
         return value_ != c.value_;
     }
 
-    uint32_t operator ()() const
+    explicit operator bool() = delete;
+
+    uint32_t operator ()()
     {
         return value_;
     }
 
-    static const ReturnCode_t RETCODE_OK;
-    static const ReturnCode_t RETCODE_ERROR;
-    static const ReturnCode_t RETCODE_UNSUPPORTED;
-    static const ReturnCode_t RETCODE_BAD_PARAMETER;
-    static const ReturnCode_t RETCODE_PRECONDITION_NOT_MET;
-    static const ReturnCode_t RETCODE_OUT_OF_RESOURCES;
-    static const ReturnCode_t RETCODE_NOT_ENABLED;
-    static const ReturnCode_t RETCODE_IMMUTABLE_POLICY;
-    static const ReturnCode_t RETCODE_INCONSISTENT_POLICY;
-    static const ReturnCode_t RETCODE_ALREADY_DELETED;
-    static const ReturnCode_t RETCODE_TIMEOUT;
-    static const ReturnCode_t RETCODE_NO_DATA;
-    static const ReturnCode_t RETCODE_ILLEGAL_OPERATION;
-#if HAVE_SECURITY
-    static const ReturnCode_t RETCODE_NOT_ALLOWED_BY_SECURITY;
-#endif // HAVE_SECURITY
+    bool operator !()
+    {
+        return value_ != 0;
+    }
 
-private:
-
-    uint32_t value_ = ReturnCode_t::RETCODE_OK.value_;
 };
+
+template<class T>
+std::enable_if_t<std::is_arithmetic_v<T> || std::is_enum_v<T>, bool>
+operator==(T a, const ReturnCode_t& b)
+{
+    return b == a;
+}
+
+template<class T>
+std::enable_if_t<std::is_arithmetic_v<T> || std::is_enum_v<T>, bool>
+operator!=(T a, const ReturnCode_t& b)
+{
+    return b != a;
+}
 
 // TODO Remove this alias when Fast-RTPS reaches version 2
 using ResponseCode = ReturnCode_t;

--- a/include/fastrtps/types/TypesBase.h
+++ b/include/fastrtps/types/TypesBase.h
@@ -239,14 +239,14 @@ public:
 };
 
 template<class T>
-std::enable_if_t<std::is_arithmetic_v<T> || std::is_enum_v<T>, bool>
+typename std::enable_if<std::is_arithmetic<T>::value || std::is_enum<T>::value, bool>::type
 operator==(T a, const ReturnCode_t& b)
 {
     return b == a;
 }
 
 template<class T>
-std::enable_if_t<std::is_arithmetic_v<T> || std::is_enum_v<T>, bool>
+typename std::enable_if<std::is_arithmetic<T>::value || std::is_enum<T>::value, bool>::type
 operator!=(T a, const ReturnCode_t& b)
 {
     return b != a;

--- a/include/fastrtps/types/TypesBase.h
+++ b/include/fastrtps/types/TypesBase.h
@@ -240,14 +240,18 @@ public:
 
 template<class T>
 typename std::enable_if<std::is_arithmetic<T>::value || std::is_enum<T>::value, bool>::type
-operator==(T a, const ReturnCode_t& b)
+operator ==(
+        T a,
+        const ReturnCode_t& b)
 {
     return b == a;
 }
 
 template<class T>
 typename std::enable_if<std::is_arithmetic<T>::value || std::is_enum<T>::value, bool>::type
-operator!=(T a, const ReturnCode_t& b)
+operator !=(
+        T a,
+        const ReturnCode_t& b)
 {
     return b != a;
 }

--- a/src/cpp/dynamic-types/TypesBase.cpp
+++ b/src/cpp/dynamic-types/TypesBase.cpp
@@ -26,24 +26,6 @@ using namespace rtps;
 
 namespace types {
 
-const ReturnCode_t ReturnCode_t::RETCODE_OK = {0};
-const ReturnCode_t ReturnCode_t::RETCODE_ERROR = {1};
-const ReturnCode_t ReturnCode_t::RETCODE_UNSUPPORTED = {2};
-const ReturnCode_t ReturnCode_t::RETCODE_BAD_PARAMETER = {3};
-const ReturnCode_t ReturnCode_t::RETCODE_PRECONDITION_NOT_MET = {4};
-const ReturnCode_t ReturnCode_t::RETCODE_OUT_OF_RESOURCES = {5};
-const ReturnCode_t ReturnCode_t::RETCODE_NOT_ENABLED = {6};
-const ReturnCode_t ReturnCode_t::RETCODE_IMMUTABLE_POLICY = {7};
-const ReturnCode_t ReturnCode_t::RETCODE_INCONSISTENT_POLICY = {8};
-const ReturnCode_t ReturnCode_t::RETCODE_ALREADY_DELETED = {9};
-const ReturnCode_t ReturnCode_t::RETCODE_TIMEOUT = {10};
-const ReturnCode_t ReturnCode_t::RETCODE_NO_DATA = {11};
-const ReturnCode_t ReturnCode_t::RETCODE_ILLEGAL_OPERATION = {12};
-#if HAVE_SECURITY
-const ReturnCode_t ReturnCode_t::RETCODE_NOT_ALLOWED_BY_SECURITY = {13};
-#endif // HAVE_SECURITY
-
-
 void MemberFlag::serialize(
         eprosima::fastcdr::Cdr& cdr) const
 {

--- a/versions.md
+++ b/versions.md
@@ -4,6 +4,8 @@ Forthcoming
 
 * Added eprosima::fastdds::dds::DataReader::get_unread_count (ABI break)
 
+* Refactor eprosima::fastrtps::type::ReturnCode_t. Now the constant global objects are no longer available (ABI break)
+
 Version 2.2.0
 -------------
 


### PR DESCRIPTION
`types::ReturnCode_t` error codes could not be used in *case* statements of a `switch` control sentence.
This refactor solves the issue. The following is now valid:
```C++
ReturnCode_t res =
    reader->take_next_sample(...);

switch ( res() )
{
    case ReturnCode_t::RETCODE_OK:
    ...
        break;

    case ReturnCode_t::RETCODE_NO_DATA:
    ...
        break;
}
```