### PR TITLE
Fixed LogMacrosTests.default_macros_test [12575]

### DIFF
--- a/test/unittest/logging/log_macros/LogMacrosDefaultTests.cpp
+++ b/test/unittest/logging/log_macros/LogMacrosDefaultTests.cpp
@@ -26,11 +26,11 @@ TEST_F(LogMacrosTests, default_macros_test)
     logWarning(SampleCategory, "Sample warning message");
     logInfo(SampleCategory, "Sample info message");
 
-    unsigned int expected_result = 3;
-
-#if !(__DEBUG || _DEBUG)
-    --expected_result;
-#endif // CMAKE_BUILD_TYPE == DEBUG_TYPE
+#if defined(_DEBUG) || defined(__DEBUG) || !defined(NDEBUG)
+    static constexpr unsigned int expected_result = 3;
+#else
+    static constexpr unsigned int expected_result = 2;
+#endif // debug macros check
 
     auto consumedEntries = HELPER_WaitForEntries(expected_result);
     ASSERT_EQ(expected_result, consumedEntries.size());

--- a/test/unittest/logging/log_macros/LogMacrosDefaultTests.cpp
+++ b/test/unittest/logging/log_macros/LogMacrosDefaultTests.cpp
@@ -18,13 +18,28 @@
 #include "LogMacros.hpp"
 #include <gtest/gtest.h>
 
+#define log_str(x) #x
+#define macro_print(mname) std::cout << #mname << " = " << \
+            (std::string(#mname) == log_str(mname) ? "" : log_str(mname)) << std::endl
+
 /* WARNING - This test will fail with any LOG_NO_ CMake option set different than default configuration
  * Check all log levels are active in debug mode, or INFO is not active in Release mode */
 TEST_F(LogMacrosTests, default_macros_test)
 {
+    std::cout << std::endl << "logInfo #define'd related constants:" << std::endl;
+    macro_print(HAVE_LOG_NO_INFO);
+    macro_print(FASTDDS_ENFORCE_LOG_INFO);
+    macro_print(__INTERNALDEBUG);
+    macro_print(_INTERNALDEBUG);
+    macro_print(_DEBUG);
+    macro_print(__DEBUG);
+    macro_print(NDEBUG);
+    std::cout << std::endl;
+
     logError(SampleCategory, "Sample error message");
     logWarning(SampleCategory, "Sample warning message");
     logInfo(SampleCategory, "Sample info message");
+
 
 #if defined(_DEBUG) || defined(__DEBUG) || !defined(NDEBUG)
     static constexpr unsigned int expected_result = 3;

--- a/test/unittest/logging/log_macros/LogMacrosDefaultTests.cpp
+++ b/test/unittest/logging/log_macros/LogMacrosDefaultTests.cpp
@@ -40,8 +40,11 @@ TEST_F(LogMacrosTests, default_macros_test)
     logWarning(SampleCategory, "Sample warning message");
     logInfo(SampleCategory, "Sample info message");
 
+#if defined(NDEBUG) && !HAVE_LOG_NO_INFO
+#error "Unexpected default values for NDEBUG and HAVE_LOG_NO_INFO"
+#endif  // Check default macro values
 
-#if defined(_DEBUG) || defined(__DEBUG) || !defined(NDEBUG)
+#if !HAVE_LOG_NO_INFO && (defined(_DEBUG) || defined(__DEBUG) || !defined(NDEBUG))
     static constexpr unsigned int expected_result = 3;
 #else
     static constexpr unsigned int expected_result = 2;

--- a/test/unittest/logging/log_macros/LogMacrosDefaultTests.cpp
+++ b/test/unittest/logging/log_macros/LogMacrosDefaultTests.cpp
@@ -20,7 +20,7 @@
 
 #define log_str(x) #x
 #define macro_print(mname) std::cout << #mname << " = " << \
-            (std::string(#mname) == log_str(mname) ? "" : log_str(mname)) << std::endl
+        (std::string(#mname) == log_str(mname) ? "" : log_str(mname)) << std::endl
 
 /* WARNING - This test will fail with any LOG_NO_ CMake option set different than default configuration
  * Check all log levels are active in debug mode, or INFO is not active in Release mode */

--- a/test/unittest/logging/log_macros/LogMacrosDefaultTests.cpp
+++ b/test/unittest/logging/log_macros/LogMacrosDefaultTests.cpp
@@ -41,7 +41,9 @@ TEST_F(LogMacrosTests, default_macros_test)
     logInfo(SampleCategory, "Sample info message");
 
 #if defined(NDEBUG) && !HAVE_LOG_NO_INFO
-#error "Unexpected default values for NDEBUG and HAVE_LOG_NO_INFO"
+#    if !defined(_MSC_VER )
+#        error "Unexpected default values for NDEBUG and HAVE_LOG_NO_INFO"
+#    endif  // Visual Studio specific behavior
 #endif  // Check default macro values
 
 #if !HAVE_LOG_NO_INFO && (defined(_DEBUG) || defined(__DEBUG) || !defined(NDEBUG))


### PR DESCRIPTION
The test referenced in the title has been failing consistently on Windows since #2089 was merged.

On that PR, the following assumption was made:

> HAVE_LOG_NO_INFO can be set by users with -DLOG_NO_INFO, which defaults to OFF in debug and ON in every other configuration.

But the default behavior is different for Visual Studio since #1775, as `LOG_NO_INFO` is always OFF on multiconfig CMake generators (i.e. Visual Studio).

This PR adds a build check on the default values for NDEBUG and LOG_NO_INFO, and adapts the way the expected result is calculated.