### PR TITLE
[11993] Assuring proper history clean up when a reader unmatches a writer keeping abi compatibility

### DIFF
--- a/include/fastdds/rtps/history/ReaderHistory.h
+++ b/include/fastdds/rtps/history/ReaderHistory.h
@@ -50,7 +50,7 @@ public:
      */
     RTPS_DllAPI ReaderHistory(
             const HistoryAttributes& att);
-    RTPS_DllAPI virtual ~ReaderHistory() override;
+    RTPS_DllAPI ~ReaderHistory() override;
 
     /**
      * Virtual method that is called when a new change is received.

--- a/include/fastrtps/subscriber/SubscriberHistory.h
+++ b/include/fastrtps/subscriber/SubscriberHistory.h
@@ -64,6 +64,17 @@ public:
     virtual ~SubscriberHistory();
 
     /**
+     * Remove a specific change from the history.
+     * No Thread Safe
+     * @param removal iterator to the CacheChange_t to remove.
+     * @param release defaults to true and hints if the CacheChange_t should return to the pool
+     * @return iterator to the next CacheChange_t or end iterator.
+     */
+    RTPS_DllAPI iterator remove_change_nts(
+            const_iterator removal,
+            bool release = true) override;
+
+    /**
      * Called when a change is received by the Subscriber. Will add the change to the history.
      * @pre Change should not be already present in the history.
      * @param[in] change The received change

--- a/include/fastrtps/subscriber/SubscriberHistory.h
+++ b/include/fastrtps/subscriber/SubscriberHistory.h
@@ -83,7 +83,7 @@ public:
      */
     bool received_change(
             rtps::CacheChange_t* change,
-            size_t unknown_missing_changes_up_to);
+            size_t unknown_missing_changes_up_to) override;
 
     /** @name Read or take data methods.
      * Methods to read or take data from the History.

--- a/include/fastrtps/subscriber/SubscriberHistory.h
+++ b/include/fastrtps/subscriber/SubscriberHistory.h
@@ -61,7 +61,7 @@ public:
             uint32_t payloadMax,
             rtps::MemoryManagementPolicy_t mempolicy);
 
-    virtual ~SubscriberHistory();
+    ~SubscriberHistory() override;
 
     /**
      * Remove a specific change from the history.
@@ -70,7 +70,7 @@ public:
      * @param release defaults to true and hints if the CacheChange_t should return to the pool
      * @return iterator to the next CacheChange_t or end iterator.
      */
-    RTPS_DllAPI iterator remove_change_nts(
+    iterator remove_change_nts(
             const_iterator removal,
             bool release = true) override;
 

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -680,8 +680,8 @@ std::pair<bool, SubscriberHistory::instance_info> SubscriberHistory::lookup_inst
     return { false, {InstanceHandle_t(), nullptr} };
 }
 
-History::iterator SubscriberHistory::remove_change_nts(
-        History::const_iterator removal,
+ReaderHistory::iterator SubscriberHistory::remove_change_nts(
+        ReaderHistory::const_iterator removal,
         bool release)
 {
     CacheChange_t* p_sample = nullptr;

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -680,5 +680,34 @@ std::pair<bool, SubscriberHistory::instance_info> SubscriberHistory::lookup_inst
     return { false, {InstanceHandle_t(), nullptr} };
 }
 
+History::iterator SubscriberHistory::remove_change_nts(
+        History::const_iterator removal,
+        bool release)
+{
+    if ( removal != changesEnd())
+    {
+        CacheChange_t* const p_sample = *removal;
+
+        // clean any references to this CacheChange in the key state collection
+        for ( auto mit = keyed_changes_.begin(); mit != keyed_changes_.end();)
+        {
+            auto& c = mit->second.cache_changes;
+            c.erase(std::remove(c.begin(), c.end(), p_sample), c.end());
+
+            if (c.empty())
+            {
+                mit = keyed_changes_.erase(mit);
+            }
+            else
+            {
+                ++mit;
+            }
+        }
+    }
+
+    // call the base class
+    return ReaderHistory::remove_change_nts(removal, release);
+}
+
 } // namespace fastrtps
 } // namsepace eprosima

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -698,11 +698,6 @@ ReaderHistory::iterator SubscriberHistory::remove_change_nts(
 
         auto& c = it->second.cache_changes;
         c.erase(std::remove(c.begin(), c.end(), p_sample), c.end());
-
-        if (c.empty())
-        {
-            keyed_changes_.erase(it);
-        }
     }
 
     // call the base class

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -684,24 +684,24 @@ History::iterator SubscriberHistory::remove_change_nts(
         History::const_iterator removal,
         bool release)
 {
-    if ( removal != changesEnd())
+    CacheChange_t* p_sample = nullptr;
+
+    if ( removal != changesEnd()
+            && (p_sample = *removal)->instanceHandle.isDefined()
+            && topic_att_.getTopicKind() == WITH_KEY)
     {
-        CacheChange_t* const p_sample = *removal;
-
         // clean any references to this CacheChange in the key state collection
-        for ( auto mit = keyed_changes_.begin(); mit != keyed_changes_.end();)
-        {
-            auto& c = mit->second.cache_changes;
-            c.erase(std::remove(c.begin(), c.end(), p_sample), c.end());
+        auto it = keyed_changes_.find(p_sample->instanceHandle);
 
-            if (c.empty())
-            {
-                mit = keyed_changes_.erase(mit);
-            }
-            else
-            {
-                ++mit;
-            }
+        // if keyed and in history must be in the map
+        assert(it != keyed_changes_.end());
+
+        auto& c = it->second.cache_changes;
+        c.erase(std::remove(c.begin(), c.end(), p_sample), c.end());
+
+        if (c.empty())
+        {
+            keyed_changes_.erase(it);
         }
     }
 

--- a/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
+++ b/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
@@ -109,8 +109,10 @@ public:
     }
 
     virtual iterator remove_change_nts(
-            const_iterator removal)
+            const_iterator removal,
+            bool release = true)
     {
+        (void)release;
         return m_changes.erase(removal);
     }
 

--- a/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
+++ b/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
@@ -46,6 +46,10 @@ public:
     {
     }
 
+    virtual ~ReaderHistory()
+    {
+    }
+
     // *INDENT-OFF* Uncrustify makes a mess with MOCK_METHOD macros
     MOCK_METHOD1(remove_change_mock, bool(CacheChange_t*));
 
@@ -66,6 +70,13 @@ public:
         change->sequenceNumber = ++last_sequence_number_;
         samples_number_mutex_.unlock();
         return ret;
+    }
+
+    virtual bool received_change(
+            CacheChange_t*,
+            size_t)
+    {
+        return true;
     }
 
     bool remove_change(
@@ -97,7 +108,7 @@ public:
         return m_changes.cend();
     }
 
-    iterator remove_change_nts(
+    virtual iterator remove_change_nts(
             const_iterator removal)
     {
         return m_changes.erase(removal);

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -1806,7 +1806,7 @@ TEST_F(DataReaderTests, check_key_history_wholesomeness_on_unmatch)
     // wait for termination
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
     // check expected result, if query thread hangs res = ReturnCode_t::RETCODE_OK
-    ASSERT_EQ(res, ReturnCode_t::RETCODE_BAD_PARAMETER);
+    ASSERT_NE(res, ReturnCode_t::RETCODE_OK);
     query.join();
 }
 

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -1749,6 +1749,67 @@ TEST_F(DataReaderTests, get_listening_locators)
     EXPECT_TRUE(multicast_found);
 }
 
+/*
+ * Issue https://github.com/eProsima/Fast-DDS/issues/2044 highlighted that a DataWriter removal may left DataReaders
+ * Histories in an invalid state. DataWriter removal triggers the clean up of any related sample in DataReader's
+ * History. Because the key related internal state was not updated and kept sample dangling references.
+ * */
+
+TEST_F(DataReaderTests, check_key_history_wholesomeness_on_unmatch)
+{
+    // handle_ok_ (1)
+    create_instance_handles();
+
+    // Set up entities
+    DataReaderQos reader_qos = DATAREADER_QOS_DEFAULT;
+    reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
+    reader_qos.history().kind = KEEP_ALL_HISTORY_QOS;
+
+    DataWriterQos writer_qos = DATAWRITER_QOS_DEFAULT;
+    writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
+    writer_qos.history().kind = KEEP_ALL_HISTORY_QOS;
+
+    // defaults to footopic using type FooType
+    create_entities(
+        nullptr,
+        reader_qos,
+        SUBSCRIBER_QOS_DEFAULT,
+        writer_qos);
+
+    // add a key sample
+    FooType sample;
+    std::array<char, 256> msg = {"checking robustness"};
+
+    sample.index(1);
+    sample.message(msg);
+
+    ASSERT_TRUE(data_writer_->write(&sample));
+
+    // wait till the DataReader receives the data
+    ASSERT_TRUE(data_reader_->wait_for_unread_message(Duration_t(3, 0)));
+
+    // now the writer is removed
+    ASSERT_EQ(publisher_->delete_datawriter(data_writer_), ReturnCode_t::RETCODE_OK);
+    data_writer_ = nullptr;
+
+    // here the DataReader History state must be coherent and don't loop endlessly
+    ReturnCode_t res;
+    std::thread query([this, &res]()
+            {
+                FooSeq samples;
+                SampleInfoSeq infos;
+
+                res = data_reader_->take_instance(samples, infos, LENGTH_UNLIMITED, handle_ok_);
+            });
+
+    // Check if the thread hangs
+    // wait for termination
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    // check expected result, if query thread hangs res = ReturnCode_t::RETCODE_OK
+    ASSERT_EQ(res, ReturnCode_t::RETCODE_BAD_PARAMETER);
+    query.join();
+}
+
 class DataReaderUnsupportedTests : public ::testing::Test
 {
 public:


### PR DESCRIPTION
This PR solves the issue https://github.com/eProsima/Fast-DDS/issues/2044 and workarounds the abi break introduced in https://github.com/eProsima/Fast-DDS/pull/2053.