### PR TITLE
Allow fully qualified name in TypeDescriptor

### DIFF
--- a/src/cpp/dynamic-types/TypeDescriptor.cpp
+++ b/src/cpp/dynamic-types/TypeDescriptor.cpp
@@ -255,7 +255,9 @@ bool TypeDescriptor::is_type_name_consistent(
         // All characters must be letters, numbers or underscore.
         for (uint32_t i = 1; i < sName.length(); ++i)
         {
-            if (!std::isalnum(sName[i]) && sName[i] != 95)
+            // Type's fully qualified name is a concatenation of module names
+            // with the name of a type inside of those modules.
+            if (!std::isalnum(sName[i]) && sName[i] != 95 && sName[i] != 58)
             {
                 return false;
             }


### PR DESCRIPTION
According to the DDS-XTypes spec 7.5.2.4.10, the name of TypeDescriptor
should be the fully qualified name, which is the concatenation of
module names with the name of a type inside of those modules.

This change will allow an object of DynamicTypeBuilder to set a type
name that contains colon in it.

Related issue: https://gitmemory.com/issue/eProsima/Fast-RTPS-Gen/21/603785610