### PR TITLE
[10714] Create and delete domainParticipant implementation

### DIFF
--- a/include/fastdds/statistics/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/statistics/dds/domain/DomainParticipant.hpp
@@ -97,7 +97,6 @@ public:
      */
     RTPS_DllAPI ReturnCode_t enable() override;
 
-
 protected:
 
     /**
@@ -128,8 +127,8 @@ protected:
      */
     void delete_statistics_builtin_entities();
 
-   eprosima::fastdds::dds::Publisher* builtin_publisher_;
-    
+    eprosima::fastdds::dds::Publisher* builtin_publisher_;
+
     friend class eprosima::fastdds::dds::DomainParticipantFactory;
 };
 

--- a/include/fastdds/statistics/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/statistics/dds/domain/DomainParticipant.hpp
@@ -22,7 +22,10 @@
 
 #include <string>
 
+#include <fastdds/dds/core/status/StatusMask.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
+#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
+#include <fastdds/dds/publisher/Publisher.hpp>
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
 #include <fastrtps/fastrtps_dll.h>
 #include <fastrtps/types/TypesBase.h>
@@ -87,6 +90,42 @@ public:
      */
     RTPS_DllAPI static const DomainParticipant* narrow(
             const eprosima::fastdds::dds::DomainParticipant* domain_participant);
+
+    /**
+     * @brief This operation enables the statistics DomainParticipant
+     * @return RETCODE_OK
+     */
+    RTPS_DllAPI ReturnCode_t enable() override;
+
+
+protected:
+
+    /**
+     * Constructor
+     */
+    DomainParticipant(
+            const eprosima::fastdds::dds::StatusMask& mask)
+        : eprosima::fastdds::dds::DomainParticipant(mask)
+    {
+    }
+
+    /**
+     * Auxiliary function to create the statistics builtin entities.
+     * @return true if succesfully created statistics DDS entities,
+     * false otherwise.
+     */
+    void create_statistics_builtin_entities();
+
+    /**
+     * Auxiliary function to enable statistics builtin datawriters.
+     * @param topic_list string with the semicolon separated list of statistics topics.
+     */
+    void enable_statistics_builtin_datawriters(
+            const std::string& topic_list);
+
+   eprosima::fastdds::dds::Publisher* builtin_publisher_;
+    
+    friend class eprosima::fastdds::dds::DomainParticipantFactory;
 };
 
 /* Environment variable to specify a semicolon-separated list of topic names that define the statistics DataWriters that

--- a/include/fastdds/statistics/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/statistics/dds/domain/DomainParticipant.hpp
@@ -89,6 +89,13 @@ public:
             const eprosima::fastdds::dds::DomainParticipant* domain_participant);
 };
 
+/* Environment variable to specify a semicolon-separated list of topic names that define the statistics DataWriters that
+ * the DomainParticipant will enable when enabled itself.
+ * The topic names must conform to the topic names aliases defined in @ref topic_names.hpp.
+ * For the variable to take any effect the CMake option FASTDDS_STATISTICS must be enabled.
+ */
+const char* const FASTDDS_STATISTICS_ENVIRONMENT_VARIABLE = "FASTDDS_STATISTICS";
+
 } // namespace dds
 } // namespace statistics
 } // namespace fastdds

--- a/include/fastdds/statistics/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/statistics/dds/domain/DomainParticipant.hpp
@@ -123,6 +123,11 @@ protected:
     void enable_statistics_builtin_datawriters(
             const std::string& topic_list);
 
+    /**
+     * Auxiliary function to delete the statistics builtin entities.
+     */
+    void delete_statistics_builtin_entities();
+
    eprosima::fastdds::dds::Publisher* builtin_publisher_;
     
     friend class eprosima::fastdds::dds::DomainParticipantFactory;

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -17,22 +17,23 @@
  *
  */
 
-#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
-#include <fastdds/rtps/RTPSDomain.h>
-#include <fastdds/rtps/participant/RTPSParticipant.h>
-
 #include <fastdds/dds/domain/DomainParticipant.hpp>
-#include <fastdds/domain/DomainParticipantImpl.hpp>
-
+#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/log/Log.hpp>
-
+#include <fastdds/rtps/participant/RTPSParticipant.h>
+#include <fastdds/rtps/RTPSDomain.h>
+#include <fastdds/statistics/dds/domain/DomainParticipant.hpp>
+#include <fastrtps/types/DynamicDataFactory.h>
+#include <fastrtps/types/DynamicTypeBuilderFactory.h>
+#include <fastrtps/types/TypeObjectFactory.h>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 
-#include <fastrtps/types/DynamicTypeBuilderFactory.h>
-#include <fastrtps/types/DynamicDataFactory.h>
-#include <fastrtps/types/TypeObjectFactory.h>
-
+#include <fastdds/domain/DomainParticipantImpl.hpp>
 #include <rtps/history/TopicPayloadPoolRegistry.hpp>
+
+
+
+
 
 using namespace eprosima::fastrtps::xmlparser;
 
@@ -161,7 +162,12 @@ DomainParticipant* DomainParticipantFactory::create_participant(
 
     const DomainParticipantQos& pqos = (&qos == &PARTICIPANT_QOS_DEFAULT) ? default_participant_qos_ : qos;
 
+#ifndef FASTDDS_STATISTICS
     DomainParticipant* dom_part = new DomainParticipant(mask);
+#else
+    eprosima::fastdds::statistics::dds::DomainParticipant* dom_part =
+            new eprosima::fastdds::statistics::dds::DomainParticipant(mask);
+#endif // FASTDDS_STATISTICS
     DomainParticipantImpl* dom_part_impl = new DomainParticipantImpl(dom_part, did, pqos, listen);
 
     {

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -119,9 +119,9 @@ ReturnCode_t DomainParticipantFactory::delete_participant(
 #ifdef FASTDDS_STATISTICS
         // Delete builtin statistics entities
         eprosima::fastdds::statistics::dds::DomainParticipant* stat_part =
-            eprosima::fastdds::statistics::dds::DomainParticipant::narrow(part);
+                eprosima::fastdds::statistics::dds::DomainParticipant::narrow(part);
         stat_part->delete_statistics_builtin_entities();
-#endif
+#endif // ifdef FASTDDS_STATISTICS
         if (part->has_active_entities())
         {
             return ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -116,6 +116,12 @@ ReturnCode_t DomainParticipantFactory::delete_participant(
 
     if (part != nullptr)
     {
+#ifdef FASTDDS_STATISTICS
+        // Delete builtin statistics entities
+        eprosima::fastdds::statistics::dds::DomainParticipant* stat_part =
+            eprosima::fastdds::statistics::dds::DomainParticipant::narrow(part);
+        stat_part->delete_statistics_builtin_entities();
+#endif
         if (part->has_active_entities())
         {
             return ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;

--- a/src/cpp/statistics/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipant.cpp
@@ -20,11 +20,13 @@
 
 #include <string>
 #include <sstream>
+#include <vector>
 
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
 #include <fastdds/dds/publisher/qos/PublisherQos.hpp>
+#include <fastdds/dds/publisher/DataWriter.hpp>
 #include <fastdds/statistics/dds/publisher/qos/DataWriterQos.hpp>
 #include <fastrtps/types/TypesBase.h>
 
@@ -137,6 +139,20 @@ void DomainParticipant::enable_statistics_builtin_datawriters(
             logError(STATISTICS_DOMAIN_PARTICIPANT, "Topic " << topic << "is not a valid statistics topic name/alias");
         }
     }
+}
+
+void DomainParticipant::delete_statistics_builtin_entities()
+{
+    std::vector<eprosima::fastdds::dds::DataWriter*> builtin_writers;
+    builtin_publisher_->get_datawriters(builtin_writers);
+    for (auto writer : builtin_writers)
+    {
+        std::string topic_name = writer->get_topic()->get_name();
+        disable_statistics_datawriter(topic_name);
+    }
+
+    // Delete builtin_publisher
+    impl_->delete_publisher(builtin_publisher_);
 }
 
 } // dds

--- a/src/cpp/statistics/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipant.cpp
@@ -82,7 +82,7 @@ ReturnCode_t DomainParticipant::enable()
 {
     ReturnCode_t ret = eprosima::fastdds::dds::DomainParticipant::enable();
 
-    if(enable_)
+    if (enable_)
     {
         create_statistics_builtin_entities();
     }
@@ -98,7 +98,7 @@ void DomainParticipant::create_statistics_builtin_entities()
     // Enable statistics datawriters
     // 1. Find fastdds_statistics PropertyPolicyQos
     const std::string* property_topic_list = eprosima::fastrtps::rtps::PropertyPolicyHelper::find_property(
-            impl_->get_qos().properties(), "fastdds.statistics");
+        impl_->get_qos().properties(), "fastdds.statistics");
 
     if (nullptr != property_topic_list)
     {

--- a/src/cpp/statistics/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipant.cpp
@@ -132,8 +132,8 @@ void DomainParticipant::enable_statistics_builtin_datawriters(
         // case RETCODE_INCONSISTENT_POLICY cannot happen. STATISTICS_DATAWRITER_QOS is consitent.
         // case RETCODE_UNSUPPORTED cannot happen because this method is only called if FASTDDS_STATISTICS
         // CMake option is enabled
-        assert(ret != RETCODE_INCONSISTENT_POLICY);
-        assert(ret != RETCODE_UNSUPPORTED);
+        assert(ret != ReturnCode_t::RETCODE_INCONSISTENT_POLICY);
+        assert(ret != ReturnCode_t::RETCODE_UNSUPPORTED);
         if (ret == ReturnCode_t::RETCODE_BAD_PARAMETER)
         {
             logError(STATISTICS_DOMAIN_PARTICIPANT, "Topic " << topic << "is not a valid statistics topic name/alias");

--- a/test/blackbox/CMakeLists.txt
+++ b/test/blackbox/CMakeLists.txt
@@ -254,6 +254,8 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
             ${CMAKE_CURRENT_BINARY_DIR}/PubSubReader.xml)
         configure_file(${CMAKE_CURRENT_SOURCE_DIR}/persistence.xml
             ${CMAKE_CURRENT_BINARY_DIR}/persistence.xml)
+        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/StatisticsDomainParticipant.xml
+            ${CMAKE_CURRENT_BINARY_DIR}/StatisticsDomainParticipant.xml)
         configure_file(${CMAKE_CURRENT_SOURCE_DIR}/utils/check_guid.py
             ${CMAKE_CURRENT_BINARY_DIR}/check_guid.py)
 
@@ -288,6 +290,8 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
                 ${DDS_BLACKBOXTESTS_SOURCE}
                 api/dds-pim/ReqRepHelloWorldRequester.cpp
                 api/dds-pim/ReqRepHelloWorldReplier.cpp
+                ${PROJECT_SOURCE_DIR}/src/cpp/statistics/types/types.cxx
+                ${PROJECT_SOURCE_DIR}/src/cpp/statistics/types/typesPubSubTypes.cxx
                 )
             add_executable(BlackboxTests_DDS_PIM ${BLACKBOXTESTS_FASTDDS_PIM_SOURCE})
             target_compile_definitions(BlackboxTests_DDS_PIM PRIVATE

--- a/test/blackbox/StatisticsDomainParticipant.xml
+++ b/test/blackbox/StatisticsDomainParticipant.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"  ?>
+<dds xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles">
+    <profiles>          
+        <participant profile_name="statistics_participant" is_default_profile="true">
+            <rtps>
+                <propertiesPolicy>
+                    <properties>
+                        <property>
+                            <name>fastdds.statistics</name>
+                            <value>SUBSCRIPTION_THROUGHPUT_TOPIC;NACKFRAG_COUNT_TOPIC;SAMPLE_DATAS_TOPIC</value>
+                        </property>
+                    </properties>
+                </propertiesPolicy>
+            </rtps>
+        </participant>
+    </profiles>
+</dds>

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -247,7 +247,8 @@ public:
 
     PubSubReader(
             const std::string& topic_name,
-            bool take = true)
+            bool take = true,
+            bool statistics = false)
         : participant_listener_(*this)
         , listener_(*this)
         , participant_(nullptr)
@@ -279,9 +280,12 @@ public:
         , message_receive_count_(0)
     {
         // Generate topic name
-        std::ostringstream t;
-        t << topic_name_ << "_" << asio::ip::host_name() << "_" << GET_PID();
-        topic_name_ = t.str();
+        if (!statistics)
+        {
+            std::ostringstream t;
+            t << topic_name_ << "_" << asio::ip::host_name() << "_" << GET_PID();
+            topic_name_ = t.str();
+        }
 
         if (enable_datasharing)
         {

--- a/test/blackbox/common/DDSBlackboxTestsStatisticsDomainParticipant.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsStatisticsDomainParticipant.cpp
@@ -33,7 +33,8 @@ class WriterReaderDataTest : public eprosima::fastdds::statistics::WriterReaderD
 {
 public:
 
-    bool operator==(const WriterReaderDataTest &x) const
+    bool operator ==(
+            const WriterReaderDataTest& x) const
     {
         if (this->writer_guid().guidPrefix().value() == x.writer_guid().guidPrefix().value() &&
                 this->writer_guid().entityId().value() == x.writer_guid().entityId().value() &&
@@ -45,13 +46,15 @@ public:
         }
         return false;
     }
+
 };
 
 class Locator2LocatorDataTest : public eprosima::fastdds::statistics::Locator2LocatorData
 {
 public:
 
-    bool operator==(const Locator2LocatorDataTest &x) const
+    bool operator ==(
+            const Locator2LocatorDataTest& x) const
     {
         if (this->src_locator().kind() == x.src_locator().kind() &&
                 this->src_locator().port() == x.src_locator().port() &&
@@ -65,13 +68,15 @@ public:
         }
         return false;
     }
+
 };
 
 class Entity2LocatorTrafficTest : public eprosima::fastdds::statistics::Entity2LocatorTraffic
 {
 public:
 
-    bool operator==(const Entity2LocatorTrafficTest &x) const
+    bool operator ==(
+            const Entity2LocatorTrafficTest& x) const
     {
         if (this->src_guid().guidPrefix().value() == x.src_guid().guidPrefix().value() &&
                 this->src_guid().entityId().value() == x.src_guid().entityId().value() &&
@@ -86,13 +91,15 @@ public:
         }
         return false;
     }
+
 };
 
 class DiscoveryTimeTest : public eprosima::fastdds::statistics::DiscoveryTime
 {
 public:
 
-    bool operator==(const DiscoveryTimeTest &x) const
+    bool operator ==(
+            const DiscoveryTimeTest& x) const
     {
         if (this->local_participant_guid().guidPrefix().value() == x.local_participant_guid().guidPrefix().value() &&
                 this->local_participant_guid().entityId().value() == x.local_participant_guid().entityId().value() &&
@@ -104,13 +111,15 @@ public:
         }
         return false;
     }
+
 };
 
 class PhysicalDataTest : public eprosima::fastdds::statistics::PhysicalData
 {
 public:
 
-    bool operator==(const PhysicalDataTest &x) const
+    bool operator ==(
+            const PhysicalDataTest& x) const
     {
         if (this->participant_guid().guidPrefix().value() == x.participant_guid().guidPrefix().value() &&
                 this->participant_guid().entityId().value() == x.participant_guid().entityId().value() &&
@@ -122,13 +131,15 @@ public:
         }
         return false;
     }
+
 };
 
 class EntityDataTest : public eprosima::fastdds::statistics::EntityData
 {
 public:
 
-    bool operator==(const EntityDataTest &x) const
+    bool operator ==(
+            const EntityDataTest& x) const
     {
         if (this->guid().guidPrefix().value() == x.guid().guidPrefix().value() &&
                 this->guid().entityId().value() == x.guid().entityId().value() &&
@@ -138,13 +149,15 @@ public:
         }
         return false;
     }
+
 };
 
 class EntityCountTest : public eprosima::fastdds::statistics::EntityCount
 {
 public:
 
-    bool operator==(const EntityCountTest &x) const
+    bool operator ==(
+            const EntityCountTest& x) const
     {
         if (this->guid().guidPrefix().value() == x.guid().guidPrefix().value() &&
                 this->guid().entityId().value() == x.guid().entityId().value() &&
@@ -154,13 +167,15 @@ public:
         }
         return false;
     }
+
 };
 
 class SampleIdentityCountTest : public eprosima::fastdds::statistics::SampleIdentityCount
 {
 public:
 
-    bool operator==(const SampleIdentityCountTest &x) const
+    bool operator ==(
+            const SampleIdentityCountTest& x) const
     {
         if (this->sample_id().writer_guid().guidPrefix().value() == x.sample_id().writer_guid().guidPrefix().value() &&
                 this->sample_id().writer_guid().entityId().value() == x.sample_id().writer_guid().entityId().value() &&
@@ -172,6 +187,7 @@ public:
         }
         return false;
     }
+
 };
 
 class WriterReaderDataPubSubTypeTest : public eprosima::fastdds::statistics::WriterReaderDataPubSubType
@@ -264,15 +280,15 @@ TEST(StatisticsDomainParticipant, CreateParticipant)
 
     // Create statistics DataReaders
     PubSubReader<WriterReaderDataPubSubTypeTest> history_latency_reader(
-            eprosima::fastdds::statistics::HISTORY_LATENCY_TOPIC, true, true);
+        eprosima::fastdds::statistics::HISTORY_LATENCY_TOPIC, true, true);
     PubSubReader<Locator2LocatorDataPubSubTypeTest> network_latency_reader(
-            eprosima::fastdds::statistics::NETWORK_LATENCY_TOPIC, true, true);
+        eprosima::fastdds::statistics::NETWORK_LATENCY_TOPIC, true, true);
     PubSubReader<Entity2LocatorTrafficPubSubTypeTest> rtps_lost_reader(
-            eprosima::fastdds::statistics::RTPS_LOST_TOPIC, true, true);
+        eprosima::fastdds::statistics::RTPS_LOST_TOPIC, true, true);
     PubSubReader<DiscoveryTimePubSubTypeTest> discovery_reader(
-            eprosima::fastdds::statistics::DISCOVERY_TOPIC, true, true);
+        eprosima::fastdds::statistics::DISCOVERY_TOPIC, true, true);
     PubSubReader<PhysicalDataPubSubTypeTest> physical_data_reader(
-            eprosima::fastdds::statistics::PHYSICAL_DATA_TOPIC, true, true);
+        eprosima::fastdds::statistics::PHYSICAL_DATA_TOPIC, true, true);
 
     // 1. Set environment variable and create participant using Qos set by code
     const char* value = "HISTORY_LATENCY_TOPIC;NETWORK_LATENCY_TOPIC;RTPS_LOST_TOPIC";
@@ -346,9 +362,9 @@ TEST(StatisticsDomainParticipant, CreateParticipant)
     EXPECT_EQ(null_type, participant->find_type(sample_identity_count_type.get_type_name()));
 
     EXPECT_EQ(nullptr, participant->lookup_topicdescription(
-            eprosima::fastdds::statistics::PUBLICATION_THROUGHPUT_TOPIC));
+                eprosima::fastdds::statistics::PUBLICATION_THROUGHPUT_TOPIC));
     EXPECT_EQ(nullptr, participant->lookup_topicdescription(
-            eprosima::fastdds::statistics::SUBSCRIPTION_THROUGHPUT_TOPIC));
+                eprosima::fastdds::statistics::SUBSCRIPTION_THROUGHPUT_TOPIC));
     EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::RTPS_SENT_TOPIC));
     EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::RESENT_DATAS_TOPIC));
     EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::HEARTBEAT_COUNT_TOPIC));
@@ -409,15 +425,15 @@ TEST(StatisticsDomainParticipant, CreateParticipantUsingXML)
 
     // Create statistics DataReaders
     PubSubReader<EntityDataPubSubTypeTest> publication_throughput_reader(
-            eprosima::fastdds::statistics::PUBLICATION_THROUGHPUT_TOPIC, true, true);
+        eprosima::fastdds::statistics::PUBLICATION_THROUGHPUT_TOPIC, true, true);
     PubSubReader<EntityDataPubSubTypeTest> subscription_throughput_reader(
-            eprosima::fastdds::statistics::SUBSCRIPTION_THROUGHPUT_TOPIC, true, true);
+        eprosima::fastdds::statistics::SUBSCRIPTION_THROUGHPUT_TOPIC, true, true);
     PubSubReader<EntityCountPubSubTypeTest> heartbeat_count_reader(
-            eprosima::fastdds::statistics::HEARTBEAT_COUNT_TOPIC, true, true);
+        eprosima::fastdds::statistics::HEARTBEAT_COUNT_TOPIC, true, true);
     PubSubReader<EntityCountPubSubTypeTest> nackfrag_count_reader(
-            eprosima::fastdds::statistics::NACKFRAG_COUNT_TOPIC, true, true);
+        eprosima::fastdds::statistics::NACKFRAG_COUNT_TOPIC, true, true);
     PubSubReader<SampleIdentityCountPubSubTypeTest> sample_datas_reader(
-            eprosima::fastdds::statistics::SAMPLE_DATAS_TOPIC, true, true);
+        eprosima::fastdds::statistics::SAMPLE_DATAS_TOPIC, true, true);
 
     // 1. Set environment variable and create participant using Qos set by code
     const char* value = "PUBLICATION_THROUGHPUT_TOPIC;HEARTBEAT_COUNT_TOPIC";
@@ -438,7 +454,7 @@ TEST(StatisticsDomainParticipant, CreateParticipantUsingXML)
     // 2. Check that the statistics topics and types related to the statistics DataWriters enabled using the
     // environment variable exist.
     EXPECT_NE(nullptr, participant->lookup_topicdescription(
-            eprosima::fastdds::statistics::PUBLICATION_THROUGHPUT_TOPIC));
+                eprosima::fastdds::statistics::PUBLICATION_THROUGHPUT_TOPIC));
     EXPECT_EQ(throughput_type, participant->find_type(throughput_type.get_type_name()));
 
     EXPECT_NE(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::HEARTBEAT_COUNT_TOPIC));
@@ -447,7 +463,7 @@ TEST(StatisticsDomainParticipant, CreateParticipantUsingXML)
     // Check that the statistics topics and types related to the statistics DataWriters set with the PropertyPolicyQos
     // have been created correctly.
     EXPECT_NE(nullptr, participant->lookup_topicdescription(
-            eprosima::fastdds::statistics::SUBSCRIPTION_THROUGHPUT_TOPIC));
+                eprosima::fastdds::statistics::SUBSCRIPTION_THROUGHPUT_TOPIC));
     EXPECT_EQ(throughput_type, participant->find_type(throughput_type.get_type_name()));
 
     EXPECT_NE(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::NACKFRAG_COUNT_TOPIC));

--- a/test/blackbox/common/DDSBlackboxTestsStatisticsDomainParticipant.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsStatisticsDomainParticipant.cpp
@@ -1,0 +1,518 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdlib.h>
+
+#include <gtest/gtest.h>
+
+#include "BlackboxTests.hpp"
+#include "PubSubReader.hpp"
+
+#include <fastdds/dds/domain/DomainParticipant.hpp>
+#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
+#include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
+#include <fastdds/dds/topic/TypeSupport.hpp>
+#include <fastdds/statistics/dds/domain/DomainParticipant.hpp>
+#include <fastdds/statistics/topic_names.hpp>
+#include <fastrtps/types/TypesBase.h>
+#include <statistics/types/types.h>
+#include <statistics/types/typesPubSubTypes.h>
+
+class WriterReaderDataTest : public eprosima::fastdds::statistics::WriterReaderData
+{
+public:
+
+    bool operator==(const WriterReaderDataTest &x) const
+    {
+        if (this->writer_guid().guidPrefix().value() == x.writer_guid().guidPrefix().value() &&
+                this->writer_guid().entityId().value() == x.writer_guid().entityId().value() &&
+                this->reader_guid().guidPrefix().value() == x.reader_guid().guidPrefix().value() &&
+                this->reader_guid().entityId().value() == x.reader_guid().entityId().value() &&
+                this->data() == x.data())
+        {
+            return true;
+        }
+        return false;
+    }
+};
+
+class Locator2LocatorDataTest : public eprosima::fastdds::statistics::Locator2LocatorData
+{
+public:
+
+    bool operator==(const Locator2LocatorDataTest &x) const
+    {
+        if (this->src_locator().kind() == x.src_locator().kind() &&
+                this->src_locator().port() == x.src_locator().port() &&
+                this->src_locator().address() == x.src_locator().address() &&
+                this->dst_locator().kind() == x.dst_locator().kind() &&
+                this->dst_locator().port() == x.dst_locator().port() &&
+                this->dst_locator().address() == x.dst_locator().address() &&
+                this->data() == x.data())
+        {
+            return true;
+        }
+        return false;
+    }
+};
+
+class Entity2LocatorTrafficTest : public eprosima::fastdds::statistics::Entity2LocatorTraffic
+{
+public:
+
+    bool operator==(const Entity2LocatorTrafficTest &x) const
+    {
+        if (this->src_guid().guidPrefix().value() == x.src_guid().guidPrefix().value() &&
+                this->src_guid().entityId().value() == x.src_guid().entityId().value() &&
+                this->dst_locator().kind() == x.dst_locator().kind() &&
+                this->dst_locator().port() == x.dst_locator().port() &&
+                this->dst_locator().address() == x.dst_locator().address() &&
+                this->packet_count() == x.packet_count() &&
+                this->byte_count() == x.byte_count() &&
+                this->byte_magnitude_order() == x.byte_magnitude_order())
+        {
+            return true;
+        }
+        return false;
+    }
+};
+
+class DiscoveryTimeTest : public eprosima::fastdds::statistics::DiscoveryTime
+{
+public:
+
+    bool operator==(const DiscoveryTimeTest &x) const
+    {
+        if (this->local_participant_guid().guidPrefix().value() == x.local_participant_guid().guidPrefix().value() &&
+                this->local_participant_guid().entityId().value() == x.local_participant_guid().entityId().value() &&
+                this->remote_entity_guid().guidPrefix().value() == x.remote_entity_guid().guidPrefix().value() &&
+                this->remote_entity_guid().entityId().value() == x.remote_entity_guid().entityId().value() &&
+                this->time() == x.time())
+        {
+            return true;
+        }
+        return false;
+    }
+};
+
+class PhysicalDataTest : public eprosima::fastdds::statistics::PhysicalData
+{
+public:
+
+    bool operator==(const PhysicalDataTest &x) const
+    {
+        if (this->participant_guid().guidPrefix().value() == x.participant_guid().guidPrefix().value() &&
+                this->participant_guid().entityId().value() == x.participant_guid().entityId().value() &&
+                this->host() == x.host() &&
+                this->user() == x.user() &&
+                this->process() == x.process())
+        {
+            return true;
+        }
+        return false;
+    }
+};
+
+class EntityDataTest : public eprosima::fastdds::statistics::EntityData
+{
+public:
+
+    bool operator==(const EntityDataTest &x) const
+    {
+        if (this->guid().guidPrefix().value() == x.guid().guidPrefix().value() &&
+                this->guid().entityId().value() == x.guid().entityId().value() &&
+                this->data() == x.data())
+        {
+            return true;
+        }
+        return false;
+    }
+};
+
+class EntityCountTest : public eprosima::fastdds::statistics::EntityCount
+{
+public:
+
+    bool operator==(const EntityCountTest &x) const
+    {
+        if (this->guid().guidPrefix().value() == x.guid().guidPrefix().value() &&
+                this->guid().entityId().value() == x.guid().entityId().value() &&
+                this->count() == x.count())
+        {
+            return true;
+        }
+        return false;
+    }
+};
+
+class SampleIdentityCountTest : public eprosima::fastdds::statistics::SampleIdentityCount
+{
+public:
+
+    bool operator==(const SampleIdentityCountTest &x) const
+    {
+        if (this->sample_id().writer_guid().guidPrefix().value() == x.sample_id().writer_guid().guidPrefix().value() &&
+                this->sample_id().writer_guid().entityId().value() == x.sample_id().writer_guid().entityId().value() &&
+                this->sample_id().sequence_number().high() == x.sample_id().sequence_number().high() &&
+                this->sample_id().sequence_number().low() == x.sample_id().sequence_number().low() &&
+                this->count() == x.count())
+        {
+            return true;
+        }
+        return false;
+    }
+};
+
+class WriterReaderDataPubSubTypeTest : public eprosima::fastdds::statistics::WriterReaderDataPubSubType
+{
+public:
+
+    typedef WriterReaderDataTest type;
+};
+
+class Locator2LocatorDataPubSubTypeTest : public eprosima::fastdds::statistics::Locator2LocatorDataPubSubType
+{
+public:
+
+    typedef Locator2LocatorDataTest type;
+};
+
+class Entity2LocatorTrafficPubSubTypeTest : public eprosima::fastdds::statistics::Entity2LocatorTrafficPubSubType
+{
+public:
+
+    typedef Entity2LocatorTrafficTest type;
+};
+
+class DiscoveryTimePubSubTypeTest : public eprosima::fastdds::statistics::DiscoveryTimePubSubType
+{
+public:
+
+    typedef DiscoveryTimeTest type;
+};
+
+class PhysicalDataPubSubTypeTest : public eprosima::fastdds::statistics::PhysicalDataPubSubType
+{
+public:
+
+    typedef PhysicalDataTest type;
+};
+
+class EntityDataPubSubTypeTest : public eprosima::fastdds::statistics::EntityDataPubSubType
+{
+public:
+
+    typedef EntityDataTest type;
+};
+
+class EntityCountPubSubTypeTest : public eprosima::fastdds::statistics::EntityCountPubSubType
+{
+public:
+
+    typedef EntityCountTest type;
+};
+
+class SampleIdentityCountPubSubTypeTest : public eprosima::fastdds::statistics::SampleIdentityCountPubSubType
+{
+public:
+
+    typedef SampleIdentityCountTest type;
+};
+
+/*
+ * This test checks that when the environment variable is correctly set, the proper statistics DataWriters are created
+ * and enabled.
+ * This test is only valid when FASTDDS_STATISTICS CMake option is set. Otherwise the test is empty.
+ * 0. Setup test: create DDS entities needed for the test: TypeSupports, DataReaders...
+ * 1. Set environment variable and create participant using a Qos set by code.
+ * 2. Check that topics, types and datawriters have been created correctly.
+ * 3. Check that those topics and types that have not been enabled does not exist.
+ */
+TEST(StatisticsDomainParticipant, CreateParticipant)
+{
+#ifdef FASTDDS_STATISTICS
+    // 0. Setup test
+    // Create TypeSupports
+    eprosima::fastdds::dds::TypeSupport history_latency_type(
+        new eprosima::fastdds::statistics::WriterReaderDataPubSubType);
+    eprosima::fastdds::dds::TypeSupport network_latency_type(
+        new eprosima::fastdds::statistics::Locator2LocatorDataPubSubType);
+    eprosima::fastdds::dds::TypeSupport throughput_type(
+        new eprosima::fastdds::statistics::EntityDataPubSubType);
+    eprosima::fastdds::dds::TypeSupport rtps_traffic_type(
+        new eprosima::fastdds::statistics::Entity2LocatorTrafficPubSubType);
+    eprosima::fastdds::dds::TypeSupport count_type(
+        new eprosima::fastdds::statistics::EntityCountPubSubType);
+    eprosima::fastdds::dds::TypeSupport discovery_type(
+        new eprosima::fastdds::statistics::DiscoveryTimePubSubType);
+    eprosima::fastdds::dds::TypeSupport sample_identity_count_type(
+        new eprosima::fastdds::statistics::SampleIdentityCountPubSubType);
+    eprosima::fastdds::dds::TypeSupport physical_data_type(
+        new eprosima::fastdds::statistics::PhysicalDataPubSubType);
+    eprosima::fastdds::dds::TypeSupport null_type(nullptr);
+
+    // Create statistics DataReaders
+    PubSubReader<WriterReaderDataPubSubTypeTest> history_latency_reader(
+            eprosima::fastdds::statistics::HISTORY_LATENCY_TOPIC, true, true);
+    PubSubReader<Locator2LocatorDataPubSubTypeTest> network_latency_reader(
+            eprosima::fastdds::statistics::NETWORK_LATENCY_TOPIC, true, true);
+    PubSubReader<Entity2LocatorTrafficPubSubTypeTest> rtps_lost_reader(
+            eprosima::fastdds::statistics::RTPS_LOST_TOPIC, true, true);
+    PubSubReader<DiscoveryTimePubSubTypeTest> discovery_reader(
+            eprosima::fastdds::statistics::DISCOVERY_TOPIC, true, true);
+    PubSubReader<PhysicalDataPubSubTypeTest> physical_data_reader(
+            eprosima::fastdds::statistics::PHYSICAL_DATA_TOPIC, true, true);
+
+    // 1. Set environment variable and create participant using Qos set by code
+    const char* value = "HISTORY_LATENCY_TOPIC;NETWORK_LATENCY_TOPIC;RTPS_LOST_TOPIC";
+#ifdef _WIN32
+    ASSERT_EQ(0, _putenv_s(eprosima::fastdds::statistics::dds::FASTDDS_STATISTICS_ENVIRONMENT_VARIABLE, value));
+#else
+    ASSERT_EQ(0, setenv(eprosima::fastdds::statistics::dds::FASTDDS_STATISTICS_ENVIRONMENT_VARIABLE, value, 1));
+#endif // ifdef _WIN32
+
+    // There is no problem if some topic name is repeated.
+    eprosima::fastdds::dds::DomainParticipantQos pqos;
+    pqos.properties().properties().emplace_back("fastdds.statistics",
+            "HISTORY_LATENCY_TOPIC;DISCOVERY_TOPIC;PHYSICAL_DATA_TOPIC");
+
+    eprosima::fastdds::dds::DomainParticipant* participant =
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->
+                    create_participant(0, pqos);
+    ASSERT_NE(participant, nullptr);
+
+    // 2. Check that the statistics topics and types related to the statistics DataWriters enabled using the
+    // environment variable exist.
+    EXPECT_NE(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::HISTORY_LATENCY_TOPIC));
+    EXPECT_EQ(history_latency_type, participant->find_type(history_latency_type.get_type_name()));
+
+    EXPECT_NE(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::NETWORK_LATENCY_TOPIC));
+    EXPECT_EQ(network_latency_type, participant->find_type(network_latency_type.get_type_name()));
+
+    EXPECT_NE(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::RTPS_LOST_TOPIC));
+    EXPECT_EQ(rtps_traffic_type, participant->find_type(rtps_traffic_type.get_type_name()));
+
+    // Check that the statistics topics and types related to the statistics DataWriters set with the PropertyPolicyQos
+    // have been created correctly.
+    EXPECT_NE(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::DISCOVERY_TOPIC));
+    EXPECT_EQ(discovery_type, participant->find_type(discovery_type.get_type_name()));
+
+    EXPECT_NE(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::PHYSICAL_DATA_TOPIC));
+    EXPECT_EQ(physical_data_type, participant->find_type(physical_data_type.get_type_name()));
+
+    // Before initializing the DataReaders the environment variable should be unset.
+    // Otherwise each domainParticipant (each DataReader is launched in its own domainParticipant) will also enable
+    // the statistics DataWriters set with the environment variable.
+#ifdef _WIN32
+    ASSERT_EQ(0, _putenv_s(eprosima::fastdds::statistics::dds::FASTDDS_STATISTICS_ENVIRONMENT_VARIABLE, ""));
+#else
+    ASSERT_EQ(0, unsetenv(eprosima::fastdds::statistics::dds::FASTDDS_STATISTICS_ENVIRONMENT_VARIABLE));
+#endif // ifdef _WIN32
+
+    // Check that the statistics DataWriters has been created by matching a corresponding DataReader on those topics
+    history_latency_reader.init();
+    network_latency_reader.init();
+    rtps_lost_reader.init();
+    discovery_reader.init();
+    physical_data_reader.init();
+
+    ASSERT_TRUE(history_latency_reader.isInitialized());
+    ASSERT_TRUE(network_latency_reader.isInitialized());
+    ASSERT_TRUE(rtps_lost_reader.isInitialized());
+    ASSERT_TRUE(discovery_reader.isInitialized());
+    ASSERT_TRUE(physical_data_reader.isInitialized());
+
+    // Wait for discovery. If there is discovery the test will pass. Otherwise, the test will timeout.
+    history_latency_reader.wait_discovery();
+    network_latency_reader.wait_discovery();
+    rtps_lost_reader.wait_discovery();
+    discovery_reader.wait_discovery();
+    physical_data_reader.wait_discovery();
+
+    // 3. Check that those topics and types related to the statistics DataWriters not enabled does not exist.
+    EXPECT_EQ(null_type, participant->find_type(throughput_type.get_type_name()));
+    EXPECT_EQ(null_type, participant->find_type(count_type.get_type_name()));
+    EXPECT_EQ(null_type, participant->find_type(sample_identity_count_type.get_type_name()));
+
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(
+            eprosima::fastdds::statistics::PUBLICATION_THROUGHPUT_TOPIC));
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(
+            eprosima::fastdds::statistics::SUBSCRIPTION_THROUGHPUT_TOPIC));
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::RTPS_SENT_TOPIC));
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::RESENT_DATAS_TOPIC));
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::HEARTBEAT_COUNT_TOPIC));
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::ACKNACK_COUNT_TOPIC));
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::NACKFRAG_COUNT_TOPIC));
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::GAP_COUNT_TOPIC));
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::DATA_COUNT_TOPIC));
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::PDP_PACKETS_TOPIC));
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::EDP_PACKETS_TOPIC));
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::SAMPLE_DATAS_TOPIC));
+
+    // 4. Remove DDS entities
+    history_latency_reader.destroy();
+    network_latency_reader.destroy();
+    rtps_lost_reader.destroy();
+    discovery_reader.destroy();
+    physical_data_reader.destroy();
+
+    EXPECT_EQ(eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(participant),
+            eprosima::fastrtps::types::ReturnCode_t::RETCODE_OK);
+#endif // FASTDDS_STATISTICS
+}
+
+/*
+ * This test is similar to the previous test. In this case the Qos are read from an XML file instead of setting them
+ * directly in the code.
+ * This test is only valid when FASTDDS_STATISTICS CMake option is set. Otherwise the test is empty.
+ * 0. Setup test: create DDS entities needed for the test: TypeSupports, DataReaders...
+ * 1. Set environment variable and create participant using a Qos set by XML.
+ * 2. Check that topics, types and datawriters have been created correctly.
+ * 3. Check that those topics and types that have not been enabled does not exist.
+ */
+TEST(StatisticsDomainParticipant, CreateParticipantUsingXML)
+{
+#ifdef FASTDDS_STATISTICS
+    // 0. Setup test
+    std::string xml_file = "StatisticsDomainParticipant.xml";
+    std::string participant_profile_name = "statistics_participant";
+
+    // Create TypeSupports
+    eprosima::fastdds::dds::TypeSupport history_latency_type(
+        new eprosima::fastdds::statistics::WriterReaderDataPubSubType);
+    eprosima::fastdds::dds::TypeSupport network_latency_type(
+        new eprosima::fastdds::statistics::Locator2LocatorDataPubSubType);
+    eprosima::fastdds::dds::TypeSupport throughput_type(
+        new eprosima::fastdds::statistics::EntityDataPubSubType);
+    eprosima::fastdds::dds::TypeSupport rtps_traffic_type(
+        new eprosima::fastdds::statistics::Entity2LocatorTrafficPubSubType);
+    eprosima::fastdds::dds::TypeSupport count_type(
+        new eprosima::fastdds::statistics::EntityCountPubSubType);
+    eprosima::fastdds::dds::TypeSupport discovery_type(
+        new eprosima::fastdds::statistics::DiscoveryTimePubSubType);
+    eprosima::fastdds::dds::TypeSupport sample_identity_count_type(
+        new eprosima::fastdds::statistics::SampleIdentityCountPubSubType);
+    eprosima::fastdds::dds::TypeSupport physical_data_type(
+        new eprosima::fastdds::statistics::PhysicalDataPubSubType);
+    eprosima::fastdds::dds::TypeSupport null_type(nullptr);
+
+    // Create statistics DataReaders
+    PubSubReader<EntityDataPubSubTypeTest> publication_throughput_reader(
+            eprosima::fastdds::statistics::PUBLICATION_THROUGHPUT_TOPIC, true, true);
+    PubSubReader<EntityDataPubSubTypeTest> subscription_throughput_reader(
+            eprosima::fastdds::statistics::SUBSCRIPTION_THROUGHPUT_TOPIC, true, true);
+    PubSubReader<EntityCountPubSubTypeTest> heartbeat_count_reader(
+            eprosima::fastdds::statistics::HEARTBEAT_COUNT_TOPIC, true, true);
+    PubSubReader<EntityCountPubSubTypeTest> nackfrag_count_reader(
+            eprosima::fastdds::statistics::NACKFRAG_COUNT_TOPIC, true, true);
+    PubSubReader<SampleIdentityCountPubSubTypeTest> sample_datas_reader(
+            eprosima::fastdds::statistics::SAMPLE_DATAS_TOPIC, true, true);
+
+    // 1. Set environment variable and create participant using Qos set by code
+    const char* value = "PUBLICATION_THROUGHPUT_TOPIC;HEARTBEAT_COUNT_TOPIC";
+#ifdef _WIN32
+    ASSERT_EQ(0, _putenv_s(eprosima::fastdds::statistics::dds::FASTDDS_STATISTICS_ENVIRONMENT_VARIABLE, value));
+#else
+    ASSERT_EQ(0, setenv(eprosima::fastdds::statistics::dds::FASTDDS_STATISTICS_ENVIRONMENT_VARIABLE, value, 1));
+#endif // ifdef _WIN32
+
+    // Load XML profiles
+    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->load_XML_profiles_file(xml_file);
+
+    eprosima::fastdds::dds::DomainParticipant* participant =
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->
+                    create_participant_with_profile(0, participant_profile_name);
+    ASSERT_NE(participant, nullptr);
+
+    // 2. Check that the statistics topics and types related to the statistics DataWriters enabled using the
+    // environment variable exist.
+    EXPECT_NE(nullptr, participant->lookup_topicdescription(
+            eprosima::fastdds::statistics::PUBLICATION_THROUGHPUT_TOPIC));
+    EXPECT_EQ(throughput_type, participant->find_type(throughput_type.get_type_name()));
+
+    EXPECT_NE(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::HEARTBEAT_COUNT_TOPIC));
+    EXPECT_EQ(count_type, participant->find_type(count_type.get_type_name()));
+
+    // Check that the statistics topics and types related to the statistics DataWriters set with the PropertyPolicyQos
+    // have been created correctly.
+    EXPECT_NE(nullptr, participant->lookup_topicdescription(
+            eprosima::fastdds::statistics::SUBSCRIPTION_THROUGHPUT_TOPIC));
+    EXPECT_EQ(throughput_type, participant->find_type(throughput_type.get_type_name()));
+
+    EXPECT_NE(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::NACKFRAG_COUNT_TOPIC));
+    EXPECT_EQ(count_type, participant->find_type(count_type.get_type_name()));
+
+    EXPECT_NE(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::SAMPLE_DATAS_TOPIC));
+    EXPECT_EQ(sample_identity_count_type, participant->find_type(sample_identity_count_type.get_type_name()));
+
+    // Before initializing the DataReaders the environment variable should be unset.
+    // Otherwise each domainParticipant (each DataReader is launched in its own domainParticipant) will also enable
+    // the statistics DataWriters set with the environment variable.
+#ifdef _WIN32
+    ASSERT_EQ(0, _putenv_s(eprosima::fastdds::statistics::dds::FASTDDS_STATISTICS_ENVIRONMENT_VARIABLE, ""));
+#else
+    ASSERT_EQ(0, unsetenv(eprosima::fastdds::statistics::dds::FASTDDS_STATISTICS_ENVIRONMENT_VARIABLE));
+#endif // ifdef _WIN32
+
+    // Check that the statistics DataWriters has been created by matching a corresponding DataReader on those topics
+    publication_throughput_reader.init();
+    subscription_throughput_reader.init();
+    heartbeat_count_reader.init();
+    nackfrag_count_reader.init();
+    sample_datas_reader.init();
+
+    ASSERT_TRUE(publication_throughput_reader.isInitialized());
+    ASSERT_TRUE(subscription_throughput_reader.isInitialized());
+    ASSERT_TRUE(heartbeat_count_reader.isInitialized());
+    ASSERT_TRUE(nackfrag_count_reader.isInitialized());
+    ASSERT_TRUE(sample_datas_reader.isInitialized());
+
+    // Wait for discovery. If there is discovery the test will pass. Otherwise, the test will timeout.
+    publication_throughput_reader.wait_discovery();
+    subscription_throughput_reader.wait_discovery();
+    heartbeat_count_reader.wait_discovery();
+    nackfrag_count_reader.wait_discovery();
+    sample_datas_reader.wait_discovery();
+
+    // 3. Check that those topics and types related to the statistics DataWriters not enabled does not exist.
+    EXPECT_EQ(null_type, participant->find_type(history_latency_type.get_type_name()));
+    EXPECT_EQ(null_type, participant->find_type(network_latency_type.get_type_name()));
+    EXPECT_EQ(null_type, participant->find_type(rtps_traffic_type.get_type_name()));
+    EXPECT_EQ(null_type, participant->find_type(discovery_type.get_type_name()));
+    EXPECT_EQ(null_type, participant->find_type(physical_data_type.get_type_name()));
+
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::HISTORY_LATENCY_TOPIC));
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::NETWORK_LATENCY_TOPIC));
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::RTPS_SENT_TOPIC));
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::RTPS_LOST_TOPIC));
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::RESENT_DATAS_TOPIC));
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::ACKNACK_COUNT_TOPIC));
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::GAP_COUNT_TOPIC));
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::DATA_COUNT_TOPIC));
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::PDP_PACKETS_TOPIC));
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::EDP_PACKETS_TOPIC));
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::DISCOVERY_TOPIC));
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::PHYSICAL_DATA_TOPIC));
+
+    // 4. Remove DDS entities
+    publication_throughput_reader.destroy();
+    subscription_throughput_reader.destroy();
+    heartbeat_count_reader.destroy();
+    nackfrag_count_reader.destroy();
+    sample_datas_reader.destroy();
+
+    EXPECT_EQ(eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(participant),
+            eprosima::fastrtps::types::ReturnCode_t::RETCODE_OK);
+#endif // FASTDDS_STATISTICS
+}

--- a/test/unittest/dds/status/CMakeLists.txt
+++ b/test/unittest/dds/status/CMakeLists.txt
@@ -90,6 +90,8 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/string_convert.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastrtps_deprecated/publisher/PublisherHistory.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/statistics/fastdds/domain/DomainParticipant.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/statistics/fastdds/publisher/qos/DataWriterQos.cpp
             )
 
         # External sources

--- a/test/unittest/statistics/dds/CMakeLists.txt
+++ b/test/unittest/statistics/dds/CMakeLists.txt
@@ -45,7 +45,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             )
         target_include_directories(StatisticsQosTests PRIVATE ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include ${PROJECT_SOURCE_DIR}/src/cpp)
-        target_link_libraries(StatisticsQosTests fastrtps ${GTEST_LIBRARIES})
+        target_link_libraries(StatisticsQosTests fastrtps fastcdr ${GTEST_LIBRARIES})
         add_gtest(StatisticsQosTests SOURCES ${STATISTICS_QOS_TESTS_SOURCE})
     endif()
 endif()

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantTests.cpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantTests.cpp
@@ -66,6 +66,7 @@ protected:
         delete mutex_;
         mutex_ = nullptr;
     }
+
 };
 
 /*
@@ -510,8 +511,10 @@ TEST_F(StatisticsDomainParticipantTests, CreateParticipantWithInvalidTopicName)
 
     EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::HISTORY_LATENCY_TOPIC));
     EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::NETWORK_LATENCY_TOPIC));
-    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::PUBLICATION_THROUGHPUT_TOPIC));
-    EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::SUBSCRIPTION_THROUGHPUT_TOPIC));
+    EXPECT_EQ(nullptr,
+            participant->lookup_topicdescription(eprosima::fastdds::statistics::PUBLICATION_THROUGHPUT_TOPIC));
+    EXPECT_EQ(nullptr, participant->lookup_topicdescription(
+                eprosima::fastdds::statistics::SUBSCRIPTION_THROUGHPUT_TOPIC));
     EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::RTPS_SENT_TOPIC));
     EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::RTPS_LOST_TOPIC));
     EXPECT_EQ(nullptr, participant->lookup_topicdescription(eprosima::fastdds::statistics::RESENT_DATAS_TOPIC));


### PR DESCRIPTION
This PR includes:

* Auxiliary methods to create and enable builtin statistics entities.
* Auxiliary methods to delete builtin statistics entities.
* Additional blackbox tests that checks creation and destruction of statistics domain participant
* Additional unit test that checks statistics participant creation with invalid topic name.
* Add FASTDDS_STATISTICS environment variable