### PR TITLE
Fix partition copy in QoS [11451]

### DIFF
--- a/src/cpp/fastdds/publisher/qos/WriterQos.cpp
+++ b/src/cpp/fastdds/publisher/qos/WriterQos.cpp
@@ -95,7 +95,7 @@ void WriterQos::setQos(
         m_presentation = qos.m_presentation;
         m_presentation.hasChanged = true;
     }
-    if (first_time || qos.m_partition.names().size() > 0)
+    if (first_time || qos.m_partition.names() != m_partition.names())
     {
         m_partition = qos.m_partition;
         m_partition.hasChanged = true;

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1070,6 +1070,7 @@ bool PDP::remove_remote_participant(
         // Return reader proxy objects to pool
         for (auto pit : *pdata->m_readers)
         {
+            pit.second->clear();
             reader_proxies_pool_.push_back(pit.second);
         }
         pdata->m_readers->clear();
@@ -1077,6 +1078,7 @@ bool PDP::remove_remote_participant(
         // Return writer proxy objects to pool
         for (auto pit : *pdata->m_writers)
         {
+            pit.second->clear();
             writer_proxies_pool_.push_back(pit.second);
         }
         pdata->m_writers->clear();


### PR DESCRIPTION
This PR fixes a bug where a QoS is copied from one ReaderProxyData to another but partition names are not copied if the list is empty. 

Specifically, this code path: 

```
/// src/cpp/rtps/builtin/discovery/participant/PDP.cpp   

         else
            {
                // Pool is not empty, use entry from pool
                ret_val = reader_proxies_pool_.back();
                reader_proxies_pool_.pop_back();
            }

            // Add to ParticipantProxyData
            (*pit->m_readers)[reader_guid.entityId] = ret_val;
```