### PR TITLE
Fix statistics writers sometimes uses the user's publisher [12391]

### DIFF
--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -473,6 +473,15 @@ Publisher* DomainParticipantImpl::create_publisher(
         PublisherListener* listener,
         const StatusMask& mask)
 {
+    return create_publisher(qos, nullptr, listener, mask);
+}
+
+Publisher* DomainParticipantImpl::create_publisher(
+        const PublisherQos& qos,
+        PublisherImpl** impl,
+        PublisherListener* listener,
+        const StatusMask& mask)
+{
     if (!PublisherImpl::check_qos(qos))
     {
         // The PublisherImpl::check_qos() function is not yet implemented and always returns ReturnCode_t::RETCODE_OK.
@@ -505,6 +514,11 @@ Publisher* DomainParticipantImpl::create_publisher(
         ReturnCode_t ret_publisher_enable = pub->enable();
         assert(ReturnCode_t::RETCODE_OK == ret_publisher_enable);
         (void)ret_publisher_enable;
+    }
+
+    if (impl)
+    {
+        *impl = pubimpl;
     }
 
     return pub;

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -121,6 +121,20 @@ public:
 
     /**
      * Create a Publisher in this Participant.
+     * @param qos QoS of the Publisher.
+     * @param[out] impl Return a pointer to the created Publisher's implementation.
+     * @param listenerer Pointer to the listener.
+     * @param mask StatusMask
+     * @return Pointer to the created Publisher.
+     */
+    Publisher* create_publisher(
+            const PublisherQos& qos,
+            PublisherImpl** impl,
+            PublisherListener* listener = nullptr,
+            const StatusMask& mask = StatusMask::all());
+
+    /**
+     * Create a Publisher in this Participant.
      * @param profile_name Publisher profile name.
      * @param listener Pointer to the listener.
      * @param mask StatusMask

--- a/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.cpp
@@ -226,12 +226,7 @@ efd::PublisherImpl* DomainParticipantImpl::create_publisher_impl(
         const efd::PublisherQos& qos,
         efd::PublisherListener* listener)
 {
-    auto impl = new PublisherImpl(this, qos, listener, statistics_listener_);
-    if (nullptr == builtin_publisher_impl_)
-    {
-        builtin_publisher_impl_ = impl;
-    }
-    return impl;
+    return new PublisherImpl(this, qos, listener, statistics_listener_);
 }
 
 efd::SubscriberImpl* DomainParticipantImpl::create_subscriber_impl(
@@ -243,8 +238,13 @@ efd::SubscriberImpl* DomainParticipantImpl::create_subscriber_impl(
 
 void DomainParticipantImpl::create_statistics_builtin_entities()
 {
+    efd::PublisherImpl* builtin_publisher_impl = nullptr;
+
     // Builtin publisher
-    builtin_publisher_ = create_publisher(efd::PUBLISHER_QOS_DEFAULT);
+    builtin_publisher_ = create_publisher(efd::PUBLISHER_QOS_DEFAULT, &builtin_publisher_impl);
+
+    builtin_publisher_impl_ = dynamic_cast<PublisherImpl*>(builtin_publisher_impl);
+    assert(nullptr != builtin_publisher_impl_);
 
     // Enable statistics datawriters
     // 1. Find fastdds_statistics PropertyPolicyQos

--- a/test/blackbox/common/DDSBlackboxTestsStatistics.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsStatistics.cpp
@@ -304,13 +304,9 @@ TEST(DDSStatistics, simple_statistics_second_writer)
 TEST(DDSStatistics, statistics_with_partition_on_user)
 {
 #ifdef FASTDDS_STATISTICS
-    auto transport = std::make_shared<UDPv4TransportDescriptor>();
     auto domain_id = GET_PID() % 100;
 
     DomainParticipantQos p_qos = PARTICIPANT_QOS_DEFAULT;
-    p_qos.transport().use_builtin_transports = false;
-    p_qos.transport().user_transports.push_back(transport);
-
     DomainParticipantFactory* participant_factory = DomainParticipantFactory::get_instance();
 
     // We disable the auto-enabling so the builtin entities do not get created.
@@ -344,9 +340,6 @@ TEST(DDSStatistics, statistics_with_partition_on_user)
     auto subscriber_p2 = p2->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
     ASSERT_NE(nullptr, subscriber_p1);
     ASSERT_NE(nullptr, subscriber_p2);
-
-    // We enable the Publisher so we have everything enabled prior to enabling statistics
-    user_pub_1->enable();
 
     auto physical_data_reader_1 = enable_statistics(statistics_p1, subscriber_p1, statistics::PHYSICAL_DATA_TOPIC);
     auto physical_data_reader_2 = enable_statistics(statistics_p2, subscriber_p2, statistics::PHYSICAL_DATA_TOPIC);

--- a/test/blackbox/common/DDSBlackboxTestsStatistics.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsStatistics.cpp
@@ -61,8 +61,10 @@ static DataReader* enable_statistics(
         Subscriber* subscriber,
         const std::string& topic_name)
 {
+    auto qos = statistics::dds::STATISTICS_DATAWRITER_QOS;
+    qos.history().depth = 10;
     EXPECT_EQ(ReturnCode_t::RETCODE_OK, participant->enable_statistics_datawriter(
-                topic_name, statistics::dds::STATISTICS_DATAWRITER_QOS));
+                topic_name, qos));
 
     auto topic_desc = participant->lookup_topicdescription(topic_name);
     EXPECT_NE(nullptr, topic_desc);

--- a/test/blackbox/common/DDSBlackboxTestsStatistics.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsStatistics.cpp
@@ -172,7 +172,7 @@ TEST(DDSStatistics, simple_statistics_datareaders)
         {"RTPS_SENT_TOPIC",                 statistics::RTPS_SENT_TOPIC,                num_samples},
         {"NETWORK_LATENCY_TOPIC",           statistics::NETWORK_LATENCY_TOPIC,          num_samples},
         {"PUBLICATION_THROUGHPUT_TOPIC",    statistics::PUBLICATION_THROUGHPUT_TOPIC,   num_samples},
-        {"HEARTBEAT_COUNT_TOPIC",           statistics::HEARTBEAT_COUNT_TOPIC,          num_samples},
+        {"HEARTBEAT_COUNT_TOPIC",           statistics::HEARTBEAT_COUNT_TOPIC,          1},
         {"SAMPLE_DATAS_TOPIC",              statistics::SAMPLE_DATAS_TOPIC,             num_samples},
         {"DISCOVERY_TOPIC",                 statistics::DISCOVERY_TOPIC,                1},
         {"PDP_PACKETS_TOPIC",               statistics::PDP_PACKETS_TOPIC,              1},

--- a/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
+++ b/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
@@ -137,7 +137,7 @@ public:
         return listener_;
     }
 
-    Publisher* DomainParticipantImpl::create_publisher(
+    Publisher* create_publisher(
             const PublisherQos& qos,
             PublisherListener* listener,
             const StatusMask& mask)

--- a/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
+++ b/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
@@ -137,8 +137,17 @@ public:
         return listener_;
     }
 
+    Publisher* DomainParticipantImpl::create_publisher(
+            const PublisherQos& qos,
+            PublisherListener* listener,
+            const StatusMask& mask)
+    {
+        return create_publisher(qos, nullptr, listener, mask);
+    }
+
     Publisher* create_publisher(
             const PublisherQos& qos,
+            PublisherImpl** impl,
             PublisherListener* listener = nullptr,
             const StatusMask& mask = StatusMask::all())
     {
@@ -149,6 +158,12 @@ public:
         std::lock_guard<std::mutex> lock(mtx_pubs_);
         publishers_[pub] = pubimpl;
         pub->enable();
+
+        if (impl)
+        {
+            *impl = pubimpl;
+        }
+
         return pub;
     }
 


### PR DESCRIPTION
This can lead to an error. If the user's publisher is configured with a partition, there will no matching with statistics_backend