### PR TITLE
Reservation of EntityId in DDS layer [12669]

### DIFF
--- a/include/fastdds/rtps/RTPSDomain.h
+++ b/include/fastdds/rtps/RTPSDomain.h
@@ -202,7 +202,7 @@ public:
     /**
      * Create a RTPSReader in a participant using a custom payload pool.
      * @param p Pointer to the RTPSParticipant.
-     * @param entity_id Specific entity id to use for the created writer.
+     * @param entity_id Specific entity id to use for the created reader.
      * @param ratt Reader Attributes.
      * @param payload_pool Shared pointer to the IPayloadPool
      * @param hist Pointer to the ReaderHistory.

--- a/include/fastdds/rtps/RTPSDomain.h
+++ b/include/fastdds/rtps/RTPSDomain.h
@@ -181,7 +181,7 @@ public:
             ReaderListener* listen = nullptr);
 
     /**
-     * Create a RTPSWriter in a participant using a custom payload pool.
+     * Create a RTPReader in a participant using a custom payload pool.
      * @param p Pointer to the RTPSParticipant.
      * @param ratt Reader Attributes.
      * @param payload_pool Shared pointer to the IPayloadPool
@@ -194,6 +194,27 @@ public:
      */
     RTPS_DllAPI static RTPSReader* createRTPSReader(
             RTPSParticipant* p,
+            ReaderAttributes& ratt,
+            const std::shared_ptr<IPayloadPool>& payload_pool,
+            ReaderHistory* hist,
+            ReaderListener* listen = nullptr);
+
+    /**
+     * Create a RTPSReader in a participant using a custom payload pool.
+     * @param p Pointer to the RTPSParticipant.
+     * @param entity_id Specific entity id to use for the created writer.
+     * @param ratt Reader Attributes.
+     * @param payload_pool Shared pointer to the IPayloadPool
+     * @param hist Pointer to the ReaderHistory.
+     * @param listen Pointer to the ReaderListener.
+     * @return Pointer to the created RTPSReader.
+     *
+     * \warning The returned pointer is invalidated after a call to removeRTPSReader() or stopAll(),
+     *          so its use may result in undefined behaviour.
+     */
+    RTPS_DllAPI static RTPSReader* createRTPSReader(
+            RTPSParticipant* p,
+            const EntityId_t& entity_id,
             ReaderAttributes& ratt,
             const std::shared_ptr<IPayloadPool>& payload_pool,
             ReaderHistory* hist,

--- a/include/fastdds/rtps/attributes/EndpointAttributes.h
+++ b/include/fastdds/rtps/attributes/EndpointAttributes.h
@@ -108,7 +108,7 @@ public:
      * @param id User defined ID to be set
      */
     inline void setUserDefinedID(
-            uint8_t id)
+            int16_t id)
     {
         m_userDefinedID = id;
     }
@@ -118,7 +118,7 @@ public:
      * @param id Entity ID to be set
      */
     inline void setEntityID(
-            uint8_t id)
+            int16_t id)
     {
         m_entityID = id;
     }

--- a/include/fastdds/rtps/participant/RTPSParticipant.h
+++ b/include/fastdds/rtps/participant/RTPSParticipant.h
@@ -52,6 +52,7 @@ class RTPSWriter;
 class RTPSReader;
 class WriterProxyData;
 class ReaderProxyData;
+class EndpointAttributes;
 class WriterAttributes;
 class ReaderAttributes;
 class ResourceEvent;

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -404,6 +404,11 @@ public:
     DomainParticipantListener* get_listener_for(
             const StatusMask& status);
 
+    uint32_t& id_counter()
+    {
+        return id_counter_;
+    }
+
 protected:
 
     //!Domain id
@@ -469,6 +474,8 @@ protected:
 
     // All parent's child requests
     std::map<fastrtps::rtps::SampleIdentity, std::vector<fastrtps::rtps::SampleIdentity>> parent_requests_;
+
+    uint32_t id_counter_ = 0;
 
     class MyRTPSParticipantListener : public fastrtps::rtps::RTPSParticipantListener
     {

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -145,6 +145,8 @@ DataWriterImpl::DataWriterImpl(
     EndpointAttributes endpoint_attributes;
     endpoint_attributes.endpointKind = WRITER;
     endpoint_attributes.topicKind = type_->m_isGetKeyDefined ? WITH_KEY : NO_KEY;
+    endpoint_attributes.setEntityID(qos_.endpoint().entity_id);
+    endpoint_attributes.setUserDefinedID(qos_.endpoint().user_defined_id);
     fastrtps::rtps::RTPSParticipantImpl::preprocess_endpoint_attributes<WRITER, 0x03, 0x02>(
         EntityId_t::unknown(), publisher_->get_participant_impl()->id_counter(), endpoint_attributes, guid_.entityId);
     guid_.guidPrefix = publisher_->get_participant_impl()->guid().guidPrefix;
@@ -187,8 +189,8 @@ ReturnCode_t DataWriterImpl::enable()
     w_att.mode = qos_.publish_mode().kind == SYNCHRONOUS_PUBLISH_MODE ? SYNCHRONOUS_WRITER : ASYNCHRONOUS_WRITER;
     w_att.flow_controller_name = qos_.publish_mode().flow_controller_name;
     w_att.endpoint.properties = qos_.properties();
-    w_att.endpoint.setEntityID(static_cast<uint8_t>(qos_.endpoint().entity_id));
-    w_att.endpoint.setUserDefinedID(static_cast<uint8_t>(qos_.endpoint().user_defined_id));
+    w_att.endpoint.setEntityID(qos_.endpoint().entity_id);
+    w_att.endpoint.setUserDefinedID(qos_.endpoint().user_defined_id);
     w_att.times = qos_.reliable_writer_qos().times;
     w_att.liveliness_kind = qos_.liveliness().kind;
     w_att.liveliness_lease_duration = qos_.liveliness().lease_duration;

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -187,17 +187,8 @@ ReturnCode_t DataWriterImpl::enable()
     w_att.mode = qos_.publish_mode().kind == SYNCHRONOUS_PUBLISH_MODE ? SYNCHRONOUS_WRITER : ASYNCHRONOUS_WRITER;
     w_att.flow_controller_name = qos_.publish_mode().flow_controller_name;
     w_att.endpoint.properties = qos_.properties();
-
-    if (qos_.endpoint().entity_id > 0)
-    {
-        w_att.endpoint.setEntityID(static_cast<uint8_t>(qos_.endpoint().entity_id));
-    }
-
-    if (qos_.endpoint().user_defined_id > 0)
-    {
-        w_att.endpoint.setUserDefinedID(static_cast<uint8_t>(qos_.endpoint().user_defined_id));
-    }
-
+    w_att.endpoint.setEntityID(static_cast<uint8_t>(qos_.endpoint().entity_id));
+    w_att.endpoint.setUserDefinedID(static_cast<uint8_t>(qos_.endpoint().user_defined_id));
     w_att.times = qos_.reliable_writer_qos().times;
     w_att.liveliness_kind = qos_.liveliness().kind;
     w_att.liveliness_lease_duration = qos_.liveliness().lease_duration;

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -104,6 +104,14 @@ protected:
             const DataWriterQos& qos,
             DataWriterListener* listener = nullptr);
 
+    DataWriterImpl(
+            PublisherImpl* p,
+            TypeSupport type,
+            Topic* topic,
+            const DataWriterQos& qos,
+            const fastrtps::rtps::EntityId_t& entity_id,
+            DataWriterListener* listener = nullptr);
+
 public:
 
     virtual ~DataWriterImpl();
@@ -374,12 +382,7 @@ protected:
 
     std::unique_ptr<LoanCollection> loans_;
 
-    virtual fastrtps::rtps::RTPSWriter* create_rtps_writer(
-            fastrtps::rtps::RTPSParticipant* p,
-            fastrtps::rtps::WriterAttributes& watt,
-            const std::shared_ptr<IPayloadPool>& payload_pool,
-            fastrtps::rtps::WriterHistory* hist,
-            fastrtps::rtps::WriterListener* listen);
+    fastrtps::rtps::GUID_t guid_;
 
     /**
      *

--- a/src/cpp/fastdds/publisher/PublisherImpl.hpp
+++ b/src/cpp/fastdds/publisher/PublisherImpl.hpp
@@ -151,6 +151,10 @@ public:
 
     ReturnCode_t delete_contained_entities();
 
+    DomainParticipantImpl* get_participant_impl()
+    {
+        return participant_;
+    }
 
     ReturnCode_t set_default_datawriter_qos(
             const DataWriterQos& qos);

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -163,17 +163,8 @@ ReturnCode_t DataReaderImpl::enable()
     att.endpoint.unicastLocatorList = qos_.endpoint().unicast_locator_list;
     att.endpoint.remoteLocatorList = qos_.endpoint().remote_locator_list;
     att.endpoint.properties = qos_.properties();
-
-    if (qos_.endpoint().entity_id > 0)
-    {
-        att.endpoint.setEntityID(static_cast<uint8_t>(qos_.endpoint().entity_id));
-    }
-
-    if (qos_.endpoint().user_defined_id > 0)
-    {
-        att.endpoint.setUserDefinedID(static_cast<uint8_t>(qos_.endpoint().user_defined_id));
-    }
-
+    att.endpoint.setEntityID(qos_.endpoint().entity_id);
+    att.endpoint.setUserDefinedID(qos_.endpoint().user_defined_id);
     att.times = qos_.reliable_reader_qos().times;
     att.liveliness_lease_duration = qos_.liveliness().lease_duration;
     att.liveliness_kind_ = qos_.liveliness().kind;

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -144,6 +144,8 @@ DataReaderImpl::DataReaderImpl(
     EndpointAttributes endpoint_attributes;
     endpoint_attributes.endpointKind = READER;
     endpoint_attributes.topicKind = type_->m_isGetKeyDefined ? WITH_KEY : NO_KEY;
+    endpoint_attributes.setEntityID(qos_.endpoint().entity_id);
+    endpoint_attributes.setUserDefinedID(qos_.endpoint().user_defined_id);
     fastrtps::rtps::RTPSParticipantImpl::preprocess_endpoint_attributes<READER, 0x04, 0x07>(
         EntityId_t::unknown(), subscriber_->get_participant_impl()->id_counter(), endpoint_attributes, guid_.entityId);
     guid_.guidPrefix = subscriber_->get_participant_impl()->guid().guidPrefix;

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -336,6 +336,8 @@ protected:
     //!Listener
     DataReaderListener* listener_ = nullptr;
 
+    fastrtps::rtps::GUID_t guid_;
+
     class InnerDataReaderListener : public fastrtps::rtps::ReaderListener
     {
     public:

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
@@ -156,6 +156,11 @@ public:
 
     const DomainParticipant* get_participant() const;
 
+    DomainParticipantImpl* get_participant_impl()
+    {
+        return participant_;
+    }
+
     const fastrtps::rtps::RTPSParticipant* rtps_participant() const
     {
         return rtps_participant_;

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -378,6 +378,26 @@ RTPSReader* RTPSDomain::createRTPSReader(
     return nullptr;
 }
 
+RTPSReader* RTPSDomain::createRTPSReader(
+        RTPSParticipant* p,
+        const EntityId_t& entity_id,
+        ReaderAttributes& ratt,
+        const std::shared_ptr<IPayloadPool>& payload_pool,
+        ReaderHistory* rhist,
+        ReaderListener* rlisten)
+{
+    RTPSParticipantImpl* impl = p->mp_impl;
+    if (impl)
+    {
+        RTPSReader* reader;
+        if (impl->createReader(&reader, ratt, payload_pool, rhist, rlisten, entity_id))
+        {
+            return reader;
+        }
+    }
+    return nullptr;
+}
+
 bool RTPSDomain::removeRTPSReader(
         RTPSReader* reader)
 {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -506,6 +506,7 @@ RTPSParticipantImpl::~RTPSParticipantImpl()
 template <EndpointKind_t kind, octet no_key, octet with_key>
 bool RTPSParticipantImpl::preprocess_endpoint_attributes(
         const EntityId_t& entity_id,
+        uint32_t& id_counter,
         EndpointAttributes& att,
         EntityId_t& entId)
 {
@@ -544,19 +545,12 @@ bool RTPSParticipantImpl::preprocess_endpoint_attributes(
         }
         else
         {
-            IdCounter++;
-            idnum = IdCounter;
+            idnum = ++id_counter;
         }
 
         entId.value[2] = octet(idnum);
         entId.value[1] = octet(idnum >> 8);
         entId.value[0] = octet(idnum >> 16);
-        if (this->existsEntityId(entId, kind))
-        {
-            logError(RTPS_PARTICIPANT,
-                    "A " << debug_label << " with the same entityId already exists in this RTPSParticipant");
-            return false;
-        }
     }
     else
     {
@@ -600,8 +594,15 @@ bool RTPSParticipantImpl::create_writer(
     std::string type = (param.endpoint.reliabilityKind == RELIABLE) ? "RELIABLE" : "BEST_EFFORT";
     logInfo(RTPS_PARTICIPANT, "Creating writer of type " << type);
     EntityId_t entId;
-    if (!preprocess_endpoint_attributes<WRITER, 0x03, 0x02>(entity_id, param.endpoint, entId))
+    if (!preprocess_endpoint_attributes<WRITER, 0x03, 0x02>(entity_id, IdCounter, param.endpoint, entId))
     {
+        return false;
+    }
+
+    if (existsEntityId(entId, WRITER))
+    {
+        logError(RTPS_PARTICIPANT,
+                "A writer with the same entityId already exists in this RTPSParticipant");
         return false;
     }
 
@@ -785,8 +786,15 @@ bool RTPSParticipantImpl::create_reader(
     std::string type = (param.endpoint.reliabilityKind == RELIABLE) ? "RELIABLE" : "BEST_EFFORT";
     logInfo(RTPS_PARTICIPANT, "Creating reader of type " << type);
     EntityId_t entId;
-    if (!preprocess_endpoint_attributes<READER, 0x04, 0x07>(entity_id, param.endpoint, entId))
+    if (!preprocess_endpoint_attributes<READER, 0x04, 0x07>(entity_id, IdCounter, param.endpoint, entId))
     {
+        return false;
+    }
+
+    if (existsEntityId(entId, READER))
+    {
+        logError(RTPS_PARTICIPANT,
+                "A reader with the same entityId already exists in this RTPSParticipant");
         return false;
     }
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -532,11 +532,11 @@ bool RTPSParticipantImpl::preprocess_endpoint_attributes(
     {
         if (att.topicKind == NO_KEY)
         {
-            entId.value[3] = no_key;
+            entId.value[3] = (-2 == att.getUserDefinedID() && 0 < att.getEntityID()) ? (0x60) | no_key : no_key;
         }
         else if (att.topicKind == WITH_KEY)
         {
-            entId.value[3] = with_key;
+            entId.value[3] = (-2 == att.getUserDefinedID() && 0 < att.getEntityID()) ? (0x60) | with_key : with_key;
         }
         uint32_t idnum;
         if (att.getEntityID() > 0)

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -682,12 +682,6 @@ private:
             const EndpointAttributes& param,
             IPersistenceService*& service);
 
-    template <EndpointKind_t kind, octet no_key, octet with_key>
-    bool preprocess_endpoint_attributes(
-            const EntityId_t& entity_id,
-            EndpointAttributes& att,
-            EntityId_t& entId);
-
     template<typename Functor>
     bool create_writer(
             RTPSWriter** writer_out,
@@ -938,6 +932,13 @@ public:
      * Function run when the RTPSDomain is notified that the environment file has changed.
      */
     void environment_file_has_changed();
+
+    template <EndpointKind_t kind, octet no_key, octet with_key>
+    static bool preprocess_endpoint_attributes(
+            const EntityId_t& entity_id,
+            uint32_t& id_count,
+            EndpointAttributes& att,
+            EntityId_t& entId);
 
 #if HAVE_SECURITY
     void set_endpoint_rtps_protection_supports(

--- a/src/cpp/statistics/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/statistics/fastdds/publisher/DataWriterImpl.hpp
@@ -48,8 +48,7 @@ public:
             efd::Topic* topic,
             const efd::DataWriterQos& qos,
             const eprosima::fastrtps::rtps::EntityId_t& entity_id)
-        : BaseType(p, type, topic, qos, nullptr)
-        , entity_id_(entity_id)
+        : BaseType(p, type, topic, qos, entity_id, nullptr)
     {
     }
 
@@ -92,27 +91,9 @@ public:
         BaseType::disable();
     }
 
-protected:
-
-    fastrtps::rtps::RTPSWriter* create_rtps_writer(
-            fastrtps::rtps::RTPSParticipant* p,
-            fastrtps::rtps::WriterAttributes& watt,
-            const std::shared_ptr<IPayloadPool>& payload_pool,
-            fastrtps::rtps::WriterHistory* hist,
-            fastrtps::rtps::WriterListener* listen) override
-    {
-        if (entity_id_.unknown() == entity_id_)
-        {
-            return BaseType::create_rtps_writer(p, watt, payload_pool, hist, listen);
-        }
-
-        return fastrtps::rtps::RTPSDomain::createRTPSWriter(p, entity_id_, watt, payload_pool, hist, listen);
-    }
-
 private:
 
     std::shared_ptr<IListener> statistics_listener_;
-    eprosima::fastrtps::rtps::EntityId_t entity_id_;
 };
 
 } // dds

--- a/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
+++ b/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
@@ -634,6 +634,11 @@ public:
         return nullptr;
     }
 
+    uint32_t& id_counter()
+    {
+        return id_counter_;
+    }
+
 protected:
 
     DomainId_t domain_id_;
@@ -653,6 +658,7 @@ protected:
     std::map<std::string, TypeSupport> types_;
     mutable std::mutex mtx_types_;
     TopicQos default_topic_qos_;
+    uint32_t id_counter_ = 0;
 
     class MyRTPSParticipantListener : public fastrtps::rtps::RTPSParticipantListener
     {

--- a/test/mock/rtps/RTPSDomain/fastdds/rtps/RTPSDomain.h
+++ b/test/mock/rtps/RTPSDomain/fastdds/rtps/RTPSDomain.h
@@ -127,6 +127,18 @@ public:
         return reader_;
     }
 
+    static RTPSReader* createRTPSReader(
+            RTPSParticipant*,
+            const EntityId_t&,
+            ReaderAttributes&,
+            const std::shared_ptr<IPayloadPool>&,
+            ReaderHistory*,
+            ReaderListener* listen = nullptr)
+    {
+        reader_->setListener(listen);
+        return reader_;
+    }
+
     static bool removeRTPSReader(
             RTPSReader*)
     {

--- a/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
+++ b/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
@@ -260,6 +260,16 @@ public:
     {
     }
 
+    template <EndpointKind_t kind, octet no_key, octet with_key>
+    static bool preprocess_endpoint_attributes(
+        const EntityId_t&,
+        uint32_t&,
+        EndpointAttributes&,
+        EntityId_t&)
+    {
+        return true;
+    }
+
 private:
 
     MockParticipantListener listener_;

--- a/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
+++ b/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
@@ -262,10 +262,10 @@ public:
 
     template <EndpointKind_t kind, octet no_key, octet with_key>
     static bool preprocess_endpoint_attributes(
-        const EntityId_t&,
-        uint32_t&,
-        EndpointAttributes&,
-        EntityId_t&)
+            const EntityId_t&,
+            uint32_t&,
+            EndpointAttributes&,
+            EntityId_t&)
     {
         return true;
     }

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -331,8 +331,14 @@ TEST(DataWriterTests, get_guid)
     }
     discovery_listener;
 
+    DomainParticipantQos participant_qos = PARTICIPANT_QOS_DEFAULT;
+    participant_qos.wire_protocol().builtin.discovery_config.ignoreParticipantFlags =
+            static_cast<eprosima::fastrtps::rtps::ParticipantFilteringFlags_t>(
+        eprosima::fastrtps::rtps::ParticipantFilteringFlags_t::FILTER_DIFFERENT_HOST |
+        eprosima::fastrtps::rtps::ParticipantFilteringFlags_t::FILTER_DIFFERENT_PROCESS);
+
     DomainParticipant* listener_participant =
-            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT,
+            DomainParticipantFactory::get_instance()->create_participant(0, participant_qos,
                     &discovery_listener,
                     StatusMask::none());
 
@@ -340,11 +346,6 @@ TEST(DataWriterTests, get_guid)
     DomainParticipantFactory::get_instance()->get_qos(factory_qos);
     factory_qos.entity_factory().autoenable_created_entities = false;
     DomainParticipantFactory::get_instance()->set_qos(factory_qos);
-    DomainParticipantQos participant_qos = PARTICIPANT_QOS_DEFAULT;
-    participant_qos.wire_protocol().builtin.discovery_config.ignoreParticipantFlags =
-            static_cast<eprosima::fastrtps::rtps::ParticipantFilteringFlags_t>(
-        eprosima::fastrtps::rtps::ParticipantFilteringFlags_t::FILTER_DIFFERENT_HOST |
-        eprosima::fastrtps::rtps::ParticipantFilteringFlags_t::FILTER_DIFFERENT_PROCESS);
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(0, participant_qos);
     ASSERT_NE(participant, nullptr);

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -18,6 +18,7 @@
 #include <fastdds/dds/builtin/topic/SubscriptionBuiltinTopicData.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
+#include <fastdds/dds/domain/DomainParticipantListener.hpp>
 #include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
 #include <fastdds/dds/publisher/DataWriter.hpp>
 #include <fastdds/dds/publisher/DataWriterListener.hpp>
@@ -34,6 +35,9 @@
 #include "../../logging/mock/MockConsumer.h"
 
 #include <fastdds/publisher/DataWriterImpl.hpp>
+
+#include <mutex>
+#include <condition_variable>
 
 namespace eprosima {
 namespace fastdds {
@@ -293,6 +297,81 @@ TEST(DataWriterTests, get_type)
     ASSERT_NE(datawriter, nullptr);
 
     ASSERT_EQ(type, datawriter->get_type());
+
+    ASSERT_TRUE(publisher->delete_datawriter(datawriter) == ReturnCode_t::RETCODE_OK);
+    ASSERT_TRUE(participant->delete_topic(topic) == ReturnCode_t::RETCODE_OK);
+    ASSERT_TRUE(participant->delete_publisher(publisher) == ReturnCode_t::RETCODE_OK);
+    ASSERT_TRUE(DomainParticipantFactory::get_instance()->delete_participant(participant) == ReturnCode_t::RETCODE_OK);
+}
+
+TEST(DataWriterTests, get_guid)
+{
+    class DiscoveryListener : public DomainParticipantListener
+    {
+    public:
+
+        void on_publisher_discovery(
+                DomainParticipant* participant,
+                fastrtps::rtps::WriterDiscoveryInfo&& info)
+        {
+            std::unique_lock<std::mutex> lock(mutex);
+            if (fastrtps::rtps::WriterDiscoveryInfo::DISCOVERED_WRITER == info.status)
+            {
+                guid = info.info.guid();
+                cv.notify_one();
+            }
+        }
+
+        fastrtps::rtps::GUID_t guid;
+        std::mutex mutex;
+        std::condition_variable cv;
+    }
+    discovery_listener;
+
+    DomainParticipant* listener_participant =
+            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT,
+                    &discovery_listener,
+                    StatusMask::none());
+
+    DomainParticipantFactoryQos factory_qos;
+    DomainParticipantFactory::get_instance()->get_qos(factory_qos);
+    factory_qos.entity_factory().autoenable_created_entities = false;
+    DomainParticipantFactory::get_instance()->set_qos(factory_qos);
+    DomainParticipant* participant =
+            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
+
+    Publisher* publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT);
+    ASSERT_NE(publisher, nullptr);
+
+    TypeSupport type(new TopicDataTypeMock());
+    type.register_type(participant);
+
+    Topic* topic = participant->create_topic("footopic", type.get_type_name(), TOPIC_QOS_DEFAULT);
+    ASSERT_NE(topic, nullptr);
+
+    DataWriter* datawriter = publisher->create_datawriter(topic, DATAWRITER_QOS_DEFAULT);
+    ASSERT_NE(datawriter, nullptr);
+
+    fastrtps::rtps::GUID_t guid = datawriter->guid();
+
+    participant->enable();
+
+    factory_qos.entity_factory().autoenable_created_entities = true;
+    DomainParticipantFactory::get_instance()->set_qos(factory_qos);
+
+    {
+        std::unique_lock<std::mutex> lock(discovery_listener.mutex);
+        discovery_listener.cv.wait(lock);
+    }
+    ASSERT_EQ(guid, discovery_listener.guid);
+
+    ASSERT_TRUE(publisher->delete_datawriter(datawriter) == ReturnCode_t::RETCODE_OK);
+    ASSERT_TRUE(participant->delete_topic(topic) == ReturnCode_t::RETCODE_OK);
+    ASSERT_TRUE(participant->delete_publisher(publisher) == ReturnCode_t::RETCODE_OK);
+    ASSERT_TRUE(DomainParticipantFactory::get_instance()->delete_participant(participant) == ReturnCode_t::RETCODE_OK);
+    ASSERT_TRUE(DomainParticipantFactory::get_instance()->delete_participant(
+                listener_participant) == ReturnCode_t::RETCODE_OK);
 }
 
 TEST(DataWriterTests, ChangeDataWriterQos)

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -311,7 +311,7 @@ TEST(DataWriterTests, get_guid)
     public:
 
         void on_publisher_discovery(
-                DomainParticipant* participant,
+                DomainParticipant*,
                 fastrtps::rtps::WriterDiscoveryInfo&& info)
         {
             std::unique_lock<std::mutex> lock(mutex);

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -362,7 +362,10 @@ TEST(DataWriterTests, get_guid)
 
     {
         std::unique_lock<std::mutex> lock(discovery_listener.mutex);
-        discovery_listener.cv.wait(lock);
+        discovery_listener.cv.wait(lock, [&]()
+                {
+                    return fastrtps::rtps::GUID_t::unknown() != discovery_listener.guid;
+                });
     }
     ASSERT_EQ(guid, discovery_listener.guid);
 

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -304,6 +304,9 @@ TEST(DataWriterTests, get_type)
     ASSERT_TRUE(DomainParticipantFactory::get_instance()->delete_participant(participant) == ReturnCode_t::RETCODE_OK);
 }
 
+/*!
+ * This test checks `DataWriter::get_guid` function works when the entity was created but not enabled.
+ */
 TEST(DataWriterTests, get_guid)
 {
     class DiscoveryListener : public DomainParticipantListener

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -340,8 +340,13 @@ TEST(DataWriterTests, get_guid)
     DomainParticipantFactory::get_instance()->get_qos(factory_qos);
     factory_qos.entity_factory().autoenable_created_entities = false;
     DomainParticipantFactory::get_instance()->set_qos(factory_qos);
+    DomainParticipantQos participant_qos = PARTICIPANT_QOS_DEFAULT;
+    participant_qos.wire_protocol().builtin.discovery_config.ignoreParticipantFlags =
+            static_cast<eprosima::fastrtps::rtps::ParticipantFilteringFlags_t>(
+        eprosima::fastrtps::rtps::ParticipantFilteringFlags_t::FILTER_DIFFERENT_HOST |
+        eprosima::fastrtps::rtps::ParticipantFilteringFlags_t::FILTER_DIFFERENT_PROCESS);
     DomainParticipant* participant =
-            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+            DomainParticipantFactory::get_instance()->create_participant(0, participant_qos);
     ASSERT_NE(participant, nullptr);
 
     Publisher* publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT);

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -555,7 +555,7 @@ TEST_F(DataReaderTests, get_guid)
     public:
 
         void on_subscriber_discovery(
-                DomainParticipant* participant,
+                DomainParticipant*,
                 fastrtps::rtps::ReaderDiscoveryInfo&& info)
         {
             std::unique_lock<std::mutex> lock(mutex);

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -606,7 +606,10 @@ TEST_F(DataReaderTests, get_guid)
 
     {
         std::unique_lock<std::mutex> lock(discovery_listener.mutex);
-        discovery_listener.cv.wait(lock);
+        discovery_listener.cv.wait(lock, [&]()
+                {
+                    return fastrtps::rtps::GUID_t::unknown() != discovery_listener.guid;
+                });
     }
     ASSERT_EQ(guid, discovery_listener.guid);
 

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -575,8 +575,14 @@ TEST_F(DataReaderTests, get_guid)
     }
     discovery_listener;
 
+    DomainParticipantQos participant_qos = PARTICIPANT_QOS_DEFAULT;
+    participant_qos.wire_protocol().builtin.discovery_config.ignoreParticipantFlags =
+            static_cast<eprosima::fastrtps::rtps::ParticipantFilteringFlags_t>(
+        eprosima::fastrtps::rtps::ParticipantFilteringFlags_t::FILTER_DIFFERENT_HOST |
+        eprosima::fastrtps::rtps::ParticipantFilteringFlags_t::FILTER_DIFFERENT_PROCESS);
+
     DomainParticipant* listener_participant =
-            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT,
+            DomainParticipantFactory::get_instance()->create_participant(0, participant_qos,
                     &discovery_listener,
                     StatusMask::none());
 
@@ -584,11 +590,6 @@ TEST_F(DataReaderTests, get_guid)
     DomainParticipantFactory::get_instance()->get_qos(factory_qos);
     factory_qos.entity_factory().autoenable_created_entities = false;
     DomainParticipantFactory::get_instance()->set_qos(factory_qos);
-    DomainParticipantQos participant_qos = PARTICIPANT_QOS_DEFAULT;
-    participant_qos.wire_protocol().builtin.discovery_config.ignoreParticipantFlags =
-            static_cast<eprosima::fastrtps::rtps::ParticipantFilteringFlags_t>(
-        eprosima::fastrtps::rtps::ParticipantFilteringFlags_t::FILTER_DIFFERENT_HOST |
-        eprosima::fastrtps::rtps::ParticipantFilteringFlags_t::FILTER_DIFFERENT_PROCESS);
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(0, participant_qos);
     ASSERT_NE(participant, nullptr);

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -548,6 +548,9 @@ protected:
 
 };
 
+/*!
+ * This test checks `DataReader::get_guid` function works when the entity was created but not enabled.
+ */
 TEST_F(DataReaderTests, get_guid)
 {
     class DiscoveryListener : public DomainParticipantListener

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -584,8 +584,13 @@ TEST_F(DataReaderTests, get_guid)
     DomainParticipantFactory::get_instance()->get_qos(factory_qos);
     factory_qos.entity_factory().autoenable_created_entities = false;
     DomainParticipantFactory::get_instance()->set_qos(factory_qos);
+    DomainParticipantQos participant_qos = PARTICIPANT_QOS_DEFAULT;
+    participant_qos.wire_protocol().builtin.discovery_config.ignoreParticipantFlags =
+            static_cast<eprosima::fastrtps::rtps::ParticipantFilteringFlags_t>(
+        eprosima::fastrtps::rtps::ParticipantFilteringFlags_t::FILTER_DIFFERENT_HOST |
+        eprosima::fastrtps::rtps::ParticipantFilteringFlags_t::FILTER_DIFFERENT_PROCESS);
     DomainParticipant* participant =
-            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+            DomainParticipantFactory::get_instance()->create_participant(0, participant_qos);
     ASSERT_NE(participant, nullptr);
 
     Subscriber* subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT);


### PR DESCRIPTION
Currently when the user creates a Datawriter or Datareader not enabled, the `get_guid()` functions return `GUID_t::unknown()`.

This PR fixes this and improve DDS API generating the GUID in the entity creation instead of in the enabling.