### PR TITLE
[11056] Fix building errors in Windows when `FASTDDS_STATISTICS` CMake option is enabled

### DIFF
--- a/src/cpp/statistics/types/types.cxx
+++ b/src/cpp/statistics/types/types.cxx
@@ -95,10 +95,8 @@ size_t eprosima::fastdds::statistics::detail::EntityId_s::getCdrSerializedSize(
     size_t initial_alignment = current_alignment;
 
 
-    if ((4) > 0)
-    {
-        current_alignment += ((4) * 1) + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
-    }
+    current_alignment += ((4) * 1) + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
+
 
     return current_alignment - initial_alignment;
 }
@@ -241,10 +239,8 @@ size_t eprosima::fastdds::statistics::detail::GuidPrefix_s::getCdrSerializedSize
     size_t initial_alignment = current_alignment;
 
 
-    if ((12) > 0)
-    {
-        current_alignment += ((12) * 1) + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
-    }
+    current_alignment += ((12) * 1) + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
+
 
     return current_alignment - initial_alignment;
 }
@@ -978,10 +974,7 @@ size_t eprosima::fastdds::statistics::detail::Locator_s::getCdrSerializedSize(
     current_alignment += 4 + eprosima::fastcdr::Cdr::alignment(current_alignment, 4);
 
 
-    if ((16) > 0)
-    {
-        current_alignment += ((16) * 1) + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
-    }
+    current_alignment += ((16) * 1) + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
 
 
     return current_alignment - initial_alignment;

--- a/test/unittest/statistics/dds/CMakeLists.txt
+++ b/test/unittest/statistics/dds/CMakeLists.txt
@@ -22,7 +22,9 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         endif()
 
         set(STATISTICS_DOMAINPARTICIPANT_TESTS_SOURCE
-            StatisticsDomainParticipantTests.cpp)
+            StatisticsDomainParticipantTests.cpp
+			${PROJECT_SOURCE_DIR}/src/cpp/statistics/types/typesPubSubTypes.cxx
+			${PROJECT_SOURCE_DIR}/src/cpp/statistics/types/types.cxx)
         set(STATISTICS_QOS_TESTS_SOURCE
             StatisticsQosTests.cpp)
 
@@ -33,7 +35,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             )
         target_include_directories(StatisticsDomainParticipantTests PRIVATE ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include ${PROJECT_SOURCE_DIR}/src/cpp)
-        target_link_libraries(StatisticsDomainParticipantTests fastrtps ${GTEST_LIBRARIES})
+        target_link_libraries(StatisticsDomainParticipantTests fastrtps fastcdr ${GTEST_LIBRARIES})
         add_gtest(StatisticsDomainParticipantTests SOURCES ${STATISTICS_DOMAINPARTICIPANT_TESTS_SOURCE})
 
         add_executable(StatisticsQosTests ${STATISTICS_QOS_TESTS_SOURCE})

--- a/test/unittest/statistics/dds/CMakeLists.txt
+++ b/test/unittest/statistics/dds/CMakeLists.txt
@@ -23,8 +23,8 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
 
         set(STATISTICS_DOMAINPARTICIPANT_TESTS_SOURCE
             StatisticsDomainParticipantTests.cpp
-			${PROJECT_SOURCE_DIR}/src/cpp/statistics/types/typesPubSubTypes.cxx
-			${PROJECT_SOURCE_DIR}/src/cpp/statistics/types/types.cxx)
+            ${PROJECT_SOURCE_DIR}/src/cpp/statistics/types/typesPubSubTypes.cxx
+            ${PROJECT_SOURCE_DIR}/src/cpp/statistics/types/types.cxx)
         set(STATISTICS_QOS_TESTS_SOURCE
             StatisticsQosTests.cpp)
 

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -42,7 +42,7 @@ namespace rtps {
 struct MockListener : IListener
 {
     MOCK_METHOD1(on_statistics_data, void(
-	        const Data&));
+                const Data&));
 };
 
 /*

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -41,7 +41,8 @@ namespace rtps {
 
 struct MockListener : IListener
 {
-    MOCK_METHOD(void, on_statistics_data, (const Data& ), (override));
+    MOCK_METHOD1(on_statistics_data, void(
+	        const Data&));
 };
 
 /*


### PR DESCRIPTION
This PR fixes warnings and errors that appear when building with the CMake option `FASTDDS_STATISTICS` in Windows.

* Fix warning C4127 `conditional expression is constant` in `src/cpp/statistics/types/types.cxx`.
* Fix MOCK_METHOD macro call in `RTPSStatisticsTests`.
* Fix error LNK2019 building `StatisticsDomainParticipantTests`.