### PR TITLE
[12199] Reload environment file information

### DIFF
--- a/include/fastdds/rtps/RTPSDomain.h
+++ b/include/fastdds/rtps/RTPSDomain.h
@@ -23,13 +23,14 @@
 #include <mutex>
 #include <set>
 
-#if defined(_WIN32) || defined(__unix__)
-#include <FileWatch.hpp>
-#endif // defined(_WIN32) || defined(__unix__)
-
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
 #include <fastdds/rtps/common/Types.h>
 #include <fastdds/rtps/history/IPayloadPool.h>
+
+namespace filewatch {
+template<class T>
+class FileWatch;
+} // filewatch
 
 namespace eprosima {
 

--- a/include/fastdds/rtps/RTPSDomain.h
+++ b/include/fastdds/rtps/RTPSDomain.h
@@ -28,7 +28,6 @@
 #include <fastdds/rtps/history/IPayloadPool.h>
 
 namespace eprosima {
-
 namespace fastrtps {
 namespace rtps {
 

--- a/include/fastdds/rtps/RTPSDomain.h
+++ b/include/fastdds/rtps/RTPSDomain.h
@@ -19,16 +19,26 @@
 #ifndef _FASTDDS_RTPS_DOMAIN_H_
 #define _FASTDDS_RTPS_DOMAIN_H_
 
-#include <fastdds/rtps/common/Types.h>
-#include <fastdds/rtps/history/IPayloadPool.h>
-
-#include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
-
 #include <atomic>
 #include <mutex>
 #include <set>
 
+#if defined(_WIN32) || defined(__unix__)
+#include <FileWatch.hpp>
+#endif // defined(_WIN32) || defined(__unix__)
+
+#include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
+#include <fastdds/rtps/common/Types.h>
+#include <fastdds/rtps/history/IPayloadPool.h>
+
 namespace eprosima {
+
+#if defined(_WIN32) || defined(__unix__)
+using FileWatchHandle = std::unique_ptr<filewatch::FileWatch<std::string>>;
+#else
+using FileWatchHandle = void*;
+#endif // defined(_WIN32) || defined(__unix__)
+
 namespace fastrtps {
 namespace rtps {
 
@@ -47,7 +57,7 @@ class RTPSDomainImpl;
 
 /**
  * Class RTPSDomain,it manages the creation and destruction of RTPSParticipant RTPSWriter and RTPSReader. It stores
- * a list of all created RTPSParticipant. Is has only static methods.
+ * a list of all created RTPSParticipant. It has only static methods.
  * @ingroup RTPS_MODULE
  */
 class RTPSDomain
@@ -266,6 +276,11 @@ private:
     static void removeRTPSParticipant_nts(
             t_p_RTPSParticipant&);
 
+    /**
+     * Callback run when the monitored environment file is modified
+     */
+    static void file_watch_callback();
+
     static std::mutex m_mutex;
 
     static std::atomic<uint32_t> m_maxRTPSParticipantID;
@@ -273,6 +288,8 @@ private:
     static std::vector<t_p_RTPSParticipant> m_RTPSParticipants;
 
     static std::set<uint32_t> m_RTPSParticipantIDs;
+
+    static FileWatchHandle file_watch_handle_;
 };
 
 } // namespace rtps

--- a/include/fastdds/rtps/RTPSDomain.h
+++ b/include/fastdds/rtps/RTPSDomain.h
@@ -27,18 +27,7 @@
 #include <fastdds/rtps/common/Types.h>
 #include <fastdds/rtps/history/IPayloadPool.h>
 
-namespace filewatch {
-template<class T>
-class FileWatch;
-} // filewatch
-
 namespace eprosima {
-
-#if defined(_WIN32) || defined(__unix__)
-using FileWatchHandle = std::unique_ptr<filewatch::FileWatch<std::string>>;
-#else
-using FileWatchHandle = void*;
-#endif // defined(_WIN32) || defined(__unix__)
 
 namespace fastrtps {
 namespace rtps {
@@ -277,11 +266,6 @@ private:
     static void removeRTPSParticipant_nts(
             t_p_RTPSParticipant&);
 
-    /**
-     * Callback run when the monitored environment file is modified
-     */
-    static void file_watch_callback();
-
     static std::mutex m_mutex;
 
     static std::atomic<uint32_t> m_maxRTPSParticipantID;
@@ -289,8 +273,6 @@ private:
     static std::vector<t_p_RTPSParticipant> m_RTPSParticipants;
 
     static std::set<uint32_t> m_RTPSParticipantIDs;
-
-    static FileWatchHandle file_watch_handle_;
 };
 
 } // namespace rtps

--- a/include/fastdds/rtps/attributes/ServerAttributes.h
+++ b/include/fastdds/rtps/attributes/ServerAttributes.h
@@ -123,15 +123,6 @@ const char* const DEFAULT_ROS2_SERVER_GUIDPREFIX = "44.53.00.5f.45.50.52.4f.53.4
 const char* const DEFAULT_ROS2_MASTER_URI = "ROS_DISCOVERY_SERVER";
 
 /**
- * Environment variable to specify the name of a file (including or not the path) where the environment variables
- * could be defined.
- * Thus, the user can modify the environment variables' values in runtime.
- *
- * TODO(jlbueno) Currently only ROS_DISCOVERY_SERVER environment variable is supported.
- */
-const char* const FASTDDS_ENVIRONMENT_FILE_ENV_VAR = "FASTDDS_ENVIRONMENT_FILE";
-
-/**
  * Retrieves a semicolon-separated list of locators from a string, and
  * populates a RemoteServerList_t mapping list position to default guid.
  * @param[in] list servers listening locator list.

--- a/include/fastdds/rtps/participant/RTPSParticipant.h
+++ b/include/fastdds/rtps/participant/RTPSParticipant.h
@@ -297,11 +297,6 @@ private:
     //!Pointer to the implementation.
     RTPSParticipantImpl* mp_impl;
 
-    /**
-     * Client override flag: SIMPLE participant that has been overriden with the environment variable and transform
-     * into a client.
-     */
-    bool client_override_;
 };
 
 } // namespace rtps

--- a/include/fastdds/rtps/participant/RTPSParticipant.h
+++ b/include/fastdds/rtps/participant/RTPSParticipant.h
@@ -296,6 +296,12 @@ private:
 
     //!Pointer to the implementation.
     RTPSParticipantImpl* mp_impl;
+
+    /**
+     * Client override flag: SIMPLE participant that has been overriden with the environment variable and transform
+     * into a client.
+     */
+    bool client_override_;
 };
 
 } // namespace rtps

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -30,7 +30,7 @@
 #include <fastdds/domain/DomainParticipantImpl.hpp>
 #include <rtps/history/TopicPayloadPoolRegistry.hpp>
 #include <statistics/fastdds/domain/DomainParticipantImpl.hpp>
-
+#include <utils/SystemInfo.hpp>
 
 
 
@@ -326,6 +326,7 @@ ReturnCode_t DomainParticipantFactory::load_profiles()
 {
     if (false == default_xml_profiles_loaded)
     {
+        SystemInfo::set_environment_file();
         XMLProfileManager::loadDefaultXMLFile();
         // Only load profile once
         default_xml_profiles_loaded = true;

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -113,7 +113,7 @@ RTPSParticipant* RTPSDomain::createParticipant(
     }
 
     // Only the first time, initialize environment file watch if the corresponding environment variable is set
-    if (m_RTPSParticipantIDs.empty())
+    if (!RTPSDomainImpl::file_watch_handle_)
     {
         if (!SystemInfo::get_environment_file().empty())
         {
@@ -549,6 +549,7 @@ void RTPSDomainImpl::file_watch_callback()
     // Ensure that all changes have been saved by the OS
     std::this_thread::sleep_for(std::chrono::seconds(1));
     // For all RTPSParticipantImpl registered in the RTPSDomain, call RTPSParticipantImpl::environment_file_has_changed
+    std::lock_guard<std::mutex> guard(RTPSDomain::m_mutex);
     for (auto participant : RTPSDomain::m_RTPSParticipants)
     {
         participant.second->environment_file_has_changed();

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -119,7 +119,7 @@ RTPSParticipant* RTPSDomain::createParticipant(
         {
             // Create filewatch
             RTPSDomainImpl::file_watch_handle_ = SystemInfo::watch_file(SystemInfo::get_environment_file(),
-                RTPSDomainImpl::file_watch_callback);
+                            RTPSDomainImpl::file_watch_callback);
         }
     }
 

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -430,7 +430,7 @@ RTPSParticipant* RTPSDomain::clientServerEnvironmentCreationOverride(
     {
         // client successfully created
         logInfo(DOMAIN, "Auto default server-client setup. Default client created.");
-        part->client_override_ = true;
+        part->mp_impl->client_override(true);
         return part;
     }
 

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -61,7 +61,7 @@ std::mutex RTPSDomain::m_mutex;
 std::atomic<uint32_t> RTPSDomain::m_maxRTPSParticipantID(1);
 std::vector<RTPSDomain::t_p_RTPSParticipant> RTPSDomain::m_RTPSParticipants;
 std::set<uint32_t> RTPSDomain::m_RTPSParticipantIDs;
-FileWatchHandle RTPSDomain::file_watch_handle_;
+FileWatchHandle RTPSDomainImpl::file_watch_handle_;
 
 void RTPSDomain::stopAll()
 {
@@ -69,7 +69,7 @@ void RTPSDomain::stopAll()
     logInfo(RTPS_PARTICIPANT, "DELETING ALL ENDPOINTS IN THIS DOMAIN");
 
     // Stop monitoring environment file
-    SystemInfo::stop_watching_file(file_watch_handle_);
+    SystemInfo::stop_watching_file(RTPSDomainImpl::file_watch_handle_);
 
     while (m_RTPSParticipants.size() > 0)
     {
@@ -118,7 +118,8 @@ RTPSParticipant* RTPSDomain::createParticipant(
         if (!SystemInfo::get_environment_file().empty())
         {
             // Create filewatch
-            file_watch_handle_ = SystemInfo::watch_file(SystemInfo::get_environment_file(), file_watch_callback);
+            RTPSDomainImpl::file_watch_handle_ = SystemInfo::watch_file(SystemInfo::get_environment_file(),
+                RTPSDomainImpl::file_watch_callback);
         }
     }
 
@@ -543,12 +544,12 @@ bool RTPSDomainImpl::should_intraprocess_between(
     return false;
 }
 
-void RTPSDomain::file_watch_callback()
+void RTPSDomainImpl::file_watch_callback()
 {
     // Ensure that all changes have been saved by the OS
     std::this_thread::sleep_for(std::chrono::seconds(1));
     // For all RTPSParticipantImpl registered in the RTPSDomain, call RTPSParticipantImpl::environment_file_has_changed
-    for (auto participant : m_RTPSParticipants)
+    for (auto participant : RTPSDomain::m_RTPSParticipants)
     {
         participant.second->environment_file_has_changed();
     }

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -23,10 +23,6 @@
 #include <cstdlib>
 #include <regex>
 
-#if defined(_WIN32) || defined(__unix__)
-#include <FileWatch.hpp>
-#endif // defined(_WIN32) || defined(__unix__)
-
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/rtps/history/WriterHistory.h>
 #include <fastdds/rtps/participant/RTPSParticipant.h>

--- a/src/cpp/rtps/RTPSDomainImpl.hpp
+++ b/src/cpp/rtps/RTPSDomainImpl.hpp
@@ -12,13 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <fastrtps/rtps/RTPSDomain.h>
-
-#include <fastrtps/rtps/reader/RTPSReader.h>
-#include <fastrtps/rtps/writer/RTPSWriter.h>
 
 #include <chrono>
 #include <thread>
+
+#if defined(_WIN32) || defined(__unix__)
+#include <FileWatch.hpp>
+#endif // defined(_WIN32) || defined(__unix__)
+
+#include <fastrtps/rtps/reader/RTPSReader.h>
+#include <fastrtps/rtps/RTPSDomain.h>
+#include <fastrtps/rtps/writer/RTPSWriter.h>
+
+#include <utils/SystemInfo.hpp>
 
 namespace eprosima {
 namespace fastrtps {
@@ -108,6 +114,13 @@ public:
     static bool should_intraprocess_between(
             const GUID_t& local_guid,
             const GUID_t& matched_guid);
+
+    /**
+     * Callback run when the monitored environment file is modified
+     */
+    static void file_watch_callback();
+
+    static FileWatchHandle file_watch_handle_;
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -631,27 +631,7 @@ const std::string& ros_discovery_server_env()
 bool load_environment_server_info(
         RemoteServerList_t& attributes)
 {
-    static std::string filename;
-    std::string remote_servers_list;
-    // Try to load environment file
-    if (filename.empty())
-    {
-        SystemInfo::get_env(FASTDDS_ENVIRONMENT_FILE_ENV_VAR, filename);
-    }
-
-    bool result = false;
-    if (!filename.empty() && ReturnCode_t::RETCODE_OK == SystemInfo::load_environment_file(filename,
-            DEFAULT_ROS2_MASTER_URI, remote_servers_list))
-    {
-        result = load_environment_server_info(remote_servers_list, attributes);
-    }
-    else
-    {
-        // If there is no environment file or if the file does not contain the DEFAULT_ROS2_MASTER_URI environment variable
-        // try to find if the variable has been set directly in the environment.
-        result = load_environment_server_info(ros_discovery_server_env(), attributes);
-    }
-    return result;
+    return load_environment_server_info(ros_discovery_server_env(), attributes);
 }
 
 bool load_environment_server_info(

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -624,13 +624,7 @@ void PDPClient::match_pdp_reader_nts_(
 const std::string& ros_discovery_server_env()
 {
     static std::string servers;
-    {
-        const char* data;
-        if (eprosima::ReturnCode_t::RETCODE_OK == SystemInfo::get_env(DEFAULT_ROS2_MASTER_URI, &data))
-        {
-            servers = data;
-        }
-    }
+    SystemInfo::get_env(DEFAULT_ROS2_MASTER_URI, servers);
     return servers;
 }
 
@@ -642,11 +636,7 @@ bool load_environment_server_info(
     // Try to load environment file
     if (filename.empty())
     {
-        const char* data;
-        if (eprosima::ReturnCode_t::RETCODE_OK == SystemInfo::get_env(FASTDDS_ENVIRONMENT_FILE_ENV_VAR, &data))
-        {
-            filename = data;
-        }
+        SystemInfo::get_env(FASTDDS_ENVIRONMENT_FILE_ENV_VAR, filename);
     }
 
     bool result = false;

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -638,9 +638,10 @@ bool load_environment_server_info(
         std::string list,
         RemoteServerList_t& attributes)
 {
+    attributes.clear();
     if (list.empty())
     {
-        return false;
+        return true;
     }
 
     /* Parsing ancillary regex */
@@ -652,7 +653,6 @@ bool load_environment_server_info(
     try
     {
         // Do the parsing and populate the list
-        attributes.clear();
         RemoteServerAttributes server_att;
         Locator_t server_locator(LOCATOR_KIND_UDPv4, DEFAULT_ROS2_SERVER_PORT);
         int server_id = 0;

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -29,6 +29,7 @@ RTPSParticipant::RTPSParticipant(
         RTPSParticipantImpl* pimpl)
     : mp_impl(pimpl)
 {
+    client_override_ = false;
 }
 
 RTPSParticipant::~RTPSParticipant()

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -29,7 +29,6 @@ RTPSParticipant::RTPSParticipant(
         RTPSParticipantImpl* pimpl)
     : mp_impl(pimpl)
 {
-    client_override_ = false;
 }
 
 RTPSParticipant::~RTPSParticipant()

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -427,6 +427,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         RTPSParticipantListener* plisten)
     : RTPSParticipantImpl(domain_id, PParam, guidP, c_GuidPrefix_Unknown, par, plisten)
 {
+    client_override_ = false;
 }
 
 void RTPSParticipantImpl::enable()
@@ -2174,7 +2175,7 @@ void RTPSParticipantImpl::environment_file_has_changed()
     // Only if it is a server/backup or a client override
     if (DiscoveryProtocol_t::SERVER == m_att.builtin.discovery_config.discoveryProtocol ||
             DiscoveryProtocol_t::BACKUP == m_att.builtin.discovery_config.discoveryProtocol ||
-            mp_userParticipant->client_override_)
+            client_override_)
     {
         if (load_environment_server_info(patt.builtin.discovery_config.m_DiscoveryServers))
         {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -2171,7 +2171,7 @@ DurabilityKind_t RTPSParticipantImpl::get_persistence_durability_red_line(
 
 void RTPSParticipantImpl::environment_file_has_changed()
 {
-    RTPSParticipantAttributes patt;
+    RTPSParticipantAttributes patt = m_att;
     // Only if it is a server/backup or a client override
     if (DiscoveryProtocol_t::SERVER == m_att.builtin.discovery_config.discoveryProtocol ||
             DiscoveryProtocol_t::BACKUP == m_att.builtin.discovery_config.discoveryProtocol ||

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -2173,10 +2173,10 @@ void RTPSParticipantImpl::environment_file_has_changed()
     RTPSParticipantAttributes patt;
     // Only if it is a server/backup or a client override
     if (DiscoveryProtocol_t::SERVER == m_att.builtin.discovery_config.discoveryProtocol ||
-        DiscoveryProtocol_t::BACKUP == m_att.builtin.discovery_config.discoveryProtocol ||
-        mp_userParticipant->client_override_)
+            DiscoveryProtocol_t::BACKUP == m_att.builtin.discovery_config.discoveryProtocol ||
+            mp_userParticipant->client_override_)
     {
-        if(load_environment_server_info(patt.builtin.discovery_config.m_DiscoveryServers))
+        if (load_environment_server_info(patt.builtin.discovery_config.m_DiscoveryServers))
         {
             update_attributes(patt);
         }
@@ -2184,7 +2184,7 @@ void RTPSParticipantImpl::environment_file_has_changed()
     else
     {
         logWarning(RTPS_QOS_CHECK, "Trying to add Discovery Servers to a participant which is not a SERVER, BACKUP " <<
-            "or an overriden CLIENT (SIMPLE participant transformed into CLIENT with the environment variable)");
+                "or an overriden CLIENT (SIMPLE participant transformed into CLIENT with the environment variable)");
     }
 }
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -25,47 +25,37 @@
 #include <mutex>
 #include <sstream>
 
-#include <rtps/persistence/PersistenceService.h>
-#include <rtps/history/BasicPayloadPool.hpp>
-
-#include <fastrtps/utils/IPFinder.h>
-#include <fastrtps/utils/Semaphore.h>
-
-#include <fastrtps/xmlparser/XMLProfileManager.h>
-
 #include <fastdds/dds/log/Log.hpp>
-
-#include <fastdds/rtps/RTPSDomain.h>
-
-#include <fastdds/rtps/messages/MessageReceiver.h>
-
+#include <fastdds/rtps/attributes/ServerAttributes.h>
+#include <fastdds/rtps/builtin/BuiltinProtocols.h>
+#include <fastdds/rtps/builtin/discovery/participant/PDPSimple.h>
+#include <fastdds/rtps/builtin/data/ParticipantProxyData.h>
+#include <fastdds/rtps/builtin/liveliness/WLP.h>
 #include <fastdds/rtps/history/WriterHistory.h>
-
+#include <fastdds/rtps/messages/MessageReceiver.h>
 #include <fastdds/rtps/participant/RTPSParticipant.h>
-
+#include <fastdds/rtps/reader/StatelessReader.h>
+#include <fastdds/rtps/reader/StatefulReader.h>
+#include <fastdds/rtps/reader/StatelessPersistentReader.h>
+#include <fastdds/rtps/reader/StatefulPersistentReader.h>
+#include <fastdds/rtps/RTPSDomain.h>
+#include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
+#include <fastdds/rtps/transport/TCPv4TransportDescriptor.h>
+#include <fastdds/rtps/transport/TCPv6TransportDescriptor.h>
+#include <fastdds/rtps/transport/shared_mem/SharedMemTransportDescriptor.h>
 #include <fastdds/rtps/writer/StatelessWriter.h>
 #include <fastdds/rtps/writer/StatefulWriter.h>
 #include <fastdds/rtps/writer/StatelessPersistentWriter.h>
 #include <fastdds/rtps/writer/StatefulPersistentWriter.h>
 
-#include <fastdds/rtps/reader/StatelessReader.h>
-#include <fastdds/rtps/reader/StatefulReader.h>
-#include <fastdds/rtps/reader/StatelessPersistentReader.h>
-#include <fastdds/rtps/reader/StatefulPersistentReader.h>
-
-#include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
-#include <fastdds/rtps/transport/TCPv4TransportDescriptor.h>
-#include <fastdds/rtps/transport/TCPv6TransportDescriptor.h>
-#include <fastdds/rtps/transport/shared_mem/SharedMemTransportDescriptor.h>
-
-#include <fastdds/rtps/builtin/BuiltinProtocols.h>
-#include <fastdds/rtps/builtin/discovery/participant/PDPSimple.h>
-#include <fastdds/rtps/builtin/data/ParticipantProxyData.h>
-#include <fastdds/rtps/builtin/liveliness/WLP.h>
+#include <fastrtps/utils/IPFinder.h>
+#include <fastrtps/utils/Semaphore.h>
+#include <fastrtps/xmlparser/XMLProfileManager.h>
 
 #include <rtps/builtin/discovery/participant/PDPServer.hpp>
 #include <rtps/builtin/discovery/participant/PDPClient.h>
-
+#include <rtps/history/BasicPayloadPool.hpp>
+#include <rtps/persistence/PersistenceService.h>
 #include <statistics/rtps/GuidUtils.hpp>
 
 namespace eprosima {
@@ -1183,6 +1173,46 @@ void RTPSParticipantImpl::update_attributes(
         return;
     }
 
+    // Check that the remote servers list is consistent: all the already known remote servers must be included in the
+    // list and only new remote servers can be added.
+    for (auto existing_server : m_att.builtin.discovery_config.m_DiscoveryServers)
+    {
+        bool contained = false;
+        bool locator_contained = false;
+        for (auto incoming_server : patt.builtin.discovery_config.m_DiscoveryServers)
+        {
+            if (existing_server.guidPrefix == incoming_server.guidPrefix)
+            {
+                for (auto incoming_locator : incoming_server.metatrafficUnicastLocatorList)
+                {
+                    for (auto existing_locator : existing_server.metatrafficUnicastLocatorList)
+                    {
+                        if (incoming_locator == existing_locator)
+                        {
+                            locator_contained = true;
+                            break;
+                        }
+                    }
+                    if (!locator_contained)
+                    {
+                        logWarning(RTPS_QOS_CHECK,
+                                "Discovery Servers cannot add/modify their locators: " << incoming_locator <<
+                                " has not been added")
+                        return;
+                    }
+                }
+                contained = true;
+                break;
+            }
+        }
+        if (!contained)
+        {
+            logWarning(RTPS_QOS_CHECK,
+                    "Discovery Servers cannot be removed from the list; they can only be added");
+            return;
+        }
+    }
+
     // Update RTPSParticipantAttributes member
     m_att.userData = patt.userData;
 
@@ -2136,6 +2166,26 @@ DurabilityKind_t RTPSParticipantImpl::get_persistence_durability_red_line(
     }
 
     return durability_red_line;
+}
+
+void RTPSParticipantImpl::environment_file_has_changed()
+{
+    RTPSParticipantAttributes patt;
+    // Only if it is a server/backup or a client override
+    if (DiscoveryProtocol_t::SERVER == m_att.builtin.discovery_config.discoveryProtocol ||
+        DiscoveryProtocol_t::BACKUP == m_att.builtin.discovery_config.discoveryProtocol ||
+        mp_userParticipant->client_override_)
+    {
+        if(load_environment_server_info(patt.builtin.discovery_config.m_DiscoveryServers))
+        {
+            update_attributes(patt);
+        }
+    }
+    else
+    {
+        logWarning(RTPS_QOS_CHECK, "Trying to add Discovery Servers to a participant which is not a SERVER, BACKUP " <<
+            "or an overriden CLIENT (SIMPLE participant transformed into CLIENT with the environment variable)");
+    }
 }
 
 #ifdef FASTDDS_STATISTICS

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -899,6 +899,11 @@ public:
 
     bool networkFactoryHasRegisteredTransports() const;
 
+    /**
+     * Function run when the RTPSDomain is notified that the environment file has changed.
+     */
+    void environment_file_has_changed();
+
 #if HAVE_SECURITY
     void set_endpoint_rtps_protection_supports(
             Endpoint* endpoint,

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -483,13 +483,14 @@ public:
     //! Getter client_override flag
     bool client_override()
     {
-            return client_override_;
+        return client_override_;
     }
 
     //! Setter client_override flag
-    void client_override(bool value)
+    void client_override(
+            bool value)
     {
-            client_override_ = value;
+        client_override_ = value;
     }
 
 private:

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -480,6 +480,18 @@ public:
             const LocatorList_t& MulticastLocatorList,
             const LocatorList_t& UnicastLocatorList) const;
 
+    //! Getter client_override flag
+    bool client_override()
+    {
+            return client_override_;
+    }
+
+    //! Setter client_override flag
+    void client_override(bool value)
+    {
+            client_override_ = value;
+    }
+
 private:
 
     //! DomainId
@@ -517,6 +529,12 @@ private:
     std::function<bool(const std::string&)> type_check_fn_;
     //!Pool of send buffers
     std::unique_ptr<SendBuffersManager> send_buffers_;
+
+    /**
+     * Client override flag: SIMPLE participant that has been overriden with the environment variable and transformed
+     * into a client.
+     */
+    bool client_override_;
 
 #if HAVE_SECURITY
     // Security manager

--- a/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.cpp
@@ -258,11 +258,7 @@ void DomainParticipantImpl::create_statistics_builtin_entities()
 
     // 2. FASTDDS_STATISTICS environment variable
     std::string env_topic_list;
-    const char* data;
-    if (ReturnCode_t::RETCODE_OK == SystemInfo::get_env(FASTDDS_STATISTICS_ENVIRONMENT_VARIABLE, &data))
-    {
-        env_topic_list = data;
-    }
+    SystemInfo::get_env(FASTDDS_STATISTICS_ENVIRONMENT_VARIABLE, env_topic_list);
 
     if (!env_topic_list.empty())
     {

--- a/src/cpp/utils/SystemInfo.cpp
+++ b/src/cpp/utils/SystemInfo.cpp
@@ -145,16 +145,16 @@ const std::string& SystemInfo::get_environment_file()
 
 FileWatchHandle SystemInfo::watch_file(
         std::string filename,
-        std::function<void(const std::string&)> callback)
+        std::function<void()> callback)
 {
 #if defined(_WIN32) || defined(__unix__)
     return FileWatchHandle (new filewatch::FileWatch<std::string>(filename,
-                   [callback](const std::string& path, const filewatch::Event change_type)
+                   [callback](const std::string& /*path*/, const filewatch::Event change_type)
                    {
                        switch (change_type)
                        {
                            case filewatch::Event::modified:
-                               callback(path);
+                               callback();
                                break;
                            default:
                                // No-op

--- a/src/cpp/utils/SystemInfo.cpp
+++ b/src/cpp/utils/SystemInfo.cpp
@@ -23,6 +23,7 @@
 #endif // _WIN32
 
 #include <fstream>
+#include <string>
 
 #include <json.hpp>
 #include <fastrtps/types/TypesBase.h>
@@ -32,17 +33,22 @@ namespace eprosima {
 using ReturnCode_t = fastrtps::types::ReturnCode_t;
 
 ReturnCode_t SystemInfo::get_env(
-        const char* env_name,
-        const char** env_value)
+        const std::string& env_name,
+        std::string& env_value)
 {
-    if (env_name == nullptr || env_value == nullptr || *env_name == '\0')
+    if (env_name.empty())
     {
         return ReturnCode_t::RETCODE_BAD_PARAMETER;
     }
 
 #pragma warning(suppress:4996)
-    *env_value = getenv(env_name);
-    if (*env_value == nullptr)
+    char* data;
+    data = getenv(env_name.c_str());
+    if (nullptr != data)
+    {
+        env_value = data;
+    }
+    else
     {
         return ReturnCode_t::RETCODE_NO_DATA;
     }

--- a/src/cpp/utils/SystemInfo.cpp
+++ b/src/cpp/utils/SystemInfo.cpp
@@ -92,6 +92,16 @@ bool SystemInfo::file_exists(
     return (stat(filename.c_str(), &s) == 0 && s.st_mode & S_IFREG);
 }
 
+ReturnCode_t SystemInfo::set_environment_file()
+{
+    return SystemInfo::get_env(FASTDDS_ENVIRONMENT_FILE_ENV_VAR, SystemInfo::environment_file_);
+}
+
+const std::string& SystemInfo::get_environment_file()
+{
+    return SystemInfo::environment_file_;
+}
+
 ReturnCode_t SystemInfo::load_environment_file(
         const std::string& filename,
         const std::string& env_name,
@@ -163,5 +173,7 @@ void SystemInfo::stop_watching_file(
 #endif // if defined(_WIN32) || defined(__unix__)
     static_cast<void>(handle);
 }
+
+std::string SystemInfo::environment_file_;
 
 } // eprosima

--- a/src/cpp/utils/SystemInfo.cpp
+++ b/src/cpp/utils/SystemInfo.cpp
@@ -47,8 +47,8 @@ ReturnCode_t SystemInfo::get_env(
         return ReturnCode_t::RETCODE_OK;
     }
 
-#pragma warning(suppress:4996)
     char* data;
+#pragma warning(suppress:4996)
     data = getenv(env_name.c_str());
     if (nullptr != data)
     {

--- a/src/cpp/utils/SystemInfo.hpp
+++ b/src/cpp/utils/SystemInfo.hpp
@@ -104,6 +104,23 @@ public:
             std::string& env_value);
 
     /**
+     * Read environment variable contained in the environment file.
+     *
+     * @param [in] filename path/name of the environment file.
+     * @param [in] env_name environment variable name to read from the file.
+     * @param [out] env_value environment variable value read from the file.
+     *
+     * @return RETCODE_OK if succesful.
+     * RETCODE_BAD_PARAMETER if the file does not exist.
+     * RETCODE_NO_DATA if the file exists but there is no information about the environment variable.
+     * RETCODE_ERROR if the file is empty or malformed.
+     */
+    static ReturnCode_t get_env(
+            const std::string& filename,
+            const std::string& env_name,
+            std::string& env_value);
+
+    /**
      * Get the effective username of the person that launched the application
      * This implementation follows the whoami implementation for POSIX
      * (https://github.com/coreutils/coreutils/blob/master/src/whoami.c)
@@ -151,23 +168,6 @@ public:
      * @return Path/filename contained in the environment variable.
      */
     static const std::string& get_environment_file();
-
-    /**
-     * Read environment variable contained in the environment file.
-     *
-     * @param [in] filename path/name of the environment file.
-     * @param [in] env_name environment variable name to read from the file.
-     * @param [out] env_value environment variable value read from the file.
-     *
-     * @return RETCODE_OK if succesful.
-     * RETCODE_BAD_PARAMETER if the file does not exist.
-     * RETCODE_NO_DATA if the file exists but there is no information about the environment variable.
-     * RETCODE_ERROR if the file is empty or malformed.
-     */
-    static ReturnCode_t load_environment_file(
-            const std::string& filename,
-            const std::string& env_name,
-            std::string& env_value);
 
     /**
      * Start a thread that watches for changes in the given file and executes a callback when the file changes.

--- a/src/cpp/utils/SystemInfo.hpp
+++ b/src/cpp/utils/SystemInfo.hpp
@@ -86,24 +86,22 @@ public:
     }
 
     /**
-     * Retrieve the value of a given environment variable if it exists, or nullptr.
-     * The c-string which is returned in the env_value output parameter is only valid until the next time this function
-     * is called, because it is a direct pointer to the static storage.
-     * Modifying the string returned in env_value invokes undefined behavior.
-     * If the environment variable is not set, a nullptr will be returned.
+     * Retrieve the value of a given environment variable if it exists.
+     * The string which is returned in the env_value output parameter is not modified
+     * if the environment variable is not set.
      *
      * This function is thread-safe as long as no other function modifies the host environment (in particular, POSIX
      * functions setenv, unsetenv and putenv would introduce a data race if called without synchronization.)
      *
-     * \param [in] env_name the name of the environment variable
-     * \param [out] env_value pointer to the value c-string
+     * \param [in] env_name name of the environment variable.
+     * \param [out] env_value value of the environment variable.
      * @return RETCODE_OK if the environment variable is set.
      * RETCODE_NO_DATA if the environment variable is unset.
      * RETCODE_BAD_PARAMETER if the provided parameters are not valid.
      */
     static ReturnCode_t get_env(
-            const char* env_name,
-            const char** env_value);
+            const std::string& env_name,
+            std::string& env_value);
 
     /**
      * Get the effective username of the person that launched the application

--- a/src/cpp/utils/SystemInfo.hpp
+++ b/src/cpp/utils/SystemInfo.hpp
@@ -136,6 +136,23 @@ public:
             const std::string& filename);
 
     /**
+     * Read FASTDDS_ENVIRONMENT_FILE_ENV_VAR environment value and save its value.
+     * Use get_environment_file to read its value.
+     *
+     * @return RETCODE_OK if the environment variable is set.
+     * RETCODE_NO_DATA if the environment variable is unset.
+     */
+    static ReturnCode_t set_environment_file();
+
+    /**
+     * Getter for the path/filename contained in the FASTDDS_ENVIRONMENT_FILE_ENV_VAR.
+     * The value is set calling set_environment_file().
+     *
+     * @return Path/filename contained in the environment variable.
+     */
+    static const std::string& get_environment_file();
+
+    /**
      * Read environment variable contained in the environment file.
      *
      * @param [in] filename path/name of the environment file.
@@ -185,7 +202,18 @@ private:
 
     SystemInfo() = default;
 
+    static std::string environment_file_;
+
 };
+
+/**
+ * Environment variable to specify the name of a file (including or not the path) where the environment variables
+ * could be defined.
+ * Thus, the user can modify the environment variables' values in runtime.
+ *
+ * TODO(jlbueno) Currently only ROS_DISCOVERY_SERVER environment variable is supported.
+ */
+const char* const FASTDDS_ENVIRONMENT_FILE_ENV_VAR = "FASTDDS_ENVIRONMENT_FILE";
 
 } // namespace eprosima
 

--- a/src/cpp/utils/SystemInfo.hpp
+++ b/src/cpp/utils/SystemInfo.hpp
@@ -185,7 +185,7 @@ public:
      */
     static FileWatchHandle watch_file(
             std::string filename,
-            std::function<void(const std::string&)> callback);
+            std::function<void()> callback);
 
     /**
      * Stop a file watcher.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,7 @@ if(EPROSIMA_BUILD_TESTS)
     add_subdirectory(unittest)
     add_subdirectory(xtypes)
     add_subdirectory(dds/communication)
+    add_subdirectory(dds/discovery)
 
     if(UNIX AND NOT APPLE AND STRICT_REALTIME)
         add_subdirectory(realtime)

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -29,6 +29,8 @@
 
 #include <fastdds/rtps/attributes/ServerAttributes.h>
 
+#include <utils/SystemInfo.hpp>
+
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 using test_UDPv4Transport = eprosima::fastdds::rtps::test_UDPv4Transport;
@@ -1328,9 +1330,9 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
 
     // Set environment variable
 #ifdef _WIN32
-    _putenv_s(FASTDDS_ENVIRONMENT_FILE_ENV_VAR, filename.c_str());
+    _putenv_s(eprosima::FASTDDS_ENVIRONMENT_FILE_ENV_VAR, filename.c_str());
 #else
-    setenv(FASTDDS_ENVIRONMENT_FILE_ENV_VAR, filename.c_str(), 1);
+    setenv(eprosima::FASTDDS_ENVIRONMENT_FILE_ENV_VAR, filename.c_str(), 1);
 #endif // _WIN32
 
     output.clear();

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -1325,47 +1325,4 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
 
     ASSERT_TRUE(load_environment_server_info(text, output));
     ASSERT_EQ(output, standard);
-
-    // 11. Check loading from environment file
-    std::string filename = "environment_file.json";
-
-    // Set environment variable
-#ifdef _WIN32
-    _putenv_s(eprosima::FASTDDS_ENVIRONMENT_FILE_ENV_VAR, filename.c_str());
-#else
-    setenv(eprosima::FASTDDS_ENVIRONMENT_FILE_ENV_VAR, filename.c_str(), 1);
-#endif // _WIN32
-    eprosima::SystemInfo::set_environment_file();
-
-    output.clear();
-    standard.clear();
-
-    att.clear();
-    IPLocator::setIPv4(loc, string("127.0.0.1"));
-    IPLocator::setPhysicalPort(loc, 11811);
-    att.metatrafficUnicastLocatorList.push_back(loc);
-    get_server_client_default_guidPrefix(0, att.guidPrefix);
-    standard.push_back(att);
-
-    att.clear();
-    IPLocator::setIPv4(loc, string("192.168.36.34"));
-    IPLocator::setPhysicalPort(loc, 14520);
-    att.metatrafficUnicastLocatorList.push_back(loc);
-    get_server_client_default_guidPrefix(2, att.guidPrefix);
-    standard.push_back(att);
-
-    EXPECT_TRUE(load_environment_server_info(output));
-    EXPECT_EQ(output, standard);
-
-    // 12. Setting also the environment variable gets overriden by the environment file
-    output.clear();
-#ifdef _WIN32
-    _putenv_s(DEFAULT_ROS2_MASTER_URI, text.c_str());
-#else
-    setenv(DEFAULT_ROS2_MASTER_URI, text.c_str(), 1);
-#endif // _WIN32
-
-    EXPECT_TRUE(load_environment_server_info(output));
-    EXPECT_EQ(output, standard);
-
 }

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -1203,7 +1203,8 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
     text = "";
     output.clear();
 
-    ASSERT_FALSE(load_environment_server_info(text, output));
+    ASSERT_TRUE(load_environment_server_info(text, output));
+    ASSERT_TRUE(output.empty());
 
     // 5. check at least one server be present scenario is hadled
     text = ";;;;";
@@ -1334,6 +1335,7 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
 #else
     setenv(eprosima::FASTDDS_ENVIRONMENT_FILE_ENV_VAR, filename.c_str(), 1);
 #endif // _WIN32
+    eprosima::SystemInfo::set_environment_file();
 
     output.clear();
     standard.clear();

--- a/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
@@ -78,10 +78,10 @@ TEST(DDSDiscovery, AddDiscoveryServerToList)
     using namespace eprosima::fastrtps::rtps;
 
     /* Get random port from the environment */
-    const char* value = nullptr;
-    if (eprosima::ReturnCode_t::RETCODE_OK != SystemInfo::instance().get_env("W_UNICAST_PORT_RANDOM_NUMBER", &value))
+    std::string value;
+    if (eprosima::ReturnCode_t::RETCODE_OK != SystemInfo::get_env("W_UNICAST_PORT_RANDOM_NUMBER", value))
     {
-        value = &std::string("11811")[0];
+        value = std::string("11811");
     }
 
     /* Create first server */
@@ -100,7 +100,7 @@ TEST(DDSDiscovery, AddDiscoveryServerToList)
     // Generate server's listening locator
     Locator_t locator_server_1;
     IPLocator::setIPv4(locator_server_1, 127, 0, 0, 1);
-    uint32_t server_1_port = atol(value);
+    uint32_t server_1_port = atol(value.c_str());
     locator_server_1.port = server_1_port;
     server_1_qos.builtin.metatrafficUnicastLocatorList.push_back(locator_server_1);
     // Init server
@@ -118,7 +118,7 @@ TEST(DDSDiscovery, AddDiscoveryServerToList)
     // Generate server's listening locator
     Locator_t locator_server_2;
     IPLocator::setIPv4(locator_server_2, 127, 0, 0, 1);
-    uint32_t server_2_port = atol(value) + 1;
+    uint32_t server_2_port = atol(value.c_str()) + 1;
     locator_server_2.port = server_2_port;
     server_2_qos.builtin.metatrafficUnicastLocatorList.push_back(locator_server_2);
     // Init server

--- a/test/dds/discovery/CMakeLists.txt
+++ b/test/dds/discovery/CMakeLists.txt
@@ -1,0 +1,54 @@
+# Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
+    find_package(PythonInterp 3)
+
+    ###########################################################################
+    # Binaries
+    ###########################################################################
+    set(DDS_PARTICIPANT_SOURCE
+        ParticipantModule.cpp
+        ParticipantMain.cpp
+        )
+
+    add_executable(DDSParticipantDiscovery ${DDS_PARTICIPANT_SOURCE})
+    target_compile_definitions(DDSParticipantDiscovery PRIVATE
+        $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+        $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG>
+        )
+    target_link_libraries(DDSParticipantDiscovery fastrtps ${CMAKE_DL_LIBS})
+
+    ###########################################################################
+    # Necessary files
+    ###########################################################################
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/client_server_dynamic_discovery.py
+        ${CMAKE_CURRENT_BINARY_DIR}/client_server_dynamic_discovery.py COPYONLY)
+
+    string(RANDOM LENGTH 4 ALPHABET 0123456789 W_UNICAST_PORT_RANDOM_NUMBER)
+    math(EXPR W_UNICAST_PORT_RANDOM_NUMBER "${W_UNICAST_PORT_RANDOM_NUMBER} + 0")
+    if(W_UNICAST_PORT_RANDOM_NUMBER LESS 1025)
+        math(EXPR W_UNICAST_PORT_RANDOM_NUMBER "${W_UNICAST_PORT_RANDOM_NUMBER} + 1024")
+    endif()
+
+    if(PYTHONINTERP_FOUND)
+        add_test(NAME AddDiscoveryServerToListFromEnvironmentFile
+            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/client_server_dynamic_discovery.py)
+
+        set_property(TEST AddDiscoveryServerToListFromEnvironmentFile PROPERTY ENVIRONMENT
+            "CLIENT_SERVER_DYNAMIC_DISCOVERY_BIN=$<TARGET_FILE:DDSParticipantDiscovery>")
+        set_property(TEST AddDiscoveryServerToListFromEnvironmentFile PROPERTY ENVIRONMENT
+            "W_UNICAST_PORT_RANDOM_NUMBER=${W_UNICAST_PORT_RANDOM_NUMBER}")
+    endif()
+endif()

--- a/test/dds/discovery/CMakeLists.txt
+++ b/test/dds/discovery/CMakeLists.txt
@@ -48,7 +48,12 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
 
         set_property(TEST AddDiscoveryServerToListFromEnvironmentFile PROPERTY ENVIRONMENT
             "CLIENT_SERVER_DYNAMIC_DISCOVERY_BIN=$<TARGET_FILE:DDSParticipantDiscovery>")
-        set_property(TEST AddDiscoveryServerToListFromEnvironmentFile PROPERTY ENVIRONMENT
+        set_property(TEST AddDiscoveryServerToListFromEnvironmentFile APPEND PROPERTY ENVIRONMENT
             "W_UNICAST_PORT_RANDOM_NUMBER=${W_UNICAST_PORT_RANDOM_NUMBER}")
+        if(WIN32)
+            string(REPLACE ";" "\\;" WIN_PATH "$ENV{PATH}")
+            set_property(TEST AddDiscoveryServerToListFromEnvironmentFile APPEND PROPERTY ENVIRONMENT
+                "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$<TARGET_FILE_DIR:fastcdr>\\;${WIN_PATH}")
+        endif()
     endif()
 endif()

--- a/test/dds/discovery/CMakeLists.txt
+++ b/test/dds/discovery/CMakeLists.txt
@@ -42,7 +42,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
         math(EXPR W_UNICAST_PORT_RANDOM_NUMBER "${W_UNICAST_PORT_RANDOM_NUMBER} + 1024")
     endif()
 
-    if(PYTHONINTERP_FOUND AND NOT APPLE)
+    if(PYTHONINTERP_FOUND AND NOT APPLE AND NOT WIN32)
         add_test(NAME AddDiscoveryServerToListFromEnvironmentFile
             COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/client_server_dynamic_discovery.py)
 

--- a/test/dds/discovery/CMakeLists.txt
+++ b/test/dds/discovery/CMakeLists.txt
@@ -42,7 +42,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
         math(EXPR W_UNICAST_PORT_RANDOM_NUMBER "${W_UNICAST_PORT_RANDOM_NUMBER} + 1024")
     endif()
 
-    if(PYTHONINTERP_FOUND)
+    if(PYTHONINTERP_FOUND AND NOT APPLE)
         add_test(NAME AddDiscoveryServerToListFromEnvironmentFile
             COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/client_server_dynamic_discovery.py)
 

--- a/test/dds/discovery/ParticipantMain.cpp
+++ b/test/dds/discovery/ParticipantMain.cpp
@@ -1,0 +1,114 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file ParticipantMain.cpp
+ */
+
+#include <condition_variable>
+#include <csignal>
+#include <cstring>
+#include <iostream>
+#include <mutex>
+#include <regex>
+#include <string>
+
+#include "ParticipantModule.hpp"
+
+#include <fastdds/dds/log/Log.hpp>
+
+using Log = eprosima::fastdds::dds::Log;
+
+/**
+ * ARGUMENTS
+ * --guid_prefix <str>
+ * --discovery_protocol <str>
+ * --unicast_metatraffic_locator <str>
+ */
+
+volatile sig_atomic_t signal_status = 0;
+std::mutex signal_mutex;
+std::condition_variable signal_cv;
+
+void sigint_handler(
+        int signum)
+{
+    signal_status = signum;
+    signal_cv.notify_one();
+}
+
+int main(
+        int argc,
+        char** argv)
+{
+    Log::SetVerbosity(Log::Warning);
+    Log::SetCategoryFilter(std::regex("(RTPS_QOS_CHECK)"));
+    Log::SetErrorStringFilter(std::regex("(Discovery Servers)"));
+
+    int arg_count = 1;
+    std::string guid_prefix;
+    std::string discovery_protocol;
+    std::string unicast_metatraffic_locator;
+
+    while (arg_count < argc)
+    {
+        if(strcmp(argv[arg_count], "--guid_prefix") == 0)
+        {
+            if (++arg_count >= argc)
+            {
+                std::cout << "--guid_prefix expects a parameter\n";
+                return -1;
+            }
+            guid_prefix = argv[arg_count];
+        }
+        else if (strcmp(argv[arg_count], "--discovery_protocol") == 0)
+        {
+            if (++arg_count >= argc)
+            {
+                std::cout << "--discovery_protocol expects a parameter\n";
+                return -1;
+            }
+            discovery_protocol = argv[arg_count];
+        }
+        else if (strcmp(argv[arg_count], "--unicast_metatraffic_locator") == 0)
+        {
+            if (++arg_count >= argc)
+            {
+                std::cout << "--unicast_metatraffic_locator expects a parameter\n";
+                return -1;
+            }
+            unicast_metatraffic_locator = argv[arg_count];
+        }
+        else
+        {
+            std::cout << "Wrong argument " << argv[arg_count] << std::endl;
+            return -1;
+        }
+        ++arg_count;
+    }
+
+    eprosima::fastdds::dds::ParticipantModule participant(discovery_protocol, guid_prefix, unicast_metatraffic_locator);
+
+    if (participant.init())
+    {
+        std::unique_lock<std::mutex> lock(signal_mutex);
+        signal(SIGINT, sigint_handler);
+        signal_cv.wait(lock, []
+                {
+                    return 0 != signal_status;
+                });
+        return 0;
+    }
+    return -1;
+}

--- a/test/dds/discovery/ParticipantMain.cpp
+++ b/test/dds/discovery/ParticipantMain.cpp
@@ -63,7 +63,7 @@ int main(
 
     while (arg_count < argc)
     {
-        if(strcmp(argv[arg_count], "--guid_prefix") == 0)
+        if (strcmp(argv[arg_count], "--guid_prefix") == 0)
         {
             if (++arg_count >= argc)
             {

--- a/test/dds/discovery/ParticipantModule.cpp
+++ b/test/dds/discovery/ParticipantModule.cpp
@@ -1,0 +1,108 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file ParticipantModule.cpp
+ */
+
+# include "ParticipantModule.hpp"
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include <fastdds/dds/domain/DomainParticipant.hpp>
+#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
+#include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
+#include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
+#include <fastdds/rtps/common/Locator.h>
+#include <fastdds/rtps/participant/ParticipantDiscoveryInfo.h>
+#include <fastrtps/utils/IPLocator.h>
+
+using namespace eprosima::fastdds::dds;
+using namespace eprosima::fastdds::rtps;
+using namespace eprosima::fastrtps::rtps;
+
+ParticipantModule::ParticipantModule(
+        const std::string& discovery_protocol,
+        const std::string& guid_prefix,
+        const std::string& unicast_metatraffic_port)
+{
+    if (discovery_protocol.compare(ParticipantType::SERVER) == 0)
+    {
+        discovery_protocol_ = DiscoveryProtocol_t::SERVER;
+        std::istringstream server_guid_prefix_str(guid_prefix);
+        server_guid_prefix_str >> server_guid_prefix_;
+        unicast_metatraffic_port_ = atoi(unicast_metatraffic_port.c_str());
+    }
+    else if (discovery_protocol.compare(ParticipantType::CLIENT) == 0)
+    {
+        discovery_protocol_ = DiscoveryProtocol_t::CLIENT;
+    }
+    else
+    {
+        discovery_protocol_ = DiscoveryProtocol_t::SIMPLE;
+    }
+}
+
+ParticipantModule::~ParticipantModule()
+{
+    if (nullptr != participant_)
+    {
+        DomainParticipantFactory::get_instance()->delete_participant(participant_);
+    }
+}
+
+bool ParticipantModule::init()
+{
+    DomainParticipantQos participant_qos;
+    participant_qos.wire_protocol().builtin.discovery_config.discoveryProtocol = discovery_protocol_;
+    if (DiscoveryProtocol_t::SERVER == discovery_protocol_)
+    {
+        participant_qos.wire_protocol().prefix = server_guid_prefix_;
+        Locator_t locator_server;
+        IPLocator::setIPv4(locator_server, "127.0.0.1");
+        locator_server.port = unicast_metatraffic_port_;
+        participant_qos.wire_protocol().builtin.metatrafficUnicastLocatorList.push_back(locator_server);
+    }
+    participant_ = DomainParticipantFactory::get_instance()->create_participant(0, participant_qos, this);
+
+    if (nullptr == participant_)
+    {
+        return false;
+    }
+    return true;
+}
+
+void ParticipantModule::on_participant_discovery(
+        DomainParticipant* participant,
+        ParticipantDiscoveryInfo&& info)
+{
+    if (info.status == ParticipantDiscoveryInfo::DISCOVERED_PARTICIPANT)
+    {
+        std::cout << "Participant " << participant->guid() << " discovered participant " << info.info.m_guid << ": "
+                  << ++matched_ << std::endl;
+    }
+    else if (info.status == ParticipantDiscoveryInfo::CHANGED_QOS_PARTICIPANT)
+    {
+        std::cout << "Participant " << participant->guid() << " detected changes on participant " << info.info.m_guid
+                  << std::endl;
+    }
+    else if (info.status == ParticipantDiscoveryInfo::REMOVED_PARTICIPANT ||
+            info.status == ParticipantDiscoveryInfo::DROPPED_PARTICIPANT)
+    {
+        std::cout << "Participant " << participant->guid() << " undiscovered participant " << info.info.m_guid << ": "
+                  << --matched_ << std::endl;
+    }
+}

--- a/test/dds/discovery/ParticipantModule.hpp
+++ b/test/dds/discovery/ParticipantModule.hpp
@@ -47,7 +47,7 @@ public:
     void on_participant_discovery(
             DomainParticipant* participant,
             ParticipantDiscoveryInfo&& info) override;
-    
+
     bool init();
 
 private:

--- a/test/dds/discovery/ParticipantModule.hpp
+++ b/test/dds/discovery/ParticipantModule.hpp
@@ -1,0 +1,67 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributes under the License is distributes on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permisssions and
+// limitations under the license.
+
+/**
+ * @file ParticipantModule.hpp
+ */
+
+#ifndef TEST_DDS_COMMUNICATION_PARTICIPANTMODULE_HPP
+#define TEST_DDS_COMMUNICATION_PARTICIPANTMODULE_HPP
+
+#include <string>
+
+#include <fastdds/dds/domain/DomainParticipant.hpp>
+#include <fastdds/dds/domain/DomainParticipantListener.hpp>
+#include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
+#include <fastdds/rtps/common/GuidPrefix_t.hpp>
+#include <fastdds/rtps/participant/ParticipantDiscoveryInfo.h>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+
+using namespace eprosima::fastrtps::rtps;
+
+class ParticipantModule : public DomainParticipantListener
+{
+public:
+
+    ParticipantModule(
+            const std::string& discovery_protocol,
+            const std::string& guid_prefix,
+            const std::string& unicast_metatraffic_port);
+
+    ~ParticipantModule();
+
+    void on_participant_discovery(
+            DomainParticipant* participant,
+            ParticipantDiscoveryInfo&& info) override;
+    
+    bool init();
+
+private:
+
+    unsigned int matched_ = 0;
+    bool run_ = true;
+    DomainParticipant* participant_ = nullptr;
+    DiscoveryProtocol_t discovery_protocol_;
+    GuidPrefix_t server_guid_prefix_;
+    uint32_t unicast_metatraffic_port_;
+};
+
+} // dds
+} // fastdds
+} // eprosima
+
+#endif // TEST_DDS_COMMUNICATION_PARTICIPANTMODULE.HPP

--- a/test/dds/discovery/ParticipantModule.hpp
+++ b/test/dds/discovery/ParticipantModule.hpp
@@ -53,7 +53,6 @@ public:
 private:
 
     unsigned int matched_ = 0;
-    bool run_ = true;
     DomainParticipant* participant_ = nullptr;
     DiscoveryProtocol_t discovery_protocol_;
     GuidPrefix_t server_guid_prefix_;

--- a/test/dds/discovery/client_server_dynamic_discovery.py
+++ b/test/dds/discovery/client_server_dynamic_discovery.py
@@ -44,8 +44,6 @@ assert(process_command)
 def output_reader(proc, outq):
     for line in iter(proc.stdout.readline, b''):
         outq.put(line.decode('utf-8'))
-    for line in iter(proc.stderr.readline, b''):
-        outq.put(line.decode('utf-8'))
 
 def first_step(outq):
     first_step_fulfilled = False
@@ -411,22 +409,22 @@ server_1_process = subprocess.Popen([process_command,
     "--guid_prefix", "44.53.00.5F.45.50.52.4F.53.49.4D.41",
     "--unicast_metatraffic_locator", random_port_server_1],
     env={"FASTDDS_ENVIRONMENT_FILE": server_1_env_file},
-    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 server_2_process = subprocess.Popen([process_command,
     "--discovery_protocol", "SERVER",
     "--guid_prefix", "44.53.01.5F.45.50.52.4F.53.49.4D.41",
     "--unicast_metatraffic_locator", random_port_server_2],
     env={"FASTDDS_ENVIRONMENT_FILE": server_2_env_file},
-    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 # The client must be DiscoveryProtocol::SIMPLE to use the environment variable
 client_override_process = subprocess.Popen(process_command,
     env={"FASTDDS_ENVIRONMENT_FILE": client_env_file},
-    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 # DiscoveryProtocol::CLIENT, environment variable does not apply either initializing as updating
 client_process = subprocess.Popen([process_command,
     "--discovery_protocol", "CLIENT"],
     env={"FASTDDS_ENVIRONMENT_FILE": client_env_file},
-    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
 stop_threads = False
 t_0 = threading.Thread(target=communication, args=(server_1_process,outq,outt,cv))

--- a/test/dds/discovery/client_server_dynamic_discovery.py
+++ b/test/dds/discovery/client_server_dynamic_discovery.py
@@ -1,0 +1,538 @@
+# Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import glob
+import os
+import queue
+import subprocess
+import sys
+import threading
+import time
+
+script_dir = os.path.dirname(os.path.realpath(__file__))
+
+# Test executable
+process_command = os.environ.get(
+    'CLIENT_SERVER_DYNAMIC_DISCOVERY_BIN')
+if not process_command:
+    process_files = glob.glob(
+        os.path.join(
+           script_dir,
+           '**/DDSParticipantDiscovery*'),
+        recursive=True)
+    pf = iter(process_files)
+    process_command = next(pf, None)
+    while process_command and \
+        (not os.path.isfile(process_command)
+         or not os.access(process_command,
+         os.X_OK)):
+        process_command = next(pf, None)
+assert(process_command)
+
+# Thread that read process output and push it into a queue
+def output_reader(proc, outq):
+    for line in iter(proc.stdout.readline, b''):
+        outq.put(line.decode('utf-8'))
+    for line in iter(proc.stderr.readline, b''):
+        outq.put(line.decode('utf-8'))
+
+def first_step(outq):
+    first_step_fulfilled = False
+    server_1_discover_client = False
+    count = 0
+    initial_time = time.time()
+    while not first_step_fulfilled:
+        global stop_threads
+        if stop_threads:
+            break
+        try:
+            line = outq.get(block=False).rstrip()
+            print(line)
+            sys.stdout.flush()
+
+            assert '44.53.00.5f.45.50.52.4f.53.49.4d.41' in line
+            assert 'discovered participant' in line
+            count = count + 1
+            if 'discovered participant 44.53.00.5f.45.50.52.4f.53.49.4d.41|0.0.1.c1: 1' in line:
+                print('CLIENT OVERRIDE discovered SERVER 1')
+                server_1_discover_client = True
+        except queue.Empty:
+            # Ensure that 2 s has passed so the file watch can detect that the file has changed
+            if server_1_discover_client and count >= 2 and (time.time() - initial_time) > 2:
+                if count == 2:
+                    first_step_fulfilled = True
+                else:
+                    print('ERROR: More discoveries than expected')
+                    stop_threads = True
+                    sys.exit(1)
+            sys.stdout.flush()
+        except AssertionError:
+            print('ASSERTION ERROR: ' + line)
+            stop_threads = True
+            sys.exit(1)
+        time.sleep(0.1)
+
+def second_step(outq):
+    second_step_fulfilled = False
+    server_2_discover_client = False
+    client_2_warning = False
+    count = 0
+    initial_time = time.time()
+    while not second_step_fulfilled:
+        global stop_threads
+        if stop_threads:
+            break
+        try:
+            line = outq.get(block=False).rstrip()
+            print(line)
+            sys.stdout.flush()
+
+            if 'discovered participant' in line:
+                assert '44.53.01.5f.45.50.52.4f.53.49.4d.41' in line
+                count = count + 1
+                if 'discovered participant 44.53.01.5f.45.50.52.4f.53.49.4d.41|0.0.1.c1: 2' in line:
+                    print('CLIENT OVERRIDE discovered SERVER 2')
+                    server_2_discover_client = True
+            elif 'Warning' in line:
+                # Client 2 does not discover anyone
+                assert 'Trying to add Discovery Servers to a participant which is not a SERVER, BACKUP or an' in line
+                assert 'overriden CLIENT (SIMPLE participant transformed into CLIENT with the environment variable)' in line
+                client_2_warning = True
+            else:
+                assert 'detected changes on participant' in line
+        except queue.Empty:
+            # Ensure that 2 s has passed so the file watch can detect that the file has changed
+            if server_2_discover_client and client_2_warning and count >= 2 and (time.time() - initial_time) > 2:
+                if count == 2:
+                    second_step_fulfilled = True
+                else:
+                    print('ERROR: More discoveries than expected')
+                    stop_threads = True
+                    sys.exit(1)
+            sys.stdout.flush()
+        except AssertionError:
+            print('ASSERTION ERROR: ' + line)
+            stop_threads = True
+            sys.exit(1)
+        time.sleep(0.1)
+
+def third_step(outq):
+    third_step_fulfilled = False
+    server_1_discover_server_2 = False
+    server_2_discover_server_1 = False
+    initial_time = time.time()
+    while not third_step_fulfilled:
+        global stop_threads
+        if stop_threads:
+            break
+        try:
+            line = outq.get(block=False).rstrip()
+            print(line)
+            sys.stdout.flush()
+
+            if 'Participant 44.53.01.5f.45.50.52.4f.53.49.4d.41|0.0.1.c1 discovered participant' in line and \
+                '44.53.00.5f.45.50.52.4f.53.49.4d.41|0.0.1.c1: 2' in line:
+                print ('SERVER 2 discovers SERVER 1')
+                server_2_discover_server_1 = True
+            elif 'Participant 44.53.00.5f.45.50.52.4f.53.49.4d.41|0.0.1.c1 discovered participant' in line and \
+                '44.53.01.5f.45.50.52.4f.53.49.4d.41|0.0.1.c1: 2' in line:
+                print ('SERVER 1 discovers SERVER 2')
+                server_1_discover_server_2 = True
+            else:
+                assert 'detected changes on participant' in line
+        except queue.Empty:
+            # Ensure that 2 s has passed so the file watch can detect that the file has changed
+            if server_1_discover_server_2 and server_2_discover_server_1 and (time.time() - initial_time) > 2:
+                third_step_fulfilled = True
+            sys.stdout.flush()
+        except AssertionError:
+            print('ASSERTION ERROR: ' + line)
+            stop_threads = True
+            sys.exit(1)
+        time.sleep(0.1)
+
+def fourth_step(outq):
+    fourth_step_fulfilled = False
+    warning_client_1 = False
+    warning_client_2 = False
+    count = 0
+    initial_time = time.time()
+    while not fourth_step_fulfilled:
+        global stop_threads
+        if stop_threads:
+            break
+        try:
+            line = outq.get(block=False).rstrip()
+            print(line)
+            sys.stdout.flush()
+
+            if 'Trying to add Discovery Servers to a participant which is not a SERVER, BACKUP or an' in line \
+                and 'overriden CLIENT (SIMPLE participant transformed into CLIENT with the environment variable)' in line:
+                warning_client_2 = True
+            elif 'Discovery Servers cannot add/modify their locators' in line:
+                warning_client_1 = True
+            elif 'discovered participant' in line:
+                count = count + 1
+        except queue.Empty:
+            # Ensure that 2 s has passed so the file watch can detect that the file has changed
+            if warning_client_1 and warning_client_2 and count == 0 and (time.time() - initial_time) > 2:
+                fourth_step_fulfilled = True
+            elif count > 0:
+                print('ERROR: More discoveries than expected')
+                stop_threads = True
+                sys.exit(1)
+            sys.stdout.flush()
+        except AssertionError:
+            print('ASSERTION ERROR: ' + line)
+            stop_threads = True
+            sys.exit(1)
+        time.sleep(0.1)
+
+def fifth_step(outq):
+    fifth_step_fulfilled = False
+    warning = False
+    count = 0
+    initial_time = time.time()
+    while not fifth_step_fulfilled:
+        global stop_threads
+        if stop_threads:
+            break
+        try:
+            line = outq.get(block=False).rstrip()
+            print(line)
+            sys.stdout.flush()
+
+            if 'Discovery Servers cannot add/modify their locators' in line:
+                warning = True
+            elif 'discovered participant' in line:
+                count = count + 1
+        except queue.Empty:
+            # Ensure that 2 s has passed so the file watch can detect that the file has changed
+            if warning and count == 0 and (time.time() - initial_time) > 2:
+                fifth_step_fulfilled = True
+            elif count > 0:
+                print('ERROR: More discoveries than expected')
+                stop_threads = True
+                sys.exit(1)
+            sys.stdout.flush()
+        except AssertionError:
+            print('ASSERTION ERROR: ' + line)
+            stop_threads = True
+            sys.exit(1)
+        time.sleep(0.1)
+
+def sixth_step(outq):
+    sixth_step_fulfilled = False
+    warning_client_1 = False
+    warning_client_2 = False
+    count = 0
+    initial_time = time.time()
+    while not sixth_step_fulfilled:
+        global stop_threads
+        if stop_threads:
+            break
+        try:
+            line = outq.get(block=False).rstrip()
+            print(line)
+            sys.stdout.flush()
+
+            if 'Trying to add Discovery Servers to a participant which is not a SERVER, BACKUP or an' in line \
+                and 'overriden CLIENT (SIMPLE participant transformed into CLIENT with the environment variable)' in line:
+                warning_client_2 = True
+            elif 'Discovery Servers cannot be removed from the list; they can only be added' in line:
+                warning_client_1 = True
+            elif 'discovered participant' in line:
+                count = count + 1
+        except queue.Empty:
+            # Ensure that 2 s has passed so the file watch can detect that the file has changed
+            if warning_client_1 and warning_client_2 and count == 0 and (time.time() - initial_time) > 2:
+                sixth_step_fulfilled = True
+            elif count > 0:
+                print('ERROR: More discoveries than expected')
+                stop_threads = True
+                sys.exit(1)
+            sys.stdout.flush()
+        except AssertionError:
+            print('ASSERTION ERROR: ' + line)
+            stop_threads = True
+            sys.exit(1)
+        time.sleep(0.1)
+
+def seventh_step(outq):
+    seventh_step_fulfilled = False
+    warning = False
+    count = 0
+    initial_time = time.time()
+    while not seventh_step_fulfilled:
+        global stop_threads
+        if stop_threads:
+            break
+        try:
+            line = outq.get(block=False).rstrip()
+            print(line)
+            sys.stdout.flush()
+
+            if 'Discovery Servers cannot be removed from the list; they can only be added' in line:
+                warning = True
+            elif 'discovered participant' in line:
+                count = count + 1
+        except queue.Empty:
+            # Ensure that 2 s has passed so the file watch can detect that the file has changed
+            if warning and count == 0 and (time.time() - initial_time) > 2:
+                seventh_step_fulfilled = True
+            elif count > 0:
+                print('ERROR: More discoveries than expected')
+                stop_threads = True
+                sys.exit(1)
+            sys.stdout.flush()
+        except AssertionError:
+            print('ASSERTION ERROR: ' + line)
+            stop_threads = True
+            sys.exit(1)
+        time.sleep(0.1)
+
+def exit(cv):
+    cv.release()
+    print('ERROR: timeout without expected discovery happening')
+    global stop_threads
+    stop_threads = True
+    os.remove(server_1_env_file)
+    os.remove(server_2_env_file)
+    os.remove(client_env_file)
+    sys.exit(1)
+
+def communication(proc, outq, outt, cv):
+    """A"""
+    t = threading.Thread(target=output_reader, args=(proc,outq))
+    t.start()
+
+    try:
+        time.sleep(0.2)
+
+        while True:
+            global stop_threads
+            if stop_threads:
+                break
+            try:
+                line = outt.get(block=False).rstrip()
+                print(line)
+                sys.stdout.flush()
+
+                if "FIRST STEP" in line:
+                    first_step(outq)
+                    cv.acquire()
+                    cv.notify()
+                    cv.release()
+                elif "SECOND STEP" in line:
+                    second_step(outq)
+                    cv.acquire()
+                    cv.notify()
+                    cv.release()
+                elif "THIRD STEP" in line:
+                    third_step(outq)
+                    cv.acquire()
+                    cv.notify()
+                    cv.release()
+                elif "FOURTH STEP" in line:
+                    fourth_step(outq)
+                    cv.acquire()
+                    cv.notify()
+                    cv.release()
+                elif "FIFTH STEP" in line:
+                    fifth_step(outq)
+                    cv.acquire()
+                    cv.notify()
+                    cv.release()
+                elif "SIXTH STEP" in line:
+                    sixth_step(outq)
+                    cv.acquire()
+                    cv.notify()
+                    cv.release()
+                elif "SEVENTH STEP" in line:
+                    seventh_step(outq)
+                    cv.acquire()
+                    cv.notify()
+                    cv.release()
+                
+ 
+            except queue.Empty:
+                sys.stdout.flush()
+            
+            time.sleep(0.1)
+    finally:
+        proc.terminate()
+
+    while outq.empty() != True:
+        line = outq.get(block=False).rstrip()
+        print(line)
+
+    t.join()
+
+# Random unicast port
+random_port_server_1 = os.environ.get(
+    'W_UNICAST_PORT_RANDOM_NUMBER')
+random_port_server_2 = str(int(random_port_server_1) + 1)
+
+# Condition variable
+cv = threading.Condition()
+
+# Environment files
+server_1_env_file = "server_1_env_file.json"
+server_2_env_file = "server_2_env_file.json"
+client_env_file = "client_env_file.json"
+# Both server environment files are created empty
+open(server_1_env_file, 'w+').close()
+open(server_2_env_file, 'w+').close()
+# Client environment file should include the locator for the first server
+f = open(client_env_file, 'w+')
+f.write('{"ROS_DISCOVERY_SERVER": "localhost:')
+f.write(random_port_server_1)
+f.write('"}')
+f.close()
+
+outq = queue.Queue()
+outt = queue.Queue()
+outt.put("TEST RUNNING\n")
+outt.put("FIRST STEP: Override Client discovers Server 1\n")
+
+server_1_process = subprocess.Popen([process_command,
+    "--discovery_protocol", "SERVER",
+    "--guid_prefix", "44.53.00.5F.45.50.52.4F.53.49.4D.41",
+    "--unicast_metatraffic_locator", random_port_server_1],
+    env={"FASTDDS_ENVIRONMENT_FILE": server_1_env_file},
+    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+server_2_process = subprocess.Popen([process_command,
+    "--discovery_protocol", "SERVER",
+    "--guid_prefix", "44.53.01.5F.45.50.52.4F.53.49.4D.41",
+    "--unicast_metatraffic_locator", random_port_server_2],
+    env={"FASTDDS_ENVIRONMENT_FILE": server_2_env_file},
+    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+# The client must be DiscoveryProtocol::SIMPLE to use the environment variable
+client_override_process = subprocess.Popen(process_command,
+    env={"FASTDDS_ENVIRONMENT_FILE": client_env_file},
+    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+# DiscoveryProtocol::CLIENT, environment variable does not apply either initializing as updating
+client_process = subprocess.Popen([process_command,
+    "--discovery_protocol", "CLIENT"],
+    env={"FASTDDS_ENVIRONMENT_FILE": client_env_file},
+    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+stop_threads = False
+t_0 = threading.Thread(target=communication, args=(server_1_process,outq,outt,cv))
+t_1 = threading.Thread(target=communication, args=(server_2_process,outq,outt,cv))
+t_2 = threading.Thread(target=communication, args=(client_override_process,outq,outt,cv))
+t_3 = threading.Thread(target=communication, args=(client_process,outq,outt,cv))
+
+t_0.start()
+t_1.start()
+t_2.start()
+t_3.start()
+
+# Wait 10 seconds for the condition variable to be notified
+cv.acquire()
+result = cv.wait(10)
+if result == False:
+    exit(cv)
+
+outt.put("SECOND STEP: Override Client discovers both Servers. Normal Client does not discover anyone\n")
+
+# Add second server to client
+f = open(client_env_file, 'w+')
+f.write('{"ROS_DISCOVERY_SERVER": "localhost:')
+f.write(random_port_server_1)
+f.write(';localhost:')
+f.write(random_port_server_2)
+f.write('"}')
+f.close()
+
+result = cv.wait(10)
+if result == False:
+    exit(cv)
+
+outt.put("THIRD STEP: Both Servers discover each other\n")
+
+# Add second server to first server
+f = open(server_1_env_file, 'w+')
+f.write('{"ROS_DISCOVERY_SERVER": ";localhost:')
+f.write(random_port_server_2)
+f.write('"}')
+f.close()
+
+result = cv.wait(10)
+if result == False:
+    exit(cv)
+
+outt.put("FOURTH STEP: Changing a Server locator from the Client list outputs a Log Warning\n")
+
+# Change first server locator from client list
+f = open(client_env_file, 'w+')
+f.write('{"ROS_DISCOVERY_SERVER": "localhost:11811;localhost:')
+f.write(random_port_server_2)
+f.write('"}')
+f.close()
+
+result = cv.wait(10)
+if result == False:
+    exit(cv)
+
+outt.put("FIFTH STEP: Changing a Server locator from the Server list outputs a Log Warning\n")
+
+# Change server locator from server list
+f = open(server_1_env_file, 'w+')
+f.write('{"ROS_DISCOVERY_SERVER": ";localhost:11811"}')
+f.close()
+
+result = cv.wait(10)
+if result == False:
+    exit(cv)
+
+outt.put("SIXTH STEP: Removing a Server from the Client list outputs a Log Warning\n")
+
+# Remove first server from client list
+f = open(client_env_file, 'w+')
+f.write('{"ROS_DISCOVERY_SERVER": ";localhost:')
+f.write(random_port_server_2)
+f.write('"}')
+f.close()
+
+result = cv.wait(10)
+if result == False:
+    exit(cv)
+
+outt.put("SEVENTH STEP: Removing a Server from the  Server list outputs a Log Warning\n")
+
+# Remove server from the server 1 list
+f = open(server_1_env_file, 'w+')
+f.write('{"ROS_DISCOVERY_SERVER": ""}')
+f.close()
+
+result = cv.wait(10)
+if result == False:
+    exit(cv)
+
+outt.put("Killing processes\n")
+
+cv.release()
+# Kill processes
+stop_threads = True
+
+t_0.join()
+t_1.join()
+t_2.join()
+t_3.join()
+
+# Delete files
+os.remove(server_1_env_file)
+os.remove(server_2_env_file)
+os.remove(client_env_file)

--- a/test/unittest/utils/SystemInfoTests.cpp
+++ b/test/unittest/utils/SystemInfoTests.cpp
@@ -157,6 +157,27 @@ TEST_F(SystemInfoTests, FileExistsTest)
 }
 
 /**
+ * Test that checks set_environment_file and get_environment_file
+ */
+TEST(SystemInfoTests, EnvironmentFileTest)
+{
+    // 1. Environment variable not set: call to set_environment_variable returns RETCODE_NO_DATA and
+    // get_environment_file returns empty
+    EXPECT_EQ(ReturnCode_t::RETCODE_NO_DATA, eprosima::SystemInfo::set_environment_file());
+    EXPECT_TRUE(eprosima::SystemInfo::get_environment_file().empty());
+
+    // 2. Set environment file variable and see that it returns correctly
+    const std::string value("TESTING");    
+#ifdef _WIN32
+    ASSERT_EQ(0, _putenv_s(eprosima::FASTDDS_ENVIRONMENT_FILE_ENV_VAR, value.c_str()));
+#else
+    ASSERT_EQ(0, setenv(eprosima::FASTDDS_ENVIRONMENT_FILE_ENV_VAR, value.c_str(), 1));
+#endif // _WIN32
+    EXPECT_EQ(ReturnCode_t::RETCODE_OK, eprosima::SystemInfo::set_environment_file());
+    EXPECT_EQ(0, eprosima::SystemInfo::get_environment_file().compare(value));
+}
+
+/**
  * This test checks the load_environment_file method of the SystemInfo class
  */
 TEST_F(SystemInfoTests, LoadEnvironmentFileTest)

--- a/test/unittest/utils/SystemInfoTests.cpp
+++ b/test/unittest/utils/SystemInfoTests.cpp
@@ -88,7 +88,7 @@ TEST_F(SystemInfoTests, GetEnvTest)
 #ifdef _WIN32
     ASSERT_EQ(0, _putenv_s(env_var_name.c_str(), value.c_str()));
     ASSERT_EQ(0, _putenv_s(eprosima::FASTDDS_ENVIRONMENT_FILE_ENV_VAR, filename.c_str()));
-    ASSERT_EQ(0, _putenv_s(eprosima::fastdds::rtps::DEFAULT_ROS_MASTER_URI, value.c_str()));
+    ASSERT_EQ(0, _putenv_s(eprosima::fastdds::rtps::DEFAULT_ROS2_MASTER_URI, value.c_str()));
     ASSERT_EQ(0, _putenv_s("EMPTY_ENV_VAR", value.c_str()));
 #else
     ASSERT_EQ(0, setenv(env_var_name.c_str(), value.c_str(), 1));

--- a/test/unittest/utils/SystemInfoTests.cpp
+++ b/test/unittest/utils/SystemInfoTests.cpp
@@ -19,6 +19,7 @@
 #include <functional>
 #include <mutex>
 #include <stdlib.h>
+#include <string>
 #include <thread>
 
 #ifdef _WIN32
@@ -82,30 +83,28 @@ protected:
  */
 TEST_F(SystemInfoTests, GetEnvTest)
 {
-    const char* env_var_name = "TEST_ENVIRONMENT_VARIABLE";
-    const char* value = "TESTING";
-    const char* env_value;
+    const std::string env_var_name("TEST_ENVIRONMENT_VARIABLE");
+    const std::string value("TESTING");
+    std::string env_value;
 
     // 1. Set the testing environment variable
 #ifdef _WIN32
-    ASSERT_EQ(0, _putenv_s(env_var_name, value));
+    ASSERT_EQ(0, _putenv_s(env_var_name.c_str(), value.c_str()));
 #else
-    ASSERT_EQ(0, setenv(env_var_name, value, 1));
+    ASSERT_EQ(0, setenv(env_var_name.c_str(), value.c_str(), 1));
 #endif // _WIN32
 
     // 2. Read environment variable
-    EXPECT_EQ(eprosima::SystemInfo::get_env(env_var_name, &env_value), ReturnCode_t::RETCODE_OK);
-    EXPECT_EQ(strcmp(env_value, value), 0);
+    EXPECT_EQ(eprosima::SystemInfo::get_env(env_var_name, env_value), ReturnCode_t::RETCODE_OK);
+    EXPECT_EQ(env_value.compare(value), 0);
 
-    // 3. Bad parameters
-    EXPECT_EQ(eprosima::SystemInfo::get_env(nullptr, &env_value), ReturnCode_t::RETCODE_BAD_PARAMETER);
-    EXPECT_EQ(eprosima::SystemInfo::get_env(env_var_name, nullptr), ReturnCode_t::RETCODE_BAD_PARAMETER);
+    // 3. Bad parameters: empty environment name
+    std::string non_init_string;
+    EXPECT_EQ(eprosima::SystemInfo::get_env("", env_value), ReturnCode_t::RETCODE_BAD_PARAMETER);
+    EXPECT_EQ(eprosima::SystemInfo::get_env(non_init_string, env_value), ReturnCode_t::RETCODE_BAD_PARAMETER);
 
-    // 4. Empty environment name
-    EXPECT_EQ(eprosima::SystemInfo::get_env("", &env_value), ReturnCode_t::RETCODE_BAD_PARAMETER);
-
-    // 5. Invalid environment name
-    EXPECT_EQ(eprosima::SystemInfo::get_env("INVALID_NAME", &env_value), ReturnCode_t::RETCODE_NO_DATA);
+    // 4. Invalid environment name
+    EXPECT_EQ(eprosima::SystemInfo::get_env("INVALID_NAME", env_value), ReturnCode_t::RETCODE_NO_DATA);
 }
 
 /*

--- a/test/unittest/utils/SystemInfoTests.cpp
+++ b/test/unittest/utils/SystemInfoTests.cpp
@@ -202,7 +202,7 @@ TEST_F(SystemInfoTests, FileExistsTest)
 /**
  * Test that checks set_environment_file and get_environment_file
  */
-TEST(SystemInfoTests, EnvironmentFileTest)
+TEST_F(SystemInfoTests, EnvironmentFileTest)
 {
     // 1. Environment variable not set: call to set_environment_variable returns RETCODE_NO_DATA and
     // get_environment_file returns empty
@@ -230,7 +230,7 @@ TEST_F(SystemInfoTests, FileWatchTest)
 
     // Create filewatch
     eprosima::FileWatchHandle watch =
-            eprosima::SystemInfo::watch_file(filename, [&](const std::string&)
+            eprosima::SystemInfo::watch_file(filename, [&]()
                     {
                         {
                             std::unique_lock<std::mutex> lck(*mutex_);

--- a/test/unittest/utils/SystemInfoTests.cpp
+++ b/test/unittest/utils/SystemInfoTests.cpp
@@ -210,7 +210,7 @@ TEST_F(SystemInfoTests, EnvironmentFileTest)
     EXPECT_TRUE(eprosima::SystemInfo::get_environment_file().empty());
 
     // 2. Set environment file variable and see that it returns correctly
-    const std::string value("TESTING");    
+    const std::string value("TESTING");
 #ifdef _WIN32
     ASSERT_EQ(0, _putenv_s(eprosima::FASTDDS_ENVIRONMENT_FILE_ENV_VAR, value.c_str()));
 #else


### PR DESCRIPTION
This PR implements the final functionality. Monitoring the environment file and applying the changes when the watcher triggers.

It also includes the refactor of `SystemInfo::get_env` to use `std::string` instead of `char*`.