### PR TITLE
Fix asan and undefined behavior error [10916]

### DIFF
--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -36,7 +36,6 @@
 #include <fastrtps/types/TypeObject.h>
 #include <fastrtps/utils/collections/ResourceLimitedVector.hpp>
 
-
 namespace eprosima {
 namespace fastdds {
 namespace dds {

--- a/include/fastdds/rtps/common/SerializedPayload.h
+++ b/include/fastdds/rtps/common/SerializedPayload.h
@@ -124,6 +124,10 @@ struct RTPS_DllAPI SerializedPayload_t
             }
         }
         encapsulation = serData->encapsulation;
+        if (length == 0)
+        {
+            return true;
+        }
         memcpy(data, serData->data, length);
         return true;
     }

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -161,6 +161,7 @@ set(${PROJECT_NAME}_source_files
     fastdds/core/condition/StatusCondition.cpp
     fastdds/core/condition/WaitSet.cpp
     fastdds/core/policy/ParameterList.cpp
+    fastdds/core/policy/QosPolicyUtils.cpp
     fastdds/publisher/qos/WriterQos.cpp
     fastdds/subscriber/qos/ReaderQos.cpp
     rtps/builtin/BuiltinProtocols.cpp

--- a/src/cpp/fastdds/core/policy/QosPolicyUtils.cpp
+++ b/src/cpp/fastdds/core/policy/QosPolicyUtils.cpp
@@ -1,0 +1,45 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file QosPolicyUtils.cpp
+ *
+ */
+
+#include <fastdds/core/policy/QosPolicyUtils.hpp>
+
+#include <utils/Host.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace utils {
+
+// Compute the default DataSharing domain ID
+uint64_t default_domain_id()
+{
+    uint64_t id = 0;
+    Host::uint48 mac_id = Host::instance().mac_id();
+    for (size_t i = 0; i < Host::mac_id_length; ++i)
+    {
+        id |= static_cast<uint64_t>(mac_id.value[i]) << (56 - (i * 8));
+    }
+    return id;
+}
+
+}  // namespace utils
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+

--- a/src/cpp/fastdds/core/policy/QosPolicyUtils.hpp
+++ b/src/cpp/fastdds/core/policy/QosPolicyUtils.hpp
@@ -1,0 +1,38 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file QosPolicyUtils.hpp
+ *
+ */
+
+#ifndef _FASTDDS_DDS_QOS_QOSPOLICYUTILS_HPP_
+#define _FASTDDS_DDS_QOS_QOSPOLICYUTILS_HPP_
+
+#include <stdint.h>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace utils {
+
+// Compute the default DataSharing domain ID
+uint64_t default_domain_id();
+
+}  // namespace utils
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif // _FASTDDS_DDS_QOS_QOSPOLICYUTILS_HPP_

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -35,11 +35,11 @@
 
 #include <fastdds/dds/log/Log.hpp>
 #include <fastrtps/utils/TimeConversion.h>
-#include <utils/Host.hpp>
 #include <fastdds/rtps/resources/ResourceEvent.h>
 #include <fastdds/rtps/resources/TimedEvent.h>
 #include <fastdds/rtps/builtin/liveliness/WLP.h>
 #include <fastdds/core/policy/ParameterSerializer.hpp>
+#include <fastdds/core/policy/QosPolicyUtils.hpp>
 
 #include <rtps/history/TopicPayloadPoolRegistry.hpp>
 #include <rtps/DataSharing/DataSharingPayloadPool.hpp>
@@ -205,13 +205,7 @@ ReturnCode_t DataWriterImpl::enable()
         DataSharingQosPolicy datasharing(qos_.data_sharing());
         if (datasharing.domain_ids().empty())
         {
-            uint64_t id = 0;
-            Host::uint48 mac_id = Host::instance().mac_id();
-            for (size_t i = 0; i < Host::mac_id_length; ++i)
-            {
-                id |= mac_id.value[i] << (64 - i);
-            }
-            datasharing.add_domain_id(id);
+            datasharing.add_domain_id(utils::default_domain_id());
         }
         w_att.endpoint.set_data_sharing_configuration(datasharing);
     }

--- a/src/cpp/fastdds/publisher/qos/DataWriterQos.cpp
+++ b/src/cpp/fastdds/publisher/qos/DataWriterQos.cpp
@@ -18,7 +18,7 @@
  */
 
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
-#include <utils/Host.hpp>
+#include <fastdds/core/policy/QosPolicyUtils.hpp>
 
 using namespace eprosima::fastdds::dds;
 
@@ -58,13 +58,7 @@ WriterQos DataWriterQos::get_writerqos(
     if (qos.data_sharing.kind() != OFF &&
             qos.data_sharing.domain_ids().empty())
     {
-        uint64_t id = 0;
-        Host::uint48 mac_id = Host::instance().mac_id();
-        for (size_t i = 0; i < Host::mac_id_length; ++i)
-        {
-            id |= static_cast<uint64_t>(mac_id.value[i]) << (56 - (i * 8));
-        }
-        qos.data_sharing.add_domain_id(id);
+        qos.data_sharing.add_domain_id(utils::default_domain_id());
     }
 
     return qos;

--- a/src/cpp/fastdds/publisher/qos/DataWriterQos.cpp
+++ b/src/cpp/fastdds/publisher/qos/DataWriterQos.cpp
@@ -62,7 +62,7 @@ WriterQos DataWriterQos::get_writerqos(
         Host::uint48 mac_id = Host::instance().mac_id();
         for (size_t i = 0; i < Host::mac_id_length; ++i)
         {
-            id |= mac_id.value[i] << (64 - i);
+            id |= static_cast<uint64_t>(mac_id.value[i]) << (56 - (i * 8));
         }
         qos.data_sharing.add_domain_id(id);
     }

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -36,13 +36,13 @@
 #include <fastdds/rtps/reader/RTPSReader.h>
 #include <fastdds/rtps/resources/ResourceEvent.h>
 #include <fastdds/rtps/resources/TimedEvent.h>
+#include <fastdds/core/policy/QosPolicyUtils.hpp>
 
 #include <fastdds/subscriber/SubscriberImpl.hpp>
 #include <fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp>
 #include <fastdds/subscriber/DataReaderImpl/StateFilter.hpp>
 
 #include <fastrtps/utils/TimeConversion.h>
-#include <utils/Host.hpp>
 #include <fastrtps/subscriber/SampleInfo.h>
 
 #include <rtps/history/TopicPayloadPoolRegistry.hpp>
@@ -202,13 +202,7 @@ ReturnCode_t DataReaderImpl::enable()
         DataSharingQosPolicy datasharing(qos_.data_sharing());
         if (datasharing.domain_ids().empty())
         {
-            uint64_t id = 0;
-            Host::uint48 mac_id = Host::instance().mac_id();
-            for (size_t i = 0; i < Host::mac_id_length; ++i)
-            {
-                id |= mac_id.value[i] << (64 - i);
-            }
-            datasharing.add_domain_id(id);
+            datasharing.add_domain_id(utils::default_domain_id());
         }
         att.endpoint.set_data_sharing_configuration(datasharing);
     }

--- a/src/cpp/fastdds/subscriber/qos/DataReaderQos.cpp
+++ b/src/cpp/fastdds/subscriber/qos/DataReaderQos.cpp
@@ -18,8 +18,7 @@
  */
 
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
-#include <utils/Host.hpp>
-#include <fastdds/dds/log/Log.hpp>
+#include <fastdds/core/policy/QosPolicyUtils.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -54,13 +53,7 @@ ReaderQos DataReaderQos::get_readerqos(
     if (qos.data_sharing.kind() != OFF &&
             qos.data_sharing.domain_ids().empty())
     {
-        uint64_t id = 0;
-        Host::uint48 mac_id = Host::instance().mac_id();
-        for (size_t i = 0; i < Host::mac_id_length; ++i)
-        {
-            id |= static_cast<uint64_t>(mac_id.value[i]) << (56 - (i * 8));
-        }
-        qos.data_sharing.add_domain_id(id);
+        qos.data_sharing.add_domain_id(utils::default_domain_id());
     }
 
     return qos;

--- a/src/cpp/fastdds/subscriber/qos/DataReaderQos.cpp
+++ b/src/cpp/fastdds/subscriber/qos/DataReaderQos.cpp
@@ -58,7 +58,7 @@ ReaderQos DataReaderQos::get_readerqos(
         Host::uint48 mac_id = Host::instance().mac_id();
         for (size_t i = 0; i < Host::mac_id_length; ++i)
         {
-            id |= mac_id.value[i] << (64 - i);
+            id |= static_cast<uint64_t>(mac_id.value[i]) << (56 - (i * 8));
         }
         qos.data_sharing.add_domain_id(id);
     }
@@ -69,4 +69,3 @@ ReaderQos DataReaderQos::get_readerqos(
 } /* namespace dds */
 } /* namespace fastdds */
 } /* namespace eprosima */
-

--- a/test/unittest/dds/status/CMakeLists.txt
+++ b/test/unittest/dds/status/CMakeLists.txt
@@ -21,6 +21,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         find_package(Threads REQUIRED)
 
         set(LISTENERTESTS_SOURCE ListenerTests.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/policy/QosPolicyUtils.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/domain/DomainParticipant.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/domain/DomainParticipantImpl.cpp


### PR DESCRIPTION
Fix two error reported by AddressSanitizer and UndefinedBehaviorSanitizer.

The AddressSanitizer error is trivial.

For the UndefinedBehaviorSanitizer error, left shifting a uint64 by 64 bits is considered undefined behavior. See this article for reference.

This is take 2 of an earlier PR: https://github.com/eProsima/Fast-DDS/pull/1834