### PR TITLE
Document and assert RTPS entity pointers lifetime [11579]

### DIFF
--- a/include/fastdds/rtps/RTPSDomain.h
+++ b/include/fastdds/rtps/RTPSDomain.h
@@ -61,6 +61,9 @@ public:
      * Method to shut down all RTPSParticipants, readers, writers, etc.
      * It must be called at the end of the process to avoid memory leaks.
      * It also shut downs the DomainRTPSParticipant.
+     *
+     * \post After this call, all the pointers to RTPS entities are invalidated and their use may
+     *       result in undefined behaviour.
      */
     RTPS_DllAPI static void stopAll();
 
@@ -70,6 +73,9 @@ public:
      * @param attrs RTPSParticipant Attributes.
      * @param plisten Pointer to the ParticipantListener.
      * @return Pointer to the RTPSParticipant.
+     *
+     * \warning The returned pointer is invalidated after a call to removeRTPSParticipant() or stopAll(),
+     *          so its use may result in undefined behaviour.
      */
     RTPS_DllAPI static RTPSParticipant* createParticipant(
             uint32_t domain_id,
@@ -83,6 +89,9 @@ public:
      * @param attrs RTPSParticipant Attributes.
      * @param plisten Pointer to the ParticipantListener.
      * @return Pointer to the RTPSParticipant.
+     *
+     * \warning The returned pointer is invalidated after a call to removeRTPSParticipant() or stopAll(),
+     *          so its use may result in undefined behaviour.
      */
     RTPS_DllAPI static RTPSParticipant* createParticipant(
             uint32_t domain_id,
@@ -97,6 +106,9 @@ public:
      * @param hist Pointer to the WriterHistory.
      * @param listen Pointer to the WriterListener.
      * @return Pointer to the created RTPSWriter.
+     *
+     * \warning The returned pointer is invalidated after a call to removeRTPSWriter() or stopAll(),
+     *          so its use may result in undefined behaviour.
      */
     RTPS_DllAPI static RTPSWriter* createRTPSWriter(
             RTPSParticipant* p,
@@ -112,6 +124,9 @@ public:
      * @param hist Pointer to the WriterHistory.
      * @param listen Pointer to the WriterListener.
      * @return Pointer to the created RTPSWriter.
+     *
+     * \warning The returned pointer is invalidated after a call to removeRTPSWriter() or stopAll(),
+     *          so its use may result in undefined behaviour.
      */
     RTPS_DllAPI static RTPSWriter* createRTPSWriter(
             RTPSParticipant* p,
@@ -129,6 +144,9 @@ public:
      * @param hist Pointer to the WriterHistory.
      * @param listen Pointer to the WriterListener.
      * @return Pointer to the created RTPSWriter.
+     *
+     * \warning The returned pointer is invalidated after a call to removeRTPSWriter() or stopAll(),
+     *          so its use may result in undefined behaviour.
      */
     RTPS_DllAPI static RTPSWriter* createRTPSWriter(
             RTPSParticipant* p,
@@ -153,6 +171,9 @@ public:
      * @param hist Pointer to the ReaderHistory.
      * @param listen Pointer to the ReaderListener.
      * @return Pointer to the created RTPSReader.
+     *
+     * \warning The returned pointer is invalidated after a call to removeRTPSReader() or stopAll(),
+     *          so its use may result in undefined behaviour.
      */
     RTPS_DllAPI static RTPSReader* createRTPSReader(
             RTPSParticipant* p,
@@ -168,6 +189,9 @@ public:
      * @param hist Pointer to the ReaderHistory.
      * @param listen Pointer to the ReaderListener.
      * @return Pointer to the created RTPSReader.
+     *
+     * \warning The returned pointer is invalidated after a call to removeRTPSReader() or stopAll(),
+     *          so its use may result in undefined behaviour.
      */
     RTPS_DllAPI static RTPSReader* createRTPSReader(
             RTPSParticipant* p,
@@ -209,6 +233,9 @@ public:
      * @param attrs RTPSParticipant Attributes.
      * @param listen Pointer to the ParticipantListener.
      * @return Pointer to the RTPSParticipant.
+     *
+     * \warning The returned pointer is invalidated after a call to removeRTPSParticipant() or stopAll(),
+     *          so its use may result in undefined behaviour.
      */
     static RTPSParticipant* clientServerEnvironmentCreationOverride(
             uint32_t domain_id,

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -212,22 +212,22 @@ RTPSParticipant* RTPSDomain::createParticipant(
 bool RTPSDomain::removeRTPSParticipant(
         RTPSParticipant* p)
 {
-    if (p != nullptr)
+    for (auto it = m_RTPSParticipants.begin(); it != m_RTPSParticipants.end(); ++it)
     {
-        p->mp_impl->disable();
-
-        std::unique_lock<std::mutex> lock(m_mutex);
-        for (auto it = m_RTPSParticipants.begin(); it != m_RTPSParticipants.end(); ++it)
+        if (it->first == p)
         {
-            if (it->second->getGuid().guidPrefix == p->getGuid().guidPrefix)
+            if (p->mp_impl != nullptr)
             {
-                RTPSDomain::t_p_RTPSParticipant participant = *it;
-                m_RTPSParticipants.erase(it);
-                m_RTPSParticipantIDs.erase(m_RTPSParticipantIDs.find(participant.second->getRTPSParticipantID()));
-                lock.unlock();
-                removeRTPSParticipant_nts(participant);
-                return true;
+                p->mp_impl->disable();
             }
+
+            std::unique_lock<std::mutex> lock(m_mutex);
+            RTPSDomain::t_p_RTPSParticipant participant = *it;
+            m_RTPSParticipants.erase(it);
+            m_RTPSParticipantIDs.erase(m_RTPSParticipantIDs.find(participant.second->getRTPSParticipantID()));
+            lock.unlock();
+            removeRTPSParticipant_nts(participant);
+            return true;
         }
     }
     logError(RTPS_PARTICIPANT, "RTPSParticipant not valid or not recognized");
@@ -237,6 +237,11 @@ bool RTPSDomain::removeRTPSParticipant(
 void RTPSDomain::removeRTPSParticipant_nts(
         RTPSDomain::t_p_RTPSParticipant& participant)
 {
+    // Set in the RTPSParticipant the pointer to the impl to nullptr as a way to mark that this
+    // RTPSParticipant instance has become invalid.
+    participant.first->mp_impl = nullptr;
+    // The destructor of RTPSParticipantImpl already deletes the associated RTPSParticipant, so
+    // there is no need to do it here manually.
     delete(participant.second);
 }
 

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -239,7 +239,7 @@ void RTPSDomain::removeRTPSParticipant_nts(
         RTPSDomain::t_p_RTPSParticipant& participant)
 {
     // The destructor of RTPSParticipantImpl already deletes the associated RTPSParticipant and sets
-    // its pointter to the RTPSParticipant to nullptr, so  there is no need to do it here manually.
+    // its pointer to the RTPSParticipant to nullptr, so there is no need to do it here manually.
     delete(participant.second);
 }
 

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -33,7 +33,7 @@ RTPSParticipant::RTPSParticipant(
 
 RTPSParticipant::~RTPSParticipant()
 {
-
+    mp_impl = nullptr;
 }
 
 const GUID_t& RTPSParticipant::getGuid() const

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -471,6 +471,7 @@ RTPSParticipantImpl::~RTPSParticipantImpl()
 
     delete mp_ResourceSemaphore;
     delete mp_userParticipant;
+    mp_userParticipant = nullptr;
     send_resource_list_.clear();
 
     delete mp_mutex;

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -1123,7 +1123,6 @@ void StatefulReader::change_read_by_user(
     {
         // This may not be the change read with highest SN,
         // need to find largest SN to ACK
-        std::vector<CacheChange_t*>::iterator last_read_from_writer;
         for (std::vector<CacheChange_t*>::iterator it = mp_history->changesBegin();
                 it != mp_history->changesEnd(); ++it)
         {


### PR DESCRIPTION
This PR prevents accessing to an already deleted `RTPSParticipant`. This case may arise when an application does:
1. Create an RTPSParticipant an save the pointer
2. Call to `RTPSDomain::stopAll()`
3. Call to `RTPSDomain::removeRTPSParticipant()` with the saved pointer.

`stopAll()` already deleted all the created `RTPSParticipant`s, so accessing to the memory segment using the pointer obtained on creation is dangerous at best. We can not prevent applications to manipulate the pointer after calling `stopAll()` (thus breaking the contract), but we definitely should not do so within Fast DDS.