### PR TITLE
Keep changes inside instances sorted by source timestamp [12421]

### DIFF
--- a/include/fastdds/rtps/history/ReaderHistory.h
+++ b/include/fastdds/rtps/history/ReaderHistory.h
@@ -126,9 +126,6 @@ protected:
     RTPS_DllAPI void do_release_cache(
             CacheChange_t* ch) override;
 
-    iterator get_first_change_with_minimum_ts(
-            const Time_t timestamp);
-
     //!Pointer to the reader
     RTPSReader* mp_reader;
 

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -283,7 +283,7 @@ bool SubscriberHistory::add_received_change_with_key(
         }
 
         //ADD TO KEY VECTOR
-        sorted_vector_insert(instance_changes, a_change,
+        eprosima::utilities::collections::sorted_vector_insert(instance_changes, a_change,
                 [](const CacheChange_t* lhs, const CacheChange_t* rhs)
                 {
                     return lhs->sourceTimestamp < rhs->sourceTimestamp;

--- a/src/cpp/rtps/history/ReaderHistory.cpp
+++ b/src/cpp/rtps/history/ReaderHistory.cpp
@@ -73,7 +73,7 @@ bool ReaderHistory::add_change(
         logError(RTPS_READER_HISTORY, "The Writer GUID_t must be defined");
     }
 
-    sorted_vector_insert(m_changes, a_change,
+    eprosima::utilities::collections::sorted_vector_insert(m_changes, a_change,
             [](const CacheChange_t* lhs, const CacheChange_t* rhs)
             {
                 return lhs->sourceTimestamp < rhs->sourceTimestamp;

--- a/src/cpp/utils/collections/sorted_vector_insert.hpp
+++ b/src/cpp/utils/collections/sorted_vector_insert.hpp
@@ -1,0 +1,59 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file sorted_vector_insert.hpp
+ */
+
+#ifndef SRC_CPP_UTILS_COLLECTIONS_SORTED_VECTOR_INSERT_HPP_
+#define SRC_CPP_UTILS_COLLECTIONS_SORTED_VECTOR_INSERT_HPP_
+
+#include <algorithm>
+
+namespace eprosima {
+
+/**
+ * @brief Insert item into sorted vector-like collection
+ *
+ * @tparam CollectionType     Type of the collection to be modified.
+ * @tparam ValueType          Type of the item to insert. The collection should support to insert a value of this type.
+ * @tparam LessThanPredicate  Predicate that performs ValueType < CollectionType::value_type comparison.
+ *
+ * @param[in,out] collection The collection to be modified.
+ * @param[in]     item       The item to be inserted.
+ * @param[in]     pred       The predicate to use for comparisons.
+ */
+template<
+    typename CollectionType,
+    typename ValueType,
+    typename LessThanPredicate>
+void sorted_vector_insert(
+        CollectionType& collection,
+        const ValueType& item,
+        const LessThanPredicate& pred)
+{
+    // Insert at the end by default
+    auto it = collection.end();
+
+    // Find insertion position when item is less than last element in collection
+    if (!collection.empty() && pred(item, *collection.rbegin()))
+    {
+        it = std::lower_bound(collection.begin(), collection.end(), item, pred);
+    }
+    collection.insert(it, item);
+}
+
+} // namespace eprosima
+
+#endif // SRC_CPP_UTILS_COLLECTIONS_SORTED_VECTOR_INSERT_HPP_

--- a/src/cpp/utils/collections/sorted_vector_insert.hpp
+++ b/src/cpp/utils/collections/sorted_vector_insert.hpp
@@ -23,6 +23,8 @@
 #include <functional>
 
 namespace eprosima {
+namespace utilities {
+namespace collections {
 
 /**
  * @brief Insert item into sorted vector-like collection
@@ -55,6 +57,8 @@ void sorted_vector_insert(
     collection.insert(it, item);
 }
 
+} // namespace collections
+} // namespace utilities
 } // namespace eprosima
 
 #endif // SRC_CPP_UTILS_COLLECTIONS_SORTED_VECTOR_INSERT_HPP_

--- a/src/cpp/utils/collections/sorted_vector_insert.hpp
+++ b/src/cpp/utils/collections/sorted_vector_insert.hpp
@@ -20,6 +20,7 @@
 #define SRC_CPP_UTILS_COLLECTIONS_SORTED_VECTOR_INSERT_HPP_
 
 #include <algorithm>
+#include <functional>
 
 namespace eprosima {
 
@@ -37,11 +38,11 @@ namespace eprosima {
 template<
     typename CollectionType,
     typename ValueType,
-    typename LessThanPredicate>
+    typename LessThanPredicate = std::less<ValueType>>
 void sorted_vector_insert(
         CollectionType& collection,
         const ValueType& item,
-        const LessThanPredicate& pred)
+        const LessThanPredicate& pred = LessThanPredicate())
 {
     // Insert at the end by default
     auto it = collection.end();

--- a/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
@@ -946,9 +946,9 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepLastWithKeyUnorderedReception)
     uint32_t depth = 10;
 
     reader.resource_limits_max_instances(keys).
-        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-        history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).
-        history_depth(depth).mem_policy(mem_policy_).init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).
+            history_depth(depth).mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -956,11 +956,11 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepLastWithKeyUnorderedReception)
     testTransport->dropDataMessagesPercentage = 25;
 
     writer.resource_limits_max_instances(keys).
-        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
-        history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).
-        history_depth(depth).mem_policy(mem_policy_).
-        disable_builtin_transport().add_user_transport_to_pparams(testTransport).
-        init();
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).
+            history_depth(depth).mem_policy(mem_policy_).
+            disable_builtin_transport().add_user_transport_to_pparams(testTransport).
+            init();
 
     ASSERT_TRUE(writer.isInitialized());
 

--- a/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
@@ -935,6 +935,50 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepLastReaderSmallDepthWithKey)
     }
 }
 
+// Regression test for redmine bug #12419
+// It uses a test transport to drop some DATA messages, in order to force unordered reception.
+TEST_P(PubSubHistory, PubSubAsReliableKeepLastWithKeyUnorderedReception)
+{
+    PubSubReader<KeyedHelloWorldType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<KeyedHelloWorldType> writer(TEST_TOPIC_NAME);
+
+    uint32_t keys = 2;
+    uint32_t depth = 10;
+
+    reader.resource_limits_max_instances(keys).
+        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+        history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).
+        history_depth(depth).mem_policy(mem_policy_).init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    auto testTransport = std::make_shared<test_UDPv4TransportDescriptor>();
+    testTransport->dropDataMessagesPercentage = 25;
+
+    writer.resource_limits_max_instances(keys).
+        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+        history_kind(eprosima::fastrtps::KEEP_LAST_HISTORY_QOS).
+        history_depth(depth).mem_policy(mem_policy_).
+        disable_builtin_transport().add_user_transport_to_pparams(testTransport).
+        init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    auto data = default_keyedhelloworld_data_generator(keys * depth);
+    reader.startReception(data);
+
+    // Send data
+    writer.send(data);
+    ASSERT_TRUE(data.empty());
+
+    reader.block_for_all();
+    reader.stopReception();
+}
+
 bool comparator(
         HelloWorld first,
         HelloWorld second)

--- a/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
+++ b/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
@@ -127,13 +127,6 @@ protected:
     std::mutex samples_number_mutex_;
     unsigned int samples_number_;
     SequenceNumber_t last_sequence_number_;
-
-    iterator get_first_change_with_minimum_ts(
-            const Time_t& /* timestamp */)
-    {
-        return m_changes.end();
-    }
-
 };
 
 } // namespace rtps


### PR DESCRIPTION
On a reliable reader, when using a topic with keys, and changes arrive unordered, they are returned in the received order instead of the sequence number order.

This PR fixes this misbehavior, and also adds a generic utility function to keep changes on a vector sorted.