### PR TITLE
Fix incosistences between Pub/Sub history and RTPS history

### DIFF
--- a/include/fastdds/rtps/history/History.h
+++ b/include/fastdds/rtps/history/History.h
@@ -181,6 +181,7 @@ public:
     RTPS_DllAPI virtual bool matches_change(
             const CacheChange_t* ch_inner,
             CacheChange_t* ch_outer);
+
     /**
      * Remove a specific change from the history.
      * @param removal iterator to the CacheChange_t to remove.

--- a/src/cpp/rtps/history/ReaderHistory.cpp
+++ b/src/cpp/rtps/history/ReaderHistory.cpp
@@ -185,9 +185,7 @@ bool ReaderHistory::remove_fragmented_changes_until(
                 if (item->is_fully_assembled() == false)
                 {
                     logInfo(RTPS_READER_HISTORY, "Removing change " << item->sequenceNumber);
-                    mp_reader->change_removed_by_history(item);
-                    mp_reader->releaseCache(item);
-                    chit = m_changes.erase(chit);
+                    chit = remove_change_nts(chit);
                     continue;
                 }
             }


### PR DESCRIPTION
When it is received a HEARTBEAT, its firstSN is used to find fragmented samples not fully assembled yet and remove them. This functionality is done by `ReaderHistory::remove_fragmented_changes_until`. But this function only removes the changes from the `ReaderHistory`, but not from `SubscriberHistory`, provoking inconsistences in the instances' vector.