### PR TITLE
Propagate servers list updates to PDPServer and PDPClient [12278]

### DIFF
--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1881,8 +1881,9 @@ bool DomainParticipantImpl::can_qos_be_updated(
         else
         {
             // This means that the only change is in wire_protocol().builtin.discovery_config.m_DiscoveryServers
-            // In that case, we need to ensure that the list in to is strictly contained in the list in from.
-            // For that, we check that every server in the current list (to) is also in the incoming one (from)
+            // In that case, we need to ensure that the current list (to) is strictly contained in the incoming
+            // list (from). For that, we check that every server in the current list (to) is also in the incoming one
+            // (from)
             for (auto existing_server : to.wire_protocol().builtin.discovery_config.m_DiscoveryServers)
             {
                 bool contained = false;

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1897,7 +1897,8 @@ bool DomainParticipantImpl::can_qos_be_updated(
                 if (!contained)
                 {
                     updatable = false;
-                    logWarning(RTPS_QOS_CHECK, "Discovery Servers cannot be removed from the list; they can only be added");
+                    logWarning(RTPS_QOS_CHECK,
+                            "Discovery Servers cannot be removed from the list; they can only be added");
                     break;
                 }
             }

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1878,7 +1878,30 @@ bool DomainParticipantImpl::can_qos_be_updated(
             logWarning(RTPS_QOS_CHECK, "WireProtocolConfigQos cannot be changed after the participant is enabled, "
                     << "with the exception of builtin.discovery_config.m_DiscoveryServers");
         }
-
+        else
+        {
+            // This means that the only change is in wire_protocol().builtin.discovery_config.m_DiscoveryServers
+            // In that case, we need to ensure that the list in to is strictly contained in the list in from.
+            // For that, we check that every server in the current list (to) is also in the incoming one (from)
+            for (auto existing_server : to.wire_protocol().builtin.discovery_config.m_DiscoveryServers)
+            {
+                bool contained = false;
+                for (auto incoming_server : from.wire_protocol().builtin.discovery_config.m_DiscoveryServers)
+                {
+                    if (existing_server.guidPrefix == incoming_server.guidPrefix)
+                    {
+                        contained = true;
+                        break;
+                    }
+                }
+                if (!contained)
+                {
+                    updatable = false;
+                    logWarning(RTPS_QOS_CHECK, "Discovery Servers cannot be removed from the list; they can only be added");
+                    break;
+                }
+            }
+        }
     }
     if (!(to.transport() == from.transport()))
     {

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <mutex>
+#include <set>
 
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/rtps/common/EntityId_t.hpp>

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -37,7 +37,7 @@ namespace ddb {
 
 DiscoveryDataBase::DiscoveryDataBase(
         fastrtps::rtps::GuidPrefix_t server_guid_prefix,
-        std::vector<fastrtps::rtps::GuidPrefix_t> servers)
+        std::set<fastrtps::rtps::GuidPrefix_t> servers)
     : server_guid_prefix_(server_guid_prefix)
     , server_acked_by_all_(servers.size() == 0)
     , servers_(servers)
@@ -65,7 +65,7 @@ void DiscoveryDataBase::add_server(
         fastrtps::rtps::GuidPrefix_t server)
 {
     logInfo(DISCOVERY_DATABASE, "Server " << server << " added");
-    servers_.push_back(server);
+    servers_.insert(server);
 }
 
 std::vector<fastrtps::rtps::CacheChange_t*> DiscoveryDataBase::clear()
@@ -1710,7 +1710,7 @@ void DiscoveryDataBase::AckedFunctor::operator () (
         {
             // If the reader proxy is from a server that we are pinging, we may not want to wait
             // for it to be acked as the routine will not stop
-            for (auto it = db_->servers_.begin(); it < db_->servers_.end(); ++it)
+            for (auto it = db_->servers_.begin(); it != db_->servers_.end(); ++it)
             {
                 if (reader_proxy->guid().guidPrefix == *it)
                 {

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
@@ -117,7 +117,7 @@ public:
 
     DiscoveryDataBase(
             fastrtps::rtps::GuidPrefix_t server_guid_prefix,
-            std::vector<fastrtps::rtps::GuidPrefix_t> servers);
+            std::set<fastrtps::rtps::GuidPrefix_t> servers);
 
     ~DiscoveryDataBase();
 
@@ -562,7 +562,7 @@ protected:
     std::atomic<bool> server_acked_by_all_;
 
     //! List of GUID prefixes of the remote servers
-    std::vector<fastrtps::rtps::GuidPrefix_t> servers_;
+    std::set<fastrtps::rtps::GuidPrefix_t> servers_;
 
     // The virtual topic associated with virtual writers and readers
     const std::string virtual_topic_ = "eprosima_server_virtual_topic";

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
@@ -20,11 +20,12 @@
 #ifndef _FASTDDS_RTPS_DISCOVERY_DATABASE_H_
 #define _FASTDDS_RTPS_DISCOVERY_DATABASE_H_
 
-#include <vector>
+#include <fstream>
+#include <iostream>
 #include <map>
 #include <mutex>
-#include <iostream>
-#include <fstream>
+#include <set>
+#include <vector>
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 #include <fastdds/rtps/writer/ReaderProxy.h>

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -597,7 +597,8 @@ void PDPClient::update_remote_servers_list()
     }
 }
 
-void PDPClient::match_pdp_writer_nts_(const eprosima::fastdds::rtps::RemoteServerAttributes& server_att)
+void PDPClient::match_pdp_writer_nts_(
+        const eprosima::fastdds::rtps::RemoteServerAttributes& server_att)
 {
     std::lock_guard<std::mutex> data_guard(temp_data_lock_);
     const NetworkFactory& network = mp_RTPSParticipant->network_factory();
@@ -610,7 +611,8 @@ void PDPClient::match_pdp_writer_nts_(const eprosima::fastdds::rtps::RemoteServe
     mp_PDPReader->matched_writer_add(temp_writer_data_);
 }
 
-void PDPClient::match_pdp_reader_nts_(const eprosima::fastdds::rtps::RemoteServerAttributes& server_att)
+void PDPClient::match_pdp_reader_nts_(
+        const eprosima::fastdds::rtps::RemoteServerAttributes& server_att)
 {
     std::lock_guard<std::mutex> data_guard(temp_data_lock_);
     const NetworkFactory& network = mp_RTPSParticipant->network_factory();

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -188,8 +188,6 @@ bool PDPClient::createPDPEndpoints()
 {
     logInfo(RTPS_PDP, "Beginning PDPClient Endpoints creation");
 
-    const NetworkFactory& network = mp_RTPSParticipant->network_factory();
-
     HistoryAttributes hatt;
     hatt.payloadMaxSize = mp_builtin->m_att.readerPayloadSize;
     hatt.initialReservedCaches = pdp_initial_reserved_caches;
@@ -220,15 +218,7 @@ bool PDPClient::createPDPEndpoints()
 
             for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
             {
-                std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-                temp_writer_data_.clear();
-                temp_writer_data_.guid(it.GetPDPWriter());
-                temp_writer_data_.set_multicast_locators(it.metatrafficMulticastLocatorList, network);
-                temp_writer_data_.set_remote_unicast_locators(it.metatrafficUnicastLocatorList, network);
-                temp_writer_data_.m_qos.m_durability.kind = TRANSIENT_DURABILITY_QOS;  // Server Information must be persistent
-                temp_writer_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
-
-                mp_PDPReader->matched_writer_add(temp_writer_data_);
+                match_pdp_writer_nts_(it);
             }
         }
     }
@@ -275,15 +265,7 @@ bool PDPClient::createPDPEndpoints()
 
             for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
             {
-                std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-                temp_reader_data_.clear();
-                temp_reader_data_.guid(it.GetPDPReader());
-                temp_reader_data_.set_multicast_locators(it.metatrafficMulticastLocatorList, network);
-                temp_reader_data_.set_remote_unicast_locators(it.metatrafficUnicastLocatorList, network);
-                temp_reader_data_.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
-                temp_reader_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
-
-                mp_PDPWriter->matched_reader_add(temp_reader_data_);
+                match_pdp_reader_nts_(it);
             }
         }
     }
@@ -585,6 +567,60 @@ bool PDPClient::match_servers_EDP_endpoints()
     }
 
     return all;
+}
+
+void PDPClient::update_remote_servers_list()
+{
+    if (!mp_PDPReader || !mp_PDPWriter)
+    {
+        logError(SERVER_CLIENT_DISCOVERY, "Cannot update server list within an uninitialized Client");
+        return;
+    }
+
+    std::lock_guard<std::recursive_mutex> lock(*getMutex());
+
+    for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
+    {
+        if (mp_PDPReader->matched_writer_is_matched(it.GetPDPWriter()))
+        {
+            continue;
+        }
+
+        match_pdp_writer_nts_(it);
+
+        if (mp_PDPWriter->matched_reader_is_matched(it.GetPDPReader()))
+        {
+            continue;
+        }
+
+        match_pdp_reader_nts_(it);
+    }
+}
+
+void PDPClient::match_pdp_writer_nts_(const eprosima::fastdds::rtps::RemoteServerAttributes& server_att)
+{
+    std::lock_guard<std::mutex> data_guard(temp_data_lock_);
+    const NetworkFactory& network = mp_RTPSParticipant->network_factory();
+    temp_writer_data_.clear();
+    temp_writer_data_.guid(server_att.GetPDPWriter());
+    temp_writer_data_.set_multicast_locators(server_att.metatrafficMulticastLocatorList, network);
+    temp_writer_data_.set_remote_unicast_locators(server_att.metatrafficUnicastLocatorList, network);
+    temp_writer_data_.m_qos.m_durability.kind = TRANSIENT_DURABILITY_QOS;
+    temp_writer_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+    mp_PDPReader->matched_writer_add(temp_writer_data_);
+}
+
+void PDPClient::match_pdp_reader_nts_(const eprosima::fastdds::rtps::RemoteServerAttributes& server_att)
+{
+    std::lock_guard<std::mutex> data_guard(temp_data_lock_);
+    const NetworkFactory& network = mp_RTPSParticipant->network_factory();
+    temp_reader_data_.clear();
+    temp_reader_data_.guid(server_att.GetPDPReader());
+    temp_reader_data_.set_multicast_locators(server_att.metatrafficMulticastLocatorList, network);
+    temp_reader_data_.set_remote_unicast_locators(server_att.metatrafficUnicastLocatorList, network);
+    temp_reader_data_.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
+    temp_reader_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+    mp_PDPWriter->matched_reader_add(temp_reader_data_);
 }
 
 const std::string& ros_discovery_server_env()

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.h
@@ -139,13 +139,15 @@ protected:
      * Manually match PDP writer endpoint of a given server. The function is not thread safe (nts) in
      * the sense that it does not take the PDP mutex. It does however take temp_data_lock_
      */
-    void match_pdp_writer_nts_(const eprosima::fastdds::rtps::RemoteServerAttributes& server_att);
+    void match_pdp_writer_nts_(
+            const eprosima::fastdds::rtps::RemoteServerAttributes& server_att);
 
     /**
      * Manually match PDP reader endpoint of a given server. The function is not thread safe (nts) in
      * the sense that it does not take the PDP mutex. It does however take temp_data_lock_
      */
-    void match_pdp_reader_nts_(const eprosima::fastdds::rtps::RemoteServerAttributes& server_att);
+    void match_pdp_reader_nts_(
+            const eprosima::fastdds::rtps::RemoteServerAttributes& server_att);
 
 private:
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.h
@@ -128,6 +128,25 @@ public:
      */
     bool match_servers_EDP_endpoints();
 
+    /*
+     * Update the list of remote servers
+     */
+    void update_remote_servers_list();
+
+protected:
+
+    /**
+     * Manually match PDP writer endpoint of a given server. The function is not thread safe (nts) in
+     * the sense that it does not take the PDP mutex. It does however take temp_data_lock_
+     */
+    void match_pdp_writer_nts_(const eprosima::fastdds::rtps::RemoteServerAttributes& server_att);
+
+    /**
+     * Manually match PDP reader endpoint of a given server. The function is not thread safe (nts) in
+     * the sense that it does not take the PDP mutex. It does however take temp_data_lock_
+     */
+    void match_pdp_reader_nts_(const eprosima::fastdds::rtps::RemoteServerAttributes& server_att);
+
 private:
 
     /**

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.h
@@ -136,15 +136,17 @@ public:
 protected:
 
     /**
-     * Manually match PDP writer endpoint of a given server. The function is not thread safe (nts) in
-     * the sense that it does not take the PDP mutex. It does however take temp_data_lock_
+     * Manually match the local PDP reader with the PDP writer of a given server. The function is
+     * not thread safe (nts) in the sense that it does not take the PDP mutex. It does however take
+     * temp_data_lock_
      */
     void match_pdp_writer_nts_(
             const eprosima::fastdds::rtps::RemoteServerAttributes& server_att);
 
     /**
-     * Manually match PDP reader endpoint of a given server. The function is not thread safe (nts) in
-     * the sense that it does not take the PDP mutex. It does however take temp_data_lock_
+     * Manually match the local PDP writer with the PDP reader of a given server. The function is
+     * not thread safe (nts) in the sense that it does not take the PDP mutex. It does however take
+     * temp_data_lock_
      */
     void match_pdp_reader_nts_(
             const eprosima::fastdds::rtps::RemoteServerAttributes& server_att);

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -904,7 +904,10 @@ bool PDPServer::server_update_routine()
 
 void PDPServer::update_remote_servers_list()
 {
-    return;
+    for (auto server : mp_builtin->m_DiscoveryServers)
+    {
+        discovery_db_.add_server(server.guidPrefix);
+    }
 }
 
 bool PDPServer::process_writers_acknowledgements()
@@ -1348,13 +1351,13 @@ bool PDPServer::pending_ack()
     return ret;
 }
 
-std::vector<fastrtps::rtps::GuidPrefix_t> PDPServer::servers_prefixes()
+std::set<fastrtps::rtps::GuidPrefix_t> PDPServer::servers_prefixes()
 {
     std::lock_guard<std::recursive_mutex> lock(*getMutex());
-    std::vector<GuidPrefix_t> servers;
+    std::set<GuidPrefix_t> servers;
     for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
     {
-        servers.push_back(it.guidPrefix);
+        servers.insert(it.guidPrefix);
     }
     return servers;
 }

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -224,8 +224,6 @@ bool PDPServer::createPDPEndpoints()
 {
     logInfo(RTPS_PDP_SERVER, "Beginning PDPServer Endpoints creation");
 
-    const NetworkFactory& network = mp_RTPSParticipant->network_factory();
-
     /***********************************
     * PDP READER
     ***********************************/
@@ -270,17 +268,7 @@ bool PDPServer::createPDPEndpoints()
             // Initial peer list doesn't make sense in server scenario. Client should match its server list
             for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
             {
-                std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-                temp_writer_data_.clear();
-                temp_writer_data_.guid(it.GetPDPWriter());
-                temp_writer_data_.set_multicast_locators(it.metatrafficMulticastLocatorList, network);
-                temp_writer_data_.set_remote_unicast_locators(it.metatrafficUnicastLocatorList, network);
-                // TODO check if this is correct, it is equal as PDPServer, but we do not know like this the durKind of the
-                // other server
-                temp_writer_data_.m_qos.m_durability.durabilityKind(durability_);
-                temp_writer_data_.m_qos.m_reliability.kind = fastrtps::RELIABLE_RELIABILITY_QOS;
-
-                mp_PDPReader->matched_writer_add(temp_writer_data_);
+                match_pdp_writer_nts_(it);
             }
         }
     }
@@ -343,15 +331,7 @@ bool PDPServer::createPDPEndpoints()
 
             for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
             {
-                std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-                temp_reader_data_.clear();
-                temp_reader_data_.guid(it.GetPDPReader());
-                temp_reader_data_.set_multicast_locators(it.metatrafficMulticastLocatorList, network);
-                temp_reader_data_.set_remote_unicast_locators(it.metatrafficUnicastLocatorList, network);
-                temp_reader_data_.m_qos.m_durability.kind = fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS;
-                temp_reader_data_.m_qos.m_reliability.kind = fastrtps::RELIABLE_RELIABILITY_QOS;
-
-                mp_PDPWriter->matched_reader_add(temp_reader_data_);
+                match_pdp_reader_nts_(it);
             }
         }
     }
@@ -904,6 +884,31 @@ bool PDPServer::server_update_routine()
 
 void PDPServer::update_remote_servers_list()
 {
+    if (!mp_PDPReader || !mp_PDPWriter)
+    {
+        logError(RTPS_PDP_SERVER, "Cannot update server list within an uninitialized Client");
+        return;
+    }
+
+    std::lock_guard<std::recursive_mutex> lock(*getMutex());
+
+    for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
+    {
+        if (mp_PDPReader->matched_writer_is_matched(it.GetPDPWriter()))
+        {
+            continue;
+        }
+
+        match_pdp_writer_nts_(it);
+
+        if (mp_PDPWriter->matched_reader_is_matched(it.GetPDPReader()))
+        {
+            continue;
+        }
+
+        match_pdp_reader_nts_(it);
+    }
+
     for (auto server : mp_builtin->m_DiscoveryServers)
     {
         discovery_db_.add_server(server.guidPrefix);
@@ -1768,6 +1773,32 @@ void PDPServer::process_backup_store()
 
     // Clear queue ddb backup
     discovery_db_.clean_backup();
+}
+
+void PDPServer::match_pdp_writer_nts_(const eprosima::fastdds::rtps::RemoteServerAttributes& server_att)
+{
+    std::lock_guard<std::mutex> data_guard(temp_data_lock_);
+    const NetworkFactory& network = mp_RTPSParticipant->network_factory();
+    temp_writer_data_.clear();
+    temp_writer_data_.guid(server_att.GetPDPWriter());
+    temp_writer_data_.set_multicast_locators(server_att.metatrafficMulticastLocatorList, network);
+    temp_writer_data_.set_remote_unicast_locators(server_att.metatrafficUnicastLocatorList, network);
+    temp_writer_data_.m_qos.m_durability.durabilityKind(durability_);
+    temp_writer_data_.m_qos.m_reliability.kind = dds::RELIABLE_RELIABILITY_QOS;
+    mp_PDPReader->matched_writer_add(temp_writer_data_);
+}
+
+void PDPServer::match_pdp_reader_nts_(const eprosima::fastdds::rtps::RemoteServerAttributes& server_att)
+{
+    std::lock_guard<std::mutex> data_guard(temp_data_lock_);
+    const NetworkFactory& network = mp_RTPSParticipant->network_factory();
+    temp_reader_data_.clear();
+    temp_reader_data_.guid(server_att.GetPDPReader());
+    temp_reader_data_.set_multicast_locators(server_att.metatrafficMulticastLocatorList, network);
+    temp_reader_data_.set_remote_unicast_locators(server_att.metatrafficUnicastLocatorList, network);
+    temp_reader_data_.m_qos.m_durability.kind = dds::TRANSIENT_LOCAL_DURABILITY_QOS;
+    temp_reader_data_.m_qos.m_reliability.kind = dds::RELIABLE_RELIABILITY_QOS;
+    mp_PDPWriter->matched_reader_add(temp_reader_data_);
 }
 
 } // namespace rtps

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -886,7 +886,7 @@ void PDPServer::update_remote_servers_list()
 {
     if (!mp_PDPReader || !mp_PDPWriter)
     {
-        logError(RTPS_PDP_SERVER, "Cannot update server list within an uninitialized Client");
+        logError(RTPS_PDP_SERVER, "Cannot update server list within an uninitialized Server");
         return;
     }
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -1775,7 +1775,8 @@ void PDPServer::process_backup_store()
     discovery_db_.clean_backup();
 }
 
-void PDPServer::match_pdp_writer_nts_(const eprosima::fastdds::rtps::RemoteServerAttributes& server_att)
+void PDPServer::match_pdp_writer_nts_(
+        const eprosima::fastdds::rtps::RemoteServerAttributes& server_att)
 {
     std::lock_guard<std::mutex> data_guard(temp_data_lock_);
     const NetworkFactory& network = mp_RTPSParticipant->network_factory();
@@ -1788,7 +1789,8 @@ void PDPServer::match_pdp_writer_nts_(const eprosima::fastdds::rtps::RemoteServe
     mp_PDPReader->matched_writer_add(temp_writer_data_);
 }
 
-void PDPServer::match_pdp_reader_nts_(const eprosima::fastdds::rtps::RemoteServerAttributes& server_att)
+void PDPServer::match_pdp_reader_nts_(
+        const eprosima::fastdds::rtps::RemoteServerAttributes& server_att)
 {
     std::lock_guard<std::mutex> data_guard(temp_data_lock_);
     const NetworkFactory& network = mp_RTPSParticipant->network_factory();

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -17,9 +17,10 @@
  *
  */
 
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <mutex>
+#include <set>
 
 #include <fastrtps/utils/TimedMutex.hpp>
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
@@ -22,11 +22,17 @@
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 #include <fastdds/rtps/builtin/discovery/participant/PDP.h>
+
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <fastdds/rtps/attributes/ServerAttributes.h>
 #include <fastdds/rtps/history/History.h>
 #include <fastdds/rtps/resources/ResourceEvent.h>
-
-#include <rtps/builtin/discovery/database/DiscoveryDataFilter.hpp>
 #include <rtps/builtin/discovery/database/DiscoveryDataBase.hpp>
+#include <rtps/builtin/discovery/database/DiscoveryDataFilter.hpp>
 #include <rtps/builtin/discovery/participant/timedevent/DServerEvent.hpp>
 
 namespace eprosima {
@@ -273,15 +279,17 @@ protected:
     void process_backup_store();
 
     /**
-     * Manually match PDP writer endpoint of a given server. The function is not thread safe (nts) in
-     * the sense that it does not take the PDP mutex. It does however take temp_data_lock_
+     * Manually match the local PDP reader with the PDP writer of a given server. The function is
+     * not thread safe (nts) in the sense that it does not take the PDP mutex. It does however take
+     * temp_data_lock_
      */
     void match_pdp_writer_nts_(
             const eprosima::fastdds::rtps::RemoteServerAttributes& server_att);
 
     /**
-     * Manually match PDP reader endpoint of a given server. The function is not thread safe (nts) in
-     * the sense that it does not take the PDP mutex. It does however take temp_data_lock_
+     * Manually match the local PDP writer with the PDP reader of a given server. The function is
+     * not thread safe (nts) in the sense that it does not take the PDP mutex. It does however take
+     * temp_data_lock_
      */
     void match_pdp_reader_nts_(
             const eprosima::fastdds::rtps::RemoteServerAttributes& server_att);

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
@@ -260,7 +260,7 @@ protected:
             nlohmann::json& ddb_json,
             std::vector<nlohmann::json>& new_changes);
 
-    std::vector<fastrtps::rtps::GuidPrefix_t> servers_prefixes();
+    std::set<fastrtps::rtps::GuidPrefix_t> servers_prefixes();
 
     // General file name for the prefix of every backup file
     std::ostringstream get_persistence_file_name_() const;

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
@@ -276,13 +276,15 @@ protected:
      * Manually match PDP writer endpoint of a given server. The function is not thread safe (nts) in
      * the sense that it does not take the PDP mutex. It does however take temp_data_lock_
      */
-    void match_pdp_writer_nts_(const eprosima::fastdds::rtps::RemoteServerAttributes& server_att);
+    void match_pdp_writer_nts_(
+            const eprosima::fastdds::rtps::RemoteServerAttributes& server_att);
 
     /**
      * Manually match PDP reader endpoint of a given server. The function is not thread safe (nts) in
      * the sense that it does not take the PDP mutex. It does however take temp_data_lock_
      */
-    void match_pdp_reader_nts_(const eprosima::fastdds::rtps::RemoteServerAttributes& server_att);
+    void match_pdp_reader_nts_(
+            const eprosima::fastdds::rtps::RemoteServerAttributes& server_att);
 
 private:
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
@@ -272,6 +272,18 @@ protected:
     // from DDB must be called during this process
     void process_backup_store();
 
+    /**
+     * Manually match PDP writer endpoint of a given server. The function is not thread safe (nts) in
+     * the sense that it does not take the PDP mutex. It does however take temp_data_lock_
+     */
+    void match_pdp_writer_nts_(const eprosima::fastdds::rtps::RemoteServerAttributes& server_att);
+
+    /**
+     * Manually match PDP reader endpoint of a given server. The function is not thread safe (nts) in
+     * the sense that it does not take the PDP mutex. It does however take temp_data_lock_
+     */
+    void match_pdp_reader_nts_(const eprosima::fastdds::rtps::RemoteServerAttributes& server_att);
+
 private:
 
     //! Server thread

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1135,7 +1135,8 @@ void RTPSParticipantImpl::update_attributes(
             for (auto incoming_server : patt.builtin.discovery_config.m_DiscoveryServers)
             {
                 eprosima::fastdds::rtps::RemoteServerList_t::iterator server_it;
-                for (server_it = m_att.builtin.discovery_config.m_DiscoveryServers.begin(); server_it != m_att.builtin.discovery_config.m_DiscoveryServers.end(); server_it++)
+                for (server_it = m_att.builtin.discovery_config.m_DiscoveryServers.begin();
+                        server_it != m_att.builtin.discovery_config.m_DiscoveryServers.end(); server_it++)
                 {
                     if (server_it->guidPrefix == incoming_server.guidPrefix)
                     {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -64,6 +64,7 @@
 #include <fastdds/rtps/builtin/liveliness/WLP.h>
 
 #include <rtps/builtin/discovery/participant/PDPServer.hpp>
+#include <rtps/builtin/discovery/participant/PDPClient.h>
 
 #include <statistics/rtps/GuidUtils.hpp>
 
@@ -1156,6 +1157,13 @@ void RTPSParticipantImpl::update_attributes(
             {
                 fastdds::rtps::PDPServer* pdp_server = static_cast<fastdds::rtps::PDPServer*>(pdp);
                 pdp_server->update_remote_servers_list();
+            }
+            // Notify PDPClient
+            else if (m_att.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::CLIENT ||
+                    m_att.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::SUPER_CLIENT)
+            {
+                fastdds::rtps::PDPClient* pdp_client = static_cast<fastdds::rtps::PDPClient*>(pdp);
+                pdp_client->update_remote_servers_list();
             }
         }
     }

--- a/test/blackbox/CMakeLists.txt
+++ b/test/blackbox/CMakeLists.txt
@@ -228,6 +228,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
         set(DDS_BLACKBOXTESTS_SOURCE
             ${DDS_BLACKBOXTESTS_TEST_SOURCE}
             ${BLACKBOXTESTS_SOURCE}
+            ${PROJECT_SOURCE_DIR}/src/cpp/utils/SystemInfo.cpp
             )
 
         # Prepare static discovery xml file for blackbox tests.

--- a/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
@@ -16,7 +16,13 @@
 
 #include "BlackboxTests.hpp"
 
+#include "PubSubParticipant.hpp"
 #include "PubSubReader.hpp"
+
+#include <fastdds/dds/core/policy/QosPolicies.hpp>
+#include <fastdds/rtps/common/Locator.h>
+
+#include <chrono>
 
 // Regression test for redmine issue 11857
 TEST(DDSDiscovery, IgnoreParticipantFlags)
@@ -53,3 +59,79 @@ TEST(DDSDiscovery, IgnoreParticipantFlags)
     EXPECT_TRUE(p1.wait_participant_discovery());
     EXPECT_TRUE(p3.wait_participant_discovery());
 }
+
+/**
+ * This test checks that adding servers to the Discovery Server list results in discovering those participants.
+ * It does so by:
+ *    1. Creating two servers and one client that is only connected to one server. At this point check discovery
+ *       state.
+ *    2. Then, connect the client to the other server and check discovery again.
+ *    3. Finally connect the two servers by adding one of them to the others list
+ */
+TEST(DDSDiscovery, AddDiscoveryServerToList)
+{
+    using namespace eprosima::fastdds::dds;
+    using namespace eprosima::fastrtps::rtps;
+
+    // Create first server
+    PubSubParticipant<HelloWorldType> server_1(0u, 0u, 0u, 0u);
+    WireProtocolConfigQos server_1_qos;
+    server_1_qos.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SERVER;
+    std::string server_1_prefix = "44.53.00.5f.45.50.52.4f.53.49.4d.41";
+    std::istringstream(server_1_prefix) >> server_1_qos.prefix;
+    Locator_t locator_server_1;
+    IPLocator::setIPv4(locator_server_1, 127, 0, 0, 1);
+    locator_server_1.port = 64863;
+    server_1_qos.builtin.metatrafficUnicastLocatorList.push_back(locator_server_1);
+    ASSERT_TRUE(server_1.wire_protocol(server_1_qos).init_participant());
+
+    // Create second server
+    PubSubParticipant<HelloWorldType> server_2(0u, 0u, 0u, 0u);
+    WireProtocolConfigQos server_2_qos;
+    server_2_qos.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SERVER;
+    std::string server_2_prefix = "44.53.00.5f.45.50.52.4f.53.49.4d.42";
+    std::istringstream(server_2_prefix) >> server_2_qos.prefix;
+    Locator_t locator_server_2;
+    IPLocator::setIPv4(locator_server_2, 127, 0, 0, 1);
+    locator_server_2.port = 64862;
+    server_2_qos.builtin.metatrafficUnicastLocatorList.push_back(locator_server_2);
+    ASSERT_TRUE(server_2.wire_protocol(server_2_qos).init_participant());
+
+    // Create a client that connects to the first server from the beginning
+    PubSubParticipant<HelloWorldType> client(0u, 0u, 0u, 0u);
+    WireProtocolConfigQos client_qos;
+    client_qos.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::CLIENT;
+    RemoteServerAttributes server_1_att;
+    server_1_att.ReadguidPrefix(server_1_prefix.c_str());
+    server_1_att.metatrafficUnicastLocatorList.push_back(Locator_t(locator_server_1));
+    client_qos.builtin.discovery_config.m_DiscoveryServers.push_back(server_1_att);
+    ASSERT_TRUE(client.wire_protocol(client_qos).init_participant());
+
+    // Check that server_1 and client_1 only know each other, and that server_2 does has not
+    // discovered anyone
+    server_1.wait_discovery(std::chrono::seconds::zero(), 1, true);
+    client.wait_discovery(std::chrono::seconds::zero(), 1, true);
+    server_2.wait_discovery(std::chrono::seconds::zero(), 0, true);
+
+    // Add server_2 to client
+    RemoteServerAttributes server_2_att;
+    server_2_att.ReadguidPrefix(server_2_prefix.c_str());
+    server_2_att.metatrafficUnicastLocatorList.push_back(Locator_t(locator_server_2));
+    client_qos.builtin.discovery_config.m_DiscoveryServers.push_back(server_2_att);
+    ASSERT_TRUE(client.update_wire_protocol(client_qos));
+
+    // Check that the servers only know about the client, and that the client known about both servers
+    server_1.wait_discovery(std::chrono::seconds::zero(), 1, true);
+    client.wait_discovery(std::chrono::seconds::zero(), 2, true);
+    server_2.wait_discovery(std::chrono::seconds::zero(), 1, true);
+
+    // Add server_2 to server_1
+    server_1_qos.builtin.discovery_config.m_DiscoveryServers.push_back(server_2_att);
+    ASSERT_TRUE(server_1.update_wire_protocol(server_1_qos));
+
+    // Check that they all know each other
+    server_1.wait_discovery(std::chrono::seconds::zero(), 2, true);
+    client.wait_discovery(std::chrono::seconds::zero(), 2, true);
+    server_2.wait_discovery(std::chrono::seconds::zero(), 2, true);
+}
+

--- a/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
@@ -90,7 +90,7 @@ TEST(DDSDiscovery, AddDiscoveryServerToList)
     WireProtocolConfigQos server_1_qos;
     server_1_qos.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SERVER;
     // Generate random GUID prefix
-    srand (time(NULL));
+    srand((unsigned)time(NULL));
     GuidPrefix_t server_1_prefix;
     for (auto i = 0; i < 12; i++)
     {

--- a/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
@@ -90,7 +90,7 @@ TEST(DDSDiscovery, AddDiscoveryServerToList)
     WireProtocolConfigQos server_1_qos;
     server_1_qos.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SERVER;
     // Generate random GUID prefix
-    srand(static_cast<unsigned>(time(NULL)));
+    srand(static_cast<unsigned>(time(nullptr)));
     GuidPrefix_t server_1_prefix;
     for (auto i = 0; i < 12; i++)
     {

--- a/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
@@ -23,6 +23,9 @@
 #include <fastdds/rtps/common/Locator.h>
 
 #include <chrono>
+#include <stdlib.h>
+#include <string>
+#include <time.h>
 
 // Regression test for redmine issue 11857
 TEST(DDSDiscovery, IgnoreParticipantFlags)
@@ -73,63 +76,93 @@ TEST(DDSDiscovery, AddDiscoveryServerToList)
     using namespace eprosima::fastdds::dds;
     using namespace eprosima::fastrtps::rtps;
 
-    // Create first server
+    /* Get random port from the environment */
+    char* value = nullptr;
+    value = std::getenv("W_UNICAST_PORT_RANDOM_NUMBER");
+    if (nullptr == value)
+    {
+        value = &std::string("11811")[0];
+    }
+
+    /* Create first server */
     PubSubParticipant<HelloWorldType> server_1(0u, 0u, 0u, 0u);
+    // Set participant as server
     WireProtocolConfigQos server_1_qos;
     server_1_qos.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SERVER;
-    std::string server_1_prefix = "44.53.00.5f.45.50.52.4f.53.49.4d.41";
-    std::istringstream(server_1_prefix) >> server_1_qos.prefix;
+    // Generate random GUID prefix
+    srand (time(NULL));
+    GuidPrefix_t server_1_prefix;
+    for (auto i = 0; i < 12; i++)
+    {
+        server_1_prefix.value[i] = eprosima::fastrtps::rtps::octet(rand() % 254);
+    }
+    server_1_qos.prefix = server_1_prefix;
+    // Generate server's listening locator
     Locator_t locator_server_1;
     IPLocator::setIPv4(locator_server_1, 127, 0, 0, 1);
-    locator_server_1.port = 64863;
+    uint32_t server_1_port = atol(value);
+    locator_server_1.port = server_1_port;
     server_1_qos.builtin.metatrafficUnicastLocatorList.push_back(locator_server_1);
+    // Init server
     ASSERT_TRUE(server_1.wire_protocol(server_1_qos).init_participant());
 
-    // Create second server
+    /* Create second server */
     PubSubParticipant<HelloWorldType> server_2(0u, 0u, 0u, 0u);
+    // Set participant as server
     WireProtocolConfigQos server_2_qos;
     server_2_qos.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SERVER;
-    std::string server_2_prefix = "44.53.00.5f.45.50.52.4f.53.49.4d.42";
-    std::istringstream(server_2_prefix) >> server_2_qos.prefix;
+    // Generate random GUID prefix
+    GuidPrefix_t server_2_prefix = server_1_prefix;
+    server_2_prefix.value[11]++;
+    server_2_qos.prefix = server_2_prefix;
+    // Generate server's listening locator
     Locator_t locator_server_2;
     IPLocator::setIPv4(locator_server_2, 127, 0, 0, 1);
-    locator_server_2.port = 64862;
+    uint32_t server_2_port = atol(value) + 1;
+    locator_server_2.port = server_2_port;
     server_2_qos.builtin.metatrafficUnicastLocatorList.push_back(locator_server_2);
+    // Init server
     ASSERT_TRUE(server_2.wire_protocol(server_2_qos).init_participant());
 
-    // Create a client that connects to the first server from the beginning
+    /* Create a client that connects to the first server from the beginning */
     PubSubParticipant<HelloWorldType> client(0u, 0u, 0u, 0u);
+    // Set participant as client
     WireProtocolConfigQos client_qos;
     client_qos.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::CLIENT;
+    // Connect to first server
     RemoteServerAttributes server_1_att;
-    server_1_att.ReadguidPrefix(server_1_prefix.c_str());
+    server_1_att.guidPrefix = server_1_prefix;
     server_1_att.metatrafficUnicastLocatorList.push_back(Locator_t(locator_server_1));
     client_qos.builtin.discovery_config.m_DiscoveryServers.push_back(server_1_att);
+    // Init client
     ASSERT_TRUE(client.wire_protocol(client_qos).init_participant());
 
-    // Check that server_1 and client_1 only know each other, and that server_2 does has not
-    // discovered anyone
+    /**
+     * Check that server_1 and client_1 only know each other, and that server_2 does has not
+     * discovered anyone
+     */
     server_1.wait_discovery(std::chrono::seconds::zero(), 1, true);
     client.wait_discovery(std::chrono::seconds::zero(), 1, true);
     server_2.wait_discovery(std::chrono::seconds::zero(), 0, true);
 
-    // Add server_2 to client
+    /* Add server_2 to client */
     RemoteServerAttributes server_2_att;
-    server_2_att.ReadguidPrefix(server_2_prefix.c_str());
+    server_2_att.guidPrefix = server_2_prefix;
     server_2_att.metatrafficUnicastLocatorList.push_back(Locator_t(locator_server_2));
     client_qos.builtin.discovery_config.m_DiscoveryServers.push_back(server_2_att);
+    // Update client's servers list
     ASSERT_TRUE(client.update_wire_protocol(client_qos));
 
-    // Check that the servers only know about the client, and that the client known about both servers
+    /* Check that the servers only know about the client, and that the client known about both servers */
     server_1.wait_discovery(std::chrono::seconds::zero(), 1, true);
     client.wait_discovery(std::chrono::seconds::zero(), 2, true);
     server_2.wait_discovery(std::chrono::seconds::zero(), 1, true);
 
-    // Add server_2 to server_1
+    /* Add server_2 to server_1 */
     server_1_qos.builtin.discovery_config.m_DiscoveryServers.push_back(server_2_att);
     ASSERT_TRUE(server_1.update_wire_protocol(server_1_qos));
 
-    // Check that they all know each other
+    /* Check that they all know each other */
     server_1.wait_discovery(std::chrono::seconds::zero(), 2, true);
     client.wait_discovery(std::chrono::seconds::zero(), 2, true);
     server_2.wait_discovery(std::chrono::seconds::zero(), 2, true);

--- a/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
@@ -12,20 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
+#include <cstdlib>
+#include <ctime>
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "BlackboxTests.hpp"
-
 #include "PubSubParticipant.hpp"
 #include "PubSubReader.hpp"
 
 #include <fastdds/dds/core/policy/QosPolicies.hpp>
 #include <fastdds/rtps/common/Locator.h>
-
-#include <chrono>
-#include <stdlib.h>
-#include <string>
-#include <time.h>
+#include <utils/SystemInfo.hpp>
 
 // Regression test for redmine issue 11857
 TEST(DDSDiscovery, IgnoreParticipantFlags)
@@ -73,13 +73,13 @@ TEST(DDSDiscovery, IgnoreParticipantFlags)
  */
 TEST(DDSDiscovery, AddDiscoveryServerToList)
 {
+    using namespace eprosima;
     using namespace eprosima::fastdds::dds;
     using namespace eprosima::fastrtps::rtps;
 
     /* Get random port from the environment */
-    char* value = nullptr;
-    value = std::getenv("W_UNICAST_PORT_RANDOM_NUMBER");
-    if (nullptr == value)
+    const char* value;
+    if (eprosima::ReturnCode_t::RETCODE_OK != SystemInfo::instance().get_env("W_UNICAST_PORT_RANDOM_NUMBER", &value))
     {
         value = &std::string("11811")[0];
     }
@@ -90,7 +90,7 @@ TEST(DDSDiscovery, AddDiscoveryServerToList)
     WireProtocolConfigQos server_1_qos;
     server_1_qos.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SERVER;
     // Generate random GUID prefix
-    srand((unsigned)time(NULL));
+    srand(static_cast<unsigned>(time(NULL)));
     GuidPrefix_t server_1_prefix;
     for (auto i = 0; i < 12; i++)
     {

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -413,18 +413,18 @@ TEST(ParticipantTests, ChangeWireProtocolQos)
     participant->get_qos(set_qos);
     ASSERT_EQ(set_qos, qos);
 
-    // Check that removing one server is OK
+    // Check that removing one server is NOT OK
     qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.pop_front();
-    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_OK);
+    ASSERT_FALSE(participant->set_qos(qos) == ReturnCode_t::RETCODE_OK);
     participant->get_qos(set_qos);
-    ASSERT_EQ(set_qos, qos);
+    ASSERT_FALSE(set_qos == qos);
 
-    // Check that removing all servers is OK
+    // Check that removing all servers is NOT OK
     fastdds::rtps::RemoteServerList_t servers;
     qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers = servers;
-    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_OK);
+    ASSERT_FALSE(participant->set_qos(qos) == ReturnCode_t::RETCODE_OK);
     participant->get_qos(set_qos);
-    ASSERT_EQ(set_qos, qos);
+    ASSERT_FALSE(set_qos == qos);
 
     // Check changing wire_protocol().prefix is NOT OK
     participant->get_qos(qos);


### PR DESCRIPTION
This PR brings the following functionality:

1. `DomainParticipantQos::wire_protocol().builtin.discovery_config.m_DiscoveryServers` can only be modified to add servers, but not to remove them.
2. Propagate new servers to `PDPServer` and `PDPClient` so that discovery can take place
3. Add simple discovery test using discovery server to check that servers added both to a SERVER and a CLIENT have the expected effect.