### PR TITLE
[11013] Implementation of both narrow methods

### DIFF
--- a/src/cpp/statistics/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipant.cpp
@@ -49,15 +49,23 @@ ReturnCode_t DomainParticipant::disable_statistics_datawriter(
 DomainParticipant* DomainParticipant::narrow(
         eprosima::fastdds::dds::DomainParticipant* domain_participant)
 {
-    (void) domain_participant;
+#ifdef FASTDDS_STATISTICS
+    return static_cast<DomainParticipant*>(domain_participant);
+#else
+    (void)domain_participant;
     return nullptr;
+#endif
 }
 
 const DomainParticipant* DomainParticipant::narrow(
         const eprosima::fastdds::dds::DomainParticipant* domain_participant)
 {
+#ifdef FASTDDS_STATISTICS
+    return static_cast<const DomainParticipant*>(domain_participant);
+#else
     (void) domain_participant;
     return nullptr;
+#endif // FASTDDS_STATISTICS
 }
 
 } // dds

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantTests.cpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantTests.cpp
@@ -59,8 +59,6 @@ TEST(StatisticsDomainParticipantTests, NarrowDomainParticipantTest)
     EXPECT_EQ(statistics_participant, nullptr);
     EXPECT_EQ(const_statistics_participant, nullptr);
 #else
-    logError(STATISTICS_DOMAINPARTICIPANT_TEST, "This test is going to fail because API is not yet implemented.")
-
     EXPECT_NE(statistics_participant, nullptr);
     EXPECT_NE(const_statistics_participant, nullptr);
 #endif // FASTDDS_STATISTICS


### PR DESCRIPTION
This PR implements both statistics DomainParticipant `narrow` methods and also removes the log error from the corresponding test.