### PR TITLE
Move unlock below the deleteUserEndpoint

### DIFF
--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -312,8 +312,9 @@ bool RTPSDomain::removeRTPSWriter(
             if (it->first->getGuid().guidPrefix == writer->getGuid().guidPrefix)
             {
                 t_p_RTPSParticipant participant = *it;
+                bool result = participant.second->deleteUserEndpoint((Endpoint*)writer);
                 lock.unlock();
-                return participant.second->deleteUserEndpoint((Endpoint*)writer);
+                return result;
             }
         }
     }
@@ -368,8 +369,9 @@ bool RTPSDomain::removeRTPSReader(
             if (it->first->getGuid().guidPrefix == reader->getGuid().guidPrefix)
             {
                 t_p_RTPSParticipant participant = *it;
+                bool result = participant.second->deleteUserEndpoint((Endpoint*)reader);
                 lock.unlock();
-                return participant.second->deleteUserEndpoint((Endpoint*)reader);
+                return result;
             }
         }
     }


### PR DESCRIPTION
Move `unlock` below the `deleteUserEndpoint` to avoid data race.

Signed-off-by: zouyonghao <yonghaoz1994@gmail.com>

Recently I got the following SEGV:

```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==547699==ERROR: AddressSanitizer: SEGV on unknown address 0x61902f800027 (pc 0x7fb4a5b7aa3f bp 0x61600000f4b0 sp 0x7fb481d8ef58 T5)
==547699==The signal is caused by a READ memory access.
    #0 0x7fb4a5b7aa3f in eprosima::fastrtps::rtps::RTPSParticipantImpl::find_local_writer(eprosima::fastrtps::rtps::GUID_t const&) (/opt/ros/foxy/lib/libfastrtps.so.2+0x2eaa3f)
    #1 0x7fb4a5b86bbc in eprosima::fastrtps::rtps::RTPSDomainImpl::find_local_writer(eprosima::fastrtps::rtps::GUID_t const&) (/opt/ros/foxy/lib/libfastrtps.so.2+0x2f6bbc)
    #2 0x7fb4a5b4e05a in eprosima::fastrtps::rtps::WriterProxy::perform_initial_ack_nack() const (/opt/ros/foxy/lib/libfastrtps.so.2+0x2be05a)
    #3 0x7fb4a5b4e11f  (/opt/ros/foxy/lib/libfastrtps.so.2+0x2be11f)
    #4 0x7fb4a5b1dfed in eprosima::fastrtps::rtps::TimedEventImpl::trigger(std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >) (/opt/ros/foxy/lib/libfastrtps.so.2+0x28dfed)
    #5 0x7fb4a5b1c865 in eprosima::fastrtps::rtps::ResourceEvent::do_timer_actions() (/opt/ros/foxy/lib/libfastrtps.so.2+0x28c865)
    #6 0x7fb4a5b1cb7a in eprosima::fastrtps::rtps::ResourceEvent::event_service() (/opt/ros/foxy/lib/libfastrtps.so.2+0x28cb7a)
    #7 0x7fb4a53f9de3  (/lib/x86_64-linux-gnu/libstdc++.so.6+0xd6de3)
    #8 0x7fb4ba2cd608 in start_thread /build/glibc-eX1tMB/glibc-2.31/nptl/pthread_create.c:477:8
    #9 0x7fb4a50e7292 in clone /build/glibc-eX1tMB/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV (/opt/ros/foxy/lib/libfastrtps.so.2+0x2eaa3f) in eprosima::fastrtps::rtps::RTPSParticipantImpl::find_local_writer(eprosima::fastrtps::rtps::GUID_t const&)
Thread T5 created by T0 here:
    #0 0x49220a in pthread_create (/home/r1/ros2_nav_fuzz/build/rtabmap_ros/rtabmap+0x49220a)
    #1 0x7fb4a53fa0a8 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) (/lib/x86_64-linux-gnu/libstdc++.so.6+0xd70a8)

==547699==ABORTING
```

I see the following code:
https://github.com/eProsima/Fast-DDS/blob/c97053e3271982c1ba6730e3d04fd0fba40c6c42/src/cpp/rtps/participant/RTPSParticipantImpl.cpp#L1120-L1128

The comments in this snippets say it is locked by a outer lock.

However, in `RTPSDomain.cpp`, the lock is unlocked before the `deleteUserEndpoint`, which will modify the `m_allWriterList`, and then cause error if another thread is iterating it.
