### PR TITLE
Periodic heartbeat also depending on ReaderProxy's low_mark [12642]

### DIFF
--- a/include/fastdds/rtps/writer/ReaderProxy.h
+++ b/include/fastdds/rtps/writer/ReaderProxy.h
@@ -219,9 +219,11 @@ public:
 
     /*!
      * @brief Returns there is some UNACKNOWLEDGED change.
+     * @param first_seq_in_history Minimum sequence number in the writer history.
      * @return There is some UNACKNOWLEDGED change.
      */
-    bool has_unacknowledged() const;
+    bool has_unacknowledged(
+            const SequenceNumber_t& first_seq_in_history) const;
 
     /**
      * Get the GUID of the reader represented by this proxy.

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -560,8 +560,14 @@ void ReaderProxy::change_has_been_removed(
     changes_for_reader_.erase(chit);
 }
 
-bool ReaderProxy::has_unacknowledged() const
+bool ReaderProxy::has_unacknowledged(
+        const SequenceNumber_t& first_seq_in_history) const
 {
+    if (first_seq_in_history > changes_low_mark_)
+    {
+        return true;
+    }
+
     for (const ChangeForReader_t& it : changes_for_reader_)
     {
         if (it.getStatus() == UNACKNOWLEDGED)

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1586,14 +1586,17 @@ bool StatefulWriter::send_periodic_heartbeat(
     bool unacked_changes = false;
     if (!liveliness)
     {
-        SequenceNumber_t firstSeq;
+        SequenceNumber_t first_seq_to_check_acknowledge = get_seq_num_min();
+        if (SequenceNumber_t::unknown() == first_seq_to_check_acknowledge)
+        {
+            first_seq_to_check_acknowledge = mp_history->next_sequence_number() - 1;
+        }
 
-        firstSeq = get_seq_num_min();
         unacked_changes = for_matched_readers(matched_local_readers_, matched_datasharing_readers_,
                         matched_remote_readers_,
-                        [firstSeq](ReaderProxy* reader)
+                        [first_seq_to_check_acknowledge](ReaderProxy* reader)
                         {
-                            return reader->has_unacknowledged(firstSeq);
+                            return reader->has_unacknowledged(first_seq_to_check_acknowledge);
                         }
                         );
 
@@ -1662,8 +1665,13 @@ void StatefulWriter::send_heartbeat_to_nts(
         bool liveliness,
         bool force /* = false */)
 {
+    SequenceNumber_t first_seq_to_check_acknowledge = get_seq_num_min();
+    if (SequenceNumber_t::unknown() == first_seq_to_check_acknowledge)
+    {
+        first_seq_to_check_acknowledge = mp_history->next_sequence_number() - 1;
+    }
     if (remoteReaderProxy.is_reliable() &&
-            (force || liveliness || remoteReaderProxy.has_unacknowledged(get_seq_num_min())))
+            (force || liveliness || remoteReaderProxy.has_unacknowledged(first_seq_to_check_acknowledge)))
     {
         if (remoteReaderProxy.is_local_reader())
         {


### PR DESCRIPTION
Using new flow controllers for low bandwidth communications I've realized periodic HEARTBEATS stop begin sent. This is caused my history's depth is low, and when the periodic heartbeat is triggered, all samples in the `ReaderProxy` are in UNSENT state.

This PR adds periodic HEARTBEAT also dependes in the low_mark. I f the low_mark is less than the minimun sequence number in the history, the HEARTBEAT is sent.