### PR TITLE
[11993] Assuring proper history clean up when a reader unmatches a writer

### DIFF
--- a/include/fastdds/rtps/history/History.h
+++ b/include/fastdds/rtps/history/History.h
@@ -160,6 +160,14 @@ public:
             CacheChange_t* ch);
 
     /**
+     * Remove all changes from the History that have a certain guid.
+     * @param a_guid Pointer to the target guid to search for.
+     * @return True if successful, even if no changes have been removed.
+     * */
+    RTPS_DllAPI virtual bool remove_changes_with_guid(
+            const GUID_t& a_guid);
+
+    /**
      * Find a specific change in the history using the matches_change method criteria.
      * @param ch Pointer to the CacheChange_t to search for.
      * @return an iterator if a suitable change is found

--- a/include/fastdds/rtps/history/ReaderHistory.h
+++ b/include/fastdds/rtps/history/ReaderHistory.h
@@ -100,8 +100,8 @@ public:
      * @param a_guid Pointer to the target guid to search for.
      * @return True if successful, even if no changes have been removed.
      * */
-    RTPS_DllAPI bool remove_changes_with_guid(
-            const GUID_t& a_guid);
+    bool remove_changes_with_guid(
+            const GUID_t& a_guid) override;
 
     /**
      * Remove all fragmented changes from certain writer up to certain sequence number.

--- a/include/fastdds/rtps/history/ReaderHistory.h
+++ b/include/fastdds/rtps/history/ReaderHistory.h
@@ -50,7 +50,7 @@ public:
      */
     RTPS_DllAPI ReaderHistory(
             const HistoryAttributes& att);
-    RTPS_DllAPI virtual ~ReaderHistory() override;
+    RTPS_DllAPI ~ReaderHistory() override;
 
     /**
      * Virtual method that is called when a new change is received.

--- a/include/fastrtps/subscriber/SubscriberHistory.h
+++ b/include/fastrtps/subscriber/SubscriberHistory.h
@@ -61,7 +61,7 @@ public:
             uint32_t payloadMax,
             rtps::MemoryManagementPolicy_t mempolicy);
 
-    virtual ~SubscriberHistory();
+    ~SubscriberHistory() override;
 
     /**
      * Called when a change is received by the Subscriber. Will add the change to the history.
@@ -72,7 +72,7 @@ public:
      */
     bool received_change(
             rtps::CacheChange_t* change,
-            size_t unknown_missing_changes_up_to);
+            size_t unknown_missing_changes_up_to) override;
 
     /** @name Read or take data methods.
      * Methods to read or take data from the History.

--- a/include/fastrtps/subscriber/SubscriberHistory.h
+++ b/include/fastrtps/subscriber/SubscriberHistory.h
@@ -102,6 +102,14 @@ public:
             SampleInfo_t* info);
 
     /**
+     * Remove all changes from the History that have a certain guid.
+     * @param a_guid Pointer to the target guid to search for.
+     * @return True if successful, even if no changes have been removed.
+     * */
+    bool remove_changes_with_guid(
+            const fastrtps::rtps::GUID_t& a_guid) override;
+
+    /**
      * This method is called to remove a change from the SubscriberHistory.
      * @param change Pointer to the CacheChange_t.
      * @return True if removed.

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -26,6 +26,7 @@
 #include <fastdds/dds/topic/TopicDataType.hpp>
 #include <fastdds/dds/log/Log.hpp>
 
+#include <algorithm>
 #include <limits>
 #include <mutex>
 
@@ -521,17 +522,15 @@ bool SubscriberHistory::remove_changes_with_guid(
     for ( auto mit = keyed_changes_.begin(); mit != keyed_changes_.end();)
     {
         auto& caches = mit->second.cache_changes;
-        for ( auto vit = caches.begin(); vit != caches.end();)
-        {
-            if ((*vit)->writerGUID == a_guid )
-            {
-                vit = caches.erase(vit);
-            }
-            else
-            {
-                ++vit;
-            }
-        }
+        caches.erase(
+                std::remove_if(
+                    caches.begin(),
+                    caches.end(),
+                    [&a_guid](CacheChange_t const* const pSample) -> bool
+                    {
+                        return pSample->writerGUID == a_guid;
+                    }),
+                caches.end());
 
         if ( caches.empty())
         {

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -519,7 +519,7 @@ bool SubscriberHistory::remove_changes_with_guid(
     std::lock_guard<RecursiveTimedMutex> guard(*mp_mutex);
 
     // clean this class related data
-    for ( auto mit = keyed_changes_.begin(); mit != keyed_changes_.end();)
+    for ( auto mit = keyed_changes_.begin(); mit != keyed_changes_.end(); ++mit)
     {
         auto& caches = mit->second.cache_changes;
         caches.erase(
@@ -531,15 +531,6 @@ bool SubscriberHistory::remove_changes_with_guid(
                     return pSample->writerGUID == a_guid;
                 }),
             caches.end());
-
-        if ( caches.empty())
-        {
-            mit = keyed_changes_.erase(mit);
-        }
-        else
-        {
-            ++mit;
-        }
     }
 
     // clean base class related data

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -523,14 +523,14 @@ bool SubscriberHistory::remove_changes_with_guid(
     {
         auto& caches = mit->second.cache_changes;
         caches.erase(
-                std::remove_if(
-                    caches.begin(),
-                    caches.end(),
-                    [&a_guid](CacheChange_t const* const pSample) -> bool
-                    {
-                        return pSample->writerGUID == a_guid;
-                    }),
-                caches.end());
+            std::remove_if(
+                caches.begin(),
+                caches.end(),
+                [&a_guid](CacheChange_t const* const pSample) -> bool
+                {
+                    return pSample->writerGUID == a_guid;
+                }),
+            caches.end());
 
         if ( caches.empty())
         {

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -512,6 +512,41 @@ bool SubscriberHistory::remove_change_sub(
     return false;
 }
 
+bool SubscriberHistory::remove_changes_with_guid(
+        const GUID_t& a_guid)
+{
+    std::lock_guard<RecursiveTimedMutex> guard(*mp_mutex);
+
+    // clean this class related data
+    for( auto mit = keyed_changes_.begin(); mit != keyed_changes_.end();)
+    {
+        auto & caches = mit->second.cache_changes;
+        for ( auto vit = caches.begin(); vit != caches.end();)
+        {
+            if ( (*vit)->writerGUID == a_guid )
+            {
+                vit = caches.erase(vit);
+            }
+            else
+            {
+                ++vit;
+            }
+        }
+
+        if ( caches.empty() )
+        {
+            mit = keyed_changes_.erase(mit);
+        }
+        else
+        {
+            ++mit;
+        }
+    }
+
+    // clean base class related data
+    return ReaderHistory::remove_changes_with_guid(a_guid);
+}
+
 bool SubscriberHistory::remove_change_sub(
         CacheChange_t* change,
         iterator& it)

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -518,12 +518,12 @@ bool SubscriberHistory::remove_changes_with_guid(
     std::lock_guard<RecursiveTimedMutex> guard(*mp_mutex);
 
     // clean this class related data
-    for( auto mit = keyed_changes_.begin(); mit != keyed_changes_.end();)
+    for ( auto mit = keyed_changes_.begin(); mit != keyed_changes_.end();)
     {
-        auto & caches = mit->second.cache_changes;
+        auto& caches = mit->second.cache_changes;
         for ( auto vit = caches.begin(); vit != caches.end();)
         {
-            if ( (*vit)->writerGUID == a_guid )
+            if ((*vit)->writerGUID == a_guid )
             {
                 vit = caches.erase(vit);
             }
@@ -533,7 +533,7 @@ bool SubscriberHistory::remove_changes_with_guid(
             }
         }
 
-        if ( caches.empty() )
+        if ( caches.empty())
         {
             mit = keyed_changes_.erase(mit);
         }

--- a/src/cpp/rtps/history/History.cpp
+++ b/src/cpp/rtps/history/History.cpp
@@ -113,6 +113,32 @@ bool History::remove_change(
     return true;
 }
 
+bool History::remove_changes_with_guid(
+        const GUID_t& a_guid)
+{
+    if (mp_mutex == nullptr)
+    {
+        logError(RTPS_HISTORY, "History needs proper initialization before any removal");
+        return false;
+    }
+
+    //Lock scope
+    std::lock_guard<RecursiveTimedMutex> guard(*mp_mutex);
+    for (std::vector<CacheChange_t*>::iterator chit = m_changes.begin(); chit != m_changes.end();)
+    {
+        if ((*chit)->writerGUID == a_guid)
+        {
+            chit = remove_change_nts(chit);
+        }
+        else
+        {
+            ++chit;
+        }
+    }
+
+    return true;
+}
+
 bool History::remove_all_changes()
 {
     if (mp_mutex == nullptr)

--- a/src/cpp/rtps/history/ReaderHistory.cpp
+++ b/src/cpp/rtps/history/ReaderHistory.cpp
@@ -127,36 +127,14 @@ History::iterator ReaderHistory::remove_change_nts(
 bool ReaderHistory::remove_changes_with_guid(
         const GUID_t& a_guid)
 {
-    std::vector<CacheChange_t*> changes_to_remove;
-
-    if (mp_reader == nullptr || mp_mutex == nullptr)
+    if (mp_reader == nullptr)
     {
-        logError(RTPS_READER_HISTORY, "You need to create a Reader with History before removing any changes");
+        logError(RTPS_READER_HISTORY, "ReaderHistory must be linked with a Reader before any removal");
         return false;
     }
 
-    {
-        //Lock scope
-        std::lock_guard<RecursiveTimedMutex> guard(*mp_mutex);
-        for (std::vector<CacheChange_t*>::iterator chit = m_changes.begin(); chit != m_changes.end(); ++chit)
-        {
-            if ((*chit)->writerGUID == a_guid)
-            {
-                changes_to_remove.push_back((*chit));
-            }
-        }
-    }//End lock scope
-
-    for (std::vector<CacheChange_t*>::iterator chit = changes_to_remove.begin(); chit != changes_to_remove.end();
-            ++chit)
-    {
-        if (!remove_change(*chit))
-        {
-            logError(RTPS_READER_HISTORY, "One of the cachechanged in the GUID removal bulk could not be removed");
-            return false;
-        }
-    }
-    return true;
+    // actual removal on base class
+    return History::remove_changes_with_guid(a_guid);
 }
 
 bool ReaderHistory::remove_fragmented_changes_until(

--- a/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
+++ b/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
@@ -46,6 +46,8 @@ public:
     {
     }
 
+    virtual ~ReaderHistory() {}
+
     // *INDENT-OFF* Uncrustify makes a mess with MOCK_METHOD macros
     MOCK_METHOD1(remove_change_mock, bool(CacheChange_t*));
 
@@ -74,6 +76,19 @@ public:
         bool ret = remove_change_mock(change);
         delete change;
         return ret;
+    }
+
+    virtual bool remove_changes_with_guid(
+            const GUID_t& )
+    {
+        return true;
+    }
+
+    virtual bool received_change(
+            CacheChange_t*,
+            size_t)
+    {
+        return true;
     }
 
     inline RecursiveTimedMutex* getMutex()

--- a/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
+++ b/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
@@ -46,7 +46,9 @@ public:
     {
     }
 
-    virtual ~ReaderHistory() {}
+    virtual ~ReaderHistory()
+    {
+    }
 
     // *INDENT-OFF* Uncrustify makes a mess with MOCK_METHOD macros
     MOCK_METHOD1(remove_change_mock, bool(CacheChange_t*));

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -1771,10 +1771,10 @@ TEST_F(DataReaderTests, check_key_history_wholesomeness_on_unmatch)
 
     // defaults to footopic using type FooType
     create_entities(
-            nullptr,
-            reader_qos,
-            SUBSCRIBER_QOS_DEFAULT,
-            writer_qos);
+        nullptr,
+        reader_qos,
+        SUBSCRIBER_QOS_DEFAULT,
+        writer_qos);
 
     // add a key sample
     FooType sample;
@@ -1786,7 +1786,7 @@ TEST_F(DataReaderTests, check_key_history_wholesomeness_on_unmatch)
     ASSERT_TRUE(data_writer_->write(&sample));
 
     // wait till the DataReader receives the data
-    ASSERT_TRUE(data_reader_->wait_for_unread_message(Duration_t(3,0)));
+    ASSERT_TRUE(data_reader_->wait_for_unread_message(Duration_t(3, 0)));
 
     // now the writer is removed
     ASSERT_EQ(publisher_->delete_datawriter(data_writer_), ReturnCode_t::RETCODE_OK);
@@ -1794,12 +1794,13 @@ TEST_F(DataReaderTests, check_key_history_wholesomeness_on_unmatch)
 
     // here the DataReader History state must be coherent and don't loop endlessly
     ReturnCode_t res;
-    std::thread query([this, &res]() {
-        FooSeq samples;
-        SampleInfoSeq infos;
+    std::thread query([this, &res]()
+            {
+                FooSeq samples;
+                SampleInfoSeq infos;
 
-        res = data_reader_->take_instance(samples, infos, LENGTH_UNLIMITED, handle_ok_);
-    });
+                res = data_reader_->take_instance(samples, infos, LENGTH_UNLIMITED, handle_ok_);
+            });
 
     // Check if the thread hangs
     // wait for termination

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -1749,6 +1749,66 @@ TEST_F(DataReaderTests, get_listening_locators)
     EXPECT_TRUE(multicast_found);
 }
 
+/*
+ * Issue https://github.com/eProsima/Fast-DDS/issues/2044 highlighted that a DataWriter removal may left DataReaders
+ * Histories in an invalid state. DataWriter removal triggers the clean up of any related sample in DataReader's
+ * History. Because the key related internal state was not updated and kept sample dangling references.
+ * */
+
+TEST_F(DataReaderTests, check_key_history_wholesomeness_on_unmatch)
+{
+    // handle_ok_ (1)
+    create_instance_handles();
+
+    // Set up entities
+    DataReaderQos reader_qos = DATAREADER_QOS_DEFAULT;
+    reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
+    reader_qos.history().kind = KEEP_ALL_HISTORY_QOS;
+
+    DataWriterQos writer_qos = DATAWRITER_QOS_DEFAULT;
+    writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
+    writer_qos.history().kind = KEEP_ALL_HISTORY_QOS;
+
+    // defaults to footopic using type FooType
+    create_entities(
+            nullptr,
+            reader_qos,
+            SUBSCRIBER_QOS_DEFAULT,
+            writer_qos);
+
+    // add a key sample
+    FooType sample;
+    std::array<char, 256> msg = {"checking robustness"};
+
+    sample.index(1);
+    sample.message(msg);
+
+    ASSERT_TRUE(data_writer_->write(&sample));
+
+    // wait till the DataReader receives the data
+    ASSERT_TRUE(data_reader_->wait_for_unread_message(Duration_t(3,0)));
+
+    // now the writer is removed
+    ASSERT_EQ(publisher_->delete_datawriter(data_writer_), ReturnCode_t::RETCODE_OK);
+    data_writer_ = nullptr;
+
+    // here the DataReader History state must be coherent and don't loop endlessly
+    ReturnCode_t res;
+    std::thread query([this, &res]() {
+        FooSeq samples;
+        SampleInfoSeq infos;
+
+        res = data_reader_->take_instance(samples, infos, LENGTH_UNLIMITED, handle_ok_);
+    });
+
+    // Check if the thread hangs
+    // wait for termination
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    // check expected result, if query thread hangs res = ReturnCode_t::RETCODE_OK
+    ASSERT_EQ(res, ReturnCode_t::RETCODE_BAD_PARAMETER);
+    query.join();
+}
+
 class DataReaderUnsupportedTests : public ::testing::Test
 {
 public:

--- a/test/unittest/utils/BitmapRangeTests.cpp
+++ b/test/unittest/utils/BitmapRangeTests.cpp
@@ -431,6 +431,8 @@ TEST_F(BitmapRangeTests, full_range)
 
 TEST_F(BitmapRangeTests, serialization)
 {
+    using value_type = TestType::bitmap_type::value_type;
+
     uint32_t num_bits;
     uint32_t num_longs;
     TestType::bitmap_type bitmap;
@@ -455,6 +457,25 @@ TEST_F(BitmapRangeTests, serialization)
     EXPECT_EQ(num_bits, 20u);
     EXPECT_EQ(num_longs, 1u);
     EXPECT_EQ(bitmap[0], 0xFFFFF000u);
+
+    // Case when whole bitmap elements are used
+    uint32_t test_longs = 1;
+
+    do
+    {
+        uint32_t test_bits = test_longs * sizeof(value_type) * 8;
+        bitmap.fill(std::numeric_limits<uint32_t>::max());
+        uut.bitmap_set(test_bits, bitmap.data());
+        uut.bitmap_get(num_bits, bitmap, num_longs);
+        EXPECT_EQ(num_bits, test_bits);
+        EXPECT_EQ(num_longs, test_longs);
+
+        // use a vector as result pattern
+        std::vector<value_type> pattern(test_longs, std::numeric_limits<uint32_t>::max());
+        pattern.resize(bitmap.max_size(), 0);
+        EXPECT_TRUE(std::equal(bitmap.begin(), bitmap.end(), pattern.begin()));
+    }
+    while ( ++test_longs <= bitmap.max_size());
 }
 
 TEST_F(BitmapRangeTests, traversal)

--- a/versions.md
+++ b/versions.md
@@ -1,6 +1,8 @@
 Forthcoming
 -----------
 
+* Promoted `eProsima::fastrtps::SubscriberHistory::remove_changes_with_guid` to virtual method (ABI break)
+
 Version 2.3.0
 -------------
 


### PR DESCRIPTION
This meets issue https://github.com/eProsima/Fast-DDS/issues/2044
This PR will superseed https://github.com/eProsima/Fast-DDS/pull/2056 on 2.4 release
