### PR TITLE
Update from fastrtpsgen to fastddsgen

### DIFF
--- a/fastrtps.repos
+++ b/fastrtps.repos
@@ -11,11 +11,11 @@ repositories:
         type: git
         url: https://github.com/eProsima/Fast-DDS.git
         version: master
-    fastrtpsgen:
+    fastddsgen:
         type: git
         url: https://github.com/eProsima/Fast-DDS-Gen.git
         version: master
-    fastrtpsgen/thirdparty/idl-parser:
+    fastddsgen/thirdparty/idl-parser:
         type: git
         url: https://github.com/eProsima/IDL-Parser.git
         version: master


### PR DESCRIPTION
This PR modifies the name of the folders where `fastddsgen` is going to be downloaded from the `.repos` file.

This PR is needed for eProsima/Fast-DDS-docs#266

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>