### PR TITLE
Check for NDEBUG in logInfo [12218]

### DIFF
--- a/include/fastdds/dds/log/Log.hpp
+++ b/include/fastdds/dds/log/Log.hpp
@@ -291,7 +291,8 @@ protected:
 // Allow multiconfig platforms like windows to disable info queueing on Release and other non-debug configs
 #if !HAVE_LOG_NO_INFO &&  \
     (defined(FASTDDS_ENFORCE_LOG_INFO) || \
-    ((defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG)) && (defined(_DEBUG) || defined(__DEBUG))))
+    ((defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG)) && (defined(_DEBUG) || defined(__DEBUG) || \
+    !defined(NDEBUG))))
 #define logInfo_(cat, msg)                                                                              \
     {                                                                                                   \
         using namespace eprosima::fastdds::dds;                                                         \


### PR DESCRIPTION
As it is right now, `logInfo` only produces messages under the following conditions:
1. `HAVE_LOG_NO_INFO` is false AND
2. Either `FASTDDS_ENFORCE_LOG_INFO` is defined OR
3. `__INTERNALDEBUG` or `_INTERNALDEBUG` is defined AND `_DEBUG` or `__DEBUG` is defined.

* `HAVE_LOG_NO_INFO` can be set by users with `-DLOG_NO_INFO`, which defaults to OFF in debug and ON in every other configuration.
* `FASTDDS_ENFORCE_LOG_INFO` can be defined by the user and defaults to OFF
* `__INTERNALDEBUG` is defined when compiling Fast DDS with `-DINTERNAL_DEBUG`, which defaults to OFF
* `_INTERNALDEBUG` can be defined by the user. Fast DDS does not define it, nor Fast DDS CMakeLists
* `_DEBUG` is defined when using Windows config generators in build type is debug
* `__DEBUG` is defined iff `CMAKE_BUILD_TYPE` is set to exactly `Debug` (other casing will not match)

This means that a Linux user building in debug with `CMAKE_BUILD_TYPE=DEBUG` (or something other than Debug) and with `-DINTERNAL_DEBUG` can end up with no log infos. This PR adds an additional check for case 3, which is check for either `_DEBUG`, `__DEBUG` or that `NDEBUG` is not defined. `NDEBUG` is actually a C++ standard definition that must be set when building is something other than debug. CMake adds this definition by itself, so no CMakeLists.txt needs to be modified.

Signed-off-by: Eduardo Ponz Segrelles <eduardoponz@eprosima.com>