### PR TITLE
Correctly update memory policy on writers and readers [11348]

### DIFF
--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1486,7 +1486,7 @@ std::shared_ptr<IPayloadPool> DataWriterImpl::get_payload_pool()
         // When the user requested PREALLOCATED_WITH_REALLOC, but we know the type cannot
         // grow, we translate the policy into bare PREALLOCATED
         if (PREALLOCATED_WITH_REALLOC_MEMORY_MODE == history_.m_att.memoryPolicy &&
-            (type_->is_bounded() || type_->is_plain()))
+                (type_->is_bounded() || type_->is_plain()))
         {
             history_.m_att.memoryPolicy = PREALLOCATED_MEMORY_MODE;
         }

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1483,15 +1483,15 @@ std::shared_ptr<IPayloadPool> DataWriterImpl::get_payload_pool()
 {
     if (!payload_pool_)
     {
-        PoolConfig config = PoolConfig::from_history_attributes(history_.m_att);
-
         // When the user requested PREALLOCATED_WITH_REALLOC, but we know the type cannot
         // grow, we translate the policy into bare PREALLOCATED
-        if (PREALLOCATED_WITH_REALLOC_MEMORY_MODE == config.memory_policy &&
-                (type_->is_bounded() || type_->is_plain()))
+        if (PREALLOCATED_WITH_REALLOC_MEMORY_MODE == history_.m_att.memoryPolicy &&
+            (type_->is_bounded() || type_->is_plain()))
         {
-            config.memory_policy = PREALLOCATED_MEMORY_MODE;
+            history_.m_att.memoryPolicy = PREALLOCATED_MEMORY_MODE;
         }
+
+        PoolConfig config = PoolConfig::from_history_attributes(history_.m_att);
 
         // Avoid calling the serialization size functors on PREALLOCATED mode
         fixed_payload_size_ = config.memory_policy == PREALLOCATED_MEMORY_MODE ? config.payload_initial_size : 0u;

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1383,7 +1383,7 @@ std::shared_ptr<IPayloadPool> DataReaderImpl::get_payload_pool()
     // When the user requested PREALLOCATED_WITH_REALLOC, but we know the type cannot
     // grow, we translate the policy into bare PREALLOCATED
     if (PREALLOCATED_WITH_REALLOC_MEMORY_MODE == history_.m_att.memoryPolicy &&
-        (type_->is_bounded() || type_->is_plain()))
+            (type_->is_bounded() || type_->is_plain()))
     {
         history_.m_att.memoryPolicy = PREALLOCATED_MEMORY_MODE;
     }

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1380,7 +1380,15 @@ DataReaderListener* DataReaderImpl::get_listener_for(
 
 std::shared_ptr<IPayloadPool> DataReaderImpl::get_payload_pool()
 {
-    PoolConfig config = PoolConfig::from_history_attributes(history_.m_att );
+    // When the user requested PREALLOCATED_WITH_REALLOC, but we know the type cannot
+    // grow, we translate the policy into bare PREALLOCATED
+    if (PREALLOCATED_WITH_REALLOC_MEMORY_MODE == history_.m_att.memoryPolicy &&
+        (type_->is_bounded() || type_->is_plain()))
+    {
+        history_.m_att.memoryPolicy = PREALLOCATED_MEMORY_MODE;
+    }
+
+    PoolConfig config = PoolConfig::from_history_attributes(history_.m_att);
 
     if (!payload_pool_)
     {

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -728,6 +728,13 @@ public:
         return *this;
     }
 
+    PubSubWriter& mem_policy(
+            const eprosima::fastrtps::rtps::MemoryManagementPolicy mem_policy)
+    {
+        datawriter_qos_.endpoint().history_memory_policy = mem_policy;
+        return *this;
+    }
+
     PubSubWriter& deadline_period(
             const eprosima::fastrtps::Duration_t deadline_period)
     {

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
@@ -610,6 +610,13 @@ public:
         return *this;
     }
 
+    PubSubWriter& mem_policy(
+            const eprosima::fastrtps::rtps::MemoryManagementPolicy mem_policy)
+    {
+        publisher_attr_.historyMemoryPolicy = mem_policy;
+        return *this;
+    }
+
     PubSubWriter& deadline_period(
             const eprosima::fastrtps::Duration_t deadline_period)
     {

--- a/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
@@ -20,6 +20,7 @@
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 #include <rtps/transport/test_UDPv4Transport.h>
 #include <gtest/gtest.h>
+#include <tuple>
 
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastdds::rtps;
@@ -31,14 +32,16 @@ enum communication_type
     DATASHARING
 };
 
-class PubSubHistory : public testing::TestWithParam<communication_type>
+using test_params = std::tuple<communication_type, rtps::MemoryManagementPolicy>;
+
+class PubSubHistory : public testing::TestWithParam<test_params>
 {
 public:
 
     void SetUp() override
     {
         LibrarySettingsAttributes library_settings;
-        switch (GetParam())
+        switch (std::get<0>(GetParam()))
         {
             case INTRAPROCESS:
                 library_settings.intraprocess_delivery = IntraprocessDeliveryType::INTRAPROCESS_FULL;
@@ -51,12 +54,14 @@ public:
             default:
                 break;
         }
+
+        mem_policy_ = std::get<1>(GetParam());
     }
 
     void TearDown() override
     {
         LibrarySettingsAttributes library_settings;
-        switch (GetParam())
+        switch (std::get<0>(GetParam()))
         {
             case INTRAPROCESS:
                 library_settings.intraprocess_delivery = IntraprocessDeliveryType::INTRAPROCESS_OFF;
@@ -71,6 +76,8 @@ public:
         }
     }
 
+protected:
+    rtps::MemoryManagementPolicy mem_policy_;
 };
 
 // Test created to check bug #1568 (Github #34)
@@ -82,14 +89,14 @@ TEST_P(PubSubHistory, PubSubAsNonReliableKeepLastReaderSmallDepth)
     reader.history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).
             history_depth(2).
             resource_limits_allocated_samples(2).
-            resource_limits_max_samples(2).init();
+            resource_limits_max_samples(2).mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
     // Needs a deeper pool for datasharing
     // because reader does not process anything until everything is sent
     writer.reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS)
-            .resource_limits_extra_samples(10).init();
+            .resource_limits_extra_samples(10).mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -131,7 +138,7 @@ TEST_P(PubSubHistory, CacheChangeReleaseTest)
     reader.history_depth(1);
     reader.resource_limits_allocated_samples(1);
     reader.resource_limits_max_samples(1);
-    reader.init();
+    reader.mem_policy(mem_policy_).init();
     ASSERT_TRUE(reader.isInitialized());
 
     writer.resource_limits_allocated_samples(1);
@@ -139,7 +146,7 @@ TEST_P(PubSubHistory, CacheChangeReleaseTest)
     writer.history_kind(KEEP_LAST_HISTORY_QOS);
     writer.history_depth(1);
     writer.reliability(BEST_EFFORT_RELIABILITY_QOS);
-    writer.init();
+    writer.mem_policy(mem_policy_).init();
     ASSERT_TRUE(writer.isInitialized());
 
 
@@ -169,11 +176,11 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepLastReaderSmallDepth)
             history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).
             history_depth(2).
             resource_limits_allocated_samples(2).
-            resource_limits_max_samples(2).init();
+            resource_limits_max_samples(2).mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
-    writer.resource_limits_extra_samples(10).init();
+    writer.resource_limits_extra_samples(10).mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -222,13 +229,13 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepLastWriterSmallDepth)
 {
     PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
     PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
-    reader.reliability(RELIABLE_RELIABILITY_QOS).init();
+    reader.reliability(RELIABLE_RELIABILITY_QOS).mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
     writer.
             history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).
-            history_depth(2).init();
+            history_depth(2).mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -371,14 +378,14 @@ TEST_P(PubSubHistory, PubReliableKeepAllSubNonReliable)
     PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
     PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
 
-    reader.init();
+    reader.mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
     writer.reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
             history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
             resource_limits_allocated_samples(1).
-            resource_limits_max_samples(1).init();
+            resource_limits_max_samples(1).mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -404,10 +411,10 @@ TEST_P(PubSubHistory, StatefulReaderCacheChangeRelease)
     PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
 
     reader.history_depth(2).
-            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).mem_policy(mem_policy_).init();
     ASSERT_TRUE(reader.isInitialized());
     writer.history_depth(2).
-            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).mem_policy(mem_policy_).init();
     ASSERT_TRUE(writer.isInitialized());
 
     writer.wait_discovery();
@@ -450,7 +457,7 @@ TEST_P(PubSubHistory, PubSubAsReliableMultithreadKeepLast1)
     PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
 
     reader.history_depth(1).
-            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -461,7 +468,7 @@ TEST_P(PubSubHistory, PubSubAsReliableMultithreadKeepLast1)
         writer.resource_limits_extra_samples(200);
     }
 
-    writer.history_depth(1).init();
+    writer.history_depth(1).mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -506,13 +513,13 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepLastReaderSmallDepthTwoPublishers)
     writer.max_blocking_time({ 120, 0 });
     writer2.max_blocking_time({ 120, 0 });
 
-    reader.init();
+    reader.mem_policy(mem_policy_).init();
     ASSERT_TRUE(reader.isInitialized());
 
-    writer.init();
+    writer.mem_policy(mem_policy_).init();
     ASSERT_TRUE(writer.isInitialized());
 
-    writer2.init();
+    writer2.mem_policy(mem_policy_).init();
     ASSERT_TRUE(writer2.isInitialized());
 
     // Wait for discovery.
@@ -568,12 +575,12 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepLastWithKey)
 
     reader.resource_limits_max_instances(keys).
             reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-            history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).init();
+            history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
     writer.resource_limits_max_instances(keys).
-            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -601,7 +608,7 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepAllWithKeyAndMaxSamplesPerInstance)
 
     reader.resource_limits_max_instances(keys).
             reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-            history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).init();
+            history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -609,7 +616,7 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepAllWithKeyAndMaxSamplesPerInstance)
             .resource_limits_max_samples_per_instance(1)
             .history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS)
             .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
-            .init();
+            .mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -707,7 +714,7 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepAllWithKeyAndInfiniteMaxSamplesPerInst
 
     reader.resource_limits_max_instances(keys).
             reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-            history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).init();
+            history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -715,7 +722,7 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepAllWithKeyAndInfiniteMaxSamplesPerInst
             .resource_limits_max_samples_per_instance(0)
             .history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS)
             .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
-            .init();
+            .mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -752,14 +759,14 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepAllWithKeyAndInfiniteMaxInstances)
 
     reader.resource_limits_max_instances(keys).
             reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-            history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).init();
+            history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
     writer.resource_limits_max_instances(0)
             .history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS)
             .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
-            .init();
+            .mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -796,7 +803,7 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepAllWithKeyAndMaxSamples)
 
     reader.resource_limits_max_instances(keys).
             reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-            history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).init();
+            history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -806,7 +813,7 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepAllWithKeyAndMaxSamples)
             .resource_limits_max_samples_per_instance(2)
             .history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS)
             .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
-            .init();
+            .mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -840,7 +847,7 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepAllWithoutKeyAndMaxSamples)
     PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
 
     reader.reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-            history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).init();
+            history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -848,7 +855,7 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepAllWithoutKeyAndMaxSamples)
             .resource_limits_allocated_samples(2)
             .history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS)
             .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
-            .init();
+            .mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -890,7 +897,7 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepLastReaderSmallDepthWithKey)
             resource_limits_max_instances(keys).
             resource_limits_max_samples_per_instance(depth).
             reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-            history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).init();
+            history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -899,7 +906,7 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepLastReaderSmallDepthWithKey)
             resource_limits_allocated_samples(keys * depth).
             resource_limits_max_instances(keys).
             resource_limits_max_samples_per_instance(depth).
-            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -956,7 +963,7 @@ TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1)
             .history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS)
             .history_depth(10)
             .resource_limits_allocated_samples(10)
-            .resource_limits_max_samples(10).init();
+            .resource_limits_max_samples(10).mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -967,7 +974,7 @@ TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1)
     reader.reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
             .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
             .history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS)
-            .history_depth(1).init();
+            .history_depth(1).mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -997,7 +1004,7 @@ TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1Data300Kb)
             .history_depth(static_cast<int32_t>(data.size()))
             .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
             .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
-            .init();
+            .mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -1011,7 +1018,7 @@ TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1Data300Kb)
             .history_depth(1)
             .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
             .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
-            .init();
+            .mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -1052,7 +1059,7 @@ TEST_P(PubSubHistory, WriterWithoutReadersTransientLocal)
             .reliability(RELIABLE_RELIABILITY_QOS)
             .resource_limits_allocated_samples(13)
             .resource_limits_max_samples(13)
-            .init();
+            .mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -1061,7 +1068,7 @@ TEST_P(PubSubHistory, WriterWithoutReadersTransientLocal)
     reader
             .reliability(RELIABLE_RELIABILITY_QOS)
             .durability_kind(TRANSIENT_LOCAL_DURABILITY_QOS)
-            .init();
+            .mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -1099,10 +1106,10 @@ TEST_P(PubSubHistory, WriterUnmatchClearsHistory)
     PubSubWriter<HelloWorldType> writer2(TEST_TOPIC_NAME);
 
     //Reader with limited history size
-    reader.history_depth(2).reliability(RELIABLE_RELIABILITY_QOS).init();
+    reader.history_depth(2).reliability(RELIABLE_RELIABILITY_QOS).mem_policy(mem_policy_).init();
     ASSERT_TRUE(reader.isInitialized());
 
-    writer.history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).init();
+    writer.history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).mem_policy(mem_policy_).init();
     ASSERT_TRUE(writer.isInitialized());
 
     // Wait for discovery.
@@ -1123,7 +1130,7 @@ TEST_P(PubSubHistory, WriterUnmatchClearsHistory)
 
     // Create another writer and send more data
     // Reader should be able to get the new data
-    writer2.history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).init();
+    writer2.history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).mem_policy(mem_policy_).init();
     ASSERT_TRUE(writer.isInitialized());
     writer2.wait_discovery();
     reader.wait_discovery();
@@ -1144,20 +1151,44 @@ TEST_P(PubSubHistory, WriterUnmatchClearsHistory)
 
 GTEST_INSTANTIATE_TEST_MACRO(PubSubHistory,
         PubSubHistory,
-        testing::Values(TRANSPORT, INTRAPROCESS, DATASHARING),
+        testing::Combine(
+            testing::Values(TRANSPORT, INTRAPROCESS, DATASHARING),
+            testing::Values(
+                rtps::PREALLOCATED_MEMORY_MODE,
+                rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE,
+                rtps::DYNAMIC_RESERVE_MEMORY_MODE,
+                rtps::DYNAMIC_REUSABLE_MEMORY_MODE)),
         [](const testing::TestParamInfo<PubSubHistory::ParamType>& info)
         {
-            switch (info.param)
+            std::string suffix;
+            switch (std::get<1>(info.param))
+            {
+                default:
+                case rtps::PREALLOCATED_MEMORY_MODE:
+                    suffix = "_PREALLOCATED";
+                    break;
+                case rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE:
+                    suffix = "_PREALLOCATED_WITH_REALLOC";
+                    break;
+                case rtps::DYNAMIC_RESERVE_MEMORY_MODE:
+                    suffix = "_DYNAMIC_RESERVE";
+                    break;
+                case rtps::DYNAMIC_REUSABLE_MEMORY_MODE:
+                    suffix = "_DYNAMIC_REUSABLE";
+                    break;
+            }
+
+            switch (std::get<0>(info.param))
             {
                 case INTRAPROCESS:
-                    return "Intraprocess";
+                    return "Intraprocess" + suffix;
                     break;
                 case DATASHARING:
-                    return "Datasharing";
+                    return "Datasharing" + suffix;
                     break;
                 case TRANSPORT:
                 default:
-                    return "Transport";
+                    return "Transport" + suffix;
             }
 
         });

--- a/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
@@ -77,6 +77,7 @@ public:
     }
 
 protected:
+
     rtps::MemoryManagementPolicy mem_policy_;
 };
 


### PR DESCRIPTION
This PR fixes an assertion on writers with bounded types and `PREALLOCATED_WITH_REALLOC` policy, and also sets `PREALLOCATED` on readers with bounded types and `PREALLOCATED_WITH_REALLOC`