### PR TITLE
[12196] Add UserDataQoS blackbox test

### DIFF
--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -512,6 +512,20 @@ public:
         return *this;
     }
 
+    PubSubParticipant& user_data(
+            const std::vector<eprosima::fastrtps::rtps::octet>& user_data)
+    {
+        participant_qos_.user_data().data_vec(user_data);
+        return *this;
+    }
+
+    bool update_user_data(
+            const std::vector<eprosima::fastrtps::rtps::octet>& user_data)
+    {
+        participant_qos_.user_data().data_vec(user_data);
+        return ReturnCode_t::RETCODE_OK == participant_->set_qos(participant_qos_);
+    }
+
     PubSubParticipant& pub_property_policy(
             const eprosima::fastrtps::rtps::PropertyPolicy property_policy)
     {

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -39,6 +39,7 @@
 #include <fastdds/dds/subscriber/DataReaderListener.hpp>
 #include <fastdds/dds/subscriber/Subscriber.hpp>
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
+#include <fastdds/rtps/participant/ParticipantDiscoveryInfo.h>
 
 /**
  * @brief A class with one participant that can have multiple publishers and subscribers
@@ -144,6 +145,57 @@ private:
         PubSubParticipant* participant_;
     };
 
+    class ParticipantListener : public eprosima::fastdds::dds::DomainParticipantListener
+    {
+        friend class PubSubParticipant;
+
+    public:
+
+        ParticipantListener(
+                PubSubParticipant* participant)
+            : participant_(participant)
+        {
+        }
+
+        ~ParticipantListener() = default;
+
+        void on_participant_discovery(
+                eprosima::fastdds::dds::DomainParticipant*,
+                eprosima::fastrtps::rtps::ParticipantDiscoveryInfo&& info)
+        {
+            if (participant_->on_discovery_ != nullptr)
+            {
+                std::unique_lock<std::mutex> lock(participant_->mutex_discovery_);
+                participant_->discovery_result_ |= participant_->on_discovery_(info);
+                participant_->cv_discovery_.notify_one();
+            }
+
+            if (participant_->on_participant_qos_update_ != nullptr)
+            {
+                std::unique_lock<std::mutex> lock(participant_->mutex_discovery_);
+                participant_->participant_qos_updated_ |= participant_->on_participant_qos_update_(info);
+                participant_->cv_discovery_.notify_one();
+            }
+
+            if (info.status == eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::DISCOVERED_PARTICIPANT)
+            {
+                participant_->participant_matched();
+            }
+            else if (info.status == eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::REMOVED_PARTICIPANT ||
+                    info.status == eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::DROPPED_PARTICIPANT)
+            {
+                participant_->participant_unmatched();
+            }
+        }
+
+    private:
+
+        ParticipantListener& operator=(
+                const ParticipantListener&) = delete;
+        PubSubParticipant* participant_;
+
+    };
+
 public:
 
     PubSubParticipant(
@@ -158,8 +210,14 @@ public:
         , num_expected_publishers_(num_expected_publishers)
         , publishers_(num_publishers)
         , subscribers_(num_subscribers)
+        , participant_listener_(this)
         , pub_listener_(this)
         , sub_listener_(this)
+        , matched_(0)
+        , on_discovery_(nullptr)
+        , on_participant_qos_update_(nullptr)
+        , discovery_result_(false)
+        , participant_qos_updated_(false)
         , pub_matched_(0)
         , sub_matched_(0)
         , pub_times_liveliness_lost_(0)
@@ -242,9 +300,13 @@ public:
 
     bool init_participant()
     {
+        matched_ = 0;
+
         participant_ = eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->create_participant(
             (uint32_t)GET_PID() % 230,
-            participant_qos_);
+            participant_qos_,
+            &participant_listener_,
+            eprosima::fastdds::dds::StatusMask::none());
 
         if (participant_ != nullptr)
         {
@@ -358,6 +420,44 @@ public:
             unsigned int index = 0)
     {
         std::get<2>(publishers_[index])->assert_liveliness();
+    }
+
+    bool wait_discovery(
+            std::chrono::seconds timeout = std::chrono::seconds::zero())
+    {
+        bool ret_value = true;
+        std::unique_lock<std::mutex> lock(mutex_discovery_);
+
+        std::cout << "Participant is waiting discovery..." << std::endl;
+
+        if (timeout == std::chrono::seconds::zero())
+        {
+            cv_discovery_.wait(lock, [&]()
+                     {
+                         return matched_ != 0;
+                     });
+        }
+        else
+        {
+            if(!cv_discovery_.wait_for(lock, timeout, [&]()
+                     {
+                         return matched_ != 0;
+                     }))
+            {
+                ret_value = false;
+            }
+        }
+
+        if (ret_value)
+        {
+            std::cout << "Participant discovery finished successfully..." << std::endl;
+        }
+        else
+        {
+            std::cout << "Participant discovery finished unsuccessfully..." << std::endl;
+        }
+
+        return ret_value;
     }
 
     void pub_wait_discovery(
@@ -683,10 +783,64 @@ public:
         return sub_times_liveliness_recovered_;
     }
 
+    void wait_discovery_result()
+    {
+        std::unique_lock<std::mutex> lock(mutex_discovery_);
+
+        std::cout << "Participant is waiting discovery result..." << std::endl;
+
+        cv_discovery_.wait(lock, [&]() ->  bool
+                {
+                    return discovery_result_;
+                });
+
+        std::cout << "Participant gets discovery result..." << std::endl;
+    }
+
+    void wait_qos_update()
+    {
+        std::unique_lock<std::mutex> lock(mutex_discovery_);
+
+        std::cout << "Participant is waiting QoS update..." << std::endl;
+
+        cv_discovery_.wait(lock, [&]() -> bool
+                {
+                    return participant_qos_updated_;
+                });
+
+        std::cout << "Participant gets QoS update..." << std::endl;
+    }
+
+    void set_on_discovery_function(
+            std::function<bool(const eprosima::fastrtps::rtps::ParticipantDiscoveryInfo&)> f)
+    {
+        on_discovery_ = f;
+    }
+
+    void set_on_participant_qos_update_function(
+            std::function<bool(const eprosima::fastrtps::rtps::ParticipantDiscoveryInfo&)> f)
+    {
+        on_participant_qos_update_ = f;
+    }
+
 private:
 
     PubSubParticipant& operator =(
             const PubSubParticipant&) = delete;
+
+    void participant_matched()
+    {
+        std::unique_lock<std::mutex> lock(mutex_discovery_);
+        ++matched_;
+        cv_discovery_.notify_one();
+    }
+
+    void participant_unmatched()
+    {
+        std::unique_lock<std::mutex> lock(mutex_discovery_);
+        --matched_;
+        cv_discovery_.notify_one();
+    }
 
     void pub_matched()
     {
@@ -742,12 +896,23 @@ private:
     eprosima::fastdds::dds::DataWriterQos datawriter_qos_;
     //! Subscriber attributes
     eprosima::fastdds::dds::DataReaderQos datareader_qos_;
+    //! A listener for participants
+    ParticipantListener participant_listener_;
     //! A listener for publishers
     PubListener pub_listener_;
     //! A listener for subscribers
     SubListener sub_listener_;
     std::string publisher_topicname_;
     std::string subscriber_topicname_;
+
+    //! Discovery
+    std::mutex mutex_discovery_;
+    std::condition_variable cv_discovery_;
+    std::atomic<unsigned int> matched_;
+    std::function<bool(const eprosima::fastrtps::rtps::ParticipantDiscoveryInfo& info)> on_discovery_;
+    std::function<bool(const eprosima::fastrtps::rtps::ParticipantDiscoveryInfo& info)> on_participant_qos_update_;
+    bool discovery_result_;
+    bool participant_qos_updated_;
 
     std::mutex pub_mutex_;
     std::mutex sub_mutex_;

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -190,7 +190,7 @@ private:
 
     private:
 
-        ParticipantListener& operator=(
+        ParticipantListener& operator =(
                 const ParticipantListener&) = delete;
         PubSubParticipant* participant_;
 
@@ -433,16 +433,16 @@ public:
         if (timeout == std::chrono::seconds::zero())
         {
             cv_discovery_.wait(lock, [&]()
-                     {
-                         return matched_ != 0;
-                     });
+                    {
+                        return matched_ != 0;
+                    });
         }
         else
         {
-            if(!cv_discovery_.wait_for(lock, timeout, [&]()
-                     {
-                         return matched_ != 0;
-                     }))
+            if (!cv_discovery_.wait_for(lock, timeout, [&]()
+                    {
+                        return matched_ != 0;
+                    }))
             {
                 ret_value = false;
             }

--- a/test/blackbox/common/DDSBlackboxTestsUserDataQos.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsUserDataQos.cpp
@@ -1,0 +1,137 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "BlackboxTests.hpp"
+
+#include "PubSubParticipant.hpp"
+
+#include <fastdds/rtps/common/Types.h>
+#include <fastdds/rtps/participant/ParticipantDiscoveryInfo.h>
+#include <fastrtps/attributes/LibrarySettingsAttributes.h>
+#include <fastrtps/xmlparser/XMLProfileManager.h>
+
+using namespace eprosima::fastrtps;
+
+enum communication_type
+{
+    TRANSPORT,
+    INTRAPROCESS,
+    DATASHARING
+};
+
+class UserDataQos : public testing::TestWithParam<communication_type>
+{
+public:
+
+    void SetUp() override
+    {
+        LibrarySettingsAttributes library_settings;
+        switch (GetParam())
+        {
+            case INTRAPROCESS:
+                library_settings.intraprocess_delivery = IntraprocessDeliveryType::INTRAPROCESS_FULL;
+                xmlparser::XMLProfileManager::library_settings(library_settings);
+                break;
+            case DATASHARING:
+                enable_datasharing = true;
+                break;
+            case TRANSPORT:
+            default:
+                break;
+        }
+    }
+
+    void TearDown() override
+    {
+        LibrarySettingsAttributes library_settings;
+        switch (GetParam())
+        {
+            case INTRAPROCESS:
+                library_settings.intraprocess_delivery = IntraprocessDeliveryType::INTRAPROCESS_OFF;
+                xmlparser::XMLProfileManager::library_settings(library_settings);
+                break;
+            case DATASHARING:
+                enable_datasharing = false;
+                break;
+            case TRANSPORT:
+            default:
+                break;
+        }
+    }
+};
+
+/**
+ * This test checks that the user data updates once the participant is initialized are correctly applied
+ * In order to check that the user data is correctly updated, tow participants are created and the discovery info is
+ * checked.
+ */
+TEST_P(UserDataQos, update_user_data_qos)
+{
+    PubSubParticipant<HelloWorldType> participant_1(0u, 0u, 0u, 0u);
+    ASSERT_TRUE(participant_1.user_data({'a', 'b', 'c', 'd', 'e'}).init_participant());
+
+    PubSubParticipant<HelloWorldType> participant_2(0u, 0u, 0u, 0u);
+    ASSERT_TRUE(participant_2.init_participant());
+
+    participant_2.set_on_discovery_function([&](const rtps::ParticipantDiscoveryInfo& info) -> bool
+            {
+                std::cout << "Received USER_DATA: ";
+                for (auto i : info.info.m_userData)
+                {
+                    std::cout << i << ' ';
+                }
+                std::cout << std::endl;
+                return info.info.m_userData == std::vector<rtps::octet>({'a', 'b', 'c', 'd', 'e'});
+            });
+
+    participant_1.wait_discovery();
+    participant_2.wait_discovery();
+    participant_2.wait_discovery_result();
+
+    // Update user data
+    ASSERT_TRUE(participant_1.update_user_data({'f', 'g'}));
+
+    participant_2.set_on_participant_qos_update_function([&](const rtps::ParticipantDiscoveryInfo& info) -> bool
+            {
+                return info.info.m_userData == std::vector<rtps::octet>({'f', 'g'});
+            });
+    participant_2.wait_qos_update();
+}
+
+#ifdef INSTANTIATE_TEST_SUITE_P
+#define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_SUITE_P(x, y, z, w)
+#else
+#define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_CASE_P(x, y, z, w)
+#endif // INSTANTIATE_TEST_SUITE_P
+
+GTEST_INSTANTIATE_TEST_MACRO(UserDataQos,
+        UserDataQos,
+        testing::Values(TRANSPORT, INTRAPROCESS, DATASHARING),
+        [](const testing::TestParamInfo<UserDataQos::ParamType>& info)
+        {
+            switch (info.param)
+            {
+                case INTRAPROCESS:
+                    return "Intraprocess";
+                    break;
+                case DATASHARING:
+                    return "Datasharing";
+                    break;
+                case TRANSPORT:
+                default:
+                    return "Transport";
+            }
+        });

--- a/test/blackbox/common/DDSBlackboxTestsUserDataQos.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsUserDataQos.cpp
@@ -97,6 +97,16 @@ TEST_P(UserDataQos, update_user_data_qos)
                 std::cout << std::endl;
                 return info.info.m_userData == std::vector<rtps::octet>({'a', 'b', 'c', 'd', 'e'});
             });
+    participant_2.set_on_participant_qos_update_function([&](const rtps::ParticipantDiscoveryInfo& info) -> bool
+            {
+                std::cout << "Received USER_DATA: ";
+                for (auto i : info.info.m_userData)
+                {
+                    std::cout << i << ' ';
+                }
+                std::cout << std::endl;
+                return info.info.m_userData == std::vector<rtps::octet>({'f', 'g'});
+            });
 
     participant_1.wait_discovery();
     participant_2.wait_discovery();
@@ -105,10 +115,6 @@ TEST_P(UserDataQos, update_user_data_qos)
     // Update user data
     ASSERT_TRUE(participant_1.update_user_data({'f', 'g'}));
 
-    participant_2.set_on_participant_qos_update_function([&](const rtps::ParticipantDiscoveryInfo& info) -> bool
-            {
-                return info.info.m_userData == std::vector<rtps::octet>({'f', 'g'});
-            });
     participant_2.wait_qos_update();
 }
 

--- a/test/blackbox/common/DDSBlackboxTestsUserDataQos.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsUserDataQos.cpp
@@ -85,7 +85,6 @@ TEST_P(UserDataQos, update_user_data_qos)
     ASSERT_TRUE(participant_1.user_data({'a', 'b', 'c', 'd', 'e'}).init_participant());
 
     PubSubParticipant<HelloWorldType> participant_2(0u, 0u, 0u, 0u);
-    ASSERT_TRUE(participant_2.init_participant());
 
     participant_2.set_on_discovery_function([&](const rtps::ParticipantDiscoveryInfo& info) -> bool
             {
@@ -108,8 +107,9 @@ TEST_P(UserDataQos, update_user_data_qos)
                 return info.info.m_userData == std::vector<rtps::octet>({'f', 'g'});
             });
 
+    ASSERT_TRUE(participant_2.init_participant());
+
     participant_1.wait_discovery();
-    participant_2.wait_discovery();
     participant_2.wait_discovery_result();
 
     // Update user data

--- a/test/blackbox/common/DDSBlackboxTestsUserDataQos.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsUserDataQos.cpp
@@ -71,6 +71,7 @@ public:
                 break;
         }
     }
+
 };
 
 /**


### PR DESCRIPTION
This PR should be merged after #2113 (review from commit "Modify blackbox PubSubParticipant API to include UserDataQosPolicy").

The PR add a DDS API blackbox test that checks that the update of the `UserDataQos` is correctly updated and sent to other participants. In order to implement the test the DDS API `PubSubParticipant` has been completed to have participant discovery callbacks available.