### PR TITLE
WireProtocolConfigQos update through DomainParticipant::set_qos [12197]

### DIFF
--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1848,6 +1848,7 @@ bool DomainParticipantImpl::can_qos_be_updated(
             !(to.wire_protocol().builtin.discovery_config.leaseDuration_announcementperiod == from.wire_protocol().builtin.discovery_config.leaseDuration_announcementperiod) ||
             !(to.wire_protocol().builtin.discovery_config.initial_announcements == from.wire_protocol().builtin.discovery_config.initial_announcements) ||
             !(to.wire_protocol().builtin.discovery_config.m_simpleEDP == from.wire_protocol().builtin.discovery_config.m_simpleEDP) ||
+            !(strcmp(to.wire_protocol().builtin.discovery_config.static_edp_xml_config(), from.wire_protocol().builtin.discovery_config.static_edp_xml_config()) == 0) ||
             !(to.wire_protocol().builtin.discovery_config.ignoreParticipantFlags == from.wire_protocol().builtin.discovery_config.ignoreParticipantFlags))))
         {
             updatable = false;

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1819,41 +1819,64 @@ bool DomainParticipantImpl::can_qos_be_updated(
     if (!(to.wire_protocol() == from.wire_protocol()))
     {
         // Check that the only modification was in wire_protocol().discovery_config.m_DiscoveryServers
-        if ((to.wire_protocol().builtin.discovery_config.m_DiscoveryServers == from.wire_protocol().builtin.discovery_config.m_DiscoveryServers) ||
-            (!(to.wire_protocol().builtin.discovery_config.m_DiscoveryServers == from.wire_protocol().builtin.discovery_config.m_DiscoveryServers) &&
-            (!(to.wire_protocol().prefix == from.wire_protocol().prefix) ||
-            !(to.wire_protocol().participant_id == from.wire_protocol().participant_id) ||
-            !(to.wire_protocol().port == from.wire_protocol().port) ||
-            !(to.wire_protocol().throughput_controller == from.wire_protocol().throughput_controller) ||
-            !(to.wire_protocol().default_unicast_locator_list == from.wire_protocol().default_unicast_locator_list) ||
-            !(to.wire_protocol().default_multicast_locator_list == from.wire_protocol().default_multicast_locator_list) ||
-            !(to.wire_protocol().builtin.use_WriterLivelinessProtocol == from.wire_protocol().builtin.use_WriterLivelinessProtocol) ||
-            !(to.wire_protocol().builtin.typelookup_config.use_client == from.wire_protocol().builtin.typelookup_config.use_client) ||
-            !(to.wire_protocol().builtin.typelookup_config.use_server == from.wire_protocol().builtin.typelookup_config.use_server) ||
-            !(to.wire_protocol().builtin.metatrafficUnicastLocatorList == from.wire_protocol().builtin.metatrafficUnicastLocatorList) ||
-            !(to.wire_protocol().builtin.metatrafficMulticastLocatorList == from.wire_protocol().builtin.metatrafficMulticastLocatorList) ||
-            !(to.wire_protocol().builtin.initialPeersList == from.wire_protocol().builtin.initialPeersList) ||
-            !(to.wire_protocol().builtin.readerHistoryMemoryPolicy == from.wire_protocol().builtin.readerHistoryMemoryPolicy) ||
-            !(to.wire_protocol().builtin.readerPayloadSize == from.wire_protocol().builtin.readerPayloadSize) ||
-            !(to.wire_protocol().builtin.writerHistoryMemoryPolicy == from.wire_protocol().builtin.writerHistoryMemoryPolicy) ||
-            !(to.wire_protocol().builtin.writerPayloadSize == from.wire_protocol().builtin.writerPayloadSize) ||
-            !(to.wire_protocol().builtin.mutation_tries == from.wire_protocol().builtin.mutation_tries) ||
-            !(to.wire_protocol().builtin.avoid_builtin_multicast == from.wire_protocol().builtin.avoid_builtin_multicast) ||
-            !(to.wire_protocol().builtin.discovery_config.discoveryProtocol == from.wire_protocol().builtin.discovery_config.discoveryProtocol) ||
-            !(to.wire_protocol().builtin.discovery_config.use_SIMPLE_EndpointDiscoveryProtocol == from.wire_protocol().builtin.discovery_config.use_SIMPLE_EndpointDiscoveryProtocol) ||
-            !(to.wire_protocol().builtin.discovery_config.use_STATIC_EndpointDiscoveryProtocol == from.wire_protocol().builtin.discovery_config.use_STATIC_EndpointDiscoveryProtocol) ||
-            !(to.wire_protocol().builtin.discovery_config.discoveryServer_client_syncperiod == from.wire_protocol().builtin.discovery_config.discoveryServer_client_syncperiod) ||
-            !(to.wire_protocol().builtin.discovery_config.m_PDPfactory == from.wire_protocol().builtin.discovery_config.m_PDPfactory) ||
-            !(to.wire_protocol().builtin.discovery_config.leaseDuration == from.wire_protocol().builtin.discovery_config.leaseDuration) ||
-            !(to.wire_protocol().builtin.discovery_config.leaseDuration_announcementperiod == from.wire_protocol().builtin.discovery_config.leaseDuration_announcementperiod) ||
-            !(to.wire_protocol().builtin.discovery_config.initial_announcements == from.wire_protocol().builtin.discovery_config.initial_announcements) ||
-            !(to.wire_protocol().builtin.discovery_config.m_simpleEDP == from.wire_protocol().builtin.discovery_config.m_simpleEDP) ||
-            !(strcmp(to.wire_protocol().builtin.discovery_config.static_edp_xml_config(), from.wire_protocol().builtin.discovery_config.static_edp_xml_config()) == 0) ||
-            !(to.wire_protocol().builtin.discovery_config.ignoreParticipantFlags == from.wire_protocol().builtin.discovery_config.ignoreParticipantFlags))))
+        if ((to.wire_protocol().builtin.discovery_config.m_DiscoveryServers ==
+                from.wire_protocol().builtin.discovery_config.m_DiscoveryServers) ||
+                (!(to.wire_protocol().builtin.discovery_config.m_DiscoveryServers ==
+                from.wire_protocol().builtin.discovery_config.m_DiscoveryServers) &&
+                (!(to.wire_protocol().prefix == from.wire_protocol().prefix) ||
+                !(to.wire_protocol().participant_id == from.wire_protocol().participant_id) ||
+                !(to.wire_protocol().port == from.wire_protocol().port) ||
+                !(to.wire_protocol().throughput_controller == from.wire_protocol().throughput_controller) ||
+                !(to.wire_protocol().default_unicast_locator_list ==
+                from.wire_protocol().default_unicast_locator_list) ||
+                !(to.wire_protocol().default_multicast_locator_list ==
+                from.wire_protocol().default_multicast_locator_list) ||
+                !(to.wire_protocol().builtin.use_WriterLivelinessProtocol ==
+                from.wire_protocol().builtin.use_WriterLivelinessProtocol) ||
+                !(to.wire_protocol().builtin.typelookup_config.use_client ==
+                from.wire_protocol().builtin.typelookup_config.use_client) ||
+                !(to.wire_protocol().builtin.typelookup_config.use_server ==
+                from.wire_protocol().builtin.typelookup_config.use_server) ||
+                !(to.wire_protocol().builtin.metatrafficUnicastLocatorList ==
+                from.wire_protocol().builtin.metatrafficUnicastLocatorList) ||
+                !(to.wire_protocol().builtin.metatrafficMulticastLocatorList ==
+                from.wire_protocol().builtin.metatrafficMulticastLocatorList) ||
+                !(to.wire_protocol().builtin.initialPeersList == from.wire_protocol().builtin.initialPeersList) ||
+                !(to.wire_protocol().builtin.readerHistoryMemoryPolicy ==
+                from.wire_protocol().builtin.readerHistoryMemoryPolicy) ||
+                !(to.wire_protocol().builtin.readerPayloadSize == from.wire_protocol().builtin.readerPayloadSize) ||
+                !(to.wire_protocol().builtin.writerHistoryMemoryPolicy ==
+                from.wire_protocol().builtin.writerHistoryMemoryPolicy) ||
+                !(to.wire_protocol().builtin.writerPayloadSize == from.wire_protocol().builtin.writerPayloadSize) ||
+                !(to.wire_protocol().builtin.mutation_tries == from.wire_protocol().builtin.mutation_tries) ||
+                !(to.wire_protocol().builtin.avoid_builtin_multicast ==
+                from.wire_protocol().builtin.avoid_builtin_multicast) ||
+                !(to.wire_protocol().builtin.discovery_config.discoveryProtocol ==
+                from.wire_protocol().builtin.discovery_config.discoveryProtocol) ||
+                !(to.wire_protocol().builtin.discovery_config.use_SIMPLE_EndpointDiscoveryProtocol ==
+                from.wire_protocol().builtin.discovery_config.use_SIMPLE_EndpointDiscoveryProtocol) ||
+                !(to.wire_protocol().builtin.discovery_config.use_STATIC_EndpointDiscoveryProtocol ==
+                from.wire_protocol().builtin.discovery_config.use_STATIC_EndpointDiscoveryProtocol) ||
+                !(to.wire_protocol().builtin.discovery_config.discoveryServer_client_syncperiod ==
+                from.wire_protocol().builtin.discovery_config.discoveryServer_client_syncperiod) ||
+                !(to.wire_protocol().builtin.discovery_config.m_PDPfactory ==
+                from.wire_protocol().builtin.discovery_config.m_PDPfactory) ||
+                !(to.wire_protocol().builtin.discovery_config.leaseDuration ==
+                from.wire_protocol().builtin.discovery_config.leaseDuration) ||
+                !(to.wire_protocol().builtin.discovery_config.leaseDuration_announcementperiod ==
+                from.wire_protocol().builtin.discovery_config.leaseDuration_announcementperiod) ||
+                !(to.wire_protocol().builtin.discovery_config.initial_announcements ==
+                from.wire_protocol().builtin.discovery_config.initial_announcements) ||
+                !(to.wire_protocol().builtin.discovery_config.m_simpleEDP ==
+                from.wire_protocol().builtin.discovery_config.m_simpleEDP) ||
+                !(strcmp(to.wire_protocol().builtin.discovery_config.static_edp_xml_config(),
+                from.wire_protocol().builtin.discovery_config.static_edp_xml_config()) == 0) ||
+                !(to.wire_protocol().builtin.discovery_config.ignoreParticipantFlags ==
+                from.wire_protocol().builtin.discovery_config.ignoreParticipantFlags))))
         {
             updatable = false;
             logWarning(RTPS_QOS_CHECK, "WireProtocolConfigQos cannot be changed after the participant is enabled, "
-                      << "with the exception of builtin.discovery_config.m_DiscoveryServers");
+                    << "with the exception of builtin.discovery_config.m_DiscoveryServers");
         }
 
     }

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1769,9 +1769,14 @@ bool DomainParticipantImpl::set_qos(
     {
         to.properties() = from.properties();
     }
-    if (first_time && !(to.wire_protocol() == from.wire_protocol()))
+    if (!(to.wire_protocol() == from.wire_protocol()))
     {
         to.wire_protocol() = from.wire_protocol();
+        to.wire_protocol().hasChanged = true;
+        if (!first_time)
+        {
+            qos_should_be_updated = true;
+        }
     }
     if (first_time && !(to.transport() == from.transport()))
     {
@@ -1813,8 +1818,43 @@ bool DomainParticipantImpl::can_qos_be_updated(
     }
     if (!(to.wire_protocol() == from.wire_protocol()))
     {
-        updatable = false;
-        logWarning(RTPS_QOS_CHECK, "WireProtocolConfigQos cannot be changed after the participant is enabled");
+        // Check that the only modification was in wire_protocol().discovery_config.m_DiscoveryServers
+        if ((to.wire_protocol().builtin.discovery_config.m_DiscoveryServers == from.wire_protocol().builtin.discovery_config.m_DiscoveryServers) ||
+            (!(to.wire_protocol().builtin.discovery_config.m_DiscoveryServers == from.wire_protocol().builtin.discovery_config.m_DiscoveryServers) &&
+            (!(to.wire_protocol().prefix == from.wire_protocol().prefix) ||
+            !(to.wire_protocol().participant_id == from.wire_protocol().participant_id) ||
+            !(to.wire_protocol().port == from.wire_protocol().port) ||
+            !(to.wire_protocol().throughput_controller == from.wire_protocol().throughput_controller) ||
+            !(to.wire_protocol().default_unicast_locator_list == from.wire_protocol().default_unicast_locator_list) ||
+            !(to.wire_protocol().default_multicast_locator_list == from.wire_protocol().default_multicast_locator_list) ||
+            !(to.wire_protocol().builtin.use_WriterLivelinessProtocol == from.wire_protocol().builtin.use_WriterLivelinessProtocol) ||
+            !(to.wire_protocol().builtin.typelookup_config.use_client == from.wire_protocol().builtin.typelookup_config.use_client) ||
+            !(to.wire_protocol().builtin.typelookup_config.use_server == from.wire_protocol().builtin.typelookup_config.use_server) ||
+            !(to.wire_protocol().builtin.metatrafficUnicastLocatorList == from.wire_protocol().builtin.metatrafficUnicastLocatorList) ||
+            !(to.wire_protocol().builtin.metatrafficMulticastLocatorList == from.wire_protocol().builtin.metatrafficMulticastLocatorList) ||
+            !(to.wire_protocol().builtin.initialPeersList == from.wire_protocol().builtin.initialPeersList) ||
+            !(to.wire_protocol().builtin.readerHistoryMemoryPolicy == from.wire_protocol().builtin.readerHistoryMemoryPolicy) ||
+            !(to.wire_protocol().builtin.readerPayloadSize == from.wire_protocol().builtin.readerPayloadSize) ||
+            !(to.wire_protocol().builtin.writerHistoryMemoryPolicy == from.wire_protocol().builtin.writerHistoryMemoryPolicy) ||
+            !(to.wire_protocol().builtin.writerPayloadSize == from.wire_protocol().builtin.writerPayloadSize) ||
+            !(to.wire_protocol().builtin.mutation_tries == from.wire_protocol().builtin.mutation_tries) ||
+            !(to.wire_protocol().builtin.avoid_builtin_multicast == from.wire_protocol().builtin.avoid_builtin_multicast) ||
+            !(to.wire_protocol().builtin.discovery_config.discoveryProtocol == from.wire_protocol().builtin.discovery_config.discoveryProtocol) ||
+            !(to.wire_protocol().builtin.discovery_config.use_SIMPLE_EndpointDiscoveryProtocol == from.wire_protocol().builtin.discovery_config.use_SIMPLE_EndpointDiscoveryProtocol) ||
+            !(to.wire_protocol().builtin.discovery_config.use_STATIC_EndpointDiscoveryProtocol == from.wire_protocol().builtin.discovery_config.use_STATIC_EndpointDiscoveryProtocol) ||
+            !(to.wire_protocol().builtin.discovery_config.discoveryServer_client_syncperiod == from.wire_protocol().builtin.discovery_config.discoveryServer_client_syncperiod) ||
+            !(to.wire_protocol().builtin.discovery_config.m_PDPfactory == from.wire_protocol().builtin.discovery_config.m_PDPfactory) ||
+            !(to.wire_protocol().builtin.discovery_config.leaseDuration == from.wire_protocol().builtin.discovery_config.leaseDuration) ||
+            !(to.wire_protocol().builtin.discovery_config.leaseDuration_announcementperiod == from.wire_protocol().builtin.discovery_config.leaseDuration_announcementperiod) ||
+            !(to.wire_protocol().builtin.discovery_config.initial_announcements == from.wire_protocol().builtin.discovery_config.initial_announcements) ||
+            !(to.wire_protocol().builtin.discovery_config.m_simpleEDP == from.wire_protocol().builtin.discovery_config.m_simpleEDP) ||
+            !(to.wire_protocol().builtin.discovery_config.ignoreParticipantFlags == from.wire_protocol().builtin.discovery_config.ignoreParticipantFlags))))
+        {
+            updatable = false;
+            logWarning(RTPS_QOS_CHECK, "WireProtocolConfigQos cannot be changed after the participant is enabled, "
+                      << "with the exception of builtin.discovery_config.m_DiscoveryServers");
+        }
+
     }
     if (!(to.transport() == from.transport()))
     {

--- a/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
+++ b/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
@@ -597,6 +597,7 @@ protected:
             const DomainParticipantQos& /*from*/,
             bool /*first_time*/)
     {
+        return false;
     }
 
     static ReturnCode_t check_qos(

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -509,7 +509,8 @@ TEST(ParticipantTests, ChangeWireProtocolQos)
 
     // Check changing wire_protocol().builtin.readerHistoryMemoryPolicy is NOT OK
     participant->get_qos(qos);
-    qos.wire_protocol().builtin.readerHistoryMemoryPolicy = fastrtps::rtps::MemoryManagementPolicy_t::DYNAMIC_RESERVE_MEMORY_MODE;
+    qos.wire_protocol().builtin.readerHistoryMemoryPolicy =
+            fastrtps::rtps::MemoryManagementPolicy_t::DYNAMIC_RESERVE_MEMORY_MODE;
     ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
     participant->get_qos(set_qos);
     ASSERT_FALSE(set_qos == qos);
@@ -523,7 +524,8 @@ TEST(ParticipantTests, ChangeWireProtocolQos)
 
     // Check changing wire_protocol().builtin.writerHistoryMemoryPolicy is NOT OK
     participant->get_qos(qos);
-    qos.wire_protocol().builtin.writerHistoryMemoryPolicy = fastrtps::rtps::MemoryManagementPolicy_t::DYNAMIC_RESERVE_MEMORY_MODE;
+    qos.wire_protocol().builtin.writerHistoryMemoryPolicy =
+            fastrtps::rtps::MemoryManagementPolicy_t::DYNAMIC_RESERVE_MEMORY_MODE;
     ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
     participant->get_qos(set_qos);
     ASSERT_FALSE(set_qos == qos);
@@ -604,8 +606,10 @@ TEST(ParticipantTests, ChangeWireProtocolQos)
     qos.wire_protocol().builtin.discovery_config.m_simpleEDP.use_PublicationWriterANDSubscriptionReader ^= true;
     qos.wire_protocol().builtin.discovery_config.m_simpleEDP.use_PublicationReaderANDSubscriptionWriter ^= true;
 #if HAVE_SECURITY
-    qos.wire_protocol().builtin.discovery_config.m_simpleEDP.enable_builtin_secure_publications_writer_and_subscriptions_reader ^= true;
-    qos.wire_protocol().builtin.discovery_config.m_simpleEDP.enable_builtin_secure_subscriptions_writer_and_publications_reader ^= true;
+    qos.wire_protocol().builtin.discovery_config.m_simpleEDP.
+            enable_builtin_secure_publications_writer_and_subscriptions_reader ^= true;
+    qos.wire_protocol().builtin.discovery_config.m_simpleEDP.
+            enable_builtin_secure_subscriptions_writer_and_publications_reader ^= true;
 #endif // if HAVE_SECURITY
     ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
     participant->get_qos(set_qos);
@@ -614,17 +618,17 @@ TEST(ParticipantTests, ChangeWireProtocolQos)
     // Check changing wire_protocol().builtin.discovery_config.static_edp_xml_config() is NOT OK
     participant->get_qos(qos);
     std::string static_xml = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
-        "<staticdiscovery>" \
+            "<staticdiscovery>" \
             "<participant profile_name=\"participant_profile_static_edp\">" \
-                "<rtps>" \
-                    "<builtin>" \
-                        "<discovery_config>" \
-                            "<EDP>STATIC</EDP>" \
-                        "</discovery_config>" \
-                    "</builtin>" \
-                "</rtps>" \
+            "<rtps>" \
+            "<builtin>" \
+            "<discovery_config>" \
+            "<EDP>STATIC</EDP>" \
+            "</discovery_config>" \
+            "</builtin>" \
+            "</rtps>" \
             "</participant>" \
-        "</staticdiscovery>";
+            "</staticdiscovery>";
     qos.wire_protocol().builtin.discovery_config.static_edp_xml_config(static_xml.c_str());
     ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
     participant->get_qos(set_qos);
@@ -632,7 +636,8 @@ TEST(ParticipantTests, ChangeWireProtocolQos)
 
     // Check changing wire_protocol().builtin.discovery_config.ignoreParticipantFlags is NOT OK
     participant->get_qos(qos);
-    qos.wire_protocol().builtin.discovery_config.ignoreParticipantFlags = fastrtps::rtps::ParticipantFilteringFlags::FILTER_DIFFERENT_HOST;
+    qos.wire_protocol().builtin.discovery_config.ignoreParticipantFlags =
+            fastrtps::rtps::ParticipantFilteringFlags::FILTER_DIFFERENT_HOST;
     ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
     participant->get_qos(set_qos);
     ASSERT_FALSE(set_qos == qos);


### PR DESCRIPTION
This PR enables updating `WireProtocolConfigQos` iff the only modified field is the list of remote discovery servers.

**IMPORTANT**: Merge after #2113 