### PR TITLE
Synchronize TCP reception to wait for RTCP header. [11562]

### DIFF
--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
@@ -155,6 +155,7 @@ size_t TCPChannelResourceBasic::send(
 
     if (eConnecting < connection_status_)
     {
+        std::lock_guard<std::mutex> send_guard(send_mutex_);
         if (header_size > 0)
         {
             std::array<asio::const_buffer, 2> buffers;

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.h
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.h
@@ -15,6 +15,7 @@
 #ifndef _FASTDDS_TCP_CHANNEL_RESOURCE_BASIC_
 #define _FASTDDS_TCP_CHANNEL_RESOURCE_BASIC_
 
+#include <mutex>
 #include <asio.hpp>
 #include <rtps/transport/TCPChannelResource.h>
 
@@ -25,6 +26,8 @@ namespace rtps {
 class TCPChannelResourceBasic : public TCPChannelResource
 {
     asio::io_service& service_;
+
+    std::mutex send_mutex_;
     std::shared_ptr<asio::ip::tcp::socket> socket_;
 
 public:

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -886,10 +886,10 @@ bool receive_header(
             if (0 == bytes_needed)
             {
                 size_t skip =
-                    (tcp_header.rtcp[0] != 'R') ? 1 :
-                    (tcp_header.rtcp[1] != 'T') ? 2 :
-                    (tcp_header.rtcp[2] != 'C') ? 3 :
-                    (tcp_header.rtcp[3] != 'P') ? 4 : 0;
+                        (tcp_header.rtcp[0] != 'R') ? 1 :
+                        (tcp_header.rtcp[1] != 'T') ? 2 :
+                        (tcp_header.rtcp[2] != 'C') ? 3 :
+                        (tcp_header.rtcp[3] != 'P') ? 4 : 0;
 
                 if (skip && (skip < 4))
                 {
@@ -950,7 +950,7 @@ bool TCPTransportInterface::Receive(
         asio::error_code ec;
 
         bool header_found = false;
-        
+
         do
         {
             header_found = receive_header(channel, tcp_header, ec);

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -884,13 +884,13 @@ bool receive_header(
             bytes_needed -= bytes_read;
             if (0 == bytes_needed)
             {
-                size_t skip =
-                        (tcp_header.rtcp[0] != 'R') ? 1 :
-                        (tcp_header.rtcp[1] != 'T') ? 2 :
-                        (tcp_header.rtcp[2] != 'C') ? 3 :
-                        (tcp_header.rtcp[3] != 'P') ? 4 : 0;
+                size_t skip =                                 // Text   Next possible match   Skip to next match
+                        (tcp_header.rtcp[0] != 'R') ? 1 :     // X---   XRTCP                 1
+                        (tcp_header.rtcp[1] != 'T') ? 1 :     // RX--   RRTCP                 1
+                        (tcp_header.rtcp[2] != 'C') ? 2 :     // RTX-   RTRTCP                2
+                        (tcp_header.rtcp[3] != 'P') ? 3 : 0;  // RTCX   RTCRTCP               3
 
-                if (skip && (skip < 4))
+                if (skip)
                 {
                     memmove(ptr, &ptr[skip], 4 - skip);
                 }

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -868,12 +868,11 @@ bool receive_header(
 {
     // Cleanup header
     octet* ptr = tcp_header.address();
-    char* begin = (char*)ptr;
     memset(ptr, 0, sizeof(TCPHeader));
 
     // Prepare read position
     octet* read_pos = ptr;
-    size_t bytes_needed = 4; // TCPHeader::size();
+    size_t bytes_needed = 4;
 
     // Wait for sync
     while (bytes_needed > 0)

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -861,6 +861,69 @@ bool TCPTransportInterface::read_body(
     return true;
 }
 
+bool receive_header(
+        std::shared_ptr<TCPChannelResource>& channel,
+        TCPHeader& tcp_header,
+        asio::error_code& ec)
+{
+    // Cleanup header
+    octet* ptr = tcp_header.address();
+    char* begin = (char*)ptr;
+    memset(ptr, 0, sizeof(TCPHeader));
+
+    // Prepare read position
+    octet* read_pos = ptr;
+    size_t bytes_needed = 4; // TCPHeader::size();
+
+    // Wait for sync
+    while (bytes_needed > 0)
+    {
+        size_t bytes_read = channel->read(read_pos, bytes_needed, ec);
+        if (bytes_read > 0)
+        {
+            read_pos += bytes_read;
+            bytes_needed -= bytes_read;
+            if (0 == bytes_needed)
+            {
+                size_t skip =
+                    (tcp_header.rtcp[0] != 'R') ? 1 :
+                    (tcp_header.rtcp[1] != 'T') ? 2 :
+                    (tcp_header.rtcp[2] != 'C') ? 3 :
+                    (tcp_header.rtcp[3] != 'P') ? 4 : 0;
+
+                if (skip && (skip < 4))
+                {
+                    memmove(ptr, &ptr[skip], 4 - skip);
+                }
+
+                read_pos -= skip;
+                bytes_needed = skip;
+            }
+        }
+        else if (ec)
+        {
+            return 0;
+        }
+    }
+
+    bytes_needed = TCPHeader::size() - 4;
+    while (bytes_needed > 0)
+    {
+        size_t bytes_read = channel->read(read_pos, bytes_needed, ec);
+        if (bytes_read > 0)
+        {
+            read_pos += bytes_read;
+            bytes_needed -= bytes_read;
+        }
+        else if (ec)
+        {
+            return 0;
+        }
+    }
+
+    return TCPHeader::size();
+}
+
 /**
  * On TCP, we must receive the header (14 Bytes) and then,
  * the rest of the message, whose length is on the header.
@@ -886,117 +949,96 @@ bool TCPTransportInterface::Receive(
         TCPHeader tcp_header;
         asio::error_code ec;
 
-        size_t bytes_received = channel->read(reinterpret_cast<octet*>(&tcp_header),
-                        TCPHeader::size(), ec);
-
-        remote_locator = channel->locator();
-
-        if (bytes_received != TCPHeader::size())
+        bool header_found = false;
+        
+        do
         {
-            if (bytes_received > 0)
-            {
-                logError(RTCP_MSG_IN, "Bad TCP header size: " << bytes_received << " (expected: : "
-                                                              << TCPHeader::size() << ")" << ec.message());
-                close_tcp_socket(channel);
-            }
-            else if (ec)
-            {
-                logWarning(DEBUG, "Error reading TCP header: " << ec.message());
-                close_tcp_socket(channel);
-            }
+            header_found = receive_header(channel, tcp_header, ec);
+        } while (!header_found && !ec);
 
+        if (ec)
+        {
+            logWarning(DEBUG, "Error reading TCP header: " << ec.message());
+            close_tcp_socket(channel);
             success = false;
         }
         else
         {
-            // Check RTPC Header
-            if (tcp_header.rtcp[0] != 'R'
-                    || tcp_header.rtcp[1] != 'T'
-                    || tcp_header.rtcp[2] != 'C'
-                    || tcp_header.rtcp[3] != 'P')
+            size_t body_size = tcp_header.length - static_cast<uint32_t>(TCPHeader::size());
+
+            if (body_size > receive_buffer_capacity)
             {
-                logError(RTCP_MSG_IN, "Bad RTCP header identifier, closing connection.");
-                close_tcp_socket(channel);
+                logError(RTCP_MSG_IN, "Size of incoming TCP message is bigger than buffer capacity: "
+                        << static_cast<uint32_t>(body_size) << " vs. " << receive_buffer_capacity << ". "
+                        << "The full message will be dropped.");
                 success = false;
+                // Drop the message
+                size_t to_read = body_size;
+                size_t read_block = receive_buffer_capacity;
+                uint32_t readed;
+                while (read_block > 0)
+                {
+                    read_body(receive_buffer, receive_buffer_capacity, &readed, channel,
+                            read_block);
+                    to_read -= readed;
+                    read_block = (to_read >= receive_buffer_capacity) ? receive_buffer_capacity : to_read;
+                }
             }
             else
             {
-                size_t body_size = tcp_header.length - static_cast<uint32_t>(TCPHeader::size());
+                logInfo(RTCP_MSG_IN, "Received RTCP MSG. Logical Port " << tcp_header.logical_port);
+                success = read_body(receive_buffer, receive_buffer_capacity, &receive_buffer_size,
+                                channel, body_size);
 
-                if (body_size > receive_buffer_capacity)
+                if (success)
                 {
-                    logError(RTCP_MSG_IN, "Size of incoming TCP message is bigger than buffer capacity: "
-                            << static_cast<uint32_t>(body_size) << " vs. " << receive_buffer_capacity << ". "
-                            << "The full message will be dropped.");
-                    success = false;
-                    // Drop the message
-                    size_t to_read = body_size;
-                    size_t read_block = receive_buffer_capacity;
-                    uint32_t readed;
-                    while (read_block > 0)
+                    if (configuration()->check_crc
+                            && !check_crc(tcp_header, receive_buffer, receive_buffer_size))
                     {
-                        read_body(receive_buffer, receive_buffer_capacity, &readed, channel,
-                                read_block);
-                        to_read -= readed;
-                        read_block = (to_read >= receive_buffer_capacity) ? receive_buffer_capacity : to_read;
+                        logWarning(RTCP_MSG_IN, "Bad TCP header CRC");
                     }
-                }
-                else
-                {
-                    logInfo(RTCP_MSG_IN, "Received RTCP MSG. Logical Port " << tcp_header.logical_port);
-                    success = read_body(receive_buffer, receive_buffer_capacity, &receive_buffer_size,
-                                    channel, body_size);
 
-                    if (success)
+                    if (tcp_header.logical_port == 0)
                     {
-                        if (configuration()->check_crc
-                                && !check_crc(tcp_header, receive_buffer, receive_buffer_size))
+                        std::shared_ptr<RTCPMessageManager> rtcp_message_manager;
+                        if (TCPChannelResource::eConnectionStatus::eDisconnected != channel->connection_status())
+
                         {
-                            logWarning(RTCP_MSG_IN, "Bad TCP header CRC");
+                            std::unique_lock<std::mutex> lock(rtcp_message_manager_mutex_);
+                            rtcp_message_manager = rtcp_manager.lock();
                         }
 
-                        if (tcp_header.logical_port == 0)
+                        if (rtcp_message_manager)
                         {
-                            std::shared_ptr<RTCPMessageManager> rtcp_message_manager;
-                            if (TCPChannelResource::eConnectionStatus::eDisconnected != channel->connection_status())
+                            // The channel is not going to be deleted because we lock it for reading.
+                            ResponseCode responseCode = rtcp_message_manager->processRTCPMessage(
+                                channel, receive_buffer, body_size);
 
+                            if (responseCode != RETCODE_OK)
                             {
-                                std::unique_lock<std::mutex> lock(rtcp_message_manager_mutex_);
-                                rtcp_message_manager = rtcp_manager.lock();
-                            }
-
-                            if (rtcp_message_manager)
-                            {
-                                // The channel is not going to be deleted because we lock it for reading.
-                                ResponseCode responseCode = rtcp_message_manager->processRTCPMessage(
-                                    channel, receive_buffer, body_size);
-
-                                if (responseCode != RETCODE_OK)
-                                {
-                                    close_tcp_socket(channel);
-                                }
-                                success = false;
-
-                                std::unique_lock<std::mutex> lock(rtcp_message_manager_mutex_);
-                                rtcp_message_manager.reset();
-                                rtcp_message_manager_cv_.notify_one();
-                            }
-                            else
-                            {
-                                success = false;
                                 close_tcp_socket(channel);
                             }
+                            success = false;
 
+                            std::unique_lock<std::mutex> lock(rtcp_message_manager_mutex_);
+                            rtcp_message_manager.reset();
+                            rtcp_message_manager_cv_.notify_one();
                         }
                         else
                         {
-                            IPLocator::setLogicalPort(remote_locator, tcp_header.logical_port);
-                            logInfo(RTCP_MSG_IN, "[RECEIVE] From: " << remote_locator \
-                                                                    << " - " << receive_buffer_size << " bytes.");
+                            success = false;
+                            close_tcp_socket(channel);
                         }
+
                     }
-                    // Error message already shown by read_body method.
+                    else
+                    {
+                        IPLocator::setLogicalPort(remote_locator, tcp_header.logical_port);
+                        logInfo(RTCP_MSG_IN, "[RECEIVE] From: " << remote_locator \
+                                                                << " - " << receive_buffer_size << " bytes.");
+                    }
                 }
+                // Error message already shown by read_body method.
             }
         }
     }

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -901,7 +901,7 @@ bool receive_header(
         }
         else if (ec)
         {
-            return 0;
+            return false;
         }
     }
 
@@ -916,11 +916,11 @@ bool receive_header(
         }
         else if (ec)
         {
-            return 0;
+            return false;
         }
     }
 
-    return TCPHeader::size();
+    return true;
 }
 
 /**
@@ -957,7 +957,10 @@ bool TCPTransportInterface::Receive(
 
         if (ec)
         {
-            logWarning(DEBUG, "Error reading TCP header: " << ec.message());
+            if (ec != asio::error::eof)
+            {
+                logWarning(DEBUG, "Error reading TCP header: " << ec.message());
+            }
             close_tcp_socket(channel);
             success = false;
         }

--- a/src/cpp/rtps/transport/tcp/RTCPHeader.h
+++ b/src/cpp/rtps/transport/tcp/RTCPHeader.h
@@ -37,7 +37,7 @@ struct TCPHeader
     uint16_t logical_port;
 
     TCPHeader()
-        : length(sizeof(TCPHeader))
+        : length(TCPHEADER_SIZE)
         , crc(0)
         , logical_port(0)
     {

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -1425,7 +1425,7 @@ TEST_F(TCPv4Tests, receive_unordered_data)
 
     EXPECT_TRUE(!sender.close(ec));
 
-    EXPECT_EQ(1, receiver.num_received[0]);
+    EXPECT_EQ(2, receiver.num_received[0]);
     EXPECT_EQ(1, receiver.num_received[1]);
     EXPECT_EQ(0, receiver.num_received[2]);
 

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -1419,12 +1419,12 @@ TEST_F(TCPv4Tests, receive_unordered_data)
     std::array<std::size_t, 3> expected_number{ 0, 0, 0 };
 
     auto send_first = [&]()
-    {
-        expected_number[0]++;
-        bytes_1[0]++;
-        EXPECT_EQ(TCPHeader::size(), asio::write(sender, asio::buffer(&h1, TCPHeader::size()), ec));
-        EXPECT_EQ(num_bytes_1, asio::write(sender, asio::buffer(bytes_1.data(), bytes_1.size()), ec));
-    };
+            {
+                expected_number[0]++;
+                bytes_1[0]++;
+                EXPECT_EQ(TCPHeader::size(), asio::write(sender, asio::buffer(&h1, TCPHeader::size()), ec));
+                EXPECT_EQ(num_bytes_1, asio::write(sender, asio::buffer(bytes_1.data(), bytes_1.size()), ec));
+            };
 
     // Send first synchronized
     send_first();

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -25,11 +25,12 @@
 #include <fastrtps/utils/IPFinder.h>
 #include <fastrtps/utils/IPLocator.h>
 #include <rtps/transport/TCPv4Transport.h>
-//#include "../../../src/cpp/rtps/transport/TCPSenderResource.hpp"
+#include <rtps/transport/tcp/RTCPHeader.h>
 
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 using TCPv4Transport = eprosima::fastdds::rtps::TCPv4Transport;
+using TCPHeader = eprosima::fastdds::rtps::TCPHeader;
 
 #if defined(_WIN32)
 #define GET_PID _getpid
@@ -1330,6 +1331,106 @@ TEST_F(TCPv4Tests, send_and_receive_between_blocked_interfaces_ports)
 }
 
 #endif // ifndef __APPLE__
+
+TEST_F(TCPv4Tests, receive_unordered_data)
+{
+    constexpr uint16_t logical_port = 7410;
+    constexpr uint32_t num_bytes_1 = 3;
+    constexpr uint32_t num_bytes_2 = 13;
+
+    struct Receiver : public TransportReceiverInterface
+    {
+        std::array<std::size_t, 3> num_received{ 0, 0, 0 };
+
+        void OnDataReceived(
+            const octet* data,
+            const uint32_t size,
+            const Locator_t& local_locator,
+            const Locator_t& remote_locator) override
+        {
+            static_cast<void>(data);
+            static_cast<void>(local_locator);
+            static_cast<void>(remote_locator);
+
+            std::cout << "Received " << size << " bytes" << std::endl;
+
+            switch (size)
+            {
+                case num_bytes_1:
+                    num_received[0]++;
+                    break;
+                case num_bytes_2:
+                    num_received[1]++;
+                    break;
+                default:
+                    num_received[2]++;
+                    break;
+            }
+        }
+    } receiver;
+
+    TCPv4TransportDescriptor test_descriptor = descriptor;
+    test_descriptor.check_crc = false;
+    TCPv4Transport uut(test_descriptor);
+    ASSERT_TRUE(uut.init()) << "Failed to initialize transport. Port " << g_default_port << " may be in use";
+
+    Locator_t input_locator;
+    input_locator.kind = LOCATOR_KIND_TCPv4;
+    input_locator.port = g_default_port;
+    IPLocator::setIPv4(input_locator, 127, 0, 0, 1);
+    IPLocator::setLogicalPort(input_locator, logical_port);
+
+    EXPECT_TRUE(uut.OpenInputChannel(input_locator, &receiver, 0xFFFF));
+
+    // Let acceptor to be open
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    asio::error_code ec;
+    asio::io_context ctx;
+
+    asio::ip::tcp::socket sender(ctx);
+    asio::ip::tcp::endpoint destination;
+    destination.port(g_default_port);
+    destination.address(asio::ip::address::from_string("127.0.0.1"));
+    sender.connect(destination, ec);
+    ASSERT_TRUE(!ec) << ec;
+
+    std::array<octet, num_bytes_1> bytes_1;
+    std::array<octet, num_bytes_2> bytes_2;
+
+    TCPHeader h1;
+    h1.logical_port = logical_port;
+    h1.length = num_bytes_1 + TCPHeader::size();
+
+    TCPHeader h2;
+    h2.logical_port = logical_port;
+    h2.length = num_bytes_2 + TCPHeader::size();
+
+    // Send first without interleaving
+    EXPECT_EQ(sizeof(TCPHeader), asio::write(sender, asio::buffer(&h1, sizeof(TCPHeader)), ec));
+    EXPECT_EQ(num_bytes_1, asio::write(sender, asio::buffer(bytes_1.data(), bytes_1.size()), ec));
+
+    // Interleave headers and data
+    EXPECT_EQ(sizeof(TCPHeader), asio::write(sender, asio::buffer(&h1, sizeof(TCPHeader)), ec));
+    EXPECT_EQ(sizeof(TCPHeader), asio::write(sender, asio::buffer(&h2, sizeof(TCPHeader)), ec));
+    EXPECT_EQ(num_bytes_1, asio::write(sender, asio::buffer(bytes_1.data(), bytes_1.size()), ec));
+    EXPECT_EQ(num_bytes_2, asio::write(sender, asio::buffer(bytes_2.data(), bytes_2.size()), ec));
+
+    // Send second without interleaving
+    EXPECT_EQ(sizeof(TCPHeader), asio::write(sender, asio::buffer(&h2, sizeof(TCPHeader)), ec));
+    EXPECT_EQ(num_bytes_2, asio::write(sender, asio::buffer(bytes_2.data(), bytes_2.size()), ec));
+
+    // Wait for data to be received
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    EXPECT_TRUE(!sender.close(ec));
+
+    EXPECT_EQ(1, receiver.num_received[0]);
+    EXPECT_EQ(1, receiver.num_received[1]);
+    EXPECT_EQ(0, receiver.num_received[2]);
+
+    EXPECT_TRUE(uut.CloseInputChannel(input_locator));
+}
 
 void TCPv4Tests::HELPER_SetDescriptorDefaults()
 {

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -1343,10 +1343,10 @@ TEST_F(TCPv4Tests, receive_unordered_data)
         std::array<std::size_t, 3> num_received{ 0, 0, 0 };
 
         void OnDataReceived(
-            const octet* data,
-            const uint32_t size,
-            const Locator_t& local_locator,
-            const Locator_t& remote_locator) override
+                const octet* data,
+                const uint32_t size,
+                const Locator_t& local_locator,
+                const Locator_t& remote_locator) override
         {
             static_cast<void>(data);
             static_cast<void>(local_locator);
@@ -1367,7 +1367,9 @@ TEST_F(TCPv4Tests, receive_unordered_data)
                     break;
             }
         }
-    } receiver;
+
+    }
+    receiver;
 
     TCPv4TransportDescriptor test_descriptor = descriptor;
     test_descriptor.check_crc = false;


### PR DESCRIPTION
This PR should fix issue #1268 by always waiting for the RTCP header, consuming bytes if they come unordered.