### PR TITLE
Fix interval loop on events [11929]

### DIFF
--- a/src/cpp/rtps/resources/ResourceEvent.cpp
+++ b/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -182,7 +182,7 @@ void ResourceEvent::event_service()
         auto current_time = std::chrono::steady_clock::now();
         if (current_time > next_trigger)
         {
-            next_trigger = current_time += std::chrono::microseconds(1);
+            next_trigger = current_time += std::chrono::microseconds(10);
         }
 
         cv_.wait_until(lock, next_trigger);

--- a/src/cpp/rtps/resources/ResourceEvent.cpp
+++ b/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -179,6 +179,12 @@ void ResourceEvent::event_service()
                 current_time_ + std::chrono::seconds(1) :
                 active_timers_[0]->next_trigger_time();
 
+        auto current_time = std::chrono::steady_clock::now();
+        if (current_time > next_trigger)
+        {
+            next_trigger = current_time += std::chrono::microseconds(1);
+        }
+
         cv_.wait_until(lock, next_trigger);
 
         // Don't allow other threads to manipulate the timer collections

--- a/src/cpp/rtps/resources/ResourceEvent.cpp
+++ b/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -182,7 +182,7 @@ void ResourceEvent::event_service()
         auto current_time = std::chrono::steady_clock::now();
         if (current_time > next_trigger)
         {
-            next_trigger = current_time += std::chrono::microseconds(10);
+            next_trigger = current_time + std::chrono::microseconds(10);
         }
 
         cv_.wait_until(lock, next_trigger);


### PR DESCRIPTION
When the interval of an event is too low, the `ResourceEvent` thread can enter in to a loop.