### PR TITLE
Read/Take return NO_DATA if a future change is found [12134]

### DIFF
--- a/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
@@ -140,39 +140,38 @@ struct ReadTakeCommand
 
                 // If the change is in the future we can skip the remaining changes in the history, as they will be
                 // in the future also
-                if (is_future_change)
+                if (!is_future_change)
                 {
-                    break;
-                }
 
-                // Add sample and info to collections
-                ReturnCode_t previous_return_value = return_value_;
-                bool added = add_sample(change, remove_change);
-                reader_->end_sample_access_nts(change, wp, added);
+                    // Add sample and info to collections
+                    ReturnCode_t previous_return_value = return_value_;
+                    bool added = add_sample(change, remove_change);
+                    reader_->end_sample_access_nts(change, wp, added);
 
-                // Check if the payload is dirty
-                if (added && !check_datasharing_validity(change, data_values_.has_ownership(), wp))
-                {
-                    // Decrement length of collections
-                    --current_slot_;
-                    ++remaining_samples_;
-                    data_values_.length(current_slot_);
-                    sample_infos_.length(current_slot_);
+                    // Check if the payload is dirty
+                    if (added && !check_datasharing_validity(change, data_values_.has_ownership(), wp))
+                    {
+                        // Decrement length of collections
+                        --current_slot_;
+                        ++remaining_samples_;
+                        data_values_.length(current_slot_);
+                        sample_infos_.length(current_slot_);
 
-                    return_value_ = previous_return_value;
-                    finished_ = false;
+                        return_value_ = previous_return_value;
+                        finished_ = false;
 
-                    remove_change = true;
-                    added = false;
-                }
+                        remove_change = true;
+                        added = false;
+                    }
 
-                if (remove_change || (added && take_samples))
-                {
-                    // Remove from history
-                    history_.remove_change_sub(change, it);
+                    if (remove_change || (added && take_samples))
+                    {
+                        // Remove from history
+                        history_.remove_change_sub(change, it);
 
-                    // Current iterator will point to change next to the one removed. Avoid incrementing.
-                    continue;
+                        // Current iterator will point to change next to the one removed. Avoid incrementing.
+                        continue;
+                    }
                 }
             }
 

--- a/test/unittest/dds/subscriber/CMakeLists.txt
+++ b/test/unittest/dds/subscriber/CMakeLists.txt
@@ -22,7 +22,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
 
         set(SUBSCRIBERTESTS_SOURCE SubscriberTests.cpp)
         set(DATAREADERTESTS_SOURCE DataReaderTests.cpp)
-        
+
         if(WIN32)
             add_definitions(-D_WIN32_WINNT=0x0601)
         endif()
@@ -43,8 +43,6 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
 
         add_executable(DataReaderTests ${DATAREADERTESTS_SOURCE})
         target_compile_definitions(DataReaderTests PRIVATE FASTRTPS_NO_LIB
-            BOOST_ASIO_STANDALONE
-            ASIO_STANDALONE
             $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
             $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
             )

--- a/test/unittest/dds/subscriber/CMakeLists.txt
+++ b/test/unittest/dds/subscriber/CMakeLists.txt
@@ -43,6 +43,8 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
 
         add_executable(DataReaderTests ${DATAREADERTESTS_SOURCE})
         target_compile_definitions(DataReaderTests PRIVATE FASTRTPS_NO_LIB
+            BOOST_ASIO_STANDALONE
+            ASIO_STANDALONE
             $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
             $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
             )


### PR DESCRIPTION
`ReadTakeCommand` breaks the search of new changes if it found a future change of a writer although there is unread changes from other writers.