### PR TITLE
Move TypeDescriptor::stateTable from header to implementation. [11841]

### DIFF
--- a/include/fastrtps/types/TypeDescriptor.h
+++ b/include/fastrtps/types/TypeDescriptor.h
@@ -25,23 +25,6 @@ namespace eprosima {
 namespace fastrtps {
 namespace types {
 
-enum FSM_INPUTS
-{
-    LETTER = 1,
-    NUMBER,
-    UNDERSCORE,
-    COLON,
-    OTHER
-};
-
-enum FSM_STATES
-{
-    INVALID = 0,
-    SINGLECOLON,
-    DOUBLECOLON,
-    VALID
-};
-
 class TypeDescriptor
 {
 protected:
@@ -54,13 +37,6 @@ protected:
     DynamicType_ptr element_type_;          // Value Type for arrays, sequences, maps, bitmasks.
     DynamicType_ptr key_element_type_;      // Key Type for maps.
     std::vector<AnnotationDescriptor*> annotation_; // Annotations to apply
-
-    const int stateTable[4][6] = {
-        /* Input:     letter,  number,  underscore, colon,       other */
-        {INVALID,     VALID,   INVALID, INVALID,    INVALID,     INVALID},
-        {SINGLECOLON, INVALID, INVALID, INVALID,    DOUBLECOLON, INVALID},
-        {DOUBLECOLON, VALID,   INVALID, INVALID,    INVALID,     INVALID},
-        {VALID,       VALID,   VALID,   VALID,      SINGLECOLON, INVALID}};
 
     void clean();
 

--- a/src/cpp/dynamic-types/TypeDescriptor.cpp
+++ b/src/cpp/dynamic-types/TypeDescriptor.cpp
@@ -25,6 +25,32 @@ namespace eprosima {
 namespace fastrtps {
 namespace types {
 
+enum FSM_INPUTS
+{
+    LETTER = 1,
+    NUMBER,
+    UNDERSCORE,
+    COLON,
+    OTHER
+};
+
+enum FSM_STATES
+{
+    INVALID = 0,
+    SINGLECOLON,
+    DOUBLECOLON,
+    VALID
+};
+
+static const int stateTable[4][6] =
+{
+    /* Input:     letter,  number,  underscore, colon,       other */
+    {INVALID,     VALID,   INVALID, INVALID,    INVALID,     INVALID},
+    {SINGLECOLON, INVALID, INVALID, INVALID,    DOUBLECOLON, INVALID},
+    {DOUBLECOLON, VALID,   INVALID, INVALID,    INVALID,     INVALID},
+    {VALID,       VALID,   VALID,   VALID,      SINGLECOLON, INVALID}
+};
+
 TypeDescriptor::TypeDescriptor()
     : kind_(0)
     , name_("")


### PR DESCRIPTION
Just what the title says.

Related to #2014