### PR TITLE
Fix deadlock with security and timers. [11923]

### DIFF
--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -479,7 +479,6 @@ void SecurityManager::destroy()
                 authentication_plugin_->return_sharedsecret_handle(shared_secret_handle, exception);
             }
 
-            //auths_to_remove.push_back(dp_it.second.get_auth());
             DiscoveredParticipantInfo::AuthUniquePtr remote_participant_info = dp_it.second.get_auth();
             remove_discovered_participant_info(remote_participant_info);
             auths_to_remove.push_back(std::move(remote_participant_info));
@@ -571,7 +570,9 @@ bool SecurityManager::restore_discovered_participant_info(
     }
     else
     {
-        DiscoveredParticipantInfo::AuthUniquePtr remote_participant_info = std::move(auth_ptr);
+                // AuthUniquePtr must be removed after unlock SecurityManager's mutex.
+                // This is to avoid a deadlock with TimedEvents.
+                DiscoveredParticipantInfo::AuthUniquePtr remote_participant_info = std::move(auth_ptr);
         remove_discovered_participant_info(remote_participant_info);
         lock.unlock();
     }
@@ -747,6 +748,8 @@ void SecurityManager::remove_participant(
             authentication_plugin_->return_sharedsecret_handle(shared_secret_handle, exception);
         }
 
+        // AuthUniquePtr must be removed after unlock SecurityManager's mutex.
+        // This is to avoid a deadlock with TimedEvents.
         DiscoveredParticipantInfo::AuthUniquePtr remote_participant_info = dp_it->second.get_auth();
         remove_discovered_participant_info(remote_participant_info);
 

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -570,9 +570,9 @@ bool SecurityManager::restore_discovered_participant_info(
     }
     else
     {
-                // AuthUniquePtr must be removed after unlock SecurityManager's mutex.
-                // This is to avoid a deadlock with TimedEvents.
-                DiscoveredParticipantInfo::AuthUniquePtr remote_participant_info = std::move(auth_ptr);
+        // AuthUniquePtr must be removed after unlock SecurityManager's mutex.
+        // This is to avoid a deadlock with TimedEvents.
+        DiscoveredParticipantInfo::AuthUniquePtr remote_participant_info = std::move(auth_ptr);
         remove_discovered_participant_info(remote_participant_info);
         lock.unlock();
     }

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -455,6 +455,10 @@ void SecurityManager::destroy()
 
         SecurityException exception;
 
+        // AuthUniquePtr must be removed after unlock SecurityManager's mutex.
+        // This is to avoid a deadlock with TimedEvents.
+        std::vector<DiscoveredParticipantInfo::AuthUniquePtr> auths_to_remove;
+
         for (auto& dp_it : discovered_participants_)
         {
             ParticipantCryptoHandle* participant_crypto_handle = dp_it.second.get_participant_crypto();
@@ -475,7 +479,10 @@ void SecurityManager::destroy()
                 authentication_plugin_->return_sharedsecret_handle(shared_secret_handle, exception);
             }
 
-            remove_discovered_participant_info(dp_it.second.get_auth());
+            //auths_to_remove.push_back(dp_it.second.get_auth());
+            DiscoveredParticipantInfo::AuthUniquePtr remote_participant_info = dp_it.second.get_auth();
+            remove_discovered_participant_info(remote_participant_info);
+            auths_to_remove.push_back(std::move(remote_participant_info));
         }
 
         discovered_participants_.clear();
@@ -499,6 +506,8 @@ void SecurityManager::destroy()
         }
 
         mutex_.unlock();
+
+        auths_to_remove.clear();
 
         delete_entities();
 
@@ -528,7 +537,7 @@ void SecurityManager::destroy()
 }
 
 void SecurityManager::remove_discovered_participant_info(
-        DiscoveredParticipantInfo::AuthUniquePtr&& auth_ptr)
+        const DiscoveredParticipantInfo::AuthUniquePtr& auth_ptr)
 {
     SecurityException exception;
 
@@ -562,7 +571,9 @@ bool SecurityManager::restore_discovered_participant_info(
     }
     else
     {
-        remove_discovered_participant_info(std::move(auth_ptr));
+        DiscoveredParticipantInfo::AuthUniquePtr remote_participant_info = std::move(auth_ptr);
+        remove_discovered_participant_info(remote_participant_info);
+        lock.unlock();
     }
 
     return returned_value;
@@ -736,9 +747,11 @@ void SecurityManager::remove_participant(
             authentication_plugin_->return_sharedsecret_handle(shared_secret_handle, exception);
         }
 
-        remove_discovered_participant_info(dp_it->second.get_auth());
+        DiscoveredParticipantInfo::AuthUniquePtr remote_participant_info = dp_it->second.get_auth();
+        remove_discovered_participant_info(remote_participant_info);
 
         discovered_participants_.erase(dp_it);
+        lock.unlock();
     }
 }
 

--- a/src/cpp/rtps/security/SecurityManager.h
+++ b/src/cpp/rtps/security/SecurityManager.h
@@ -426,7 +426,7 @@ private:
     void cancel_init();
 
     void remove_discovered_participant_info(
-            DiscoveredParticipantInfo::AuthUniquePtr&& auth_ptr);
+            const DiscoveredParticipantInfo::AuthUniquePtr& auth_ptr);
 
     bool restore_discovered_participant_info(
             const GUID_t& remote_participant_key,


### PR DESCRIPTION
This PR fixes a deadlock between the `SecurityManager`'s mutex and the `DiscoveredParticipantInfo`'s event. The destruction of the `DiscoveryParticipantInfo` have to happen without the `SecurityManager`'s mutex locked.