### PR TITLE
Adding enable value to RTPS Participant [13981]

### DIFF
--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -129,7 +129,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     , mp_ResourceSemaphore(new Semaphore(0))
     , IdCounter(0)
     , type_check_fn_(nullptr)
-    , enabled_(false)
+    , enabled_status_(false)
     , client_override_(false)
     , internal_metatraffic_locators_(false)
     , internal_default_locators_(false)
@@ -430,7 +430,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
 
 void RTPSParticipantImpl::enable()
 {
-    if (!enabled_)
+    if (!enabled_status_)
     {
         // Start builtin protocols
         if (!mp_builtinProtocols->initBuiltinProtocols(this, m_att.builtin))
@@ -444,13 +444,13 @@ void RTPSParticipantImpl::enable()
             receiver.Receiver->RegisterReceiver(receiver.mp_receiver);
         }
 
-        enabled_ = true;
+        enabled_status_.store(true);
     }
 }
 
 void RTPSParticipantImpl::disable()
 {
-    if (enabled_)
+    if (enabled_status_)
     {
         // Ensure that other participants will not accidentally discover this one
         if (mp_builtinProtocols && mp_builtinProtocols->mp_PDP)
@@ -484,7 +484,7 @@ void RTPSParticipantImpl::disable()
         delete(mp_builtinProtocols);
         mp_builtinProtocols = nullptr;
 
-        enabled_ = false;
+        enabled_status_.store(false);
     }
 }
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -538,6 +538,8 @@ private:
     std::function<bool(const std::string&)> type_check_fn_;
     //!Pool of send buffers
     std::unique_ptr<SendBuffersManager> send_buffers_;
+    //! Whether the Participant has been enabled
+    bool enabled_;
 
     /**
      * Client override flag: SIMPLE participant that has been overriden with the environment variable and transformed

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -19,20 +19,21 @@
 #ifndef _RTPS_PARTICIPANT_RTPSPARTICIPANTIMPL_H_
 #define _RTPS_PARTICIPANT_RTPSPARTICIPANTIMPL_H_
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+#include <atomic>
+#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <list>
-#include <sys/types.h>
 #include <mutex>
-#include <atomic>
-#include <chrono>
-#include <fastrtps/utils/Semaphore.h>
+#include <sys/types.h>
 
 #if defined(_WIN32)
 #include <process.h>
 #else
 #include <unistd.h>
 #endif // if defined(_WIN32)
+
+#include <fastrtps/utils/Semaphore.h>
 
 #include <rtps/messages/RTPSMessageGroup_t.hpp>
 #include <rtps/messages/SendBuffersManager.hpp>
@@ -497,6 +498,7 @@ public:
     GuidPrefix_t get_persistence_guid_prefix() const
     {
         return m_persistence_guid.guidPrefix;
+
     }
 
 private:
@@ -539,7 +541,7 @@ private:
     //!Pool of send buffers
     std::unique_ptr<SendBuffersManager> send_buffers_;
     //! Whether the Participant has been enabled
-    bool enabled_;
+    std::atomic<bool> enabled_status_;
 
     /**
      * Client override flag: SIMPLE participant that has been overriden with the environment variable and transformed


### PR DESCRIPTION
In case of TCP, when closing the application each locator is eliminated twice (second time without success).
This is because in `RTPSDomain::removeRTPSParticipant` is used `disabled()` and is used again in destruction.
These duplication of erasing a locator leads in some cases to a Warning (when the locator receives a data, but this locator has already been closed):
`[RTCP Warning] Received Message, but no TransportReceiverInterface attached: 11802 -> Function perform_listen_operation`

**No tests implemented.**

Signed-off-by: jparisu <javierparis@eprosima.com>