### PR TITLE
Fix Dynamic Types key parser from XML [12549]

### DIFF
--- a/src/cpp/rtps/xmlparser/XMLDynamicParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLDynamicParser.cpp
@@ -1345,10 +1345,10 @@ p_dynamictypebuilder_t XMLParser::parseXMLMemberDynamicType(
     {
         if (strncmp(memberTopicKey, "true", 5) == 0)
         {
-            memberBuilder->apply_annotation(types::ANNOTATION_KEY_ID, "value", "true");
+            memberBuilder->apply_annotation(types::ANNOTATION_KEY_ID, types::ANNOTATION_KEY_ID, "true");
             if (p_dynamictype != nullptr)
             {
-                p_dynamictype->apply_annotation(types::ANNOTATION_KEY_ID, "value", "true");
+                p_dynamictype->apply_annotation(types::ANNOTATION_KEY_ID, types::ANNOTATION_KEY_ID, "true");
             }
         }
     }


### PR DESCRIPTION
This hotfix solves an error on the XML types parser for Dynamic Types.
The `key` was not being parsed correctly, and so the type could not handle keys. 

Signed-off-by: jparisu <javierparis@eprosima.com>