### PR TITLE
Allow fully qualified name in TypeDescriptor [11063]

### DIFF
--- a/include/fastrtps/types/TypeDescriptor.h
+++ b/include/fastrtps/types/TypeDescriptor.h
@@ -56,11 +56,11 @@ protected:
     std::vector<AnnotationDescriptor*> annotation_; // Annotations to apply
 
     const int stateTable[4][6] = {
-            /* Input:     letter,  number,  underscore, colon,       other */
-            {INVALID,     VALID,   INVALID, INVALID,    INVALID,     INVALID},
-            {SINGLECOLON, INVALID, INVALID, INVALID,    DOUBLECOLON, INVALID},
-            {DOUBLECOLON, VALID,   INVALID, INVALID,    INVALID,     INVALID},
-            {VALID,       VALID,   VALID,   VALID,      SINGLECOLON, INVALID}};
+        /* Input:     letter,  number,  underscore, colon,       other */
+        {INVALID,     VALID,   INVALID, INVALID,    INVALID,     INVALID},
+        {SINGLECOLON, INVALID, INVALID, INVALID,    DOUBLECOLON, INVALID},
+        {DOUBLECOLON, VALID,   INVALID, INVALID,    INVALID,     INVALID},
+        {VALID,       VALID,   VALID,   VALID,      SINGLECOLON, INVALID}};
 
     void clean();
 

--- a/include/fastrtps/types/TypeDescriptor.h
+++ b/include/fastrtps/types/TypeDescriptor.h
@@ -25,6 +25,23 @@ namespace eprosima {
 namespace fastrtps {
 namespace types {
 
+enum FSM_INPUTS
+{
+    LETTER = 1,
+    NUMBER,
+    UNDERSCORE,
+    COLON,
+    OTHER
+};
+
+enum FSM_STATES
+{
+    INVALID = 0,
+    SINGLECOLON,
+    DOUBLECOLON,
+    VALID
+};
+
 class TypeDescriptor
 {
 protected:
@@ -37,6 +54,12 @@ protected:
     DynamicType_ptr element_type_;          // Value Type for arrays, sequences, maps, bitmasks.
     DynamicType_ptr key_element_type_;      // Key Type for maps.
     std::vector<AnnotationDescriptor*> annotation_; // Annotations to apply
+
+    /* INPUT CHAR:                        letter,  number,  underscore, colon,       other */
+    int stateTable[4][6] = {{INVALID,     VALID,   INVALID, INVALID,    INVALID,     INVALID},
+    /* STATE 1 */           {SINGLECOLON, INVALID, INVALID, INVALID,    DOUBLECOLON, INVALID},
+    /* STATE 2 */           {DOUBLECOLON, VALID,   INVALID, INVALID,    INVALID,     INVALID},
+    /* STATE 3 */           {VALID,       VALID,   VALID,   VALID,      SINGLECOLON, INVALID}};
 
     void clean();
 

--- a/include/fastrtps/types/TypeDescriptor.h
+++ b/include/fastrtps/types/TypeDescriptor.h
@@ -55,11 +55,12 @@ protected:
     DynamicType_ptr key_element_type_;      // Key Type for maps.
     std::vector<AnnotationDescriptor*> annotation_; // Annotations to apply
 
-    /* INPUT CHAR:                        letter,  number,  underscore, colon,       other */
-    int stateTable[4][6] = {{INVALID,     VALID,   INVALID, INVALID,    INVALID,     INVALID},
-    /* STATE 1 */           {SINGLECOLON, INVALID, INVALID, INVALID,    DOUBLECOLON, INVALID},
-    /* STATE 2 */           {DOUBLECOLON, VALID,   INVALID, INVALID,    INVALID,     INVALID},
-    /* STATE 3 */           {VALID,       VALID,   VALID,   VALID,      SINGLECOLON, INVALID}};
+    const int stateTable[4][6] = {
+            /* Input:     letter,  number,  underscore, colon,       other */
+            {INVALID,     VALID,   INVALID, INVALID,    INVALID,     INVALID},
+            {SINGLECOLON, INVALID, INVALID, INVALID,    DOUBLECOLON, INVALID},
+            {DOUBLECOLON, VALID,   INVALID, INVALID,    INVALID,     INVALID},
+            {VALID,       VALID,   VALID,   VALID,      SINGLECOLON, INVALID}};
 
     void clean();
 

--- a/test/unittest/xtypes/XTypesTests.cpp
+++ b/test/unittest/xtypes/XTypesTests.cpp
@@ -24,23 +24,25 @@
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::types;
 
-class XTypesTests: public ::testing::Test
+class XTypesTests : public ::testing::Test
 {
-    public:
-        XTypesTests()
-        {
-            //registerTypesTypes();
-        }
+public:
 
-        ~XTypesTests()
-        {
-            TypeObjectFactory::delete_instance();
-            eprosima::fastdds::dds::Log::KillThread();
-        }
+    XTypesTests()
+    {
+        //registerTypesTypes();
+    }
 
-        virtual void TearDown()
-        {
-        }
+    ~XTypesTests()
+    {
+        TypeObjectFactory::delete_instance();
+        eprosima::fastdds::dds::Log::KillThread();
+    }
+
+    virtual void TearDown()
+    {
+    }
+
 };
 
 TEST_F(XTypesTests, EnumMinimalCoercion)
@@ -782,7 +784,9 @@ TEST_F(XTypesTests, TypeDescriptorFullyQualifiedName)
     ASSERT_FALSE(my_descriptor->is_consistent());
 }
 
-int main(int argc, char **argv)
+int main(
+        int argc,
+        char** argv)
 {
     eprosima::fastdds::dds::Log::SetVerbosity(eprosima::fastdds::dds::Log::Info);
 

--- a/test/unittest/xtypes/XTypesTests.cpp
+++ b/test/unittest/xtypes/XTypesTests.cpp
@@ -18,6 +18,8 @@
 #include "idl/TypesTypeObject.h"
 #include "idl/WideEnumTypeObject.h"
 #include <gtest/gtest.h>
+#include <fastrtps/types/DynamicTypeBuilderFactory.h>
+#include <fastrtps/types/TypeDescriptor.h>
 
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::types;
@@ -729,6 +731,55 @@ TEST_F(XTypesTests, SimpleUnionCompleteCoercion)
     consistencyQos.m_kind = DISALLOW_TYPE_COERCION;
     ASSERT_FALSE(basic_union->consistent(*basic_wide_union, consistencyQos));
     ASSERT_FALSE(basic_wide_union->consistent(*basic_union, consistencyQos));
+}
+
+TEST_F(XTypesTests, TypeDescriptorFullyQualifiedName)
+{
+    DynamicTypeBuilder_ptr my_builder(DynamicTypeBuilderFactory::get_instance()->create_struct_builder());
+    my_builder->add_member(0, "x", DynamicTypeBuilderFactory::get_instance()->create_float32_type());
+    my_builder->add_member(0, "y", DynamicTypeBuilderFactory::get_instance()->create_float32_type());
+    my_builder->add_member(0, "z", DynamicTypeBuilderFactory::get_instance()->create_float32_type());
+    const TypeDescriptor* my_descriptor = my_builder->get_type_descriptor();
+
+    my_builder->set_name("Position");
+    ASSERT_TRUE(my_descriptor->is_consistent());
+    my_builder->set_name("Position_");
+    ASSERT_TRUE(my_descriptor->is_consistent());
+    my_builder->set_name("Position123");
+    ASSERT_TRUE(my_descriptor->is_consistent());
+    my_builder->set_name("position_123");
+    ASSERT_TRUE(my_descriptor->is_consistent());
+    my_builder->set_name("_Position");
+    ASSERT_FALSE(my_descriptor->is_consistent());
+    my_builder->set_name("123Position");
+    ASSERT_FALSE(my_descriptor->is_consistent());
+    my_builder->set_name("Position&");
+    ASSERT_FALSE(my_descriptor->is_consistent());
+
+    my_builder->set_name("my_interface::action::dds_::Position");
+    ASSERT_TRUE(my_descriptor->is_consistent());
+    my_builder->set_name("my_interface:action::dds_::Position");
+    ASSERT_FALSE(my_descriptor->is_consistent());
+    my_builder->set_name("my_interface:::action::dds_::Position");
+    ASSERT_FALSE(my_descriptor->is_consistent());
+    my_builder->set_name("_my_interface::action::dds_::Position");
+    ASSERT_FALSE(my_descriptor->is_consistent());
+    my_builder->set_name("1my_interface::action::dds_::Position");
+    ASSERT_FALSE(my_descriptor->is_consistent());
+    my_builder->set_name(":my_interface::action::dds_::Position");
+    ASSERT_FALSE(my_descriptor->is_consistent());
+    my_builder->set_name("::my_interface::action::dds_::Position");
+    ASSERT_FALSE(my_descriptor->is_consistent());
+    my_builder->set_name("$my_interface::action::dds_::Position");
+    ASSERT_FALSE(my_descriptor->is_consistent());
+    my_builder->set_name("my_interface::2action::dds_::Position");
+    ASSERT_FALSE(my_descriptor->is_consistent());
+    my_builder->set_name("my_interface::_action::dds_::Position");
+    ASSERT_FALSE(my_descriptor->is_consistent());
+    my_builder->set_name("my_interface::*action::dds_::Position");
+    ASSERT_FALSE(my_descriptor->is_consistent());
+    my_builder->set_name("my_interface::action*::dds_::Position");
+    ASSERT_FALSE(my_descriptor->is_consistent());
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
According to the DDS-XTypes spec 7.5.2.4.10, the name of TypeDescriptor
should be the fully qualified name, which is the concatenation of
module names with the name of a type inside of those modules.

This change will allow an object of DynamicTypeBuilder to set a type
name that contains colon in it. Sometimes it's necessary to use a fully
qualified name in dynamic types to communicate to some existing
ros2 topic directly.

Related issue: https://gitmemory.com/issue/eProsima/Fast-RTPS-Gen/21/603785610
