### PR TITLE
Limit SequenceNumberSet number of bits on deserialization [11875]

### DIFF
--- a/include/fastdds/rtps/common/SequenceNumber.h
+++ b/include/fastdds/rtps/common/SequenceNumber.h
@@ -18,13 +18,15 @@
 
 #ifndef _FASTDDS_RPTS_ELEM_SEQNUM_H_
 #define _FASTDDS_RPTS_ELEM_SEQNUM_H_
-#include <fastrtps/fastrtps_dll.h>
-#include <fastrtps/utils/fixed_size_bitmap.hpp>
-#include <fastdds/rtps/common/Types.h>
 
 #include <algorithm>
 #include <cassert>
+#include <limits>
 #include <vector>
+
+#include <fastrtps/fastrtps_dll.h>
+#include <fastrtps/utils/fixed_size_bitmap.hpp>
+#include <fastdds/rtps/common/Types.h>
 
 namespace eprosima {
 namespace fastrtps {
@@ -84,6 +86,7 @@ struct RTPS_DllAPI SequenceNumber_t
         ++low;
         if (low == 0)
         {
+            assert(std::numeric_limits<decltype(high)>::max() > high);
             ++high;
         }
 
@@ -112,6 +115,7 @@ struct RTPS_DllAPI SequenceNumber_t
         if (low < aux_low)
         {
             // Being the type of the parameter an 'int', the increment of 'high' will be as much as 1.
+            assert(std::numeric_limits<decltype(high)>::max() > high);
             ++high;
         }
 
@@ -240,6 +244,7 @@ inline SequenceNumber_t operator -(
     if (inc > seq.low)
     {
         // Being the type of the parameter an 'uint32_t', the decrement of 'high' will be as much as 1.
+        assert(0 < res.high);
         --res.high;
     }
 
@@ -261,6 +266,7 @@ inline SequenceNumber_t operator +(
     if (res.low < seq.low)
     {
         // Being the type of the parameter an 'uint32_t', the increment of 'high' will be as much as 1.
+        assert(std::numeric_limits<decltype(res.high)>::max() > res.high);
         ++res.high;
     }
 
@@ -282,6 +288,7 @@ inline SequenceNumber_t operator -(
 
     if (minuend.low < subtrahend.low)
     {
+        assert(0 < res.high);
         --res.high;
     }
 

--- a/include/fastdds/rtps/messages/CDRMessage.hpp
+++ b/include/fastdds/rtps/messages/CDRMessage.hpp
@@ -265,7 +265,6 @@ inline SequenceNumberSet_t CDRMessage::readSequenceNumberSet(
     if (valid)
     {
         SequenceNumberSet_t sns(seqNum, numBits);
-        sns.base(seqNum);
         sns.bitmap_set(numBits, bitmap);
         return sns;
     }

--- a/include/fastdds/rtps/messages/CDRMessage.hpp
+++ b/include/fastdds/rtps/messages/CDRMessage.hpp
@@ -248,7 +248,6 @@ inline SequenceNumberSet_t CDRMessage::readSequenceNumberSet(
         CDRMessage_t* msg)
 {
     bool valid = true;
-    SequenceNumberSet_t sns(c_SequenceNumber_Unknown);
 
     SequenceNumber_t seqNum;
     valid &= CDRMessage::readSequenceNumber(msg, &seqNum);
@@ -265,11 +264,13 @@ inline SequenceNumberSet_t CDRMessage::readSequenceNumberSet(
 
     if (valid)
     {
+        SequenceNumberSet_t sns(seqNum, numBits);
         sns.base(seqNum);
         sns.bitmap_set(numBits, bitmap);
+        return sns;
     }
 
-    return sns;
+    return SequenceNumberSet_t (c_SequenceNumber_Unknown);
 }
 
 inline bool CDRMessage::readFragmentNumberSet(

--- a/include/fastrtps/utils/fixed_size_bitmap.hpp
+++ b/include/fastrtps/utils/fixed_size_bitmap.hpp
@@ -101,8 +101,22 @@ public:
      */
     explicit BitmapRange(
             T base) noexcept
+        : BitmapRange(base, NBITS - 1)
+    {
+    }
+
+    /**
+     * Range specific constructor.
+     * Constructs an empty range with specified base and maximum bits.
+     *
+     * @param base      Specific base value for the created range.
+     * @param max_bits  Specific maximum number of bits.
+     */
+    BitmapRange(
+            T base,
+            uint32_t max_bits) noexcept
         : base_(base)
-        , range_max_(base + (NBITS - 1))
+        , range_max_(base_ + (std::min)(max_bits, NBITS - 1))
         , bitmap_()
         , num_bits_(0u)
     {
@@ -130,6 +144,23 @@ public:
     {
         base_ = base;
         range_max_ = base_ + (NBITS - 1);
+        num_bits_ = 0;
+        bitmap_.fill(0u);
+    }
+
+    /**
+     * Set a new base and maximum bits for the range.
+     * This method resets the range and sets a new value for its base, as long as a maximum number of bits.
+     *
+     * @param base      New base value to set.
+     * @param max_bits  New maximum number of bits.
+     */
+    void base(
+            T base,
+            uint32_t max_bits) noexcept
+    {
+        base_ = base;
+        range_max_ = base_ + (std::min)(max_bits, NBITS - 1);
         num_bits_ = 0;
         bitmap_.fill(0u);
     }

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -537,7 +537,7 @@ bool MessageReceiver::checkRTPSHeader(
     msg->pos += 4;
 
     //CHECK AND SET protocol version
-    if (msg->buffer[msg->pos] <= c_ProtocolVersion.m_major)
+    if (msg->buffer[msg->pos] == c_ProtocolVersion.m_major)
     {
         source_version_.m_major = msg->buffer[msg->pos];
         msg->pos++;


### PR DESCRIPTION
This PR limits the maximum number of bits on the deserialization of SequenceNumberSet (i.e. ACKNACK and GAP submessages) to avoid a signed integer overflow on the high part of the sequence number.

As a bonus, it also drops messages with a protocol major version number lower than 2.