### PR TITLE
Validate sequence range on CDRMessage::readSequenceNumberSet [11920]

### DIFF
--- a/include/fastdds/rtps/messages/CDRMessage.hpp
+++ b/include/fastdds/rtps/messages/CDRMessage.hpp
@@ -258,7 +258,7 @@ inline SequenceNumberSet_t CDRMessage::readSequenceNumberSet(
     valid &= (seqNum.high >= 0);
     if (valid && std::numeric_limits<int32_t>::max() == seqNum.high)
     {
-        numBits = (std::min)(numBits, std::numeric_limits<uint32_t>::max() - seqNum.high);
+        numBits = (std::min)(numBits, std::numeric_limits<uint32_t>::max() - seqNum.low);
     }
 
     uint32_t n_longs = (numBits + 31u) / 32u;

--- a/include/fastdds/rtps/messages/CDRMessage.hpp
+++ b/include/fastdds/rtps/messages/CDRMessage.hpp
@@ -22,6 +22,7 @@
 #include <cassert>
 #include <cstring>
 #include <algorithm>
+#include <limits>
 #include <vector>
 
 #include <fastdds/dds/core/policy/ParameterTypes.hpp>
@@ -254,6 +255,11 @@ inline SequenceNumberSet_t CDRMessage::readSequenceNumberSet(
     uint32_t numBits = 0;
     valid &= CDRMessage::readUInt32(msg, &numBits);
     valid &= (numBits <= 256u);
+    valid &= (seqNum.high >= 0);
+    if (valid && std::numeric_limits<int32_t>::max() == seqNum.high)
+    {
+        numBits = (std::min)(numBits, std::numeric_limits<uint32_t>::max() - seqNum.high);
+    }
 
     uint32_t n_longs = (numBits + 31u) / 32u;
     uint32_t bitmap[8];


### PR DESCRIPTION
As a follow-up of #2027, this PR adds a validation check to avoid overflowing the high part of the sequence number.