### PR TITLE
[foxy] Fix: gap not being sent [14675]

### DIFF
--- a/include/fastdds/rtps/writer/ReaderProxy.h
+++ b/include/fastdds/rtps/writer/ReaderProxy.h
@@ -48,6 +48,7 @@ namespace rtps {
 class StatefulWriter;
 class TimedEvent;
 class RTPSReader;
+class RTPSGapBuilder;
 
 /**
  * ReaderProxy class that helps to keep the state of a specific Reader with respect to the RTPSWriter.
@@ -139,10 +140,13 @@ public:
     /**
      * Mark all changes in the vector as requested.
      * @param seq_num_set Bitmap of sequence numbers.
+     * @param gap_builder RTPSGapBuilder reference uses for adding  each requested change that is irrelevant for the
+     * requester.
      * @return true if at least one change has been marked as REQUESTED, false otherwise.
      */
     bool requested_changes_set(
-            const SequenceNumberSet_t& seq_num_set);
+            const SequenceNumberSet_t& seq_num_set,
+            RTPSGapBuilder& gap_builder);
 
     /**
      * Performs processing of preemptive acknack

--- a/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
@@ -44,7 +44,7 @@ private:
     {
         struct Status
         {
-            // When buffers are enqued in a port this validity_id is copied to the BufferDescriptor in the port.
+            // When buffers are enqueued in a port this validity_id is copied to the BufferDescriptor in the port.
             // If the sender process needs to recover the buffer by force, just increment this validity_id, the
             // receiver process must check this validity_id vs the validity_id in the BufferDescriptor, if not equal
             // the buffer has been invalidated by the sender.
@@ -77,7 +77,7 @@ private:
 
         /**
          * Atomically invalidates a buffer, only, when the buffer is valid for the caller.
-         * @return true when succedded, false when the buffer was invalid for the caller.
+         * @return true when succeeded, false when the buffer was invalid for the caller.
          */
         inline bool invalidate_buffer(
                 uint32_t listener_validity_id)
@@ -96,7 +96,7 @@ private:
 
         /**
          * Atomically invalidates a buffer, only, if the buffer is not being processed.
-         * @return true when succedded, false otherwise.
+         * @return true when succeeded, false otherwise.
          */
         bool invalidate_if_not_processing()
         {
@@ -109,7 +109,7 @@ private:
                     std::memory_order_relaxed))
             {
             }
-
+            logWarning(RTPS_TRANSPORT_SHM, "Buffer is being invalidated, segment_size may be insufficient");
             return (s.processing_count == 0);
         }
 
@@ -124,7 +124,7 @@ private:
 
         /**
          * Atomically decrease enqueued count & increase the buffer processing counts, only, if the buffer is valid.
-         * @return true when succedded, false when the buffer has been invalidated.
+         * @return true when succeeded, false when the buffer has been invalidated.
          */
         inline bool dec_enqueued_inc_processing_counts(
                 uint32_t listener_validity_id)
@@ -143,7 +143,7 @@ private:
 
         /**
          * Atomically increase the buffer processing count, only, if the buffer is valid.
-         * @return true when succedded, false when the buffer has been invalidated.
+         * @return true when succeeded, false when the buffer has been invalidated.
          */
         inline bool inc_processing_count(
                 uint32_t listener_validity_id)
@@ -162,7 +162,7 @@ private:
 
         /**
          * Atomically increase the buffer enqueued count, only, if the buffer is valid.
-         * @return true when succedded, false when the buffer has been invalidated.
+         * @return true when succeeded, false when the buffer has been invalidated.
          */
         inline bool inc_enqueued_count(
                 uint32_t listener_validity_id)
@@ -181,7 +181,7 @@ private:
 
         /**
          * Atomically decrease the buffer enqueued count, only, if the buffer is valid.
-         * @return true when succedded, false when the buffer has been invalidated.
+         * @return true when succeeded, false when the buffer has been invalidated.
          */
         inline bool dec_enqueued_count(
                 uint32_t listener_validity_id)
@@ -206,7 +206,7 @@ private:
 
         /**
          * Atomically decrease the buffer processing count, only, if the buffer is valid.
-         * @return true when succedded, false when the buffer has been invalidated.
+         * @return true when succeeded, false when the buffer has been invalidated.
          */
         inline bool dec_processing_count(
                 uint32_t listener_validity_id)
@@ -581,7 +581,7 @@ public:
                 }
                 else // No enough space, try to recover oldest not processing buffers
                 {
-                    // Buffer is not beign processed by any listener
+                    // Buffer is not being processed by any listener
                     if ((*it)->invalidate_if_not_processing())
                     {
                         release_buffer(*it);
@@ -668,7 +668,7 @@ public:
         }
 
         /**
-         * Extract the first buffer enqued in the port.
+         * Extract the first buffer enqueued in the port.
          * If the queue is empty, blocks until a buffer is pushed
          * to the port.
          * @return A shared_ptr to the buffer, this shared_ptr can be nullptr if the


### PR DESCRIPTION
* Port small SHM segment warning message
* Fix bug with gap not being sent with heartbeat message

This PR fixes a problem with my service test: https://github.com/ros2/rmw_fastrtps/issues/559
That test will eventually fail cuz of client won't receive response from service. Right now gaps will be sent after reader-writer match, but there could be a kind of race:
* Writer matches a reader in the service
* Writer sends heartbeat and gap messages
* Reader matches a writer in the client

In that case initial gap message will be lost and reader will be asking for sequence set from heartbeat forever.

Seems like that issue is already fixed in master branch.