### PR TITLE
Fix deadlock using asynchronous publication and statistics [12396]

### DIFF
--- a/include/fastdds/rtps/flowcontrol/FlowControllerConsts.hpp
+++ b/include/fastdds/rtps/flowcontrol/FlowControllerConsts.hpp
@@ -23,6 +23,7 @@ namespace rtps {
 
 //! Name of the default flow controller.
 extern RTPS_DllAPI const char* const FASTDDS_FLOW_CONTROLLER_DEFAULT;
+//! Name of the default flow controller for statistics writers.
 extern RTPS_DllAPI const char* const FASTDDS_STATISTICS_FLOW_CONTROLLER_DEFAULT;
 
 } // namespace rtps

--- a/include/fastdds/rtps/flowcontrol/FlowControllerConsts.hpp
+++ b/include/fastdds/rtps/flowcontrol/FlowControllerConsts.hpp
@@ -23,6 +23,7 @@ namespace rtps {
 
 //! Name of the default flow controller.
 extern RTPS_DllAPI const char* const FASTDDS_FLOW_CONTROLLER_DEFAULT;
+extern RTPS_DllAPI const char* const FASTDDS_STATISTICS_FLOW_CONTROLLER_DEFAULT;
 
 } // namespace rtps
 } // namespace fastdds

--- a/src/cpp/rtps/flowcontrol/FlowControllerConsts.cpp
+++ b/src/cpp/rtps/flowcontrol/FlowControllerConsts.cpp
@@ -5,6 +5,7 @@ namespace fastdds {
 namespace rtps {
 
 const char* const FASTDDS_FLOW_CONTROLLER_DEFAULT = "FastDDSFlowControllerDefault";
+const char* const FASTDDS_STATISTICS_FLOW_CONTROLLER_DEFAULT = "FastDDSStatisticsFlowControllerDefault";
 
 } // namespace rtps
 } // namespace fastdds

--- a/src/cpp/rtps/flowcontrol/FlowControllerFactory.cpp
+++ b/src/cpp/rtps/flowcontrol/FlowControllerFactory.cpp
@@ -10,6 +10,9 @@ namespace rtps {
 const char* const pure_sync_flow_controller_name = "PureSyncFlowController";
 const char* const sync_flow_controller_name = "SyncFlowController";
 const char* const async_flow_controller_name = "AsyncFlowController";
+#ifdef FASTDDS_STATISTICS
+const char* const async_statistics_flow_controller_name = "AsyncStatisticsFlowController";
+#endif // ifndef FASTDDS_STATISTICS
 
 void FlowControllerFactory::init(
         fastrtps::rtps::RTPSParticipantImpl* participant)
@@ -32,6 +35,13 @@ void FlowControllerFactory::init(
                               std::unique_ptr<FlowController>(
                                   new FlowControllerImpl<FlowControllerAsyncPublishMode,
                                   FlowControllerFifoSchedule>(participant_, nullptr))});
+
+#ifdef FASTDDS_STATISTICS
+    flow_controllers_.insert({async_statistics_flow_controller_name,
+                              std::unique_ptr<FlowController>(
+                                  new FlowControllerImpl<FlowControllerAsyncPublishMode,
+                                  FlowControllerFifoSchedule>(participant_, nullptr))});
+#endif // ifndef FASTDDS_STATISTICS
 }
 
 void FlowControllerFactory::register_flow_controller (
@@ -147,6 +157,13 @@ FlowController* FlowControllerFactory::retrieve_flow_controller(
             returned_flow = flow_controllers_[async_flow_controller_name].get();
         }
     }
+#ifdef FASTDDS_STATISTICS
+    else if (0 == flow_controller_name.compare(FASTDDS_STATISTICS_FLOW_CONTROLLER_DEFAULT))
+    {
+        assert(fastrtps::rtps::ASYNCHRONOUS_WRITER == writer_attributes.mode);
+        returned_flow = flow_controllers_[async_statistics_flow_controller_name].get();
+    }
+#endif // ifdef FASTDDS_STATISTICS
     else
     {
         auto it = flow_controllers_.find(flow_controller_name);

--- a/src/cpp/statistics/fastdds/publisher/qos/DataWriterQos.cpp
+++ b/src/cpp/statistics/fastdds/publisher/qos/DataWriterQos.cpp
@@ -31,6 +31,7 @@ DataWriterQos::DataWriterQos()
     reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
     durability().kind = eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS;
     publish_mode().kind = eprosima::fastdds::dds::ASYNCHRONOUS_PUBLISH_MODE;
+    publish_mode().flow_controller_name = eprosima::fastdds::rtps::FASTDDS_STATISTICS_FLOW_CONTROLLER_DEFAULT;
     history().kind = eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS;
     history().depth = 100;
     properties().properties().emplace_back("fastdds.push_mode", "false");


### PR DESCRIPTION
From a call of a user's writer `write()` function, internally is a call of a statistics's writer `write()` function. Using asynchronous publication mode, this second call will call again the FlowController's mutex leading into a deadlock. This PR creates another asynchronous thread specially for statistics writers.