### PR TITLE
Add an explicit build dependency on libssl-dev

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
   <url type="repository">https://github.com/eProsima/Fast-DDS</url>
 
   <build_depend>asio</build_depend>
+  <build_depend>libssl-dev</build_depend>
 
   <build_export_depend>libssl-dev</build_export_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -15,14 +15,10 @@
   <url type="repository">https://github.com/eProsima/Fast-DDS</url>
 
   <build_depend>asio</build_depend>
-  <build_depend>libssl-dev</build_depend>
-
-  <build_export_depend>libssl-dev</build_export_depend>
-
-  <exec_depend>libssl-dev</exec_depend>
 
   <depend>fastcdr</depend>
   <depend>foonathan_memory_vendor</depend>
+  <depend>libssl-dev</depend>
   <depend>tinyxml2</depend>
 
   <buildtool_depend>cmake</buildtool_depend>


### PR DESCRIPTION
It appears that libasio-dev is pulling in this dependency at build time, but it is actually directly needed to build Fast-DDS with SECURITY=ON.