### PR TITLE
Allow DomainParticipantQos updates for UserDataQosPolicy and adding new servers to the remote server list

### DIFF
--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -105,7 +105,7 @@ class QosPolicy
 {
 public:
 
-    //! Boolean that indicates if the Qos has been changed
+    //! Boolean that indicates if the Qos has been changed with respect to the default Qos.
     bool hasChanged;
 
     /**

--- a/include/fastdds/rtps/participant/RTPSParticipant.h
+++ b/include/fastdds/rtps/participant/RTPSParticipant.h
@@ -149,6 +149,14 @@ public:
             const ReaderQos& rqos);
 
     /**
+     * Update participant attributes.
+     * @param patt New participant attributes.
+     * @return True on success, false otherwise.
+     */
+    bool update_attributes(
+            const RTPSParticipantAttributes& patt);
+
+    /**
      * Update writer QOS
      * @param Writer to update
      * @param topicAtt Topic Attributes where you want to register it.

--- a/include/fastdds/rtps/participant/RTPSParticipant.h
+++ b/include/fastdds/rtps/participant/RTPSParticipant.h
@@ -153,7 +153,7 @@ public:
      * @param patt New participant attributes.
      * @return True on success, false otherwise.
      */
-    bool update_attributes(
+    void update_attributes(
             const RTPSParticipantAttributes& patt);
 
     /**

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1879,7 +1879,32 @@ bool DomainParticipantImpl::can_qos_be_updated(
             logWarning(RTPS_QOS_CHECK, "WireProtocolConfigQos cannot be changed after the participant is enabled, "
                     << "with the exception of builtin.discovery_config.m_DiscoveryServers");
         }
-
+        else
+        {
+            // This means that the only change is in wire_protocol().builtin.discovery_config.m_DiscoveryServers
+            // In that case, we need to ensure that the current list (to) is strictly contained in the incoming
+            // list (from). For that, we check that every server in the current list (to) is also in the incoming one
+            // (from)
+            for (auto existing_server : to.wire_protocol().builtin.discovery_config.m_DiscoveryServers)
+            {
+                bool contained = false;
+                for (auto incoming_server : from.wire_protocol().builtin.discovery_config.m_DiscoveryServers)
+                {
+                    if (existing_server.guidPrefix == incoming_server.guidPrefix)
+                    {
+                        contained = true;
+                        break;
+                    }
+                }
+                if (!contained)
+                {
+                    updatable = false;
+                    logWarning(RTPS_QOS_CHECK,
+                            "Discovery Servers cannot be removed from the list; they can only be added");
+                    break;
+                }
+            }
+        }
     }
     if (!(to.transport() == from.transport()))
     {

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1770,9 +1770,14 @@ bool DomainParticipantImpl::set_qos(
     {
         to.properties() = from.properties();
     }
-    if (first_time && !(to.wire_protocol() == from.wire_protocol()))
+    if (!(to.wire_protocol() == from.wire_protocol()))
     {
         to.wire_protocol() = from.wire_protocol();
+        to.wire_protocol().hasChanged = true;
+        if (!first_time)
+        {
+            qos_should_be_updated = true;
+        }
     }
     if (first_time && !(to.transport() == from.transport()))
     {
@@ -1814,8 +1819,67 @@ bool DomainParticipantImpl::can_qos_be_updated(
     }
     if (!(to.wire_protocol() == from.wire_protocol()))
     {
-        updatable = false;
-        logWarning(RTPS_QOS_CHECK, "WireProtocolConfigQos cannot be changed after the participant is enabled");
+        // Check that the only modification was in wire_protocol().discovery_config.m_DiscoveryServers
+        if ((to.wire_protocol().builtin.discovery_config.m_DiscoveryServers ==
+                from.wire_protocol().builtin.discovery_config.m_DiscoveryServers) ||
+                (!(to.wire_protocol().builtin.discovery_config.m_DiscoveryServers ==
+                from.wire_protocol().builtin.discovery_config.m_DiscoveryServers) &&
+                (!(to.wire_protocol().prefix == from.wire_protocol().prefix) ||
+                !(to.wire_protocol().participant_id == from.wire_protocol().participant_id) ||
+                !(to.wire_protocol().port == from.wire_protocol().port) ||
+                !(to.wire_protocol().throughput_controller == from.wire_protocol().throughput_controller) ||
+                !(to.wire_protocol().default_unicast_locator_list ==
+                from.wire_protocol().default_unicast_locator_list) ||
+                !(to.wire_protocol().default_multicast_locator_list ==
+                from.wire_protocol().default_multicast_locator_list) ||
+                !(to.wire_protocol().builtin.use_WriterLivelinessProtocol ==
+                from.wire_protocol().builtin.use_WriterLivelinessProtocol) ||
+                !(to.wire_protocol().builtin.typelookup_config.use_client ==
+                from.wire_protocol().builtin.typelookup_config.use_client) ||
+                !(to.wire_protocol().builtin.typelookup_config.use_server ==
+                from.wire_protocol().builtin.typelookup_config.use_server) ||
+                !(to.wire_protocol().builtin.metatrafficUnicastLocatorList ==
+                from.wire_protocol().builtin.metatrafficUnicastLocatorList) ||
+                !(to.wire_protocol().builtin.metatrafficMulticastLocatorList ==
+                from.wire_protocol().builtin.metatrafficMulticastLocatorList) ||
+                !(to.wire_protocol().builtin.initialPeersList == from.wire_protocol().builtin.initialPeersList) ||
+                !(to.wire_protocol().builtin.readerHistoryMemoryPolicy ==
+                from.wire_protocol().builtin.readerHistoryMemoryPolicy) ||
+                !(to.wire_protocol().builtin.readerPayloadSize == from.wire_protocol().builtin.readerPayloadSize) ||
+                !(to.wire_protocol().builtin.writerHistoryMemoryPolicy ==
+                from.wire_protocol().builtin.writerHistoryMemoryPolicy) ||
+                !(to.wire_protocol().builtin.writerPayloadSize == from.wire_protocol().builtin.writerPayloadSize) ||
+                !(to.wire_protocol().builtin.mutation_tries == from.wire_protocol().builtin.mutation_tries) ||
+                !(to.wire_protocol().builtin.avoid_builtin_multicast ==
+                from.wire_protocol().builtin.avoid_builtin_multicast) ||
+                !(to.wire_protocol().builtin.discovery_config.discoveryProtocol ==
+                from.wire_protocol().builtin.discovery_config.discoveryProtocol) ||
+                !(to.wire_protocol().builtin.discovery_config.use_SIMPLE_EndpointDiscoveryProtocol ==
+                from.wire_protocol().builtin.discovery_config.use_SIMPLE_EndpointDiscoveryProtocol) ||
+                !(to.wire_protocol().builtin.discovery_config.use_STATIC_EndpointDiscoveryProtocol ==
+                from.wire_protocol().builtin.discovery_config.use_STATIC_EndpointDiscoveryProtocol) ||
+                !(to.wire_protocol().builtin.discovery_config.discoveryServer_client_syncperiod ==
+                from.wire_protocol().builtin.discovery_config.discoveryServer_client_syncperiod) ||
+                !(to.wire_protocol().builtin.discovery_config.m_PDPfactory ==
+                from.wire_protocol().builtin.discovery_config.m_PDPfactory) ||
+                !(to.wire_protocol().builtin.discovery_config.leaseDuration ==
+                from.wire_protocol().builtin.discovery_config.leaseDuration) ||
+                !(to.wire_protocol().builtin.discovery_config.leaseDuration_announcementperiod ==
+                from.wire_protocol().builtin.discovery_config.leaseDuration_announcementperiod) ||
+                !(to.wire_protocol().builtin.discovery_config.initial_announcements ==
+                from.wire_protocol().builtin.discovery_config.initial_announcements) ||
+                !(to.wire_protocol().builtin.discovery_config.m_simpleEDP ==
+                from.wire_protocol().builtin.discovery_config.m_simpleEDP) ||
+                !(strcmp(to.wire_protocol().builtin.discovery_config.static_edp_xml_config(),
+                from.wire_protocol().builtin.discovery_config.static_edp_xml_config()) == 0) ||
+                !(to.wire_protocol().builtin.discovery_config.ignoreParticipantFlags ==
+                from.wire_protocol().builtin.discovery_config.ignoreParticipantFlags))))
+        {
+            updatable = false;
+            logWarning(RTPS_QOS_CHECK, "WireProtocolConfigQos cannot be changed after the participant is enabled, "
+                    << "with the exception of builtin.discovery_config.m_DiscoveryServers");
+        }
+
     }
     if (!(to.transport() == from.transport()))
     {

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -559,7 +559,17 @@ protected:
     std::string get_inner_type_name(
             const fastrtps::rtps::SampleIdentity& id) const;
 
-    static void set_qos(
+    /**
+     * Set the DomainParticipantQos checking if the Qos can be updated or not
+     *
+     * @param to DomainParticipantQos to be updated
+     * @param from DomainParticipantQos desired
+     * @param first_time Whether the DomainParticipant has been already initialized or not
+     *
+     * @return true if there has been a changed in one of the attributes that can be updated.
+     * false otherwise.
+     */
+    static bool set_qos(
             DomainParticipantQos& to,
             const DomainParticipantQos& from,
             bool first_time);

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -394,6 +394,7 @@ RTPSParticipant* RTPSDomain::clientServerEnvironmentCreationOverride(
     RTPSParticipantAttributes client_att(att);
 
     // Retrieve the info from the environment variable
+    // TODO(jlbueno) This should be protected with the PDP mutex.
     if (!load_environment_server_info(client_att.builtin.discovery_config.m_DiscoveryServers))
     {
         // it's not an error, the environment variable may not be set. Any issue with environment

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -79,6 +79,9 @@ bool BuiltinProtocols::initBuiltinProtocols(
     m_metatrafficUnicastLocatorList = m_att.metatrafficUnicastLocatorList;
     m_metatrafficMulticastLocatorList = m_att.metatrafficMulticastLocatorList;
     m_initialPeersList = m_att.initialPeersList;
+
+    // TODO(jlbueno) The access to the list should be protected with the PDP mutex but requires a refactor on PDPClient
+    // and PDPServer: read the remote servers list after the initialization of PDP.
     m_DiscoveryServers = m_att.discovery_config.m_DiscoveryServers;
 
     transform_server_remote_locators(p_part->network_factory());
@@ -160,6 +163,8 @@ bool BuiltinProtocols::updateMetatrafficLocators(
 void BuiltinProtocols::transform_server_remote_locators(
         NetworkFactory& nf)
 {
+    // TODO(jlbueno) The access to the list should be protected with the PDP mutex but requires a refactor on PDPClient
+    // and PDPServer: read the remote servers list after the initialization of PDP.
     for (eprosima::fastdds::rtps::RemoteServerAttributes& rs : m_DiscoveryServers)
     {
         for (Locator_t& loc : rs.metatrafficUnicastLocatorList)

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <mutex>
+#include <set>
 
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/rtps/common/EntityId_t.hpp>
@@ -37,7 +38,7 @@ namespace ddb {
 
 DiscoveryDataBase::DiscoveryDataBase(
         fastrtps::rtps::GuidPrefix_t server_guid_prefix,
-        std::vector<fastrtps::rtps::GuidPrefix_t> servers)
+        std::set<fastrtps::rtps::GuidPrefix_t> servers)
     : server_guid_prefix_(server_guid_prefix)
     , server_acked_by_all_(servers.size() == 0)
     , servers_(servers)
@@ -65,7 +66,7 @@ void DiscoveryDataBase::add_server(
         fastrtps::rtps::GuidPrefix_t server)
 {
     logInfo(DISCOVERY_DATABASE, "Server " << server << " added");
-    servers_.push_back(server);
+    servers_.insert(server);
 }
 
 std::vector<fastrtps::rtps::CacheChange_t*> DiscoveryDataBase::clear()
@@ -1716,7 +1717,7 @@ void DiscoveryDataBase::AckedFunctor::operator () (
         {
             // If the reader proxy is from a server that we are pinging, we may not want to wait
             // for it to be acked as the routine will not stop
-            for (auto it = db_->servers_.begin(); it < db_->servers_.end(); ++it)
+            for (auto it = db_->servers_.begin(); it != db_->servers_.end(); ++it)
             {
                 if (reader_proxy->guid().guidPrefix == *it)
                 {

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
@@ -20,11 +20,12 @@
 #ifndef _FASTDDS_RTPS_DISCOVERY_DATABASE_H_
 #define _FASTDDS_RTPS_DISCOVERY_DATABASE_H_
 
-#include <vector>
+#include <fstream>
+#include <iostream>
 #include <map>
 #include <mutex>
-#include <iostream>
-#include <fstream>
+#include <set>
+#include <vector>
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 #include <fastdds/rtps/writer/ReaderProxy.h>
@@ -117,7 +118,7 @@ public:
 
     DiscoveryDataBase(
             fastrtps::rtps::GuidPrefix_t server_guid_prefix,
-            std::vector<fastrtps::rtps::GuidPrefix_t> servers);
+            std::set<fastrtps::rtps::GuidPrefix_t> servers);
 
     ~DiscoveryDataBase();
 
@@ -562,7 +563,7 @@ protected:
     std::atomic<bool> server_acked_by_all_;
 
     //! List of GUID prefixes of the remote servers
-    std::vector<fastrtps::rtps::GuidPrefix_t> servers_;
+    std::set<fastrtps::rtps::GuidPrefix_t> servers_;
 
     // The virtual topic associated with virtual writers and readers
     const std::string virtual_topic_ = "eprosima_server_virtual_topic";

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1073,6 +1073,7 @@ ParticipantProxyData* PDP::get_participant_proxy_data(
 
 std::list<eprosima::fastdds::rtps::RemoteServerAttributes>& PDP::remote_server_attributes()
 {
+    std::unique_lock<std::recursive_mutex> lock(*getMutex());
     return mp_builtin->m_DiscoveryServers;
 }
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -215,19 +215,22 @@ bool PDPClient::createPDPEndpoints()
         //        mp_RTPSParticipant->set_endpoint_rtps_protection_supports(rout, false);
         //#endif
         // Initial peer list doesn't make sense in server scenario. Client should match its server list
-        for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
         {
-            std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-            temp_writer_data_.clear();
-            temp_writer_data_.guid(it.GetPDPWriter());
-            temp_writer_data_.set_multicast_locators(it.metatrafficMulticastLocatorList, network);
-            temp_writer_data_.set_remote_unicast_locators(it.metatrafficUnicastLocatorList, network);
-            temp_writer_data_.m_qos.m_durability.kind = TRANSIENT_DURABILITY_QOS;  // Server Information must be persistent
-            temp_writer_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+            std::lock_guard<std::recursive_mutex> lock(*getMutex());
 
-            mp_PDPReader->matched_writer_add(temp_writer_data_);
+            for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
+            {
+                std::lock_guard<std::mutex> data_guard(temp_data_lock_);
+                temp_writer_data_.clear();
+                temp_writer_data_.guid(it.GetPDPWriter());
+                temp_writer_data_.set_multicast_locators(it.metatrafficMulticastLocatorList, network);
+                temp_writer_data_.set_remote_unicast_locators(it.metatrafficUnicastLocatorList, network);
+                temp_writer_data_.m_qos.m_durability.kind = TRANSIENT_DURABILITY_QOS;  // Server Information must be persistent
+                temp_writer_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+
+                mp_PDPReader->matched_writer_add(temp_writer_data_);
+            }
         }
-
     }
     else
     {
@@ -267,19 +270,22 @@ bool PDPClient::createPDPEndpoints()
         //#if HAVE_SECURITY
         //        mp_RTPSParticipant->set_endpoint_rtps_protection_supports(wout, false);
         //#endif
-        for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
         {
-            std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-            temp_reader_data_.clear();
-            temp_reader_data_.guid(it.GetPDPReader());
-            temp_reader_data_.set_multicast_locators(it.metatrafficMulticastLocatorList, network);
-            temp_reader_data_.set_remote_unicast_locators(it.metatrafficUnicastLocatorList, network);
-            temp_reader_data_.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
-            temp_reader_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+            std::lock_guard<std::recursive_mutex> lock(*getMutex());
 
-            mp_PDPWriter->matched_reader_add(temp_reader_data_);
+            for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
+            {
+                std::lock_guard<std::mutex> data_guard(temp_data_lock_);
+                temp_reader_data_.clear();
+                temp_reader_data_.guid(it.GetPDPReader());
+                temp_reader_data_.set_multicast_locators(it.metatrafficMulticastLocatorList, network);
+                temp_reader_data_.set_remote_unicast_locators(it.metatrafficUnicastLocatorList, network);
+                temp_reader_data_.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
+                temp_reader_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+
+                mp_PDPWriter->matched_reader_add(temp_reader_data_);
+            }
         }
-
     }
     else
     {

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.h
@@ -128,6 +128,29 @@ public:
      */
     bool match_servers_EDP_endpoints();
 
+    /*
+     * Update the list of remote servers
+     */
+    void update_remote_servers_list();
+
+protected:
+
+    /**
+     * Manually match the local PDP reader with the PDP writer of a given server. The function is
+     * not thread safe (nts) in the sense that it does not take the PDP mutex. It does however take
+     * temp_data_lock_
+     */
+    void match_pdp_writer_nts_(
+            const eprosima::fastdds::rtps::RemoteServerAttributes& server_att);
+
+    /**
+     * Manually match the local PDP writer with the PDP reader of a given server. The function is
+     * not thread safe (nts) in the sense that it does not take the PDP mutex. It does however take
+     * temp_data_lock_
+     */
+    void match_pdp_reader_nts_(
+            const eprosima::fastdds::rtps::RemoteServerAttributes& server_att);
+
 private:
 
     /**

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -69,13 +69,17 @@ PDPServer::PDPServer(
 {
     // Add remote servers from environment variable
     RemoteServerList_t env_servers;
-    if (load_environment_server_info(env_servers))
     {
-        for (auto server : env_servers)
+        std::lock_guard<std::recursive_mutex> lock(*getMutex());
+
+        if (load_environment_server_info(env_servers))
         {
-            mp_builtin->m_DiscoveryServers.push_back(server);
-            m_discovery.discovery_config.m_DiscoveryServers.push_back(server);
-            discovery_db_.add_server(server.guidPrefix);
+            for (auto server : env_servers)
+            {
+                mp_builtin->m_DiscoveryServers.push_back(server);
+                m_discovery.discovery_config.m_DiscoveryServers.push_back(server);
+                discovery_db_.add_server(server.guidPrefix);
+            }
         }
     }
 }
@@ -260,20 +264,24 @@ bool PDPServer::createPDPEndpoints()
         // Enable unknown clients to reach this reader
         mp_PDPReader->enableMessagesFromUnkownWriters(true);
 
-        // Initial peer list doesn't make sense in server scenario. Client should match its server list
-        for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
         {
-            std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-            temp_writer_data_.clear();
-            temp_writer_data_.guid(it.GetPDPWriter());
-            temp_writer_data_.set_multicast_locators(it.metatrafficMulticastLocatorList, network);
-            temp_writer_data_.set_remote_unicast_locators(it.metatrafficUnicastLocatorList, network);
-            // TODO check if this is correct, it is equal as PDPServer, but we do not know like this the durKind of the
-            // other server
-            temp_writer_data_.m_qos.m_durability.durabilityKind(durability_);
-            temp_writer_data_.m_qos.m_reliability.kind = fastrtps::RELIABLE_RELIABILITY_QOS;
+            std::lock_guard<std::recursive_mutex> lock(*getMutex());
 
-            mp_PDPReader->matched_writer_add(temp_writer_data_);
+            // Initial peer list doesn't make sense in server scenario. Client should match its server list
+            for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
+            {
+                std::lock_guard<std::mutex> data_guard(temp_data_lock_);
+                temp_writer_data_.clear();
+                temp_writer_data_.guid(it.GetPDPWriter());
+                temp_writer_data_.set_multicast_locators(it.metatrafficMulticastLocatorList, network);
+                temp_writer_data_.set_remote_unicast_locators(it.metatrafficUnicastLocatorList, network);
+                // TODO check if this is correct, it is equal as PDPServer, but we do not know like this the durKind of the
+                // other server
+                temp_writer_data_.m_qos.m_durability.durabilityKind(durability_);
+                temp_writer_data_.m_qos.m_reliability.kind = fastrtps::RELIABLE_RELIABILITY_QOS;
+
+                mp_PDPReader->matched_writer_add(temp_writer_data_);
+            }
         }
     }
     // Could not create PDP Reader, so return false
@@ -330,17 +338,21 @@ bool PDPServer::createPDPEndpoints()
         // Enable separate sending so the filter can be called for each change and reader proxy
         mp_PDPWriter->set_separate_sending(true);
 
-        for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
         {
-            std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-            temp_reader_data_.clear();
-            temp_reader_data_.guid(it.GetPDPReader());
-            temp_reader_data_.set_multicast_locators(it.metatrafficMulticastLocatorList, network);
-            temp_reader_data_.set_remote_unicast_locators(it.metatrafficUnicastLocatorList, network);
-            temp_reader_data_.m_qos.m_durability.kind = fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS;
-            temp_reader_data_.m_qos.m_reliability.kind = fastrtps::RELIABLE_RELIABILITY_QOS;
+            std::lock_guard<std::recursive_mutex> lock(*getMutex());
 
-            mp_PDPWriter->matched_reader_add(temp_reader_data_);
+            for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
+            {
+                std::lock_guard<std::mutex> data_guard(temp_data_lock_);
+                temp_reader_data_.clear();
+                temp_reader_data_.guid(it.GetPDPReader());
+                temp_reader_data_.set_multicast_locators(it.metatrafficMulticastLocatorList, network);
+                temp_reader_data_.set_remote_unicast_locators(it.metatrafficUnicastLocatorList, network);
+                temp_reader_data_.m_qos.m_durability.kind = fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS;
+                temp_reader_data_.m_qos.m_reliability.kind = fastrtps::RELIABLE_RELIABILITY_QOS;
+
+                mp_PDPWriter->matched_reader_add(temp_reader_data_);
+            }
         }
     }
     // Could not create PDP Writer, so return false
@@ -1339,6 +1351,7 @@ bool PDPServer::pending_ack()
 
 std::vector<fastrtps::rtps::GuidPrefix_t> PDPServer::servers_prefixes()
 {
+    std::lock_guard<std::recursive_mutex> lock(*getMutex());
     std::vector<GuidPrefix_t> servers;
     for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
     {
@@ -1368,16 +1381,20 @@ void PDPServer::ping_remote_servers()
     LocatorList locators;
 
     // Iterate over the list of servers
-    for (auto& server : mp_builtin->m_DiscoveryServers)
     {
+        std::lock_guard<std::recursive_mutex> lock(*getMutex());
 
-        // If the server is the the ack_pending list, then add its GUID and locator to send the announcement
-        auto server_it = std::find(ack_pending_servers.begin(), ack_pending_servers.end(), server.guidPrefix);
-        if (server_it != ack_pending_servers.end())
+        for (auto& server : mp_builtin->m_DiscoveryServers)
         {
-            // get the info to send to this already known locators
-            remote_readers.push_back(GUID_t(server.guidPrefix, c_EntityId_SPDPReader));
-            locators.push_back(server.metatrafficUnicastLocatorList);
+
+            // If the server is the the ack_pending list, then add its GUID and locator to send the announcement
+            auto server_it = std::find(ack_pending_servers.begin(), ack_pending_servers.end(), server.guidPrefix);
+            if (server_it != ack_pending_servers.end())
+            {
+                // get the info to send to this already known locators
+                remote_readers.push_back(GUID_t(server.guidPrefix, c_EntityId_SPDPReader));
+                locators.push_back(server.metatrafficUnicastLocatorList);
+            }
         }
     }
     send_announcement(discovery_db().cache_change_own_participant(), remote_readers, locators);

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -891,6 +891,11 @@ bool PDPServer::server_update_routine()
     return pending_work && discovery_db_.is_enabled();
 }
 
+void PDPServer::update_remote_servers_list()
+{
+    return;
+}
+
 bool PDPServer::process_writers_acknowledgements()
 {
     logInfo(RTPS_PDP_SERVER, "process_writers_acknowledgements start");

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
@@ -22,11 +22,17 @@
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 #include <fastdds/rtps/builtin/discovery/participant/PDP.h>
+
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <fastdds/rtps/attributes/ServerAttributes.h>
 #include <fastdds/rtps/history/History.h>
 #include <fastdds/rtps/resources/ResourceEvent.h>
-
-#include <rtps/builtin/discovery/database/DiscoveryDataFilter.hpp>
 #include <rtps/builtin/discovery/database/DiscoveryDataBase.hpp>
+#include <rtps/builtin/discovery/database/DiscoveryDataFilter.hpp>
 #include <rtps/builtin/discovery/participant/timedevent/DServerEvent.hpp>
 
 namespace eprosima {
@@ -260,7 +266,7 @@ protected:
             nlohmann::json& ddb_json,
             std::vector<nlohmann::json>& new_changes);
 
-    std::vector<fastrtps::rtps::GuidPrefix_t> servers_prefixes();
+    std::set<fastrtps::rtps::GuidPrefix_t> servers_prefixes();
 
     // General file name for the prefix of every backup file
     std::ostringstream get_persistence_file_name_() const;
@@ -271,6 +277,22 @@ protected:
     // queues empty. If not, there will be some information that could be lost. For this, the lock_incoming_data()
     // from DDB must be called during this process
     void process_backup_store();
+
+    /**
+     * Manually match the local PDP reader with the PDP writer of a given server. The function is
+     * not thread safe (nts) in the sense that it does not take the PDP mutex. It does however take
+     * temp_data_lock_
+     */
+    void match_pdp_writer_nts_(
+            const eprosima::fastdds::rtps::RemoteServerAttributes& server_att);
+
+    /**
+     * Manually match the local PDP writer with the PDP reader of a given server. The function is
+     * not thread safe (nts) in the sense that it does not take the PDP mutex. It does however take
+     * temp_data_lock_
+     */
+    void match_pdp_reader_nts_(
+            const eprosima::fastdds::rtps::RemoteServerAttributes& server_att);
 
 private:
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
@@ -171,6 +171,12 @@ public:
 
     fastdds::rtps::ddb::DiscoveryDataBase& discovery_db();
 
+    /**
+     * Access to the remote servers list
+     * This method is not thread safe.
+     * The return reference may be invalidated if the user modifies simultaneously the remote server list.
+     * @return constant reference to the remote servers list
+     */
     const RemoteServerList_t& servers();
 
 protected:

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
@@ -164,6 +164,11 @@ public:
      */
     bool server_update_routine();
 
+    /*
+     * Update the list of remote servers
+     */
+    void update_remote_servers_list();
+
     fastdds::rtps::ddb::DiscoveryDataBase& discovery_db();
 
     const RemoteServerList_t& servers();

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -91,6 +91,12 @@ bool RTPSParticipant::registerReader(
     return mp_impl->registerReader(Reader, topicAtt, rqos);
 }
 
+bool RTPSParticipant::update_attributes(
+        const RTPSParticipantAttributes& patt)
+{
+    return mp_impl->update_attributes(patt);
+}
+
 bool RTPSParticipant::updateWriter(
         RTPSWriter* Writer,
         const TopicAttributes& topicAtt,

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -91,10 +91,10 @@ bool RTPSParticipant::registerReader(
     return mp_impl->registerReader(Reader, topicAtt, rqos);
 }
 
-bool RTPSParticipant::update_attributes(
+void RTPSParticipant::update_attributes(
         const RTPSParticipantAttributes& patt)
 {
-    return mp_impl->update_attributes(patt);
+    mp_impl->update_attributes(patt);
 }
 
 bool RTPSParticipant::updateWriter(

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1170,6 +1170,13 @@ bool RTPSParticipantImpl::registerReader(
     return this->mp_builtinProtocols->addLocalReader(reader, topicAtt, rqos);
 }
 
+bool RTPSParticipantImpl::update_attributes(
+        const RTPSParticipantAttributes& patt)
+{
+    static_cast<void>(patt);
+    return false;
+}
+
 bool RTPSParticipantImpl::updateLocalWriter(
         RTPSWriter* Writer,
         const TopicAttributes& topicAtt,

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -63,6 +63,8 @@
 #include <fastdds/rtps/builtin/data/ParticipantProxyData.h>
 #include <fastdds/rtps/builtin/liveliness/WLP.h>
 
+#include <rtps/builtin/discovery/participant/PDPServer.hpp>
+
 #include <statistics/rtps/GuidUtils.hpp>
 
 namespace eprosima {
@@ -1170,11 +1172,46 @@ bool RTPSParticipantImpl::registerReader(
     return this->mp_builtinProtocols->addLocalReader(reader, topicAtt, rqos);
 }
 
-bool RTPSParticipantImpl::update_attributes(
+void RTPSParticipantImpl::update_attributes(
         const RTPSParticipantAttributes& patt)
 {
-    static_cast<void>(patt);
-    return false;
+    // Check if there are changes
+    if (patt.builtin.discovery_config.m_DiscoveryServers == m_att.builtin.discovery_config.m_DiscoveryServers
+            && patt.userData == m_att.userData)
+    {
+        return;
+    }
+
+    // Update RTPSParticipantAttributes member
+    m_att.builtin.discovery_config.m_DiscoveryServers = patt.builtin.discovery_config.m_DiscoveryServers;
+    m_att.userData = patt.userData;
+
+    auto pdp = mp_builtinProtocols->mp_PDP;
+    {
+        std::unique_lock<std::recursive_mutex> lock(*pdp->getMutex());
+
+        // Update user data
+        auto local_participant_proxy_data = pdp->getLocalParticipantProxyData();
+        local_participant_proxy_data->m_userData.data_vec(m_att.userData);
+
+        // Update remote servers list
+        if (m_att.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::CLIENT ||
+                m_att.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::SUPER_CLIENT ||
+                m_att.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::SERVER ||
+                m_att.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::BACKUP)
+        {
+            mp_builtinProtocols->m_DiscoveryServers = m_att.builtin.discovery_config.m_DiscoveryServers;
+            if (m_att.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::SERVER ||
+                    m_att.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::BACKUP)
+            {
+                fastdds::rtps::PDPServer* pdp_server = static_cast<fastdds::rtps::PDPServer*>(pdp);
+                pdp_server->update_remote_servers_list();
+            }
+        }
+    }
+
+    // Send DATA(P)
+    pdp->announceParticipantState(true);
 }
 
 bool RTPSParticipantImpl::updateLocalWriter(

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -798,6 +798,14 @@ public:
             const ReaderQos& rqos);
 
     /**
+     * Update participant attributes.
+     * @param patt New participant attributes.
+     * @return True on success, false otherwise.
+     */
+    bool update_attributes(
+            const RTPSParticipantAttributes& patt);
+
+    /**
      * Update local writer QoS
      * @param Writer Writer to update
      * @param wqos New QoS for the writer

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -802,7 +802,7 @@ public:
      * @param patt New participant attributes.
      * @return True on success, false otherwise.
      */
-    bool update_attributes(
+    void update_attributes(
             const RTPSParticipantAttributes& patt);
 
     /**

--- a/test/blackbox/CMakeLists.txt
+++ b/test/blackbox/CMakeLists.txt
@@ -227,6 +227,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
     set(DDS_BLACKBOXTESTS_SOURCE
         ${DDS_BLACKBOXTESTS_TEST_SOURCE}
         ${BLACKBOXTESTS_SOURCE}
+        ${PROJECT_SOURCE_DIR}/src/cpp/utils/SystemInfo.cpp
         )
 
     # Prepare static discovery xml file for blackbox tests.

--- a/test/blackbox/common/DDSBlackboxTestsUserDataQos.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsUserDataQos.cpp
@@ -1,0 +1,144 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "BlackboxTests.hpp"
+
+#include "PubSubParticipant.hpp"
+
+#include <fastdds/rtps/common/Types.h>
+#include <fastdds/rtps/participant/ParticipantDiscoveryInfo.h>
+#include <fastrtps/attributes/LibrarySettingsAttributes.h>
+#include <fastrtps/xmlparser/XMLProfileManager.h>
+
+using namespace eprosima::fastrtps;
+
+enum communication_type
+{
+    TRANSPORT,
+    INTRAPROCESS,
+    DATASHARING
+};
+
+class UserDataQos : public testing::TestWithParam<communication_type>
+{
+public:
+
+    void SetUp() override
+    {
+        LibrarySettingsAttributes library_settings;
+        switch (GetParam())
+        {
+            case INTRAPROCESS:
+                library_settings.intraprocess_delivery = IntraprocessDeliveryType::INTRAPROCESS_FULL;
+                xmlparser::XMLProfileManager::library_settings(library_settings);
+                break;
+            case DATASHARING:
+                enable_datasharing = true;
+                break;
+            case TRANSPORT:
+            default:
+                break;
+        }
+    }
+
+    void TearDown() override
+    {
+        LibrarySettingsAttributes library_settings;
+        switch (GetParam())
+        {
+            case INTRAPROCESS:
+                library_settings.intraprocess_delivery = IntraprocessDeliveryType::INTRAPROCESS_OFF;
+                xmlparser::XMLProfileManager::library_settings(library_settings);
+                break;
+            case DATASHARING:
+                enable_datasharing = false;
+                break;
+            case TRANSPORT:
+            default:
+                break;
+        }
+    }
+
+};
+
+/**
+ * This test checks that the user data updates once the participant is initialized are correctly applied
+ * In order to check that the user data is correctly updated, tow participants are created and the discovery info is
+ * checked.
+ */
+TEST_P(UserDataQos, update_user_data_qos)
+{
+    PubSubParticipant<HelloWorldType> participant_1(0u, 0u, 0u, 0u);
+    ASSERT_TRUE(participant_1.user_data({'a', 'b', 'c', 'd', 'e'}).init_participant());
+
+    PubSubParticipant<HelloWorldType> participant_2(0u, 0u, 0u, 0u);
+
+    participant_2.set_on_discovery_function([&](const rtps::ParticipantDiscoveryInfo& info) -> bool
+            {
+                std::cout << "Received USER_DATA: ";
+                for (auto i : info.info.m_userData)
+                {
+                    std::cout << i << ' ';
+                }
+                std::cout << std::endl;
+                return info.info.m_userData == std::vector<rtps::octet>({'a', 'b', 'c', 'd', 'e'});
+            });
+    participant_2.set_on_participant_qos_update_function([&](const rtps::ParticipantDiscoveryInfo& info) -> bool
+            {
+                std::cout << "Received USER_DATA: ";
+                for (auto i : info.info.m_userData)
+                {
+                    std::cout << i << ' ';
+                }
+                std::cout << std::endl;
+                return info.info.m_userData == std::vector<rtps::octet>({'f', 'g'});
+            });
+
+    ASSERT_TRUE(participant_2.init_participant());
+
+    participant_1.wait_discovery();
+    participant_2.wait_discovery_result();
+
+    // Update user data
+    ASSERT_TRUE(participant_1.update_user_data({'f', 'g'}));
+
+    participant_2.wait_qos_update();
+}
+
+#ifdef INSTANTIATE_TEST_SUITE_P
+#define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_SUITE_P(x, y, z, w)
+#else
+#define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_CASE_P(x, y, z, w)
+#endif // INSTANTIATE_TEST_SUITE_P
+
+GTEST_INSTANTIATE_TEST_MACRO(UserDataQos,
+        UserDataQos,
+        testing::Values(TRANSPORT, INTRAPROCESS, DATASHARING),
+        [](const testing::TestParamInfo<UserDataQos::ParamType>& info)
+        {
+            switch (info.param)
+            {
+                case INTRAPROCESS:
+                    return "Intraprocess";
+                    break;
+                case DATASHARING:
+                    return "Datasharing";
+                    break;
+                case TRANSPORT:
+                default:
+                    return "Transport";
+            }
+        });

--- a/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
+++ b/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
@@ -592,7 +592,7 @@ protected:
         return new SubscriberImpl(this, qos, listener);
     }
 
-    static void set_qos(
+    static bool set_qos(
             DomainParticipantQos& /*to*/,
             const DomainParticipantQos& /*from*/,
             bool /*first_time*/)

--- a/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
+++ b/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
@@ -597,6 +597,7 @@ protected:
             const DomainParticipantQos& /*from*/,
             bool /*first_time*/)
     {
+        return false;
     }
 
     static ReturnCode_t check_qos(

--- a/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.h
+++ b/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.h
@@ -163,6 +163,13 @@ public:
         return attributes_;
     }
 
+    bool update_attributes(
+            const RTPSParticipantAttributes& patt)
+    {
+        static_cast<void>(patt);
+        return true;
+    }
+
 #if HAVE_SECURITY
 
     MOCK_METHOD1(is_security_enabled_for_writer, bool(

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -413,18 +413,18 @@ TEST(ParticipantTests, ChangeWireProtocolQos)
     participant->get_qos(set_qos);
     ASSERT_EQ(set_qos, qos);
 
-    // Check that removing one server is OK
+    // Check that removing one server is NOT OK
     qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.pop_front();
-    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_OK);
+    ASSERT_FALSE(participant->set_qos(qos) == ReturnCode_t::RETCODE_OK);
     participant->get_qos(set_qos);
-    ASSERT_EQ(set_qos, qos);
+    ASSERT_FALSE(set_qos == qos);
 
-    // Check that removing all servers is OK
+    // Check that removing all servers is NOT OK
     fastdds::rtps::RemoteServerList_t servers;
     qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers = servers;
-    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_OK);
+    ASSERT_FALSE(participant->set_qos(qos) == ReturnCode_t::RETCODE_OK);
     participant->get_qos(set_qos);
-    ASSERT_EQ(set_qos, qos);
+    ASSERT_FALSE(set_qos == qos);
 
     // Check changing wire_protocol().prefix is NOT OK
     participant->get_qos(qos);

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -376,6 +376,275 @@ TEST(ParticipantTests, ChangePSMDomainParticipantQos)
 
 }
 
+/** This test checks that the only mutable element in WireProtocolQosPolicy is the list of remote servers.
+ * The checks exclude:
+ *    1. wire_protocol().port since its data member cannot be neither initialized nor get
+ *    2. wire_protocol().builtin.discovery_config.m_PDPFactory since it is a deprecated interface for RTPS
+ *       applications to implement a different discovery mechanism.
+ */
+TEST(ParticipantTests, ChangeWireProtocolQos)
+{
+    DomainParticipant* participant =
+            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+    DomainParticipantQos qos;
+    participant->get_qos(qos);
+
+    ASSERT_EQ(qos, PARTICIPANT_QOS_DEFAULT);
+
+    // Check that just adding two servers is OK
+    rtps::RemoteServerAttributes server;
+    server.ReadguidPrefix("44.53.00.5f.45.50.52.4f.53.49.4d.41");
+    fastrtps::rtps::Locator_t locator;
+    fastrtps::rtps::IPLocator::setIPv4(locator, 192, 168, 1, 133);
+    locator.port = 64863;
+    server.metatrafficUnicastLocatorList.push_back(locator);
+    qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.push_back(server);
+
+    rtps::RemoteServerAttributes server_2;
+    server_2.ReadguidPrefix("44.53.00.5f.45.50.52.4f.53.49.4d.42");
+    fastrtps::rtps::Locator_t locator_2;
+    fastrtps::rtps::IPLocator::setIPv4(locator_2, 192, 168, 1, 134);
+    locator_2.port = 64862;
+    server_2.metatrafficUnicastLocatorList.push_back(locator_2);
+    qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.push_back(server_2);
+
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_OK);
+    DomainParticipantQos set_qos;
+    participant->get_qos(set_qos);
+    ASSERT_EQ(set_qos, qos);
+
+    // Check that removing one server is OK
+    qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.pop_front();
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_OK);
+    participant->get_qos(set_qos);
+    ASSERT_EQ(set_qos, qos);
+
+    // Check that removing all servers is OK
+    fastdds::rtps::RemoteServerList_t servers;
+    qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers = servers;
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_OK);
+    participant->get_qos(set_qos);
+    ASSERT_EQ(set_qos, qos);
+
+    // Check changing wire_protocol().prefix is NOT OK
+    participant->get_qos(qos);
+    std::istringstream("44.53.00.5f.45.50.52.4f.53.49.4d.41") >> qos.wire_protocol().prefix;
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().participant_id is NOT OK
+    participant->get_qos(qos);
+    qos.wire_protocol().participant_id = 7;
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().throughput_controller is NOT OK
+    participant->get_qos(qos);
+    fastrtps::rtps::ThroughputControllerDescriptor controller{300000, 1000};
+    qos.wire_protocol().throughput_controller = controller;
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().default_unicast_locator_list is NOT OK
+    participant->get_qos(qos);
+    fastrtps::rtps::Locator_t loc;
+    fastrtps::rtps::IPLocator::setIPv4(loc, "192.0.0.0");
+    loc.port = static_cast<uint16_t>(12);
+    qos.wire_protocol().default_unicast_locator_list.push_back(loc);
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().default_multicast_locator_list is NOT OK
+    participant->get_qos(qos);
+    qos.wire_protocol().default_multicast_locator_list.push_back(loc);
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().builtin.use_WriterLivelinessProtocol is NOT OK
+    participant->get_qos(qos);
+    qos.wire_protocol().builtin.use_WriterLivelinessProtocol ^= true;
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().builtin.typelookup_config.use_client is NOT OK
+    participant->get_qos(qos);
+    qos.wire_protocol().builtin.typelookup_config.use_client ^= true;
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().builtin.typelookup_config.use_server is NOT OK
+    participant->get_qos(qos);
+    qos.wire_protocol().builtin.typelookup_config.use_server ^= true;
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().builtin.metatrafficUnicastLocatorList is NOT OK
+    participant->get_qos(qos);
+    qos.wire_protocol().builtin.metatrafficUnicastLocatorList.push_back(loc);
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().builtin.metatrafficMulticastLocatorList is NOT OK
+    participant->get_qos(qos);
+    qos.wire_protocol().builtin.metatrafficMulticastLocatorList.push_back(loc);
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().builtin.initialPeersList is NOT OK
+    participant->get_qos(qos);
+    qos.wire_protocol().builtin.initialPeersList.push_back(loc);
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().builtin.readerHistoryMemoryPolicy is NOT OK
+    participant->get_qos(qos);
+    qos.wire_protocol().builtin.readerHistoryMemoryPolicy =
+            fastrtps::rtps::MemoryManagementPolicy_t::DYNAMIC_RESERVE_MEMORY_MODE;
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().builtin.readerPayloadSize is NOT OK
+    participant->get_qos(qos);
+    qos.wire_protocol().builtin.readerPayloadSize = 27;
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().builtin.writerHistoryMemoryPolicy is NOT OK
+    participant->get_qos(qos);
+    qos.wire_protocol().builtin.writerHistoryMemoryPolicy =
+            fastrtps::rtps::MemoryManagementPolicy_t::DYNAMIC_RESERVE_MEMORY_MODE;
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().builtin.writerPayloadSize is NOT OK
+    participant->get_qos(qos);
+    qos.wire_protocol().builtin.writerPayloadSize = 27;
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().builtin.mutation_tries is NOT OK
+    participant->get_qos(qos);
+    qos.wire_protocol().builtin.mutation_tries = 27;
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().builtin.avoid_builtin_multicast is NOT OK
+    participant->get_qos(qos);
+    qos.wire_protocol().builtin.avoid_builtin_multicast ^= true;
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().builtin.discovery_config.discoveryProtocol is NOT OK
+    participant->get_qos(qos);
+    qos.wire_protocol().builtin.discovery_config.discoveryProtocol = fastrtps::rtps::DiscoveryProtocol_t::NONE;
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().builtin.discovery_config.use_SIMPLE_EndpointDiscoveryProtocol is NOT OK
+    participant->get_qos(qos);
+    qos.wire_protocol().builtin.discovery_config.use_SIMPLE_EndpointDiscoveryProtocol ^= true;
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().builtin.discovery_config.use_STATIC_EndpointDiscoveryProtocol is NOT OK
+    participant->get_qos(qos);
+    qos.wire_protocol().builtin.discovery_config.use_STATIC_EndpointDiscoveryProtocol ^= true;
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().builtin.discovery_config.discoveryServer_client_syncperiod is NOT OK
+    participant->get_qos(qos);
+    qos.wire_protocol().builtin.discovery_config.discoveryServer_client_syncperiod = { 27, 27};
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().builtin.discovery_config.leaseDuration is NOT OK
+    participant->get_qos(qos);
+    qos.wire_protocol().builtin.discovery_config.leaseDuration = { 27, 27};
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().builtin.discovery_config.leaseDuration_announcementperiod is NOT OK
+    participant->get_qos(qos);
+    qos.wire_protocol().builtin.discovery_config.leaseDuration_announcementperiod = { 27, 27};
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().builtin.discovery_config.initial_announcements is NOT OK
+    participant->get_qos(qos);
+    qos.wire_protocol().builtin.discovery_config.initial_announcements.count = 27;
+    qos.wire_protocol().builtin.discovery_config.initial_announcements.period = {27, 27};
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().builtin.discovery_config.m_simpleEDP is NOT OK
+    participant->get_qos(qos);
+    qos.wire_protocol().builtin.discovery_config.m_simpleEDP.use_PublicationWriterANDSubscriptionReader ^= true;
+    qos.wire_protocol().builtin.discovery_config.m_simpleEDP.use_PublicationReaderANDSubscriptionWriter ^= true;
+#if HAVE_SECURITY
+    qos.wire_protocol().builtin.discovery_config.m_simpleEDP.
+            enable_builtin_secure_publications_writer_and_subscriptions_reader ^= true;
+    qos.wire_protocol().builtin.discovery_config.m_simpleEDP.
+            enable_builtin_secure_subscriptions_writer_and_publications_reader ^= true;
+#endif // if HAVE_SECURITY
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().builtin.discovery_config.static_edp_xml_config() is NOT OK
+    participant->get_qos(qos);
+    std::string static_xml = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
+            "<staticdiscovery>" \
+            "<participant profile_name=\"participant_profile_static_edp\">" \
+            "<rtps>" \
+            "<builtin>" \
+            "<discovery_config>" \
+            "<EDP>STATIC</EDP>" \
+            "</discovery_config>" \
+            "</builtin>" \
+            "</rtps>" \
+            "</participant>" \
+            "</staticdiscovery>";
+    qos.wire_protocol().builtin.discovery_config.static_edp_xml_config(static_xml.c_str());
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    // Check changing wire_protocol().builtin.discovery_config.ignoreParticipantFlags is NOT OK
+    participant->get_qos(qos);
+    qos.wire_protocol().builtin.discovery_config.ignoreParticipantFlags =
+            fastrtps::rtps::ParticipantFilteringFlags::FILTER_DIFFERENT_HOST;
+    ASSERT_TRUE(participant->set_qos(qos) == ReturnCode_t::RETCODE_IMMUTABLE_POLICY);
+    participant->get_qos(set_qos);
+    ASSERT_FALSE(set_qos == qos);
+
+    ASSERT_TRUE(DomainParticipantFactory::get_instance()->delete_participant(participant) == ReturnCode_t::RETCODE_OK);
+}
+
 TEST(ParticipantTests, EntityFactoryBehavior)
 {
     DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();


### PR DESCRIPTION
This PR includes:

* Fix the DDS and RTPS layer link to propagate the DomainParticipantQos updates
* Implementation to allow updates of `user_data`.
* Implementation to allow adding new servers to the remote servers list.
* Blackbox tests that checks both functionalities
* Corresponding unit test when possible