### PR TITLE
Lifespan support in Persistent DataWriters [10997]

### DIFF
--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -310,6 +310,15 @@ ReturnCode_t DataWriterImpl::enable()
                     },
                     qos_.lifespan().duration.to_ns() * 1e-6);
 
+    // In case it has been loaded from the persistence DB, expire old samples.
+    if (qos_.lifespan().duration != c_TimeInfinite)
+    {
+        if (lifespan_expired())
+        {
+            lifespan_timer_->restart_timer();
+        }
+    }
+
     // REGISTER THE WRITER
     WriterQos wqos = qos_.get_writerqos(get_publisher()->get_qos(), topic_->get_qos());
     if (!is_data_sharing_compatible_)

--- a/src/cpp/fastrtps_deprecated/participant/ParticipantImpl.cpp
+++ b/src/cpp/fastrtps_deprecated/participant/ParticipantImpl.cpp
@@ -27,6 +27,7 @@
 #include <fastdds/rtps/participant/RTPSParticipant.h>
 #include <fastdds/rtps/reader/ReaderDiscoveryInfo.h>
 #include <fastdds/rtps/writer/WriterDiscoveryInfo.h>
+#include <fastdds/rtps/resources/TimedEvent.h>
 #include <fastrtps/attributes/PublisherAttributes.h>
 #include <fastrtps/attributes/SubscriberAttributes.h>
 #include <fastrtps/participant/ParticipantListener.h>
@@ -233,6 +234,13 @@ Publisher* ParticipantImpl::createPublisher(
 
     // In case it has been loaded from the persistence DB, rebuild instances on history
     pubimpl->m_history.rebuild_instances();
+    if (att.qos.m_lifespan.duration != c_TimeInfinite)
+    {
+        if (pubimpl->lifespan_expired())
+        {
+            pubimpl->lifespan_timer_->restart_timer();
+        }
+    }
 
     //SAVE THE PUBLISHER PAIR
     t_p_PublisherPair pubpair;

--- a/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
@@ -172,18 +172,11 @@ TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithLifespanBefore)
     PubSubWriter<Data1mbType> writer(TEST_TOPIC_NAME);
     PubSubReader<Data1mbType> reader(TEST_TOPIC_NAME);
 
-    auto testTransport = std::make_shared<UDPv4TransportDescriptor>();
-    testTransport->sendBufferSize = 32768;
-    testTransport->maxMessageSize = 32768;
-    testTransport->receiveBufferSize = 32768;
-
     writer
             .history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS)
             .resource_limits_max_samples(100)
             .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
             .make_persistent(db_file_name(), "77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64")
-            .disable_builtin_transport()
-            .add_user_transport_to_pparams(testTransport)
             .lifespan_period({1, 0})
             .init();
 

--- a/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
@@ -215,7 +215,7 @@ TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithLifespanBefore)
     reader.startReception(unreceived_data);
 
     // Wait expecting not receiving data.
-    ASSERT_EQ(0, reader.block_for_all(std::chrono::seconds(1)));
+    ASSERT_EQ(0u, reader.block_for_all(std::chrono::seconds(1)));
 }
 
 TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithLifespanSendingBefore)
@@ -223,18 +223,11 @@ TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithLifespanSendingBef
     PubSubWriter<Data1mbType> writer(TEST_TOPIC_NAME);
     PubSubReader<Data1mbType> reader(TEST_TOPIC_NAME);
 
-    auto testTransport = std::make_shared<UDPv4TransportDescriptor>();
-    testTransport->sendBufferSize = 32768;
-    testTransport->maxMessageSize = 32768;
-    testTransport->receiveBufferSize = 32768;
-
     writer
             .history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS)
             .resource_limits_max_samples(100)
             .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
             .make_persistent(db_file_name(), "77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64")
-            .disable_builtin_transport()
-            .add_user_transport_to_pparams(testTransport)
             .lifespan_period({0, 100})
             .init();
 
@@ -281,7 +274,7 @@ TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithLifespanSendingBef
     reader.startReception(unreceived_data);
 
     // Wait expecting not receiving data.
-    ASSERT_EQ(0, reader.block_for_all(std::chrono::seconds(1)));
+    ASSERT_EQ(0u, reader.block_for_all(std::chrono::seconds(1)));
 }
 
 TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithLifespanAfter)
@@ -289,18 +282,11 @@ TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithLifespanAfter)
     PubSubWriter<Data1mbType> writer(TEST_TOPIC_NAME);
     PubSubReader<Data1mbType> reader(TEST_TOPIC_NAME);
 
-    auto testTransport = std::make_shared<UDPv4TransportDescriptor>();
-    testTransport->sendBufferSize = 32768;
-    testTransport->maxMessageSize = 32768;
-    testTransport->receiveBufferSize = 32768;
-
     writer
             .history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS)
             .resource_limits_max_samples(100)
             .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
             .make_persistent(db_file_name(), "77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64")
-            .disable_builtin_transport()
-            .add_user_transport_to_pparams(testTransport)
             .lifespan_period({1, 0})
             .init();
 
@@ -340,7 +326,7 @@ TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithLifespanAfter)
     reader.startReception(unreceived_data);
 
     // Wait expecting not receiving data.
-    ASSERT_EQ(0, reader.block_for_all(std::chrono::seconds(1)));
+    ASSERT_EQ(0u, reader.block_for_all(std::chrono::seconds(1)));
 }
 
 


### PR DESCRIPTION
Right now when a persistent writer with lifespan is initialized, the lifespan is not set for loaded samples. This PR fix this and after load the samples, initialize lifespan timer.

This PR depends on #1837.