### PR TITLE
[11278] UDPv6 refactor and tests

### DIFF
--- a/src/cpp/rtps/transport/UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/UDPv4Transport.cpp
@@ -116,7 +116,7 @@ UDPv4Transport::UDPv4Transport(
 
         if (interface_whitelist_.empty())
         {
-            logError(TRANSPORT, "All whitelist interfaces where filtered out");
+            logError(TRANSPORT, "All whitelist interfaces were filtered out");
             interface_whitelist_.emplace_back(ip::address_v4::from_string("192.0.2.0"));
         }
     }

--- a/src/cpp/rtps/transport/UDPv6Transport.cpp
+++ b/src/cpp/rtps/transport/UDPv6Transport.cpp
@@ -362,17 +362,17 @@ bool UDPv6Transport::OpenInputChannel(
                     // Bind to multicast address
                     UDPChannelResource* p_channel_resource;
                     p_channel_resource = CreateInputChannelResource(locatorAddressStr, locator, true, maxMsgSize,
-                            receiver);
+                                    receiver);
                     mInputSockets[IPLocator::getPhysicalPort(locator)].push_back(p_channel_resource);
 
                     // Join group on all whitelisted interfaces
                     for (auto& ip : interface_whitelist_)
                     {
                         p_channel_resource->socket()->set_option(ip::multicast::join_group(locatorAddress,
-                            ip.scope_id()));
+                                ip.scope_id()));
                     }
                 }
-                catch(asio::system_error const& e)
+                catch (asio::system_error const& e)
                 {
                     logWarning(RTPS_MSG_OUT, "UDPTransport Error binding " << locatorAddressStr << " at port: (" <<
                             IPLocator::getPhysicalPort(locator) << ") with msg: " << e.what());
@@ -398,7 +398,7 @@ bool UDPv6Transport::OpenInputChannel(
                         try
                         {
                             channelResource->socket()->set_option(ip::multicast::join_group(locatorAddress,
-                                ip.scope_id()));
+                                    ip.scope_id()));
                         }
                         catch (std::system_error& ex)
                         {

--- a/src/cpp/rtps/transport/UDPv6Transport.h
+++ b/src/cpp/rtps/transport/UDPv6Transport.h
@@ -141,10 +141,6 @@ protected:
     virtual bool is_interface_allowed(
             const std::string& interface) const override;
 
-    //! Checks if the given interface is allowed by the white list.
-    bool is_interface_allowed(
-            const asio::ip::address_v6& ip) const;
-
     //! Checks if the interfaces white list is empty.
     virtual bool is_interface_whitelist_empty() const override;
     std::vector<asio::ip::address_v6> interface_whitelist_;
@@ -156,6 +152,11 @@ protected:
     virtual void SetSocketOutboundInterface(
             eProsimaUDPSocket&,
             const std::string&) override;
+
+    //! Checks if the IP address is the same without taking into account the scope of the IPv6 address
+    bool compare_ips(
+            const std::string& ip1,
+            const std::string& ip2) const;
 };
 
 } // namespace rtps

--- a/src/cpp/statistics/rtps/messages/RTPSStatisticsMessages.hpp
+++ b/src/cpp/statistics/rtps/messages/RTPSStatisticsMessages.hpp
@@ -22,7 +22,6 @@
 #include <cstdint>
 
 #include <fastdds/rtps/common/CDRMessage_t.h>
-#include <fastdds/rtps/common/Locator.h>
 #include <fastdds/rtps/common/Types.h>
 #include <fastdds/rtps/messages/CDRMessage.h>
 #include <fastdds/rtps/messages/RTPSMessageCreator.h>
@@ -53,31 +52,15 @@ struct StatisticsSubmessageData
         {
             sequence++;
             auto new_bytes = bytes + message_size;
-            bytes_high += (new_bytes < bytes);
+            if (new_bytes < bytes)
+            {
+                bytes_high++;
+            }
             bytes = new_bytes;
-        }
-
-        static Sequence distance(
-                const Sequence& from,
-                const Sequence& to)
-        {
-            // Check to >= from
-            assert(to.sequence >= from.sequence);
-            assert(to.bytes_high >= from.bytes_high);
-            assert((to.bytes_high > from.bytes_high) || (to.bytes >= from.bytes));
-
-            Sequence ret;
-            ret.sequence = to.sequence - from.sequence;
-            ret.bytes_high = to.bytes_high - from.bytes_high;
-            ret.bytes = to.bytes - from.bytes;
-            ret.bytes_high -= (ret.bytes > to.bytes);
-
-            return ret;
         }
 
     };
 
-    eprosima::fastrtps::rtps::Locator_t destination;
     TimeStamp ts{};
     Sequence seq{};
 };
@@ -130,7 +113,6 @@ inline void read_statistics_submessage(
 
     // Read all fields
     using namespace eprosima::fastrtps::rtps;
-    CDRMessage::readLocator(msg, &data.destination);
     CDRMessage::readInt32(msg, &data.ts.seconds);
     CDRMessage::readUInt32(msg, &data.ts.fraction);
     CDRMessage::readUInt64(msg, &data.seq.sequence);
@@ -148,15 +130,17 @@ inline uint32_t get_statistics_message_pos(
         const eprosima::fastrtps::rtps::octet* send_buffer,
         uint32_t send_buffer_size)
 {
-    // Only used on an assert
-    static_cast<void>(send_buffer);
+    // zero can be use as an error value because the minimum valid value
+    // is RTPSMESSAGE_HEADER_SIZE
+    uint32_t statistics_pos = 0;
 
     // Message should contain RTPS header and statistic submessage
-    assert(statistics_submessage_length + RTPSMESSAGE_HEADER_SIZE <= send_buffer_size);
-
-    // The last submessage should be the statistics submessage
-    uint32_t statistics_pos = send_buffer_size - statistics_submessage_length;
-    assert(FASTDDS_STATISTICS_NETWORK_SUBMESSAGE == send_buffer[statistics_pos]);
+    if (statistics_submessage_length + RTPSMESSAGE_HEADER_SIZE <= send_buffer_size)
+    {
+        // The last submessage should be the statistics submessage
+        statistics_pos = send_buffer_size - statistics_submessage_length;
+        assert(FASTDDS_STATISTICS_NETWORK_SUBMESSAGE == send_buffer[statistics_pos]);
+    }
 
     return statistics_pos;
 }
@@ -164,12 +148,10 @@ inline uint32_t get_statistics_message_pos(
 #endif // FASTDDS_STATISTICS
 
 inline void set_statistics_submessage_from_transport(
-        const eprosima::fastrtps::rtps::Locator_t& destination,
         const eprosima::fastrtps::rtps::octet* send_buffer,
         uint32_t send_buffer_size,
         StatisticsSubmessageData::Sequence& sequence)
 {
-    static_cast<void>(destination);
     static_cast<void>(send_buffer);
     static_cast<void>(send_buffer_size);
     static_cast<void>(sequence);
@@ -179,23 +161,25 @@ inline void set_statistics_submessage_from_transport(
 
     uint32_t statistics_pos = get_statistics_message_pos(send_buffer, send_buffer_size);
 
-    // Accumulate bytes on sequence
-    sequence.add_message(send_buffer_size);
+    if ( 0 != statistics_pos )
+    {
+        // Accumulate bytes on sequence
+        sequence.add_message(send_buffer_size);
 
-    // Skip the submessage header
-    statistics_pos += RTPSMESSAGE_SUBMESSAGEHEADER_SIZE;
+        // Skip the submessage header
+        statistics_pos += RTPSMESSAGE_SUBMESSAGEHEADER_SIZE;
 
-    // Set current timestamp and sequence
-    auto submessage = (StatisticsSubmessageData*)(&send_buffer[statistics_pos]);
-    Time_t ts;
-    Time_t::now(ts);
+        // Set current timestamp and sequence
+        auto submessage = (StatisticsSubmessageData*)(&send_buffer[statistics_pos]);
+        Time_t ts;
+        Time_t::now(ts);
 
-    submessage->destination = destination;
-    submessage->ts.seconds = ts.seconds();
-    submessage->ts.fraction = ts.fraction();
-    submessage->seq.sequence = sequence.sequence;
-    submessage->seq.bytes = sequence.bytes;
-    submessage->seq.bytes_high = sequence.bytes_high;
+        submessage->ts.seconds = ts.seconds();
+        submessage->ts.fraction = ts.fraction();
+        submessage->seq.sequence = sequence.sequence;
+        submessage->seq.bytes = sequence.bytes;
+        submessage->seq.bytes_high = sequence.bytes_high;
+    }
 #endif // FASTDDS_STATISTICS
 }
 
@@ -207,7 +191,11 @@ inline void remove_statistics_submessage(
     static_cast<void>(send_buffer_size);
 
 #ifdef FASTDDS_STATISTICS
-    send_buffer_size = get_statistics_message_pos(send_buffer, send_buffer_size);
+    uint32_t statistics_pos = get_statistics_message_pos(send_buffer, send_buffer_size);
+    if ( 0 != statistics_pos )
+    {
+        send_buffer_size = statistics_pos;
+    }
 #endif // FASTDDS_STATISTICS
 }
 

--- a/src/cpp/statistics/rtps/messages/RTPSStatisticsMessages.hpp
+++ b/src/cpp/statistics/rtps/messages/RTPSStatisticsMessages.hpp
@@ -138,8 +138,12 @@ inline uint32_t get_statistics_message_pos(
     if (statistics_submessage_length + RTPSMESSAGE_HEADER_SIZE <= send_buffer_size)
     {
         // The last submessage should be the statistics submessage
-        statistics_pos = send_buffer_size - statistics_submessage_length;
-        assert(FASTDDS_STATISTICS_NETWORK_SUBMESSAGE == send_buffer[statistics_pos]);
+        uint32_t pos = send_buffer_size - statistics_submessage_length;
+        if (FASTDDS_STATISTICS_NETWORK_SUBMESSAGE == send_buffer[pos])
+        {
+            // only succeed if the message is properly formatted
+            statistics_pos = pos;
+        }
     }
 
     return statistics_pos;

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -20,25 +20,25 @@
 #ifndef _TEST_BLACKBOX_PUBSUBPARTICIPANT_HPP_
 #define _TEST_BLACKBOX_PUBSUBPARTICIPANT_HPP_
 
-#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
-#include <fastdds/dds/domain/DomainParticipant.hpp>
-#include <fastdds/dds/domain/DomainParticipantListener.hpp>
-#include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
-#include <fastdds/dds/publisher/Publisher.hpp>
-#include <fastdds/dds/publisher/DataWriter.hpp>
-#include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
-#include <fastdds/dds/publisher/DataWriterListener.hpp>
-#include <fastdds/dds/subscriber/Subscriber.hpp>
-#include <fastdds/dds/subscriber/DataReader.hpp>
-#include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
-#include <fastdds/dds/subscriber/DataReaderListener.hpp>
+#include <condition_variable>
+#include <thread>
+#include <tuple>
+#include <vector>
 
 #include <asio.hpp>
-#include <condition_variable>
 #include <gtest/gtest.h>
-#include <thread>
-#include <vector>
-#include <tuple>
+#include <fastdds/dds/domain/DomainParticipant.hpp>
+#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
+#include <fastdds/dds/domain/DomainParticipantListener.hpp>
+#include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
+#include <fastdds/dds/publisher/DataWriter.hpp>
+#include <fastdds/dds/publisher/DataWriterListener.hpp>
+#include <fastdds/dds/publisher/Publisher.hpp>
+#include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
+#include <fastdds/dds/subscriber/DataReader.hpp>
+#include <fastdds/dds/subscriber/DataReaderListener.hpp>
+#include <fastdds/dds/subscriber/Subscriber.hpp>
+#include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 
 /**
  * @brief A class with one participant that can have multiple publishers and subscribers
@@ -496,6 +496,19 @@ public:
             const eprosima::fastrtps::rtps::PropertyPolicy property_policy)
     {
         participant_qos_.properties() = property_policy;
+        return *this;
+    }
+
+    PubSubParticipant& disable_builtin_transport()
+    {
+        participant_qos_.transport().use_builtin_transports = false;
+        return *this;
+    }
+
+    PubSubParticipant& add_user_transport_to_pparams(
+            std::shared_ptr<eprosima::fastdds::rtps::TransportDescriptorInterface> userTransportDescriptor)
+    {
+        participant_qos_.transport().user_transports.push_back(userTransportDescriptor);
         return *this;
     }
 

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -1108,6 +1108,25 @@ public:
         return *this;
     }
 
+    PubSubReader& disable_multicast_ipv6(
+            int32_t participantId)
+    {
+        participant_qos_.wire_protocol().participant_id = participantId;
+
+        eprosima::fastdds::rtps::LocatorList default_unicast_locators;
+        eprosima::fastdds::rtps::Locator default_unicast_locator;
+        default_unicast_locator.kind = LOCATOR_KIND_UDPv6;
+
+        default_unicast_locators.push_back(default_unicast_locator);
+        participant_qos_.wire_protocol().builtin.metatrafficUnicastLocatorList = default_unicast_locators;
+
+        eprosima::fastdds::rtps::Locator loopback_locator;
+        loopback_locator.kind = LOCATOR_KIND_UDPv6;
+        IPLocator::setIPv6(loopback_locator, "::1");
+        participant_qos_.wire_protocol().builtin.initialPeersList.push_back(loopback_locator);
+        return *this;
+    }
+
     PubSubReader& property_policy(
             const eprosima::fastrtps::rtps::PropertyPolicy& property_policy)
     {

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -25,12 +25,11 @@
 #include <list>
 #include <string>
 
+#include <asio.hpp>
+#include <gtest/gtest.h>
 #if _MSC_VER
 #include <Windows.h>
 #endif // _MSC_VER
-
-#include <asio.hpp>
-#include <gtest/gtest.h>
 #include <fastdds/dds/core/UserAllocatedSequence.hpp>
 #include <fastdds/dds/core/policy/QosPolicies.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -20,17 +20,17 @@
 #ifndef _TEST_BLACKBOX_PUBSUBREADER_HPP_
 #define _TEST_BLACKBOX_PUBSUBREADER_HPP_
 
-#include <string>
-#include <list>
 #include <atomic>
 #include <condition_variable>
-#include <asio.hpp>
-#include <gtest/gtest.h>
+#include <list>
+#include <string>
 
 #if _MSC_VER
 #include <Windows.h>
 #endif // _MSC_VER
 
+#include <asio.hpp>
+#include <gtest/gtest.h>
 #include <fastdds/dds/core/UserAllocatedSequence.hpp>
 #include <fastdds/dds/core/policy/QosPolicies.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
@@ -43,15 +43,18 @@
 #include <fastdds/dds/subscriber/Subscriber.hpp>
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 #include <fastdds/dds/topic/Topic.hpp>
-#include <fastrtps/subscriber/SampleInfo.h>
+#include <fastdds/rtps/transport/UDPTransportDescriptor.h>
+#include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
+#include <fastdds/rtps/transport/UDPv6TransportDescriptor.h>
 #include <fastrtps/xmlparser/XMLParser.h>
 #include <fastrtps/xmlparser/XMLTree.h>
 #include <fastrtps/utils/IPLocator.h>
-#include <fastrtps/transport/UDPv4TransportDescriptor.h>
 
 using DomainParticipantFactory = eprosima::fastdds::dds::DomainParticipantFactory;
 using eprosima::fastrtps::rtps::IPLocator;
-using eprosima::fastrtps::rtps::UDPv4TransportDescriptor;
+using eprosima::fastdds::rtps::UDPTransportDescriptor;
+using eprosima::fastdds::rtps::UDPv4TransportDescriptor;
+using eprosima::fastdds::rtps::UDPv6TransportDescriptor;
 
 template<class TypeSupport>
 class PubSubReader
@@ -825,7 +828,7 @@ public:
     }
 
     PubSubReader& add_user_transport_to_pparams(
-            std::shared_ptr<eprosima::fastrtps::rtps::TransportDescriptorInterface> userTransportDescriptor)
+            std::shared_ptr<eprosima::fastdds::rtps::TransportDescriptorInterface> userTransportDescriptor)
     {
         participant_qos_.transport().user_transports.push_back(userTransportDescriptor);
         return *this;
@@ -1098,31 +1101,20 @@ public:
 
         eprosima::fastdds::rtps::LocatorList default_unicast_locators;
         eprosima::fastdds::rtps::Locator default_unicast_locator;
+        eprosima::fastdds::rtps::Locator loopback_locator;
+        if (!use_udpv4)
+        {
+            default_unicast_locator.kind = LOCATOR_KIND_UDPv6;
+            loopback_locator.kind = LOCATOR_KIND_UDPv6;
+        }
 
         default_unicast_locators.push_back(default_unicast_locator);
         participant_qos_.wire_protocol().builtin.metatrafficUnicastLocatorList = default_unicast_locators;
 
-        eprosima::fastdds::rtps::Locator loopback_locator;
-        IPLocator::setIPv4(loopback_locator, 127, 0, 0, 1);
-        participant_qos_.wire_protocol().builtin.initialPeersList.push_back(loopback_locator);
-        return *this;
-    }
-
-    PubSubReader& disable_multicast_ipv6(
-            int32_t participantId)
-    {
-        participant_qos_.wire_protocol().participant_id = participantId;
-
-        eprosima::fastdds::rtps::LocatorList default_unicast_locators;
-        eprosima::fastdds::rtps::Locator default_unicast_locator;
-        default_unicast_locator.kind = LOCATOR_KIND_UDPv6;
-
-        default_unicast_locators.push_back(default_unicast_locator);
-        participant_qos_.wire_protocol().builtin.metatrafficUnicastLocatorList = default_unicast_locators;
-
-        eprosima::fastdds::rtps::Locator loopback_locator;
-        loopback_locator.kind = LOCATOR_KIND_UDPv6;
-        IPLocator::setIPv6(loopback_locator, "::1");
+        if (!IPLocator::setIPv4(loopback_locator, 127, 0, 0, 1))
+        {
+            IPLocator::setIPv6(loopback_locator, "::1");
+        }
         participant_qos_.wire_protocol().builtin.initialPeersList.push_back(loopback_locator);
         return *this;
     }
@@ -1235,7 +1227,15 @@ public:
             uint32_t maxInitialPeerRange)
     {
         participant_qos_.transport().use_builtin_transports = false;
-        std::shared_ptr<UDPv4TransportDescriptor> descriptor = std::make_shared<UDPv4TransportDescriptor>();
+        std::shared_ptr<UDPTransportDescriptor> descriptor;
+        if (use_udpv4)
+        {
+            descriptor = std::make_shared<UDPv4TransportDescriptor>();
+        }
+        else
+        {
+            descriptor = std::make_shared<UDPv6TransportDescriptor>();
+        }
         descriptor->maxInitialPeersRange = maxInitialPeerRange;
         participant_qos_.transport().user_transports.push_back(descriptor);
         return *this;

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -1146,6 +1146,25 @@ public:
         return *this;
     }
 
+    PubSubWriter& disable_multicast_ipv6(
+            int32_t participantId)
+    {
+        participant_qos_.wire_protocol().participant_id = participantId;
+
+        eprosima::fastdds::rtps::LocatorList default_unicast_locators;
+        eprosima::fastdds::rtps::Locator default_unicast_locator;
+        default_unicast_locator.kind = LOCATOR_KIND_UDPv6;
+
+        default_unicast_locators.push_back(default_unicast_locator);
+        participant_qos_.wire_protocol().builtin.metatrafficUnicastLocatorList = default_unicast_locators;
+
+        eprosima::fastdds::rtps::Locator loopback_locator;
+        loopback_locator.kind = LOCATOR_KIND_UDPv6;
+        IPLocator::setIPv6(loopback_locator, "::1");
+        participant_qos_.wire_protocol().builtin.initialPeersList.push_back(loopback_locator);
+        return *this;
+    }
+
     PubSubWriter& partition(
             const std::string& partition)
     {

--- a/test/blackbox/api/fastrtps_deprecated/PubSubParticipant.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubParticipant.hpp
@@ -20,22 +20,23 @@
 #ifndef _TEST_BLACKBOX_PUBSUBPARTICIPANT_HPP_
 #define _TEST_BLACKBOX_PUBSUBPARTICIPANT_HPP_
 
-#include <fastrtps/fastrtps_fwd.h>
+#include <condition_variable>
+#include <thread>
+#include <vector>
+
+#include <asio.hpp>
+#include <gtest/gtest.h>
 #include <fastrtps/Domain.h>
+#include <fastrtps/fastrtps_fwd.h>
+#include <fastrtps/attributes/ParticipantAttributes.h>
+#include <fastrtps/attributes/PublisherAttributes.h>
 #include <fastrtps/participant/Participant.h>
 #include <fastrtps/participant/ParticipantListener.h>
-#include <fastrtps/attributes/ParticipantAttributes.h>
 #include <fastrtps/publisher/Publisher.h>
 #include <fastrtps/publisher/PublisherListener.h>
 #include <fastrtps/subscriber/Subscriber.h>
 #include <fastrtps/subscriber/SubscriberListener.h>
-#include <fastrtps/attributes/PublisherAttributes.h>
-
-#include <asio.hpp>
-#include <condition_variable>
-#include <gtest/gtest.h>
-#include <thread>
-#include <vector>
+#include <fastrtps/transport/TransportDescriptorInterface.h>
 
 namespace eprosima {
 namespace fastrtps {
@@ -404,6 +405,19 @@ public:
             const eprosima::fastrtps::rtps::PropertyPolicy property_policy)
     {
         participant_attr_.rtps.properties = property_policy;
+        return *this;
+    }
+
+    PubSubParticipant& disable_builtin_transport()
+    {
+        participant_attr_.rtps.useBuiltinTransports = false;
+        return *this;
+    }
+
+    PubSubParticipant& add_user_transport_to_pparams(
+            std::shared_ptr<eprosima::fastrtps::rtps::TransportDescriptorInterface> userTransportDescriptor)
+    {
+        participant_attr_.rtps.userTransports.push_back(userTransportDescriptor);
         return *this;
     }
 

--- a/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
@@ -956,6 +956,25 @@ public:
         return *this;
     }
 
+    PubSubReader& disable_multicast_ipv6(
+            int32_t participantId)
+    {
+        participant_attr_.rtps.participantID = participantId;
+
+        eprosima::fastrtps::rtps::LocatorList_t default_unicast_locators;
+        eprosima::fastrtps::rtps::Locator_t default_unicast_locator;
+        default_unicast_locator.kind = LOCATOR_KIND_UDPv6;
+
+        default_unicast_locators.push_back(default_unicast_locator);
+        participant_attr_.rtps.builtin.metatrafficUnicastLocatorList = default_unicast_locators;
+
+        eprosima::fastrtps::rtps::Locator_t loopback_locator;
+        loopback_locator.kind = LOCATOR_KIND_UDPv6;
+        IPLocator::setIPv6(loopback_locator, "::1");
+        participant_attr_.rtps.builtin.initialPeersList.push_back(loopback_locator);
+        return *this;
+    }
+
     PubSubReader& property_policy(
             const eprosima::fastrtps::rtps::PropertyPolicy property_policy)
     {

--- a/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
@@ -20,29 +20,33 @@
 #ifndef _TEST_BLACKBOX_PUBSUBREADER_HPP_
 #define _TEST_BLACKBOX_PUBSUBREADER_HPP_
 
-#include <fastrtps/fastrtps_fwd.h>
-#include <fastrtps/Domain.h>
-#include <fastrtps/participant/Participant.h>
-#include <fastrtps/participant/ParticipantListener.h>
-#include <fastrtps/attributes/ParticipantAttributes.h>
-#include <fastrtps/subscriber/Subscriber.h>
-#include <fastrtps/subscriber/SubscriberListener.h>
-#include <fastrtps/attributes/SubscriberAttributes.h>
-#include <fastrtps/subscriber/SampleInfo.h>
-#include <fastrtps/xmlparser/XMLParser.h>
-#include <fastrtps/xmlparser/XMLTree.h>
-#include <fastrtps/utils/IPLocator.h>
-#include <fastrtps/transport/UDPv4TransportDescriptor.h>
-
-#include <string>
-#include <list>
 #include <atomic>
 #include <condition_variable>
+#include <list>
+#include <string>
+
 #include <asio.hpp>
 #include <gtest/gtest.h>
+#include <fastrtps/attributes/ParticipantAttributes.h>
+#include <fastrtps/attributes/SubscriberAttributes.h>
+#include <fastrtps/Domain.h>
+#include <fastrtps/fastrtps_fwd.h>
+#include <fastrtps/participant/Participant.h>
+#include <fastrtps/participant/ParticipantListener.h>
+#include <fastrtps/subscriber/SampleInfo.h>
+#include <fastrtps/subscriber/Subscriber.h>
+#include <fastrtps/subscriber/SubscriberListener.h>
+#include <fastrtps/transport/UDPTransportDescriptor.h>
+#include <fastrtps/transport/UDPv4TransportDescriptor.h>
+#include <fastrtps/transport/UDPv6TransportDescriptor.h>
+#include <fastrtps/utils/IPLocator.h>
+#include <fastrtps/xmlparser/XMLParser.h>
+#include <fastrtps/xmlparser/XMLTree.h>
 
 using eprosima::fastrtps::rtps::IPLocator;
+using eprosima::fastrtps::rtps::UDPTransportDescriptor;
 using eprosima::fastrtps::rtps::UDPv4TransportDescriptor;
+using eprosima::fastrtps::rtps::UDPv6TransportDescriptor;
 
 template<class TypeSupport>
 class PubSubReader
@@ -946,31 +950,20 @@ public:
 
         eprosima::fastrtps::rtps::LocatorList_t default_unicast_locators;
         eprosima::fastrtps::rtps::Locator_t default_unicast_locator;
+        eprosima::fastrtps::rtps::Locator_t loopback_locator;
+        if (!use_udpv4)
+        {
+            default_unicast_locator.kind = LOCATOR_KIND_UDPv6;
+            loopback_locator.kind = LOCATOR_KIND_UDPv6;
+        }
 
         default_unicast_locators.push_back(default_unicast_locator);
         participant_attr_.rtps.builtin.metatrafficUnicastLocatorList = default_unicast_locators;
 
-        eprosima::fastrtps::rtps::Locator_t loopback_locator;
-        IPLocator::setIPv4(loopback_locator, 127, 0, 0, 1);
-        participant_attr_.rtps.builtin.initialPeersList.push_back(loopback_locator);
-        return *this;
-    }
-
-    PubSubReader& disable_multicast_ipv6(
-            int32_t participantId)
-    {
-        participant_attr_.rtps.participantID = participantId;
-
-        eprosima::fastrtps::rtps::LocatorList_t default_unicast_locators;
-        eprosima::fastrtps::rtps::Locator_t default_unicast_locator;
-        default_unicast_locator.kind = LOCATOR_KIND_UDPv6;
-
-        default_unicast_locators.push_back(default_unicast_locator);
-        participant_attr_.rtps.builtin.metatrafficUnicastLocatorList = default_unicast_locators;
-
-        eprosima::fastrtps::rtps::Locator_t loopback_locator;
-        loopback_locator.kind = LOCATOR_KIND_UDPv6;
-        IPLocator::setIPv6(loopback_locator, "::1");
+        if (!IPLocator::setIPv4(loopback_locator, 127, 0, 0, 1))
+        {
+            IPLocator::setIPv6(loopback_locator, "::1");
+        }
         participant_attr_.rtps.builtin.initialPeersList.push_back(loopback_locator);
         return *this;
     }
@@ -1058,7 +1051,15 @@ public:
             uint32_t maxInitialPeerRange)
     {
         participant_attr_.rtps.useBuiltinTransports = false;
-        std::shared_ptr<UDPv4TransportDescriptor> descriptor = std::make_shared<UDPv4TransportDescriptor>();
+        std::shared_ptr<UDPTransportDescriptor> descriptor;
+        if (use_udpv4)
+        {
+            descriptor = std::make_shared<UDPv4TransportDescriptor>();
+        }
+        else
+        {
+            descriptor = std::make_shared<UDPv6TransportDescriptor>();
+        }
         descriptor->maxInitialPeersRange = maxInitialPeerRange;
         participant_attr_.rtps.userTransports.push_back(descriptor);
         return *this;

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
@@ -1019,6 +1019,25 @@ public:
         return *this;
     }
 
+    PubSubWriter& disable_multicast_ipv6(
+            int32_t participantId)
+    {
+        participant_attr_.rtps.participantID = participantId;
+
+        eprosima::fastrtps::rtps::LocatorList_t default_unicast_locators;
+        eprosima::fastrtps::rtps::Locator_t default_unicast_locator;
+        default_unicast_locator.kind = LOCATOR_KIND_UDPv6;
+
+        default_unicast_locators.push_back(default_unicast_locator);
+        participant_attr_.rtps.builtin.metatrafficUnicastLocatorList = default_unicast_locators;
+
+        eprosima::fastrtps::rtps::Locator_t loopback_locator;
+        loopback_locator.kind = LOCATOR_KIND_UDPv6;
+        IPLocator::setIPv6(loopback_locator, "::1");
+        participant_attr_.rtps.builtin.initialPeersList.push_back(loopback_locator);
+        return *this;
+    }
+
     PubSubWriter& partition(
             const std::string& partition)
     {

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
@@ -20,31 +20,36 @@
 #ifndef _TEST_BLACKBOX_PUBSUBWRITER_HPP_
 #define _TEST_BLACKBOX_PUBSUBWRITER_HPP_
 
-#include <fastrtps/fastrtps_fwd.h>
-#include <fastrtps/Domain.h>
-#include <fastrtps/participant/Participant.h>
-#include <fastrtps/participant/ParticipantListener.h>
-#include <fastrtps/attributes/ParticipantAttributes.h>
-#include <fastrtps/publisher/Publisher.h>
-#include <fastrtps/publisher/PublisherListener.h>
-#include <fastrtps/attributes/PublisherAttributes.h>
-#include <fastrtps/rtps/common/Locator.h>
-#include <fastrtps/rtps/builtin/data/ReaderProxyData.h>
-#include <fastrtps/rtps/builtin/data/WriterProxyData.h>
-#include <fastrtps/xmlparser/XMLParser.h>
-#include <fastrtps/xmlparser/XMLTree.h>
-#include <fastrtps/utils/IPLocator.h>
-#include <fastrtps/transport/UDPv4TransportDescriptor.h>
-#include <string>
+#include <condition_variable>
 #include <list>
 #include <map>
-#include <condition_variable>
-#include <asio.hpp>
-#include <gtest/gtest.h>
+#include <string>
 #include <thread>
 
+#include <asio.hpp>
+#include <gtest/gtest.h>
+#include <fastrtps/attributes/ParticipantAttributes.h>
+#include <fastrtps/attributes/PublisherAttributes.h>
+#include <fastrtps/Domain.h>
+#include <fastrtps/fastrtps_fwd.h>
+#include <fastrtps/participant/Participant.h>
+#include <fastrtps/participant/ParticipantListener.h>
+#include <fastrtps/publisher/Publisher.h>
+#include <fastrtps/publisher/PublisherListener.h>
+#include <fastrtps/rtps/builtin/data/ReaderProxyData.h>
+#include <fastrtps/rtps/builtin/data/WriterProxyData.h>
+#include <fastrtps/rtps/common/Locator.h>
+#include <fastrtps/transport/UDPTransportDescriptor.h>
+#include <fastrtps/transport/UDPv4TransportDescriptor.h>
+#include <fastrtps/transport/UDPv6TransportDescriptor.h>
+#include <fastrtps/utils/IPLocator.h>
+#include <fastrtps/xmlparser/XMLParser.h>
+#include <fastrtps/xmlparser/XMLTree.h>
+
 using eprosima::fastrtps::rtps::IPLocator;
+using eprosima::fastrtps::rtps::UDPTransportDescriptor;
 using eprosima::fastrtps::rtps::UDPv4TransportDescriptor;
+using eprosima::fastrtps::rtps::UDPv6TransportDescriptor;
 
 template<class TypeSupport>
 class PubSubWriter
@@ -1009,31 +1014,20 @@ public:
 
         eprosima::fastrtps::rtps::LocatorList_t default_unicast_locators;
         eprosima::fastrtps::rtps::Locator_t default_unicast_locator;
+        eprosima::fastrtps::rtps::Locator_t loopback_locator;
+        if (!use_udpv4)
+        {
+            default_unicast_locator.kind = LOCATOR_KIND_UDPv6;
+            loopback_locator.kind = LOCATOR_KIND_UDPv6;
+        }
 
         default_unicast_locators.push_back(default_unicast_locator);
         participant_attr_.rtps.builtin.metatrafficUnicastLocatorList = default_unicast_locators;
 
-        eprosima::fastrtps::rtps::Locator_t loopback_locator;
-        IPLocator::setIPv4(loopback_locator, 127, 0, 0, 1);
-        participant_attr_.rtps.builtin.initialPeersList.push_back(loopback_locator);
-        return *this;
-    }
-
-    PubSubWriter& disable_multicast_ipv6(
-            int32_t participantId)
-    {
-        participant_attr_.rtps.participantID = participantId;
-
-        eprosima::fastrtps::rtps::LocatorList_t default_unicast_locators;
-        eprosima::fastrtps::rtps::Locator_t default_unicast_locator;
-        default_unicast_locator.kind = LOCATOR_KIND_UDPv6;
-
-        default_unicast_locators.push_back(default_unicast_locator);
-        participant_attr_.rtps.builtin.metatrafficUnicastLocatorList = default_unicast_locators;
-
-        eprosima::fastrtps::rtps::Locator_t loopback_locator;
-        loopback_locator.kind = LOCATOR_KIND_UDPv6;
-        IPLocator::setIPv6(loopback_locator, "::1");
+        if(!IPLocator::setIPv4(loopback_locator, 127, 0, 0, 1))
+        {
+            IPLocator::setIPv6(loopback_locator, "::1");
+        }
         participant_attr_.rtps.builtin.initialPeersList.push_back(loopback_locator);
         return *this;
     }
@@ -1093,7 +1087,15 @@ public:
             uint32_t maxInitialPeerRange)
     {
         participant_attr_.rtps.useBuiltinTransports = false;
-        std::shared_ptr<UDPv4TransportDescriptor> descriptor = std::make_shared<UDPv4TransportDescriptor>();
+        std::shared_ptr<UDPTransportDescriptor> descriptor;
+        if (use_udpv4)
+        {
+            descriptor = std::make_shared<UDPv4TransportDescriptor>();
+        }
+        else
+        {
+            descriptor = std::make_shared<UDPv6TransportDescriptor>();
+        }
         descriptor->maxInitialPeersRange = maxInitialPeerRange;
         participant_attr_.rtps.userTransports.push_back(descriptor);
         return *this;

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
@@ -1024,7 +1024,7 @@ public:
         default_unicast_locators.push_back(default_unicast_locator);
         participant_attr_.rtps.builtin.metatrafficUnicastLocatorList = default_unicast_locators;
 
-        if(!IPLocator::setIPv4(loopback_locator, 127, 0, 0, 1))
+        if (!IPLocator::setIPv4(loopback_locator, 127, 0, 0, 1))
         {
             IPLocator::setIPv6(loopback_locator, "::1");
         }

--- a/test/blackbox/common/BlackboxTests.cpp
+++ b/test/blackbox/common/BlackboxTests.cpp
@@ -33,6 +33,7 @@ using namespace eprosima::fastrtps::rtps;
 uint16_t global_port = 0;
 bool enable_datasharing;
 bool use_pull_mode;
+bool use_udpv4;
 
 uint16_t get_port()
 {
@@ -66,6 +67,7 @@ public:
         eprosima::fastrtps::xmlparser::XMLProfileManager::library_settings(att);
         enable_datasharing = false;
         use_pull_mode = false;
+        use_udpv4 = true;
 
         //Log::SetVerbosity(eprosima::fastdds::dds::Log::Info);
         //Log::SetCategoryFilter(std::regex("(SECURITY)"));

--- a/test/blackbox/common/BlackboxTests.hpp
+++ b/test/blackbox/common/BlackboxTests.hpp
@@ -51,6 +51,7 @@ extern void tls_init();
 extern uint16_t global_port;
 extern bool enable_datasharing;
 extern bool use_pull_mode;
+extern bool use_udpv4;
 
 /****** Auxiliary print functions  ******/
 template<class Type>

--- a/test/blackbox/common/BlackboxTestsNetworkConf.cpp
+++ b/test/blackbox/common/BlackboxTestsNetworkConf.cpp
@@ -12,22 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
 #include "BlackboxTests.hpp"
 #include "PubSubReader.hpp"
 #include "PubSubWriter.hpp"
 #include "PubSubParticipant.hpp"
 
+#include <fastdds/dds/log/Log.hpp>
+#include <fastdds/rtps/transport/UDPv6TransportDescriptor.h>
 #include <fastrtps/rtps/common/Locator.h>
 #include <fastrtps/utils/IPFinder.h>
 #include <rtps/transport/UDPv4Transport.h>
 
-#include <gtest/gtest.h>
 
-#include <memory>
 
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 using UDPv4Transport = eprosima::fastdds::rtps::UDPv4Transport;
+using UDPv6TransportDescriptor = eprosima::fastdds::rtps::UDPv6TransportDescriptor;
 
 static void GetIP4s(
         std::vector<IPFinder::info_IP>& interfaces)
@@ -43,6 +48,23 @@ static void GetIP4s(
     std::for_each(interfaces.begin(), interfaces.end(), [](IPFinder::info_IP& loc)
             {
                 loc.locator.kind = LOCATOR_KIND_UDPv4;
+            });
+}
+
+static void GetIP6s(
+        std::vector<IPFinder::info_IP>& interfaces)
+{
+    IPFinder::getIPs(&interfaces, false);
+    auto new_end = remove_if(interfaces.begin(),
+                    interfaces.end(),
+                    [](IPFinder::info_IP ip)
+                    {
+                        return ip.type != IPFinder::IP6 && ip.type != IPFinder::IP6_LOCAL;
+                    });
+    interfaces.erase(new_end, interfaces.end());
+    std::for_each(interfaces.begin(), interfaces.end(), [](IPFinder::info_IP& loc)
+            {
+                loc.locator.kind = LOCATOR_KIND_UDPv6;
             });
 }
 
@@ -184,6 +206,42 @@ TEST(BlackBox, PubSubInterfaceWhitelistLocalhost)
     reader.block_for_all();
 }
 
+TEST(BlackBox, PubSubInterfaceWhitelistLocalhostIPv6)
+{
+    PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+
+    std::shared_ptr<UDPv6TransportDescriptor> descriptor = std::make_shared<UDPv6TransportDescriptor>();
+    descriptor->interfaceWhiteList.push_back("::1");
+
+    reader.reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).history_depth(10).
+            disable_multicast_ipv6(0).
+            disable_builtin_transport().
+            add_user_transport_to_pparams(descriptor).init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer.reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).history_depth(10).
+            disable_multicast_ipv6(1).
+            disable_builtin_transport().
+            add_user_transport_to_pparams(descriptor).init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Because its volatile the durability
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    auto data = default_helloworld_data_generator();
+
+    reader.startReception(data);
+
+    writer.send(data);
+    ASSERT_TRUE(data.empty());
+    reader.block_for_all();
+}
+
 TEST(BlackBox, PubSubInterfaceWhitelistUnicast)
 {
     PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
@@ -193,6 +251,46 @@ TEST(BlackBox, PubSubInterfaceWhitelistUnicast)
     GetIP4s(interfaces);
 
     std::shared_ptr<UDPv4TransportDescriptor> descriptor = std::make_shared<UDPv4TransportDescriptor>();
+    for (const auto& interface : interfaces)
+    {
+        descriptor->interfaceWhiteList.push_back(interface.name);
+    }
+
+    reader.reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).history_depth(10).
+            disable_builtin_transport().
+            add_user_transport_to_pparams(descriptor).init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer.reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).history_depth(10).
+            disable_builtin_transport().
+            add_user_transport_to_pparams(descriptor).init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Because its volatile the durability
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    auto data = default_helloworld_data_generator();
+
+    reader.startReception(data);
+
+    writer.send(data);
+    ASSERT_TRUE(data.empty());
+    reader.block_for_all();
+}
+
+TEST(BlackBox, PubSubInterfaceWhitelistUnicastIPv6)
+{
+    PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+
+    std::vector<IPFinder::info_IP> interfaces;
+    GetIP6s(interfaces);
+
+    std::shared_ptr<UDPv6TransportDescriptor> descriptor = std::make_shared<UDPv6TransportDescriptor>();
     for (const auto& interface : interfaces)
     {
         descriptor->interfaceWhiteList.push_back(interface.name);
@@ -316,6 +414,72 @@ TEST(BlackBox, PubGetSendingLocatorsWhitelist)
         for (size_t idx = 0; idx < interfaces.size(); ++idx)
         {
             if (interfaces[idx].name == locator_ip)
+            {
+                std::cout << "Found " << locator_ip << std::endl;
+                interfaces_found[idx] = true;
+                break;
+            }
+        }
+    }
+    EXPECT_TRUE(std::all_of(interfaces_found.cbegin(), interfaces_found.cend(),
+            [](const bool& v)
+            {
+                return v;
+            }));
+
+    for (size_t i = 0; i < interfaces.size(); ++i)
+    {
+        if (!interfaces_found[i])
+        {
+            std::cout << "Interface '" << interfaces[i].name << "' not found" << std::endl;
+        }
+    }
+}
+
+TEST(BlackBox, PubGetSendingLocatorsWhitelistIPv6)
+{
+    PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+
+    std::vector<IPFinder::info_IP> interfaces;
+    GetIP6s(interfaces);
+
+    constexpr uint32_t port = 31337u;
+
+    std::shared_ptr<UDPv6TransportDescriptor> descriptor = std::make_shared<UDPv6TransportDescriptor>();
+    descriptor->m_output_udp_socket = static_cast<uint16_t>(port);
+    for (const auto& interface : interfaces)
+    {
+        std::cout << "Adding interface '" << interface.name << "' (" << interface.name.size() << ")" << std::endl;
+        descriptor->interfaceWhiteList.push_back(interface.name);
+    }
+
+    writer.disable_builtin_transport().
+            add_user_transport_to_pparams(descriptor).
+            init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    LocatorList_t locators;
+    writer.get_native_writer().get_sending_locators(locators);
+
+    std::vector<bool> interfaces_found(interfaces.size(), false);
+
+    EXPECT_EQ(interfaces.size(), locators.size());
+    for (const Locator_t& locator : locators)
+    {
+        std::cout << "Checking locator " << locator << std::endl;
+
+        EXPECT_EQ(locator.port, port);
+        EXPECT_EQ(locator.kind, LOCATOR_KIND_UDPv6);
+
+        auto locator_ip = IPLocator::ip_to_string(locator);
+        std::cout << "Checking '" << locator_ip << "' (" << locator_ip.size() << ")" << std::endl;
+        for (size_t idx = 0; idx < interfaces.size(); ++idx)
+        {
+            // Remove ipv6 scope address information to compare
+            std::string substr1 = interfaces[idx].name.substr(0, interfaces[idx].name.find('%'));
+            std::cout << substr1 << "\t" << locator_ip << std::endl;
+            if (substr1 == locator_ip)
             {
                 std::cout << "Found " << locator_ip << std::endl;
                 interfaces_found[idx] = true;

--- a/test/blackbox/common/BlackboxTestsNetworkConf.cpp
+++ b/test/blackbox/common/BlackboxTestsNetworkConf.cpp
@@ -47,7 +47,7 @@ public:
         else
         {
             descriptor_ = std::make_shared<UDPv6TransportDescriptor>();
-        }    
+        }
     }
 
     void TearDown() override

--- a/test/blackbox/common/BlackboxTestsTransportUDP.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportUDP.cpp
@@ -47,7 +47,7 @@ public:
         else
         {
             test_transport_ = std::make_shared<UDPv6TransportDescriptor>();
-        }    
+        }
     }
 
     void TearDown() override
@@ -55,7 +55,8 @@ public:
         use_udpv4 = true;
     }
 
-    void get_ip_address(LocatorList_t* loc)
+    void get_ip_address(
+            LocatorList_t* loc)
     {
         if (use_udpv4)
         {

--- a/test/unittest/transport/UDPv4Tests.cpp
+++ b/test/unittest/transport/UDPv4Tests.cpp
@@ -90,27 +90,6 @@ TEST_F(UDPv4Tests, locators_with_kind_1_supported)
     ASSERT_FALSE(transportUnderTest.IsLocatorSupported(unsupportedLocator));
 }
 
-TEST_F(UDPv4Tests, opening_and_closing_output_channel)
-{
-    // Given
-    UDPv4Transport transportUnderTest(descriptor);
-    transportUnderTest.init();
-
-    Locator_t genericOutputChannelLocator;
-    genericOutputChannelLocator.kind = LOCATOR_KIND_UDPv4;
-    genericOutputChannelLocator.port = g_default_port; // arbitrary
-
-    // Then
-    /*
-       ASSERT_FALSE (transportUnderTest.IsOutputChannelOpen(genericOutputChannelLocator));
-       ASSERT_TRUE  (transportUnderTest.OpenOutputChannel(genericOutputChannelLocator));
-       ASSERT_TRUE  (transportUnderTest.IsOutputChannelOpen(genericOutputChannelLocator));
-       ASSERT_TRUE  (transportUnderTest.CloseOutputChannel(genericOutputChannelLocator));
-       ASSERT_FALSE (transportUnderTest.IsOutputChannelOpen(genericOutputChannelLocator));
-       ASSERT_FALSE (transportUnderTest.CloseOutputChannel(genericOutputChannelLocator));
-     */
-}
-
 TEST_F(UDPv4Tests, opening_and_closing_input_channel)
 {
     // Given

--- a/test/unittest/transport/UDPv4Tests.cpp
+++ b/test/unittest/transport/UDPv4Tests.cpp
@@ -353,7 +353,7 @@ TEST_F(UDPv4Tests, send_to_allowed_interface)
             Locator_t remoteMulticastLocator;
             remoteMulticastLocator.port = g_default_port;
             remoteMulticastLocator.kind = LOCATOR_KIND_UDPv4;
-            IPLocator::setIPv4(remoteMulticastLocator, 239, 255, 1, 4); // Loopback
+            IPLocator::setIPv4(remoteMulticastLocator, 239, 255, 1, 4);
 
             LocatorList_t locator_list;
             locator_list.push_back(remoteMulticastLocator);

--- a/test/unittest/transport/UDPv4Tests.cpp
+++ b/test/unittest/transport/UDPv4Tests.cpp
@@ -24,7 +24,6 @@
 #include <fastrtps/utils/IPFinder.h>
 #include <fastrtps/utils/IPLocator.h>
 #include <rtps/transport/UDPv4Transport.h>
-#include <statistics/rtps/messages/RTPSStatisticsMessages.hpp>
 
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
@@ -65,76 +64,15 @@ public:
 
     ~UDPv4Tests()
     {
+        //Log::KillThread();
     }
 
     void HELPER_SetDescriptorDefaults();
-
-    // With FASTDDS_STATISTICS=ON the test buffers
-    // must fulfill expectations
-    static std::string HELPER_statistics_format_if_needed(
-            const std::string& message);
-
-    template<class T>
-    static std::vector<T> HELPER_statistics_format_if_needed(
-            const std::vector<T>& message);
 
     UDPv4TransportDescriptor descriptor;
     std::unique_ptr<std::thread> senderThread;
     std::unique_ptr<std::thread> receiverThread;
 };
-
-#ifdef FASTDDS_STATISTICS
-
-std::string UDPv4Tests::HELPER_statistics_format_if_needed(
-        const std::string& message)
-{
-    std::string message_buffer(
-        message.length() + RTPSMESSAGE_HEADER_SIZE + eprosima::fastdds::statistics::rtps::statistics_submessage_length,
-        0);
-
-    message_buffer.replace(0, message.length(), message);
-
-    message_buffer[message.length() +
-            RTPSMESSAGE_HEADER_SIZE] = static_cast<char>(FASTDDS_STATISTICS_NETWORK_SUBMESSAGE);
-
-    return message_buffer;
-}
-
-template<class T>
-std::vector<T> UDPv4Tests::HELPER_statistics_format_if_needed(
-        const std::vector<T>& message)
-{
-    std::vector<T> message_buffer(
-        message.size() + RTPSMESSAGE_HEADER_SIZE + eprosima::fastdds::statistics::rtps::statistics_submessage_length,
-        0);
-
-    std::copy(
-            message.begin(),
-            message.end(),
-            message_buffer.begin());
-
-    message_buffer[message.size() + RTPSMESSAGE_HEADER_SIZE]
-        = static_cast<T>(FASTDDS_STATISTICS_NETWORK_SUBMESSAGE);
-
-    return message_buffer;
-}
-
-#elif // FASTDDS_STATISTICS
-
-std::string UDPv4Tests::HELPER_statistics_format_if_needed(
-        const std::string& message)
-{
-    return message;
-}
-
-template<class T>
-std::vector<T> UDPv4Tests::HELPER_statistics_format_if_needed(
-        const std::vector<T>& message)
-{
-    return message;
-}
-
-#endif // FASTDDS_STATISTICS
 
 TEST_F(UDPv4Tests, locators_with_kind_1_supported)
 {
@@ -194,15 +132,12 @@ TEST_F(UDPv4Tests, send_and_receive_between_ports)
     ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, outputChannelLocator)); // Includes loopback
     ASSERT_FALSE(send_resource_list.empty());
     ASSERT_TRUE(transportUnderTest.IsInputChannelOpen(multicastLocator));
-
-    std::string message = "Hello";
-    auto message_buffer = HELPER_statistics_format_if_needed(message);
+    octet message[5] = { 'H', 'e', 'l', 'l', 'o' };
 
     Semaphore sem;
     std::function<void()> recCallback = [&]()
             {
-                EXPECT_EQ(message.compare(
-                            reinterpret_cast<const char*>(msg_recv->data)), 0);
+                EXPECT_EQ(memcmp(message, msg_recv->data, 5), 0);
                 sem.post();
             };
 
@@ -216,12 +151,8 @@ TEST_F(UDPv4Tests, send_and_receive_between_ports)
                 Locators locators_begin(locator_list.begin());
                 Locators locators_end(locator_list.end());
 
-                EXPECT_TRUE(send_resource_list.at(0)->send(
-                            reinterpret_cast<const octet*>(message_buffer.data()),
-                            static_cast<uint32_t>(message_buffer.length()),
-                            &locators_begin,
-                            &locators_end,
-                            (std::chrono::steady_clock::now() + std::chrono::microseconds(100))));
+                EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, &locators_begin, &locators_end,
+                        (std::chrono::steady_clock::now() + std::chrono::microseconds(100))));
             };
 
     senderThread.reset(new std::thread(sendThreadFunction));
@@ -693,8 +624,8 @@ TEST_F(UDPv4Tests, simple_throughput)
 
     Semaphore sem_end_subscriber;
 
-    std::vector<octet> message(sample_size,'?');
-    auto sample_data = HELPER_statistics_format_if_needed(message);
+    octet sample_data[sample_size];
+    memset(sample_data, 0, sizeof(sample_data));
 
     Locator_t sub_locator;
     sub_locator.kind = LOCATOR_KIND_UDPv4;
@@ -731,15 +662,12 @@ TEST_F(UDPv4Tests, simple_throughput)
 
     auto t0 = std::chrono::high_resolution_clock::now();
 
-    for (int i = 0; i < num_samples_per_batch; ++i)
+    for (int i = 0; i < num_samples_per_batch; i++)
     {
         Locators locators_begin(send_locators_list.begin());
         Locators locators_end(send_locators_list.end());
 
-        EXPECT_TRUE(send_resource_list.at(0)->send(
-                sample_data.data(),
-                static_cast<uint32_t>(sample_data.size()),
-                &locators_begin, &locators_end,
+        EXPECT_TRUE(send_resource_list.at(0)->send(sample_data, sizeof(sample_data), &locators_begin, &locators_end,
                 (std::chrono::steady_clock::now() + std::chrono::milliseconds(100))));
     }
 
@@ -758,16 +686,6 @@ void UDPv4Tests::HELPER_SetDescriptorDefaults()
     descriptor.sendBufferSize = 5;
     descriptor.receiveBufferSize = 5;
     descriptor.interfaceWhiteList.clear();
-
-#ifdef FASTDDS_STATISTICS
-    {
-        uint32_t statistics_overhead = RTPSMESSAGE_HEADER_SIZE
-                + eprosima::fastdds::statistics::rtps::statistics_submessage_length;
-        descriptor.maxMessageSize += statistics_overhead;
-        descriptor.sendBufferSize +=  statistics_overhead;
-        descriptor.receiveBufferSize +=  statistics_overhead;
-    }
-#endif // FASTDDS_STATISTICS
 }
 
 int main(

--- a/test/unittest/transport/UDPv6Tests.cpp
+++ b/test/unittest/transport/UDPv6Tests.cpp
@@ -155,34 +155,34 @@ TEST_F(UDPv6Tests, send_and_receive_between_ports)
     IPLocator::setIPv6(outputChannelLocator, "ff31::8000:1234");
 
     MockReceiverResource receiver(transportUnderTest, multicastLocator);
-    MockMessageReceiver *msg_recv = dynamic_cast<MockMessageReceiver*>(receiver.CreateMessageReceiver());
+    MockMessageReceiver* msg_recv = dynamic_cast<MockMessageReceiver*>(receiver.CreateMessageReceiver());
 
     SendResourceList send_resource_list;
     ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, outputChannelLocator)); // Includes loopback
     ASSERT_FALSE(send_resource_list.empty());
     ASSERT_TRUE(transportUnderTest.IsInputChannelOpen(multicastLocator));
-    octet message[5] = { 'H','e','l','l','o' };
+    octet message[5] = { 'H', 'e', 'l', 'l', 'o' };
 
     Semaphore sem;
     std::function<void()> recCallback = [&]()
-    {
-        EXPECT_EQ(memcmp(message,msg_recv->data,5), 0);
-        sem.post();
-    };
+            {
+                EXPECT_EQ(memcmp(message, msg_recv->data, 5), 0);
+                sem.post();
+            };
 
     msg_recv->setCallback(recCallback);
 
     auto sendThreadFunction = [&]()
-    {
-        LocatorList_t locator_list;
-        locator_list.push_back(multicastLocator);
+            {
+                LocatorList_t locator_list;
+                locator_list.push_back(multicastLocator);
 
-        Locators locators_begin(locator_list.begin());
-        Locators locators_end(locator_list.end());
+                Locators locators_begin(locator_list.begin());
+                Locators locators_end(locator_list.end());
 
-        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, &locators_begin, &locators_end,
-                (std::chrono::steady_clock::now() + std::chrono::microseconds(100))));
-    };
+                EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, &locators_begin, &locators_end,
+                        (std::chrono::steady_clock::now() + std::chrono::microseconds(100))));
+            };
 
     senderThread.reset(new std::thread(sendThreadFunction));
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -203,37 +203,37 @@ TEST_F(UDPv6Tests, send_to_loopback)
     Locator_t outputChannelLocator;
     outputChannelLocator.port = g_default_port + 1;
     outputChannelLocator.kind = LOCATOR_KIND_UDPv6;
-    IPLocator::setIPv6(outputChannelLocator,0,0,0,0,0,0,0,1); // Loopback
+    IPLocator::setIPv6(outputChannelLocator, 0, 0, 0, 0, 0, 0, 0, 1); // Loopback
 
     MockReceiverResource receiver(transportUnderTest, multicastLocator);
-    MockMessageReceiver *msg_recv = dynamic_cast<MockMessageReceiver*>(receiver.CreateMessageReceiver());
+    MockMessageReceiver* msg_recv = dynamic_cast<MockMessageReceiver*>(receiver.CreateMessageReceiver());
 
     SendResourceList send_resource_list;
     ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, outputChannelLocator));
     ASSERT_FALSE(send_resource_list.empty());
     ASSERT_TRUE(transportUnderTest.IsInputChannelOpen(multicastLocator));
-    octet message[5] = { 'H','e','l','l','o' };
+    octet message[5] = { 'H', 'e', 'l', 'l', 'o' };
 
     Semaphore sem;
     std::function<void()> recCallback = [&]()
-    {
-        EXPECT_EQ(memcmp(message,msg_recv->data,5), 0);
-        sem.post();
-    };
+            {
+                EXPECT_EQ(memcmp(message, msg_recv->data, 5), 0);
+                sem.post();
+            };
 
     msg_recv->setCallback(recCallback);
 
     auto sendThreadFunction = [&]()
-    {
-        LocatorList_t locator_list;
-        locator_list.push_back(multicastLocator);
+            {
+                LocatorList_t locator_list;
+                locator_list.push_back(multicastLocator);
 
-        Locators locators_begin(locator_list.begin());
-        Locators locators_end(locator_list.end());
+                Locators locators_begin(locator_list.begin());
+                Locators locators_end(locator_list.end());
 
-        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, &locators_begin, &locators_end,
-                (std::chrono::steady_clock::now() + std::chrono::microseconds(100))));
-    };
+                EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, &locators_begin, &locators_end,
+                        (std::chrono::steady_clock::now() + std::chrono::microseconds(100))));
+            };
 
     senderThread.reset(new std::thread(sendThreadFunction));
     std::this_thread::sleep_for(std::chrono::milliseconds(1));

--- a/test/unittest/transport/UDPv6Tests.cpp
+++ b/test/unittest/transport/UDPv6Tests.cpp
@@ -118,7 +118,6 @@ TEST_F(UDPv6Tests, locators_with_kind_2_supported)
     ASSERT_FALSE(transportUnderTest.IsLocatorSupported(unsupportedLocator));
 }
 
-#ifndef __APPLE__
 TEST_F(UDPv6Tests, opening_and_closing_input_channel)
 {
     // Given
@@ -139,20 +138,22 @@ TEST_F(UDPv6Tests, opening_and_closing_input_channel)
     ASSERT_FALSE (transportUnderTest.CloseInputChannel(multicastFilterLocator));
 }
 
+#ifndef __APPLE__
 TEST_F(UDPv6Tests, send_and_receive_between_ports)
 {
     UDPv6Transport transportUnderTest(descriptor);
     transportUnderTest.init();
 
     Locator_t multicastLocator;
+    std::string address("ff31::8000:1234");
     multicastLocator.port = g_default_port;
     multicastLocator.kind = LOCATOR_KIND_UDPv6;
-    IPLocator::setIPv6(multicastLocator, "ff31::8000:1234");
+    IPLocator::setIPv6(multicastLocator, address);
 
     Locator_t outputChannelLocator;
     outputChannelLocator.port = g_default_port + 1;
     outputChannelLocator.kind = LOCATOR_KIND_UDPv6;
-    IPLocator::setIPv6(outputChannelLocator, "ff31::8000:1234");
+    IPLocator::setIPv6(outputChannelLocator, address);
 
     MockReceiverResource receiver(transportUnderTest, multicastLocator);
     MockMessageReceiver* msg_recv = dynamic_cast<MockMessageReceiver*>(receiver.CreateMessageReceiver());
@@ -198,7 +199,7 @@ TEST_F(UDPv6Tests, send_to_loopback)
     Locator_t multicastLocator;
     multicastLocator.port = g_default_port;
     multicastLocator.kind = LOCATOR_KIND_UDPv6;
-    IPLocator::setIPv6(multicastLocator, "ff31::8000:1234");
+    IPLocator::setIPv6(multicastLocator, std::string("ff31::8000:1234"));
 
     Locator_t outputChannelLocator;
     outputChannelLocator.port = g_default_port + 1;
@@ -279,7 +280,7 @@ TEST_F(UDPv6Tests, RemoteToMainLocal_simply_strips_out_address_leaving_IP_ANY)
     Locator_t remote_locator;
     remote_locator.kind = LOCATOR_KIND_UDPv6;
     remote_locator.port = g_default_port;
-    IPLocator::setIPv6(remote_locator, "fe80::ffff:dede:dede");
+    IPLocator::setIPv6(remote_locator, std::string("fe80::ffff:dede:dede"));
 
     // When
     Locator_t mainLocalLocator = transportUnderTest.RemoteToMainLocal(remote_locator);
@@ -299,13 +300,13 @@ TEST_F(UDPv6Tests, match_if_port_AND_address_matches)
     Locator_t locatorAlpha;
     locatorAlpha.kind = LOCATOR_KIND_UDPv6;
     locatorAlpha.port = g_default_port;
-    IPLocator::setIPv6(locatorAlpha, "ff1e::ffff:efff:1");
+    IPLocator::setIPv6(locatorAlpha, std::string("ff1e::ffff:efff:1"));
     Locator_t locatorBeta = locatorAlpha;
 
     // Then
     ASSERT_TRUE(transportUnderTest.DoInputLocatorsMatch(locatorAlpha, locatorBeta));
 
-    IPLocator::setIPv6(locatorBeta, "fe80::ffff:6464:6464");
+    IPLocator::setIPv6(locatorBeta, std::string("fe80::ffff:6464:6464"));
     // Then
     ASSERT_TRUE(transportUnderTest.DoInputLocatorsMatch(locatorAlpha, locatorBeta));
 }
@@ -319,7 +320,7 @@ TEST_F(UDPv6Tests, send_to_wrong_interface)
     Locator_t outputChannelLocator;
     outputChannelLocator.port = g_default_port;
     outputChannelLocator.kind = LOCATOR_KIND_UDPv6;
-    IPLocator::setIPv6(outputChannelLocator, "::1"); // Loopback
+    IPLocator::setIPv6(outputChannelLocator, std::string("::1")); // Loopback
     ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, outputChannelLocator));
     ASSERT_FALSE(send_resource_list.empty());
 
@@ -331,7 +332,7 @@ TEST_F(UDPv6Tests, send_to_wrong_interface)
     Locators locators_end(locator_list.end());
 
     //Sending through a different IP will NOT work, except 0.0.0.0
-    IPLocator::setIPv6(outputChannelLocator, "fe80::ffff:6f6f:6f6f");
+    IPLocator::setIPv6(outputChannelLocator, std::string("fe80::ffff:6f6f:6f6f"));
     std::vector<octet> message = { 'H', 'e', 'l', 'l', 'o' };
     ASSERT_FALSE(send_resource_list.at(0)->send(message.data(), (uint32_t)message.size(), &locators_begin,
             &locators_end,
@@ -348,7 +349,7 @@ TEST_F(UDPv6Tests, send_to_blocked_interface)
     Locator_t outputChannelLocator;
     outputChannelLocator.port = g_default_port;
     outputChannelLocator.kind = LOCATOR_KIND_UDPv6;
-    IPLocator::setIPv6(outputChannelLocator, "::1"); // Loopback
+    IPLocator::setIPv6(outputChannelLocator, std::string("::1")); // Loopback
     ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, outputChannelLocator));
     ASSERT_TRUE(send_resource_list.empty());
 }
@@ -385,7 +386,7 @@ TEST_F(UDPv6Tests, send_to_allowed_interface)
             Locator_t remoteMulticastLocator;
             remoteMulticastLocator.port = g_default_port;
             remoteMulticastLocator.kind = LOCATOR_KIND_UDPv6;
-            IPLocator::setIPv6(remoteMulticastLocator, "ff1e::ffff:efff:104");
+            IPLocator::setIPv6(remoteMulticastLocator, std::string("ff1e::ffff:efff:104"));
 
             LocatorList_t locator_list;
             locator_list.push_back(remoteMulticastLocator);
@@ -428,7 +429,7 @@ TEST_F(UDPv6Tests, send_and_receive_between_allowed_sockets_using_localhost)
     Locator_t unicastLocator;
     unicastLocator.port = g_default_port;
     unicastLocator.kind = LOCATOR_KIND_UDPv6;
-    IPLocator::setIPv6(unicastLocator, "::1");
+    IPLocator::setIPv6(unicastLocator, std::string("::1"));
 
     LocatorList_t locator_list;
     locator_list.push_back(unicastLocator);
@@ -436,7 +437,7 @@ TEST_F(UDPv6Tests, send_and_receive_between_allowed_sockets_using_localhost)
     Locator_t outputChannelLocator;
     outputChannelLocator.port = g_default_port + 1;
     outputChannelLocator.kind = LOCATOR_KIND_UDPv6;
-    IPLocator::setIPv6(outputChannelLocator, "::1");
+    IPLocator::setIPv6(outputChannelLocator, std::string("::1"));
 
     MockReceiverResource receiver(transportUnderTest, unicastLocator);
     MockMessageReceiver* msg_recv = dynamic_cast<MockMessageReceiver*>(receiver.CreateMessageReceiver());
@@ -549,7 +550,7 @@ TEST_F(UDPv6Tests, send_and_receive_between_allowed_sockets_using_unicast_to_mul
         Locator_t unicastLocator;
         unicastLocator.port = g_default_port;
         unicastLocator.kind = LOCATOR_KIND_UDPv6;
-        IPLocator::setIPv6(unicastLocator, "ff1e::ffff:efff:104");
+        IPLocator::setIPv6(unicastLocator, std::string("ff1e::ffff:efff:104"));
 
         LocatorList_t locator_list;
         locator_list.push_back(unicastLocator);
@@ -610,7 +611,7 @@ TEST_F(UDPv6Tests, open_and_close_two_multicast_transports_with_whitelist)
         Locator_t multicastLocator;
         multicastLocator.port = g_default_port;
         multicastLocator.kind = LOCATOR_KIND_UDPv6;
-        IPLocator::setIPv6(multicastLocator, "ff00::efff:0104");
+        IPLocator::setIPv6(multicastLocator, std::string("ff00::efff:0104"));
 
         std::cout << "Opening input channels" << std::endl;
         ASSERT_TRUE(transport1.OpenInputChannel(multicastLocator, nullptr, 65500));
@@ -663,7 +664,7 @@ TEST_F(UDPv6Tests, simple_throughput)
     Locator_t sub_locator;
     sub_locator.kind = LOCATOR_KIND_UDPv6;
     sub_locator.port = 50000;
-    IPLocator::setIPv4(sub_locator, "::1");
+    IPLocator::setIPv6(sub_locator, std::string("::1"));
 
     UDPv6TransportDescriptor my_descriptor;
 
@@ -724,7 +725,6 @@ int main(
         int argc,
         char** argv)
 {
-    eprosima::fastdds::dds::Log::SetVerbosity(eprosima::fastdds::dds::Log::Info);
     g_default_port = get_port();
 
     testing::InitGoogleTest(&argc, argv);

--- a/test/unittest/transport/UDPv6Tests.cpp
+++ b/test/unittest/transport/UDPv6Tests.cpp
@@ -240,7 +240,168 @@ TEST_F(UDPv6Tests, send_to_loopback)
     senderThread->join();
     sem.wait();
 }
+#endif // ifndef __APPLE__
 
+TEST_F(UDPv6Tests, send_is_rejected_if_buffer_size_is_bigger_to_size_specified_in_descriptor)
+{
+    // Given
+    UDPv6Transport transportUnderTest(descriptor);
+    transportUnderTest.init();
+
+    SendResourceList send_resource_list;
+    Locator_t genericOutputChannelLocator;
+    genericOutputChannelLocator.kind = LOCATOR_KIND_UDPv6;
+    genericOutputChannelLocator.port = g_default_port;
+    ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, genericOutputChannelLocator));
+    ASSERT_FALSE(send_resource_list.empty());
+
+    Locator_t destinationLocator;
+    destinationLocator.kind = LOCATOR_KIND_UDPv6;
+    destinationLocator.port = g_default_port + 1;
+
+    LocatorList_t locator_list;
+    locator_list.push_back(destinationLocator);
+    Locators locators_begin(locator_list.begin());
+    Locators locators_end(locator_list.end());
+
+    // Then
+    std::vector<octet> receiveBufferWrongSize(descriptor.sendBufferSize + 1);
+    ASSERT_FALSE(send_resource_list.at(0)->send(receiveBufferWrongSize.data(), (uint32_t)receiveBufferWrongSize.size(),
+            &locators_begin, &locators_end, (std::chrono::steady_clock::now() + std::chrono::microseconds(100))));
+}
+
+TEST_F(UDPv6Tests, RemoteToMainLocal_simply_strips_out_address_leaving_IP_ANY)
+{
+    // Given
+    UDPv6Transport transportUnderTest(descriptor);
+    transportUnderTest.init();
+
+    Locator_t remote_locator;
+    remote_locator.kind = LOCATOR_KIND_UDPv6;
+    remote_locator.port = g_default_port;
+    IPLocator::setIPv6(remote_locator, "fe80::ffff:dede:dede");
+
+    // When
+    Locator_t mainLocalLocator = transportUnderTest.RemoteToMainLocal(remote_locator);
+
+    ASSERT_EQ(mainLocalLocator.port, remote_locator.port);
+    ASSERT_EQ(mainLocalLocator.kind, remote_locator.kind);
+
+    ASSERT_EQ(IPLocator::toIPv6string(mainLocalLocator), s_IPv6AddressAny);
+}
+
+TEST_F(UDPv6Tests, match_if_port_AND_address_matches)
+{
+    // Given
+    UDPv6Transport transportUnderTest(descriptor);
+    transportUnderTest.init();
+
+    Locator_t locatorAlpha;
+    locatorAlpha.kind = LOCATOR_KIND_UDPv6;
+    locatorAlpha.port = g_default_port;
+    IPLocator::setIPv6(locatorAlpha, "ff1e::ffff:efff:1");
+    Locator_t locatorBeta = locatorAlpha;
+
+    // Then
+    ASSERT_TRUE(transportUnderTest.DoInputLocatorsMatch(locatorAlpha, locatorBeta));
+
+    IPLocator::setIPv6(locatorBeta, "fe80::ffff:6464:6464");
+    // Then
+    ASSERT_TRUE(transportUnderTest.DoInputLocatorsMatch(locatorAlpha, locatorBeta));
+}
+
+TEST_F(UDPv6Tests, send_to_wrong_interface)
+{
+    UDPv6Transport transportUnderTest(descriptor);
+    transportUnderTest.init();
+
+    SendResourceList send_resource_list;
+    Locator_t outputChannelLocator;
+    outputChannelLocator.port = g_default_port;
+    outputChannelLocator.kind = LOCATOR_KIND_UDPv6;
+    IPLocator::setIPv6(outputChannelLocator, "::1"); // Loopback
+    ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, outputChannelLocator));
+    ASSERT_FALSE(send_resource_list.empty());
+
+    LocatorList_t locator_list;
+    Locator_t locator;
+    locator.kind = LOCATOR_KIND_UDPv6;
+    locator_list.push_back(locator);
+    Locators locators_begin(locator_list.begin());
+    Locators locators_end(locator_list.end());
+
+    //Sending through a different IP will NOT work, except 0.0.0.0
+    IPLocator::setIPv6(outputChannelLocator, "fe80::ffff:6f6f:6f6f");
+    std::vector<octet> message = { 'H', 'e', 'l', 'l', 'o' };
+    ASSERT_FALSE(send_resource_list.at(0)->send(message.data(), (uint32_t)message.size(), &locators_begin,
+            &locators_end,
+            (std::chrono::steady_clock::now() + std::chrono::microseconds(100))));
+}
+
+TEST_F(UDPv6Tests, send_to_blocked_interface)
+{
+    descriptor.interfaceWhiteList.emplace_back("fe80::ffff:6f6f:6f6f");
+    UDPv6Transport transportUnderTest(descriptor);
+    transportUnderTest.init();
+
+    SendResourceList send_resource_list;
+    Locator_t outputChannelLocator;
+    outputChannelLocator.port = g_default_port;
+    outputChannelLocator.kind = LOCATOR_KIND_UDPv6;
+    IPLocator::setIPv6(outputChannelLocator, "::1"); // Loopback
+    ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, outputChannelLocator));
+    ASSERT_TRUE(send_resource_list.empty());
+}
+
+TEST_F(UDPv6Tests, send_to_allowed_interface)
+{
+    LocatorList_t interfaces;
+    if (IPFinder::getAllIPAddress(&interfaces))
+    {
+        Locator_t locator;
+        for (auto& tmpLocator : interfaces)
+        {
+            if (tmpLocator.kind == LOCATOR_KIND_UDPv6 && IPLocator::toIPv6string(tmpLocator) != "::1")
+            {
+                locator = tmpLocator;
+                break;
+            }
+        }
+
+        if (IsAddressDefined(locator))
+        {
+            descriptor.interfaceWhiteList.emplace_back(IPLocator::toIPv6string(locator));
+            UDPv6Transport transportUnderTest(descriptor);
+            transportUnderTest.init();
+
+            SendResourceList send_resource_list;
+            Locator_t outputChannelLocator;
+            outputChannelLocator.port = g_default_port;
+            outputChannelLocator.kind = LOCATOR_KIND_UDPv6;
+            IPLocator::setIPv6(outputChannelLocator, IPLocator::toIPv6string(locator));
+            ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, outputChannelLocator));
+            ASSERT_FALSE(send_resource_list.empty());
+
+            Locator_t remoteMulticastLocator;
+            remoteMulticastLocator.port = g_default_port;
+            remoteMulticastLocator.kind = LOCATOR_KIND_UDPv6;
+            IPLocator::setIPv6(remoteMulticastLocator, "ff1e::ffff:efff:104");
+
+            LocatorList_t locator_list;
+            locator_list.push_back(remoteMulticastLocator);
+            Locators locators_begin(locator_list.begin());
+            Locators locators_end(locator_list.end());
+
+            // Sending through a ALLOWED IP will work
+            std::vector<octet> message = { 'H', 'e', 'l', 'l', 'o' };
+            ASSERT_TRUE(send_resource_list.at(0)->send(message.data(), (uint32_t)message.size(),
+                    &locators_begin, &locators_end,
+                    (std::chrono::steady_clock::now() + std::chrono::microseconds(100))));
+        }
+    }
+}
+
+#ifndef __APPLE__
 static void GetIP6s(
         std::vector<IPFinder::info_IP>& interfaces)
 {
@@ -256,6 +417,180 @@ static void GetIP6s(
             {
                 loc.locator.kind = LOCATOR_KIND_UDPv6;
             });
+}
+
+TEST_F(UDPv6Tests, send_and_receive_between_allowed_sockets_using_localhost)
+{
+    descriptor.interfaceWhiteList.emplace_back("::1");
+    UDPv6Transport transportUnderTest(descriptor);
+    transportUnderTest.init();
+
+    Locator_t unicastLocator;
+    unicastLocator.port = g_default_port;
+    unicastLocator.kind = LOCATOR_KIND_UDPv6;
+    IPLocator::setIPv6(unicastLocator, "::1");
+
+    LocatorList_t locator_list;
+    locator_list.push_back(unicastLocator);
+
+    Locator_t outputChannelLocator;
+    outputChannelLocator.port = g_default_port + 1;
+    outputChannelLocator.kind = LOCATOR_KIND_UDPv6;
+    IPLocator::setIPv6(outputChannelLocator, "::1");
+
+    MockReceiverResource receiver(transportUnderTest, unicastLocator);
+    MockMessageReceiver* msg_recv = dynamic_cast<MockMessageReceiver*>(receiver.CreateMessageReceiver());
+
+    SendResourceList send_resource_list;
+    ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, outputChannelLocator)); // Includes loopback
+    ASSERT_FALSE(send_resource_list.empty());
+    ASSERT_TRUE(transportUnderTest.IsInputChannelOpen(unicastLocator));
+    octet message[5] = { 'H', 'e', 'l', 'l', 'o' };
+
+    Semaphore sem;
+    std::function<void()> recCallback = [&]()
+            {
+                EXPECT_EQ(memcmp(message, msg_recv->data, 5), 0);
+                sem.post();
+            };
+
+    msg_recv->setCallback(recCallback);
+
+    auto sendThreadFunction = [&]()
+            {
+                Locators locators_begin(locator_list.begin());
+                Locators locators_end(locator_list.end());
+
+                EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, &locators_begin, &locators_end,
+                        (std::chrono::steady_clock::now() + std::chrono::microseconds(100))));
+            };
+
+    senderThread.reset(new std::thread(sendThreadFunction));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    senderThread->join();
+    sem.wait();
+}
+
+TEST_F(UDPv6Tests, send_and_receive_between_allowed_sockets_using_unicast)
+{
+    std::vector<IPFinder::info_IP> interfaces;
+    GetIP6s(interfaces);
+
+    if (interfaces.size() > 0)
+    {
+        for (const auto& interface : interfaces)
+        {
+            descriptor.interfaceWhiteList.push_back(interface.name);
+        }
+        UDPv6Transport transportUnderTest(descriptor);
+        transportUnderTest.init();
+
+        Locator_t unicastLocator;
+        unicastLocator.port = g_default_port;
+        unicastLocator.kind = LOCATOR_KIND_UDPv6;
+        IPLocator::setIPv6(unicastLocator, interfaces.at(0).name);
+
+        LocatorList_t locator_list;
+        locator_list.push_back(unicastLocator);
+
+        Locator_t outputChannelLocator;
+        outputChannelLocator.port = g_default_port + 1;
+        outputChannelLocator.kind = LOCATOR_KIND_UDPv6;
+        IPLocator::setIPv6(outputChannelLocator, interfaces.at(0).name);
+
+        MockReceiverResource receiver(transportUnderTest, unicastLocator);
+        MockMessageReceiver* msg_recv = dynamic_cast<MockMessageReceiver*>(receiver.CreateMessageReceiver());
+
+        SendResourceList send_resource_list;
+        ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, outputChannelLocator)); // Includes loopback
+        ASSERT_FALSE(send_resource_list.empty());
+        ASSERT_TRUE(transportUnderTest.IsInputChannelOpen(unicastLocator));
+        octet message[5] = { 'H', 'e', 'l', 'l', 'o' };
+
+        Semaphore sem;
+        std::function<void()> recCallback = [&]()
+                {
+                    EXPECT_EQ(memcmp(message, msg_recv->data, 5), 0);
+                    sem.post();
+                };
+
+        msg_recv->setCallback(recCallback);
+
+        auto sendThreadFunction = [&]()
+                {
+                    Locators locators_begin(locator_list.begin());
+                    Locators locators_end(locator_list.end());
+
+                    EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, &locators_begin, &locators_end,
+                            (std::chrono::steady_clock::now() + std::chrono::microseconds(100))));
+                };
+
+        senderThread.reset(new std::thread(sendThreadFunction));
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        senderThread->join();
+        sem.wait();
+    }
+}
+
+TEST_F(UDPv6Tests, send_and_receive_between_allowed_sockets_using_unicast_to_multicast)
+{
+    std::vector<IPFinder::info_IP> interfaces;
+    GetIP6s(interfaces);
+
+    if (interfaces.size() > 0)
+    {
+        for (const auto& interface : interfaces)
+        {
+            descriptor.interfaceWhiteList.push_back(interface.name);
+        }
+        UDPv6Transport transportUnderTest(descriptor);
+        transportUnderTest.init();
+
+        Locator_t unicastLocator;
+        unicastLocator.port = g_default_port;
+        unicastLocator.kind = LOCATOR_KIND_UDPv6;
+        IPLocator::setIPv6(unicastLocator, "ff1e::ffff:efff:104");
+
+        LocatorList_t locator_list;
+        locator_list.push_back(unicastLocator);
+
+        Locator_t outputChannelLocator;
+        outputChannelLocator.port = g_default_port + 1;
+        outputChannelLocator.kind = LOCATOR_KIND_UDPv6;
+        IPLocator::setIPv6(outputChannelLocator, interfaces.at(0).name);
+
+        MockReceiverResource receiver(transportUnderTest, unicastLocator);
+        MockMessageReceiver* msg_recv = dynamic_cast<MockMessageReceiver*>(receiver.CreateMessageReceiver());
+
+        SendResourceList send_resource_list;
+        ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, outputChannelLocator)); // Includes loopback
+        ASSERT_FALSE(send_resource_list.empty());
+        ASSERT_TRUE(transportUnderTest.IsInputChannelOpen(unicastLocator));
+        octet message[5] = { 'H', 'e', 'l', 'l', 'o' };
+
+        Semaphore sem;
+        std::function<void()> recCallback = [&]()
+                {
+                    EXPECT_EQ(memcmp(message, msg_recv->data, 5), 0);
+                    sem.post();
+                };
+
+        msg_recv->setCallback(recCallback);
+
+        auto sendThreadFunction = [&]()
+                {
+                    Locators locators_begin(locator_list.begin());
+                    Locators locators_end(locator_list.end());
+
+                    EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, &locators_begin, &locators_end,
+                            (std::chrono::steady_clock::now() + std::chrono::microseconds(100))));
+                };
+
+        senderThread.reset(new std::thread(sendThreadFunction));
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        senderThread->join();
+        sem.wait();
+    }
 }
 
 TEST_F(UDPv6Tests, open_and_close_two_multicast_transports_with_whitelist)
@@ -287,6 +622,96 @@ TEST_F(UDPv6Tests, open_and_close_two_multicast_transports_with_whitelist)
     }
 }
 #endif // ifndef __APPLE__
+
+TEST_F(UDPv6Tests, open_a_blocked_socket)
+{
+    std::vector<IPFinder::info_IP> ip_list;
+    IPFinder::getIPs(&ip_list);
+
+    for (const IPFinder::info_IP& ip : ip_list)
+    {
+        if (IPFinder::IP6 == ip.type)
+        {
+            descriptor.interfaceWhiteList.emplace_back("::1");
+            UDPv6Transport transportUnderTest(descriptor);
+            transportUnderTest.init();
+
+            Locator_t multicastLocator;
+            multicastLocator.port = g_default_port;
+            multicastLocator.kind = LOCATOR_KIND_UDPv6;
+            IPLocator::setIPv6(multicastLocator, ip.name);
+
+            MockReceiverResource receiver(transportUnderTest, multicastLocator);
+            ASSERT_FALSE(transportUnderTest.IsInputChannelOpen(multicastLocator));
+            break;
+        }
+    }
+}
+
+TEST_F(UDPv6Tests, simple_throughput)
+{
+    const size_t sample_size = 1024;
+    int num_samples_per_batch = 100000;
+
+    std::atomic<int> samples_received(0);
+
+    Semaphore sem_end_subscriber;
+
+    octet sample_data[sample_size];
+    memset(sample_data, 0, sizeof(sample_data));
+
+    Locator_t sub_locator;
+    sub_locator.kind = LOCATOR_KIND_UDPv6;
+    sub_locator.port = 50000;
+    IPLocator::setIPv4(sub_locator, "::1");
+
+    UDPv6TransportDescriptor my_descriptor;
+
+    // Subscriber
+
+    UDPv6Transport sub_transport(my_descriptor);
+    ASSERT_TRUE(sub_transport.init());
+
+    MockReceiverResource sub_receiver(sub_transport, sub_locator);
+    MockMessageReceiver* sub_msg_recv = dynamic_cast<MockMessageReceiver*>(sub_receiver.CreateMessageReceiver());
+
+    std::function<void()> sub_callback = [&]()
+            {
+                samples_received.fetch_add(1);
+            };
+
+    sub_msg_recv->setCallback(sub_callback);
+
+    // Publisher
+
+    UDPv6Transport pub_transport(my_descriptor);
+    ASSERT_TRUE(pub_transport.init());
+
+    LocatorList_t send_locators_list;
+    send_locators_list.push_back(sub_locator);
+
+    SendResourceList send_resource_list;
+    ASSERT_TRUE(pub_transport.OpenOutputChannel(send_resource_list, sub_locator));
+
+    auto t0 = std::chrono::high_resolution_clock::now();
+
+    for (int i = 0; i < num_samples_per_batch; i++)
+    {
+        Locators locators_begin(send_locators_list.begin());
+        Locators locators_end(send_locators_list.end());
+
+        EXPECT_TRUE(send_resource_list.at(0)->send(sample_data, sizeof(sample_data), &locators_begin, &locators_end,
+                (std::chrono::steady_clock::now() + std::chrono::milliseconds(100))));
+    }
+
+    auto t1 = std::chrono::high_resolution_clock::now();
+
+    auto real_samples_received = samples_received.load();
+    printf("Samples [sent,received] [%d,%d] send_time_per_sample %.3f(us)\n"
+            , num_samples_per_batch
+            , real_samples_received
+            , std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count() / (num_samples_per_batch * 1000.0));
+}
 
 void UDPv6Tests::HELPER_SetDescriptorDefaults()
 {


### PR DESCRIPTION
This PR updates UDPv6 and includes several tests to check this feature. This PR fixes the whitelist interface feature for UDPv6 (fixes #1923).

There was a bug when comparing IPv6. IPv6 address has an scope that is included after the address separated by `%`. There is a new method that allows the comparison of IPv6 addresses without taking into account the scope. This way the user can simply whitelist using the IPv6 address without having to include the name of the interface so Asio can infer the scope of the given address. It also works if the scope is given.

IPv6 feature is not completely tested so this PR is going to be a draft while some tests are included to ensure that the feature is stable and working in the most usual cases.