### PR TITLE
Fix ABBA deadlock in flow controller core [12394]

### DIFF
--- a/include/fastdds/rtps/messages/RTPSMessageGroup.h
+++ b/include/fastdds/rtps/messages/RTPSMessageGroup.h
@@ -100,7 +100,7 @@ public:
     RTPSMessageGroup(
             RTPSParticipantImpl* participant,
             Endpoint* endpoint,
-            const RTPSMessageSenderInterface* msg_sender,
+            RTPSMessageSenderInterface* msg_sender,
             std::chrono::steady_clock::time_point max_blocking_time_point =
             std::chrono::steady_clock::now() + std::chrono::hours(24));
 
@@ -217,7 +217,7 @@ public:
      */
     void sender(
             Endpoint* endpoint,
-            const RTPSMessageSenderInterface* msg_sender)
+            RTPSMessageSenderInterface* msg_sender)
     {
         assert((endpoint != nullptr && msg_sender != nullptr) || (endpoint == nullptr && msg_sender == nullptr));
         if (endpoint != endpoint_ || msg_sender != sender_)
@@ -293,7 +293,7 @@ private:
             const SequenceNumberSet_t& gap_bitmap,
             const EntityId_t& reader_id);
 
-    const RTPSMessageSenderInterface* sender_ = nullptr;
+    RTPSMessageSenderInterface* sender_ = nullptr;
 
     Endpoint* endpoint_ = nullptr;
 

--- a/include/fastdds/rtps/messages/RTPSMessageSenderInterface.hpp
+++ b/include/fastdds/rtps/messages/RTPSMessageSenderInterface.hpp
@@ -80,6 +80,18 @@ public:
     virtual bool send(
             CDRMessage_t* message,
             std::chrono::steady_clock::time_point max_blocking_time_point) const = 0;
+
+    /*!
+     * Lock the object.
+     */
+    virtual void lock() = 0;
+
+    /*!
+     * Lock the object.
+     */
+    virtual void unlock() = 0;
+
+
 };
 
 } /* namespace rtps */

--- a/include/fastdds/rtps/reader/RTPSReader.h
+++ b/include/fastdds/rtps/reader/RTPSReader.h
@@ -315,7 +315,7 @@ public:
      */
     virtual void change_read_by_user(
             CacheChange_t* change,
-            const WriterProxy* writer,
+            WriterProxy* writer,
             bool mark_as_read = true) = 0;
 
     /**

--- a/include/fastdds/rtps/reader/StatefulReader.h
+++ b/include/fastdds/rtps/reader/StatefulReader.h
@@ -246,7 +246,7 @@ public:
     void send_acknack(
             const WriterProxy* writer,
             const SequenceNumberSet_t& sns,
-            const RTPSMessageSenderInterface* sender,
+            RTPSMessageSenderInterface* sender,
             bool is_final);
 
     /**
@@ -257,7 +257,7 @@ public:
      */
     void send_acknack(
             const WriterProxy* writer,
-            const RTPSMessageSenderInterface* sender,
+            RTPSMessageSenderInterface* sender,
             bool heartbeat_was_final);
 
     /**
@@ -313,7 +313,7 @@ public:
      */
     void change_read_by_user(
             CacheChange_t* change,
-            const WriterProxy* writer,
+            WriterProxy* writer,
             bool mark_as_read = true) override;
 
 private:

--- a/include/fastdds/rtps/reader/StatelessReader.h
+++ b/include/fastdds/rtps/reader/StatelessReader.h
@@ -247,7 +247,7 @@ public:
      */
     void change_read_by_user(
             CacheChange_t* change,
-            const WriterProxy* writer,
+            WriterProxy* writer,
             bool mark_as_read = true) override;
 
 private:

--- a/include/fastdds/rtps/writer/LocatorSelectorSender.hpp
+++ b/include/fastdds/rtps/writer/LocatorSelectorSender.hpp
@@ -23,10 +23,10 @@ public:
             RTPSWriter& writer,
             ResourceLimitedContainerConfig matched_readers_allocation
             )
-        : writer(writer)
-        , locator_selector(matched_readers_allocation)
+        : locator_selector(matched_readers_allocation)
         , all_remote_readers(matched_readers_allocation)
         , all_remote_participants(matched_readers_allocation)
+        , writer_(writer)
     {
     }
 
@@ -75,13 +75,35 @@ public:
             CDRMessage_t* message,
             std::chrono::steady_clock::time_point max_blocking_time_point) const override;
 
-    RTPSWriter& writer;
+    /*!
+     * Lock the object.
+     *
+     * This kind of object needs to be locked because could be used outside the writer's mutex.
+     */
+    void lock() override
+    {
+        mutex_.lock();
+    }
+
+    /*!
+     * Unlock the object.
+     */
+    void unlock() override
+    {
+        mutex_.unlock();
+    }
 
     fastrtps::rtps::LocatorSelector locator_selector;
 
     ResourceLimitedVector<GUID_t> all_remote_readers;
 
     ResourceLimitedVector<GuidPrefix_t> all_remote_participants;
+
+private:
+
+    RTPSWriter& writer_;
+
+    std::recursive_mutex mutex_;
 };
 
 } // namespace rtps

--- a/include/fastdds/rtps/writer/ReaderLocator.h
+++ b/include/fastdds/rtps/writer/ReaderLocator.h
@@ -231,6 +231,22 @@ public:
 
     }
 
+    /*
+     * Do nothing.
+     * This object always is protected by writer's mutex.
+     */
+    void lock() override
+    {
+    }
+
+    /*
+     * Do nothing.
+     * This object always is protected by writer's mutex.
+     */
+    void unlock() override
+    {
+    }
+
 private:
 
     RTPSWriter* owner_;

--- a/include/fastdds/rtps/writer/ReaderProxy.h
+++ b/include/fastdds/rtps/writer/ReaderProxy.h
@@ -351,7 +351,7 @@ public:
         return locator_info_.locator_selector_entry();
     }
 
-    const RTPSMessageSenderInterface* message_sender() const
+    RTPSMessageSenderInterface* message_sender()
     {
         return &locator_info_;
     }

--- a/src/cpp/rtps/builtin/discovery/participant/DirectMessageSender.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/DirectMessageSender.hpp
@@ -85,6 +85,20 @@ public:
             CDRMessage_t* message,
             std::chrono::steady_clock::time_point max_blocking_time_point) const override;
 
+    /*
+     * Do nothing.
+     */
+    void lock() override
+    {
+    }
+
+    /*
+     * Do nothing.
+     */
+    void unlock() override
+    {
+    }
+
 private:
 
     RTPSParticipantImpl* participant_;

--- a/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp
+++ b/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp
@@ -1141,6 +1141,7 @@ private:
     {
         // This call should be made with writer's mutex locked.
         fastrtps::rtps::LocatorSelectorSender& locator_selector = writer->get_general_locator_selector();
+        std::lock_guard<fastrtps::rtps::LocatorSelectorSender> lock(locator_selector);
         fastrtps::rtps::RTPSMessageGroup group(participant_, writer, &locator_selector);
         if (fastrtps::rtps::DeliveryRetCode::DELIVERED !=
                 writer->deliver_sample_nts(change, group, locator_selector, max_blocking_time))
@@ -1324,6 +1325,7 @@ private:
 
                 fastrtps::rtps::LocatorSelectorSender& locator_selector =
                         current_writer->get_async_locator_selector();
+                locator_selector.lock();
                 async_mode.group.sender(current_writer, &locator_selector);
 
                 // Remove previously from queue, because deliver_sample_nts could call FlowController::remove_sample()
@@ -1349,11 +1351,13 @@ private:
 
                     async_mode.process_deliver_retcode(ret_delivery);
 
+                    locator_selector.unlock();
                     current_writer->getMutex().unlock();
                     // Unlock mutex_ and try again.
                     break;
                 }
 
+                locator_selector.unlock();
                 current_writer->getMutex().unlock();
 
                 sched.work_done();

--- a/src/cpp/rtps/messages/RTPSMessageGroup.cpp
+++ b/src/cpp/rtps/messages/RTPSMessageGroup.cpp
@@ -180,7 +180,7 @@ RTPSMessageGroup::RTPSMessageGroup(
 RTPSMessageGroup::RTPSMessageGroup(
         RTPSParticipantImpl* participant,
         Endpoint* endpoint,
-        const RTPSMessageSenderInterface* msg_sender,
+        RTPSMessageSenderInterface* msg_sender,
         std::chrono::steady_clock::time_point max_blocking_time_point)
     : RTPSMessageGroup(participant)
 {
@@ -236,7 +236,7 @@ void RTPSMessageGroup::send()
 
         if (full_msg_->length > RTPSMESSAGE_HEADER_SIZE)
         {
-            std::unique_lock<RecursiveTimedMutex> lock(endpoint_->getMutex());
+            std::lock_guard<RTPSMessageSenderInterface> lock(*sender_);
 
 #if HAVE_SECURITY
             // TODO(Ricardo) Control message size if it will be encrypted.

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -1112,7 +1112,7 @@ void StatefulReader::end_sample_access_nts(
 
 void StatefulReader::change_read_by_user(
         CacheChange_t* change,
-        const WriterProxy* writer,
+        WriterProxy* writer,
         bool mark_as_read)
 {
     assert(writer != nullptr);
@@ -1166,7 +1166,7 @@ void StatefulReader::change_read_by_user(
 void StatefulReader::send_acknack(
         const WriterProxy* writer,
         const SequenceNumberSet_t& sns,
-        const RTPSMessageSenderInterface* sender,
+        RTPSMessageSenderInterface* sender,
         bool is_final)
 {
 
@@ -1193,7 +1193,7 @@ void StatefulReader::send_acknack(
 
 void StatefulReader::send_acknack(
         const WriterProxy* writer,
-        const RTPSMessageSenderInterface* sender,
+        RTPSMessageSenderInterface* sender,
         bool heartbeat_was_final)
 {
     // Protect reader

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -372,7 +372,7 @@ void StatelessReader::end_sample_access_nts(
 
 void StatelessReader::change_read_by_user(
         CacheChange_t* change,
-        const WriterProxy* /*writer*/,
+        WriterProxy* /*writer*/,
         bool mark_as_read)
 {
     // Mark change as read

--- a/src/cpp/rtps/reader/WriterProxy.cpp
+++ b/src/cpp/rtps/reader/WriterProxy.cpp
@@ -487,7 +487,7 @@ SequenceNumber_t WriterProxy::next_cache_change_to_be_notified()
     return SequenceNumber_t::unknown();
 }
 
-void WriterProxy::perform_initial_ack_nack() const
+void WriterProxy::perform_initial_ack_nack()
 {
     // Send initial NACK.
     SequenceNumberSet_t sns(SequenceNumber_t(0, 0));
@@ -506,7 +506,7 @@ void WriterProxy::perform_initial_ack_nack() const
     }
 }
 
-void WriterProxy::perform_heartbeat_response() const
+void WriterProxy::perform_heartbeat_response()
 {
     reader_->send_acknack(this, this, heartbeat_final_flag_.load());
 }

--- a/src/cpp/rtps/reader/WriterProxy.h
+++ b/src/cpp/rtps/reader/WriterProxy.h
@@ -241,12 +241,12 @@ public:
     /**
      * Sends a preemptive acknack to the writer represented by this proxy.
      */
-    void perform_initial_ack_nack() const;
+    void perform_initial_ack_nack();
 
     /**
      * Sends the necessary acknac and nackfrag messages to answer the last received heartbeat message.
      */
-    void perform_heartbeat_response() const;
+    void perform_heartbeat_response();
 
     /**
      * Process an incoming heartbeat from the writer represented by this proxy.
@@ -335,6 +335,22 @@ public:
     bool is_datasharing_writer() const
     {
         return is_datasharing_writer_;
+    }
+
+    /*
+     * Do nothing.
+     * This object always is protected by reader's mutex.
+     */
+    void lock() override
+    {
+    }
+
+    /*
+     * Do nothing.
+     * This object always is protected by reader's mutex.
+     */
+    void unlock() override
+    {
     }
 
 private:

--- a/src/cpp/rtps/writer/LocatorSelectorSender.cpp
+++ b/src/cpp/rtps/writer/LocatorSelectorSender.cpp
@@ -9,7 +9,7 @@ bool LocatorSelectorSender::send(
         CDRMessage_t* message,
         std::chrono::steady_clock::time_point max_blocking_time_point) const
 {
-    return writer.send_nts(message, *this, max_blocking_time_point);
+    return writer_.send_nts(message, *this, max_blocking_time_point);
 }
 
 } // namespace rtps

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -414,6 +414,7 @@ bool StatelessWriter::matched_reader_add(
         const ReaderProxyData& data)
 {
     std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
+    std::lock_guard<LocatorSelectorSender> locator_selector_guard(locator_selector_);
 
     assert(data.guid() != c_Guid_Unknown);
 
@@ -522,6 +523,7 @@ bool StatelessWriter::matched_reader_remove(
         const GUID_t& reader_guid)
 {
     std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
+    std::lock_guard<LocatorSelectorSender> locator_selector_guard(locator_selector_);
 
     if (locator_selector_.locator_selector.remove_entry(reader_guid))
     {
@@ -619,7 +621,7 @@ bool StatelessWriter::send_nts(
 DeliveryRetCode StatelessWriter::deliver_sample_nts(
         CacheChange_t* cache_change,
         RTPSMessageGroup& group,
-        LocatorSelectorSender& locator_selector,
+        LocatorSelectorSender& locator_selector, // Object locked by FlowControllerImpl
         const std::chrono::time_point<std::chrono::steady_clock>& /*TODO max_blocking_time*/)
 {
     size_t num_locators = locator_selector.locator_selector.selected_size() + fixed_locators_.size();

--- a/test/mock/rtps/RTPSWriter/fastdds/rtps/writer/RTPSWriter.h
+++ b/test/mock/rtps/RTPSWriter/fastdds/rtps/writer/RTPSWriter.h
@@ -42,6 +42,8 @@ class RTPSWriter : public Endpoint
 public:
 
     RTPSWriter()
+        : general_locator_selector_(*this, ResourceLimitedContainerConfig())
+        , async_locator_selector_(*this, ResourceLimitedContainerConfig())
     {
         static uint8_t entity_id = 0;
         // Generate a guid.
@@ -247,9 +249,9 @@ public:
 
     LivelinessLostStatus liveliness_lost_status_;
 
-    LocatorSelectorSender general_locator_selector_ = LocatorSelectorSender(*this, ResourceLimitedContainerConfig());
+    LocatorSelectorSender general_locator_selector_;
 
-    LocatorSelectorSender async_locator_selector_ = LocatorSelectorSender(*this, ResourceLimitedContainerConfig());
+    LocatorSelectorSender async_locator_selector_;
 };
 
 } // namespace rtps

--- a/test/mock/rtps/ReaderLocator/fastdds/rtps/writer/ReaderLocator.h
+++ b/test/mock/rtps/ReaderLocator/fastdds/rtps/writer/ReaderLocator.h
@@ -233,7 +233,7 @@ public:
         return 0;
     }
 
-    void lock()
+    void lock() override
     {
     }
 

--- a/test/mock/rtps/ReaderLocator/fastdds/rtps/writer/ReaderLocator.h
+++ b/test/mock/rtps/ReaderLocator/fastdds/rtps/writer/ReaderLocator.h
@@ -233,6 +233,14 @@ public:
         return 0;
     }
 
+    void lock()
+    {
+    }
+
+    void unlock() override
+    {
+    }
+
 private:
 
     GUID_t remote_guid_;


### PR DESCRIPTION
`RTPSMessageGroup` used by the flow controller could lead in a ABBA deadlock when the sender is changed. This PR fixes this. Instead of use the writer's mutex, the LocatorSelectorSender has its own mutex.