### PR TITLE
[12357] Fix doxygen documentation

### DIFF
--- a/include/fastdds/rtps/writer/RTPSWriter.h
+++ b/include/fastdds/rtps/writer/RTPSWriter.h
@@ -407,7 +407,7 @@ public:
      * @param group RTPSMessageGroup reference uses for generating the RTPS message.
      * @param locator_selector RTPSMessageSenderInterface reference uses for selecting locators. The reference has to
      * be a member of this RTPSWriter object.
-     * @param max_blocking_time_point Future timepoint where blocking send should end.
+     * @param max_blocking_time Future timepoint where blocking send should end.
      * @return Return code.
      * @note Must be non-thread safe.
      */

--- a/include/fastdds/rtps/writer/ReaderProxy.h
+++ b/include/fastdds/rtps/writer/ReaderProxy.h
@@ -133,7 +133,7 @@ public:
      * @param[out] gap_seq Return, when it is its first delivery (should be relevant seq_num), the sequence number of
      * the first sequence of the gap [first, seq_num). Otherwise return SequenceNumber_t::unknown().
      * @param[out] need_reactivate_periodic_heartbeat Indicates if the heartbeat period event has to be restarted.
-     * 
+     *
      * @return true if the change is marked to be sent. False otherwise.
      */
     bool change_is_unsent(

--- a/include/fastdds/rtps/writer/ReaderProxy.h
+++ b/include/fastdds/rtps/writer/ReaderProxy.h
@@ -129,10 +129,12 @@ public:
      * Check if a specific change is marked to be sent to this reader.
      *
      * @param[in]  seq_num Sequence number of the change to be checked.
-     * @param[out] next_unsent_frag,Returns next fragment to be sent.
+     * @param[out] next_unsent_frag Return next fragment to be sent.
      * @param[out] gap_seq Return, when it is its first delivery (should be relevant seq_num), the sequence number of
      * the first sequence of the gap [first, seq_num). Otherwise return SequenceNumber_t::unknown().
      * @param[out] need_reactivate_periodic_heartbeat Indicates if the heartbeat period event has to be restarted.
+     * 
+     * @return true if the change is marked to be sent. False otherwise.
      */
     bool change_is_unsent(
             const SequenceNumber_t& seq_num,
@@ -151,7 +153,7 @@ public:
     /**
      * Mark all changes in the vector as requested.
      * @param seq_num_set Bitmap of sequence numbers.
-     * @parm gap_builder RTPSGapBuilder reference uses for adding  each requested change that is irrelevant for the
+     * @param gap_builder RTPSGapBuilder reference uses for adding  each requested change that is irrelevant for the
      * requester.
      * @return true if at least one change has been marked as REQUESTED, false otherwise.
      */
@@ -161,7 +163,7 @@ public:
 
     /**
      * Performs processing of preemptive acknack
-     * @func functor called, if the requester is a local reader, for each changes moved to UNSENT status.
+     * @param func functor called, if the requester is a local reader, for each changes moved to UNSENT status.
      * @return true if a heartbeat should be sent, false otherwise.
      */
     bool process_initial_acknack(

--- a/include/fastdds/rtps/writer/StatefulWriter.h
+++ b/include/fastdds/rtps/writer/StatefulWriter.h
@@ -391,7 +391,7 @@ public:
      * @param group RTPSMessageGroup reference uses for generating the RTPS message.
      * @param locator_selector RTPSMessageSenderInterface reference uses for selecting locators. The reference has to
      * be a member of this RTPSWriter object.
-     * @param max_blocking_time_point Future timepoint where blocking send should end.
+     * @param max_blocking_time Future timepoint where blocking send should end.
      * @return Return code.
      * @note Must be non-thread safe.
      */

--- a/include/fastdds/rtps/writer/StatelessWriter.h
+++ b/include/fastdds/rtps/writer/StatelessWriter.h
@@ -153,6 +153,8 @@ public:
      * Send a message through this interface.
      *
      * @param message Pointer to the buffer with the message already serialized.
+     * @param locator_selector RTPSMessageSenderInterface reference uses for selecting locators. The reference has to
+     * be a member of this RTPSWriter object.
      * @param max_blocking_time_point Future timepoint where blocking send should end.
      */
     bool send_nts(
@@ -180,7 +182,7 @@ public:
      * @param group RTPSMessageGroup reference uses for generating the RTPS message.
      * @param locator_selector RTPSMessageSenderInterface reference uses for selecting locators. The reference has to
      * be a member of this RTPSWriter object.
-     * @param max_blocking_time_point Future timepoint where blocking send should end.
+     * @param max_blocking_time Future timepoint where blocking send should end.
      * @return Return code.
      * @note Must be non-thread safe.
      */

--- a/include/fastdds/statistics/rtps/StatisticsCommon.hpp
+++ b/include/fastdds/statistics/rtps/StatisticsCommon.hpp
@@ -268,8 +268,8 @@ protected:
 
     /**
      * @brief Report a change on the number of DATA / DATAFRAG submessages sent for a specific sample.
-     * @param SampleIdentity of the affected sample.
-     * @param Current total number of submessages sent for the affected sample.
+     * Parameter: SampleIdentity of the affected sample.
+     * Parameter: Current total number of submessages sent for the affected sample.
      */
     inline void on_sample_datas(
             const fastrtps::rtps::SampleIdentity&,
@@ -279,7 +279,7 @@ protected:
 
     /**
      * @brief Report that a HEARTBEAT message is sent
-     * @param current count of heartbeats
+     * Parameter: current count of heartbeats
      */
     inline void on_heartbeat(
             uint32_t)
@@ -288,7 +288,7 @@ protected:
 
     /**
      * @brief Report that a DATA / DATA_FRAG message is generated
-     * @param number of locators to which the message will be sent
+     * Parameter: number of locators to which the message will be sent
      */
     inline void on_data_generated(
             size_t)
@@ -302,7 +302,7 @@ protected:
 
     /**
      * @brief Reports publication throughtput based on last added sample to writer's history
-     * @param size of the message sent
+     * Parameter: size of the message sent
      */
     inline void on_publish_throughput(
             uint32_t)
@@ -316,7 +316,7 @@ protected:
 
     /*
      * @brief Report that several changes are marked for redelivery
-     * @param number of changes to redeliver
+     * Parameter: number of changes to redeliver
      */
     inline void on_resent_data(
             uint32_t)
@@ -335,8 +335,8 @@ protected:
 
     /**
      * @brief Report that a sample has been notified to the user.
-     * @param GUID of the writer from where the sample was received.
-     * @param Source timestamp received from the writer for the sample being notified.
+     * Parameter: GUID of the writer from where the sample was received.
+     * Parameter: Source timestamp received from the writer for the sample being notified.
      */
     inline void on_data_notify(
             const fastrtps::rtps::GUID_t&,
@@ -346,7 +346,7 @@ protected:
 
     /**
      * @brief Report that an ACKNACK message is sent
-     * @param current count of ACKNACKs
+     * Parameter: current count of ACKNACKs
      */
     inline void on_acknack(
             int32_t)
@@ -355,7 +355,7 @@ protected:
 
     /**
      * @brief Report that a NACKFRAG message is sent
-     * @param current count of NACKFRAGs
+     * Parameter: current count of NACKFRAGs
      */
     inline void on_nackfrag(
             int32_t)
@@ -364,7 +364,7 @@ protected:
 
     /**
      * @brief Reports subscription throughtput based on last added sample to reader's history
-     * @param size of the message received
+     * Parameter: size of the message received
      */
     inline void on_subscribe_throughput(
             uint32_t)


### PR DESCRIPTION
Since the merge of #1996, the Fast DDS docs nightly job has been failing. This PR fixes the doxygen warning issued by this PR and some previous ones (Statistics Module)