### PR TITLE
[12196] DomainParticipantQos propagation to the RTPS layer implementation

### DIFF
--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -105,7 +105,7 @@ class QosPolicy
 {
 public:
 
-    //! Boolean that indicates if the Qos has been changed
+    //! Boolean that indicates if the Qos has been changed with respect to the default Qos.
     bool hasChanged;
 
     /**

--- a/include/fastdds/rtps/participant/RTPSParticipant.h
+++ b/include/fastdds/rtps/participant/RTPSParticipant.h
@@ -153,7 +153,7 @@ public:
      * @param patt New participant attributes.
      * @return True on success, false otherwise.
      */
-    bool update_attributes(
+    void update_attributes(
             const RTPSParticipantAttributes& patt);
 
     /**

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -351,6 +351,9 @@ ReturnCode_t DomainParticipantImpl::set_qos(
         fastrtps::rtps::RTPSParticipantAttributes patt;
         set_attributes_from_qos(patt, qos_);
         rtps_participant_->update_attributes(patt);
+
+        // Reset flag
+        qos_.user_data().hasChanged = false;
     }
 
     return ReturnCode_t::RETCODE_OK;
@@ -1754,7 +1757,10 @@ void DomainParticipantImpl::set_qos(
     if (!(to.user_data() == from.user_data()))
     {
         to.user_data() = from.user_data();
-        to.user_data().hasChanged = true;
+        if (!first_time)
+        {
+            to.user_data().hasChanged = true;
+        }
     }
     if (first_time && !(to.allocation() == from.allocation()))
     {

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -344,7 +344,7 @@ ReturnCode_t DomainParticipantImpl::set_qos(
         return ReturnCode_t::RETCODE_IMMUTABLE_POLICY;
     }
 
-    if (enabled && set_qos(qos_, qos_to_set, !enabled))
+    if (set_qos(qos_, qos_to_set, !enabled) && enabled)
     {
         // Notify the participant that there is a QoS update
         fastrtps::rtps::RTPSParticipantAttributes patt;

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -345,7 +345,7 @@ ReturnCode_t DomainParticipantImpl::set_qos(
     }
     set_qos(qos_, qos_to_set, !enabled);
 
-    if (qos_.user_data().hasChanged)
+    if (enabled && qos_.user_data().hasChanged)
     {
         // Notify the participant that there is a QoS update
         fastrtps::rtps::RTPSParticipantAttributes patt;

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -29,6 +29,7 @@
 #include <fastdds/dds/subscriber/DataReader.hpp>
 #include <fastdds/dds/publisher/DataWriter.hpp>
 
+#include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
 #include <fastdds/rtps/RTPSDomain.h>
 #include <fastdds/rtps/builtin/liveliness/WLP.h>
 #include <fastdds/rtps/participant/ParticipantDiscoveryInfo.h>
@@ -343,6 +344,15 @@ ReturnCode_t DomainParticipantImpl::set_qos(
         return ReturnCode_t::RETCODE_IMMUTABLE_POLICY;
     }
     set_qos(qos_, qos_to_set, !enabled);
+
+    if (qos_.user_data().hasChanged)
+    {
+        // Notify the participant that there is a QoS update
+        fastrtps::rtps::RTPSParticipantAttributes patt;
+        set_attributes_from_qos(patt, qos_);
+        rtps_participant_->update_attributes(patt);
+    }
+
     return ReturnCode_t::RETCODE_OK;
 }
 

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1746,7 +1746,7 @@ bool DomainParticipantImpl::set_qos(
         const DomainParticipantQos& from,
         bool first_time)
 {
-    bool qos_has_changed = false;
+    bool qos_should_be_updated = false;
 
     if (!(to.entity_factory() == from.entity_factory()))
     {
@@ -1758,7 +1758,7 @@ bool DomainParticipantImpl::set_qos(
         to.user_data().hasChanged = true;
         if (!first_time)
         {
-            qos_has_changed = true;
+            qos_should_be_updated = true;
         }
     }
     if (first_time && !(to.allocation() == from.allocation()))
@@ -1782,7 +1782,7 @@ bool DomainParticipantImpl::set_qos(
         to.name() = from.name();
     }
 
-    return qos_has_changed;
+    return qos_should_be_updated;
 }
 
 fastrtps::types::ReturnCode_t DomainParticipantImpl::check_qos(

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -559,7 +559,7 @@ protected:
     std::string get_inner_type_name(
             const fastrtps::rtps::SampleIdentity& id) const;
 
-    static void set_qos(
+    static bool set_qos(
             DomainParticipantQos& to,
             const DomainParticipantQos& from,
             bool first_time);

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -559,6 +559,16 @@ protected:
     std::string get_inner_type_name(
             const fastrtps::rtps::SampleIdentity& id) const;
 
+    /**
+     * Set the DomainParticipantQos checking if the Qos can be updated or not
+     *
+     * @param to DomainParticipantQos to be updated
+     * @param from DomainParticipantQos desired
+     * @param first_time Whether the DomainParticipant has been already initialized or not
+     *
+     * @return true if there has been a changed in one of the attributes that can be updated.
+     * false otherwise.
+     */
     static bool set_qos(
             DomainParticipantQos& to,
             const DomainParticipantQos& from,

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -394,6 +394,7 @@ RTPSParticipant* RTPSDomain::clientServerEnvironmentCreationOverride(
     RTPSParticipantAttributes client_att(att);
 
     // Retrieve the info from the environment variable
+    // TODO(jlbueno) This should be protected with the PDP mutex.
     if (!load_environment_server_info(client_att.builtin.discovery_config.m_DiscoveryServers))
     {
         // it's not an error, the environment variable may not be set. Any issue with environment

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -80,6 +80,12 @@ bool BuiltinProtocols::initBuiltinProtocols(
     m_metatrafficMulticastLocatorList = m_att.metatrafficMulticastLocatorList;
     m_initialPeersList = m_att.initialPeersList;
 
+    // TODO(jlbueno) The access to the list should be protected with the PDP mutex but requires a refactor on PDPClient
+    // and PDPServer: read the remote servers list after the initialization of PDP.
+    m_DiscoveryServers = m_att.discovery_config.m_DiscoveryServers;
+
+    transform_server_remote_locators(p_part->network_factory());
+
     const RTPSParticipantAllocationAttributes& allocation = p_part->getRTPSParticipantAttributes().allocation;
 
     // PDP
@@ -126,13 +132,6 @@ bool BuiltinProtocols::initBuiltinProtocols(
         return false;
     }
 
-    {
-        std::unique_lock<std::recursive_mutex> lock(*mp_PDP->getMutex());
-        m_DiscoveryServers = m_att.discovery_config.m_DiscoveryServers;
-    }
-
-    transform_server_remote_locators(p_part->network_factory());
-
     // WLP
     if (m_att.use_WriterLivelinessProtocol)
     {
@@ -164,7 +163,8 @@ bool BuiltinProtocols::updateMetatrafficLocators(
 void BuiltinProtocols::transform_server_remote_locators(
         NetworkFactory& nf)
 {
-    std::unique_lock<std::recursive_mutex> lock(*mp_PDP->getMutex());
+    // TODO(jlbueno) The access to the list should be protected with the PDP mutex but requires a refactor on PDPClient
+    // and PDPServer: read the remote servers list after the initialization of PDP.
     for (eprosima::fastdds::rtps::RemoteServerAttributes& rs : m_DiscoveryServers)
     {
         for (Locator_t& loc : rs.metatrafficUnicastLocatorList)

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -79,9 +79,6 @@ bool BuiltinProtocols::initBuiltinProtocols(
     m_metatrafficUnicastLocatorList = m_att.metatrafficUnicastLocatorList;
     m_metatrafficMulticastLocatorList = m_att.metatrafficMulticastLocatorList;
     m_initialPeersList = m_att.initialPeersList;
-    m_DiscoveryServers = m_att.discovery_config.m_DiscoveryServers;
-
-    transform_server_remote_locators(p_part->network_factory());
 
     const RTPSParticipantAllocationAttributes& allocation = p_part->getRTPSParticipantAttributes().allocation;
 
@@ -129,6 +126,13 @@ bool BuiltinProtocols::initBuiltinProtocols(
         return false;
     }
 
+    {
+        std::unique_lock<std::recursive_mutex> lock(*mp_PDP->getMutex());
+        m_DiscoveryServers = m_att.discovery_config.m_DiscoveryServers;
+    }
+
+    transform_server_remote_locators(p_part->network_factory());
+
     // WLP
     if (m_att.use_WriterLivelinessProtocol)
     {
@@ -160,6 +164,7 @@ bool BuiltinProtocols::updateMetatrafficLocators(
 void BuiltinProtocols::transform_server_remote_locators(
         NetworkFactory& nf)
 {
+    std::unique_lock<std::recursive_mutex> lock(*mp_PDP->getMutex());
     for (eprosima::fastdds::rtps::RemoteServerAttributes& rs : m_DiscoveryServers)
     {
         for (Locator_t& loc : rs.metatrafficUnicastLocatorList)

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1075,6 +1075,7 @@ ParticipantProxyData* PDP::get_participant_proxy_data(
 
 std::list<eprosima::fastdds::rtps::RemoteServerAttributes>& PDP::remote_server_attributes()
 {
+    std::unique_lock<std::recursive_mutex> lock(*getMutex());
     return mp_builtin->m_DiscoveryServers;
 }
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -215,19 +215,22 @@ bool PDPClient::createPDPEndpoints()
         //        mp_RTPSParticipant->set_endpoint_rtps_protection_supports(rout, false);
         //#endif
         // Initial peer list doesn't make sense in server scenario. Client should match its server list
-        for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
         {
-            std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-            temp_writer_data_.clear();
-            temp_writer_data_.guid(it.GetPDPWriter());
-            temp_writer_data_.set_multicast_locators(it.metatrafficMulticastLocatorList, network);
-            temp_writer_data_.set_remote_unicast_locators(it.metatrafficUnicastLocatorList, network);
-            temp_writer_data_.m_qos.m_durability.kind = TRANSIENT_DURABILITY_QOS;  // Server Information must be persistent
-            temp_writer_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+            std::lock_guard<std::recursive_mutex> lock(*getMutex());
 
-            mp_PDPReader->matched_writer_add(temp_writer_data_);
+            for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
+            {
+                std::lock_guard<std::mutex> data_guard(temp_data_lock_);
+                temp_writer_data_.clear();
+                temp_writer_data_.guid(it.GetPDPWriter());
+                temp_writer_data_.set_multicast_locators(it.metatrafficMulticastLocatorList, network);
+                temp_writer_data_.set_remote_unicast_locators(it.metatrafficUnicastLocatorList, network);
+                temp_writer_data_.m_qos.m_durability.kind = TRANSIENT_DURABILITY_QOS;  // Server Information must be persistent
+                temp_writer_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+
+                mp_PDPReader->matched_writer_add(temp_writer_data_);
+            }
         }
-
     }
     else
     {
@@ -267,19 +270,22 @@ bool PDPClient::createPDPEndpoints()
         //#if HAVE_SECURITY
         //        mp_RTPSParticipant->set_endpoint_rtps_protection_supports(wout, false);
         //#endif
-        for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
         {
-            std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-            temp_reader_data_.clear();
-            temp_reader_data_.guid(it.GetPDPReader());
-            temp_reader_data_.set_multicast_locators(it.metatrafficMulticastLocatorList, network);
-            temp_reader_data_.set_remote_unicast_locators(it.metatrafficUnicastLocatorList, network);
-            temp_reader_data_.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
-            temp_reader_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+            std::lock_guard<std::recursive_mutex> lock(*getMutex());
 
-            mp_PDPWriter->matched_reader_add(temp_reader_data_);
+            for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
+            {
+                std::lock_guard<std::mutex> data_guard(temp_data_lock_);
+                temp_reader_data_.clear();
+                temp_reader_data_.guid(it.GetPDPReader());
+                temp_reader_data_.set_multicast_locators(it.metatrafficMulticastLocatorList, network);
+                temp_reader_data_.set_remote_unicast_locators(it.metatrafficUnicastLocatorList, network);
+                temp_reader_data_.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
+                temp_reader_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+
+                mp_PDPWriter->matched_reader_add(temp_reader_data_);
+            }
         }
-
     }
     else
     {

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -1236,7 +1236,6 @@ fastdds::rtps::ddb::DiscoveryDataBase& PDPServer::discovery_db()
 
 const RemoteServerList_t& PDPServer::servers()
 {
-    std::lock_guard<std::recursive_mutex> lock(*getMutex());
     return mp_builtin->m_DiscoveryServers;
 }
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -69,13 +69,17 @@ PDPServer::PDPServer(
 {
     // Add remote servers from environment variable
     RemoteServerList_t env_servers;
-    if (load_environment_server_info(env_servers))
     {
-        for (auto server : env_servers)
+        std::lock_guard<std::recursive_mutex> lock(*getMutex());
+
+        if (load_environment_server_info(env_servers))
         {
-            mp_builtin->m_DiscoveryServers.push_back(server);
-            m_discovery.discovery_config.m_DiscoveryServers.push_back(server);
-            discovery_db_.add_server(server.guidPrefix);
+            for (auto server : env_servers)
+            {
+                mp_builtin->m_DiscoveryServers.push_back(server);
+                m_discovery.discovery_config.m_DiscoveryServers.push_back(server);
+                discovery_db_.add_server(server.guidPrefix);
+            }
         }
     }
 }
@@ -260,20 +264,24 @@ bool PDPServer::createPDPEndpoints()
         // Enable unknown clients to reach this reader
         mp_PDPReader->enableMessagesFromUnkownWriters(true);
 
-        // Initial peer list doesn't make sense in server scenario. Client should match its server list
-        for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
         {
-            std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-            temp_writer_data_.clear();
-            temp_writer_data_.guid(it.GetPDPWriter());
-            temp_writer_data_.set_multicast_locators(it.metatrafficMulticastLocatorList, network);
-            temp_writer_data_.set_remote_unicast_locators(it.metatrafficUnicastLocatorList, network);
-            // TODO check if this is correct, it is equal as PDPServer, but we do not know like this the durKind of the
-            // other server
-            temp_writer_data_.m_qos.m_durability.durabilityKind(durability_);
-            temp_writer_data_.m_qos.m_reliability.kind = fastrtps::RELIABLE_RELIABILITY_QOS;
+            std::lock_guard<std::recursive_mutex> lock(*getMutex());
 
-            mp_PDPReader->matched_writer_add(temp_writer_data_);
+            // Initial peer list doesn't make sense in server scenario. Client should match its server list
+            for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
+            {
+                std::lock_guard<std::mutex> data_guard(temp_data_lock_);
+                temp_writer_data_.clear();
+                temp_writer_data_.guid(it.GetPDPWriter());
+                temp_writer_data_.set_multicast_locators(it.metatrafficMulticastLocatorList, network);
+                temp_writer_data_.set_remote_unicast_locators(it.metatrafficUnicastLocatorList, network);
+                // TODO check if this is correct, it is equal as PDPServer, but we do not know like this the durKind of the
+                // other server
+                temp_writer_data_.m_qos.m_durability.durabilityKind(durability_);
+                temp_writer_data_.m_qos.m_reliability.kind = fastrtps::RELIABLE_RELIABILITY_QOS;
+
+                mp_PDPReader->matched_writer_add(temp_writer_data_);
+            }
         }
     }
     // Could not create PDP Reader, so return false
@@ -330,17 +338,21 @@ bool PDPServer::createPDPEndpoints()
         // Enable separate sending so the filter can be called for each change and reader proxy
         mp_PDPWriter->set_separate_sending(true);
 
-        for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
         {
-            std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-            temp_reader_data_.clear();
-            temp_reader_data_.guid(it.GetPDPReader());
-            temp_reader_data_.set_multicast_locators(it.metatrafficMulticastLocatorList, network);
-            temp_reader_data_.set_remote_unicast_locators(it.metatrafficUnicastLocatorList, network);
-            temp_reader_data_.m_qos.m_durability.kind = fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS;
-            temp_reader_data_.m_qos.m_reliability.kind = fastrtps::RELIABLE_RELIABILITY_QOS;
+            std::lock_guard<std::recursive_mutex> lock(*getMutex());
 
-            mp_PDPWriter->matched_reader_add(temp_reader_data_);
+            for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
+            {
+                std::lock_guard<std::mutex> data_guard(temp_data_lock_);
+                temp_reader_data_.clear();
+                temp_reader_data_.guid(it.GetPDPReader());
+                temp_reader_data_.set_multicast_locators(it.metatrafficMulticastLocatorList, network);
+                temp_reader_data_.set_remote_unicast_locators(it.metatrafficUnicastLocatorList, network);
+                temp_reader_data_.m_qos.m_durability.kind = fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS;
+                temp_reader_data_.m_qos.m_reliability.kind = fastrtps::RELIABLE_RELIABILITY_QOS;
+
+                mp_PDPWriter->matched_reader_add(temp_reader_data_);
+            }
         }
     }
     // Could not create PDP Writer, so return false
@@ -1224,6 +1236,7 @@ fastdds::rtps::ddb::DiscoveryDataBase& PDPServer::discovery_db()
 
 const RemoteServerList_t& PDPServer::servers()
 {
+    std::lock_guard<std::recursive_mutex> lock(*getMutex());
     return mp_builtin->m_DiscoveryServers;
 }
 
@@ -1338,6 +1351,7 @@ bool PDPServer::pending_ack()
 
 std::vector<fastrtps::rtps::GuidPrefix_t> PDPServer::servers_prefixes()
 {
+    std::lock_guard<std::recursive_mutex> lock(*getMutex());
     std::vector<GuidPrefix_t> servers;
     for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
     {
@@ -1367,16 +1381,20 @@ void PDPServer::ping_remote_servers()
     LocatorList locators;
 
     // Iterate over the list of servers
-    for (auto& server : mp_builtin->m_DiscoveryServers)
     {
+        std::lock_guard<std::recursive_mutex> lock(*getMutex());
 
-        // If the server is the the ack_pending list, then add its GUID and locator to send the announcement
-        auto server_it = std::find(ack_pending_servers.begin(), ack_pending_servers.end(), server.guidPrefix);
-        if (server_it != ack_pending_servers.end())
+        for (auto& server : mp_builtin->m_DiscoveryServers)
         {
-            // get the info to send to this already known locators
-            remote_readers.push_back(GUID_t(server.guidPrefix, c_EntityId_SPDPReader));
-            locators.push_back(server.metatrafficUnicastLocatorList);
+
+            // If the server is the the ack_pending list, then add its GUID and locator to send the announcement
+            auto server_it = std::find(ack_pending_servers.begin(), ack_pending_servers.end(), server.guidPrefix);
+            if (server_it != ack_pending_servers.end())
+            {
+                // get the info to send to this already known locators
+                remote_readers.push_back(GUID_t(server.guidPrefix, c_EntityId_SPDPReader));
+                locators.push_back(server.metatrafficUnicastLocatorList);
+            }
         }
     }
     send_announcement(discovery_db().cache_change_own_participant(), remote_readers, locators);

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
@@ -171,6 +171,12 @@ public:
 
     fastdds::rtps::ddb::DiscoveryDataBase& discovery_db();
 
+    /**
+     * Access to the remote servers list
+     * This method is not thread safe.
+     * The return reference may be invalidated if the user modifies simultaneously the remote server list.
+     * @return constant reference to the remote servers list
+     */
     const RemoteServerList_t& servers();
 
 protected:

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -91,10 +91,10 @@ bool RTPSParticipant::registerReader(
     return mp_impl->registerReader(Reader, topicAtt, rqos);
 }
 
-bool RTPSParticipant::update_attributes(
+void RTPSParticipant::update_attributes(
         const RTPSParticipantAttributes& patt)
 {
-    return mp_impl->update_attributes(patt);
+    mp_impl->update_attributes(patt);
 }
 
 bool RTPSParticipant::updateWriter(

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1114,11 +1114,21 @@ bool RTPSParticipantImpl::update_attributes(
         local_participant_proxy_data->m_userData.data_vec(patt.userData);
 
         // Update remote servers list
-        mp_builtinProtocols->m_DiscoveryServers = patt.builtin.discovery_config.m_DiscoveryServers;
-        mp_builtinProtocols->m_att.discovery_config.m_DiscoveryServers =
-            patt.builtin.discovery_config.m_DiscoveryServers;
-        fastdds::rtps::PDPServer* pdp_server = static_cast<fastdds::rtps::PDPServer*>(pdp);
-        pdp_server->update_remote_servers_list();
+        if (patt.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::CLIENT ||
+                patt.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::SUPER_CLIENT ||
+                patt.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::SERVER ||
+                patt.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::BACKUP)
+        {
+            mp_builtinProtocols->m_DiscoveryServers = patt.builtin.discovery_config.m_DiscoveryServers;
+            mp_builtinProtocols->m_att.discovery_config.m_DiscoveryServers =
+                patt.builtin.discovery_config.m_DiscoveryServers;
+            if (patt.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::SERVER ||
+                    patt.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::BACKUP)
+            {
+                fastdds::rtps::PDPServer* pdp_server = static_cast<fastdds::rtps::PDPServer*>(pdp);
+                pdp_server->update_remote_servers_list();
+            }
+        }
     }
 
     // Send DATA(P)

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1108,7 +1108,7 @@ void RTPSParticipantImpl::update_attributes(
 {
     // Check if there are changes
     if (patt.builtin.discovery_config.m_DiscoveryServers == m_att.builtin.discovery_config.m_DiscoveryServers
-            || patt.userData == m_att.userData)
+            && patt.userData == m_att.userData)
     {
         return;
     }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1121,7 +1121,7 @@ bool RTPSParticipantImpl::update_attributes(
         {
             mp_builtinProtocols->m_DiscoveryServers = patt.builtin.discovery_config.m_DiscoveryServers;
             mp_builtinProtocols->m_att.discovery_config.m_DiscoveryServers =
-                patt.builtin.discovery_config.m_DiscoveryServers;
+                    patt.builtin.discovery_config.m_DiscoveryServers;
             if (patt.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::SERVER ||
                     patt.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::BACKUP)
             {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1104,8 +1104,17 @@ bool RTPSParticipantImpl::registerReader(
 bool RTPSParticipantImpl::update_attributes(
         const RTPSParticipantAttributes& patt)
 {
-    static_cast<void>(patt);
-    return false;
+    // Update user data
+    auto pdp = mp_builtinProtocols->mp_PDP;
+    pdp->getMutex()->lock();
+    auto local_participant_proxy_data = pdp->getLocalParticipantProxyData();
+    local_participant_proxy_data->m_userData.data_vec(patt.userData);
+    pdp->getMutex()->unlock();
+
+    // Send DATA(P)
+    pdp->announceParticipantState(true);
+
+    return true;
 }
 
 bool RTPSParticipantImpl::updateLocalWriter(

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -63,6 +63,8 @@
 #include <fastdds/rtps/builtin/data/ParticipantProxyData.h>
 #include <fastdds/rtps/builtin/liveliness/WLP.h>
 
+#include <rtps/builtin/discovery/participant/PDPServer.hpp>
+
 #include <statistics/rtps/GuidUtils.hpp>
 
 namespace eprosima {
@@ -1110,6 +1112,12 @@ bool RTPSParticipantImpl::update_attributes(
     auto local_participant_proxy_data = pdp->getLocalParticipantProxyData();
     local_participant_proxy_data->m_userData.data_vec(patt.userData);
     pdp->getMutex()->unlock();
+
+    // Update remote servers list
+    mp_builtinProtocols->m_DiscoveryServers = patt.builtin.discovery_config.m_DiscoveryServers;
+    mp_builtinProtocols->m_att.discovery_config.m_DiscoveryServers = patt.builtin.discovery_config.m_DiscoveryServers;
+    fastdds::rtps::PDPServer* pdp_server = static_cast<fastdds::rtps::PDPServer*>(pdp);
+    pdp_server->update_remote_servers_list(); 
 
     // Send DATA(P)
     pdp->announceParticipantState(true);

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1115,7 +1115,7 @@ void RTPSParticipantImpl::update_attributes(
 
     // Update RTPSParticipantAttributes member
     m_att.builtin.discovery_config.m_DiscoveryServers = patt.builtin.discovery_config.m_DiscoveryServers;
-    m_att.userData = m_att.userData;
+    m_att.userData = patt.userData;
 
     auto pdp = mp_builtinProtocols->mp_PDP;
     {
@@ -1123,7 +1123,7 @@ void RTPSParticipantImpl::update_attributes(
 
         // Update user data
         auto local_participant_proxy_data = pdp->getLocalParticipantProxyData();
-        local_participant_proxy_data->m_userData.data_vec(patt.userData);
+        local_participant_proxy_data->m_userData.data_vec(m_att.userData);
 
         // Update remote servers list
         if (m_att.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::CLIENT ||
@@ -1131,9 +1131,7 @@ void RTPSParticipantImpl::update_attributes(
                 m_att.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::SERVER ||
                 m_att.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::BACKUP)
         {
-            mp_builtinProtocols->m_DiscoveryServers = patt.builtin.discovery_config.m_DiscoveryServers;
-            mp_builtinProtocols->m_att.discovery_config.m_DiscoveryServers =
-                    patt.builtin.discovery_config.m_DiscoveryServers;
+            mp_builtinProtocols->m_DiscoveryServers = m_att.builtin.discovery_config.m_DiscoveryServers;
             if (m_att.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::SERVER ||
                     m_att.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::BACKUP)
             {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -813,7 +813,7 @@ public:
      * @param patt New participant attributes.
      * @return True on success, false otherwise.
      */
-    bool update_attributes(
+    void update_attributes(
             const RTPSParticipantAttributes& patt);
 
     /**

--- a/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
+++ b/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
@@ -592,7 +592,7 @@ protected:
         return new SubscriberImpl(this, qos, listener);
     }
 
-    static void set_qos(
+    static bool set_qos(
             DomainParticipantQos& /*to*/,
             const DomainParticipantQos& /*from*/,
             bool /*first_time*/)

--- a/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.h
+++ b/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.h
@@ -163,6 +163,13 @@ public:
         return attributes_;
     }
 
+    bool update_attributes(
+            const RTPSParticipantAttributes& patt)
+    {
+        static_cast<void>(patt);
+        return true;
+    }
+
 #if HAVE_SECURITY
 
     MOCK_METHOD1(is_security_enabled_for_writer, bool(


### PR DESCRIPTION
This PR implements the link between the DDS and the RTPS layer to propagate the updates to the `DomainParticipantQos`.
It also includes the access protection of the remote servers list with the `PDP` mutex.