### PR TITLE
[12199] Refactor load environment server info to take into account environment file

### DIFF
--- a/include/fastdds/rtps/attributes/ServerAttributes.h
+++ b/include/fastdds/rtps/attributes/ServerAttributes.h
@@ -123,6 +123,15 @@ const char* const DEFAULT_ROS2_SERVER_GUIDPREFIX = "44.53.00.5f.45.50.52.4f.53.4
 const char* const DEFAULT_ROS2_MASTER_URI = "ROS_DISCOVERY_SERVER";
 
 /**
+ * Environment variable to specify the name of a file (including or not the path) where the environment variables
+ * could be defined.
+ * Thus, the user can modify the environment variables' values in runtime.
+ *
+ * TODO(jlbueno) Currently only ROS_DISCOVERY_SERVER environment variable is supported.
+ */
+const char* const FASTDDS_ENVIRONMENT_FILE_ENV_VAR = "FASTDDS_ENVIRONMENT_FILE";
+
+/**
  * Retrieves a semicolon-separated list of locators from a string, and
  * populates a RemoteServerList_t mapping list position to default guid.
  * @param[in] list servers listening locator list.
@@ -136,6 +145,13 @@ RTPS_DllAPI bool load_environment_server_info(
 /**
  * Retrieves a semicolon-separated list of locators from DEFAULT_ROS2_MASTER_URI environment variable, and
  * populates a RemoteServerList_t mapping list position to default guid.
+ *
+ * The environment variable can be read from an environment file (which allows runtime modification of the remote
+ * servers list) or directly from the environment.
+ * The value contained in the file takes precedence over the environment value (if both are set).
+ * This is to avoid conflicts because only new servers can be added to the list (containing thus all the previously
+ * known servers).
+ *
  * @param[out] attributes reference to a RemoteServerList_t to populate.
  * @return true if parsing succeeds, false otherwise
  */

--- a/test/blackbox/CMakeLists.txt
+++ b/test/blackbox/CMakeLists.txt
@@ -335,4 +335,9 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
             add_xfail_label(${CMAKE_CURRENT_SOURCE_DIR}/${BLACKBOX_XFAIL_TEST}_SECURITY.list)
         endif()
     endforeach()
+
+    # Necessary files
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/environment_file.json
+        ${CMAKE_CURRENT_BINARY_DIR}/environment_file.json COPYONLY)
+
 endif()

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef _WIN32
-#include <windows.h>
-#else
+#ifndef _WIN32
 #include <stdlib.h>
 #endif // _WIN32
 
@@ -1359,4 +1357,5 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
 
     EXPECT_TRUE(load_environment_server_info(output));
     EXPECT_EQ(output, standard);
+
 }

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -1325,7 +1325,7 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
     ASSERT_EQ(output, standard);
 
     // 11. Check loading from environment file
-    std::string filename = "../unittest/utils/environment_test_file.json";
+    std::string filename = "environment_file.json";
 
     // Set environment variable
 #ifdef _WIN32
@@ -1342,6 +1342,13 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
     IPLocator::setPhysicalPort(loc, 11811);
     att.metatrafficUnicastLocatorList.push_back(loc);
     get_server_client_default_guidPrefix(0, att.guidPrefix);
+    standard.push_back(att);
+
+    att.clear();
+    IPLocator::setIPv4(loc, string("192.168.36.34"));
+    IPLocator::setPhysicalPort(loc, 14520);
+    att.metatrafficUnicastLocatorList.push_back(loc);
+    get_server_client_default_guidPrefix(2, att.guidPrefix);
     standard.push_back(att);
 
     EXPECT_TRUE(load_environment_server_info(output));

--- a/test/blackbox/environment_file.json
+++ b/test/blackbox/environment_file.json
@@ -1,0 +1,3 @@
+{
+    "ROS_DISCOVERY_SERVER": "localhost;;192.168.36.34:14520"
+}


### PR DESCRIPTION
This PR is built over #2157. It refactors `load_environment_server_info` to check first if the environment file exists and if so, read the environment info from there. It also adds some test cases that checks this new feature.