### PR TITLE
Improve `DataWriterImpl::unregister_instance` performance and standard compliance [12622]

### DIFF
--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -589,7 +589,7 @@ ReturnCode_t DataWriterImpl::unregister_instance(
     ReturnCode_t returned_value = ReturnCode_t::RETCODE_ERROR;
     InstanceHandle_t ih = handle;
 
-#if !defined(NDEBUG)
+#if defined(NDEBUG)
     if (c_InstanceHandle_Unknown == ih)
 #endif // if !defined(NDEBUG)
     {
@@ -604,7 +604,7 @@ ReturnCode_t DataWriterImpl::unregister_instance(
     if (c_InstanceHandle_Unknown != handle && ih != handle)
     {
         logError(PUBLISHER, "handle differs from data's key.");
-        return ReturnCode_t::RETCODE_BAD_PARAMETER;
+        return ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;
     }
 #endif // if !defined(NDEBUG)
 


### PR DESCRIPTION
Only calculate the instance's key if the `handle` is `HANDLE_NIL` in Release.

In case of inconsistency between the `handle` and the instance's key, the standard establishes that it is a `RETCODE_PRECONDITION_NOT_MET`. Before this PR, `RETCODE_BAD_PARAMETER` is being returned.

Add DDS API unittest for `DataWriter::dispose` and `DataWriter::unregister_instance`.