### PR TITLE
[10715] Hotfix: remove case NONE from IDL

### DIFF
--- a/include/fastdds/statistics/types.idl
+++ b/include/fastdds/statistics/types.idl
@@ -119,24 +119,23 @@ struct PhysicalData
 @bit_bound(32)
 bitmask EventKind
 {
-    @position(0) NONE,
-    @position(1) HISTORY2HISTORY_LATENCY,
-    @position(2) NETWORK_LATENCY,
-    @position(3) PUBLICATION_THROUGHPUT,
-    @position(4) SUBSCRIPTION_THROUGHPUT,
-    @position(5) RTPS_SENT,
-    @position(6) RTPS_LOST,
-    @position(7) RESENT_DATAS,
-    @position(8) HEARTBEAT_COUNT,
-    @position(9) ACKNACK_COUNT,
-    @position(10) NACKFRAG_COUNT,
-    @position(11) GAP_COUNT,
-    @position(12) DATA_COUNT,
-    @position(13) PDP_PACKETS,
-    @position(14) EDP_PACKETS,
-    @position(15) DISCOVERED_ENTITY,
-    @position(16) SAMPLE_DATAS,
-    @position(17) PHYSICAL_DATA
+    @position(0) HISTORY2HISTORY_LATENCY,
+    @position(1) NETWORK_LATENCY,
+    @position(2) PUBLICATION_THROUGHPUT,
+    @position(3) SUBSCRIPTION_THROUGHPUT,
+    @position(4) RTPS_SENT,
+    @position(5) RTPS_LOST,
+    @position(6) RESENT_DATAS,
+    @position(7) HEARTBEAT_COUNT,
+    @position(8) ACKNACK_COUNT,
+    @position(9) NACKFRAG_COUNT,
+    @position(10) GAP_COUNT,
+    @position(11) DATA_COUNT,
+    @position(12) PDP_PACKETS,
+    @position(13) EDP_PACKETS,
+    @position(14) DISCOVERED_ENTITY,
+    @position(15) SAMPLE_DATAS,
+    @position(16) PHYSICAL_DATA
 };
 
 union Data switch(EventKind)

--- a/src/cpp/statistics/types/types.h
+++ b/src/cpp/statistics/types/types.h
@@ -2404,24 +2404,23 @@ namespace eprosima {
              */
             enum EventKind : uint32_t
             {
-                NONE = 0x01 << 0,
-                HISTORY2HISTORY_LATENCY = 0x01 << 1,
-                NETWORK_LATENCY = 0x01 << 2,
-                PUBLICATION_THROUGHPUT = 0x01 << 3,
-                SUBSCRIPTION_THROUGHPUT = 0x01 << 4,
-                RTPS_SENT = 0x01 << 5,
-                RTPS_LOST = 0x01 << 6,
-                RESENT_DATAS = 0x01 << 7,
-                HEARTBEAT_COUNT = 0x01 << 8,
-                ACKNACK_COUNT = 0x01 << 9,
-                NACKFRAG_COUNT = 0x01 << 10,
-                GAP_COUNT = 0x01 << 11,
-                DATA_COUNT = 0x01 << 12,
-                PDP_PACKETS = 0x01 << 13,
-                EDP_PACKETS = 0x01 << 14,
-                DISCOVERED_ENTITY = 0x01 << 15,
-                SAMPLE_DATAS = 0x01 << 16,
-                PHYSICAL_DATA = 0x01 << 17
+                HISTORY2HISTORY_LATENCY = 0x01 << 0,
+                NETWORK_LATENCY = 0x01 << 1,
+                PUBLICATION_THROUGHPUT = 0x01 << 2,
+                SUBSCRIPTION_THROUGHPUT = 0x01 << 3,
+                RTPS_SENT = 0x01 << 4,
+                RTPS_LOST = 0x01 << 5,
+                RESENT_DATAS = 0x01 << 6,
+                HEARTBEAT_COUNT = 0x01 << 7,
+                ACKNACK_COUNT = 0x01 << 8,
+                NACKFRAG_COUNT = 0x01 << 9,
+                GAP_COUNT = 0x01 << 10,
+                DATA_COUNT = 0x01 << 11,
+                PDP_PACKETS = 0x01 << 12,
+                EDP_PACKETS = 0x01 << 13,
+                DISCOVERED_ENTITY = 0x01 << 14,
+                SAMPLE_DATAS = 0x01 << 15,
+                PHYSICAL_DATA = 0x01 << 16
             };
             /*!
              * @brief This class represents the union Data defined by the user in the IDL file.


### PR DESCRIPTION
GCC issues a warning due to this case that does not have any data type associated.

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>