### PR TITLE
Separate initialization and enabling of BuiltinProtocols [12388]

### DIFF
--- a/include/fastdds/rtps/builtin/BuiltinProtocols.h
+++ b/include/fastdds/rtps/builtin/BuiltinProtocols.h
@@ -79,6 +79,11 @@ public:
             BuiltinAttributes& attributes);
 
     /**
+     * Enable the builtin protocols
+     */
+    void enable();
+
+    /**
      * Update the metatraffic locatorlist after it was created. Because when you create
      * the EDP readers you are not sure the selected endpoints can be used.
      * @param loclist LocatorList to update

--- a/include/fastdds/rtps/builtin/discovery/participant/PDP.h
+++ b/include/fastdds/rtps/builtin/discovery/participant/PDP.h
@@ -351,6 +351,11 @@ public:
      */
     std::list<eprosima::fastdds::rtps::RemoteServerAttributes>& remote_server_attributes();
 
+    bool is_enable()
+    {
+        return enable_;
+    }
+
 protected:
 
     //!Pointer to the builtin protocols object.
@@ -401,6 +406,8 @@ protected:
     std::recursive_mutex* mp_mutex;
     //!To protect callbacks (ParticipantProxyData&)
     std::mutex callback_mtx_;
+    //!Tell if object is enable
+    bool enable_ = false;
 
     /**
      * Adds an entry to the collection of participant proxy information.

--- a/include/fastdds/rtps/builtin/discovery/participant/PDP.h
+++ b/include/fastdds/rtps/builtin/discovery/participant/PDP.h
@@ -401,7 +401,7 @@ protected:
     std::recursive_mutex* mp_mutex;
     //!To protect callbacks (ParticipantProxyData&)
     std::mutex callback_mtx_;
-    //!Tell if object is enable
+    //!Tell if object is enabled
     bool enable_ = false;
 
     /**

--- a/include/fastdds/rtps/builtin/discovery/participant/PDP.h
+++ b/include/fastdds/rtps/builtin/discovery/participant/PDP.h
@@ -351,11 +351,6 @@ public:
      */
     std::list<eprosima::fastdds::rtps::RemoteServerAttributes>& remote_server_attributes();
 
-    bool is_enable()
-    {
-        return enable_;
-    }
-
 protected:
 
     //!Pointer to the builtin protocols object.

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -284,7 +284,6 @@ ReturnCode_t DomainParticipantImpl::enable()
 
     guid_ = part->getGuid();
     rtps_participant_ = part;
-    rtps_participant_->enable();
 
     rtps_participant_->set_check_type_function(
         [this](const std::string& type_name) -> bool
@@ -325,6 +324,8 @@ ReturnCode_t DomainParticipantImpl::enable()
             }
         }
     }
+
+    rtps_participant_->enable();
 
     return ReturnCode_t::RETCODE_OK;
 }

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -146,11 +146,14 @@ bool BuiltinProtocols::initBuiltinProtocols(
         tlm_->init_typelookup_service(mp_participantImpl);
     }
 
+    return true;
+}
+
+void BuiltinProtocols::enable()
+{
+    mp_PDP->enable();
     mp_PDP->announceParticipantState(true);
     mp_PDP->resetParticipantAnnouncement();
-    mp_PDP->enable();
-
-    return true;
 }
 
 bool BuiltinProtocols::updateMetatrafficLocators(

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -151,9 +151,12 @@ bool BuiltinProtocols::initBuiltinProtocols(
 
 void BuiltinProtocols::enable()
 {
-    mp_PDP->enable();
-    mp_PDP->announceParticipantState(true);
-    mp_PDP->resetParticipantAnnouncement();
+    if (nullptr != mp_PDP)
+    {
+        mp_PDP->enable();
+        mp_PDP->announceParticipantState(true);
+        mp_PDP->resetParticipantAnnouncement();
+    }
 }
 
 bool BuiltinProtocols::updateMetatrafficLocators(

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPStatic.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPStatic.cpp
@@ -138,10 +138,7 @@ bool EDPStatic::processLocalReaderProxyData(
     localpdata->m_properties.push_back(EDPStaticProperty::toProperty("Reader", "ALIVE", rdata->userDefinedId(),
             rdata->guid().entityId));
     mp_PDP->getMutex()->unlock();
-    if (this->mp_PDP->is_enable())
-    {
-        this->mp_PDP->announceParticipantState(true);
-    }
+    this->mp_PDP->announceParticipantState(true);
     return true;
 }
 
@@ -156,10 +153,7 @@ bool EDPStatic::processLocalWriterProxyData(
     localpdata->m_properties.push_back(EDPStaticProperty::toProperty("Writer", "ALIVE",
             wdata->userDefinedId(), wdata->guid().entityId));
     mp_PDP->getMutex()->unlock();
-    if (this->mp_PDP->is_enable())
-    {
-        this->mp_PDP->announceParticipantState(true);
-    }
+    this->mp_PDP->announceParticipantState(true);
     return true;
 }
 

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPStatic.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPStatic.cpp
@@ -138,7 +138,10 @@ bool EDPStatic::processLocalReaderProxyData(
     localpdata->m_properties.push_back(EDPStaticProperty::toProperty("Reader", "ALIVE", rdata->userDefinedId(),
             rdata->guid().entityId));
     mp_PDP->getMutex()->unlock();
-    this->mp_PDP->announceParticipantState(true);
+    if (this->mp_PDP->is_enable())
+    {
+        this->mp_PDP->announceParticipantState(true);
+    }
     return true;
 }
 
@@ -153,7 +156,10 @@ bool EDPStatic::processLocalWriterProxyData(
     localpdata->m_properties.push_back(EDPStaticProperty::toProperty("Writer", "ALIVE",
             wdata->userDefinedId(), wdata->guid().entityId));
     mp_PDP->getMutex()->unlock();
-    this->mp_PDP->announceParticipantState(true);
+    if (this->mp_PDP->is_enable())
+    {
+        this->mp_PDP->announceParticipantState(true);
+    }
     return true;
 }
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -373,7 +373,7 @@ bool PDP::initPDP(
     mp_builtin->updateMetatrafficLocators(this->mp_PDPReader->getAttributes().unicastLocatorList);
 
     mp_mutex->lock();
-    ParticipantProxyData* pdata = add_participant_proxy_data(part->getGuid(), false);
+    ParticipantProxyData* pdata = add_participant_proxy_data(mp_RTPSParticipant->getGuid(), false);
     mp_mutex->unlock();
 
     if (pdata == nullptr)
@@ -382,6 +382,11 @@ bool PDP::initPDP(
     }
     initializeParticipantProxyData(pdata);
 
+    return true;
+}
+
+bool PDP::enable()
+{
     // Create lease events on already created proxy data objects
     for (ParticipantProxyData* pool_item : participant_proxies_pool_)
     {
@@ -404,11 +409,6 @@ bool PDP::initPDP(
 
     set_initial_announcement_interval();
 
-    return true;
-}
-
-bool PDP::enable()
-{
     return mp_RTPSParticipant->enableReader(mp_PDPReader);
 }
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -409,6 +409,8 @@ bool PDP::enable()
 
     set_initial_announcement_interval();
 
+    enable_  = true;
+
     return mp_RTPSParticipant->enableReader(mp_PDPReader);
 }
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
@@ -136,6 +136,18 @@ void PDPListener::onNewCacheChangeAdded(
                             << "MTTLoc: " << pdata->metatraffic_locators
                             << " DefLoc:" << pdata->default_locators);
 
+                    RTPSParticipantListener* listener = parent_pdp_->getRTPSParticipant()->getListener();
+                    if (listener != nullptr)
+                    {
+                        std::lock_guard<std::mutex> cb_lock(parent_pdp_->callback_mtx_);
+                        ParticipantDiscoveryInfo info(*pdata);
+                        info.status = status;
+
+                        listener->onParticipantDiscovery(
+                            parent_pdp_->getRTPSParticipant()->getUserRTPSParticipant(),
+                            std::move(info));
+                    }
+
                     // Assigning remote endpoints implies sending a DATA(p) to all matched and fixed readers, since
                     // StatelessWriter::matched_reader_add marks the entire history as unsent if the added reader's
                     // durability is bigger or equal to TRANSIENT_LOCAL_DURABILITY_QOS (TRANSIENT_LOCAL or TRANSIENT),
@@ -166,10 +178,7 @@ void PDPListener::onNewCacheChangeAdded(
                 }
 
                 lock.unlock();
-            }
 
-            if (pdata != nullptr)
-            {
                 RTPSParticipantListener* listener = parent_pdp_->getRTPSParticipant()->getListener();
                 if (listener != nullptr)
                 {

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -540,32 +540,146 @@ void PDPServer::announceParticipantState(
         bool dispose /* = false */,
         WriteParams& )
 {
-    logInfo(RTPS_PDP_SERVER,
-            "Announcing Server " << mp_RTPSParticipant->getGuid() << " (new change: " << new_change << ")");
-    CacheChange_t* change = nullptr;
-
-    StatefulWriter* pW = dynamic_cast<StatefulWriter*>(mp_PDPWriter);
-    assert(pW);
-
-    /*
-       Protect writer sequence number. Make sure in order to prevent AB BA deadlock that the
-       writer mutex is systematically lock before the PDP one (if needed):
-        - transport callbacks on PDPListener
-        - initialization and removal on BuiltinProtocols::initBuiltinProtocols and ~BuiltinProtocols
-        - DSClientEvent (own thread)
-        - ResendParticipantProxyDataPeriod (participant event thread)
-     */
-    std::lock_guard<fastrtps::RecursiveTimedMutex> wlock(pW->getMutex());
-
-    if (!dispose)
+    if (enable_)
     {
-        // Create the CacheChange_t if necessary
-        if (m_hasChangedLocalPDP.exchange(false) || new_change)
+        logInfo(RTPS_PDP_SERVER,
+                "Announcing Server " << mp_RTPSParticipant->getGuid() << " (new change: " << new_change << ")");
+        CacheChange_t* change = nullptr;
+
+        StatefulWriter* pW = dynamic_cast<StatefulWriter*>(mp_PDPWriter);
+        assert(pW);
+
+        /*
+           Protect writer sequence number. Make sure in order to prevent AB BA deadlock that the
+           writer mutex is systematically lock before the PDP one (if needed):
+            - transport callbacks on PDPListener
+            - initialization and removal on BuiltinProtocols::initBuiltinProtocols and ~BuiltinProtocols
+            - DSClientEvent (own thread)
+            - ResendParticipantProxyDataPeriod (participant event thread)
+         */
+        std::lock_guard<fastrtps::RecursiveTimedMutex> wlock(pW->getMutex());
+
+        if (!dispose)
+        {
+            // Create the CacheChange_t if necessary
+            if (m_hasChangedLocalPDP.exchange(false) || new_change)
+            {
+                getMutex()->lock();
+
+                // Copy the participant data
+                ParticipantProxyData proxy_data_copy(*getLocalParticipantProxyData());
+
+                // Prepare identity
+                WriteParams wp;
+                SequenceNumber_t sn = mp_PDPWriterHistory->next_sequence_number();
+                {
+                    SampleIdentity local;
+                    local.writer_guid(mp_PDPWriter->getGuid());
+                    local.sequence_number(sn);
+                    wp.sample_identity(local);
+                    wp.related_sample_identity(local);
+                }
+
+                getMutex()->unlock();
+
+                uint32_t cdr_size = proxy_data_copy.get_serialized_size(true);
+                change = mp_PDPWriter->new_change(
+                    [cdr_size]() -> uint32_t
+                    {
+                        return cdr_size;
+                    },
+                    ALIVE, proxy_data_copy.m_key);
+
+                if (change != nullptr)
+                {
+                    CDRMessage_t aux_msg(change->serializedPayload);
+
+#if __BIG_ENDIAN__
+                    change->serializedPayload.encapsulation = (uint16_t)PL_CDR_BE;
+                    aux_msg.msg_endian = BIGEND;
+#else
+                    change->serializedPayload.encapsulation = (uint16_t)PL_CDR_LE;
+                    aux_msg.msg_endian =  LITTLEEND;
+#endif // if __BIG_ENDIAN__
+
+                    if (proxy_data_copy.writeToCDRMessage(&aux_msg, true))
+                    {
+                        change->serializedPayload.length = (uint16_t)aux_msg.length;
+                    }
+                    else
+                    {
+                        logError(RTPS_PDP_SERVER, "Cannot serialize ParticipantProxyData.");
+                        return;
+                    }
+
+                    // assign identity
+                    change->sequenceNumber = sn;
+
+                    // Create a RemoteLocatorList for metatraffic_locators
+                    fastrtps::rtps::RemoteLocatorList metatraffic_locators(
+                        mp_builtin->m_metatrafficUnicastLocatorList.size(),
+                        mp_builtin->m_metatrafficMulticastLocatorList.size());
+
+                    // Populate with server's unicast locators
+                    for (auto locator : mp_builtin->m_metatrafficUnicastLocatorList)
+                    {
+                        metatraffic_locators.add_unicast_locator(locator);
+                    }
+                    // Populate with server's multicast locators
+                    for (auto locator : mp_builtin->m_metatrafficMulticastLocatorList)
+                    {
+                        metatraffic_locators.add_multicast_locator(locator);
+                    }
+
+                    // Add our change to PDPWriterHistory
+                    mp_PDPWriterHistory->add_change(change, wp);
+                    change->write_params = wp;
+
+                    // Update the database with our own data
+                    if (discovery_db().update(
+                                change,
+                                ddb::DiscoveryParticipantChangeData(metatraffic_locators, false, true)))
+                    {
+                        // Distribute
+                        awake_routine_thread();
+                    }
+                    else
+                    {
+                        // Already there, dispose
+                        logError(RTPS_PDP_SERVER,
+                                "DiscoveryDatabase already initialized with local DATA(p) on creation");
+                        mp_PDPWriter->release_change(change);
+                    }
+                }
+                // Doesn't make sense to send the DATA directly if it hasn't been introduced in the history yet (missing
+                // sequence number.
+                return;
+            }
+            else
+            {
+                // Retrieve the CacheChange_t from the database
+                change = discovery_db().cache_change_own_participant();
+                if (nullptr == change)
+                {
+                    // This case is when the local Server DATA(P) has been included already in database by update method
+                    // but the routine thread has not consumed it yet.
+                    // This would happen when the routine thread is busy in initializing, i.e. it already has other
+                    // DATA(P) to parse before the own one is inserted by update.
+                    logWarning(RTPS_PDP_SERVER, "Local Server DATA(p) uninitialized before local on announcement. "
+                            << "It will be sent in next announce iteration.");
+                    return;
+                }
+            }
+        }
+        else
         {
             getMutex()->lock();
 
             // Copy the participant data
-            ParticipantProxyData proxy_data_copy(*getLocalParticipantProxyData());
+            ParticipantProxyData* local_participant = getLocalParticipantProxyData();
+            InstanceHandle_t key = local_participant->m_key;
+            uint32_t cdr_size = local_participant->get_serialized_size(true);
+            local_participant = nullptr;
 
             // Prepare identity
             WriteParams wp;
@@ -580,172 +694,62 @@ void PDPServer::announceParticipantState(
 
             getMutex()->unlock();
 
-            uint32_t cdr_size = proxy_data_copy.get_serialized_size(true);
-            change = mp_PDPWriter->new_change(
+            change = pW->new_change(
                 [cdr_size]() -> uint32_t
                 {
                     return cdr_size;
                 },
-                ALIVE, proxy_data_copy.m_key);
+                NOT_ALIVE_DISPOSED_UNREGISTERED, key);
 
-            if (change != nullptr)
+            // Generate the Data(Up)
+            if (nullptr != change)
             {
-                CDRMessage_t aux_msg(change->serializedPayload);
-
-#if __BIG_ENDIAN__
-                change->serializedPayload.encapsulation = (uint16_t)PL_CDR_BE;
-                aux_msg.msg_endian = BIGEND;
-#else
-                change->serializedPayload.encapsulation = (uint16_t)PL_CDR_LE;
-                aux_msg.msg_endian =  LITTLEEND;
-#endif // if __BIG_ENDIAN__
-
-                if (proxy_data_copy.writeToCDRMessage(&aux_msg, true))
-                {
-                    change->serializedPayload.length = (uint16_t)aux_msg.length;
-                }
-                else
-                {
-                    logError(RTPS_PDP_SERVER, "Cannot serialize ParticipantProxyData.");
-                    return;
-                }
-
-                // assign identity
+                // Assign identity
                 change->sequenceNumber = sn;
-
-                // Create a RemoteLocatorList for metatraffic_locators
-                fastrtps::rtps::RemoteLocatorList metatraffic_locators(
-                    mp_builtin->m_metatrafficUnicastLocatorList.size(),
-                    mp_builtin->m_metatrafficMulticastLocatorList.size());
-
-                // Populate with server's unicast locators
-                for (auto locator : mp_builtin->m_metatrafficUnicastLocatorList)
-                {
-                    metatraffic_locators.add_unicast_locator(locator);
-                }
-                // Populate with server's multicast locators
-                for (auto locator : mp_builtin->m_metatrafficMulticastLocatorList)
-                {
-                    metatraffic_locators.add_multicast_locator(locator);
-                }
-
-                // Add our change to PDPWriterHistory
-                mp_PDPWriterHistory->add_change(change, wp);
-                change->write_params = wp;
+                change->write_params = std::move(wp);
 
                 // Update the database with our own data
-                if (discovery_db().update(
-                            change,
-                            ddb::DiscoveryParticipantChangeData(metatraffic_locators, false, true)))
+                if (discovery_db().update(change, ddb::DiscoveryParticipantChangeData()))
                 {
                     // Distribute
                     awake_routine_thread();
                 }
                 else
                 {
-                    // Already there, dispose
-                    logError(RTPS_PDP_SERVER, "DiscoveryDatabase already initialized with local DATA(p) on creation");
+                    // Dispose if already there
+                    // It may happen if the participant is not removed fast enough
                     mp_PDPWriter->release_change(change);
+                    return;
                 }
-            }
-            // Doesn't make sense to send the DATA directly if it hasn't been introduced in the history yet (missing
-            // sequence number.
-            return;
-        }
-        else
-        {
-            // Retrieve the CacheChange_t from the database
-            change = discovery_db().cache_change_own_participant();
-            if (nullptr == change)
-            {
-                // This case is when the local Server DATA(P) has been included already in database by update method
-                // but the routine thread has not consumed it yet.
-                // This would happen when the routine thread is busy in initializing, i.e. it already has other
-                // DATA(P) to parse before the own one is inserted by update.
-                logWarning(RTPS_PDP_SERVER, "Local Server DATA(p) uninitialized before local on announcement. "
-                        << "It will be sent in next announce iteration.");
-                return;
-            }
-        }
-    }
-    else
-    {
-        getMutex()->lock();
-
-        // Copy the participant data
-        ParticipantProxyData* local_participant = getLocalParticipantProxyData();
-        InstanceHandle_t key = local_participant->m_key;
-        uint32_t cdr_size = local_participant->get_serialized_size(true);
-        local_participant = nullptr;
-
-        // Prepare identity
-        WriteParams wp;
-        SequenceNumber_t sn = mp_PDPWriterHistory->next_sequence_number();
-        {
-            SampleIdentity local;
-            local.writer_guid(mp_PDPWriter->getGuid());
-            local.sequence_number(sn);
-            wp.sample_identity(local);
-            wp.related_sample_identity(local);
-        }
-
-        getMutex()->unlock();
-
-        change = pW->new_change(
-            [cdr_size]() -> uint32_t
-            {
-                return cdr_size;
-            },
-            NOT_ALIVE_DISPOSED_UNREGISTERED, key);
-
-        // Generate the Data(Up)
-        if (nullptr != change)
-        {
-            // Assign identity
-            change->sequenceNumber = sn;
-            change->write_params = std::move(wp);
-
-            // Update the database with our own data
-            if (discovery_db().update(change, ddb::DiscoveryParticipantChangeData()))
-            {
-                // Distribute
-                awake_routine_thread();
             }
             else
             {
-                // Dispose if already there
-                // It may happen if the participant is not removed fast enough
-                mp_PDPWriter->release_change(change);
+                // failed to create the disposal change
+                logError(RTPS_PDP_SERVER, "Server failed to create its DATA(Up)");
                 return;
             }
         }
-        else
+
+        assert(nullptr != change);
+
+        // Force send the announcement
+
+        // Create a list of receivers based on the remote participants known by the discovery database that are direct
+        // clients or servers of this server. Add the locators of those remote participants.
+        std::vector<GUID_t> remote_readers;
+        LocatorList locators;
+
+        std::vector<GuidPrefix_t> direct_clients_and_servers = discovery_db_.direct_clients_and_servers();
+        for (GuidPrefix_t participant_prefix: direct_clients_and_servers)
         {
-            // failed to create the disposal change
-            logError(RTPS_PDP_SERVER, "Server failed to create its DATA(Up)");
-            return;
+            // Add remote reader
+            GUID_t remote_guid(participant_prefix, c_EntityId_SPDPReader);
+            remote_readers.push_back(remote_guid);
+
+            locators.push_back(discovery_db_.participant_metatraffic_locators(participant_prefix));
         }
+        send_announcement(change, remote_readers, locators, dispose);
     }
-
-    assert(nullptr != change);
-
-    // Force send the announcement
-
-    // Create a list of receivers based on the remote participants known by the discovery database that are direct
-    // clients or servers of this server. Add the locators of those remote participants.
-    std::vector<GUID_t> remote_readers;
-    LocatorList locators;
-
-    std::vector<GuidPrefix_t> direct_clients_and_servers = discovery_db_.direct_clients_and_servers();
-    for (GuidPrefix_t participant_prefix: direct_clients_and_servers)
-    {
-        // Add remote reader
-        GUID_t remote_guid(participant_prefix, c_EntityId_SPDPReader);
-        remote_readers.push_back(remote_guid);
-
-        locators.push_back(discovery_db_.participant_metatraffic_locators(participant_prefix));
-    }
-    send_announcement(change, remote_readers, locators, dispose);
 }
 
 /**

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -212,19 +212,22 @@ void PDPSimple::announceParticipantState(
         bool dispose,
         WriteParams& wp)
 {
-    PDP::announceParticipantState(new_change, dispose, wp);
-
-    if (!(dispose || new_change))
+    if (enable_)
     {
-        StatelessWriter* pW = dynamic_cast<StatelessWriter*>(mp_PDPWriter);
+        PDP::announceParticipantState(new_change, dispose, wp);
 
-        if (pW != nullptr)
+        if (!(dispose || new_change))
         {
-            pW->unsent_changes_reset();
-        }
-        else
-        {
-            logError(RTPS_PDP, "Using PDPSimple protocol with a reliable writer");
+            StatelessWriter* pW = dynamic_cast<StatelessWriter*>(mp_PDPWriter);
+
+            if (pW != nullptr)
+            {
+                pW->unsent_changes_reset();
+            }
+            else
+            {
+                logError(RTPS_PDP, "Using PDPSimple protocol with a reliable writer");
+            }
         }
     }
 }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -400,6 +400,12 @@ RTPSParticipantImpl::RTPSParticipantImpl(
 
     mp_builtinProtocols = new BuiltinProtocols();
 
+    // Start builtin protocols
+    if (!mp_builtinProtocols->initBuiltinProtocols(this, m_att.builtin))
+    {
+        logError(RTPS_PARTICIPANT, "The builtin protocols were not correctly initialized");
+    }
+
     if (c_GuidPrefix_Unknown != persistence_guid)
     {
         logInfo(RTPS_PARTICIPANT, "RTPSParticipant \"" << m_att.getName() << "\" with guidPrefix: " << m_guid.guidPrefix
@@ -425,11 +431,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
 
 void RTPSParticipantImpl::enable()
 {
-    // Start builtin protocols
-    if (!mp_builtinProtocols->initBuiltinProtocols(this, m_att.builtin))
-    {
-        logError(RTPS_PARTICIPANT, "The builtin protocols were not correctly initialized");
-    }
+    mp_builtinProtocols->enable();
 
     //Start reception
     for (auto& receiver : m_receiverResourcelist)

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -400,7 +400,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
 
     mp_builtinProtocols = new BuiltinProtocols();
 
-    // Start builtin protocols
+    // Initialize builtin protocols
     if (!mp_builtinProtocols->initBuiltinProtocols(this, m_att.builtin))
     {
         logError(RTPS_PARTICIPANT, "The builtin protocols were not correctly initialized");

--- a/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.cpp
@@ -202,12 +202,12 @@ ReturnCode_t DomainParticipantImpl::disable_statistics_datawriter(
 
 ReturnCode_t DomainParticipantImpl::enable()
 {
+    create_statistics_builtin_entities();
     ReturnCode_t ret = efd::DomainParticipantImpl::enable();
 
     if (ReturnCode_t::RETCODE_OK == ret)
     {
         rtps_participant_->add_statistics_listener(statistics_listener_, participant_statistics_mask);
-        create_statistics_builtin_entities();
     }
 
     return ret;


### PR DESCRIPTION
The goal is to improve bandwidth network when using Static Discovery. Currently when the `RTPSParticipant` is created, BuiltinProtocols are initialized and enabled at same time. Using Static Discovery provokes each time a DDS entity is enabled a new DATA(p) is sent adding this entity into the property list.

With this PR the enabling of BuiltinProtocols is done after the enabling of DDS entities. Using Static Discovery only one DATA(p) is sent with all entities information.