### PR TITLE
Avoid bad_node_size exception when cross building [12583]

### DIFF
--- a/src/cpp/utils/collections/impl/node-sizes/custom/tree_node_size_impl.hpp
+++ b/src/cpp/utils/collections/impl/node-sizes/custom/tree_node_size_impl.hpp
@@ -25,7 +25,12 @@ struct my_tree_node_type
 {
     // There is an enum tree_color {false, true} here on libstdc++, we should include it here to
     // ensure there are no alignment issues
-    enum color_t { RED = false, BLACK = true } color;
+    enum color_t
+    {
+        RED = false,
+        BLACK = true
+    }
+    color;
 
     // Three pointers on MSVC and libstdc++, two on libc++
     my_tree_node_type* parent;

--- a/src/cpp/utils/collections/impl/node-sizes/custom/tree_node_size_impl.hpp
+++ b/src/cpp/utils/collections/impl/node-sizes/custom/tree_node_size_impl.hpp
@@ -23,7 +23,9 @@
 template<typename T>
 struct my_tree_node_type
 {
-    // There is an enum rb_tree_colo {false, true} here on libstdc++, it has been included below on other_info
+    // There is an enum tree_color {false, true} here on libstdc++, we should include it here to
+    // ensure there are no alignment issues
+    enum color_t { RED = false, BLACK = true } color;
 
     // Three pointers on MSVC and libstdc++, two on libc++
     my_tree_node_type* parent;


### PR DESCRIPTION
When foonathan/memory is cross-compiled, and the `node_size_dbg` tool cannot be executed with an emulator, some custom node types are used to calculate the size of the nodes being requested to the allocator.

After some reports of a `bad_node_size` exception being thrown, I investigated this deeply, and found the custom type was not compliant with certain std implementations (libstdc++).