### PR TITLE
[10796] RESENT_DATAS tests & implementation

### DIFF
--- a/.github/workflows/statistics_coverage.yml
+++ b/.github/workflows/statistics_coverage.yml
@@ -50,7 +50,7 @@ jobs:
           colcon test \
             --packages-select fastrtps \
             --event-handlers=console_direct+ \
-            --ctest-args -R RTPSStatisticsTests -R Statistics -E CreateParticipant
+            --ctest-args -R RTPSStatisticsTests -R Statistics
 
       - name: Generate coverage report
         run: |

--- a/.github/workflows/statistics_coverage.yml
+++ b/.github/workflows/statistics_coverage.yml
@@ -34,7 +34,7 @@ jobs:
             --event-handlers=console_direct+ \
             --metas src/Fast-DDS/.github/workflows/statistics_module.meta \
             --mixin coverage-gcc
-          for target in RTPSStatisticsTests StatisticsDomainParticipantTests StatisticsQosTests StatisticsDomainParticipantMockTests BlackboxTests_DDS_PIM
+          for target in RTPSStatisticsTests StatisticsDomainParticipantTests StatisticsQosTests DomainParticipantStatisticsListenerTests StatisticsDomainParticipantMockTests BlackboxTests_DDS_PIM
           do
               colcon build \
                 --packages-select fastrtps \

--- a/.github/workflows/statistics_coverage.yml
+++ b/.github/workflows/statistics_coverage.yml
@@ -34,7 +34,7 @@ jobs:
             --event-handlers=console_direct+ \
             --metas src/Fast-DDS/.github/workflows/statistics_module.meta \
             --mixin coverage-gcc
-          for target in RTPSStatisticsTests StatisticsDomainParticipantTests StatisticsQosTests StatisticsDomainParticipantMockTests 
+          for target in RTPSStatisticsTests StatisticsDomainParticipantTests StatisticsQosTests StatisticsDomainParticipantMockTests BlackboxTests_DDS_PIM
           do
               colcon build \
                 --packages-select fastrtps \

--- a/.github/workflows/statistics_coverage.yml
+++ b/.github/workflows/statistics_coverage.yml
@@ -41,7 +41,7 @@ jobs:
                 --cmake-target $target \
                 --cmake-target-skip-unavailable \
                 --event-handlers=console_direct+ \
-                --metas src/Fast-DDS/.github/workflows/colcon.meta \
+                --metas src/Fast-DDS/.github/workflows/statistics_module.meta \
                 --mixin coverage-gcc
           done
 

--- a/.github/workflows/statistics_coverage.yml
+++ b/.github/workflows/statistics_coverage.yml
@@ -30,16 +30,27 @@ jobs:
         run: |
           cat src/Fast-DDS/.github/workflows/statistics_module.meta
           colcon build \
+            --packages-up-to fastrtps --packages-skip fastrtps \
             --event-handlers=console_direct+ \
             --metas src/Fast-DDS/.github/workflows/statistics_module.meta \
             --mixin coverage-gcc
+          for target in RTPSStatisticsTests StatisticsDomainParticipantTests StatisticsQosTests StatisticsDomainParticipantMockTests 
+          do
+              colcon build \
+                --packages-select fastrtps \
+                --cmake-target $target \
+                --cmake-target-skip-unavailable \
+                --event-handlers=console_direct+ \
+                --metas src/Fast-DDS/.github/workflows/colcon.meta \
+                --mixin coverage-gcc
+          done
 
       - name: Run tests
         run: |
           colcon test \
             --packages-select fastrtps \
             --event-handlers=console_direct+ \
-            --ctest-args -R Statistics
+            --ctest-args -R RTPSStatisticsTests -R Statistics -E CreateParticipant
 
       - name: Generate coverage report
         run: |

--- a/include/fastdds/rtps/writer/ReaderProxy.h
+++ b/include/fastdds/rtps/writer/ReaderProxy.h
@@ -235,9 +235,9 @@ public:
 
     /**
      * Turns all REQUESTED changes into UNSENT.
-     * @return true if at least one change changed its status, false otherwise.
+     * @return the number of changes that changed its status.
      */
-    bool perform_acknack_response();
+    uint32_t perform_acknack_response();
 
     /**
      * Call this to inform a change was removed from history.
@@ -466,9 +466,9 @@ private:
      * Converts all changes with a given status to a different status.
      * @param previous Status to change.
      * @param next Status to adopt.
-     * @return true when at least one change has been modified, false otherwise.
+     * @return the number of changes that have been modified.
      */
-    bool convert_status_on_all_changes(
+    uint32_t convert_status_on_all_changes(
             ChangeForReaderStatus_t previous,
             ChangeForReaderStatus_t next);
 

--- a/include/fastdds/statistics/rtps/StatisticsCommon.hpp
+++ b/include/fastdds/statistics/rtps/StatisticsCommon.hpp
@@ -159,6 +159,13 @@ protected:
 
     //! Report that a GAP message is sent
     void on_gap();
+
+    /*
+     * @brief Report that several changes are marked for redelivery
+     * @param number of changes to redeliver
+     */
+    void on_resent_data(
+            uint32_t to_send);
 };
 
 // Members are private details

--- a/include/fastdds/statistics/rtps/StatisticsCommonEmpty.hpp
+++ b/include/fastdds/statistics/rtps/StatisticsCommonEmpty.hpp
@@ -65,6 +65,15 @@ protected:
     {
     }
 
+    /*
+     * @brief Report that several changes are marked for redelivery
+     * @param number of changes to redeliver
+     */
+    inline void on_resent_data(
+            uint32_t)
+    {
+    }
+
 };
 
 class StatisticsReaderImpl

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -401,7 +401,7 @@ bool ReaderProxy::process_initial_acknack()
 {
     if (is_local_reader())
     {
-        return convert_status_on_all_changes(UNACKNOWLEDGED, UNSENT);
+        return 0 != convert_status_on_all_changes(UNACKNOWLEDGED, UNSENT);
     }
 
     return true;
@@ -498,7 +498,7 @@ bool ReaderProxy::mark_fragment_as_sent_for_change(
 
 bool ReaderProxy::perform_nack_supression()
 {
-    return convert_status_on_all_changes(UNDERWAY, UNACKNOWLEDGED);
+    return 0 != convert_status_on_all_changes(UNDERWAY, UNACKNOWLEDGED);
 }
 
 uint32_t ReaderProxy::perform_acknack_response()

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -501,12 +501,12 @@ bool ReaderProxy::perform_nack_supression()
     return convert_status_on_all_changes(UNDERWAY, UNACKNOWLEDGED);
 }
 
-bool ReaderProxy::perform_acknack_response()
+uint32_t ReaderProxy::perform_acknack_response()
 {
     return convert_status_on_all_changes(REQUESTED, UNSENT);
 }
 
-bool ReaderProxy::convert_status_on_all_changes(
+uint32_t ReaderProxy::convert_status_on_all_changes(
         ChangeForReaderStatus_t previous,
         ChangeForReaderStatus_t next)
 {
@@ -515,17 +515,17 @@ bool ReaderProxy::convert_status_on_all_changes(
     // NOTE: This is only called for REQUESTED=>UNSENT (acknack response) or
     //       UNDERWAY=>UNACKNOWLEDGED (nack supression)
 
-    bool at_least_one_modified = false;
+    uint32_t changed = 0;
     for (ChangeForReader_t& change : changes_for_reader_)
     {
         if (change.getStatus() == previous)
         {
-            at_least_one_modified = true;
+            ++changed;
             change.setStatus(next);
         }
     }
 
-    return at_least_one_modified;
+    return changed;
 }
 
 void ReaderProxy::change_has_been_removed(

--- a/src/cpp/statistics/rtps/StatisticsBase.hpp
+++ b/src/cpp/statistics/rtps/StatisticsBase.hpp
@@ -57,6 +57,7 @@ struct StatisticsWriterAncillary
 {
     unsigned long long data_counter = {};
     unsigned long long gap_counter = {};
+    unsigned long long resent_counter = {};
 };
 
 struct StatisticsReaderAncillary
@@ -69,11 +70,14 @@ template<class Function>
 Function StatisticsListenersImpl::for_each_listener(
         Function f)
 {
-    std::lock_guard<fastrtps::RecursiveTimedMutex> lock(get_statistics_mutex());
+    // Use a collection copy to prevent locking on traversal
+    std::unique_lock<fastrtps::RecursiveTimedMutex> lock(get_statistics_mutex());
+    auto listeners = members_->listeners;
+    lock.unlock();
 
     if (members_)
     {
-        for (auto& listener : members_->listeners)
+        for (auto& listener : listeners)
         {
             f(listener);
         }

--- a/src/cpp/statistics/rtps/writer/StatisticsWriterImpl.cpp
+++ b/src/cpp/statistics/rtps/writer/StatisticsWriterImpl.cpp
@@ -128,3 +128,25 @@ void StatisticsWriterImpl::on_gap()
                 listener->on_statistics_data(data);
             });
 }
+
+void StatisticsWriterImpl::on_resent_data(
+        uint32_t to_send)
+{
+    EntityCount notification;
+    notification.guid(to_statistics_type(get_guid()));
+
+    {
+        std::lock_guard<fastrtps::RecursiveTimedMutex> lock(get_statistics_mutex());
+        notification.count(get_members()->resent_counter += to_send);
+    }
+
+    // Perform the callbacks
+    Data data;
+    // note that the setter sets RESENT_DATAS by default
+    data.entity_count(notification);
+
+    for_each_listener([&data](const std::shared_ptr<IListener>& listener)
+            {
+                listener->on_statistics_data(data);
+            });
+}

--- a/src/cpp/statistics/rtps/writer/StatisticsWriterImpl.cpp
+++ b/src/cpp/statistics/rtps/writer/StatisticsWriterImpl.cpp
@@ -132,6 +132,11 @@ void StatisticsWriterImpl::on_gap()
 void StatisticsWriterImpl::on_resent_data(
         uint32_t to_send)
 {
+    if ( 0 == to_send )
+    {
+        return;
+    }
+
     EntityCount notification;
     notification.guid(to_statistics_type(get_guid()));
 

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -90,6 +90,7 @@ struct MockListener : IListener
     MOCK_METHOD1(on_heartbeat_count, void(const eprosima::fastdds::statistics::EntityCount&));
     MOCK_METHOD1(on_acknack_count, void(const eprosima::fastdds::statistics::EntityCount&));
     MOCK_METHOD1(on_data_count, void(const eprosima::fastdds::statistics::EntityCount&));
+    MOCK_METHOD1(on_resent_count, void(const eprosima::fastdds::statistics::EntityCount&));
     MOCK_METHOD1(on_gap_count, void(const eprosima::fastdds::statistics::EntityCount&));
     MOCK_METHOD1(on_nackfrag_count, void(const eprosima::fastdds::statistics::EntityCount&));
     MOCK_METHOD1(on_entity_discovery, void(const eprosima::fastdds::statistics::DiscoveryTime&));

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -916,7 +916,7 @@ TEST_F(RTPSStatisticsTests, statistics_rpts_avoid_empty_resent_callbacks)
     write_small_sample(length);
 
     // wait for the acknack to be sent before clearing the history
-    while(!acknack_sent)
+    while (!acknack_sent)
     {
         this_thread::sleep_for(chrono::milliseconds(100));
     }

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -237,6 +237,8 @@ public:
         writer_history_ = new WriterHistory(history_attributes);
 
         WriterAttributes w_att;
+        w_att.times.heartbeatPeriod.seconds = 0;
+        w_att.times.heartbeatPeriod.nanosec = 250 * 1000 * 1000; // reduce acknowledgement wait
         w_att.endpoint.reliabilityKind = reliability_qos;
         w_att.endpoint.durabilityKind = durability_qos;
 


### PR DESCRIPTION
There is a piggyback now Statistics' `for_each_listener` methods use temporary lists to prevent collection traversal with the mutex locked.