### PR TITLE
Remove not implemented warning on doxygen [12358]

### DIFF
--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -1981,7 +1981,7 @@ public:
     PublishModeQosPolicyKind kind = SYNCHRONOUS_PUBLISH_MODE;
 
     //! Name of the flow controller used when publish mode kind is ASYNCHRONOUS_PUBLISH_MODE.
-    //! @since Functionality not implemented yet. Coming soon.
+    //! @since 2.4.0
     const char* flow_controller_name = fastdds::rtps::FASTDDS_FLOW_CONTROLLER_DEFAULT;
 
     inline void clear() override

--- a/include/fastdds/dds/domain/qos/DomainParticipantQos.hpp
+++ b/include/fastdds/dds/domain/qos/DomainParticipantQos.hpp
@@ -296,7 +296,7 @@ private:
     fastrtps::string_255 name_ = "RTPSParticipant";
 
     //! User defined flow controller to use alongside.
-    //! @since Functionality not implemented yet. Coming soon.
+    //! @since 2.4.0
     FlowControllerDescriptorList flow_controllers_;
 
 };

--- a/include/fastdds/rtps/flowcontrol/FlowControllerDescriptor.hpp
+++ b/include/fastdds/rtps/flowcontrol/FlowControllerDescriptor.hpp
@@ -26,7 +26,7 @@ namespace rtps {
  * Configuration values for creating flow controllers.
  *
  * This descriptor is used to define the configuration applied in the creation of a flow controller.
- * @since Functionality not implemented yet. Coming soon.
+ * @since 2.4.0
  */
 struct FlowControllerDescriptor
 {


### PR DESCRIPTION
Flow controllers made their way to master, but doxygen was not updated accordingly.