### PR TITLE
Add missing operators to TypeSupport [11194]

### DIFF
--- a/include/fastdds/dds/topic/TypeSupport.hpp
+++ b/include/fastdds/dds/topic/TypeSupport.hpp
@@ -57,25 +57,39 @@ public:
     using Base::operator ->;
     using Base::operator *;
     using Base::operator bool;
-    using Base::operator =;
 
     /**
      * @brief Constructor
      */
-    RTPS_DllAPI TypeSupport()
-        : std::shared_ptr<fastdds::dds::TopicDataType>(nullptr)
-    {
-    }
+    RTPS_DllAPI TypeSupport() noexcept = default;
 
     /**
      * @brief Copy Constructor
      * @param type Another instance of TypeSupport
      */
     RTPS_DllAPI TypeSupport(
-            const TypeSupport& type)
-        : std::shared_ptr<fastdds::dds::TopicDataType>(type)
-    {
-    }
+            const TypeSupport& type) noexcept = default;
+
+    /**
+     * @brief Move Constructor
+     * @param type Another instance of TypeSupport
+     */
+    RTPS_DllAPI TypeSupport(
+            TypeSupport&& type) noexcept = default;
+
+    /**
+     * @brief Copy Assignment
+     * @param type Another instance of TypeSupport
+     */
+    RTPS_DllAPI TypeSupport& operator = (
+            const TypeSupport& type) noexcept = default;
+
+    /**
+     * @brief Move Assignment
+     * @param type Another instance of TypeSupport
+     */
+    RTPS_DllAPI TypeSupport& operator = (
+            TypeSupport&& type) noexcept = default;
 
     /*!
      * \brief TypeSupport constructor that receives a TopicDataType pointer.


### PR DESCRIPTION
This should fix build problems on old compilers when assigning a `TypeSupport`