### PR TITLE
[10792] Collection of data and notification to listeners PUBLICATION_THROUGHPUT

### DIFF
--- a/include/fastdds/statistics/rtps/StatisticsCommon.hpp
+++ b/include/fastdds/statistics/rtps/StatisticsCommon.hpp
@@ -172,6 +172,13 @@ protected:
     /// Notify listeners of DATA / DATA_FRAG counts
     void on_data_sent();
 
+    /**
+     * @brief Reports throughtput based on last added sample to history
+     * @param payload size of the message sent
+     */
+    void on_publish_throughput(
+            uint32_t payload);
+
     /// Report that a GAP message is sent
     void on_gap();
 

--- a/include/fastdds/statistics/rtps/StatisticsCommon.hpp
+++ b/include/fastdds/statistics/rtps/StatisticsCommon.hpp
@@ -173,7 +173,7 @@ protected:
     void on_data_sent();
 
     /**
-     * @brief Reports throughtput based on last added sample to history
+     * @brief Reports publication throughtput based on last added sample to writer's history
      * @param payload size of the message sent
      */
     void on_publish_throughput(

--- a/include/fastdds/statistics/rtps/StatisticsCommonEmpty.hpp
+++ b/include/fastdds/statistics/rtps/StatisticsCommonEmpty.hpp
@@ -78,6 +78,15 @@ protected:
     {
     }
 
+    /**
+     * @brief Reports throughtput based on last added sample to history
+     * @param size of the message sent
+     */
+    inline void on_publish_throughput(
+            uint32_t)
+    {
+    }
+
     /// Report that a GAP message is sent
     inline void on_gap()
     {

--- a/include/fastdds/statistics/rtps/StatisticsCommonEmpty.hpp
+++ b/include/fastdds/statistics/rtps/StatisticsCommonEmpty.hpp
@@ -79,7 +79,7 @@ protected:
     }
 
     /**
-     * @brief Reports throughtput based on last added sample to history
+     * @brief Reports publication throughtput based on last added sample to writer's history
      * @param size of the message sent
      */
     inline void on_publish_throughput(

--- a/include/fastdds/statistics/rtps/StatisticsCommonEmpty.hpp
+++ b/include/fastdds/statistics/rtps/StatisticsCommonEmpty.hpp
@@ -84,7 +84,7 @@ protected:
      */
     inline void on_publish_throughput(
             uint32_t)
-    {
+    {
     }
 
     /// Report that a GAP message is sent

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -657,6 +657,9 @@ void StatefulWriter::unsent_change_added_to_history(
     {
         on_data_sent();
     }
+
+    // Throughput should be notified even if no matches are available
+    on_publish_throughput(change->serializedPayload.length);
 }
 
 bool StatefulWriter::intraprocess_delivery(

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -432,6 +432,9 @@ void StatelessWriter::unsent_change_added_to_history(
     {
         on_data_sent();
     }
+
+    // Throughput should be notified even if no matches are available
+    on_publish_throughput(change->serializedPayload.length);
 }
 
 bool StatelessWriter::intraprocess_delivery(

--- a/src/cpp/statistics/rtps/StatisticsBase.hpp
+++ b/src/cpp/statistics/rtps/StatisticsBase.hpp
@@ -59,6 +59,7 @@ struct StatisticsWriterAncillary
     unsigned long long data_counter = {};
     unsigned long long gap_counter = {};
     unsigned long long resent_counter = {};
+    std::chrono::time_point<std::chrono::steady_clock> last_history_change_ = std::chrono::steady_clock::now();
 };
 
 struct StatisticsReaderAncillary

--- a/src/cpp/statistics/rtps/writer/StatisticsWriterImpl.cpp
+++ b/src/cpp/statistics/rtps/writer/StatisticsWriterImpl.cpp
@@ -188,7 +188,7 @@ void StatisticsWriterImpl::on_publish_throughput(
     {
         // update state
         time_point<steady_clock> former_timepoint;
-        auto & current_timepoint = get_members()->last_history_change_;
+        auto& current_timepoint = get_members()->last_history_change_;
         {
             lock_guard<fastrtps::RecursiveTimedMutex> lock(get_statistics_mutex());
             former_timepoint = current_timepoint;

--- a/src/cpp/statistics/rtps/writer/StatisticsWriterImpl.cpp
+++ b/src/cpp/statistics/rtps/writer/StatisticsWriterImpl.cpp
@@ -71,7 +71,7 @@ void StatisticsWriterImpl::on_sample_datas(
     // Perform the callbacks
     Data data;
     // note that the setter sets SAMPLE_DATAS by default
-    data.sample_identity_count(notification);
+    data.sample_identity_count(std::move(notification));
 
     for_each_listener([&data](const std::shared_ptr<IListener>& listener)
             {
@@ -101,7 +101,7 @@ void StatisticsWriterImpl::on_data_sent()
     // Perform the callbacks
     Data data;
     // note that the setter sets RESENT_DATAS by default
-    data.entity_count(notification);
+    data.entity_count(std::move(notification));
     data._d(EventKind::DATA_COUNT);
 
     for_each_listener([&data](const std::shared_ptr<IListener>& listener)
@@ -120,7 +120,7 @@ void StatisticsWriterImpl::on_heartbeat(
     // Perform the callbacks
     Data data;
     // note that the setter sets RESENT_DATAS by default
-    data.entity_count(notification);
+    data.entity_count(std::move(notification));
     data._d(EventKind::HEARTBEAT_COUNT);
 
     for_each_listener([&data](const std::shared_ptr<IListener>& listener)
@@ -142,7 +142,7 @@ void StatisticsWriterImpl::on_gap()
     // Perform the callbacks
     Data data;
     // note that the setter sets RESENT_DATAS by default
-    data.entity_count(notification);
+    data.entity_count(std::move(notification));
     data._d(EventKind::GAP_COUNT);
 
     for_each_listener([&data](const std::shared_ptr<IListener>& listener)
@@ -170,10 +170,43 @@ void StatisticsWriterImpl::on_resent_data(
     // Perform the callbacks
     Data data;
     // note that the setter sets RESENT_DATAS by default
-    data.entity_count(notification);
+    data.entity_count(std::move(notification));
 
     for_each_listener([&data](const std::shared_ptr<IListener>& listener)
             {
                 listener->on_statistics_data(data);
             });
+}
+
+void StatisticsWriterImpl::on_publish_throughput(
+        uint32_t payload)
+{
+    using namespace std;
+    using namespace chrono;
+
+    if (payload > 0 )
+    {
+        // update state
+        time_point<steady_clock> former_timepoint;
+        auto & current_timepoint = get_members()->last_history_change_;
+        {
+            lock_guard<fastrtps::RecursiveTimedMutex> lock(get_statistics_mutex());
+            former_timepoint = current_timepoint;
+            current_timepoint = steady_clock::now();
+        }
+
+        EntityData notification;
+        notification.guid(to_statistics_type(get_guid()));
+        notification.data(payload / duration_cast<duration<float>>(current_timepoint - former_timepoint).count());
+
+        // Perform the callbacks
+        Data data;
+        // note that the setter sets PUBLICATION_THROUGHPUT by default
+        data.entity_data(std::move(notification));
+
+        for_each_listener([&data](const std::shared_ptr<IListener>& listener)
+                {
+                    listener->on_statistics_data(data);
+                });
+    }
 }


### PR DESCRIPTION
It was decided to retake the concept of reporting rate instead of the number of bytes. The change simplifies things and if in the future the amount of bytes is necessary we can extend the **idl**.

The callback will return bytes/second ( payload size / time span since the last callback). We only need to keep the
timestamp of the last callback and initialize it on construction (creation is the first callback).
