### PR TITLE
Fix crash in dynamic type registration of primitive type array

### DIFF
--- a/src/cpp/fastrtps_deprecated/Domain.cpp
+++ b/src/cpp/fastrtps_deprecated/Domain.cpp
@@ -375,7 +375,10 @@ bool Domain::registerDynamicType(
             // Complete, just to make sure it is generated
             const TypeIdentifier* type_id_complete = typeFactory->get_type_identifier(type->getName(), true);
             const TypeObject* type_obj_complete = typeFactory->get_type_object(type->getName(), true);
-            typeFactory->add_type_object(type->getName(), type_id_complete, type_obj_complete); // Add complete
+            if (type_id_complete && type_obj_complete)
+            {
+                typeFactory->add_type_object(type->getName(), type_id_complete, type_obj_complete); // Add complete
+            }
         }
     }
     return registerType(part, type);


### PR DESCRIPTION
Don't add complete type object in type registration for plain types or EK_MINIMAL types. Otherwise, code like below would result in crash because of null TypeIdentifier pointer.
std::vector<uint32_t> lengths = {3};
DynamicType_ptr base_type = DynamicTypeBuilderFactory::get_instance()->create_int32_type();
DynamicTypeBuilder_ptr array = DynamicTypeBuilderFactory::get_instance()->create_array_builder(base_type, lengths);
array->set_name("HelloWorld");
...
Domain::registerDynamicType(mp_participant, &m_DynType);