### PR TITLE
Notify status changes [11835]

### DIFF
--- a/include/fastdds/dds/core/Entity.hpp
+++ b/include/fastdds/dds/core/Entity.hpp
@@ -45,7 +45,6 @@ public:
     RTPS_DllAPI Entity(
             const StatusMask& mask = StatusMask::all())
         : status_mask_(mask)
-        , status_changes_(StatusMask::none())
         , status_condition_(this)
         , enable_(false)
     {
@@ -92,10 +91,7 @@ public:
      *
      * @return const reference to the StatusMask with the triggered statuses set to 1
      */
-    RTPS_DllAPI const StatusMask& get_status_changes() const
-    {
-        return status_changes_;
-    }
+    RTPS_DllAPI const StatusMask& get_status_changes() const;
 
     /**
      * @brief Retrieves the instance handler that represents the Entity
@@ -144,9 +140,6 @@ protected:
 
     //! StatusMask with relevant statuses set to 1
     StatusMask status_mask_;
-
-    //! StatusMask with triggered statuses set to 1
-    StatusMask status_changes_;
 
     //! Condition associated to the Entity
     StatusCondition status_condition_;

--- a/include/fastdds/dds/core/condition/StatusCondition.hpp
+++ b/include/fastdds/dds/core/condition/StatusCondition.hpp
@@ -90,7 +90,7 @@ public:
      */
     RTPS_DllAPI Entity* get_entity() const;
 
-    detail::StatusConditionImpl* get_impl()
+    detail::StatusConditionImpl* get_impl() const
     {
         return impl_.get();
     }

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -158,6 +158,7 @@ set(${PROJECT_NAME}_source_files
     dynamic-types/DynamicDataHelper.cpp
 
     fastrtps_deprecated/attributes/TopicAttributes.cpp
+    fastdds/core/Entity.cpp
     fastdds/core/condition/Condition.cpp
     fastdds/core/condition/ConditionNotifier.cpp
     fastdds/core/condition/GuardCondition.cpp

--- a/src/cpp/fastdds/core/Entity.cpp
+++ b/src/cpp/fastdds/core/Entity.cpp
@@ -1,0 +1,35 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file Entity.cpp
+ *
+ */
+
+#include <fastdds/dds/core/Entity.hpp>
+
+#include <fastdds/core/condition/StatusConditionImpl.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+
+const StatusMask& Entity::get_status_changes() const
+{
+    return status_condition_.get_impl()->get_raw_status();
+}
+
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima

--- a/src/cpp/fastdds/core/condition/StatusConditionImpl.hpp
+++ b/src/cpp/fastdds/core/condition/StatusConditionImpl.hpp
@@ -77,6 +77,15 @@ struct StatusConditionImpl
     const StatusMask& get_enabled_statuses() const;
 
     /**
+     * @brief Retrieves the list of communication statuses that are currently triggered.
+     * @return Triggered status.
+     */
+    const StatusMask& get_raw_status() const
+    {
+        return status_;
+    }
+
+    /**
      * @brief Set the trigger value of a specific status
      * @param status The status for which to change the trigger value
      * @param trigger_value Whether the specified status should be set as triggered or non-triggered

--- a/src/cpp/fastdds/publisher/DataWriter.cpp
+++ b/src/cpp/fastdds/publisher/DataWriter.cpp
@@ -250,11 +250,7 @@ ReturnCode_t DataWriter::get_offered_incompatible_qos_status(
 ReturnCode_t DataWriter::get_publication_matched_status(
         PublicationMatchedStatus& status) const
 {
-    static_cast<void> (status);
-    return ReturnCode_t::RETCODE_UNSUPPORTED;
-    /*
-       return impl_->get_publication_matched_status(status);
-     */
+    return impl_->get_publication_matched_status(status);
 }
 
 ReturnCode_t DataWriter::get_liveliness_lost_status(

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1042,12 +1042,12 @@ bool DataWriterImpl::deadline_missed()
     deadline_missed_status_.total_count++;
     deadline_missed_status_.total_count_change++;
     deadline_missed_status_.last_instance_handle = timer_owner_;
-    if (listener_ != nullptr)
+    auto listener = get_listener_for(StatusMask::offered_deadline_missed());
+    if (nullptr != listener)
     {
         listener_->on_offered_deadline_missed(user_datawriter_, deadline_missed_status_);
+        deadline_missed_status_.total_count_change = 0;
     }
-    publisher_->publisher_listener_.on_offered_deadline_missed(user_datawriter_, deadline_missed_status_);
-    deadline_missed_status_.total_count_change = 0;
 
     if (!history_.set_next_deadline(
                 timer_owner_,

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -19,34 +19,36 @@
 #include <fastrtps/config.h>
 
 #include <fastdds/publisher/DataWriterImpl.hpp>
+
+#include <functional>
+#include <iostream>
+
+#include <fastdds/dds/domain/DomainParticipant.hpp>
+#include <fastdds/dds/log/Log.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
 #include <fastdds/dds/publisher/DataWriter.hpp>
-#include <fastrtps/attributes/TopicAttributes.h>
-#include <fastdds/publisher/PublisherImpl.hpp>
 #include <fastdds/dds/publisher/Publisher.hpp>
 #include <fastdds/dds/publisher/PublisherListener.hpp>
 
+#include <fastdds/rtps/RTPSDomain.h>
+#include <fastdds/rtps/builtin/liveliness/WLP.h>
+#include <fastdds/rtps/participant/RTPSParticipant.h>
+#include <fastdds/rtps/resources/ResourceEvent.h>
+#include <fastdds/rtps/resources/TimedEvent.h>
 #include <fastdds/rtps/writer/RTPSWriter.h>
 #include <fastdds/rtps/writer/StatefulWriter.h>
 
-#include <fastdds/dds/domain/DomainParticipant.hpp>
-#include <fastdds/rtps/participant/RTPSParticipant.h>
-#include <fastdds/rtps/RTPSDomain.h>
-
-#include <fastdds/dds/log/Log.hpp>
+#include <fastdds/publisher/PublisherImpl.hpp>
+#include <fastrtps/attributes/TopicAttributes.h>
 #include <fastrtps/utils/TimeConversion.h>
-#include <fastdds/rtps/resources/ResourceEvent.h>
-#include <fastdds/rtps/resources/TimedEvent.h>
-#include <fastdds/rtps/builtin/liveliness/WLP.h>
+
+#include <fastdds/core/condition/StatusConditionImpl.hpp>
 #include <fastdds/core/policy/ParameterSerializer.hpp>
 #include <fastdds/core/policy/QosPolicyUtils.hpp>
 
 #include <rtps/history/TopicPayloadPoolRegistry.hpp>
 #include <rtps/DataSharing/DataSharingPayloadPool.hpp>
 #include <rtps/participant/RTPSParticipantImpl.h>
-
-#include <functional>
-#include <iostream>
 
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
@@ -961,7 +963,8 @@ void DataWriterImpl::InnerDataWriterListener::on_offered_incompatible_qos(
         fastdds::dds::PolicyMask qos)
 {
     data_writer_->update_offered_incompatible_qos(qos);
-    DataWriterListener* listener = data_writer_->get_listener_for(StatusMask::offered_incompatible_qos());
+    StatusMask notify_status = StatusMask::offered_incompatible_qos();
+    DataWriterListener* listener = data_writer_->get_listener_for(notify_status);
     if (listener != nullptr)
     {
         OfferedIncompatibleQosStatus callback_status;
@@ -970,6 +973,7 @@ void DataWriterImpl::InnerDataWriterListener::on_offered_incompatible_qos(
             listener->on_offered_incompatible_qos(data_writer_->user_datawriter_, callback_status);
         }
     }
+    data_writer_->user_datawriter_->get_statuscondition().get_impl()->set_status(notify_status, true);
 }
 
 void DataWriterImpl::InnerDataWriterListener::onWriterChangeReceivedByAll(
@@ -992,12 +996,14 @@ void DataWriterImpl::InnerDataWriterListener::on_liveliness_lost(
         fastrtps::rtps::RTPSWriter* /*writer*/,
         const fastrtps::LivelinessLostStatus& status)
 {
-    DataWriterListener* listener = data_writer_->get_listener_for(StatusMask::liveliness_lost());
+    StatusMask notify_status = StatusMask::liveliness_lost();
+    DataWriterListener* listener = data_writer_->get_listener_for(notify_status);
     if (listener != nullptr)
     {
         listener->on_liveliness_lost(
             data_writer_->user_datawriter_, status);
     }
+    data_writer_->user_datawriter_->get_statuscondition().get_impl()->set_status(notify_status, true);
 }
 
 ReturnCode_t DataWriterImpl::wait_for_acknowledgments(
@@ -1042,12 +1048,14 @@ bool DataWriterImpl::deadline_missed()
     deadline_missed_status_.total_count++;
     deadline_missed_status_.total_count_change++;
     deadline_missed_status_.last_instance_handle = timer_owner_;
-    auto listener = get_listener_for(StatusMask::offered_deadline_missed());
+    StatusMask notify_status = StatusMask::offered_deadline_missed();
+    auto listener = get_listener_for(notify_status);
     if (nullptr != listener)
     {
         listener_->on_offered_deadline_missed(user_datawriter_, deadline_missed_status_);
         deadline_missed_status_.total_count_change = 0;
     }
+    user_datawriter_->get_statuscondition().get_impl()->set_status(notify_status, true);
 
     if (!history_.set_next_deadline(
                 timer_owner_,
@@ -1067,10 +1075,14 @@ ReturnCode_t DataWriterImpl::get_offered_deadline_missed_status(
         return ReturnCode_t::RETCODE_NOT_ENABLED;
     }
 
-    std::unique_lock<RecursiveTimedMutex> lock(writer_->getMutex());
+    {
+        std::unique_lock<RecursiveTimedMutex> lock(writer_->getMutex());
 
-    status = deadline_missed_status_;
-    deadline_missed_status_.total_count_change = 0;
+        status = deadline_missed_status_;
+        deadline_missed_status_.total_count_change = 0;
+    }
+
+    user_datawriter_->get_statuscondition().get_impl()->set_status(StatusMask::offered_deadline_missed(), false);
     return ReturnCode_t::RETCODE_OK;
 }
 
@@ -1082,10 +1094,14 @@ ReturnCode_t DataWriterImpl::get_offered_incompatible_qos_status(
         return ReturnCode_t::RETCODE_NOT_ENABLED;
     }
 
-    std::unique_lock<RecursiveTimedMutex> lock(writer_->getMutex());
+    {
+        std::unique_lock<RecursiveTimedMutex> lock(writer_->getMutex());
 
-    status = offered_incompatible_qos_status_;
-    offered_incompatible_qos_status_.total_count_change = 0u;
+        status = offered_incompatible_qos_status_;
+        offered_incompatible_qos_status_.total_count_change = 0u;
+    }
+
+    user_datawriter_->get_statuscondition().get_impl()->set_status(StatusMask::offered_incompatible_qos(), false);
     return ReturnCode_t::RETCODE_OK;
 }
 
@@ -1139,13 +1155,16 @@ ReturnCode_t DataWriterImpl::get_liveliness_lost_status(
         return ReturnCode_t::RETCODE_NOT_ENABLED;
     }
 
-    std::unique_lock<RecursiveTimedMutex> lock(writer_->getMutex());
+    {
+        std::unique_lock<RecursiveTimedMutex> lock(writer_->getMutex());
 
-    status.total_count = writer_->liveliness_lost_status_.total_count;
-    status.total_count_change = writer_->liveliness_lost_status_.total_count_change;
+        status.total_count = writer_->liveliness_lost_status_.total_count;
+        status.total_count_change = writer_->liveliness_lost_status_.total_count_change;
 
-    writer_->liveliness_lost_status_.total_count_change = 0u;
+        writer_->liveliness_lost_status_.total_count_change = 0u;
+    }
 
+    user_datawriter_->get_statuscondition().get_impl()->set_status(StatusMask::liveliness_lost(), false);
     return ReturnCode_t::RETCODE_OK;
 }
 

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -221,6 +221,9 @@ public:
     ReturnCode_t wait_for_acknowledgments(
             const fastrtps::Duration_t& max_wait);
 
+    ReturnCode_t get_publication_matched_status(
+            PublicationMatchedStatus& status);
+
     ReturnCode_t get_offered_deadline_missed_status(
             fastrtps::OfferedDeadlineMissedStatus& status);
 
@@ -343,6 +346,9 @@ protected:
     //! The current timer owner, i.e. the instance which started the deadline timer
     InstanceHandle_t timer_owner_;
 
+    //! The publication matched status
+    PublicationMatchedStatus publication_matched_status_;
+
     //! The offered deadline missed status
     fastrtps::OfferedDeadlineMissedStatus deadline_missed_status_;
 
@@ -413,6 +419,9 @@ protected:
      * @return True if correct.
      */
     bool remove_min_seq_change();
+
+    void update_publication_matched_status(
+            const PublicationMatchedStatus& status);
 
     /**
      * @brief A method called when an instance misses the deadline

--- a/src/cpp/fastdds/subscriber/DataReader.cpp
+++ b/src/cpp/fastdds/subscriber/DataReader.cpp
@@ -359,11 +359,7 @@ ReturnCode_t DataReader::get_sample_rejected_status(
 ReturnCode_t DataReader::get_subscription_matched_status(
         SubscriptionMatchedStatus& status) const
 {
-    static_cast<void> (status);
-    return ReturnCode_t::RETCODE_UNSUPPORTED;
-    /*
-       return impl_->get_subscription_matched_status(status);
-     */
+    return impl_->get_subscription_matched_status(status);
 }
 
 ReturnCode_t DataReader::get_matched_publication_data(

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -929,9 +929,12 @@ bool DataReaderImpl::deadline_missed()
     deadline_missed_status_.total_count++;
     deadline_missed_status_.total_count_change++;
     deadline_missed_status_.last_instance_handle = timer_owner_;
-    listener_->on_requested_deadline_missed(user_datareader_, deadline_missed_status_);
-    subscriber_->subscriber_listener_.on_requested_deadline_missed(user_datareader_, deadline_missed_status_);
-    deadline_missed_status_.total_count_change = 0;
+    auto listener = get_listener_for(StatusMask::requested_deadline_missed());
+    if (nullptr != listener)
+    {
+        listener->on_requested_deadline_missed(user_datareader_, deadline_missed_status_);
+        deadline_missed_status_.total_count_change = 0;
+    }
 
     if (!history_.set_next_deadline(
                 timer_owner_,

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -218,6 +218,9 @@ public:
      */
     const TopicDescription* get_topicdescription() const;
 
+    ReturnCode_t get_subscription_matched_status(
+            SubscriptionMatchedStatus& status);
+
     ReturnCode_t get_requested_deadline_missed_status(
             fastrtps::RequestedDeadlineMissedStatus& status);
 
@@ -373,6 +376,9 @@ protected:
     //! The current timer owner, i.e. the instance which started the deadline timer
     fastrtps::rtps::InstanceHandle_t timer_owner_;
 
+    //! Subscription matched status
+    SubscriptionMatchedStatus subscription_matched_status_;
+
     //! Liveliness changed status
     LivelinessChangedStatus liveliness_changed_status_;
 
@@ -425,6 +431,9 @@ protected:
 
     void set_read_communication_status(
             bool trigger_value);
+
+    void update_subscription_matched_status(
+            const SubscriptionMatchedStatus& status);
 
     /**
      * @brief A method called when a new cache change is added

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -423,6 +423,9 @@ protected:
             SampleInfo* info,
             bool should_take);
 
+    void set_read_communication_status(
+            bool trigger_value);
+
     /**
      * @brief A method called when a new cache change is added
      * @param change The cache change that has been added

--- a/test/unittest/dds/core/condition/StatusConditionImplTests.cpp
+++ b/test/unittest/dds/core/condition/StatusConditionImplTests.cpp
@@ -52,17 +52,22 @@ TEST(StatusConditionImplTests, notify_trigger)
     ::testing::StrictMock<ConditionNotifier> notifier;
     StatusConditionImpl uut(&notifier);
 
+    StatusMask mask_none = StatusMask::none();
     StatusMask mask_all = StatusMask::all();
     StatusMask one_mask = StatusMask::inconsistent_topic();
     StatusMask other_mask = StatusMask::data_on_readers();
+    StatusMask both_mask = one_mask;
+    both_mask |= other_mask;
 
     // Condition should be untriggered upon creation
     EXPECT_FALSE(uut.get_trigger_value());
     EXPECT_EQ(mask_all.to_string(), uut.get_enabled_statuses().to_string());
+    EXPECT_EQ(mask_none.to_string(), uut.get_raw_status().to_string());
 
     // Triggering other_mask should trigger
     auto& call1 = EXPECT_CALL(notifier, notify).Times(1);
     uut.set_status(other_mask, true);
+    EXPECT_EQ(other_mask.to_string(), uut.get_raw_status().to_string());
     EXPECT_TRUE(uut.get_trigger_value());
 
     // Setting mask to one_mask should untrigger
@@ -73,30 +78,37 @@ TEST(StatusConditionImplTests, notify_trigger)
     // Triggering one_mask should trigger
     auto& call2 = EXPECT_CALL(notifier, notify).Times(1).After(call1);
     uut.set_status(one_mask, true);
+    EXPECT_EQ(both_mask.to_string(), uut.get_raw_status().to_string());
     EXPECT_TRUE(uut.get_trigger_value());
 
     // Triggering twice should not affect trigger
     uut.set_status(one_mask, true);
+    EXPECT_EQ(both_mask.to_string(), uut.get_raw_status().to_string());
     EXPECT_TRUE(uut.get_trigger_value());
 
     // Untriggering other_mask should not affect trigger
     uut.set_status(other_mask, false);
+    EXPECT_EQ(one_mask.to_string(), uut.get_raw_status().to_string());
     EXPECT_TRUE(uut.get_trigger_value());
 
     // Triggering other_mask should not affect trigger
     uut.set_status(other_mask, true);
+    EXPECT_EQ(both_mask.to_string(), uut.get_raw_status().to_string());
     EXPECT_TRUE(uut.get_trigger_value());
 
     // Untriggering one_mask should untrigger
     uut.set_status(one_mask, false);
+    EXPECT_EQ(other_mask.to_string(), uut.get_raw_status().to_string());
     EXPECT_FALSE(uut.get_trigger_value());
 
     // Untriggering other_mask should not trigger
     uut.set_status(other_mask, false);
+    EXPECT_EQ(mask_none.to_string(), uut.get_raw_status().to_string());
     EXPECT_FALSE(uut.get_trigger_value());
 
     // Triggering other_mask should not trigger
     uut.set_status(other_mask, true);
+    EXPECT_EQ(other_mask.to_string(), uut.get_raw_status().to_string());
     EXPECT_FALSE(uut.get_trigger_value());
 
     // Setting mask to other_mask should trigger
@@ -106,6 +118,7 @@ TEST(StatusConditionImplTests, notify_trigger)
 
     // Triggering one_mask should not affect trigger
     uut.set_status(one_mask, true);
+    EXPECT_EQ(both_mask.to_string(), uut.get_raw_status().to_string());
     EXPECT_TRUE(uut.get_trigger_value());
 
     // Setting mask to one_mask should not affect trigger
@@ -115,6 +128,7 @@ TEST(StatusConditionImplTests, notify_trigger)
 
     // Untriggering other_mask should not affect trigger
     uut.set_status(other_mask, false);
+    EXPECT_EQ(one_mask.to_string(), uut.get_raw_status().to_string());
     EXPECT_TRUE(uut.get_trigger_value());
 
     // Setting mask to other_mask should untrigger

--- a/test/unittest/dds/core/entity/CMakeLists.txt
+++ b/test/unittest/dds/core/entity/CMakeLists.txt
@@ -23,6 +23,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
 
         set(ENTITY_TESTS_SOURCE
             ${PROJECT_SOURCE_DIR}/src/cpp/dynamic-types/TypesBase.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/Entity.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/condition/Condition.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/condition/ConditionNotifier.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/condition/StatusCondition.cpp

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -845,14 +845,13 @@ public:
 /*
  * This test checks that the DataWriter methods defined in the standard not yet implemented in FastDDS return
  * ReturnCode_t::RETCODE_UNSUPPORTED. The following methods are checked:
- * 1. get_publication_matched_status
- * 2. get_matched_subscription_data
- * 3. write_w_timestamp
- * 4. register_instance_w_timestamp
- * 5. unregister_instance_w_timestamp
- * 6. get_matched_subscriptions
- * 7. get_key_value
- * 8. lookup_instance
+ * 1. get_matched_subscription_data
+ * 2. write_w_timestamp
+ * 3. register_instance_w_timestamp
+ * 4. unregister_instance_w_timestamp
+ * 5. get_matched_subscriptions
+ * 6. get_key_value
+ * 7. lookup_instance
  */
 TEST_F(DataWriterUnsupportedTests, UnsupportedDataWriterMethods)
 {
@@ -871,11 +870,6 @@ TEST_F(DataWriterUnsupportedTests, UnsupportedDataWriterMethods)
 
     DataWriter* data_writer = publisher->create_datawriter(topic, DATAWRITER_QOS_DEFAULT);
     ASSERT_NE(publisher, nullptr);
-
-    PublicationMatchedStatus status;
-    EXPECT_EQ(
-        ReturnCode_t::RETCODE_UNSUPPORTED,
-        data_writer->get_publication_matched_status(status));
 
     builtin::SubscriptionBuiltinTopicData subscription_data;
     fastrtps::rtps::InstanceHandle_t subscription_handle;

--- a/test/unittest/dds/status/CMakeLists.txt
+++ b/test/unittest/dds/status/CMakeLists.txt
@@ -21,6 +21,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         find_package(Threads REQUIRED)
 
         set(LISTENERTESTS_SOURCE ListenerTests.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/Entity.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/condition/Condition.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/condition/ConditionNotifier.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/condition/StatusCondition.cpp

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -1759,17 +1759,15 @@ public:
  * ReturnCode_t::RETCODE_UNSUPPORTED. The following methods are checked:
  * 1. get_sample_lost_status
  * 2. get_sample_rejected_status
- * 3. get_subscription_matched_status
- * 4. get_subscription_matched_status
- * 5. get_matched_publication_data
- * 6. create_readcondition
- * 7. create_querycondition
- * 8. delete_readcondition
- * 9. delete_contained_entities
- * 10. get_matched_publications
- * 11. get_key_value
- * 12. lookup_instance
- * 13. wait_for_historical_data
+ * 3. get_matched_publication_data
+ * 4. create_readcondition
+ * 5. create_querycondition
+ * 6. delete_readcondition
+ * 7. delete_contained_entities
+ * 8. get_matched_publications
+ * 9. get_key_value
+ * 10. lookup_instance
+ * 11. wait_for_historical_data
  */
 TEST_F(DataReaderUnsupportedTests, UnsupportedDataReaderMethods)
 {
@@ -1797,16 +1795,6 @@ TEST_F(DataReaderUnsupportedTests, UnsupportedDataReaderMethods)
     {
         SampleRejectedStatus status;
         EXPECT_EQ(ReturnCode_t::RETCODE_UNSUPPORTED, data_reader->get_sample_rejected_status(status));
-    }
-
-    {
-        SubscriptionMatchedStatus status;
-        EXPECT_EQ(ReturnCode_t::RETCODE_UNSUPPORTED, data_reader->get_subscription_matched_status(status));
-    }
-
-    {
-        SubscriptionMatchedStatus status;
-        EXPECT_EQ(ReturnCode_t::RETCODE_UNSUPPORTED, data_reader->get_subscription_matched_status(status));
     }
 
     builtin::PublicationBuiltinTopicData publication_data;

--- a/test/unittest/statistics/dds/CMakeLists.txt
+++ b/test/unittest/statistics/dds/CMakeLists.txt
@@ -110,6 +110,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
                 ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/builtin/typelookup/TypeLookupReplyListener.cpp
                 ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/builtin/typelookup/TypeLookupRequestListener.cpp
                 ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/builtin/typelookup/common/TypeLookupTypes.cpp
+                ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/Entity.cpp
                 ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/condition/Condition.cpp
                 ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/condition/ConditionNotifier.cpp
                 ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/condition/StatusCondition.cpp


### PR DESCRIPTION
This PR:
* Performs notification of status changes using the `StatusCondition`
* Fixes listener calls for deadline statuses
* Implements `DataReader::get_subscription_matched_status`
* Implements `DataWriter::get_publication_matched_status`
* Changes the implementation of `Entity::get_status_changes` to use the raw status on `StatusConditionImpl`