### PR TITLE
Fix segmentation fault on discovery server [11922]

### DIFF
--- a/src/cpp/rtps/builtin/discovery/participant/timedevent/DSClientEvent.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/timedevent/DSClientEvent.cpp
@@ -58,6 +58,7 @@ bool DSClientEvent::event()
 
     // Iterate over remote servers to check for new unmatched servers
     ParticipantProxyData* part_proxy_data;
+    std::unique_lock<std::recursive_mutex> lock(*mp_PDP->getMutex());
     for (auto server: mp_PDP->remote_server_attributes())
     {
         // Get the participant proxy data of the server


### PR DESCRIPTION
`DSClientEvent` accesses the information of `PDPSimple` without locking its mutex. When this event is running and a new Participant is discovered, a segmentation fault occurs. This PR adds the locking of `PDPSimple`'s mutex.