### PR TITLE
Fix error in read_sample()/take_sample() operations with Datasharing [12130]

### DIFF
--- a/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
@@ -273,7 +273,6 @@ private:
             CacheChange_t* change,
             bool& deserialization_error)
     {
-        // Mark that some data is available
         bool ret_val = false;
         deserialization_error = false;
 

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
@@ -274,7 +274,6 @@ private:
             bool& deserialization_error)
     {
         // Mark that some data is available
-        return_value_ = ReturnCode_t::RETCODE_OK;
         bool ret_val = false;
         deserialization_error = false;
 
@@ -297,6 +296,8 @@ private:
                     deserialization_error = true;
                     return false;
                 }
+
+                return_value_ = ReturnCode_t::RETCODE_OK;
             }
 
             ++current_slot_;

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
@@ -297,6 +297,7 @@ private:
                     return false;
                 }
 
+                // Mark that some data is available
                 return_value_ = ReturnCode_t::RETCODE_OK;
             }
 

--- a/test/blackbox/types/Data1mbType.cpp
+++ b/test/blackbox/types/Data1mbType.cpp
@@ -48,31 +48,49 @@ bool Data1mbType::serialize(
         void* data,
         SerializedPayload_t* payload)
 {
+    bool ret_value = false;
     Data1mb* p_type = (Data1mb*) data;
-    eprosima::fastcdr::FastBuffer fastbuffer((char*)payload->data, payload->max_size); // Object that manages the raw buffer.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-            eprosima::fastcdr::Cdr::DDS_CDR);
-    payload->encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
-    // Serialize encapsulation
-    ser.serialize_encapsulation();
-    p_type->serialize(ser); // Serialize the object:
-    payload->length = (uint32_t)ser.getSerializedDataLength();  //Get the serialized length
-    return true;
+
+    try
+    {
+        eprosima::fastcdr::FastBuffer fastbuffer((char*)payload->data, payload->max_size); // Object that manages the raw buffer.
+        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+                eprosima::fastcdr::Cdr::DDS_CDR);
+        payload->encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+        // Serialize encapsulation
+        ser.serialize_encapsulation();
+        p_type->serialize(ser); // Serialize the object:
+        payload->length = (uint32_t)ser.getSerializedDataLength(); //Get the serialized length
+        ret_value = true;
+    }
+    catch (eprosima::fastcdr::exception::Exception&)
+    {
+    }
+    return ret_value;
 }
 
 bool Data1mbType::deserialize(
         SerializedPayload_t* payload,
         void* data)
 {
+    bool ret_value = false;
     Data1mb* p_type = (Data1mb*) data;  //Convert DATA to pointer of your type
-    eprosima::fastcdr::FastBuffer fastbuffer((char*)payload->data, payload->length);    // Object that manages the raw buffer.
-    eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-            eprosima::fastcdr::Cdr::DDS_CDR); // Object that deserializes the data.
-    // Deserialize encapsulation.
-    deser.read_encapsulation();
-    payload->encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
-    p_type->deserialize(deser);//Deserialize the object:
-    return true;
+
+    try
+    {
+        eprosima::fastcdr::FastBuffer fastbuffer((char*)payload->data, payload->length); // Object that manages the raw buffer.
+        eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+                eprosima::fastcdr::Cdr::DDS_CDR); // Object that deserializes the data.
+        // Deserialize encapsulation.
+        deser.read_encapsulation();
+        payload->encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+        p_type->deserialize(deser);//Deserialize the object:
+        ret_value = true;
+    }
+    catch (eprosima::fastcdr::exception::Exception&)
+    {
+    }
+    return ret_value;
 }
 
 void* Data1mbType::createData()

--- a/test/blackbox/types/Data64kbType.cpp
+++ b/test/blackbox/types/Data64kbType.cpp
@@ -48,31 +48,49 @@ bool Data64kbType::serialize(
         void* data,
         SerializedPayload_t* payload)
 {
+    bool ret_value = false;
     Data64kb* p_type = (Data64kb*) data;
-    eprosima::fastcdr::FastBuffer fastbuffer((char*)payload->data, payload->max_size); // Object that manages the raw buffer.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-            eprosima::fastcdr::Cdr::DDS_CDR);
-    payload->encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
-    // Serialize encapsulation
-    ser.serialize_encapsulation();
-    p_type->serialize(ser);     // Serialize the object:
-    payload->length = (uint32_t)ser.getSerializedDataLength();  //Get the serialized length
-    return true;
+
+    try
+    {
+        eprosima::fastcdr::FastBuffer fastbuffer((char*)payload->data, payload->max_size); // Object that manages the raw buffer.
+        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+                eprosima::fastcdr::Cdr::DDS_CDR);
+        payload->encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+        // Serialize encapsulation
+        ser.serialize_encapsulation();
+        p_type->serialize(ser); // Serialize the object:
+        payload->length = (uint32_t)ser.getSerializedDataLength(); //Get the serialized length
+        ret_value = true;
+    }
+    catch (eprosima::fastcdr::exception::Exception&)
+    {
+    }
+    return ret_value;
 }
 
 bool Data64kbType::deserialize(
         SerializedPayload_t* payload,
         void* data)
 {
+    bool ret_value = false;
     Data64kb* p_type = (Data64kb*) data;    //Convert DATA to pointer of your type
-    eprosima::fastcdr::FastBuffer fastbuffer((char*)payload->data, payload->length);    // Object that manages the raw buffer.
-    eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-            eprosima::fastcdr::Cdr::DDS_CDR); // Object that deserializes the data.
-    // Deserialize encapsulation.
-    deser.read_encapsulation();
-    payload->encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
-    p_type->deserialize(deser); //Deserialize the object:
-    return true;
+
+    try
+    {
+        eprosima::fastcdr::FastBuffer fastbuffer((char*)payload->data, payload->length); // Object that manages the raw buffer.
+        eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+                eprosima::fastcdr::Cdr::DDS_CDR); // Object that deserializes the data.
+        // Deserialize encapsulation.
+        deser.read_encapsulation();
+        payload->encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+        p_type->deserialize(deser); //Deserialize the object:
+        ret_value = true;
+    }
+    catch (eprosima::fastcdr::exception::Exception&)
+    {
+    }
+    return ret_value;
 }
 
 std::function<uint32_t()> Data64kbType::getSerializedSizeProvider(

--- a/test/blackbox/types/HelloWorldType.cpp
+++ b/test/blackbox/types/HelloWorldType.cpp
@@ -41,37 +41,54 @@ bool HelloWorldType::serialize(
         void* data,
         SerializedPayload_t* payload)
 {
+    bool ret_value = false;
     HelloWorld* hw = (HelloWorld*) data;
-    // Object that manages the raw buffer.
-    eprosima::fastcdr::FastBuffer fastbuffer((char*)payload->data, payload->max_size);
-    // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-            eprosima::fastcdr::Cdr::DDS_CDR);
-    payload->encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
-    // Serialize encapsulation
-    ser.serialize_encapsulation();
-    //serialize the object:
-    hw->serialize(ser);
-    payload->length = (uint32_t)ser.getSerializedDataLength();
-    return true;
+
+    try
+    {
+        // Object that manages the raw buffer.
+        eprosima::fastcdr::FastBuffer fastbuffer((char*)payload->data, payload->max_size);
+        // Object that serializes the data.
+        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+                eprosima::fastcdr::Cdr::DDS_CDR);
+        payload->encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+        // Serialize encapsulation
+        ser.serialize_encapsulation();
+        //serialize the object:
+        hw->serialize(ser);
+        payload->length = (uint32_t)ser.getSerializedDataLength();
+        ret_value = true;
+    }
+    catch (eprosima::fastcdr::exception::Exception&)
+    {
+    }
+    return ret_value;
 }
 
 bool HelloWorldType::deserialize(
         SerializedPayload_t* payload,
         void* data)
 {
+    bool ret_value = false;
     HelloWorld* hw = (HelloWorld*) data;
-    // Object that manages the raw buffer.
-    eprosima::fastcdr::FastBuffer fastbuffer((char*)payload->data, payload->length);
-    // Object that serializes the data.
-    eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-            eprosima::fastcdr::Cdr::DDS_CDR); // Object that deserializes the data.
-    // Deserialize encapsulation.
-    deser.read_encapsulation();
-    payload->encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
-    //serialize the object:
-    hw->deserialize(deser);
-    return true;
+    try
+    {
+        // Object that manages the raw buffer.
+        eprosima::fastcdr::FastBuffer fastbuffer((char*)payload->data, payload->length);
+        // Object that serializes the data.
+        eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+                eprosima::fastcdr::Cdr::DDS_CDR); // Object that deserializes the data.
+        // Deserialize encapsulation.
+        deser.read_encapsulation();
+        payload->encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+        //serialize the object:
+        hw->deserialize(deser);
+        ret_value = true;
+    }
+    catch (eprosima::fastcdr::exception::Exception&)
+    {
+    }
+    return ret_value;
 }
 
 std::function<uint32_t()> HelloWorldType::getSerializedSizeProvider(

--- a/test/blackbox/types/StringType.cpp
+++ b/test/blackbox/types/StringType.cpp
@@ -41,37 +41,55 @@ bool StringType::serialize(
         void* data,
         SerializedPayload_t* payload)
 {
+    bool ret_value = false;
     String* hw = (String*) data;
-    // Object that manages the raw buffer.
-    eprosima::fastcdr::FastBuffer fastbuffer((char*)payload->data, payload->max_size);
-    // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-            eprosima::fastcdr::Cdr::DDS_CDR);
-    payload->encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
-    // Serialize encapsulation
-    ser.serialize_encapsulation();
-    //serialize the object:
-    hw->serialize(ser);
-    payload->length = (uint32_t)ser.getSerializedDataLength();
-    return true;
+
+    try
+    {
+        // Object that manages the raw buffer.
+        eprosima::fastcdr::FastBuffer fastbuffer((char*)payload->data, payload->max_size);
+        // Object that serializes the data.
+        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+                eprosima::fastcdr::Cdr::DDS_CDR);
+        payload->encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+        // Serialize encapsulation
+        ser.serialize_encapsulation();
+        //serialize the object:
+        hw->serialize(ser);
+        payload->length = (uint32_t)ser.getSerializedDataLength();
+        ret_value = true;
+    }
+    catch (eprosima::fastcdr::exception::Exception&)
+    {
+    }
+    return ret_value;
 }
 
 bool StringType::deserialize(
         SerializedPayload_t* payload,
         void* data)
 {
+    bool ret_value = false;
     String* hw = (String*) data;
-    // Object that manages the raw buffer.
-    eprosima::fastcdr::FastBuffer fastbuffer((char*)payload->data, payload->length);
-    // Object that serializes the data.
-    eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-            eprosima::fastcdr::Cdr::DDS_CDR); // Object that deserializes the data.
-    // Deserialize encapsulation.
-    deser.read_encapsulation();
-    payload->encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
-    //serialize the object:
-    hw->deserialize(deser);
-    return true;
+
+    try
+    {
+        // Object that manages the raw buffer.
+        eprosima::fastcdr::FastBuffer fastbuffer((char*)payload->data, payload->length);
+        // Object that serializes the data.
+        eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+                eprosima::fastcdr::Cdr::DDS_CDR); // Object that deserializes the data.
+        // Deserialize encapsulation.
+        deser.read_encapsulation();
+        payload->encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+        //serialize the object:
+        hw->deserialize(deser);
+        ret_value =  true;
+    }
+    catch (eprosima::fastcdr::exception::Exception&)
+    {
+    }
+    return ret_value;
 }
 
 std::function<uint32_t()> StringType::getSerializedSizeProvider(

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -1069,7 +1069,7 @@ TEST_F(DataReaderTests, resource_limits)
         FooSeq data_seq;
         SampleInfoSeq info_seq;
 
-        // With length == 0 the returned code should be okNO_DATA
+        // With length == 0 the returned code should be NO_DATA
         EXPECT_EQ(no_data_code, data_reader_->read(data_seq, info_seq, 0));
 
         // Up to max_samples_per_read, max_samples will be returned

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -1069,7 +1069,9 @@ TEST_F(DataReaderTests, resource_limits)
         FooSeq data_seq;
         SampleInfoSeq info_seq;
 
-        // With length == 0 the returned code should be NO_DATA
+        //  The standard is not clear on what should be done if max_samples is 0. NO_DATA? OK with length = 0?
+        // We have assumed the correct interpretation is the first one.
+        // This test should change whenever this interpretation becomes invalid.
         EXPECT_EQ(no_data_code, data_reader_->read(data_seq, info_seq, 0));
 
         // Up to max_samples_per_read, max_samples will be returned

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -999,6 +999,7 @@ TEST_F(DataReaderTests, resource_limits)
 
     const ReturnCode_t& ok_code = ReturnCode_t::RETCODE_OK;
     const ReturnCode_t& resources_code = ReturnCode_t::RETCODE_OUT_OF_RESOURCES;
+    const ReturnCode_t& no_data_code = ReturnCode_t::RETCODE_NO_DATA;
 
     DataWriterQos writer_qos = DATAWRITER_QOS_DEFAULT;
     writer_qos.history().kind = KEEP_LAST_HISTORY_QOS;
@@ -1068,12 +1069,11 @@ TEST_F(DataReaderTests, resource_limits)
         FooSeq data_seq;
         SampleInfoSeq info_seq;
 
-        // The standard is not clear on what shold be done if max_samples is 0. NO_DATA? OK with length = 0?
-        // We have assumed the correct interpretation is the second one, so the following loop starts at 0.
-        // This test should change whenever this interpretation becomes invalid.
+        // With length == 0 the returned code should be okNO_DATA
+        EXPECT_EQ(no_data_code, data_reader_->read(data_seq, info_seq, 0));
 
         // Up to max_samples_per_read, max_samples will be returned
-        for (int32_t i = 0; i <= 10; ++i)
+        for (int32_t i = 1; i <= 10; ++i)
         {
             EXPECT_EQ(ok_code, data_reader_->read(data_seq, info_seq, i));
             check_collection(data_seq, false, i, i);

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -49,11 +49,11 @@
 #include <fastdds/rtps/common/Locator.h>
 #include <fastrtps/utils/IPLocator.h>
 
-#include "./FooBoundedType.hpp"
-#include "./FooBoundedTypeSupport.hpp"
+#include "FooBoundedType.hpp"
+#include "FooBoundedTypeSupport.hpp"
 
-#include "./FooType.hpp"
-#include "./FooTypeSupport.hpp"
+#include "FooType.hpp"
+#include "FooTypeSupport.hpp"
 
 #include "../../logging/mock/MockConsumer.h"
 
@@ -1600,6 +1600,46 @@ TEST_F(DataReaderTests, Deserialization_errors)
             check_sample_values(data_seq, "0123456789");
             EXPECT_EQ(ok_code, data_reader_->return_loan(data_seq, info_seq));
         }
+
+        {
+            FooSeq data_seq;
+            SampleInfoSeq info_seq;
+
+            // Reader should have 10 samples with the following states (R = read, N = not-read, / = removed from history)
+            // {N, N, N, N, N, N, N, N, N, N}
+
+            // This should return samples 0 to 9
+            EXPECT_EQ(ok_code, data_reader_->take(data_seq, info_seq, num_samples, READ_SAMPLE_STATE));
+            check_collection(data_seq, false, num_samples, num_samples);
+            check_sample_values(data_seq, "0123456789");
+            EXPECT_EQ(ok_code, data_reader_->return_loan(data_seq, info_seq));
+        }
+    }
+
+    // Check deserialization errors for read_next_sample and take_next_sample.
+    // Regression test for #12129
+    {
+        // Send two samples
+        for (char i = 0; i < 2; ++i)
+        {
+            data.message()[0] = 1;
+            EXPECT_EQ(ok_code, data_writer_->write(&data, handle_ok_));
+        }
+
+        // There are unread samples, so wait_for_unread should be ok
+        EXPECT_TRUE(data_reader_->wait_for_unread_message(time_to_wait));
+
+        {
+            FooType data;
+            SampleInfo info;
+            EXPECT_EQ(no_data_code, data_reader_->take_next_sample(&data, &info));
+        }
+
+        {
+            FooType data;
+            SampleInfo info;
+            EXPECT_EQ(no_data_code, data_reader_->read_next_sample(&data, &info));
+        }
     }
 
 }
@@ -2006,8 +2046,6 @@ TEST_F(DataReaderTests, read_samples_with_future_changes)
 
     ASSERT_EQ(publisher_->delete_datawriter(data_writer2), ReturnCode_t::RETCODE_OK);
 }
-
-
 
 } // namespace dds
 } // namespace fastdds

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -1632,13 +1632,11 @@ TEST_F(DataReaderTests, Deserialization_errors)
         EXPECT_TRUE(data_reader_->wait_for_unread_message(time_to_wait));
 
         {
-            FooType data;
             SampleInfo info;
             EXPECT_EQ(no_data_code, data_reader_->take_next_sample(&data, &info));
         }
 
         {
-            FooType data;
             SampleInfo info;
             EXPECT_EQ(no_data_code, data_reader_->read_next_sample(&data, &info));
         }


### PR DESCRIPTION
The bug was reproduced when reader's history is 1 depth and while read_sample()/take_sample() operation is deserializing the data, the data  is overwritten by the datawriter. The `ReadTakeCommand` returned OK and the code tries to access a 0 length vector.

Also the code was changed to return NO_DATA if the operation will return no data.