### PR TITLE
[12199] Add SystemInfo::file_exists

### DIFF
--- a/src/cpp/utils/SystemInfo.cpp
+++ b/src/cpp/utils/SystemInfo.cpp
@@ -79,6 +79,7 @@ bool SystemInfo::file_exists(
         const std::string& filename)
 {
     struct stat s;
+    // Check existence and that it is a regular file (and not a folder)
     return (stat(filename.c_str(), &s) == 0 && s.st_mode & S_IFREG);
 }
 

--- a/src/cpp/utils/SystemInfo.cpp
+++ b/src/cpp/utils/SystemInfo.cpp
@@ -14,6 +14,7 @@
 
 #include "SystemInfo.hpp"
 
+#include <sys/stat.h>
 #ifdef _WIN32
 #include <windows.h>
 #else
@@ -72,6 +73,13 @@ ReturnCode_t SystemInfo::get_username(
     }
     return ReturnCode_t::RETCODE_ERROR;
 #endif // _WIN32
+}
+
+bool SystemInfo::file_exists(
+        const std::string& filename)
+{
+    struct stat s;
+    return (stat(filename.c_str(), &s) == 0 && s.st_mode & S_IFREG);
 }
 
 } // eprosima

--- a/src/cpp/utils/SystemInfo.hpp
+++ b/src/cpp/utils/SystemInfo.hpp
@@ -116,6 +116,16 @@ public:
     static ReturnCode_t get_username(
             std::string& username);
 
+    /**
+     * Check if the file wiht name \c filename exists.
+     * \c filename can also include the path to the file.
+     * 
+     * \param [in] filename path and name of the file to check
+     * @return True if the file exists. False otherwise.
+     */
+    static bool file_exists(
+            const std::string& filename);
+
 private:
 
     SystemInfo() = default;

--- a/test/unittest/utils/CMakeLists.txt
+++ b/test/unittest/utils/CMakeLists.txt
@@ -132,4 +132,11 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/cpp ${PROJECT_BINARY_DIR}/include)
     target_link_libraries(SystemInfoTests GTest::gtest)
     add_gtest(SystemInfoTests SOURCES ${SYSTEMINFOTESTS_SOURCE})
+
+    ###############################################################################
+    # Necessary files
+    ###############################################################################
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/environment_test_file.json
+        ${CMAKE_CURRENT_BINARY_DIR}/environment_test_file.json COPYONLY)
+
 endif()


### PR DESCRIPTION
Add a method that checks that given a `filename` the file exists (ensuring also that it is a proper file and not a directory).