### PR TITLE
Fix bug using not protected code in a test [11924]

### DIFF
--- a/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
@@ -418,8 +418,9 @@ public:
         if (ret_val)
         {
             std::string topic_name = topic_name_;
+            size_t vector_size = entities_extra_.size();
 
-            for (size_t i = 0; i < entities_extra_.size(); i++)
+            for (size_t i = 0; i < vector_size; i++)
             {
                 topic_name += "/";
             }
@@ -451,7 +452,9 @@ public:
                     break;
                 }
 
+                mutex_.lock();
                 entities_extra_.push_back({topic, datawriter, datareader});
+                mutex_.unlock();
             }
         }
 


### PR DESCRIPTION
Fixes a bug in a test with multiple threads accessing a `std::vector` without protection.