### PR TITLE
[12196] Add empty api

### DIFF
--- a/include/fastdds/rtps/participant/RTPSParticipant.h
+++ b/include/fastdds/rtps/participant/RTPSParticipant.h
@@ -150,8 +150,8 @@ public:
 
     /**
      * Update participant attributes.
-     * @param pqos New participant attributes.
-     * @return True on success.
+     * @param patt New participant attributes.
+     * @return True on success, false otherwise.
      */
     bool update_attributes(
             const RTPSParticipantAttributes& patt);

--- a/include/fastdds/rtps/participant/RTPSParticipant.h
+++ b/include/fastdds/rtps/participant/RTPSParticipant.h
@@ -149,6 +149,14 @@ public:
             const ReaderQos& rqos);
 
     /**
+     * Update participant attributes.
+     * @param pqos New participant attributes.
+     * @return True on success.
+     */
+    bool update_attributes(
+            const RTPSParticipantAttributes& patt);
+
+    /**
      * Update writer QOS
      * @param Writer to update
      * @param topicAtt Topic Attributes where you want to register it.

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -890,6 +890,11 @@ bool PDPServer::server_update_routine()
     return pending_work && discovery_db_.is_enabled();
 }
 
+void PDPServer::reload_server()
+{
+    return;
+}
+
 bool PDPServer::process_writers_acknowledgements()
 {
     logInfo(RTPS_PDP_SERVER, "process_writers_acknowledgements start");

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -890,7 +890,7 @@ bool PDPServer::server_update_routine()
     return pending_work && discovery_db_.is_enabled();
 }
 
-void PDPServer::reload_server()
+void PDPServer::update_remote_servers_list()
 {
     return;
 }

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
@@ -164,6 +164,11 @@ public:
      */
     bool server_update_routine();
 
+    /*
+     * Update the list of servers
+     */
+    void reload_server();
+
     fastdds::rtps::ddb::DiscoveryDataBase& discovery_db();
 
     const RemoteServerList_t& servers();

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
@@ -165,9 +165,9 @@ public:
     bool server_update_routine();
 
     /*
-     * Update the list of servers
+     * Update the list of remote servers
      */
-    void reload_server();
+    void update_remote_servers_list();
 
     fastdds::rtps::ddb::DiscoveryDataBase& discovery_db();
 

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -91,6 +91,12 @@ bool RTPSParticipant::registerReader(
     return mp_impl->registerReader(Reader, topicAtt, rqos);
 }
 
+bool RTPSParticipant::update_attributes(
+        const RTPSParticipantAttributes& patt)
+{
+    return mp_impl->update_attributes(patt);
+}
+
 bool RTPSParticipant::updateWriter(
         RTPSWriter* Writer,
         const TopicAttributes& topicAtt,

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1101,6 +1101,13 @@ bool RTPSParticipantImpl::registerReader(
     return this->mp_builtinProtocols->addLocalReader(reader, topicAtt, rqos);
 }
 
+bool RTPSParticipantImpl::update_attributes(
+        const RTPSParticipantAttributes& patt)
+{
+    (void)patt;
+    return false;
+}
+
 bool RTPSParticipantImpl::updateLocalWriter(
         RTPSWriter* Writer,
         const TopicAttributes& topicAtt,

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1104,7 +1104,7 @@ bool RTPSParticipantImpl::registerReader(
 bool RTPSParticipantImpl::update_attributes(
         const RTPSParticipantAttributes& patt)
 {
-    (void)patt;
+    static_cast<void>(patt);
     return false;
 }
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -809,6 +809,14 @@ public:
             const ReaderQos& rqos);
 
     /**
+     * Update participant attributes
+     * @param patt New participant attributes
+     * @return True on success
+     */
+    bool update_attributes(
+            const RTPSParticipantAttributes& patt);
+
+    /**
      * Update local writer QoS
      * @param Writer Writer to update
      * @param wqos New QoS for the writer

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -809,9 +809,9 @@ public:
             const ReaderQos& rqos);
 
     /**
-     * Update participant attributes
-     * @param patt New participant attributes
-     * @return True on success
+     * Update participant attributes.
+     * @param patt New participant attributes.
+     * @return True on success, false otherwise.
      */
     bool update_attributes(
             const RTPSParticipantAttributes& patt);


### PR DESCRIPTION
This PR adds the API necessary to propagate the `DomainParticipantQos` updates to the RTPS layer.

* `set_attributes` method to `RTPSParticipant` and `RTPSParticipantImpl`
* `upload_remote_servers_list` method to `PDPServer`

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>