### PR TITLE
Fix DATA_COUNT to account for number of destinations [11446]

### DIFF
--- a/include/fastdds/rtps/writer/RTPSWriter.h
+++ b/include/fastdds/rtps/writer/RTPSWriter.h
@@ -544,7 +544,7 @@ protected:
         return sent_ok;
     }
 
-    static void add_statistics_sent_submessage(
+    void add_statistics_sent_submessage(
             CacheChange_t* change,
             size_t num_locators);
 

--- a/include/fastdds/rtps/writer/StatefulWriter.h
+++ b/include/fastdds/rtps/writer/StatefulWriter.h
@@ -106,8 +106,6 @@ private:
     //!WriterTimes
     WriterTimes m_times;
 
-    //! Vector containing all the active ReaderProxies.
-    ResourceLimitedVector<ReaderProxy*> matched_readers_;
     //! Vector containing all the remote ReaderProxies.
     ResourceLimitedVector<ReaderProxy*> matched_remote_readers_;
     //! Vector containing all the inactive, ready for reuse, ReaderProxies.

--- a/include/fastdds/statistics/rtps/StatisticsCommon.hpp
+++ b/include/fastdds/statistics/rtps/StatisticsCommon.hpp
@@ -162,11 +162,14 @@ protected:
             uint32_t count);
 
     /**
-     * @brief Report that a DATA / DATA_FRAG message is sent
-     * @param num_destinations number of locators to which the message is sent
+     * @brief Report that a DATA / DATA_FRAG message is generated
+     * @param num_destinations number of locators to which the message will be sent
      */
-    void on_data(
+    void on_data_generated(
             size_t num_destinations);
+
+    /// Notify listeners of DATA / DATA_FRAG counts
+    void on_data_sent();
 
     /// Report that a GAP message is sent
     void on_gap();

--- a/include/fastdds/statistics/rtps/StatisticsCommon.hpp
+++ b/include/fastdds/statistics/rtps/StatisticsCommon.hpp
@@ -161,11 +161,12 @@ protected:
     void on_heartbeat(
             uint32_t count);
 
-    /// Report that a DATA message is sent
-    void on_data();
-
-    /// Report that a DATA_FRAG message is sent
-    void on_data_frag();
+    /**
+     * @brief Report that a DATA / DATA_FRAG message is sent
+     * @param num_destinations number of locators to which the message is sent
+     */
+    void on_data(
+            size_t num_destinations);
 
     /// Report that a GAP message is sent
     void on_gap();

--- a/include/fastdds/statistics/rtps/StatisticsCommonEmpty.hpp
+++ b/include/fastdds/statistics/rtps/StatisticsCommonEmpty.hpp
@@ -63,11 +63,16 @@ protected:
     }
 
     /**
-     * @brief Report that a DATA / DATA_FRAG message is sent
-     * @param number of locators to which the message is sent
+     * @brief Report that a DATA / DATA_FRAG message is generated
+     * @param number of locators to which the message will be sent
      */
-    inline void on_data(
+    inline void on_data_generated(
             size_t)
+    {
+    }
+
+    /// Notify listeners of DATA / DATA_FRAG counts
+    inline void on_data_sent()
     {
     }
 

--- a/include/fastdds/statistics/rtps/StatisticsCommonEmpty.hpp
+++ b/include/fastdds/statistics/rtps/StatisticsCommonEmpty.hpp
@@ -62,13 +62,12 @@ protected:
     {
     }
 
-    /// Report that a DATA message is sent
-    inline void on_data()
-    {
-    }
-
-    /// Report that a DATA_FRAG message is sent
-    inline void on_data_frag()
+    /**
+     * @brief Report that a DATA / DATA_FRAG message is sent
+     * @param number of locators to which the message is sent
+     */
+    inline void on_data(
+            size_t)
     {
     }
 

--- a/src/cpp/rtps/messages/RTPSMessageGroup.cpp
+++ b/src/cpp/rtps/messages/RTPSMessageGroup.cpp
@@ -429,10 +429,6 @@ bool RTPSMessageGroup::add_data(
     }
 #endif // if HAVE_SECURITY
 
-    // Notify the statistics module, note that only writers add DATAs
-    assert(nullptr != dynamic_cast<RTPSWriter*>(endpoint_));
-    static_cast<RTPSWriter*>(endpoint_)->on_data();
-
     return insert_submessage(is_big_submessage);
 }
 
@@ -529,10 +525,6 @@ bool RTPSMessageGroup::add_data_frag(
         }
     }
 #endif // if HAVE_SECURITY
-
-    // Notify the statistics module, note that only writers add DATAs
-    assert(nullptr != dynamic_cast<RTPSWriter*>(endpoint_));
-    static_cast<RTPSWriter*>(endpoint_)->on_data_frag();
 
     return insert_submessage(false);
 }

--- a/src/cpp/rtps/writer/RTPSWriter.cpp
+++ b/src/cpp/rtps/writer/RTPSWriter.cpp
@@ -447,6 +447,7 @@ void RTPSWriter::add_statistics_sent_submessage(
 
 #ifdef FASTDDS_STATISTICS
     change->num_sent_submessages += num_locators;
+    on_data(num_locators);
 #endif // ifdef FASTDDS_STATISTICS
 }
 

--- a/src/cpp/rtps/writer/RTPSWriter.cpp
+++ b/src/cpp/rtps/writer/RTPSWriter.cpp
@@ -447,7 +447,7 @@ void RTPSWriter::add_statistics_sent_submessage(
 
 #ifdef FASTDDS_STATISTICS
     change->num_sent_submessages += num_locators;
-    on_data(num_locators);
+    on_data_generated(num_locators);
 #endif // ifdef FASTDDS_STATISTICS
 }
 

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -970,7 +970,7 @@ void StatefulWriter::send_changes_separatedly(
         else
         {
             SequenceNumber_t max_ack_seq = SequenceNumber_t::unknown();
-            auto sent_fun = [num_locators](
+            auto sent_fun = [this, num_locators](
                 CacheChange_t* change,
                 FragmentNumber_t /*frag*/)
                     {

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -371,7 +371,7 @@ void StatelessWriter::unsent_change_added_to_history(
                             RTPSMessageGroup group(mp_RTPSParticipant, this, *it, max_blocking_time);
                             size_t num_locators = it->locators_size();
                             send_data_or_fragments(group, change, is_inline_qos_expected_,
-                                    [num_locators](
+                                    [this, num_locators](
                                         CacheChange_t* change,
                                         FragmentNumber_t /*frag*/)
                                     {
@@ -391,7 +391,7 @@ void StatelessWriter::unsent_change_added_to_history(
                             RTPSMessageGroup group(mp_RTPSParticipant, this, *this, max_blocking_time);
                             size_t num_locators = locator_selector_.selected_size() + fixed_locators_.size();
                             send_data_or_fragments(group, change, is_inline_qos_expected_,
-                                    [num_locators](
+                                    [this, num_locators](
                                         CacheChange_t* change,
                                         FragmentNumber_t /*frag*/)
                                     {
@@ -649,7 +649,7 @@ void StatelessWriter::send_all_unsent_changes()
         {
             auto change = unsentChange.getChange();
             bool sent = send_data_or_fragments(group, change, is_inline_qos_expected_,
-                            [num_locators](
+                            [this, num_locators](
                                 CacheChange_t* change,
                                 FragmentNumber_t /*frag*/)
                             {

--- a/src/cpp/statistics/rtps/writer/StatisticsWriterImpl.cpp
+++ b/src/cpp/statistics/rtps/writer/StatisticsWriterImpl.cpp
@@ -79,8 +79,15 @@ void StatisticsWriterImpl::on_sample_datas(
             });
 }
 
-void StatisticsWriterImpl::on_data(
+void StatisticsWriterImpl::on_data_generated(
         size_t num_destinations)
+{
+    std::lock_guard<fastrtps::RecursiveTimedMutex> lock(get_statistics_mutex());
+    auto members = get_members();
+    members->data_counter += static_cast<uint64_t>(num_destinations);
+}
+
+void StatisticsWriterImpl::on_data_sent()
 {
     EntityCount notification;
     notification.guid(to_statistics_type(get_guid()));
@@ -88,7 +95,6 @@ void StatisticsWriterImpl::on_data(
     {
         std::lock_guard<fastrtps::RecursiveTimedMutex> lock(get_statistics_mutex());
         auto members = get_members();
-        members->data_counter += static_cast<uint64_t>(num_destinations);
         notification.count(members->data_counter);
     }
 

--- a/src/cpp/statistics/rtps/writer/StatisticsWriterImpl.cpp
+++ b/src/cpp/statistics/rtps/writer/StatisticsWriterImpl.cpp
@@ -79,14 +79,17 @@ void StatisticsWriterImpl::on_sample_datas(
             });
 }
 
-void StatisticsWriterImpl::on_data()
+void StatisticsWriterImpl::on_data(
+        size_t num_destinations)
 {
     EntityCount notification;
     notification.guid(to_statistics_type(get_guid()));
 
     {
         std::lock_guard<fastrtps::RecursiveTimedMutex> lock(get_statistics_mutex());
-        notification.count(++get_members()->data_counter);
+        auto members = get_members();
+        members->data_counter += static_cast<uint64_t>(num_destinations);
+        notification.count(members->data_counter);
     }
 
     // Perform the callbacks
@@ -99,12 +102,6 @@ void StatisticsWriterImpl::on_data()
             {
                 listener->on_statistics_data(data);
             });
-}
-
-void StatisticsWriterImpl::on_data_frag()
-{
-    // there is no specific EventKind thus it will be redirected to DATA_COUNT
-    on_data();
 }
 
 void StatisticsWriterImpl::on_heartbeat(


### PR DESCRIPTION
This PR builds on top of #1945 and fixes the way DATA_COUNT collect samples, in order to make it more accurate and also improve performance by calling the listener fewer times (once per `send_any_unsent_changes` / `unsent_change_added_to_history` call)