### PR TITLE
[10799] NACKFRAG_COUNT callback implementation

### DIFF
--- a/include/fastdds/rtps/reader/RTPSReader.h
+++ b/include/fastdds/rtps/reader/RTPSReader.h
@@ -48,7 +48,6 @@ struct CacheChange_t;
 struct ReaderHistoryState;
 class WriterProxyData;
 class IDataSharingListener;
-class RTPSMessageGroup;
 
 /**
  * Class RTPSReader, manages the reception of data from its matched writers.

--- a/include/fastdds/statistics/rtps/StatisticsCommon.hpp
+++ b/include/fastdds/statistics/rtps/StatisticsCommon.hpp
@@ -198,8 +198,18 @@ protected:
 
     // TODO: methods for listeners callbacks
 
-    //! Report that an ACKNACK message is sent
+    /*
+     * @brief Report that an ACKNACK message is sent
+     * @param count current count of ACKNACKs
+     */
     void on_acknack(
+            int32_t count);
+
+    /*
+     * @brief Report that a NACKFRAG message is sent
+     * @param count current count of NACKFRAGs
+     */
+    void on_nackfrag(
             int32_t count);
 };
 

--- a/include/fastdds/statistics/rtps/StatisticsCommonEmpty.hpp
+++ b/include/fastdds/statistics/rtps/StatisticsCommonEmpty.hpp
@@ -46,9 +46,8 @@ protected:
      * @param current count of heartbeats
      */
     void on_heartbeat(
-            uint32_t count)
+            uint32_t)
     {
-        (void)count;
     }
 
     //! Report that a DATA message is sent
@@ -71,9 +70,21 @@ protected:
 
     // TODO: methods for listeners callbacks
 
-    //! Report that an ACKNACK message is sent
+    /*
+     * @brief Report that an ACKNACK message is sent
+     * @param current count of ACKNACKs
+     */
     inline void on_acknack(
-            int32_t )
+            int32_t)
+    {
+    }
+
+    /*
+     * @brief Report that a NACKFRAG message is sent
+     * @param current count of NACKFRAGs
+     */
+    inline void on_nackfrag(
+            int32_t)
     {
     }
 

--- a/src/cpp/rtps/messages/RTPSMessageGroup.cpp
+++ b/src/cpp/rtps/messages/RTPSMessageGroup.cpp
@@ -790,7 +790,7 @@ bool RTPSMessageGroup::add_nackfrag(
     }
 #endif // if HAVE_SECURITY
 
-    // Notify the statistics module, note only readers add NACKFRAGs
+    // Notify the statistics module, note that only readers add NACKFRAGs
     assert(nullptr != dynamic_cast<RTPSReader*>(endpoint_));
     static_cast<RTPSReader*>(endpoint_)->on_nackfrag(count);
 

--- a/src/cpp/rtps/messages/RTPSMessageGroup.cpp
+++ b/src/cpp/rtps/messages/RTPSMessageGroup.cpp
@@ -790,6 +790,10 @@ bool RTPSMessageGroup::add_nackfrag(
     }
 #endif // if HAVE_SECURITY
 
+    // Notify the statistics module, note only readers add NACKFRAGs
+    assert(nullptr != dynamic_cast<RTPSReader*>(endpoint_));
+    static_cast<RTPSReader*>(endpoint_)->on_nackfrag(count);
+
     return insert_submessage(false);
 }
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1982,7 +1982,6 @@ bool RTPSParticipantImpl::register_in_writer(
         std::shared_ptr<fastdds::statistics::IListener> listener,
         GUID_t writer_guid)
 {
-    std::lock_guard<std::recursive_mutex> lock(*getParticipantMutex());
     bool res = false;
 
     if ( GUID_t::unknown() == writer_guid )
@@ -2006,7 +2005,6 @@ bool RTPSParticipantImpl::register_in_reader(
         std::shared_ptr<fastdds::statistics::IListener> listener,
         GUID_t reader_guid)
 {
-    std::lock_guard<std::recursive_mutex> lock(*getParticipantMutex());
     bool res = false;
 
     if ( GUID_t::unknown() == reader_guid )
@@ -2029,7 +2027,6 @@ bool RTPSParticipantImpl::register_in_reader(
 bool RTPSParticipantImpl::unregister_in_writer(
         std::shared_ptr<fastdds::statistics::IListener> listener)
 {
-    std::lock_guard<std::recursive_mutex> lock(*getParticipantMutex());
     bool res = true;
 
     for ( auto writer : m_userWriterList)
@@ -2043,7 +2040,6 @@ bool RTPSParticipantImpl::unregister_in_writer(
 bool RTPSParticipantImpl::unregister_in_reader(
         std::shared_ptr<fastdds::statistics::IListener> listener)
 {
-    std::lock_guard<std::recursive_mutex> lock(*getParticipantMutex());
     bool res = true;
 
     for ( auto reader : m_userReaderList)

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -268,6 +268,12 @@ public:
             const LocatorIteratorT& destination_locators_end,
             std::chrono::steady_clock::time_point& max_blocking_time_point)
     {
+        // notify statistics module
+        on_rtps_send(
+            destination_locators_begin,
+            destination_locators_end,
+            msg->length);
+
         bool ret_code = false;
         std::unique_lock<std::timed_mutex> lock(m_send_resources_mutex_, std::defer_lock);
 
@@ -282,12 +288,6 @@ public:
                 send_resource->send(msg->buffer, msg->length, &locators_begin, &locators_end,
                         max_blocking_time_point);
             }
-
-            // notify statistics module
-            on_rtps_send(
-                destination_locators_begin,
-                destination_locators_end,
-                msg->length);
         }
 
         return ret_code;

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -268,12 +268,6 @@ public:
             const LocatorIteratorT& destination_locators_end,
             std::chrono::steady_clock::time_point& max_blocking_time_point)
     {
-        // notify statistics module
-        on_rtps_send(
-            destination_locators_begin,
-            destination_locators_end,
-            msg->length);
-
         bool ret_code = false;
         std::unique_lock<std::timed_mutex> lock(m_send_resources_mutex_, std::defer_lock);
 
@@ -288,6 +282,14 @@ public:
                 send_resource->send(msg->buffer, msg->length, &locators_begin, &locators_end,
                         max_blocking_time_point);
             }
+
+            lock.unlock();
+
+            // notify statistics module
+            on_rtps_send(
+                destination_locators_begin,
+                destination_locators_end,
+                msg->length);
         }
 
         return ret_code;

--- a/src/cpp/statistics/rtps/reader/StatisticsReaderImpl.cpp
+++ b/src/cpp/statistics/rtps/reader/StatisticsReaderImpl.cpp
@@ -78,3 +78,22 @@ void StatisticsReaderImpl::on_acknack(
                 listener->on_statistics_data(data);
             });
 }
+
+void StatisticsReaderImpl::on_nackfrag(
+        int32_t count)
+{
+    EntityCount notification;
+    notification.guid(to_statistics_type(get_guid()));
+    notification.count(count);
+
+    // Callback
+    Data d;
+    // note that the setter sets RESENT_DATAS by default
+    d.entity_count(notification);
+    d._d(EventKind::NACKFRAG_COUNT);
+
+    for_each_listener([&d](const std::shared_ptr<IListener>& l)
+            {
+                l->on_statistics_data(d);
+            });
+}

--- a/src/cpp/statistics/rtps/reader/StatisticsReaderImpl.cpp
+++ b/src/cpp/statistics/rtps/reader/StatisticsReaderImpl.cpp
@@ -86,14 +86,14 @@ void StatisticsReaderImpl::on_nackfrag(
     notification.guid(to_statistics_type(get_guid()));
     notification.count(count);
 
-    // Callback
-    Data d;
+    // Perform the callback
+    Data data;
     // note that the setter sets RESENT_DATAS by default
-    d.entity_count(notification);
-    d._d(EventKind::NACKFRAG_COUNT);
+    data.entity_count(notification);
+    data._d(EventKind::NACKFRAG_COUNT);
 
-    for_each_listener([&d](const std::shared_ptr<IListener>& l)
+    for_each_listener([&data](const std::shared_ptr<IListener>& listener)
             {
-                l->on_statistics_data(d);
+                listener->on_statistics_data(data);
             });
 }

--- a/test/unittest/statistics/rtps/CMakeLists.txt
+++ b/test/unittest/statistics/rtps/CMakeLists.txt
@@ -27,12 +27,19 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             )
 
         add_executable(RTPSStatisticsTests ${STATISTICS_RTPS_TESTS_SOURCE})
+
         target_compile_definitions(RTPSStatisticsTests PRIVATE FASTRTPS_NO_LIB
             $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
             $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNAL_DEBUG> # Internal debug activated.
             )
+
         target_include_directories(RTPSStatisticsTests PRIVATE ${GTEST_INCLUDE_DIRS}
-            ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include ${PROJECT_SOURCE_DIR}/src/cpp)
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_BINARY_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/cpp
+            ${Asio_INCLUDE_DIR}
+            )
+
         target_link_libraries(RTPSStatisticsTests fastrtps fastcdr ${GTEST_LIBRARIES} ${GMOCK_LIBRARIES})
         add_gtest(RTPSStatisticsTests SOURCES ${STATISTICS_RTPS_TESTS_SOURCE})
 

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -534,7 +534,7 @@ TEST_F(RTPSStatisticsTests, statistics_rpts_listener_callbacks_fragmented)
             msg.pos = old_pos;
 
             // generate losses only on the first burst
-            if( keep_filtering )
+            if ( keep_filtering )
             {
                 keep_filtering = max_fragment <= fragmentNum;
                 max_fragment = fragmentNum;

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -521,17 +521,8 @@ TEST_F(RTPSStatisticsTests, statistics_rpts_listener_callbacks_fragmented)
         DATA_FRAG,
         [](fastrtps::rtps::CDRMessage_t&)-> bool
         {
-            using namespace std;
-
             static int counter = 0;
-            bool drop = ++counter % 2 == 0 && counter < 30;
-
-            if (drop)
-            {
-                cout << "transport drops DATA_FRAG message:" << counter << endl;
-            }
-
-            return drop;
+            return ++counter % 8 == 0 && counter < 60;
         });
 
     // writer callbacks through participant listener
@@ -571,8 +562,6 @@ TEST_F(RTPSStatisticsTests, statistics_rpts_listener_callbacks_fragmented)
         writer_change->serializedPayload.length = length;
         writer_change->setFragmentSize((uint16_t)length / 10, true);
     }
-
-    // std::this_thread::sleep_for(std::chrono::seconds(3));
 
     ASSERT_TRUE(writer_history_->add_change(writer_change));
 

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -14,29 +14,12 @@
 
 #include <map>
 
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
-
-#include <utils/SystemInfo.hpp>
-
-#include <rtps/transport/test_UDPv4Transport.h>
-
-#include <fastrtps/attributes/LibrarySettingsAttributes.h>
-#include <fastrtps/attributes/TopicAttributes.h>
-#include <fastrtps/attributes/LibrarySettingsAttributes.h>
-#include <fastrtps/attributes/TopicAttributes.h>
-
-#include <fastrtps/transport/test_UDPv4TransportDescriptor.h>
-
-#include <fastrtps/xmlparser/XMLProfileManager.h>
-#include <fastrtps/xmlparser/XMLProfileManager.h>
-
-#include <statistics/types/types.h>
+#include <gtest/gtest.h>
 
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/dds/publisher/qos/WriterQos.hpp>
 #include <fastdds/dds/subscriber/qos/ReaderQos.hpp>
-
 #include <fastdds/rtps/RTPSDomain.h>
 #include <fastdds/rtps/attributes/HistoryAttributes.h>
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
@@ -48,8 +31,19 @@
 #include <fastdds/rtps/participant/RTPSParticipant.h>
 #include <fastdds/rtps/reader/RTPSReader.h>
 #include <fastdds/rtps/writer/RTPSWriter.h>
-
 #include <fastdds/statistics/IListeners.hpp>
+#include <fastrtps/attributes/LibrarySettingsAttributes.h>
+#include <fastrtps/attributes/LibrarySettingsAttributes.h>
+#include <fastrtps/attributes/TopicAttributes.h>
+#include <fastrtps/attributes/TopicAttributes.h>
+#include <fastrtps/transport/test_UDPv4TransportDescriptor.h>
+#include <fastrtps/xmlparser/XMLProfileManager.h>
+#include <fastrtps/xmlparser/XMLProfileManager.h>
+
+#include <statistics/types/types.h>
+
+#include <rtps/transport/test_UDPv4Transport.h>
+#include <utils/SystemInfo.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -75,10 +69,8 @@ struct MockListener : IListener
             case DATA_COUNT:
                 on_data_count(data.entity_count());
                 break;
-            default:
-                break;
             case NACKFRAG_COUNT:
-                on_nackfrag_count(d.entity_count());
+                on_nackfrag_count(data.entity_count());
                 break;
             default:
                 break;
@@ -98,7 +90,7 @@ class RTPSStatisticsTests
     using test_Descriptor = fastdds::rtps::test_UDPv4TransportDescriptor;
 
     // transport filter, that would delegate into a custom one if provided
-    // There are specific gee
+    // Filters have specific getters and setters methods.
     class TransportFilter
     {
         friend class RTPSStatisticsTests;
@@ -528,7 +520,8 @@ TEST_F(RTPSStatisticsTests, statistics_rpts_listener_callbacks_fragmented)
             static uint32_t max_fragment = 0;
             static bool keep_filtering = true;
 
-            uint32_t fragmentNum, old_pos = msg.pos;
+            uint32_t fragmentNum;
+            uint32_t old_pos = msg.pos;
             msg.pos += 20;
             fastrtps::rtps::CDRMessage::readUInt32(&msg, &fragmentNum);
             msg.pos = old_pos;

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -80,6 +80,8 @@ struct MockListener : IListener
             case NACKFRAG_COUNT:
                 on_nackfrag_count(d.entity_count());
                 break;
+            default:
+                break;
         }
     }
 


### PR DESCRIPTION
In order to test the callback the test fixture was updated to use a special transport with leaks.
An ABBA deadlock was detected and solved.
This pull request must be merged after https://github.com/eProsima/Fast-DDS/pull/1911