### PR TITLE
Avoid sending GAP for no current history holes [12643]

### DIFF
--- a/include/fastdds/rtps/writer/ReaderProxy.h
+++ b/include/fastdds/rtps/writer/ReaderProxy.h
@@ -159,7 +159,8 @@ public:
      */
     bool requested_changes_set(
             const SequenceNumberSet_t& seq_num_set,
-            RTPSGapBuilder& gap_builder);
+            RTPSGapBuilder& gap_builder,
+            const SequenceNumber_t& min_seq_in_history);
 
     /**
      * Performs processing of preemptive acknack

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -410,6 +410,7 @@ bool ReaderProxy::requested_changes_set(
                     }
                     else if (sit > min_seq_in_history)
                     {
+                        assert(sit > changes_low_mark_);
                         gap_builder.add(sit);
                     }
                 });

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -389,27 +389,31 @@ void ReaderProxy::acked_changes_set(
 
 bool ReaderProxy::requested_changes_set(
         const SequenceNumberSet_t& seq_num_set,
-        RTPSGapBuilder& gap_builder)
+        RTPSGapBuilder& gap_builder,
+        const SequenceNumber_t& min_seq_in_history)
 {
     bool isSomeoneWasSetRequested = false;
 
-    seq_num_set.for_each([&](SequenceNumber_t sit)
-            {
-                ChangeIterator chit = find_change(sit, true);
-                if (chit != changes_for_reader_.end())
+    if (SequenceNumber_t::unknown() != min_seq_in_history)
+    {
+        seq_num_set.for_each([&](SequenceNumber_t sit)
                 {
-                    if (UNACKNOWLEDGED == chit->getStatus())
+                    ChangeIterator chit = find_change(sit, true);
+                    if (chit != changes_for_reader_.end())
                     {
-                        chit->setStatus(REQUESTED);
-                        chit->markAllFragmentsAsUnsent();
-                        isSomeoneWasSetRequested = true;
+                        if (UNACKNOWLEDGED == chit->getStatus())
+                        {
+                            chit->setStatus(REQUESTED);
+                            chit->markAllFragmentsAsUnsent();
+                            isSomeoneWasSetRequested = true;
+                        }
                     }
-                }
-                else if (sit > changes_low_mark_)
-                {
-                    gap_builder.add(sit);
-                }
-            });
+                    else if (sit > min_seq_in_history)
+                    {
+                        gap_builder.add(sit);
+                    }
+                });
+    }
 
     if (isSomeoneWasSetRequested)
     {

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1849,7 +1849,7 @@ bool StatefulWriter::process_acknack(
                                     RTPSMessageGroup group(mp_RTPSParticipant, this, remote_reader->message_sender());
                                     RTPSGapBuilder gap_builder(group);
 
-                                    if (remote_reader->requested_changes_set(sn_set, gap_builder))
+                                    if (remote_reader->requested_changes_set(sn_set, gap_builder, get_seq_num_min()))
                                     {
                                         nack_response_event_->restart_timer();
                                     }


### PR DESCRIPTION
Current mechanism could send GAP about missing samples but they are not currently a hole in the history. This information already will be in the HEARTBEAT message.

This PR avoid to send GAP of this kind of samples which their sequence number is less than minimum sequence number in the history.