### PR TITLE
[10797] HEARTBEAT_COUNT callback implementation

### DIFF
--- a/include/fastdds/rtps/writer/StatefulWriter.h
+++ b/include/fastdds/rtps/writer/StatefulWriter.h
@@ -170,7 +170,7 @@ public:
     //!Increment the HB count.
     inline void incrementHBCount()
     {
-        ++m_heartbeatCount;
+        on_heartbeat(++m_heartbeatCount);
     }
 
     /**

--- a/include/fastdds/statistics/rtps/StatisticsCommon.hpp
+++ b/include/fastdds/statistics/rtps/StatisticsCommon.hpp
@@ -144,6 +144,13 @@ protected:
 
     // TODO: methods for listeners callbacks
 
+    /*
+     * @brief Report a HEARTBEAT message is sent
+     * @param current count of heartbeats
+     */
+    void on_heartbeat(
+            uint32_t count);
+
     //! Report a DATA message is sent
     void on_data();
 

--- a/include/fastdds/statistics/rtps/StatisticsCommon.hpp
+++ b/include/fastdds/statistics/rtps/StatisticsCommon.hpp
@@ -145,16 +145,16 @@ protected:
     // TODO: methods for listeners callbacks
 
     /*
-     * @brief Report a HEARTBEAT message is sent
+     * @brief Report that a HEARTBEAT message is sent
      * @param current count of heartbeats
      */
     void on_heartbeat(
             uint32_t count);
 
-    //! Report a DATA message is sent
+    //! Report that a DATA message is sent
     void on_data();
 
-    //! Report a DATA_FRAG message is sent
+    //! Report that a DATA_FRAG message is sent
     void on_data_frag();
 
 };

--- a/include/fastdds/statistics/rtps/StatisticsCommonEmpty.hpp
+++ b/include/fastdds/statistics/rtps/StatisticsCommonEmpty.hpp
@@ -42,7 +42,7 @@ protected:
     // TODO: methods for listeners callbacks
 
     /*
-     * @brief Report a HEARTBEAT message is sent
+     * @brief Report that a HEARTBEAT message is sent
      * @param current count of heartbeats
      */
     void on_heartbeat(
@@ -51,12 +51,12 @@ protected:
         (void)count;
     }
 
-    //! Report a DATA message is sent
+    //! Report that a DATA message is sent
     inline void on_data()
     {
     }
 
-    //! Report a DATA_FRAG message is sent
+    //! Report that a DATA_FRAG message is sent
     inline void on_data_frag()
     {
     }

--- a/include/fastdds/statistics/rtps/StatisticsCommonEmpty.hpp
+++ b/include/fastdds/statistics/rtps/StatisticsCommonEmpty.hpp
@@ -41,6 +41,16 @@ protected:
 
     // TODO: methods for listeners callbacks
 
+    /*
+     * @brief Report a HEARTBEAT message is sent
+     * @param current count of heartbeats
+     */
+    void on_heartbeat(
+            uint32_t count)
+    {
+        (void)count;
+    }
+
     //! Report a DATA message is sent
     inline void on_data()
     {

--- a/src/cpp/statistics/rtps/StatisticsBase.cpp
+++ b/src/cpp/statistics/rtps/StatisticsBase.cpp
@@ -294,7 +294,7 @@ void StatisticsParticipantImpl::on_rtps_sent(
         notification.byte_magnitude_order((int16_t)floor(log10(float(val.byte_count))));
     }
 
-    // Callback
+    // Perform the callbacks
     Data data;
     // note that the setter sets RTPS_SENT by default
     data.entity2locator_traffic(notification);

--- a/src/cpp/statistics/rtps/StatisticsBase.hpp
+++ b/src/cpp/statistics/rtps/StatisticsBase.hpp
@@ -199,7 +199,7 @@ protected:
     // TODO: methods for listeners callbacks
 
     /*
-     * Report that a message that is sent by the participant
+     * Report a message that is sent by the participant
      * @param loc, destination
      * @param payload_size, size of the current message
      */
@@ -208,7 +208,7 @@ protected:
             unsigned long payload_size);
 
     /*
-     * Report that a message that is sent by the participant
+     * Report a message that is sent by the participant
      * @param destination_locators_begin, start of locators range
      * @param destination_locators_end, end of locators range
      * @param payload_size, size of the current message
@@ -263,7 +263,7 @@ protected:
     // inline methods for listeners callbacks
 
     /*
-     * Report that a message that is sent by the participant
+     * Report a message that is sent by the participant
      * @param destination_locators_begin, start of locators range
      * @param destination_locators_end, end of locators range
      * @param payload_size, size of the current message

--- a/src/cpp/statistics/rtps/StatisticsBase.hpp
+++ b/src/cpp/statistics/rtps/StatisticsBase.hpp
@@ -199,7 +199,7 @@ protected:
     // TODO: methods for listeners callbacks
 
     /*
-     * Report a message that is sent by the participant
+     * Report that a message that is sent by the participant
      * @param loc, destination
      * @param payload_size, size of the current message
      */
@@ -208,7 +208,7 @@ protected:
             unsigned long payload_size);
 
     /*
-     * Report a message that is sent by the participant
+     * Report that a message that is sent by the participant
      * @param destination_locators_begin, start of locators range
      * @param destination_locators_end, end of locators range
      * @param payload_size, size of the current message
@@ -263,7 +263,7 @@ protected:
     // inline methods for listeners callbacks
 
     /*
-     * Report a message that is sent by the participant
+     * Report that a message that is sent by the participant
      * @param destination_locators_begin, start of locators range
      * @param destination_locators_end, end of locators range
      * @param payload_size, size of the current message

--- a/src/cpp/statistics/rtps/reader/StatisticsReaderImpl.cpp
+++ b/src/cpp/statistics/rtps/reader/StatisticsReaderImpl.cpp
@@ -67,7 +67,7 @@ void StatisticsReaderImpl::on_acknack(
     notification.guid(to_statistics_type(get_guid()));
     notification.count(count);
 
-    // Callback
+    // Perform the callback
     Data data;
     // note that the setter sets RESENT_DATAS by default
     data.entity_count(notification);

--- a/src/cpp/statistics/rtps/writer/StatisticsWriterImpl.cpp
+++ b/src/cpp/statistics/rtps/writer/StatisticsWriterImpl.cpp
@@ -87,3 +87,22 @@ void StatisticsWriterImpl::on_data_frag()
     // there is no specific EventKind thus it will be redirected to DATA_COUNT
     on_data();
 }
+
+void StatisticsWriterImpl::on_heartbeat(
+        uint32_t count)
+{
+    EntityCount notification;
+    notification.guid(to_statistics_type(get_guid()));
+    notification.count(count);
+
+    // Callback
+    Data d;
+    // note that the setter sets RESENT_DATAS by default
+    d.entity_count(notification);
+    d._d(EventKind::HEARTBEAT_COUNT);
+
+    for_each_listener([&d](const std::shared_ptr<IListener>& l)
+            {
+                l->on_statistics_data(d);
+            });
+}

--- a/src/cpp/statistics/rtps/writer/StatisticsWriterImpl.cpp
+++ b/src/cpp/statistics/rtps/writer/StatisticsWriterImpl.cpp
@@ -70,7 +70,7 @@ void StatisticsWriterImpl::on_data()
         notification.count(++get_members()->data_counter);
     }
 
-    // Callback
+    // Perform the callbacks
     Data data;
     // note that the setter sets RESENT_DATAS by default
     data.entity_count(notification);
@@ -95,14 +95,14 @@ void StatisticsWriterImpl::on_heartbeat(
     notification.guid(to_statistics_type(get_guid()));
     notification.count(count);
 
-    // Callback
-    Data d;
+    // Perform the callbacks
+    Data data;
     // note that the setter sets RESENT_DATAS by default
-    d.entity_count(notification);
-    d._d(EventKind::HEARTBEAT_COUNT);
+    data.entity_count(notification);
+    data._d(EventKind::HEARTBEAT_COUNT);
 
-    for_each_listener([&d](const std::shared_ptr<IListener>& l)
+    for_each_listener([&data](const std::shared_ptr<IListener>& listener)
             {
-                l->on_statistics_data(d);
+                listener->on_statistics_data(data);
             });
 }

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -49,8 +49,7 @@ namespace rtps {
 
 struct MockListener : IListener
 {
-    MOCK_METHOD1(on_statistics_data, void(
-                const Data&));
+    MOCK_METHOD(void, on_statistics_data, (const Data&), (override));
 };
 
 class RTPSStatisticsTests

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -50,21 +50,23 @@ namespace rtps {
 struct MockListener : IListener
 {
     void on_statistics_data(
-            const Data& d) override
+            const Data& data) override
     {
-        switch (d._d())
+        switch (data._d())
         {
             case RTPS_SENT:
-                on_rtps_sent(d.entity2locator_traffic());
+                on_rtps_sent(data.entity2locator_traffic());
                 break;
             case HEARTBEAT_COUNT:
-                on_heartbeat_count(d.entity_count());
+                on_heartbeat_count(data.entity_count());
                 break;
             case ACKNACK_COUNT:
-                on_acknack_count(d.entity_count());
+                on_acknack_count(data.entity_count());
                 break;
             case DATA_COUNT:
-                on_data_count(d.entity_count());
+                on_data_count(data.entity_count());
+                break;
+            default:
                 break;
         }
     }

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -297,29 +297,30 @@ TEST_F(RTPSStatisticsTests, statistics_rpts_listener_callbacks)
     // reader specific callbacks
     auto reader_listener = make_shared<MockListener>();
     ASSERT_TRUE(reader_->add_statistics_listener(reader_listener));
-    // We must received the sent data notifications
+
+    // We must received the RTPS_SENT notifications
     EXPECT_CALL(*participant_listener, on_statistics_data)
             .Times(AtLeast(1));
-
-    // match writer and reader on a dummy topic
-    match_endpoints(false, "string", "statisticsSmallTopic");
 
     // Check callbacks on data exchange, at least, we must received:
     // + RTPSWriter: PUBLICATION_THROUGHPUT, RESENT_DATAS,
     //               GAP_COUNT, DATA_COUNT, SAMPLE_DATAS & PHYSICAL_DATA
-    //   optionally: ACKNACK_COUNT & NACKFRAG_COUNT
+    //   optionally: NACKFRAG_COUNT
     EXPECT_CALL(*writer_listener, on_statistics_data)
-            .Times(AtLeast(1));
+            .Times(AtLeast(2));
     EXPECT_CALL(*participant_writer_listener, on_statistics_data)
             .Times(AtLeast(1));
 
-    // + RTPSReader: SUBSCRIPTION_THROUGHPUT, DATA_COUNT,
+    // + RTPSReader: SUBSCRIPTION_THROUGHPUT,
     //               SAMPLE_DATAS & PHYSICAL_DATA
-    //   optionally: HEARTBEAT_COUNT
+    //   optionally: ACKNACK_COUNT
     EXPECT_CALL(*reader_listener, on_statistics_data)
             .Times(AtLeast(1));
     EXPECT_CALL(*participant_reader_listener, on_statistics_data)
             .Times(AtLeast(1));
+
+    // match writer and reader on a dummy topic
+    match_endpoints(false, "string", "statisticsSmallTopic");
 
     // exchange data
     auto writer_change = writer_->new_change(
@@ -374,11 +375,12 @@ TEST_F(RTPSStatisticsTests, statistics_rpts_listener_callbacks_fragmented)
 
     // writer callbacks through participant listener
     auto participant_listener = make_shared<MockListener>();
-    EventKind mask = static_cast<EventKind>(EventKind::DATA_COUNT | EventKind::ACKNACK_COUNT);
+    EventKind mask = static_cast<EventKind>(EventKind::DATA_COUNT |
+            EventKind::HEARTBEAT_COUNT | EventKind::ACKNACK_COUNT);
     ASSERT_TRUE(participant_->add_statistics_listener(participant_listener, mask));
 
     EXPECT_CALL(*participant_listener, on_statistics_data)
-            .Times(AtLeast(1));
+            .Times(AtLeast(2));
 
     // Create the testing endpoints
     uint16_t length = 65000;


### PR DESCRIPTION
Writers with an associated statistics listener now generate callbacks on `HEARTBEAT` submessage composition.
Mock testing has been updated to split the single `on_statistics_data()` callback into specific mock calls.
This must be merged after https://github.com/eProsima/Fast-DDS/pull/1884