### PR TITLE
[12199] Load environment file

### DIFF
--- a/src/cpp/utils/SystemInfo.cpp
+++ b/src/cpp/utils/SystemInfo.cpp
@@ -22,6 +22,9 @@
 #include <unistd.h>
 #endif // _WIN32
 
+#include <fstream>
+
+#include <json.hpp>
 #include <fastrtps/types/TypesBase.h>
 
 namespace eprosima {
@@ -81,6 +84,37 @@ bool SystemInfo::file_exists(
     struct stat s;
     // Check existence and that it is a regular file (and not a folder)
     return (stat(filename.c_str(), &s) == 0 && s.st_mode & S_IFREG);
+}
+
+ReturnCode_t SystemInfo::load_environment_file(
+        const std::string& filename,
+        const std::string& env_name,
+        std::string& env_value)
+{
+    // Check that the file exists
+    if (!SystemInfo::file_exists(filename))
+    {
+        return ReturnCode_t::RETCODE_BAD_PARAMETER;
+    }
+
+    // Read json file
+    std::ifstream file(filename);
+    nlohmann::json file_content;
+    file >> file_content;
+
+    try
+    {
+        env_value = file_content.at(env_name);
+        if (env_value.empty() || env_value.compare("") == 0)
+        {
+            return ReturnCode_t::RETCODE_NO_DATA;
+        }
+    }
+    catch(const std::exception&)
+    {
+        return ReturnCode_t::RETCODE_NO_DATA;
+    }
+    return ReturnCode_t::RETCODE_OK;
 }
 
 } // eprosima

--- a/src/cpp/utils/SystemInfo.cpp
+++ b/src/cpp/utils/SystemInfo.cpp
@@ -100,7 +100,15 @@ ReturnCode_t SystemInfo::load_environment_file(
     // Read json file
     std::ifstream file(filename);
     nlohmann::json file_content;
-    file >> file_content;
+
+    try
+    {
+        file >> file_content;
+    }
+    catch (const nlohmann::json::exception&)
+    {
+        return ReturnCode_t::RETCODE_ERROR;
+    }
 
     try
     {
@@ -110,7 +118,7 @@ ReturnCode_t SystemInfo::load_environment_file(
             return ReturnCode_t::RETCODE_NO_DATA;
         }
     }
-    catch (const std::exception&)
+    catch (const nlohmann::json::exception&)
     {
         return ReturnCode_t::RETCODE_NO_DATA;
     }

--- a/src/cpp/utils/SystemInfo.cpp
+++ b/src/cpp/utils/SystemInfo.cpp
@@ -110,7 +110,7 @@ ReturnCode_t SystemInfo::load_environment_file(
             return ReturnCode_t::RETCODE_NO_DATA;
         }
     }
-    catch(const std::exception&)
+    catch (const std::exception&)
     {
         return ReturnCode_t::RETCODE_NO_DATA;
     }

--- a/src/cpp/utils/SystemInfo.hpp
+++ b/src/cpp/utils/SystemInfo.hpp
@@ -127,7 +127,7 @@ public:
             const std::string& filename);
 
     /**
-     * Read environment vairable contained in the environment file.
+     * Read environment variable contained in the environment file.
      *
      * @param [in] filename path/name of the environment file.
      * @param [in] env_name environment variable name to read from the file.
@@ -135,7 +135,8 @@ public:
      *
      * @return RETCODE_OK if succesful.
      * RETCODE_BAD_PARAMETER if the file does not exist.
-     * RETCODE_NO_DATA if the file exists but there is no information about the environment variable
+     * RETCODE_NO_DATA if the file exists but there is no information about the environment variable.
+     * RETCODE_ERROR if the file is empty or malformed.
      */
     static ReturnCode_t load_environment_file(
             const std::string& filename,

--- a/src/cpp/utils/SystemInfo.hpp
+++ b/src/cpp/utils/SystemInfo.hpp
@@ -119,7 +119,7 @@ public:
     /**
      * Check if the file wiht name \c filename exists.
      * \c filename can also include the path to the file.
-     * 
+     *
      * \param [in] filename path/name of the file to check.
      * @return True if the file exists. False otherwise.
      */
@@ -128,11 +128,11 @@ public:
 
     /**
      * Read environment vairable contained in the environment file.
-     * 
+     *
      * @param [in] filename path/name of the environment file.
      * @param [in] env_name environment variable name to read from the file.
      * @param [out] env_value environment variable value read from the file.
-     * 
+     *
      * @return RETCODE_OK if succesful.
      * RETCODE_BAD_PARAMETER if the file does not exist.
      * RETCODE_NO_DATA if the file exists but there is no information about the environment variable

--- a/src/cpp/utils/SystemInfo.hpp
+++ b/src/cpp/utils/SystemInfo.hpp
@@ -119,12 +119,28 @@ public:
     /**
      * Check if the file wiht name \c filename exists.
      * \c filename can also include the path to the file.
-     *
-     * \param [in] filename path and name of the file to check
+     * 
+     * \param [in] filename path/name of the file to check.
      * @return True if the file exists. False otherwise.
      */
     static bool file_exists(
             const std::string& filename);
+
+    /**
+     * Read environment vairable contained in the environment file.
+     * 
+     * @param [in] filename path/name of the environment file.
+     * @param [in] env_name environment variable name to read from the file.
+     * @param [out] env_value environment variable value read from the file.
+     * 
+     * @return RETCODE_OK if succesful.
+     * RETCODE_BAD_PARAMETER if the file does not exist.
+     * RETCODE_NO_DATA if the file exists but there is no information about the environment variable
+     */
+    static ReturnCode_t load_environment_file(
+            const std::string& filename,
+            const std::string& env_name,
+            std::string& env_value);
 
 private:
 

--- a/test/unittest/utils/CMakeLists.txt
+++ b/test/unittest/utils/CMakeLists.txt
@@ -138,5 +138,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
     ###############################################################################
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/environment_test_file.json
         ${CMAKE_CURRENT_BINARY_DIR}/environment_test_file.json COPYONLY)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/empty_environment_test_file.json
+        ${CMAKE_CURRENT_BINARY_DIR}/empty_environment_test_file.json COPYONLY)
 
 endif()

--- a/test/unittest/utils/SystemInfoTests.cpp
+++ b/test/unittest/utils/SystemInfoTests.cpp
@@ -145,6 +145,12 @@ TEST(SystemInfoTests, LoadEnvironmentFileTest)
     EXPECT_EQ(ReturnCode_t::RETCODE_BAD_PARAMETER, eprosima::SystemInfo::load_environment_file(filename,
             eprosima::fastdds::rtps::DEFAULT_ROS2_MASTER_URI, environment_value));
     EXPECT_TRUE(environment_value.empty());
+
+    // 5. Check that a wrong formatted file returns RETCODE_ERROR
+    filename = "empty_environment_test_file.json";
+    EXPECT_EQ(ReturnCode_t::RETCODE_ERROR, eprosima::SystemInfo::load_environment_file(filename,
+            eprosima::fastdds::rtps::DEFAULT_ROS2_MASTER_URI, environment_value));
+    EXPECT_TRUE(environment_value.empty());
 }
 
 int main(

--- a/test/unittest/utils/SystemInfoTests.cpp
+++ b/test/unittest/utils/SystemInfoTests.cpp
@@ -22,6 +22,7 @@
 #endif // _WIN32
 
 #include <gtest/gtest.h>
+#include <fastdds/rtps/attributes/ServerAttributes.h>
 #include <fastrtps/types/TypesBase.h>
 #include <utils/SystemInfo.hpp>
 
@@ -112,6 +113,38 @@ TEST(SystemInfoTests, FileExistsTest)
     {
         EXPECT_FALSE(eprosima::SystemInfo::file_exists(current_dir));
     }
+}
+
+/**
+ * This test checks the load_environment_file method of the SystemInfo class
+ */
+TEST(SystemInfoTests, LoadEnvironmentFileTest)
+{
+    // 1. Check that reading the environment variable ROS_DISCOVERY_SERVER returns the correct information
+    std::string filename = "environment_test_file.json";
+    std::string environment_value;
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, eprosima::SystemInfo::load_environment_file(filename,
+            eprosima::fastdds::rtps::DEFAULT_ROS2_MASTER_URI, environment_value));
+    EXPECT_EQ("localhost:11811", environment_value);
+
+    // 2. Check that a non-existent tag returns RETCODE_NO_DATA
+    std::string non_existent_env_variable = "NON_EXISTENT_ENV_VARIBLE";
+    environment_value.clear();
+    EXPECT_EQ(ReturnCode_t::RETCODE_NO_DATA, eprosima::SystemInfo::load_environment_file(filename,
+            non_existent_env_variable, environment_value));
+    EXPECT_TRUE(environment_value.empty());
+
+    // 3. Check that an empty environment variable returns RETCODE_NO_DATA
+    std::string empty_environment_variable = "EMPTY_ENV_VAR";
+    EXPECT_EQ(ReturnCode_t::RETCODE_NO_DATA, eprosima::SystemInfo::load_environment_file(filename,
+            empty_environment_variable, environment_value));
+    EXPECT_TRUE(environment_value.empty());
+
+    // 4. Check that a non-existent file returns RETCODE_BAD_PARAMETER
+    filename = "non_existent.json";
+    EXPECT_EQ(ReturnCode_t::RETCODE_BAD_PARAMETER, eprosima::SystemInfo::load_environment_file(filename,
+            eprosima::fastdds::rtps::DEFAULT_ROS2_MASTER_URI, environment_value));
+    EXPECT_TRUE(environment_value.empty());
 }
 
 int main(

--- a/test/unittest/utils/environment_test_file.json
+++ b/test/unittest/utils/environment_test_file.json
@@ -1,0 +1,4 @@
+{
+    "ROS_DISCOVERY_SERVER": "localhost:11811",
+    "EMPTY_ENV_VAR": ""
+}


### PR DESCRIPTION
This PR should be merged after #2155. It implements `SystemInfo::load_environment_file` and tests its functionality.