### PR TITLE
Add support for Key annotation in TypeObjectFactory [12674]

### DIFF
--- a/src/cpp/dynamic-types/BuiltinAnnotationsTypeObject.cpp
+++ b/src/cpp/dynamic-types/BuiltinAnnotationsTypeObject.cpp
@@ -21,8 +21,10 @@
 
 #ifdef _WIN32
 // Remove linker warning LNK4221 on Visual Studio
-namespace { char dummy; }
-#endif
+namespace {
+char dummy;
+} // namespace
+#endif // ifdef _WIN32
 
 #include <fastrtps/types/BuiltinAnnotationsTypeObject.h>
 #include <utility>
@@ -36,7 +38,8 @@ namespace { char dummy; }
 
 using namespace eprosima::fastrtps::rtps;
 
-void register_builtin_annotations_types(TypeObjectFactory* factory)
+void register_builtin_annotations_types(
+        TypeObjectFactory* factory)
 {
     factory->add_type_object("id", GetidIdentifier(true), GetidObject(true));
     factory->add_type_object("id", GetidIdentifier(false), GetidObject(false));
@@ -65,8 +68,10 @@ void register_builtin_annotations_types(TypeObjectFactory* factory)
     {
         using namespace extensibility;
 
-        factory->add_type_object("ExtensibilityKind", GetExtensibilityKindIdentifier(true), GetExtensibilityKindObject(true));
-        factory->add_type_object("ExtensibilityKind", GetExtensibilityKindIdentifier(false), GetExtensibilityKindObject(false));
+        factory->add_type_object("ExtensibilityKind", GetExtensibilityKindIdentifier(true),
+                GetExtensibilityKindObject(true));
+        factory->add_type_object("ExtensibilityKind", GetExtensibilityKindIdentifier(false),
+                GetExtensibilityKindObject(false));
 
 
     }
@@ -81,6 +86,9 @@ void register_builtin_annotations_types(TypeObjectFactory* factory)
 
     factory->add_type_object("key", GetkeyIdentifier(true), GetkeyObject(true));
     factory->add_type_object("key", GetkeyIdentifier(false), GetkeyObject(false));
+
+    factory->add_type_object("Key", GetkeyIdentifier(true), GetkeyObject(true));
+    factory->add_type_object("Key", GetkeyIdentifier(false), GetkeyObject(false));
 
     factory->add_type_object("must_understand", Getmust_understandIdentifier(true), Getmust_understandObject(true));
     factory->add_type_object("must_understand", Getmust_understandIdentifier(false), Getmust_understandObject(false));
@@ -136,7 +144,8 @@ void register_builtin_annotations_types(TypeObjectFactory* factory)
 
 }
 
-const TypeIdentifier* GetidIdentifier(bool complete)
+const TypeIdentifier* GetidIdentifier(
+        bool complete)
 {
     const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("id", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
@@ -148,7 +157,8 @@ const TypeIdentifier* GetidIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("id", complete);
 }
 
-const TypeObject* GetidObject(bool complete)
+const TypeObject* GetidObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("id", complete);
     if (c_type_object != nullptr)
@@ -171,7 +181,7 @@ const TypeObject* GetMinimalidObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -186,7 +196,7 @@ const TypeObject* GetMinimalidObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -199,7 +209,7 @@ const TypeObject* GetMinimalidObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -217,7 +227,7 @@ const TypeObject* GetCompleteidObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -243,7 +253,7 @@ const TypeObject* GetCompleteidObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -256,7 +266,7 @@ const TypeObject* GetCompleteidObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -266,8 +276,8 @@ const TypeObject* GetCompleteidObject()
     return TypeObjectFactory::get_instance()->get_type_object("id", true);
 }
 
-
-const TypeIdentifier* GetautoidIdentifier(bool complete)
+const TypeIdentifier* GetautoidIdentifier(
+        bool complete)
 {
     const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("autoid", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
@@ -279,7 +289,8 @@ const TypeIdentifier* GetautoidIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("autoid", complete);
 }
 
-const TypeObject* GetautoidObject(bool complete)
+const TypeObject* GetautoidObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("autoid", complete);
     if (c_type_object != nullptr)
@@ -303,7 +314,7 @@ const TypeObject* GetMinimalautoidObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -322,7 +333,7 @@ const TypeObject* GetMinimalautoidObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -335,7 +346,7 @@ const TypeObject* GetMinimalautoidObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -354,7 +365,7 @@ const TypeObject* GetCompleteautoidObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -384,7 +395,7 @@ const TypeObject* GetCompleteautoidObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -397,7 +408,7 @@ const TypeObject* GetCompleteautoidObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -407,9 +418,9 @@ const TypeObject* GetCompleteautoidObject()
     return TypeObjectFactory::get_instance()->get_type_object("autoid", true);
 }
 
-namespace autoid
-{
-const TypeIdentifier* GetAutoidKindIdentifier(bool complete)
+namespace autoid {
+const TypeIdentifier* GetAutoidKindIdentifier(
+        bool complete)
 {
     const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("AutoidKind", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
@@ -421,7 +432,8 @@ const TypeIdentifier* GetAutoidKindIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("AutoidKind", complete);
 }
 
-const TypeObject* GetAutoidKindObject(bool complete)
+const TypeObject* GetAutoidKindObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("AutoidKind", complete);
     if (c_type_object != nullptr)
@@ -444,7 +456,7 @@ const TypeObject* GetMinimalAutoidKindObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ENUM);
 
@@ -468,7 +480,7 @@ const TypeObject* GetMinimalAutoidKindObject()
     mel_SEQUENTIAL.common().flags().IS_DEFAULT(false);
     mel_SEQUENTIAL.common().value(value++);
     MD5 SEQUENTIAL_hash("SEQUENTIAL");
-    for(int i = 0; i < 4; ++i)
+    for (int i = 0; i < 4; ++i)
     {
         mel_SEQUENTIAL.detail().name_hash()[i] = SEQUENTIAL_hash.digest[i];
     }
@@ -484,7 +496,7 @@ const TypeObject* GetMinimalAutoidKindObject()
     mel_HASH.common().flags().IS_DEFAULT(false);
     mel_HASH.common().value(value++);
     MD5 HASH_hash("HASH");
-    for(int i = 0; i < 4; ++i)
+    for (int i = 0; i < 4; ++i)
     {
         mel_HASH.detail().name_hash()[i] = HASH_hash.digest[i];
     }
@@ -495,7 +507,7 @@ const TypeObject* GetMinimalAutoidKindObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalEnumeratedType::getCdrSerializedSize(type_object->minimal().enumerated_type()) + 4));
+                MinimalEnumeratedType::getCdrSerializedSize(type_object->minimal().enumerated_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -508,7 +520,7 @@ const TypeObject* GetMinimalAutoidKindObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -526,7 +538,7 @@ const TypeObject* GetCompleteAutoidKindObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ENUM);
 
@@ -576,7 +588,7 @@ const TypeObject* GetCompleteAutoidKindObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteEnumeratedType::getCdrSerializedSize(type_object->complete().enumerated_type()) + 4));
+                CompleteEnumeratedType::getCdrSerializedSize(type_object->complete().enumerated_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -589,7 +601,7 @@ const TypeObject* GetCompleteAutoidKindObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -599,10 +611,9 @@ const TypeObject* GetCompleteAutoidKindObject()
     return TypeObjectFactory::get_instance()->get_type_object("AutoidKind", true);
 }
 
-
-
 } // autoid namespace
-const TypeIdentifier* GetoptionalIdentifier(bool complete)
+const TypeIdentifier* GetoptionalIdentifier(
+        bool complete)
 {
     const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("optional", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
@@ -614,7 +625,8 @@ const TypeIdentifier* GetoptionalIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("optional", complete);
 }
 
-const TypeObject* GetoptionalObject(bool complete)
+const TypeObject* GetoptionalObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("optional", complete);
     if (c_type_object != nullptr)
@@ -637,7 +649,7 @@ const TypeObject* GetMinimaloptionalObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -656,7 +668,7 @@ const TypeObject* GetMinimaloptionalObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -669,7 +681,7 @@ const TypeObject* GetMinimaloptionalObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -687,7 +699,7 @@ const TypeObject* GetCompleteoptionalObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -717,7 +729,7 @@ const TypeObject* GetCompleteoptionalObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -730,7 +742,7 @@ const TypeObject* GetCompleteoptionalObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -740,8 +752,8 @@ const TypeObject* GetCompleteoptionalObject()
     return TypeObjectFactory::get_instance()->get_type_object("optional", true);
 }
 
-
-const TypeIdentifier* GetpositionIdentifier(bool complete)
+const TypeIdentifier* GetpositionIdentifier(
+        bool complete)
 {
     const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("position", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
@@ -753,7 +765,8 @@ const TypeIdentifier* GetpositionIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("position", complete);
 }
 
-const TypeObject* GetpositionObject(bool complete)
+const TypeObject* GetpositionObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("position", complete);
     if (c_type_object != nullptr)
@@ -776,7 +789,7 @@ const TypeObject* GetMinimalpositionObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -791,7 +804,7 @@ const TypeObject* GetMinimalpositionObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -804,7 +817,7 @@ const TypeObject* GetMinimalpositionObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -822,7 +835,7 @@ const TypeObject* GetCompletepositionObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -848,7 +861,7 @@ const TypeObject* GetCompletepositionObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -861,7 +874,7 @@ const TypeObject* GetCompletepositionObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -871,8 +884,8 @@ const TypeObject* GetCompletepositionObject()
     return TypeObjectFactory::get_instance()->get_type_object("position", true);
 }
 
-
-const TypeIdentifier* GetvalueIdentifier(bool complete)
+const TypeIdentifier* GetvalueIdentifier(
+        bool complete)
 {
     const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("value", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
@@ -884,7 +897,8 @@ const TypeIdentifier* GetvalueIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("value", complete);
 }
 
-const TypeObject* GetvalueObject(bool complete)
+const TypeObject* GetvalueObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("value", complete);
     if (c_type_object != nullptr)
@@ -907,7 +921,7 @@ const TypeObject* GetMinimalvalueObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -922,7 +936,7 @@ const TypeObject* GetMinimalvalueObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -935,7 +949,7 @@ const TypeObject* GetMinimalvalueObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -953,7 +967,7 @@ const TypeObject* GetCompletevalueObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -979,7 +993,7 @@ const TypeObject* GetCompletevalueObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -992,7 +1006,7 @@ const TypeObject* GetCompletevalueObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -1002,10 +1016,11 @@ const TypeObject* GetCompletevalueObject()
     return TypeObjectFactory::get_instance()->get_type_object("value", true);
 }
 
-
-const TypeIdentifier* GetextensibilityIdentifier(bool complete)
+const TypeIdentifier* GetextensibilityIdentifier(
+        bool complete)
 {
-    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("extensibility", complete);
+    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("extensibility",
+                    complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
     {
         return c_identifier;
@@ -1015,7 +1030,8 @@ const TypeIdentifier* GetextensibilityIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("extensibility", complete);
 }
 
-const TypeObject* GetextensibilityObject(bool complete)
+const TypeObject* GetextensibilityObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("extensibility", complete);
     if (c_type_object != nullptr)
@@ -1039,7 +1055,7 @@ const TypeObject* GetMinimalextensibilityObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -1054,7 +1070,7 @@ const TypeObject* GetMinimalextensibilityObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -1067,7 +1083,7 @@ const TypeObject* GetMinimalextensibilityObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -1086,7 +1102,7 @@ const TypeObject* GetCompleteextensibilityObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -1112,7 +1128,7 @@ const TypeObject* GetCompleteextensibilityObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -1125,7 +1141,7 @@ const TypeObject* GetCompleteextensibilityObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -1135,11 +1151,12 @@ const TypeObject* GetCompleteextensibilityObject()
     return TypeObjectFactory::get_instance()->get_type_object("extensibility", true);
 }
 
-namespace extensibility
+namespace extensibility {
+const TypeIdentifier* GetExtensibilityKindIdentifier(
+        bool complete)
 {
-const TypeIdentifier* GetExtensibilityKindIdentifier(bool complete)
-{
-    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("ExtensibilityKind", complete);
+    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("ExtensibilityKind",
+                    complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
     {
         return c_identifier;
@@ -1149,7 +1166,8 @@ const TypeIdentifier* GetExtensibilityKindIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("ExtensibilityKind", complete);
 }
 
-const TypeObject* GetExtensibilityKindObject(bool complete)
+const TypeObject* GetExtensibilityKindObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("ExtensibilityKind", complete);
     if (c_type_object != nullptr)
@@ -1172,7 +1190,7 @@ const TypeObject* GetMinimalExtensibilityKindObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ENUM);
 
@@ -1196,7 +1214,7 @@ const TypeObject* GetMinimalExtensibilityKindObject()
     mel_FINAL.common().flags().IS_DEFAULT(false);
     mel_FINAL.common().value(value++);
     MD5 FINAL_hash("FINAL");
-    for(int i = 0; i < 4; ++i)
+    for (int i = 0; i < 4; ++i)
     {
         mel_FINAL.detail().name_hash()[i] = FINAL_hash.digest[i];
     }
@@ -1212,7 +1230,7 @@ const TypeObject* GetMinimalExtensibilityKindObject()
     mel_APPENDABLE.common().flags().IS_DEFAULT(false);
     mel_APPENDABLE.common().value(value++);
     MD5 APPENDABLE_hash("APPENDABLE");
-    for(int i = 0; i < 4; ++i)
+    for (int i = 0; i < 4; ++i)
     {
         mel_APPENDABLE.detail().name_hash()[i] = APPENDABLE_hash.digest[i];
     }
@@ -1228,7 +1246,7 @@ const TypeObject* GetMinimalExtensibilityKindObject()
     mel_MUTABLE.common().flags().IS_DEFAULT(false);
     mel_MUTABLE.common().value(value++);
     MD5 MUTABLE_hash("MUTABLE");
-    for(int i = 0; i < 4; ++i)
+    for (int i = 0; i < 4; ++i)
     {
         mel_MUTABLE.detail().name_hash()[i] = MUTABLE_hash.digest[i];
     }
@@ -1239,7 +1257,7 @@ const TypeObject* GetMinimalExtensibilityKindObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalEnumeratedType::getCdrSerializedSize(type_object->minimal().enumerated_type()) + 4));
+                MinimalEnumeratedType::getCdrSerializedSize(type_object->minimal().enumerated_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -1252,7 +1270,7 @@ const TypeObject* GetMinimalExtensibilityKindObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -1270,7 +1288,7 @@ const TypeObject* GetCompleteExtensibilityKindObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ENUM);
 
@@ -1334,7 +1352,7 @@ const TypeObject* GetCompleteExtensibilityKindObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteEnumeratedType::getCdrSerializedSize(type_object->complete().enumerated_type()) + 4));
+                CompleteEnumeratedType::getCdrSerializedSize(type_object->complete().enumerated_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -1347,7 +1365,7 @@ const TypeObject* GetCompleteExtensibilityKindObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -1357,10 +1375,9 @@ const TypeObject* GetCompleteExtensibilityKindObject()
     return TypeObjectFactory::get_instance()->get_type_object("ExtensibilityKind", true);
 }
 
-
-
 } // extensibility namespace
-const TypeIdentifier* GetfinalIdentifier(bool complete)
+const TypeIdentifier* GetfinalIdentifier(
+        bool complete)
 {
     const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("final", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
@@ -1372,7 +1389,8 @@ const TypeIdentifier* GetfinalIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("final", complete);
 }
 
-const TypeObject* GetfinalObject(bool complete)
+const TypeObject* GetfinalObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("final", complete);
     if (c_type_object != nullptr)
@@ -1395,7 +1413,7 @@ const TypeObject* GetMinimalfinalObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -1404,7 +1422,7 @@ const TypeObject* GetMinimalfinalObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -1417,7 +1435,7 @@ const TypeObject* GetMinimalfinalObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -1435,7 +1453,7 @@ const TypeObject* GetCompletefinalObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -1455,7 +1473,7 @@ const TypeObject* GetCompletefinalObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -1468,7 +1486,7 @@ const TypeObject* GetCompletefinalObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -1478,8 +1496,8 @@ const TypeObject* GetCompletefinalObject()
     return TypeObjectFactory::get_instance()->get_type_object("final", true);
 }
 
-
-const TypeIdentifier* GetappendableIdentifier(bool complete)
+const TypeIdentifier* GetappendableIdentifier(
+        bool complete)
 {
     const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("appendable", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
@@ -1491,7 +1509,8 @@ const TypeIdentifier* GetappendableIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("appendable", complete);
 }
 
-const TypeObject* GetappendableObject(bool complete)
+const TypeObject* GetappendableObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("appendable", complete);
     if (c_type_object != nullptr)
@@ -1514,7 +1533,7 @@ const TypeObject* GetMinimalappendableObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -1523,7 +1542,7 @@ const TypeObject* GetMinimalappendableObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -1536,7 +1555,7 @@ const TypeObject* GetMinimalappendableObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -1554,7 +1573,7 @@ const TypeObject* GetCompleteappendableObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -1574,7 +1593,7 @@ const TypeObject* GetCompleteappendableObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -1587,7 +1606,7 @@ const TypeObject* GetCompleteappendableObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -1597,8 +1616,8 @@ const TypeObject* GetCompleteappendableObject()
     return TypeObjectFactory::get_instance()->get_type_object("appendable", true);
 }
 
-
-const TypeIdentifier* GetmutableIdentifier(bool complete)
+const TypeIdentifier* GetmutableIdentifier(
+        bool complete)
 {
     const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("mutable", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
@@ -1610,7 +1629,8 @@ const TypeIdentifier* GetmutableIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("mutable", complete);
 }
 
-const TypeObject* GetmutableObject(bool complete)
+const TypeObject* GetmutableObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("mutable", complete);
     if (c_type_object != nullptr)
@@ -1633,7 +1653,7 @@ const TypeObject* GetMinimalmutableObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -1642,7 +1662,7 @@ const TypeObject* GetMinimalmutableObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -1655,7 +1675,7 @@ const TypeObject* GetMinimalmutableObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -1673,7 +1693,7 @@ const TypeObject* GetCompletemutableObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -1693,7 +1713,7 @@ const TypeObject* GetCompletemutableObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -1706,7 +1726,7 @@ const TypeObject* GetCompletemutableObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -1716,8 +1736,8 @@ const TypeObject* GetCompletemutableObject()
     return TypeObjectFactory::get_instance()->get_type_object("mutable", true);
 }
 
-
-const TypeIdentifier* GetkeyIdentifier(bool complete)
+const TypeIdentifier* GetkeyIdentifier(
+        bool complete)
 {
     const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("key", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
@@ -1729,7 +1749,8 @@ const TypeIdentifier* GetkeyIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("key", complete);
 }
 
-const TypeObject* GetkeyObject(bool complete)
+const TypeObject* GetkeyObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("key", complete);
     if (c_type_object != nullptr)
@@ -1752,7 +1773,7 @@ const TypeObject* GetMinimalkeyObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -1771,7 +1792,7 @@ const TypeObject* GetMinimalkeyObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -1784,7 +1805,7 @@ const TypeObject* GetMinimalkeyObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -1802,7 +1823,7 @@ const TypeObject* GetCompletekeyObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -1832,7 +1853,7 @@ const TypeObject* GetCompletekeyObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -1845,7 +1866,7 @@ const TypeObject* GetCompletekeyObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -1855,10 +1876,11 @@ const TypeObject* GetCompletekeyObject()
     return TypeObjectFactory::get_instance()->get_type_object("key", true);
 }
 
-
-const TypeIdentifier* Getmust_understandIdentifier(bool complete)
+const TypeIdentifier* Getmust_understandIdentifier(
+        bool complete)
 {
-    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("must_understand", complete);
+    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("must_understand",
+                    complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
     {
         return c_identifier;
@@ -1868,7 +1890,8 @@ const TypeIdentifier* Getmust_understandIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("must_understand", complete);
 }
 
-const TypeObject* Getmust_understandObject(bool complete)
+const TypeObject* Getmust_understandObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("must_understand", complete);
     if (c_type_object != nullptr)
@@ -1891,7 +1914,7 @@ const TypeObject* GetMinimalmust_understandObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -1910,7 +1933,7 @@ const TypeObject* GetMinimalmust_understandObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -1923,7 +1946,7 @@ const TypeObject* GetMinimalmust_understandObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -1941,7 +1964,7 @@ const TypeObject* GetCompletemust_understandObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -1971,7 +1994,7 @@ const TypeObject* GetCompletemust_understandObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -1984,7 +2007,7 @@ const TypeObject* GetCompletemust_understandObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -1994,10 +2017,11 @@ const TypeObject* GetCompletemust_understandObject()
     return TypeObjectFactory::get_instance()->get_type_object("must_understand", true);
 }
 
-
-const TypeIdentifier* Getdefault_literalIdentifier(bool complete)
+const TypeIdentifier* Getdefault_literalIdentifier(
+        bool complete)
 {
-    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("default_literal", complete);
+    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("default_literal",
+                    complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
     {
         return c_identifier;
@@ -2007,7 +2031,8 @@ const TypeIdentifier* Getdefault_literalIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("default_literal", complete);
 }
 
-const TypeObject* Getdefault_literalObject(bool complete)
+const TypeObject* Getdefault_literalObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("default_literal", complete);
     if (c_type_object != nullptr)
@@ -2030,7 +2055,7 @@ const TypeObject* GetMinimaldefault_literalObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -2039,7 +2064,7 @@ const TypeObject* GetMinimaldefault_literalObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -2052,7 +2077,7 @@ const TypeObject* GetMinimaldefault_literalObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -2070,7 +2095,7 @@ const TypeObject* GetCompletedefault_literalObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -2090,7 +2115,7 @@ const TypeObject* GetCompletedefault_literalObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -2103,7 +2128,7 @@ const TypeObject* GetCompletedefault_literalObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -2113,8 +2138,8 @@ const TypeObject* GetCompletedefault_literalObject()
     return TypeObjectFactory::get_instance()->get_type_object("default_literal", true);
 }
 
-
-const TypeIdentifier* GetdefaultIdentifier(bool complete)
+const TypeIdentifier* GetdefaultIdentifier(
+        bool complete)
 {
     const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("default", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
@@ -2126,7 +2151,8 @@ const TypeIdentifier* GetdefaultIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("default", complete);
 }
 
-const TypeObject* GetdefaultObject(bool complete)
+const TypeObject* GetdefaultObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("default", complete);
     if (c_type_object != nullptr)
@@ -2149,7 +2175,7 @@ const TypeObject* GetMinimaldefaultObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -2164,7 +2190,7 @@ const TypeObject* GetMinimaldefaultObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -2177,7 +2203,7 @@ const TypeObject* GetMinimaldefaultObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -2195,7 +2221,7 @@ const TypeObject* GetCompletedefaultObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -2221,7 +2247,7 @@ const TypeObject* GetCompletedefaultObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -2234,7 +2260,7 @@ const TypeObject* GetCompletedefaultObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -2244,8 +2270,8 @@ const TypeObject* GetCompletedefaultObject()
     return TypeObjectFactory::get_instance()->get_type_object("default", true);
 }
 
-
-const TypeIdentifier* GetrangeIdentifier(bool complete)
+const TypeIdentifier* GetrangeIdentifier(
+        bool complete)
 {
     const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("range", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
@@ -2257,7 +2283,8 @@ const TypeIdentifier* GetrangeIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("range", complete);
 }
 
-const TypeObject* GetrangeObject(bool complete)
+const TypeObject* GetrangeObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("range", complete);
     if (c_type_object != nullptr)
@@ -2280,7 +2307,7 @@ const TypeObject* GetMinimalrangeObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -2301,7 +2328,7 @@ const TypeObject* GetMinimalrangeObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -2314,7 +2341,7 @@ const TypeObject* GetMinimalrangeObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -2332,7 +2359,7 @@ const TypeObject* GetCompleterangeObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -2364,7 +2391,7 @@ const TypeObject* GetCompleterangeObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -2377,7 +2404,7 @@ const TypeObject* GetCompleterangeObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -2387,8 +2414,8 @@ const TypeObject* GetCompleterangeObject()
     return TypeObjectFactory::get_instance()->get_type_object("range", true);
 }
 
-
-const TypeIdentifier* GetminIdentifier(bool complete)
+const TypeIdentifier* GetminIdentifier(
+        bool complete)
 {
     const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("min", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
@@ -2400,7 +2427,8 @@ const TypeIdentifier* GetminIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("min", complete);
 }
 
-const TypeObject* GetminObject(bool complete)
+const TypeObject* GetminObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("min", complete);
     if (c_type_object != nullptr)
@@ -2423,7 +2451,7 @@ const TypeObject* GetMinimalminObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -2438,7 +2466,7 @@ const TypeObject* GetMinimalminObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -2451,7 +2479,7 @@ const TypeObject* GetMinimalminObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -2469,7 +2497,7 @@ const TypeObject* GetCompleteminObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -2495,7 +2523,7 @@ const TypeObject* GetCompleteminObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -2508,7 +2536,7 @@ const TypeObject* GetCompleteminObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -2518,8 +2546,8 @@ const TypeObject* GetCompleteminObject()
     return TypeObjectFactory::get_instance()->get_type_object("min", true);
 }
 
-
-const TypeIdentifier* GetmaxIdentifier(bool complete)
+const TypeIdentifier* GetmaxIdentifier(
+        bool complete)
 {
     const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("max", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
@@ -2531,7 +2559,8 @@ const TypeIdentifier* GetmaxIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("max", complete);
 }
 
-const TypeObject* GetmaxObject(bool complete)
+const TypeObject* GetmaxObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("max", complete);
     if (c_type_object != nullptr)
@@ -2554,7 +2583,7 @@ const TypeObject* GetMinimalmaxObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -2569,7 +2598,7 @@ const TypeObject* GetMinimalmaxObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -2582,7 +2611,7 @@ const TypeObject* GetMinimalmaxObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -2600,7 +2629,7 @@ const TypeObject* GetCompletemaxObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -2626,7 +2655,7 @@ const TypeObject* GetCompletemaxObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -2639,7 +2668,7 @@ const TypeObject* GetCompletemaxObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -2649,8 +2678,8 @@ const TypeObject* GetCompletemaxObject()
     return TypeObjectFactory::get_instance()->get_type_object("max", true);
 }
 
-
-const TypeIdentifier* GetunitIdentifier(bool complete)
+const TypeIdentifier* GetunitIdentifier(
+        bool complete)
 {
     const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("unit", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
@@ -2662,7 +2691,8 @@ const TypeIdentifier* GetunitIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("unit", complete);
 }
 
-const TypeObject* GetunitObject(bool complete)
+const TypeObject* GetunitObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("unit", complete);
     if (c_type_object != nullptr)
@@ -2685,7 +2715,7 @@ const TypeObject* GetMinimalunitObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -2700,7 +2730,7 @@ const TypeObject* GetMinimalunitObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -2713,7 +2743,7 @@ const TypeObject* GetMinimalunitObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -2731,7 +2761,7 @@ const TypeObject* GetCompleteunitObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -2757,7 +2787,7 @@ const TypeObject* GetCompleteunitObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -2770,7 +2800,7 @@ const TypeObject* GetCompleteunitObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -2780,8 +2810,8 @@ const TypeObject* GetCompleteunitObject()
     return TypeObjectFactory::get_instance()->get_type_object("unit", true);
 }
 
-
-const TypeIdentifier* Getbit_boundIdentifier(bool complete)
+const TypeIdentifier* Getbit_boundIdentifier(
+        bool complete)
 {
     const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("bit_bound", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
@@ -2793,7 +2823,8 @@ const TypeIdentifier* Getbit_boundIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("bit_bound", complete);
 }
 
-const TypeObject* Getbit_boundObject(bool complete)
+const TypeObject* Getbit_boundObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("bit_bound", complete);
     if (c_type_object != nullptr)
@@ -2816,7 +2847,7 @@ const TypeObject* GetMinimalbit_boundObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -2831,7 +2862,7 @@ const TypeObject* GetMinimalbit_boundObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -2844,7 +2875,7 @@ const TypeObject* GetMinimalbit_boundObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -2862,7 +2893,7 @@ const TypeObject* GetCompletebit_boundObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -2888,7 +2919,7 @@ const TypeObject* GetCompletebit_boundObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -2901,7 +2932,7 @@ const TypeObject* GetCompletebit_boundObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -2911,8 +2942,8 @@ const TypeObject* GetCompletebit_boundObject()
     return TypeObjectFactory::get_instance()->get_type_object("bit_bound", true);
 }
 
-
-const TypeIdentifier* GetexternalIdentifier(bool complete)
+const TypeIdentifier* GetexternalIdentifier(
+        bool complete)
 {
     const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("external", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
@@ -2924,7 +2955,8 @@ const TypeIdentifier* GetexternalIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("external", complete);
 }
 
-const TypeObject* GetexternalObject(bool complete)
+const TypeObject* GetexternalObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("external", complete);
     if (c_type_object != nullptr)
@@ -2947,7 +2979,7 @@ const TypeObject* GetMinimalexternalObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -2966,7 +2998,7 @@ const TypeObject* GetMinimalexternalObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -2979,7 +3011,7 @@ const TypeObject* GetMinimalexternalObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -2997,7 +3029,7 @@ const TypeObject* GetCompleteexternalObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -3027,7 +3059,7 @@ const TypeObject* GetCompleteexternalObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -3040,7 +3072,7 @@ const TypeObject* GetCompleteexternalObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -3050,8 +3082,8 @@ const TypeObject* GetCompleteexternalObject()
     return TypeObjectFactory::get_instance()->get_type_object("external", true);
 }
 
-
-const TypeIdentifier* GetnestedIdentifier(bool complete)
+const TypeIdentifier* GetnestedIdentifier(
+        bool complete)
 {
     const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("nested", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
@@ -3063,7 +3095,8 @@ const TypeIdentifier* GetnestedIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("nested", complete);
 }
 
-const TypeObject* GetnestedObject(bool complete)
+const TypeObject* GetnestedObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("nested", complete);
     if (c_type_object != nullptr)
@@ -3086,7 +3119,7 @@ const TypeObject* GetMinimalnestedObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -3105,7 +3138,7 @@ const TypeObject* GetMinimalnestedObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -3118,7 +3151,7 @@ const TypeObject* GetMinimalnestedObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -3136,7 +3169,7 @@ const TypeObject* GetCompletenestedObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -3166,7 +3199,7 @@ const TypeObject* GetCompletenestedObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -3179,7 +3212,7 @@ const TypeObject* GetCompletenestedObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -3189,8 +3222,8 @@ const TypeObject* GetCompletenestedObject()
     return TypeObjectFactory::get_instance()->get_type_object("nested", true);
 }
 
-
-const TypeIdentifier* GetverbatimIdentifier(bool complete)
+const TypeIdentifier* GetverbatimIdentifier(
+        bool complete)
 {
     const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("verbatim", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
@@ -3202,7 +3235,8 @@ const TypeIdentifier* GetverbatimIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("verbatim", complete);
 }
 
-const TypeObject* GetverbatimObject(bool complete)
+const TypeObject* GetverbatimObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("verbatim", complete);
     if (c_type_object != nullptr)
@@ -3226,7 +3260,7 @@ const TypeObject* GetMinimalverbatimObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -3261,7 +3295,7 @@ const TypeObject* GetMinimalverbatimObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -3274,7 +3308,7 @@ const TypeObject* GetMinimalverbatimObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -3293,7 +3327,7 @@ const TypeObject* GetCompleteverbatimObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -3339,7 +3373,7 @@ const TypeObject* GetCompleteverbatimObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -3352,7 +3386,7 @@ const TypeObject* GetCompleteverbatimObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -3362,11 +3396,12 @@ const TypeObject* GetCompleteverbatimObject()
     return TypeObjectFactory::get_instance()->get_type_object("verbatim", true);
 }
 
-namespace verbatim
+namespace verbatim {
+const TypeIdentifier* GetPlacementKindIdentifier(
+        bool complete)
 {
-const TypeIdentifier* GetPlacementKindIdentifier(bool complete)
-{
-    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("PlacementKind", complete);
+    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("PlacementKind",
+                    complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
     {
         return c_identifier;
@@ -3376,7 +3411,8 @@ const TypeIdentifier* GetPlacementKindIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("PlacementKind", complete);
 }
 
-const TypeObject* GetPlacementKindObject(bool complete)
+const TypeObject* GetPlacementKindObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("PlacementKind", complete);
     if (c_type_object != nullptr)
@@ -3399,7 +3435,7 @@ const TypeObject* GetMinimalPlacementKindObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ENUM);
 
@@ -3423,7 +3459,7 @@ const TypeObject* GetMinimalPlacementKindObject()
     mel_BEGIN_FILE.common().flags().IS_DEFAULT(false);
     mel_BEGIN_FILE.common().value(value++);
     MD5 BEGIN_FILE_hash("BEGIN_FILE");
-    for(int i = 0; i < 4; ++i)
+    for (int i = 0; i < 4; ++i)
     {
         mel_BEGIN_FILE.detail().name_hash()[i] = BEGIN_FILE_hash.digest[i];
     }
@@ -3439,7 +3475,7 @@ const TypeObject* GetMinimalPlacementKindObject()
     mel_BEFORE_DECLARATION.common().flags().IS_DEFAULT(false);
     mel_BEFORE_DECLARATION.common().value(value++);
     MD5 BEFORE_DECLARATION_hash("BEFORE_DECLARATION");
-    for(int i = 0; i < 4; ++i)
+    for (int i = 0; i < 4; ++i)
     {
         mel_BEFORE_DECLARATION.detail().name_hash()[i] = BEFORE_DECLARATION_hash.digest[i];
     }
@@ -3455,7 +3491,7 @@ const TypeObject* GetMinimalPlacementKindObject()
     mel_BEGIN_DECLARATION.common().flags().IS_DEFAULT(false);
     mel_BEGIN_DECLARATION.common().value(value++);
     MD5 BEGIN_DECLARATION_hash("BEGIN_DECLARATION");
-    for(int i = 0; i < 4; ++i)
+    for (int i = 0; i < 4; ++i)
     {
         mel_BEGIN_DECLARATION.detail().name_hash()[i] = BEGIN_DECLARATION_hash.digest[i];
     }
@@ -3471,7 +3507,7 @@ const TypeObject* GetMinimalPlacementKindObject()
     mel_END_DECLARATION.common().flags().IS_DEFAULT(false);
     mel_END_DECLARATION.common().value(value++);
     MD5 END_DECLARATION_hash("END_DECLARATION");
-    for(int i = 0; i < 4; ++i)
+    for (int i = 0; i < 4; ++i)
     {
         mel_END_DECLARATION.detail().name_hash()[i] = END_DECLARATION_hash.digest[i];
     }
@@ -3487,7 +3523,7 @@ const TypeObject* GetMinimalPlacementKindObject()
     mel_AFTER_DECLARATION.common().flags().IS_DEFAULT(false);
     mel_AFTER_DECLARATION.common().value(value++);
     MD5 AFTER_DECLARATION_hash("AFTER_DECLARATION");
-    for(int i = 0; i < 4; ++i)
+    for (int i = 0; i < 4; ++i)
     {
         mel_AFTER_DECLARATION.detail().name_hash()[i] = AFTER_DECLARATION_hash.digest[i];
     }
@@ -3503,7 +3539,7 @@ const TypeObject* GetMinimalPlacementKindObject()
     mel_END_FILE.common().flags().IS_DEFAULT(false);
     mel_END_FILE.common().value(value++);
     MD5 END_FILE_hash("END_FILE");
-    for(int i = 0; i < 4; ++i)
+    for (int i = 0; i < 4; ++i)
     {
         mel_END_FILE.detail().name_hash()[i] = END_FILE_hash.digest[i];
     }
@@ -3514,7 +3550,7 @@ const TypeObject* GetMinimalPlacementKindObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalEnumeratedType::getCdrSerializedSize(type_object->minimal().enumerated_type()) + 4));
+                MinimalEnumeratedType::getCdrSerializedSize(type_object->minimal().enumerated_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -3527,7 +3563,7 @@ const TypeObject* GetMinimalPlacementKindObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -3545,7 +3581,7 @@ const TypeObject* GetCompletePlacementKindObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ENUM);
 
@@ -3651,7 +3687,7 @@ const TypeObject* GetCompletePlacementKindObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteEnumeratedType::getCdrSerializedSize(type_object->complete().enumerated_type()) + 4));
+                CompleteEnumeratedType::getCdrSerializedSize(type_object->complete().enumerated_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -3664,7 +3700,7 @@ const TypeObject* GetCompletePlacementKindObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -3674,10 +3710,9 @@ const TypeObject* GetCompletePlacementKindObject()
     return TypeObjectFactory::get_instance()->get_type_object("PlacementKind", true);
 }
 
-
-
 } // verbatim namespace
-const TypeIdentifier* GetserviceIdentifier(bool complete)
+const TypeIdentifier* GetserviceIdentifier(
+        bool complete)
 {
     const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("service", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
@@ -3689,7 +3724,8 @@ const TypeIdentifier* GetserviceIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("service", complete);
 }
 
-const TypeObject* GetserviceObject(bool complete)
+const TypeObject* GetserviceObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("service", complete);
     if (c_type_object != nullptr)
@@ -3712,7 +3748,7 @@ const TypeObject* GetMinimalserviceObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -3731,7 +3767,7 @@ const TypeObject* GetMinimalserviceObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -3744,7 +3780,7 @@ const TypeObject* GetMinimalserviceObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -3762,7 +3798,7 @@ const TypeObject* GetCompleteserviceObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -3792,7 +3828,7 @@ const TypeObject* GetCompleteserviceObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -3805,7 +3841,7 @@ const TypeObject* GetCompleteserviceObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -3815,8 +3851,8 @@ const TypeObject* GetCompleteserviceObject()
     return TypeObjectFactory::get_instance()->get_type_object("service", true);
 }
 
-
-const TypeIdentifier* GetonewayIdentifier(bool complete)
+const TypeIdentifier* GetonewayIdentifier(
+        bool complete)
 {
     const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("oneway", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
@@ -3828,7 +3864,8 @@ const TypeIdentifier* GetonewayIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("oneway", complete);
 }
 
-const TypeObject* GetonewayObject(bool complete)
+const TypeObject* GetonewayObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("oneway", complete);
     if (c_type_object != nullptr)
@@ -3851,7 +3888,7 @@ const TypeObject* GetMinimalonewayObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -3870,7 +3907,7 @@ const TypeObject* GetMinimalonewayObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -3883,7 +3920,7 @@ const TypeObject* GetMinimalonewayObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -3901,7 +3938,7 @@ const TypeObject* GetCompleteonewayObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -3931,7 +3968,7 @@ const TypeObject* GetCompleteonewayObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -3944,7 +3981,7 @@ const TypeObject* GetCompleteonewayObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -3954,8 +3991,8 @@ const TypeObject* GetCompleteonewayObject()
     return TypeObjectFactory::get_instance()->get_type_object("oneway", true);
 }
 
-
-const TypeIdentifier* GetamiIdentifier(bool complete)
+const TypeIdentifier* GetamiIdentifier(
+        bool complete)
 {
     const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("ami", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
@@ -3967,7 +4004,8 @@ const TypeIdentifier* GetamiIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("ami", complete);
 }
 
-const TypeObject* GetamiObject(bool complete)
+const TypeObject* GetamiObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("ami", complete);
     if (c_type_object != nullptr)
@@ -3990,7 +4028,7 @@ const TypeObject* GetMinimalamiObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -4009,7 +4047,7 @@ const TypeObject* GetMinimalamiObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -4022,7 +4060,7 @@ const TypeObject* GetMinimalamiObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -4040,7 +4078,7 @@ const TypeObject* GetCompleteamiObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -4070,7 +4108,7 @@ const TypeObject* GetCompleteamiObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -4083,7 +4121,7 @@ const TypeObject* GetCompleteamiObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -4093,10 +4131,11 @@ const TypeObject* GetCompleteamiObject()
     return TypeObjectFactory::get_instance()->get_type_object("ami", true);
 }
 
-
-const TypeIdentifier* Getnon_serializedIdentifier(bool complete)
+const TypeIdentifier* Getnon_serializedIdentifier(
+        bool complete)
 {
-    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("non_serialized", complete);
+    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("non_serialized",
+                    complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
     {
         return c_identifier;
@@ -4106,7 +4145,8 @@ const TypeIdentifier* Getnon_serializedIdentifier(bool complete)
     return TypeObjectFactory::get_instance()->get_type_identifier("non_serialized", complete);
 }
 
-const TypeObject* Getnon_serializedObject(bool complete)
+const TypeObject* Getnon_serializedObject(
+        bool complete)
 {
     const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("non_serialized", complete);
     if (c_type_object != nullptr)
@@ -4129,7 +4169,7 @@ const TypeObject* GetMinimalnon_serializedObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_MINIMAL);
     type_object->minimal()._d(TK_ANNOTATION);
 
@@ -4148,7 +4188,7 @@ const TypeObject* GetMinimalnon_serializedObject()
     identifier._d(EK_MINIMAL);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
+                MinimalAnnotationType::getCdrSerializedSize(type_object->minimal().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -4161,7 +4201,7 @@ const TypeObject* GetMinimalnon_serializedObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
@@ -4179,7 +4219,7 @@ const TypeObject* GetCompletenon_serializedObject()
         return c_type_object;
     }
 
-    TypeObject *type_object = new TypeObject();
+    TypeObject* type_object = new TypeObject();
     type_object->_d(EK_COMPLETE);
     type_object->complete()._d(TK_ANNOTATION);
 
@@ -4209,7 +4249,7 @@ const TypeObject* GetCompletenon_serializedObject()
     identifier._d(EK_COMPLETE);
 
     SerializedPayload_t payload(static_cast<uint32_t>(
-        CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
+                CompleteAnnotationType::getCdrSerializedSize(type_object->complete().annotation_type()) + 4));
     eprosima::fastcdr::FastBuffer fastbuffer((char*) payload.data, payload.max_size);
     // Fixed endian (Page 221, EquivalenceHash definition of Extensible and Dynamic Topic Types for DDS document)
     eprosima::fastcdr::Cdr ser(
@@ -4222,7 +4262,7 @@ const TypeObject* GetCompletenon_serializedObject()
     MD5 objectHash;
     objectHash.update((char*)payload.data, payload.length);
     objectHash.finalize();
-    for(int i = 0; i < 14; ++i)
+    for (int i = 0; i < 14; ++i)
     {
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }

--- a/src/cpp/dynamic-types/TypeObjectFactory.cpp
+++ b/src/cpp/dynamic-types/TypeObjectFactory.cpp
@@ -319,24 +319,24 @@ void TypeObjectFactory::fill_minimal_information(
     switch (ident->_d())
     {
         /*
-        case TK_BOOLEAN:
-        case TK_BYTE:
-        case TK_INT16:
-        case TK_INT32:
-        case TK_INT64:
-        case TK_UINT16:
-        case TK_UINT32:
-        case TK_UINT64:
-        case TK_FLOAT32:
-        case TK_FLOAT64:
-        case TK_FLOAT128:
-        case TK_CHAR8:
-        case TK_CHAR16:
-        case TK_STRING8:
-        case TK_STRING16:
+           case TK_BOOLEAN:
+           case TK_BYTE:
+           case TK_INT16:
+           case TK_INT32:
+           case TK_INT64:
+           case TK_UINT16:
+           case TK_UINT32:
+           case TK_UINT64:
+           case TK_FLOAT32:
+           case TK_FLOAT64:
+           case TK_FLOAT128:
+           case TK_CHAR8:
+           case TK_CHAR16:
+           case TK_STRING8:
+           case TK_STRING16:
             info->minimal().dependent_typeid_count(0);
             break;
-        */
+         */
         case TK_SEQUENCE:
         {
             info->minimal().dependent_typeid_count(1);
@@ -587,24 +587,24 @@ void TypeObjectFactory::fill_complete_information(
     switch (ident->_d())
     {
         /*
-        case TK_BOOLEAN:
-        case TK_BYTE:
-        case TK_INT16:
-        case TK_INT32:
-        case TK_INT64:
-        case TK_UINT16:
-        case TK_UINT32:
-        case TK_UINT64:
-        case TK_FLOAT32:
-        case TK_FLOAT64:
-        case TK_FLOAT128:
-        case TK_CHAR8:
-        case TK_CHAR16:
-        case TK_STRING8:
-        case TK_STRING16:
+           case TK_BOOLEAN:
+           case TK_BYTE:
+           case TK_INT16:
+           case TK_INT32:
+           case TK_INT64:
+           case TK_UINT16:
+           case TK_UINT32:
+           case TK_UINT64:
+           case TK_FLOAT32:
+           case TK_FLOAT64:
+           case TK_FLOAT128:
+           case TK_CHAR8:
+           case TK_CHAR16:
+           case TK_STRING8:
+           case TK_STRING16:
             info->complete().dependent_typeid_count(0);
             break;
-        */
+         */
         case TK_SEQUENCE:
         {
             info->complete().dependent_typeid_count(1);

--- a/test/unittest/dynamic_types/DynamicComplexTypesTests.cpp
+++ b/test/unittest/dynamic_types/DynamicComplexTypesTests.cpp
@@ -37,98 +37,100 @@ using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 using namespace eprosima::fastrtps::types;
 
-class DynamicComplexTypesTests: public ::testing::Test
+class DynamicComplexTypesTests : public ::testing::Test
 {
-    public:
-        DynamicComplexTypesTests()
+public:
+
+    DynamicComplexTypesTests()
+    {
+        CompleteStruct toRegisterStatic;
+        m_factory = DynamicTypeBuilderFactory::get_instance();
+        init();
+    }
+
+    ~DynamicComplexTypesTests()
+    {
+        m_DynAutoType = nullptr;
+        //DynamicDataFactory::get_instance()->delete_data(m_DynAuto);
+
+        m_DynManualType = nullptr;
+        //DynamicDataFactory::get_instance()->delete_data(m_DynManual);
+
+        if (!DynamicTypeBuilderFactory::get_instance()->is_empty())
         {
-            CompleteStruct toRegisterStatic;
-            m_factory = DynamicTypeBuilderFactory::get_instance();
-            init();
+            logError(DYN_TEST, "DynamicTypeBuilderFactory is not empty.");
         }
 
-        ~DynamicComplexTypesTests()
+        if (!DynamicDataFactory::get_instance()->is_empty())
         {
-            m_DynAutoType = nullptr;
-            //DynamicDataFactory::get_instance()->delete_data(m_DynAuto);
-
-            m_DynManualType = nullptr;
-            //DynamicDataFactory::get_instance()->delete_data(m_DynManual);
-
-            if (!DynamicTypeBuilderFactory::get_instance()->is_empty())
-            {
-                logError(DYN_TEST, "DynamicTypeBuilderFactory is not empty.");
-            }
-
-            if (!DynamicDataFactory::get_instance()->is_empty())
-            {
-                logError(DYN_TEST, "DynamicDataFactory is not empty.");
-            }
-
-            DynamicDataFactory::delete_instance();
-            DynamicTypeBuilderFactory::delete_instance();
-            TypeObjectFactory::delete_instance();
-
-            eprosima::fastdds::dds::Log::KillThread();
+            logError(DYN_TEST, "DynamicDataFactory is not empty.");
         }
 
-        virtual void TearDown()
-        {
-        }
+        DynamicDataFactory::delete_instance();
+        DynamicTypeBuilderFactory::delete_instance();
+        TypeObjectFactory::delete_instance();
 
-        void init();
+        eprosima::fastdds::dds::Log::KillThread();
+    }
 
-        types::DynamicType_ptr GetMyEnumType();
-        types::DynamicType_ptr GetMyAliasEnumType();
-        types::DynamicType_ptr GetMyAliasEnum2Type();
-        types::DynamicType_ptr GetMyAliasEnum3Type();
-        types::DynamicType_ptr GetMyOctetArray500Type();
-        types::DynamicType_ptr GetBSAlias5Type();
-        types::DynamicType_ptr GetMA3Type();
-        types::DynamicType_ptr GetMyMiniArrayType();
-        types::DynamicType_ptr GetMySequenceLongType();
-        types::DynamicType_ptr GetBasicStructType();
-        types::DynamicType_ptr GetComplexStructType();
-        types::DynamicType_ptr GetUnionSwitchType();
-        types::DynamicType_ptr GetUnion2SwitchType();
-        types::DynamicType_ptr GetCompleteStructType();
-        types::DynamicType_ptr GetKeyedStructType();
+    virtual void TearDown()
+    {
+    }
 
-        // Static types
-        //CompleteStruct m_Static;
-        CompleteStructPubSubType m_StaticType;
-        // Dynamic Types
-        //DynamicData* m_DynAuto;
-        types::DynamicType_ptr m_DynAutoType;
-        //DynamicData* m_DynManual;
-        types::DynamicType_ptr m_DynManualType;
-        DynamicTypeBuilderFactory* m_factory;
+    void init();
 
-    private:
-        types::DynamicType_ptr m_MyEnumType;
-        types::DynamicType_ptr m_MyAliasEnumType;
-        types::DynamicType_ptr m_MyAliasEnum2Type;
-        types::DynamicType_ptr m_MyAliasEnum3Type;
-        types::DynamicType_ptr m_MyOctetArray500;
-        types::DynamicType_ptr m_BSAlias5;
-        types::DynamicType_ptr m_MA3;
-        types::DynamicType_ptr m_MyMiniArray;
-        types::DynamicType_ptr m_MySequenceLong;
-        types::DynamicType_ptr m_BasicStructType;
-        types::DynamicType_ptr m_ComplexStructType;
-        types::DynamicType_ptr m_UnionSwitchType;
-        types::DynamicType_ptr m_Union2SwitchType;
-        types::DynamicType_ptr m_CompleteStructType;
-        types::DynamicType_ptr m_KeyedStructType;
+    types::DynamicType_ptr GetMyEnumType();
+    types::DynamicType_ptr GetMyAliasEnumType();
+    types::DynamicType_ptr GetMyAliasEnum2Type();
+    types::DynamicType_ptr GetMyAliasEnum3Type();
+    types::DynamicType_ptr GetMyOctetArray500Type();
+    types::DynamicType_ptr GetBSAlias5Type();
+    types::DynamicType_ptr GetMA3Type();
+    types::DynamicType_ptr GetMyMiniArrayType();
+    types::DynamicType_ptr GetMySequenceLongType();
+    types::DynamicType_ptr GetBasicStructType();
+    types::DynamicType_ptr GetComplexStructType();
+    types::DynamicType_ptr GetUnionSwitchType();
+    types::DynamicType_ptr GetUnion2SwitchType();
+    types::DynamicType_ptr GetCompleteStructType();
+    types::DynamicType_ptr GetKeyedStructType();
+
+    // Static types
+    //CompleteStruct m_Static;
+    CompleteStructPubSubType m_StaticType;
+    // Dynamic Types
+    //DynamicData* m_DynAuto;
+    types::DynamicType_ptr m_DynAutoType;
+    //DynamicData* m_DynManual;
+    types::DynamicType_ptr m_DynManualType;
+    DynamicTypeBuilderFactory* m_factory;
+
+private:
+
+    types::DynamicType_ptr m_MyEnumType;
+    types::DynamicType_ptr m_MyAliasEnumType;
+    types::DynamicType_ptr m_MyAliasEnum2Type;
+    types::DynamicType_ptr m_MyAliasEnum3Type;
+    types::DynamicType_ptr m_MyOctetArray500;
+    types::DynamicType_ptr m_BSAlias5;
+    types::DynamicType_ptr m_MA3;
+    types::DynamicType_ptr m_MyMiniArray;
+    types::DynamicType_ptr m_MySequenceLong;
+    types::DynamicType_ptr m_BasicStructType;
+    types::DynamicType_ptr m_ComplexStructType;
+    types::DynamicType_ptr m_UnionSwitchType;
+    types::DynamicType_ptr m_Union2SwitchType;
+    types::DynamicType_ptr m_CompleteStructType;
+    types::DynamicType_ptr m_KeyedStructType;
 };
 
 /*
 
-struct KeyedStruct
-{
+   struct KeyedStruct
+   {
     @Key octet key;
     BasicStruct basic;
-};
+   };
  */
 types::DynamicType_ptr DynamicComplexTypesTests::GetKeyedStructType()
 {
@@ -177,7 +179,8 @@ types::DynamicType_ptr DynamicComplexTypesTests::GetMyAliasEnum2Type()
 {
     if (m_MyAliasEnum2Type.get() == nullptr)
     {
-        DynamicTypeBuilder_ptr myAliasEnum2_builder = m_factory->create_alias_builder(GetMyAliasEnumType(), "MyAliasEnum2");
+        DynamicTypeBuilder_ptr myAliasEnum2_builder = m_factory->create_alias_builder(
+            GetMyAliasEnumType(), "MyAliasEnum2");
         m_MyAliasEnum2Type = myAliasEnum2_builder->build();
     }
 
@@ -188,7 +191,8 @@ types::DynamicType_ptr DynamicComplexTypesTests::GetMyAliasEnum3Type()
 {
     if (m_MyAliasEnum3Type.get() == nullptr)
     {
-        DynamicTypeBuilder_ptr myAliasEnum3_builder = m_factory->create_alias_builder(GetMyAliasEnum2Type(), "MyAliasEnum3");
+        DynamicTypeBuilder_ptr myAliasEnum3_builder = m_factory->create_alias_builder(
+            GetMyAliasEnum2Type(), "MyAliasEnum3");
         m_MyAliasEnum3Type = myAliasEnum3_builder->build();
     }
 
@@ -251,7 +255,8 @@ types::DynamicType_ptr DynamicComplexTypesTests::GetMySequenceLongType()
     {
         DynamicTypeBuilder_ptr int32_builder = m_factory->create_int32_builder();
         DynamicTypeBuilder_ptr seqLong_builder = m_factory->create_sequence_builder(int32_builder.get());
-        DynamicTypeBuilder_ptr mySequenceLong_builder = m_factory->create_alias_builder(seqLong_builder.get(), "MySequenceLong");
+        DynamicTypeBuilder_ptr mySequenceLong_builder = m_factory->create_alias_builder(
+            seqLong_builder.get(), "MySequenceLong");
         m_MySequenceLong = mySequenceLong_builder->build();
     }
 
@@ -315,57 +320,67 @@ types::DynamicType_ptr DynamicComplexTypesTests::GetComplexStructType()
         DynamicTypeBuilder_ptr my_sequence_struct_builder = m_factory->create_sequence_builder(GetBasicStructType());
         DynamicTypeBuilder_ptr char_builder = m_factory->create_char8_builder();
         DynamicTypeBuilder_ptr byte_builder = m_factory->create_byte_builder();
-        DynamicTypeBuilder_ptr my_array_octet_builder = m_factory->create_array_builder(byte_builder.get(), { 500, 5, 4 });
+        DynamicTypeBuilder_ptr my_array_octet_builder = m_factory->create_array_builder(
+            byte_builder.get(), { 500, 5, 4 });
         // MyOctetArray500 is already created
-            // We reuse the bounds... { 5 }
+        // We reuse the bounds... { 5 }
         DynamicTypeBuilder_ptr my_array_struct_builder = m_factory->create_array_builder(GetBasicStructType(), { 5 });
         DynamicTypeBuilder_ptr int16_builder = m_factory->create_int16_builder();
-        DynamicTypeBuilder_ptr my_map_octet_short_builder = m_factory->create_map_builder(octet_builder.get(), int16_builder.get());
+        DynamicTypeBuilder_ptr my_map_octet_short_builder = m_factory->create_map_builder(
+            octet_builder.get(), int16_builder.get());
         DynamicTypeBuilder_ptr int32_builder = m_factory->create_int32_builder();
-        DynamicTypeBuilder_ptr my_map_long_struct_builder = m_factory->create_map_builder(int32_builder.get()->build(), GetBasicStructType());
+        DynamicTypeBuilder_ptr my_map_long_struct_builder = m_factory->create_map_builder(
+            int32_builder.get()->build(), GetBasicStructType());
         DynamicTypeBuilder_ptr seqOctet_builder = m_factory->create_sequence_builder(octet_builder.get());
         DynamicTypeBuilder_ptr seqSeqOctet_builder = m_factory->create_sequence_builder(seqOctet_builder.get());
-        DynamicTypeBuilder_ptr my_map_long_seq_octet_builder = m_factory->create_map_builder(int32_builder.get(), seqSeqOctet_builder.get());
-        DynamicTypeBuilder_ptr my_map_long_octet_array_500_builder = m_factory->create_map_builder(int32_builder.get()->build(), GetMyOctetArray500Type());
-        DynamicTypeBuilder_ptr map_octet_bsalias5_builder = m_factory->create_map_builder(octet_builder.get()->build(), GetBSAlias5Type());
-        DynamicTypeBuilder_ptr my_map_long_lol_type_builder = m_factory->create_map_builder(int32_builder.get(), map_octet_bsalias5_builder.get());
+        DynamicTypeBuilder_ptr my_map_long_seq_octet_builder = m_factory->create_map_builder(
+            int32_builder.get(), seqSeqOctet_builder.get());
+        DynamicTypeBuilder_ptr my_map_long_octet_array_500_builder = m_factory->create_map_builder(
+            int32_builder.get()->build(), GetMyOctetArray500Type());
+        DynamicTypeBuilder_ptr map_octet_bsalias5_builder = m_factory->create_map_builder(
+            octet_builder.get()->build(), GetBSAlias5Type());
+        DynamicTypeBuilder_ptr my_map_long_lol_type_builder = m_factory->create_map_builder(
+            int32_builder.get(), map_octet_bsalias5_builder.get());
         DynamicTypeBuilder_ptr my_small_string_8_builder = m_factory->create_string_builder(128);
         DynamicTypeBuilder_ptr my_small_string_16_builder = m_factory->create_wstring_builder(64);
         DynamicTypeBuilder_ptr my_large_string_8_builder = m_factory->create_string_builder(500);
         DynamicTypeBuilder_ptr my_large_string_16_builder = m_factory->create_wstring_builder(1024);
         DynamicTypeBuilder_ptr string75_8_builder = m_factory->create_string_builder(75);
-        DynamicTypeBuilder_ptr my_array_string_builder = m_factory->create_array_builder(string75_8_builder.get(), { 5, 5 });
+        DynamicTypeBuilder_ptr my_array_string_builder = m_factory->create_array_builder(
+            string75_8_builder.get(), { 5, 5 });
 
         // MA3 is already defined.
         // { 5 } being reused
         DynamicTypeBuilder_ptr my_array_arrays_builder = m_factory->create_array_builder(GetMyMiniArrayType(), { 5 });
-        DynamicTypeBuilder_ptr my_sequences_array_builder = m_factory->create_array_builder(GetMySequenceLongType(), { 23 });
+        DynamicTypeBuilder_ptr my_sequences_array_builder = m_factory->create_array_builder(
+            GetMySequenceLongType(), { 23 });
         DynamicTypeBuilder_ptr complexStruct_builder = m_factory->create_struct_builder();
 
-            // Add members to the struct.
-            int idx = 0;
-            complexStruct_builder->add_member(idx++, "my_octet", octet_builder.get());
-            complexStruct_builder->add_member(idx++, "my_basic_struct", GetBasicStructType());
-            complexStruct_builder->add_member(idx++, "my_alias_enum", GetMyAliasEnumType());
-            complexStruct_builder->add_member(idx++, "my_enum", GetMyEnumType());
-            complexStruct_builder->add_member(idx++, "my_sequence_octet", my_sequence_octet_builder.get());
-            complexStruct_builder->add_member(idx++, "my_sequence_struct", my_sequence_struct_builder.get());
-            complexStruct_builder->add_member(idx++, "my_array_octet", my_array_octet_builder.get());
-            complexStruct_builder->add_member(idx++, "my_octet_array_500", GetMyOctetArray500Type());
-            complexStruct_builder->add_member(idx++, "my_array_struct", my_array_struct_builder.get());
-            complexStruct_builder->add_member(idx++, "my_map_octet_short", my_map_octet_short_builder.get());
-            complexStruct_builder->add_member(idx++, "my_map_long_struct", my_map_long_struct_builder.get());
-            complexStruct_builder->add_member(idx++, "my_map_long_seq_octet", my_map_long_seq_octet_builder.get());
-            complexStruct_builder->add_member(idx++, "my_map_long_octet_array_500", my_map_long_octet_array_500_builder.get());
-            complexStruct_builder->add_member(idx++, "my_map_long_lol_type", my_map_long_lol_type_builder.get());
-            complexStruct_builder->add_member(idx++, "my_small_string_8", my_small_string_8_builder.get());
-            complexStruct_builder->add_member(idx++, "my_small_string_16", my_small_string_16_builder.get());
-            complexStruct_builder->add_member(idx++, "my_large_string_8", my_large_string_8_builder.get());
-            complexStruct_builder->add_member(idx++, "my_large_string_16", my_large_string_16_builder.get());
-            complexStruct_builder->add_member(idx++, "my_array_string", my_array_string_builder.get());
-            complexStruct_builder->add_member(idx++, "multi_alias_array_42", GetMA3Type());
-            complexStruct_builder->add_member(idx++, "my_array_arrays", my_array_arrays_builder.get());
-            complexStruct_builder->add_member(idx++, "my_sequences_array", my_sequences_array_builder.get());
+        // Add members to the struct.
+        int idx = 0;
+        complexStruct_builder->add_member(idx++, "my_octet", octet_builder.get());
+        complexStruct_builder->add_member(idx++, "my_basic_struct", GetBasicStructType());
+        complexStruct_builder->add_member(idx++, "my_alias_enum", GetMyAliasEnumType());
+        complexStruct_builder->add_member(idx++, "my_enum", GetMyEnumType());
+        complexStruct_builder->add_member(idx++, "my_sequence_octet", my_sequence_octet_builder.get());
+        complexStruct_builder->add_member(idx++, "my_sequence_struct", my_sequence_struct_builder.get());
+        complexStruct_builder->add_member(idx++, "my_array_octet", my_array_octet_builder.get());
+        complexStruct_builder->add_member(idx++, "my_octet_array_500", GetMyOctetArray500Type());
+        complexStruct_builder->add_member(idx++, "my_array_struct", my_array_struct_builder.get());
+        complexStruct_builder->add_member(idx++, "my_map_octet_short", my_map_octet_short_builder.get());
+        complexStruct_builder->add_member(idx++, "my_map_long_struct", my_map_long_struct_builder.get());
+        complexStruct_builder->add_member(idx++, "my_map_long_seq_octet", my_map_long_seq_octet_builder.get());
+        complexStruct_builder->add_member(idx++, "my_map_long_octet_array_500",
+                my_map_long_octet_array_500_builder.get());
+        complexStruct_builder->add_member(idx++, "my_map_long_lol_type", my_map_long_lol_type_builder.get());
+        complexStruct_builder->add_member(idx++, "my_small_string_8", my_small_string_8_builder.get());
+        complexStruct_builder->add_member(idx++, "my_small_string_16", my_small_string_16_builder.get());
+        complexStruct_builder->add_member(idx++, "my_large_string_8", my_large_string_8_builder.get());
+        complexStruct_builder->add_member(idx++, "my_large_string_16", my_large_string_16_builder.get());
+        complexStruct_builder->add_member(idx++, "my_array_string", my_array_string_builder.get());
+        complexStruct_builder->add_member(idx++, "multi_alias_array_42", GetMA3Type());
+        complexStruct_builder->add_member(idx++, "my_array_arrays", my_array_arrays_builder.get());
+        complexStruct_builder->add_member(idx++, "my_sequences_array", my_sequences_array_builder.get());
         complexStruct_builder->set_name("ComplexStruct");
         m_ComplexStructType = complexStruct_builder->build();
     }
@@ -423,8 +438,8 @@ types::DynamicType_ptr DynamicComplexTypesTests::GetCompleteStructType()
 
 void DynamicComplexTypesTests::init()
 {
-    const TypeIdentifier *id = TypeObjectFactory::get_instance()->get_type_identifier("CompleteStruct", true);
-    const TypeObject *obj = TypeObjectFactory::get_instance()->get_type_object(id);
+    const TypeIdentifier* id = TypeObjectFactory::get_instance()->get_type_identifier("CompleteStruct", true);
+    const TypeObject* obj = TypeObjectFactory::get_instance()->get_type_object(id);
     m_DynAutoType = TypeObjectFactory::get_instance()->build_dynamic_type("CompleteStruct", id, obj);
 
     m_DynManualType = GetCompleteStructType();
@@ -493,10 +508,11 @@ TEST_F(DynamicComplexTypesTests, Conversions_Test)
     TypeObject newObject;
     DynamicTypeBuilderFactory::get_instance()->build_type_object(m_DynManualType, newObject, true);
 
-    const TypeIdentifier* identifier = TypeObjectFactory::get_instance()->get_type_identifier(m_DynManualType->get_name(),
+    const TypeIdentifier* identifier = TypeObjectFactory::get_instance()->get_type_identifier(
+        m_DynManualType->get_name(),
         true);
     DynamicType_ptr newAutoType = TypeObjectFactory::get_instance()->build_dynamic_type(m_DynManualType->get_name(),
-        identifier, &newObject);
+                    identifier, &newObject);
     types::DynamicData* dynData = DynamicDataFactory::get_instance()->create_data(m_DynManualType);
     types::DynamicData* dynData2 = DynamicDataFactory::get_instance()->create_data(newAutoType);
 
@@ -563,8 +579,8 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_A_A)
     //staticData.my_union_2()._d(A);
     staticData.my_union_2().uno(156);
 
-    DynamicData *my_union = dynData->loan_value(dynData->get_member_id_by_name("my_union"));
-    DynamicData *basic = my_union->loan_value(my_union->get_member_id_by_name("basic"));
+    DynamicData* my_union = dynData->loan_value(dynData->get_member_id_by_name("my_union"));
+    DynamicData* basic = my_union->loan_value(my_union->get_member_id_by_name("basic"));
 
     basic->set_bool_value(true, basic->get_member_id_by_name("my_bool"));
     basic->set_byte_value(166, basic->get_member_id_by_name("my_octet"));
@@ -585,7 +601,7 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_A_A)
     my_union->return_loaned_value(basic);
     dynData->return_loaned_value(my_union);
 
-    DynamicData *my_union_2 = dynData->loan_value(dynData->get_member_id_by_name("my_union_2"));
+    DynamicData* my_union_2 = dynData->loan_value(dynData->get_member_id_by_name("my_union_2"));
     my_union_2->set_int32_value(156, my_union_2->get_member_id_by_name("uno"));
 
 
@@ -631,8 +647,8 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_A_B)
 
     staticData.my_union_2().imString("JuanCarlosArcereredekljnjkds");
 
-    DynamicData *my_union = dynData->loan_value(dynData->get_member_id_by_name("my_union"));
-    DynamicData *basic = my_union->loan_value(my_union->get_member_id_by_name("basic"));
+    DynamicData* my_union = dynData->loan_value(dynData->get_member_id_by_name("my_union"));
+    DynamicData* basic = my_union->loan_value(my_union->get_member_id_by_name("basic"));
 
     basic->set_bool_value(true, basic->get_member_id_by_name("my_bool"));
     basic->set_byte_value(166, basic->get_member_id_by_name("my_octet"));
@@ -653,7 +669,7 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_A_B)
     my_union->return_loaned_value(basic);
     dynData->return_loaned_value(my_union);
 
-    DynamicData *my_union_2 = dynData->loan_value(dynData->get_member_id_by_name("my_union_2"));
+    DynamicData* my_union_2 = dynData->loan_value(dynData->get_member_id_by_name("my_union_2"));
     my_union_2->set_string_value("JuanCarlosArcereredekljnjkds", my_union_2->get_member_id_by_name("imString"));
 
 
@@ -701,8 +717,8 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_A_C)
     //staticData.my_union_2()._d(A);
     staticData.my_union_2().tres(333);
 
-    DynamicData *my_union = dynData->loan_value(dynData->get_member_id_by_name("my_union"));
-    DynamicData *basic = my_union->loan_value(my_union->get_member_id_by_name("basic"));
+    DynamicData* my_union = dynData->loan_value(dynData->get_member_id_by_name("my_union"));
+    DynamicData* basic = my_union->loan_value(my_union->get_member_id_by_name("basic"));
 
     basic->set_bool_value(true, basic->get_member_id_by_name("my_bool"));
     basic->set_byte_value(166, basic->get_member_id_by_name("my_octet"));
@@ -723,7 +739,7 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_A_C)
     my_union->return_loaned_value(basic);
     dynData->return_loaned_value(my_union);
 
-    DynamicData *my_union_2 = dynData->loan_value(dynData->get_member_id_by_name("my_union_2"));
+    DynamicData* my_union_2 = dynData->loan_value(dynData->get_member_id_by_name("my_union_2"));
     my_union_2->set_int32_value(333, my_union_2->get_member_id_by_name("tres"));
 
     dynData->return_loaned_value(my_union_2);
@@ -775,7 +791,7 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_A)
         {
             for (int k = 0; k < 4; ++k)
             {
-                staticData.my_union().complex().my_array_octet()[i][j][k] = static_cast<uint8_t>(j*k);
+                staticData.my_union().complex().my_array_octet()[i][j][k] = static_cast<uint8_t>(j * k);
             }
         }
     }
@@ -786,13 +802,13 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_A)
         staticData.my_union().complex().my_array_struct()[i].my_octet(static_cast<uint8_t>(i));
         staticData.my_union().complex().my_array_struct()[i].my_int16(static_cast<int16_t>(-i));
         staticData.my_union().complex().my_array_struct()[i].my_int32(i);
-        staticData.my_union().complex().my_array_struct()[i].my_int64(i*1000);
+        staticData.my_union().complex().my_array_struct()[i].my_int64(i * 1000);
         staticData.my_union().complex().my_array_struct()[i].my_uint16(static_cast<uint16_t>(i));
         staticData.my_union().complex().my_array_struct()[i].my_uint32(i);
-        staticData.my_union().complex().my_array_struct()[i].my_uint64(i*10005);
-        staticData.my_union().complex().my_array_struct()[i].my_float32(i*5.5f);
-        staticData.my_union().complex().my_array_struct()[i].my_float64(i*8.8);
-        staticData.my_union().complex().my_array_struct()[i].my_float128(i*10.0);
+        staticData.my_union().complex().my_array_struct()[i].my_uint64(i * 10005);
+        staticData.my_union().complex().my_array_struct()[i].my_float32(i * 5.5f);
+        staticData.my_union().complex().my_array_struct()[i].my_float64(i * 8.8);
+        staticData.my_union().complex().my_array_struct()[i].my_float128(i * 10.0);
         staticData.my_union().complex().my_array_struct()[i].my_char('J');
         staticData.my_union().complex().my_array_struct()[i].my_wchar(L'C');
         staticData.my_union().complex().my_array_struct()[i].my_string("JC@eProsima");
@@ -809,43 +825,54 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_A)
     staticData.my_union().complex().my_map_long_seq_octet()[0].push_back({1, 2, 3, 4, 5});
     for (int i = 0; i < 500; ++i)
     {
-        staticData.my_union().complex().my_map_long_octet_array_500()[0][i] = i%256;
-        staticData.my_union().complex().my_map_long_octet_array_500()[10][i] = (i+55)%256;
+        staticData.my_union().complex().my_map_long_octet_array_500()[0][i] = i % 256;
+        staticData.my_union().complex().my_map_long_octet_array_500()[10][i] = (i + 55) % 256;
     }
 
-    staticData.my_union().complex().my_small_string_8("Bv7EMffURwGNqePoujdSfkF9PXN9TH125X5nGpNLfzya53tZtNJdgMROlYdZnTE1SLWzBdIU7ZyjjGvsGHkmuJUROwVPcNa9q5dRUV3KZAKNx1exL7BjhqIgQFconhd");
-    staticData.my_union().complex().my_small_string_16(L"AgzñgXsI9pXbWjYLDvvn8JUFWhxZhk9t92rdsTqylvdpqtXA6hy9dHkoBTgmF2c");
-    staticData.my_union().complex().my_large_string_8("hYE5vjcLJe6ML5DmoqQwh9ns866dAbnjkVKIKu2VF6lbkvh91ZOG2enEcdoRa8T43hR0Ym0k7tI621EQGufvzmLqxKCPgiXSp2zUTTmIWtn4fM8tC3aP1Yd0dKvn0tDobyp6p3156KvxqG3BKQ6VjFiHlMFoEyz8pjCclhXLl2cfAi97sQzXLUoPYUC5BWKyQTrA2JF6HXZM6vrbw5dc3B4AOJNGdPJ9ai6weF43h1RhnXE9MOFxPNoQnJ8gqSXYbMtpG6ZzqhUyoz0XhFDt7EOqXIgvc9SCejQTVMPeRcF5Zy57hrYZiKrCQqFWidS4BdfEAkuwESgBmEpEFOpZotwDt0TGDaLktSt3dKRsURO6TpuZ2nZNdiEJyc597ZjjQXtyKU7OCyRRqllzAnHEtoU3zd3OLTOvT5uk32N1Y64tpUte63De2EMwDNYb2eGAQfATdSt8VcGBOzJQjsmrMwMumtk48JzXXLxjo6s2vl2rNK9WQM1");
-    staticData.my_union().complex().my_large_string_16(L"nosYBfFr1s3t8rUsuUrVCWFi6moDk7GULFj6XnkebIDkjl3n2ykKxUIaLj3qNNUx0ny8DvFbdfxZBdMhBNW3fHbKrig4GkHnN1JoEo0ACiPxrARusDs3xKzvaQQrls6lVUFAUXzDOtw5f2CNVJKiruGjXUO2Lq5Mmy8ygW3eUiTlueAHA2dRXXryOFi47jS3DkmBH4aAOKcmR27KhhJnXaY0gWy3XdSnaGQNB3XvbmxQ7xXDsf1wz860WMEKP3VhdOLsmS6tKCb4sshuOlmUSyTggY7vNoxfpG1EUFP5iPro9E0tHLLdHlWf2NwU8OXCYx6KKEbs5pFMvgEstnQglsdTk0lOv6riaFkFOwx83gW1l6Pg4eXjacnJKoVh1pOeZxULLZpCECw8yRZ9z4JPHxh2C7ytkCHMKp9O4MwQwYvvvgWWLWfJgb7Ecy2tgvWLpNDzgkFrEFhaCTKitChlG422CnLSsXvTBNnF52sULH6rcwOVx3mbhqte3ld3fObtAuH3zPzjOF4vVbvUXxgZh1Zx1cey0iGfnhOZHUfUwJ3Qv0WZNcuVLvMMhhg85A3620b84MAIc2UoW9Hl4BIT7pHo41ApF0DxIPJL0QdIdAOjn0JTPZqAhoHVBQoYvivPHftk5Crd1a1J8L7hSs0s4uSQKAMTKDxy3gKLaGAg277h4iEsEZRCI4RPlPTo9nZ48s8OO2KzqrUbMkoPSTgaJEXq8GsozAzh0wtL4P3gPeHO5nQzoytoXAkiXoPph0GaTLiahYQksYeK1eVQADDqZPXC55teXKKdX4aomCufr1ZizgzkGwAmnsFmhmBSF0gvbm56NDaUVT0UqXxKxAfRjkILeWR1mW8jfn6RYJH3IWiHxEfyB23rr78NySfgzIchhrm7jEFtmwPpKPKAwzajLv0HpkrtTr38YwWeT5LzHokFAQEc6l3aWdJWapVyt9wX89dEkmPPG9torCV2ddjyF4jAKsxKvzU4pCxV6B3m16IIdnksemJ0xG8iKh4ZPsX");
+    staticData.my_union().complex().my_small_string_8(
+        "Bv7EMffURwGNqePoujdSfkF9PXN9TH125X5nGpNLfzya53tZtNJdgMROlYdZnTE1SLWzBdIU7ZyjjGvsGHkmuJUROwVPcNa9q5dRUV3KZAKNx1exL7BjhqIgQFconhd");
+    staticData.my_union().complex().my_small_string_16(
+        L"AgzñgXsI9pXbWjYLDvvn8JUFWhxZhk9t92rdsTqylvdpqtXA6hy9dHkoBTgmF2c");
+    staticData.my_union().complex().my_large_string_8(
+        "hYE5vjcLJe6ML5DmoqQwh9ns866dAbnjkVKIKu2VF6lbkvh91ZOG2enEcdoRa8T43hR0Ym0k7tI621EQGufvzmLqxKCPgiXSp2zUTTmIWtn4fM8tC3aP1Yd0dKvn0tDobyp6p3156KvxqG3BKQ6VjFiHlMFoEyz8pjCclhXLl2cfAi97sQzXLUoPYUC5BWKyQTrA2JF6HXZM6vrbw5dc3B4AOJNGdPJ9ai6weF43h1RhnXE9MOFxPNoQnJ8gqSXYbMtpG6ZzqhUyoz0XhFDt7EOqXIgvc9SCejQTVMPeRcF5Zy57hrYZiKrCQqFWidS4BdfEAkuwESgBmEpEFOpZotwDt0TGDaLktSt3dKRsURO6TpuZ2nZNdiEJyc597ZjjQXtyKU7OCyRRqllzAnHEtoU3zd3OLTOvT5uk32N1Y64tpUte63De2EMwDNYb2eGAQfATdSt8VcGBOzJQjsmrMwMumtk48JzXXLxjo6s2vl2rNK9WQM1");
+    staticData.my_union().complex().my_large_string_16(
+        L"nosYBfFr1s3t8rUsuUrVCWFi6moDk7GULFj6XnkebIDkjl3n2ykKxUIaLj3qNNUx0ny8DvFbdfxZBdMhBNW3fHbKrig4GkHnN1JoEo0ACiPxrARusDs3xKzvaQQrls6lVUFAUXzDOtw5f2CNVJKiruGjXUO2Lq5Mmy8ygW3eUiTlueAHA2dRXXryOFi47jS3DkmBH4aAOKcmR27KhhJnXaY0gWy3XdSnaGQNB3XvbmxQ7xXDsf1wz860WMEKP3VhdOLsmS6tKCb4sshuOlmUSyTggY7vNoxfpG1EUFP5iPro9E0tHLLdHlWf2NwU8OXCYx6KKEbs5pFMvgEstnQglsdTk0lOv6riaFkFOwx83gW1l6Pg4eXjacnJKoVh1pOeZxULLZpCECw8yRZ9z4JPHxh2C7ytkCHMKp9O4MwQwYvvvgWWLWfJgb7Ecy2tgvWLpNDzgkFrEFhaCTKitChlG422CnLSsXvTBNnF52sULH6rcwOVx3mbhqte3ld3fObtAuH3zPzjOF4vVbvUXxgZh1Zx1cey0iGfnhOZHUfUwJ3Qv0WZNcuVLvMMhhg85A3620b84MAIc2UoW9Hl4BIT7pHo41ApF0DxIPJL0QdIdAOjn0JTPZqAhoHVBQoYvivPHftk5Crd1a1J8L7hSs0s4uSQKAMTKDxy3gKLaGAg277h4iEsEZRCI4RPlPTo9nZ48s8OO2KzqrUbMkoPSTgaJEXq8GsozAzh0wtL4P3gPeHO5nQzoytoXAkiXoPph0GaTLiahYQksYeK1eVQADDqZPXC55teXKKdX4aomCufr1ZizgzkGwAmnsFmhmBSF0gvbm56NDaUVT0UqXxKxAfRjkILeWR1mW8jfn6RYJH3IWiHxEfyB23rr78NySfgzIchhrm7jEFtmwPpKPKAwzajLv0HpkrtTr38YwWeT5LzHokFAQEc6l3aWdJWapVyt9wX89dEkmPPG9torCV2ddjyF4jAKsxKvzU4pCxV6B3m16IIdnksemJ0xG8iKh4ZPsX");
     for (int i = 0; i < 5; ++i)
+    {
         for (int j = 0; j < 5; ++j)
-            staticData.my_union().complex().my_array_string()[i][j]="Ee4rH8nSX1xnWrlDqDJjKWtWntMia9RrZqZPznr0yIDjeroWxUUzpPVV8UK4qUF4eilYR3Dz42";
+        {
+            staticData.my_union().complex().my_array_string()[i][j] =
+                    "Ee4rH8nSX1xnWrlDqDJjKWtWntMia9RrZqZPznr0yIDjeroWxUUzpPVV8UK4qUF4eilYR3Dz42";
+        }
+    }
     for (int i = 0; i < 42; ++i)
-        staticData.my_union().complex().multi_alias_array_42()[i] = (MyEnum)(i%3);
+    {
+        staticData.my_union().complex().multi_alias_array_42()[i] = (MyEnum)(i % 3);
+    }
 
     for (int i = 0; i < 5; ++i)
     {
         for (int j = 0; j < 2; ++j)
         {
-            staticData.my_union().complex().my_array_arrays()[i][j] = i*j;
+            staticData.my_union().complex().my_array_arrays()[i][j] = i * j;
         }
     }
 
     for (int i = 0; i < 23; ++i)
     {
         staticData.my_union().complex().my_sequences_array()[i].push_back(i);
-        staticData.my_union().complex().my_sequences_array()[i].push_back(i*10);
-        staticData.my_union().complex().my_sequences_array()[i].push_back(i*100);
+        staticData.my_union().complex().my_sequences_array()[i].push_back(i * 10);
+        staticData.my_union().complex().my_sequences_array()[i].push_back(i * 100);
     }
     staticData.my_union_2()._d(A);
     staticData.my_union_2().uno(156);
 
-    DynamicData *my_union = dynData->loan_value(dynData->get_member_id_by_name("my_union"));
+    DynamicData* my_union = dynData->loan_value(dynData->get_member_id_by_name("my_union"));
 
-    DynamicData *complex = my_union->loan_value(my_union->get_member_id_by_name("complex"));
+    DynamicData* complex = my_union->loan_value(my_union->get_member_id_by_name("complex"));
     complex->set_byte_value(66, complex->get_member_id_by_name("my_octet"));
 
-    DynamicData *basic = complex->loan_value(complex->get_member_id_by_name("my_basic_struct"));
+    DynamicData* basic = complex->loan_value(complex->get_member_id_by_name("my_basic_struct"));
     basic->set_bool_value(true, basic->get_member_id_by_name("my_bool"));
     basic->set_byte_value(166, basic->get_member_id_by_name("my_octet"));
     basic->set_int16_value(-10401, basic->get_member_id_by_name("my_int16"));
@@ -866,7 +893,7 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_A)
     complex->set_enum_value("C", complex->get_member_id_by_name("my_alias_enum"));
     complex->set_enum_value("B", complex->get_member_id_by_name("my_enum"));
 
-    DynamicData *my_seq_octet = complex->loan_value(complex->get_member_id_by_name("my_sequence_octet"));
+    DynamicData* my_seq_octet = complex->loan_value(complex->get_member_id_by_name("my_sequence_octet"));
     MemberId id;
     my_seq_octet->insert_sequence_data(id);
     my_seq_octet->set_byte_value(88, id);
@@ -876,13 +903,13 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_A)
     //staticData.my_union().complex().my_sequence_octet().push_back(99);
     complex->return_loaned_value(my_seq_octet);
 
-    DynamicData *my_seq_struct = complex->loan_value(complex->get_member_id_by_name("my_sequence_struct"));
+    DynamicData* my_seq_struct = complex->loan_value(complex->get_member_id_by_name("my_sequence_struct"));
     my_seq_struct->insert_sequence_data(id);
     my_seq_struct->set_complex_value(DynamicDataFactory::get_instance()->create_copy(basic), id);
     //staticData.my_union().complex().my_sequence_struct().push_back(staticData.my_union().complex().my_basic_struct());
     complex->return_loaned_value(my_seq_struct);
 
-    DynamicData *my_array_octet = complex->loan_value(complex->get_member_id_by_name("my_array_octet"));
+    DynamicData* my_array_octet = complex->loan_value(complex->get_member_id_by_name("my_array_octet"));
     for (unsigned int i = 0; i < 500; ++i)
     {
         for (unsigned int j = 0; j < 5; ++j)
@@ -890,28 +917,28 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_A)
             for (unsigned int k = 0; k < 4; ++k)
             {
                 MemberId array_idx = my_array_octet->get_array_index({ i, j, k });
-                my_array_octet->set_byte_value(static_cast<uint8_t>(j*k), array_idx);
+                my_array_octet->set_byte_value(static_cast<uint8_t>(j * k), array_idx);
             }
         }
         //staticData.my_union().complex().my_array_octet()[i][j][k] = j*k;
     }
     complex->return_loaned_value(my_array_octet);
 
-    DynamicData *my_array_struct = complex->loan_value(complex->get_member_id_by_name("my_array_struct"));
+    DynamicData* my_array_struct = complex->loan_value(complex->get_member_id_by_name("my_array_struct"));
     for (int i = 0; i < 5; ++i)
     {
-        DynamicData *tempBasic = DynamicDataFactory::get_instance()->create_data(GetBasicStructType());
+        DynamicData* tempBasic = DynamicDataFactory::get_instance()->create_data(GetBasicStructType());
         tempBasic->set_bool_value(i % 2 == 1, tempBasic->get_member_id_by_name("my_bool"));
         tempBasic->set_byte_value(static_cast<uint8_t>(i), tempBasic->get_member_id_by_name("my_octet"));
         tempBasic->set_int16_value(static_cast<int16_t>(-i), tempBasic->get_member_id_by_name("my_int16"));
         tempBasic->set_int32_value(i, tempBasic->get_member_id_by_name("my_int32"));
-        tempBasic->set_int64_value(i*1000, tempBasic->get_member_id_by_name("my_int64"));
+        tempBasic->set_int64_value(i * 1000, tempBasic->get_member_id_by_name("my_int64"));
         tempBasic->set_uint16_value(static_cast<uint16_t>(i), tempBasic->get_member_id_by_name("my_uint16"));
         tempBasic->set_uint32_value(i, tempBasic->get_member_id_by_name("my_uint32"));
-        tempBasic->set_uint64_value(i*10005, tempBasic->get_member_id_by_name("my_uint64"));
-        tempBasic->set_float32_value(i*5.5f, tempBasic->get_member_id_by_name("my_float32"));
-        tempBasic->set_float64_value(i*8.8, tempBasic->get_member_id_by_name("my_float64"));
-        tempBasic->set_float128_value(i*10.0, tempBasic->get_member_id_by_name("my_float128"));
+        tempBasic->set_uint64_value(i * 10005, tempBasic->get_member_id_by_name("my_uint64"));
+        tempBasic->set_float32_value(i * 5.5f, tempBasic->get_member_id_by_name("my_float32"));
+        tempBasic->set_float64_value(i * 8.8, tempBasic->get_member_id_by_name("my_float64"));
+        tempBasic->set_float128_value(i * 10.0, tempBasic->get_member_id_by_name("my_float128"));
         tempBasic->set_char8_value('J', tempBasic->get_member_id_by_name("my_char"));
         tempBasic->set_char16_value(L'C', tempBasic->get_member_id_by_name("my_wchar"));
         tempBasic->set_string_value("JC@eProsima", tempBasic->get_member_id_by_name("my_string"));
@@ -926,7 +953,7 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_A)
     MemberId vId;
     MemberId ssId;
     MemberId sId;
-    DynamicData *my_map_octet_short = complex->loan_value(complex->get_member_id_by_name("my_map_octet_short"));
+    DynamicData* my_map_octet_short = complex->loan_value(complex->get_member_id_by_name("my_map_octet_short"));
     key_oct->set_byte_value(0);
     my_map_octet_short->insert_map_data(key_oct.get(), kId, vId);
     my_map_octet_short->set_int16_value((short)1340, vId);
@@ -940,7 +967,7 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_A)
 
     DynamicTypeBuilder_ptr long_builder = m_factory->create_int32_builder();
     DynamicData_ptr key(DynamicDataFactory::get_instance()->create_data(long_builder->build()));
-    DynamicData *my_map_long_struct = complex->loan_value(complex->get_member_id_by_name("my_map_long_struct"));
+    DynamicData* my_map_long_struct = complex->loan_value(complex->get_member_id_by_name("my_map_long_struct"));
 
     //DynamicData *mas3 = my_array_struct->loan_value(3);
     key = DynamicDataFactory::get_instance()->create_data(long_builder->build());
@@ -966,19 +993,19 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_A)
     key = DynamicDataFactory::get_instance()->create_data(long_builder->build());
     key->set_int32_value(1000);
     my_map_long_struct->insert_map_data(key.get(), kId, vId);
-    DynamicData *mas3 = my_map_long_struct->loan_value(vId);
+    DynamicData* mas3 = my_map_long_struct->loan_value(vId);
     int i = 3;
     mas3->set_bool_value(i % 2 == 1, mas3->get_member_id_by_name("my_bool"));
     mas3->set_byte_value(static_cast<uint8_t>(i), mas3->get_member_id_by_name("my_octet"));
     mas3->set_int16_value(static_cast<int16_t>(-i), mas3->get_member_id_by_name("my_int16"));
     mas3->set_int32_value(i, mas3->get_member_id_by_name("my_int32"));
-    mas3->set_int64_value(i*1000, mas3->get_member_id_by_name("my_int64"));
+    mas3->set_int64_value(i * 1000, mas3->get_member_id_by_name("my_int64"));
     mas3->set_uint16_value(static_cast<uint8_t>(i), mas3->get_member_id_by_name("my_uint16"));
     mas3->set_uint32_value(i, mas3->get_member_id_by_name("my_uint32"));
-    mas3->set_uint64_value(i*10005, mas3->get_member_id_by_name("my_uint64"));
-    mas3->set_float32_value(i*5.5f, mas3->get_member_id_by_name("my_float32"));
-    mas3->set_float64_value(i*8.8, mas3->get_member_id_by_name("my_float64"));
-    mas3->set_float128_value(i*10.0, mas3->get_member_id_by_name("my_float128"));
+    mas3->set_uint64_value(i * 10005, mas3->get_member_id_by_name("my_uint64"));
+    mas3->set_float32_value(i * 5.5f, mas3->get_member_id_by_name("my_float32"));
+    mas3->set_float64_value(i * 8.8, mas3->get_member_id_by_name("my_float64"));
+    mas3->set_float128_value(i * 10.0, mas3->get_member_id_by_name("my_float128"));
     mas3->set_char8_value('J', mas3->get_member_id_by_name("my_char"));
     mas3->set_char16_value(L'C', mas3->get_member_id_by_name("my_wchar"));
     mas3->set_string_value("JC@eProsima", mas3->get_member_id_by_name("my_string"));
@@ -989,26 +1016,26 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_A)
     // staticData.my_union().complex().my_map_long_struct()[55] = staticData.my_union().complex().my_basic_struct();
     complex->return_loaned_value(my_map_long_struct);
 
-    DynamicData *my_map_long_seq_octet = complex->loan_value(complex->get_member_id_by_name("my_map_long_seq_octet"));
+    DynamicData* my_map_long_seq_octet = complex->loan_value(complex->get_member_id_by_name("my_map_long_seq_octet"));
     //std::vector my_vector_octet = {1, 2, 3, 4, 5};
     //MemberId id;
     /*DynamicTypeBuilder_ptr octet_builder = m_factory->create_byte_builder();
-    types::DynamicTypeBuilder_ptr seqOctet_builder = m_factory->create_sequence_builder(octet_builder.get());
-    types::DynamicType_ptr seqSeqOctet_builder = m_factory->create_sequence_builder(seqOctet_builder.get())->build();
-    DynamicData *dataSeqOctet = seqOctet_builder->build();
-    DynamicData *dataSeqSeqOctet = seqSeqOctet_builder->build();
-    dataSeqOctet->insert_sequence_data(id);
-    dataSeqOctet->set_byte_value(1, id);
-    dataSeqOctet->insert_sequence_data(id);
-    dataSeqOctet->set_byte_value(2, id);
-    dataSeqOctet->insert_sequence_data(id);
-    dataSeqOctet->set_byte_value(3, id);
-    dataSeqOctet->insert_sequence_data(id);
-    dataSeqOctet->set_byte_value(4, id);
-    dataSeqOctet->insert_sequence_data(id);
-    dataSeqOctet->set_byte_value(5, id);
-    dataSeqSeqOctet->insert_sequence_data(id);
-    dataSeqSeqOctet->set_complex_value(dataSeqOctet, id);*/
+       types::DynamicTypeBuilder_ptr seqOctet_builder = m_factory->create_sequence_builder(octet_builder.get());
+       types::DynamicType_ptr seqSeqOctet_builder = m_factory->create_sequence_builder(seqOctet_builder.get())->build();
+       DynamicData *dataSeqOctet = seqOctet_builder->build();
+       DynamicData *dataSeqSeqOctet = seqSeqOctet_builder->build();
+       dataSeqOctet->insert_sequence_data(id);
+       dataSeqOctet->set_byte_value(1, id);
+       dataSeqOctet->insert_sequence_data(id);
+       dataSeqOctet->set_byte_value(2, id);
+       dataSeqOctet->insert_sequence_data(id);
+       dataSeqOctet->set_byte_value(3, id);
+       dataSeqOctet->insert_sequence_data(id);
+       dataSeqOctet->set_byte_value(4, id);
+       dataSeqOctet->insert_sequence_data(id);
+       dataSeqOctet->set_byte_value(5, id);
+       dataSeqSeqOctet->insert_sequence_data(id);
+       dataSeqSeqOctet->set_complex_value(dataSeqOctet, id);*/
     // insert_map_data(DynamicData_ptr key, MemberId& outKeyId, MemberId& outValueId);
     // TODO De la muerte para Juan Carlos - Esto no es NADA práctico...
 
@@ -1069,8 +1096,8 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_A)
     //staticData.my_union().complex().my_map_long_seq_octet()[0].push_back(my_vector_octet);
     complex->return_loaned_value(my_map_long_seq_octet);
 
-    DynamicData *my_map_long_octet_array_500 =
-        complex->loan_value(complex->get_member_id_by_name("my_map_long_octet_array_500"));
+    DynamicData* my_map_long_octet_array_500 =
+            complex->loan_value(complex->get_member_id_by_name("my_map_long_octet_array_500"));
 
     key = DynamicDataFactory::get_instance()->create_data(long_builder->build());
     key->set_int32_value(0);
@@ -1079,7 +1106,7 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_A)
     DynamicData* oct_array_500 = my_map_long_octet_array_500->loan_value(vId);
     for (int j = 0; j < 500; ++j)
     {
-        oct_array_500->set_byte_value(j%256, j);
+        oct_array_500->set_byte_value(j % 256, j);
         //staticData.my_union().complex().my_map_long_octet_array_500()[0][i] = i%256;
     }
     my_map_long_octet_array_500->return_loaned_value(oct_array_500);
@@ -1091,30 +1118,38 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_A)
 
     for (int j = 0; j < 500; ++j)
     {
-        oct_array_500->set_byte_value((j+55)%256, j);
+        oct_array_500->set_byte_value((j + 55) % 256, j);
         //staticData.my_union().complex().my_map_long_octet_array_500()[10][i] = (i+55)%256;
     }
     my_map_long_octet_array_500->return_loaned_value(oct_array_500);
     complex->return_loaned_value(my_map_long_octet_array_500);
 
-    complex->set_string_value("Bv7EMffURwGNqePoujdSfkF9PXN9TH125X5nGpNLfzya53tZtNJdgMROlYdZnTE1SLWzBdIU7ZyjjGvsGHkmuJUROwVPcNa9q5dRUV3KZAKNx1exL7BjhqIgQFconhd", complex->get_member_id_by_name("my_small_string_8"));
-    complex->set_wstring_value(L"AgzñgXsI9pXbWjYLDvvn8JUFWhxZhk9t92rdsTqylvdpqtXA6hy9dHkoBTgmF2c", complex->get_member_id_by_name("my_small_string_16"));
-    complex->set_string_value("hYE5vjcLJe6ML5DmoqQwh9ns866dAbnjkVKIKu2VF6lbkvh91ZOG2enEcdoRa8T43hR0Ym0k7tI621EQGufvzmLqxKCPgiXSp2zUTTmIWtn4fM8tC3aP1Yd0dKvn0tDobyp6p3156KvxqG3BKQ6VjFiHlMFoEyz8pjCclhXLl2cfAi97sQzXLUoPYUC5BWKyQTrA2JF6HXZM6vrbw5dc3B4AOJNGdPJ9ai6weF43h1RhnXE9MOFxPNoQnJ8gqSXYbMtpG6ZzqhUyoz0XhFDt7EOqXIgvc9SCejQTVMPeRcF5Zy57hrYZiKrCQqFWidS4BdfEAkuwESgBmEpEFOpZotwDt0TGDaLktSt3dKRsURO6TpuZ2nZNdiEJyc597ZjjQXtyKU7OCyRRqllzAnHEtoU3zd3OLTOvT5uk32N1Y64tpUte63De2EMwDNYb2eGAQfATdSt8VcGBOzJQjsmrMwMumtk48JzXXLxjo6s2vl2rNK9WQM1", complex->get_member_id_by_name("my_large_string_8"));
-    complex->set_wstring_value(L"nosYBfFr1s3t8rUsuUrVCWFi6moDk7GULFj6XnkebIDkjl3n2ykKxUIaLj3qNNUx0ny8DvFbdfxZBdMhBNW3fHbKrig4GkHnN1JoEo0ACiPxrARusDs3xKzvaQQrls6lVUFAUXzDOtw5f2CNVJKiruGjXUO2Lq5Mmy8ygW3eUiTlueAHA2dRXXryOFi47jS3DkmBH4aAOKcmR27KhhJnXaY0gWy3XdSnaGQNB3XvbmxQ7xXDsf1wz860WMEKP3VhdOLsmS6tKCb4sshuOlmUSyTggY7vNoxfpG1EUFP5iPro9E0tHLLdHlWf2NwU8OXCYx6KKEbs5pFMvgEstnQglsdTk0lOv6riaFkFOwx83gW1l6Pg4eXjacnJKoVh1pOeZxULLZpCECw8yRZ9z4JPHxh2C7ytkCHMKp9O4MwQwYvvvgWWLWfJgb7Ecy2tgvWLpNDzgkFrEFhaCTKitChlG422CnLSsXvTBNnF52sULH6rcwOVx3mbhqte3ld3fObtAuH3zPzjOF4vVbvUXxgZh1Zx1cey0iGfnhOZHUfUwJ3Qv0WZNcuVLvMMhhg85A3620b84MAIc2UoW9Hl4BIT7pHo41ApF0DxIPJL0QdIdAOjn0JTPZqAhoHVBQoYvivPHftk5Crd1a1J8L7hSs0s4uSQKAMTKDxy3gKLaGAg277h4iEsEZRCI4RPlPTo9nZ48s8OO2KzqrUbMkoPSTgaJEXq8GsozAzh0wtL4P3gPeHO5nQzoytoXAkiXoPph0GaTLiahYQksYeK1eVQADDqZPXC55teXKKdX4aomCufr1ZizgzkGwAmnsFmhmBSF0gvbm56NDaUVT0UqXxKxAfRjkILeWR1mW8jfn6RYJH3IWiHxEfyB23rr78NySfgzIchhrm7jEFtmwPpKPKAwzajLv0HpkrtTr38YwWeT5LzHokFAQEc6l3aWdJWapVyt9wX89dEkmPPG9torCV2ddjyF4jAKsxKvzU4pCxV6B3m16IIdnksemJ0xG8iKh4ZPsX", complex->get_member_id_by_name("my_large_string_16"));
+    complex->set_string_value(
+        "Bv7EMffURwGNqePoujdSfkF9PXN9TH125X5nGpNLfzya53tZtNJdgMROlYdZnTE1SLWzBdIU7ZyjjGvsGHkmuJUROwVPcNa9q5dRUV3KZAKNx1exL7BjhqIgQFconhd", complex->get_member_id_by_name(
+            "my_small_string_8"));
+    complex->set_wstring_value(L"AgzñgXsI9pXbWjYLDvvn8JUFWhxZhk9t92rdsTqylvdpqtXA6hy9dHkoBTgmF2c", complex->get_member_id_by_name(
+                "my_small_string_16"));
+    complex->set_string_value(
+        "hYE5vjcLJe6ML5DmoqQwh9ns866dAbnjkVKIKu2VF6lbkvh91ZOG2enEcdoRa8T43hR0Ym0k7tI621EQGufvzmLqxKCPgiXSp2zUTTmIWtn4fM8tC3aP1Yd0dKvn0tDobyp6p3156KvxqG3BKQ6VjFiHlMFoEyz8pjCclhXLl2cfAi97sQzXLUoPYUC5BWKyQTrA2JF6HXZM6vrbw5dc3B4AOJNGdPJ9ai6weF43h1RhnXE9MOFxPNoQnJ8gqSXYbMtpG6ZzqhUyoz0XhFDt7EOqXIgvc9SCejQTVMPeRcF5Zy57hrYZiKrCQqFWidS4BdfEAkuwESgBmEpEFOpZotwDt0TGDaLktSt3dKRsURO6TpuZ2nZNdiEJyc597ZjjQXtyKU7OCyRRqllzAnHEtoU3zd3OLTOvT5uk32N1Y64tpUte63De2EMwDNYb2eGAQfATdSt8VcGBOzJQjsmrMwMumtk48JzXXLxjo6s2vl2rNK9WQM1", complex->get_member_id_by_name(
+            "my_large_string_8"));
+    complex->set_wstring_value(
+        L"nosYBfFr1s3t8rUsuUrVCWFi6moDk7GULFj6XnkebIDkjl3n2ykKxUIaLj3qNNUx0ny8DvFbdfxZBdMhBNW3fHbKrig4GkHnN1JoEo0ACiPxrARusDs3xKzvaQQrls6lVUFAUXzDOtw5f2CNVJKiruGjXUO2Lq5Mmy8ygW3eUiTlueAHA2dRXXryOFi47jS3DkmBH4aAOKcmR27KhhJnXaY0gWy3XdSnaGQNB3XvbmxQ7xXDsf1wz860WMEKP3VhdOLsmS6tKCb4sshuOlmUSyTggY7vNoxfpG1EUFP5iPro9E0tHLLdHlWf2NwU8OXCYx6KKEbs5pFMvgEstnQglsdTk0lOv6riaFkFOwx83gW1l6Pg4eXjacnJKoVh1pOeZxULLZpCECw8yRZ9z4JPHxh2C7ytkCHMKp9O4MwQwYvvvgWWLWfJgb7Ecy2tgvWLpNDzgkFrEFhaCTKitChlG422CnLSsXvTBNnF52sULH6rcwOVx3mbhqte3ld3fObtAuH3zPzjOF4vVbvUXxgZh1Zx1cey0iGfnhOZHUfUwJ3Qv0WZNcuVLvMMhhg85A3620b84MAIc2UoW9Hl4BIT7pHo41ApF0DxIPJL0QdIdAOjn0JTPZqAhoHVBQoYvivPHftk5Crd1a1J8L7hSs0s4uSQKAMTKDxy3gKLaGAg277h4iEsEZRCI4RPlPTo9nZ48s8OO2KzqrUbMkoPSTgaJEXq8GsozAzh0wtL4P3gPeHO5nQzoytoXAkiXoPph0GaTLiahYQksYeK1eVQADDqZPXC55teXKKdX4aomCufr1ZizgzkGwAmnsFmhmBSF0gvbm56NDaUVT0UqXxKxAfRjkILeWR1mW8jfn6RYJH3IWiHxEfyB23rr78NySfgzIchhrm7jEFtmwPpKPKAwzajLv0HpkrtTr38YwWeT5LzHokFAQEc6l3aWdJWapVyt9wX89dEkmPPG9torCV2ddjyF4jAKsxKvzU4pCxV6B3m16IIdnksemJ0xG8iKh4ZPsX", complex->get_member_id_by_name(
+            "my_large_string_16"));
 
-    DynamicData *my_array_string = complex->loan_value(complex->get_member_id_by_name("my_array_string"));
+    DynamicData* my_array_string = complex->loan_value(complex->get_member_id_by_name("my_array_string"));
     for (unsigned int j = 0; j < 5; ++j)
     {
         for (unsigned int k = 0; k < 5; ++k)
         {
             MemberId array_idx = my_array_string->get_array_index({ j, k });
-            my_array_string->set_string_value("Ee4rH8nSX1xnWrlDqDJjKWtWntMia9RrZqZPznr0yIDjeroWxUUzpPVV8UK4qUF4eilYR3Dz42", array_idx);
+            my_array_string->set_string_value(
+                "Ee4rH8nSX1xnWrlDqDJjKWtWntMia9RrZqZPznr0yIDjeroWxUUzpPVV8UK4qUF4eilYR3Dz42", array_idx);
             //staticData.my_union().complex().my_array_string()[i][j]("Ee4rH8nSX1xnWrlDqDJjKWtWntMia9RrZqZPznr0yIDjeroWxUUzpPVV8UK4qUF4eilYR3Dz42");
         }
     }
     complex->return_loaned_value(my_array_string);
 
-    DynamicData *multi_alias_array_42 = complex->loan_value(complex->get_member_id_by_name("multi_alias_array_42"));
+    DynamicData* multi_alias_array_42 = complex->loan_value(complex->get_member_id_by_name("multi_alias_array_42"));
     for (int j = 0; j < 42; ++j)
     {
         multi_alias_array_42->set_enum_value(j % 3, j);
@@ -1122,29 +1157,29 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_A)
     }
     complex->return_loaned_value(multi_alias_array_42);
 
-    DynamicData *my_array_arrays = complex->loan_value(complex->get_member_id_by_name("my_array_arrays"));
+    DynamicData* my_array_arrays = complex->loan_value(complex->get_member_id_by_name("my_array_arrays"));
     for (unsigned int j = 0; j < 5; ++j)
     {
-        DynamicData *myMiniArray = my_array_arrays->loan_value(j);
+        DynamicData* myMiniArray = my_array_arrays->loan_value(j);
         for (unsigned int k = 0; k < 2; ++k)
         {
-            myMiniArray->set_int32_value(j*k, k);
+            myMiniArray->set_int32_value(j * k, k);
             //staticData.my_union().complex().my_array_arrays()[i][j](i*j);
         }
         my_array_arrays->return_loaned_value(myMiniArray);
     }
     complex->return_loaned_value(my_array_arrays);
 
-    DynamicData *my_sequences_array = complex->loan_value(complex->get_member_id_by_name("my_sequences_array"));
+    DynamicData* my_sequences_array = complex->loan_value(complex->get_member_id_by_name("my_sequences_array"));
     for (int j = 0; j < 23; ++j)
     {
-        DynamicData *seq = DynamicDataFactory::get_instance()->create_data(GetMySequenceLongType());
+        DynamicData* seq = DynamicDataFactory::get_instance()->create_data(GetMySequenceLongType());
         seq->insert_sequence_data(id);
         seq->set_int32_value(j, id);
         seq->insert_sequence_data(id);
-        seq->set_int32_value(j*10, id);
+        seq->set_int32_value(j * 10, id);
         seq->insert_sequence_data(id);
-        seq->set_int32_value(j*100, id);
+        seq->set_int32_value(j * 100, id);
         my_sequences_array->set_complex_value(seq, j);
         // staticData.my_union().complex().my_sequences_array()[i].push_back(i);
         // staticData.my_union().complex().my_sequences_array()[i].push_back(i*10);
@@ -1155,7 +1190,7 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_A)
     my_union->return_loaned_value(complex);
     dynData->return_loaned_value(my_union);
 
-    DynamicData *my_union_2 = dynData->loan_value(dynData->get_member_id_by_name("my_union_2"));
+    DynamicData* my_union_2 = dynData->loan_value(dynData->get_member_id_by_name("my_union_2"));
     my_union_2->set_int32_value(156, my_union_2->get_member_id_by_name("uno"));
 
     dynData->return_loaned_value(my_union_2);
@@ -1167,9 +1202,9 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_A)
     ASSERT_TRUE(pubsubType.serialize(dynData.get(), &payload));
     ASSERT_TRUE(payload.length == payloadSize);
     /*
-    std::cout << "BEGIN" << std::endl;
-    for (uint32_t j = 0; j < payload.length; j += 100)
-    {
+       std::cout << "BEGIN" << std::endl;
+       for (uint32_t j = 0; j < payload.length; j += 100)
+       {
         std::cout << std::endl;
         for (uint32_t k = 0; k < 100; k++)
         {
@@ -1185,18 +1220,18 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_A)
                 }
             }
         }
-    }
-    std::cout << "END" << std::endl;
-    */
+       }
+       std::cout << "END" << std::endl;
+     */
     CompleteStructPubSubType pbComplete;
     uint32_t payloadSize2 = static_cast<uint32_t>(m_StaticType.getSerializedSizeProvider(&staticData)());
     SerializedPayload_t stPayload(payloadSize2);
     ASSERT_TRUE(pbComplete.serialize(&staticData, &stPayload));
     ASSERT_TRUE(stPayload.length == payloadSize2);
     /*
-    std::cout << "BEGIN" << std::endl;
-    for (uint32_t j = 0; j < stPayload.length; j += 100)
-    {
+       std::cout << "BEGIN" << std::endl;
+       for (uint32_t j = 0; j < stPayload.length; j += 100)
+       {
         std::cout << std::endl;
         for (uint32_t k = 0; k < 100; k++)
         {
@@ -1212,9 +1247,9 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_A)
                 }
             }
         }
-    }
-    std::cout << "END" << std::endl;
-    */
+       }
+       std::cout << "END" << std::endl;
+     */
     types::DynamicData_ptr dynDataFromDynamic(DynamicDataFactory::get_instance()->create_data(m_DynAutoType));
     ASSERT_TRUE(pubsubType.deserialize(&payload, dynDataFromDynamic.get()));
 
@@ -1258,7 +1293,7 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_B)
         {
             for (int k = 0; k < 4; ++k)
             {
-                staticData.my_union().complex().my_array_octet()[i][j][k] = static_cast<uint8_t>(j*k);
+                staticData.my_union().complex().my_array_octet()[i][j][k] = static_cast<uint8_t>(j * k);
             }
         }
     }
@@ -1273,9 +1308,9 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_B)
         staticData.my_union().complex().my_array_struct()[i].my_uint16(static_cast<uint16_t>(i));
         staticData.my_union().complex().my_array_struct()[i].my_uint32(i);
         staticData.my_union().complex().my_array_struct()[i].my_uint64(i * 10005);
-        staticData.my_union().complex().my_array_struct()[i].my_float32(i*5.5f);
-        staticData.my_union().complex().my_array_struct()[i].my_float64(i*8.8);
-        staticData.my_union().complex().my_array_struct()[i].my_float128(i*10.0);
+        staticData.my_union().complex().my_array_struct()[i].my_float32(i * 5.5f);
+        staticData.my_union().complex().my_array_struct()[i].my_float64(i * 8.8);
+        staticData.my_union().complex().my_array_struct()[i].my_float128(i * 10.0);
         staticData.my_union().complex().my_array_struct()[i].my_char('J');
         staticData.my_union().complex().my_array_struct()[i].my_wchar(L'C');
         staticData.my_union().complex().my_array_struct()[i].my_string("JC@eProsima");
@@ -1296,21 +1331,32 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_B)
         staticData.my_union().complex().my_map_long_octet_array_500()[10][i] = (i + 55) % 256;
     }
 
-    staticData.my_union().complex().my_small_string_8("Bv7EMffURwGNqePoujdSfkF9PXN9TH125X5nGpNLfzya53tZtNJdgMROlYdZnTE1SLWzBdIU7ZyjjGvsGHkmuJUROwVPcNa9q5dRUV3KZAKNx1exL7BjhqIgQFconhd");
-    staticData.my_union().complex().my_small_string_16(L"AgzñgXsI9pXbWjYLDvvn8JUFWhxZhk9t92rdsTqylvdpqtXA6hy9dHkoBTgmF2c");
-    staticData.my_union().complex().my_large_string_8("hYE5vjcLJe6ML5DmoqQwh9ns866dAbnjkVKIKu2VF6lbkvh91ZOG2enEcdoRa8T43hR0Ym0k7tI621EQGufvzmLqxKCPgiXSp2zUTTmIWtn4fM8tC3aP1Yd0dKvn0tDobyp6p3156KvxqG3BKQ6VjFiHlMFoEyz8pjCclhXLl2cfAi97sQzXLUoPYUC5BWKyQTrA2JF6HXZM6vrbw5dc3B4AOJNGdPJ9ai6weF43h1RhnXE9MOFxPNoQnJ8gqSXYbMtpG6ZzqhUyoz0XhFDt7EOqXIgvc9SCejQTVMPeRcF5Zy57hrYZiKrCQqFWidS4BdfEAkuwESgBmEpEFOpZotwDt0TGDaLktSt3dKRsURO6TpuZ2nZNdiEJyc597ZjjQXtyKU7OCyRRqllzAnHEtoU3zd3OLTOvT5uk32N1Y64tpUte63De2EMwDNYb2eGAQfATdSt8VcGBOzJQjsmrMwMumtk48JzXXLxjo6s2vl2rNK9WQM1");
-    staticData.my_union().complex().my_large_string_16(L"nosYBfFr1s3t8rUsuUrVCWFi6moDk7GULFj6XnkebIDkjl3n2ykKxUIaLj3qNNUx0ny8DvFbdfxZBdMhBNW3fHbKrig4GkHnN1JoEo0ACiPxrARusDs3xKzvaQQrls6lVUFAUXzDOtw5f2CNVJKiruGjXUO2Lq5Mmy8ygW3eUiTlueAHA2dRXXryOFi47jS3DkmBH4aAOKcmR27KhhJnXaY0gWy3XdSnaGQNB3XvbmxQ7xXDsf1wz860WMEKP3VhdOLsmS6tKCb4sshuOlmUSyTggY7vNoxfpG1EUFP5iPro9E0tHLLdHlWf2NwU8OXCYx6KKEbs5pFMvgEstnQglsdTk0lOv6riaFkFOwx83gW1l6Pg4eXjacnJKoVh1pOeZxULLZpCECw8yRZ9z4JPHxh2C7ytkCHMKp9O4MwQwYvvvgWWLWfJgb7Ecy2tgvWLpNDzgkFrEFhaCTKitChlG422CnLSsXvTBNnF52sULH6rcwOVx3mbhqte3ld3fObtAuH3zPzjOF4vVbvUXxgZh1Zx1cey0iGfnhOZHUfUwJ3Qv0WZNcuVLvMMhhg85A3620b84MAIc2UoW9Hl4BIT7pHo41ApF0DxIPJL0QdIdAOjn0JTPZqAhoHVBQoYvivPHftk5Crd1a1J8L7hSs0s4uSQKAMTKDxy3gKLaGAg277h4iEsEZRCI4RPlPTo9nZ48s8OO2KzqrUbMkoPSTgaJEXq8GsozAzh0wtL4P3gPeHO5nQzoytoXAkiXoPph0GaTLiahYQksYeK1eVQADDqZPXC55teXKKdX4aomCufr1ZizgzkGwAmnsFmhmBSF0gvbm56NDaUVT0UqXxKxAfRjkILeWR1mW8jfn6RYJH3IWiHxEfyB23rr78NySfgzIchhrm7jEFtmwPpKPKAwzajLv0HpkrtTr38YwWeT5LzHokFAQEc6l3aWdJWapVyt9wX89dEkmPPG9torCV2ddjyF4jAKsxKvzU4pCxV6B3m16IIdnksemJ0xG8iKh4ZPsX");
+    staticData.my_union().complex().my_small_string_8(
+        "Bv7EMffURwGNqePoujdSfkF9PXN9TH125X5nGpNLfzya53tZtNJdgMROlYdZnTE1SLWzBdIU7ZyjjGvsGHkmuJUROwVPcNa9q5dRUV3KZAKNx1exL7BjhqIgQFconhd");
+    staticData.my_union().complex().my_small_string_16(
+        L"AgzñgXsI9pXbWjYLDvvn8JUFWhxZhk9t92rdsTqylvdpqtXA6hy9dHkoBTgmF2c");
+    staticData.my_union().complex().my_large_string_8(
+        "hYE5vjcLJe6ML5DmoqQwh9ns866dAbnjkVKIKu2VF6lbkvh91ZOG2enEcdoRa8T43hR0Ym0k7tI621EQGufvzmLqxKCPgiXSp2zUTTmIWtn4fM8tC3aP1Yd0dKvn0tDobyp6p3156KvxqG3BKQ6VjFiHlMFoEyz8pjCclhXLl2cfAi97sQzXLUoPYUC5BWKyQTrA2JF6HXZM6vrbw5dc3B4AOJNGdPJ9ai6weF43h1RhnXE9MOFxPNoQnJ8gqSXYbMtpG6ZzqhUyoz0XhFDt7EOqXIgvc9SCejQTVMPeRcF5Zy57hrYZiKrCQqFWidS4BdfEAkuwESgBmEpEFOpZotwDt0TGDaLktSt3dKRsURO6TpuZ2nZNdiEJyc597ZjjQXtyKU7OCyRRqllzAnHEtoU3zd3OLTOvT5uk32N1Y64tpUte63De2EMwDNYb2eGAQfATdSt8VcGBOzJQjsmrMwMumtk48JzXXLxjo6s2vl2rNK9WQM1");
+    staticData.my_union().complex().my_large_string_16(
+        L"nosYBfFr1s3t8rUsuUrVCWFi6moDk7GULFj6XnkebIDkjl3n2ykKxUIaLj3qNNUx0ny8DvFbdfxZBdMhBNW3fHbKrig4GkHnN1JoEo0ACiPxrARusDs3xKzvaQQrls6lVUFAUXzDOtw5f2CNVJKiruGjXUO2Lq5Mmy8ygW3eUiTlueAHA2dRXXryOFi47jS3DkmBH4aAOKcmR27KhhJnXaY0gWy3XdSnaGQNB3XvbmxQ7xXDsf1wz860WMEKP3VhdOLsmS6tKCb4sshuOlmUSyTggY7vNoxfpG1EUFP5iPro9E0tHLLdHlWf2NwU8OXCYx6KKEbs5pFMvgEstnQglsdTk0lOv6riaFkFOwx83gW1l6Pg4eXjacnJKoVh1pOeZxULLZpCECw8yRZ9z4JPHxh2C7ytkCHMKp9O4MwQwYvvvgWWLWfJgb7Ecy2tgvWLpNDzgkFrEFhaCTKitChlG422CnLSsXvTBNnF52sULH6rcwOVx3mbhqte3ld3fObtAuH3zPzjOF4vVbvUXxgZh1Zx1cey0iGfnhOZHUfUwJ3Qv0WZNcuVLvMMhhg85A3620b84MAIc2UoW9Hl4BIT7pHo41ApF0DxIPJL0QdIdAOjn0JTPZqAhoHVBQoYvivPHftk5Crd1a1J8L7hSs0s4uSQKAMTKDxy3gKLaGAg277h4iEsEZRCI4RPlPTo9nZ48s8OO2KzqrUbMkoPSTgaJEXq8GsozAzh0wtL4P3gPeHO5nQzoytoXAkiXoPph0GaTLiahYQksYeK1eVQADDqZPXC55teXKKdX4aomCufr1ZizgzkGwAmnsFmhmBSF0gvbm56NDaUVT0UqXxKxAfRjkILeWR1mW8jfn6RYJH3IWiHxEfyB23rr78NySfgzIchhrm7jEFtmwPpKPKAwzajLv0HpkrtTr38YwWeT5LzHokFAQEc6l3aWdJWapVyt9wX89dEkmPPG9torCV2ddjyF4jAKsxKvzU4pCxV6B3m16IIdnksemJ0xG8iKh4ZPsX");
     for (int i = 0; i < 5; ++i)
+    {
         for (int j = 0; j < 5; ++j)
-            staticData.my_union().complex().my_array_string()[i][j] = "Ee4rH8nSX1xnWrlDqDJjKWtWntMia9RrZqZPznr0yIDjeroWxUUzpPVV8UK4qUF4eilYR3Dz42";
+        {
+            staticData.my_union().complex().my_array_string()[i][j] =
+                    "Ee4rH8nSX1xnWrlDqDJjKWtWntMia9RrZqZPznr0yIDjeroWxUUzpPVV8UK4qUF4eilYR3Dz42";
+        }
+    }
     for (int i = 0; i < 42; ++i)
+    {
         staticData.my_union().complex().multi_alias_array_42()[i] = (MyEnum)(i % 3);
+    }
 
     for (int i = 0; i < 5; ++i)
     {
         for (int j = 0; j < 2; ++j)
         {
-            staticData.my_union().complex().my_array_arrays()[i][j] = i*j;
+            staticData.my_union().complex().my_array_arrays()[i][j] = i * j;
         }
     }
 
@@ -1323,12 +1369,12 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_B)
     //staticData.my_union_2()._d() = B;
     staticData.my_union_2().imString("GASCO!");
 
-    DynamicData *my_union = dynData->loan_value(dynData->get_member_id_by_name("my_union"));
+    DynamicData* my_union = dynData->loan_value(dynData->get_member_id_by_name("my_union"));
 
-    DynamicData *complex = my_union->loan_value(my_union->get_member_id_by_name("complex"));
+    DynamicData* complex = my_union->loan_value(my_union->get_member_id_by_name("complex"));
     complex->set_byte_value(66, complex->get_member_id_by_name("my_octet"));
 
-    DynamicData *basic = complex->loan_value(complex->get_member_id_by_name("my_basic_struct"));
+    DynamicData* basic = complex->loan_value(complex->get_member_id_by_name("my_basic_struct"));
     basic->set_bool_value(true, basic->get_member_id_by_name("my_bool"));
     basic->set_byte_value(166, basic->get_member_id_by_name("my_octet"));
     basic->set_int16_value(-10401, basic->get_member_id_by_name("my_int16"));
@@ -1349,7 +1395,7 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_B)
     complex->set_enum_value("C", complex->get_member_id_by_name("my_alias_enum"));
     complex->set_enum_value("B", complex->get_member_id_by_name("my_enum"));
 
-    DynamicData *my_seq_octet = complex->loan_value(complex->get_member_id_by_name("my_sequence_octet"));
+    DynamicData* my_seq_octet = complex->loan_value(complex->get_member_id_by_name("my_sequence_octet"));
     MemberId id;
     my_seq_octet->insert_sequence_data(id);
     my_seq_octet->set_byte_value(88, id);
@@ -1359,13 +1405,13 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_B)
     //staticData.my_union().complex().my_sequence_octet().push_back(99);
     complex->return_loaned_value(my_seq_octet);
 
-    DynamicData *my_seq_struct = complex->loan_value(complex->get_member_id_by_name("my_sequence_struct"));
+    DynamicData* my_seq_struct = complex->loan_value(complex->get_member_id_by_name("my_sequence_struct"));
     my_seq_struct->insert_sequence_data(id);
     my_seq_struct->set_complex_value(DynamicDataFactory::get_instance()->create_copy(basic), id);
     //staticData.my_union().complex().my_sequence_struct().push_back(staticData.my_union().complex().my_basic_struct());
     complex->return_loaned_value(my_seq_struct);
 
-    DynamicData *my_array_octet = complex->loan_value(complex->get_member_id_by_name("my_array_octet"));
+    DynamicData* my_array_octet = complex->loan_value(complex->get_member_id_by_name("my_array_octet"));
     for (unsigned int i = 0; i < 500; ++i)
     {
         for (unsigned int j = 0; j < 5; ++j)
@@ -1373,17 +1419,17 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_B)
             for (unsigned int k = 0; k < 4; ++k)
             {
                 MemberId array_idx = my_array_octet->get_array_index({ i, j, k });
-                my_array_octet->set_byte_value(static_cast<uint8_t>(j*k), array_idx);
+                my_array_octet->set_byte_value(static_cast<uint8_t>(j * k), array_idx);
             }
         }
         //staticData.my_union().complex().my_array_octet()[i][j][k] = j*k;
     }
     complex->return_loaned_value(my_array_octet);
 
-    DynamicData *my_array_struct = complex->loan_value(complex->get_member_id_by_name("my_array_struct"));
+    DynamicData* my_array_struct = complex->loan_value(complex->get_member_id_by_name("my_array_struct"));
     for (int i = 0; i < 5; ++i)
     {
-        DynamicData *tempBasic = DynamicDataFactory::get_instance()->create_data(GetBasicStructType());
+        DynamicData* tempBasic = DynamicDataFactory::get_instance()->create_data(GetBasicStructType());
         tempBasic->set_bool_value(i % 2 == 1, tempBasic->get_member_id_by_name("my_bool"));
         tempBasic->set_byte_value(static_cast<uint8_t>(i), tempBasic->get_member_id_by_name("my_octet"));
         tempBasic->set_int16_value(static_cast<int16_t>(-i), tempBasic->get_member_id_by_name("my_int16"));
@@ -1392,9 +1438,9 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_B)
         tempBasic->set_uint16_value(static_cast<uint16_t>(i), tempBasic->get_member_id_by_name("my_uint16"));
         tempBasic->set_uint32_value(i, tempBasic->get_member_id_by_name("my_uint32"));
         tempBasic->set_uint64_value(i * 10005, tempBasic->get_member_id_by_name("my_uint64"));
-        tempBasic->set_float32_value(i*5.5f, tempBasic->get_member_id_by_name("my_float32"));
-        tempBasic->set_float64_value(i*8.8, tempBasic->get_member_id_by_name("my_float64"));
-        tempBasic->set_float128_value(i*10.0, tempBasic->get_member_id_by_name("my_float128"));
+        tempBasic->set_float32_value(i * 5.5f, tempBasic->get_member_id_by_name("my_float32"));
+        tempBasic->set_float64_value(i * 8.8, tempBasic->get_member_id_by_name("my_float64"));
+        tempBasic->set_float128_value(i * 10.0, tempBasic->get_member_id_by_name("my_float128"));
         tempBasic->set_char8_value('J', tempBasic->get_member_id_by_name("my_char"));
         tempBasic->set_char16_value(L'C', tempBasic->get_member_id_by_name("my_wchar"));
         tempBasic->set_string_value("JC@eProsima", tempBasic->get_member_id_by_name("my_string"));
@@ -1409,7 +1455,7 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_B)
     MemberId vId;
     MemberId ssId;
     MemberId sId;
-    DynamicData *my_map_octet_short = complex->loan_value(complex->get_member_id_by_name("my_map_octet_short"));
+    DynamicData* my_map_octet_short = complex->loan_value(complex->get_member_id_by_name("my_map_octet_short"));
     key_oct->set_byte_value(0);
     my_map_octet_short->insert_map_data(key_oct.get(), kId, vId);
     my_map_octet_short->set_int16_value((short)1340, vId);
@@ -1423,7 +1469,7 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_B)
 
     DynamicTypeBuilder_ptr long_builder = m_factory->create_int32_builder();
     DynamicData_ptr key(DynamicDataFactory::get_instance()->create_data(long_builder->build()));
-    DynamicData *my_map_long_struct = complex->loan_value(complex->get_member_id_by_name("my_map_long_struct"));
+    DynamicData* my_map_long_struct = complex->loan_value(complex->get_member_id_by_name("my_map_long_struct"));
 
     //DynamicData *mas3 = my_array_struct->loan_value(3);
     key = DynamicDataFactory::get_instance()->create_data(long_builder->build());
@@ -1449,7 +1495,7 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_B)
     key = DynamicDataFactory::get_instance()->create_data(long_builder->build());
     key->set_int32_value(1000);
     my_map_long_struct->insert_map_data(key.get(), kId, vId);
-    DynamicData *mas3 = my_map_long_struct->loan_value(vId);
+    DynamicData* mas3 = my_map_long_struct->loan_value(vId);
     int i = 3;
     mas3->set_bool_value(i % 2 == 1, mas3->get_member_id_by_name("my_bool"));
     mas3->set_byte_value(static_cast<uint8_t>(i), mas3->get_member_id_by_name("my_octet"));
@@ -1459,9 +1505,9 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_B)
     mas3->set_uint16_value(static_cast<uint8_t>(i), mas3->get_member_id_by_name("my_uint16"));
     mas3->set_uint32_value(i, mas3->get_member_id_by_name("my_uint32"));
     mas3->set_uint64_value(i * 10005, mas3->get_member_id_by_name("my_uint64"));
-    mas3->set_float32_value(i*5.5f, mas3->get_member_id_by_name("my_float32"));
-    mas3->set_float64_value(i*8.8, mas3->get_member_id_by_name("my_float64"));
-    mas3->set_float128_value(i*10.0, mas3->get_member_id_by_name("my_float128"));
+    mas3->set_float32_value(i * 5.5f, mas3->get_member_id_by_name("my_float32"));
+    mas3->set_float64_value(i * 8.8, mas3->get_member_id_by_name("my_float64"));
+    mas3->set_float128_value(i * 10.0, mas3->get_member_id_by_name("my_float128"));
     mas3->set_char8_value('J', mas3->get_member_id_by_name("my_char"));
     mas3->set_char16_value(L'C', mas3->get_member_id_by_name("my_wchar"));
     mas3->set_string_value("JC@eProsima", mas3->get_member_id_by_name("my_string"));
@@ -1472,26 +1518,26 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_B)
     // staticData.my_union().complex().my_map_long_struct()[55] = staticData.my_union().complex().my_basic_struct();
     complex->return_loaned_value(my_map_long_struct);
 
-    DynamicData *my_map_long_seq_octet = complex->loan_value(complex->get_member_id_by_name("my_map_long_seq_octet"));
+    DynamicData* my_map_long_seq_octet = complex->loan_value(complex->get_member_id_by_name("my_map_long_seq_octet"));
     //std::vector my_vector_octet = {1, 2, 3, 4, 5};
     //MemberId id;
     /*DynamicTypeBuilder_ptr octet_builder = m_factory->create_byte_builder();
-    types::DynamicTypeBuilder_ptr seqOctet_builder = m_factory->create_sequence_builder(octet_builder.get());
-    types::DynamicType_ptr seqSeqOctet_builder = m_factory->create_sequence_builder(seqOctet_builder.get())->build();
-    DynamicData *dataSeqOctet = seqOctet_builder->build();
-    DynamicData *dataSeqSeqOctet = seqSeqOctet_builder->build();
-    dataSeqOctet->insert_sequence_data(id);
-    dataSeqOctet->set_byte_value(1, id);
-    dataSeqOctet->insert_sequence_data(id);
-    dataSeqOctet->set_byte_value(2, id);
-    dataSeqOctet->insert_sequence_data(id);
-    dataSeqOctet->set_byte_value(3, id);
-    dataSeqOctet->insert_sequence_data(id);
-    dataSeqOctet->set_byte_value(4, id);
-    dataSeqOctet->insert_sequence_data(id);
-    dataSeqOctet->set_byte_value(5, id);
-    dataSeqSeqOctet->insert_sequence_data(id);
-    dataSeqSeqOctet->set_complex_value(dataSeqOctet, id);*/
+       types::DynamicTypeBuilder_ptr seqOctet_builder = m_factory->create_sequence_builder(octet_builder.get());
+       types::DynamicType_ptr seqSeqOctet_builder = m_factory->create_sequence_builder(seqOctet_builder.get())->build();
+       DynamicData *dataSeqOctet = seqOctet_builder->build();
+       DynamicData *dataSeqSeqOctet = seqSeqOctet_builder->build();
+       dataSeqOctet->insert_sequence_data(id);
+       dataSeqOctet->set_byte_value(1, id);
+       dataSeqOctet->insert_sequence_data(id);
+       dataSeqOctet->set_byte_value(2, id);
+       dataSeqOctet->insert_sequence_data(id);
+       dataSeqOctet->set_byte_value(3, id);
+       dataSeqOctet->insert_sequence_data(id);
+       dataSeqOctet->set_byte_value(4, id);
+       dataSeqOctet->insert_sequence_data(id);
+       dataSeqOctet->set_byte_value(5, id);
+       dataSeqSeqOctet->insert_sequence_data(id);
+       dataSeqSeqOctet->set_complex_value(dataSeqOctet, id);*/
     // insert_map_data(DynamicData_ptr key, MemberId& outKeyId, MemberId& outValueId);
     // TODO De la muerte para Juan Carlos - Esto no es NADA práctico...
 
@@ -1552,8 +1598,8 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_B)
     //staticData.my_union().complex().my_map_long_seq_octet()[0].push_back(my_vector_octet);
     complex->return_loaned_value(my_map_long_seq_octet);
 
-    DynamicData *my_map_long_octet_array_500 =
-        complex->loan_value(complex->get_member_id_by_name("my_map_long_octet_array_500"));
+    DynamicData* my_map_long_octet_array_500 =
+            complex->loan_value(complex->get_member_id_by_name("my_map_long_octet_array_500"));
 
     key = DynamicDataFactory::get_instance()->create_data(long_builder->build());
     key->set_int32_value(0);
@@ -1580,24 +1626,32 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_B)
     my_map_long_octet_array_500->return_loaned_value(oct_array_500);
     complex->return_loaned_value(my_map_long_octet_array_500);
 
-    complex->set_string_value("Bv7EMffURwGNqePoujdSfkF9PXN9TH125X5nGpNLfzya53tZtNJdgMROlYdZnTE1SLWzBdIU7ZyjjGvsGHkmuJUROwVPcNa9q5dRUV3KZAKNx1exL7BjhqIgQFconhd", complex->get_member_id_by_name("my_small_string_8"));
-    complex->set_wstring_value(L"AgzñgXsI9pXbWjYLDvvn8JUFWhxZhk9t92rdsTqylvdpqtXA6hy9dHkoBTgmF2c", complex->get_member_id_by_name("my_small_string_16"));
-    complex->set_string_value("hYE5vjcLJe6ML5DmoqQwh9ns866dAbnjkVKIKu2VF6lbkvh91ZOG2enEcdoRa8T43hR0Ym0k7tI621EQGufvzmLqxKCPgiXSp2zUTTmIWtn4fM8tC3aP1Yd0dKvn0tDobyp6p3156KvxqG3BKQ6VjFiHlMFoEyz8pjCclhXLl2cfAi97sQzXLUoPYUC5BWKyQTrA2JF6HXZM6vrbw5dc3B4AOJNGdPJ9ai6weF43h1RhnXE9MOFxPNoQnJ8gqSXYbMtpG6ZzqhUyoz0XhFDt7EOqXIgvc9SCejQTVMPeRcF5Zy57hrYZiKrCQqFWidS4BdfEAkuwESgBmEpEFOpZotwDt0TGDaLktSt3dKRsURO6TpuZ2nZNdiEJyc597ZjjQXtyKU7OCyRRqllzAnHEtoU3zd3OLTOvT5uk32N1Y64tpUte63De2EMwDNYb2eGAQfATdSt8VcGBOzJQjsmrMwMumtk48JzXXLxjo6s2vl2rNK9WQM1", complex->get_member_id_by_name("my_large_string_8"));
-    complex->set_wstring_value(L"nosYBfFr1s3t8rUsuUrVCWFi6moDk7GULFj6XnkebIDkjl3n2ykKxUIaLj3qNNUx0ny8DvFbdfxZBdMhBNW3fHbKrig4GkHnN1JoEo0ACiPxrARusDs3xKzvaQQrls6lVUFAUXzDOtw5f2CNVJKiruGjXUO2Lq5Mmy8ygW3eUiTlueAHA2dRXXryOFi47jS3DkmBH4aAOKcmR27KhhJnXaY0gWy3XdSnaGQNB3XvbmxQ7xXDsf1wz860WMEKP3VhdOLsmS6tKCb4sshuOlmUSyTggY7vNoxfpG1EUFP5iPro9E0tHLLdHlWf2NwU8OXCYx6KKEbs5pFMvgEstnQglsdTk0lOv6riaFkFOwx83gW1l6Pg4eXjacnJKoVh1pOeZxULLZpCECw8yRZ9z4JPHxh2C7ytkCHMKp9O4MwQwYvvvgWWLWfJgb7Ecy2tgvWLpNDzgkFrEFhaCTKitChlG422CnLSsXvTBNnF52sULH6rcwOVx3mbhqte3ld3fObtAuH3zPzjOF4vVbvUXxgZh1Zx1cey0iGfnhOZHUfUwJ3Qv0WZNcuVLvMMhhg85A3620b84MAIc2UoW9Hl4BIT7pHo41ApF0DxIPJL0QdIdAOjn0JTPZqAhoHVBQoYvivPHftk5Crd1a1J8L7hSs0s4uSQKAMTKDxy3gKLaGAg277h4iEsEZRCI4RPlPTo9nZ48s8OO2KzqrUbMkoPSTgaJEXq8GsozAzh0wtL4P3gPeHO5nQzoytoXAkiXoPph0GaTLiahYQksYeK1eVQADDqZPXC55teXKKdX4aomCufr1ZizgzkGwAmnsFmhmBSF0gvbm56NDaUVT0UqXxKxAfRjkILeWR1mW8jfn6RYJH3IWiHxEfyB23rr78NySfgzIchhrm7jEFtmwPpKPKAwzajLv0HpkrtTr38YwWeT5LzHokFAQEc6l3aWdJWapVyt9wX89dEkmPPG9torCV2ddjyF4jAKsxKvzU4pCxV6B3m16IIdnksemJ0xG8iKh4ZPsX", complex->get_member_id_by_name("my_large_string_16"));
+    complex->set_string_value(
+        "Bv7EMffURwGNqePoujdSfkF9PXN9TH125X5nGpNLfzya53tZtNJdgMROlYdZnTE1SLWzBdIU7ZyjjGvsGHkmuJUROwVPcNa9q5dRUV3KZAKNx1exL7BjhqIgQFconhd", complex->get_member_id_by_name(
+            "my_small_string_8"));
+    complex->set_wstring_value(L"AgzñgXsI9pXbWjYLDvvn8JUFWhxZhk9t92rdsTqylvdpqtXA6hy9dHkoBTgmF2c", complex->get_member_id_by_name(
+                "my_small_string_16"));
+    complex->set_string_value(
+        "hYE5vjcLJe6ML5DmoqQwh9ns866dAbnjkVKIKu2VF6lbkvh91ZOG2enEcdoRa8T43hR0Ym0k7tI621EQGufvzmLqxKCPgiXSp2zUTTmIWtn4fM8tC3aP1Yd0dKvn0tDobyp6p3156KvxqG3BKQ6VjFiHlMFoEyz8pjCclhXLl2cfAi97sQzXLUoPYUC5BWKyQTrA2JF6HXZM6vrbw5dc3B4AOJNGdPJ9ai6weF43h1RhnXE9MOFxPNoQnJ8gqSXYbMtpG6ZzqhUyoz0XhFDt7EOqXIgvc9SCejQTVMPeRcF5Zy57hrYZiKrCQqFWidS4BdfEAkuwESgBmEpEFOpZotwDt0TGDaLktSt3dKRsURO6TpuZ2nZNdiEJyc597ZjjQXtyKU7OCyRRqllzAnHEtoU3zd3OLTOvT5uk32N1Y64tpUte63De2EMwDNYb2eGAQfATdSt8VcGBOzJQjsmrMwMumtk48JzXXLxjo6s2vl2rNK9WQM1", complex->get_member_id_by_name(
+            "my_large_string_8"));
+    complex->set_wstring_value(
+        L"nosYBfFr1s3t8rUsuUrVCWFi6moDk7GULFj6XnkebIDkjl3n2ykKxUIaLj3qNNUx0ny8DvFbdfxZBdMhBNW3fHbKrig4GkHnN1JoEo0ACiPxrARusDs3xKzvaQQrls6lVUFAUXzDOtw5f2CNVJKiruGjXUO2Lq5Mmy8ygW3eUiTlueAHA2dRXXryOFi47jS3DkmBH4aAOKcmR27KhhJnXaY0gWy3XdSnaGQNB3XvbmxQ7xXDsf1wz860WMEKP3VhdOLsmS6tKCb4sshuOlmUSyTggY7vNoxfpG1EUFP5iPro9E0tHLLdHlWf2NwU8OXCYx6KKEbs5pFMvgEstnQglsdTk0lOv6riaFkFOwx83gW1l6Pg4eXjacnJKoVh1pOeZxULLZpCECw8yRZ9z4JPHxh2C7ytkCHMKp9O4MwQwYvvvgWWLWfJgb7Ecy2tgvWLpNDzgkFrEFhaCTKitChlG422CnLSsXvTBNnF52sULH6rcwOVx3mbhqte3ld3fObtAuH3zPzjOF4vVbvUXxgZh1Zx1cey0iGfnhOZHUfUwJ3Qv0WZNcuVLvMMhhg85A3620b84MAIc2UoW9Hl4BIT7pHo41ApF0DxIPJL0QdIdAOjn0JTPZqAhoHVBQoYvivPHftk5Crd1a1J8L7hSs0s4uSQKAMTKDxy3gKLaGAg277h4iEsEZRCI4RPlPTo9nZ48s8OO2KzqrUbMkoPSTgaJEXq8GsozAzh0wtL4P3gPeHO5nQzoytoXAkiXoPph0GaTLiahYQksYeK1eVQADDqZPXC55teXKKdX4aomCufr1ZizgzkGwAmnsFmhmBSF0gvbm56NDaUVT0UqXxKxAfRjkILeWR1mW8jfn6RYJH3IWiHxEfyB23rr78NySfgzIchhrm7jEFtmwPpKPKAwzajLv0HpkrtTr38YwWeT5LzHokFAQEc6l3aWdJWapVyt9wX89dEkmPPG9torCV2ddjyF4jAKsxKvzU4pCxV6B3m16IIdnksemJ0xG8iKh4ZPsX", complex->get_member_id_by_name(
+            "my_large_string_16"));
 
-    DynamicData *my_array_string = complex->loan_value(complex->get_member_id_by_name("my_array_string"));
+    DynamicData* my_array_string = complex->loan_value(complex->get_member_id_by_name("my_array_string"));
     for (unsigned int j = 0; j < 5; ++j)
     {
         for (unsigned int k = 0; k < 5; ++k)
         {
             MemberId array_idx = my_array_string->get_array_index({ j, k });
-            my_array_string->set_string_value("Ee4rH8nSX1xnWrlDqDJjKWtWntMia9RrZqZPznr0yIDjeroWxUUzpPVV8UK4qUF4eilYR3Dz42", array_idx);
+            my_array_string->set_string_value(
+                "Ee4rH8nSX1xnWrlDqDJjKWtWntMia9RrZqZPznr0yIDjeroWxUUzpPVV8UK4qUF4eilYR3Dz42", array_idx);
             //staticData.my_union().complex().my_array_string()[i][j]("Ee4rH8nSX1xnWrlDqDJjKWtWntMia9RrZqZPznr0yIDjeroWxUUzpPVV8UK4qUF4eilYR3Dz42");
         }
     }
     complex->return_loaned_value(my_array_string);
 
-    DynamicData *multi_alias_array_42 = complex->loan_value(complex->get_member_id_by_name("multi_alias_array_42"));
+    DynamicData* multi_alias_array_42 = complex->loan_value(complex->get_member_id_by_name("multi_alias_array_42"));
     for (int j = 0; j < 42; ++j)
     {
         multi_alias_array_42->set_enum_value(j % 3, j);
@@ -1605,23 +1659,23 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_B)
     }
     complex->return_loaned_value(multi_alias_array_42);
 
-    DynamicData *my_array_arrays = complex->loan_value(complex->get_member_id_by_name("my_array_arrays"));
+    DynamicData* my_array_arrays = complex->loan_value(complex->get_member_id_by_name("my_array_arrays"));
     for (unsigned int j = 0; j < 5; ++j)
     {
-        DynamicData *myMiniArray = my_array_arrays->loan_value(j);
+        DynamicData* myMiniArray = my_array_arrays->loan_value(j);
         for (unsigned int k = 0; k < 2; ++k)
         {
-            myMiniArray->set_int32_value(j*k, k);
+            myMiniArray->set_int32_value(j * k, k);
             //staticData.my_union().complex().my_array_arrays()[i][j](i*j);
         }
         my_array_arrays->return_loaned_value(myMiniArray);
     }
     complex->return_loaned_value(my_array_arrays);
 
-    DynamicData *my_sequences_array = complex->loan_value(complex->get_member_id_by_name("my_sequences_array"));
+    DynamicData* my_sequences_array = complex->loan_value(complex->get_member_id_by_name("my_sequences_array"));
     for (int j = 0; j < 23; ++j)
     {
-        DynamicData *seq = DynamicDataFactory::get_instance()->create_data(GetMySequenceLongType());
+        DynamicData* seq = DynamicDataFactory::get_instance()->create_data(GetMySequenceLongType());
         seq->insert_sequence_data(id);
         seq->set_int32_value(j, id);
         seq->insert_sequence_data(id);
@@ -1638,7 +1692,7 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_B)
     my_union->return_loaned_value(complex);
     dynData->return_loaned_value(my_union);
 
-    DynamicData *my_union_2 = dynData->loan_value(dynData->get_member_id_by_name("my_union_2"));
+    DynamicData* my_union_2 = dynData->loan_value(dynData->get_member_id_by_name("my_union_2"));
     my_union_2->set_string_value("GASCO!", my_union_2->get_member_id_by_name("imString"));
 
     dynData->return_loaned_value(my_union_2);
@@ -1699,7 +1753,7 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_C)
         {
             for (int k = 0; k < 4; ++k)
             {
-                staticData.my_union().complex().my_array_octet()[i][j][k] = static_cast<uint8_t>(j*k);
+                staticData.my_union().complex().my_array_octet()[i][j][k] = static_cast<uint8_t>(j * k);
             }
         }
     }
@@ -1714,9 +1768,9 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_C)
         staticData.my_union().complex().my_array_struct()[i].my_uint16(static_cast<uint16_t>(i));
         staticData.my_union().complex().my_array_struct()[i].my_uint32(i);
         staticData.my_union().complex().my_array_struct()[i].my_uint64(i * 10005);
-        staticData.my_union().complex().my_array_struct()[i].my_float32(i*5.5f);
-        staticData.my_union().complex().my_array_struct()[i].my_float64(i*8.8);
-        staticData.my_union().complex().my_array_struct()[i].my_float128(i*10.0);
+        staticData.my_union().complex().my_array_struct()[i].my_float32(i * 5.5f);
+        staticData.my_union().complex().my_array_struct()[i].my_float64(i * 8.8);
+        staticData.my_union().complex().my_array_struct()[i].my_float128(i * 10.0);
         staticData.my_union().complex().my_array_struct()[i].my_char('J');
         staticData.my_union().complex().my_array_struct()[i].my_wchar(L'C');
         staticData.my_union().complex().my_array_struct()[i].my_string("JC@eProsima");
@@ -1737,21 +1791,32 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_C)
         staticData.my_union().complex().my_map_long_octet_array_500()[10][i] = (i + 55) % 256;
     }
 
-    staticData.my_union().complex().my_small_string_8("Bv7EMffURwGNqePoujdSfkF9PXN9TH125X5nGpNLfzya53tZtNJdgMROlYdZnTE1SLWzBdIU7ZyjjGvsGHkmuJUROwVPcNa9q5dRUV3KZAKNx1exL7BjhqIgQFconhd");
-    staticData.my_union().complex().my_small_string_16(L"AgzñgXsI9pXbWjYLDvvn8JUFWhxZhk9t92rdsTqylvdpqtXA6hy9dHkoBTgmF2c");
-    staticData.my_union().complex().my_large_string_8("hYE5vjcLJe6ML5DmoqQwh9ns866dAbnjkVKIKu2VF6lbkvh91ZOG2enEcdoRa8T43hR0Ym0k7tI621EQGufvzmLqxKCPgiXSp2zUTTmIWtn4fM8tC3aP1Yd0dKvn0tDobyp6p3156KvxqG3BKQ6VjFiHlMFoEyz8pjCclhXLl2cfAi97sQzXLUoPYUC5BWKyQTrA2JF6HXZM6vrbw5dc3B4AOJNGdPJ9ai6weF43h1RhnXE9MOFxPNoQnJ8gqSXYbMtpG6ZzqhUyoz0XhFDt7EOqXIgvc9SCejQTVMPeRcF5Zy57hrYZiKrCQqFWidS4BdfEAkuwESgBmEpEFOpZotwDt0TGDaLktSt3dKRsURO6TpuZ2nZNdiEJyc597ZjjQXtyKU7OCyRRqllzAnHEtoU3zd3OLTOvT5uk32N1Y64tpUte63De2EMwDNYb2eGAQfATdSt8VcGBOzJQjsmrMwMumtk48JzXXLxjo6s2vl2rNK9WQM1");
-    staticData.my_union().complex().my_large_string_16(L"nosYBfFr1s3t8rUsuUrVCWFi6moDk7GULFj6XnkebIDkjl3n2ykKxUIaLj3qNNUx0ny8DvFbdfxZBdMhBNW3fHbKrig4GkHnN1JoEo0ACiPxrARusDs3xKzvaQQrls6lVUFAUXzDOtw5f2CNVJKiruGjXUO2Lq5Mmy8ygW3eUiTlueAHA2dRXXryOFi47jS3DkmBH4aAOKcmR27KhhJnXaY0gWy3XdSnaGQNB3XvbmxQ7xXDsf1wz860WMEKP3VhdOLsmS6tKCb4sshuOlmUSyTggY7vNoxfpG1EUFP5iPro9E0tHLLdHlWf2NwU8OXCYx6KKEbs5pFMvgEstnQglsdTk0lOv6riaFkFOwx83gW1l6Pg4eXjacnJKoVh1pOeZxULLZpCECw8yRZ9z4JPHxh2C7ytkCHMKp9O4MwQwYvvvgWWLWfJgb7Ecy2tgvWLpNDzgkFrEFhaCTKitChlG422CnLSsXvTBNnF52sULH6rcwOVx3mbhqte3ld3fObtAuH3zPzjOF4vVbvUXxgZh1Zx1cey0iGfnhOZHUfUwJ3Qv0WZNcuVLvMMhhg85A3620b84MAIc2UoW9Hl4BIT7pHo41ApF0DxIPJL0QdIdAOjn0JTPZqAhoHVBQoYvivPHftk5Crd1a1J8L7hSs0s4uSQKAMTKDxy3gKLaGAg277h4iEsEZRCI4RPlPTo9nZ48s8OO2KzqrUbMkoPSTgaJEXq8GsozAzh0wtL4P3gPeHO5nQzoytoXAkiXoPph0GaTLiahYQksYeK1eVQADDqZPXC55teXKKdX4aomCufr1ZizgzkGwAmnsFmhmBSF0gvbm56NDaUVT0UqXxKxAfRjkILeWR1mW8jfn6RYJH3IWiHxEfyB23rr78NySfgzIchhrm7jEFtmwPpKPKAwzajLv0HpkrtTr38YwWeT5LzHokFAQEc6l3aWdJWapVyt9wX89dEkmPPG9torCV2ddjyF4jAKsxKvzU4pCxV6B3m16IIdnksemJ0xG8iKh4ZPsX");
+    staticData.my_union().complex().my_small_string_8(
+        "Bv7EMffURwGNqePoujdSfkF9PXN9TH125X5nGpNLfzya53tZtNJdgMROlYdZnTE1SLWzBdIU7ZyjjGvsGHkmuJUROwVPcNa9q5dRUV3KZAKNx1exL7BjhqIgQFconhd");
+    staticData.my_union().complex().my_small_string_16(
+        L"AgzñgXsI9pXbWjYLDvvn8JUFWhxZhk9t92rdsTqylvdpqtXA6hy9dHkoBTgmF2c");
+    staticData.my_union().complex().my_large_string_8(
+        "hYE5vjcLJe6ML5DmoqQwh9ns866dAbnjkVKIKu2VF6lbkvh91ZOG2enEcdoRa8T43hR0Ym0k7tI621EQGufvzmLqxKCPgiXSp2zUTTmIWtn4fM8tC3aP1Yd0dKvn0tDobyp6p3156KvxqG3BKQ6VjFiHlMFoEyz8pjCclhXLl2cfAi97sQzXLUoPYUC5BWKyQTrA2JF6HXZM6vrbw5dc3B4AOJNGdPJ9ai6weF43h1RhnXE9MOFxPNoQnJ8gqSXYbMtpG6ZzqhUyoz0XhFDt7EOqXIgvc9SCejQTVMPeRcF5Zy57hrYZiKrCQqFWidS4BdfEAkuwESgBmEpEFOpZotwDt0TGDaLktSt3dKRsURO6TpuZ2nZNdiEJyc597ZjjQXtyKU7OCyRRqllzAnHEtoU3zd3OLTOvT5uk32N1Y64tpUte63De2EMwDNYb2eGAQfATdSt8VcGBOzJQjsmrMwMumtk48JzXXLxjo6s2vl2rNK9WQM1");
+    staticData.my_union().complex().my_large_string_16(
+        L"nosYBfFr1s3t8rUsuUrVCWFi6moDk7GULFj6XnkebIDkjl3n2ykKxUIaLj3qNNUx0ny8DvFbdfxZBdMhBNW3fHbKrig4GkHnN1JoEo0ACiPxrARusDs3xKzvaQQrls6lVUFAUXzDOtw5f2CNVJKiruGjXUO2Lq5Mmy8ygW3eUiTlueAHA2dRXXryOFi47jS3DkmBH4aAOKcmR27KhhJnXaY0gWy3XdSnaGQNB3XvbmxQ7xXDsf1wz860WMEKP3VhdOLsmS6tKCb4sshuOlmUSyTggY7vNoxfpG1EUFP5iPro9E0tHLLdHlWf2NwU8OXCYx6KKEbs5pFMvgEstnQglsdTk0lOv6riaFkFOwx83gW1l6Pg4eXjacnJKoVh1pOeZxULLZpCECw8yRZ9z4JPHxh2C7ytkCHMKp9O4MwQwYvvvgWWLWfJgb7Ecy2tgvWLpNDzgkFrEFhaCTKitChlG422CnLSsXvTBNnF52sULH6rcwOVx3mbhqte3ld3fObtAuH3zPzjOF4vVbvUXxgZh1Zx1cey0iGfnhOZHUfUwJ3Qv0WZNcuVLvMMhhg85A3620b84MAIc2UoW9Hl4BIT7pHo41ApF0DxIPJL0QdIdAOjn0JTPZqAhoHVBQoYvivPHftk5Crd1a1J8L7hSs0s4uSQKAMTKDxy3gKLaGAg277h4iEsEZRCI4RPlPTo9nZ48s8OO2KzqrUbMkoPSTgaJEXq8GsozAzh0wtL4P3gPeHO5nQzoytoXAkiXoPph0GaTLiahYQksYeK1eVQADDqZPXC55teXKKdX4aomCufr1ZizgzkGwAmnsFmhmBSF0gvbm56NDaUVT0UqXxKxAfRjkILeWR1mW8jfn6RYJH3IWiHxEfyB23rr78NySfgzIchhrm7jEFtmwPpKPKAwzajLv0HpkrtTr38YwWeT5LzHokFAQEc6l3aWdJWapVyt9wX89dEkmPPG9torCV2ddjyF4jAKsxKvzU4pCxV6B3m16IIdnksemJ0xG8iKh4ZPsX");
     for (int i = 0; i < 5; ++i)
+    {
         for (int j = 0; j < 5; ++j)
-            staticData.my_union().complex().my_array_string()[i][j] = "Ee4rH8nSX1xnWrlDqDJjKWtWntMia9RrZqZPznr0yIDjeroWxUUzpPVV8UK4qUF4eilYR3Dz42";
+        {
+            staticData.my_union().complex().my_array_string()[i][j] =
+                    "Ee4rH8nSX1xnWrlDqDJjKWtWntMia9RrZqZPznr0yIDjeroWxUUzpPVV8UK4qUF4eilYR3Dz42";
+        }
+    }
     for (int i = 0; i < 42; ++i)
+    {
         staticData.my_union().complex().multi_alias_array_42()[i] = (MyEnum)(i % 3);
+    }
 
     for (int i = 0; i < 5; ++i)
     {
         for (int j = 0; j < 2; ++j)
         {
-            staticData.my_union().complex().my_array_arrays()[i][j] = i*j;
+            staticData.my_union().complex().my_array_arrays()[i][j] = i * j;
         }
     }
 
@@ -1763,12 +1828,12 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_C)
     }
     staticData.my_union_2().tres(156);
 
-    DynamicData *my_union = dynData->loan_value(dynData->get_member_id_by_name("my_union"));
+    DynamicData* my_union = dynData->loan_value(dynData->get_member_id_by_name("my_union"));
 
-    DynamicData *complex = my_union->loan_value(my_union->get_member_id_by_name("complex"));
+    DynamicData* complex = my_union->loan_value(my_union->get_member_id_by_name("complex"));
     complex->set_byte_value(66, complex->get_member_id_by_name("my_octet"));
 
-    DynamicData *basic = complex->loan_value(complex->get_member_id_by_name("my_basic_struct"));
+    DynamicData* basic = complex->loan_value(complex->get_member_id_by_name("my_basic_struct"));
     basic->set_bool_value(true, basic->get_member_id_by_name("my_bool"));
     basic->set_byte_value(166, basic->get_member_id_by_name("my_octet"));
     basic->set_int16_value(-10401, basic->get_member_id_by_name("my_int16"));
@@ -1789,7 +1854,7 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_C)
     complex->set_enum_value("C", complex->get_member_id_by_name("my_alias_enum"));
     complex->set_enum_value("B", complex->get_member_id_by_name("my_enum"));
 
-    DynamicData *my_seq_octet = complex->loan_value(complex->get_member_id_by_name("my_sequence_octet"));
+    DynamicData* my_seq_octet = complex->loan_value(complex->get_member_id_by_name("my_sequence_octet"));
     MemberId id;
     my_seq_octet->insert_sequence_data(id);
     my_seq_octet->set_byte_value(88, id);
@@ -1799,13 +1864,13 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_C)
     //staticData.my_union().complex().my_sequence_octet().push_back(99);
     complex->return_loaned_value(my_seq_octet);
 
-    DynamicData *my_seq_struct = complex->loan_value(complex->get_member_id_by_name("my_sequence_struct"));
+    DynamicData* my_seq_struct = complex->loan_value(complex->get_member_id_by_name("my_sequence_struct"));
     my_seq_struct->insert_sequence_data(id);
     my_seq_struct->set_complex_value(DynamicDataFactory::get_instance()->create_copy(basic), id);
     //staticData.my_union().complex().my_sequence_struct().push_back(staticData.my_union().complex().my_basic_struct());
     complex->return_loaned_value(my_seq_struct);
 
-    DynamicData *my_array_octet = complex->loan_value(complex->get_member_id_by_name("my_array_octet"));
+    DynamicData* my_array_octet = complex->loan_value(complex->get_member_id_by_name("my_array_octet"));
     for (unsigned int i = 0; i < 500; ++i)
     {
         for (unsigned int j = 0; j < 5; ++j)
@@ -1813,17 +1878,17 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_C)
             for (unsigned int k = 0; k < 4; ++k)
             {
                 MemberId array_idx = my_array_octet->get_array_index({ i, j, k });
-                my_array_octet->set_byte_value(static_cast<uint8_t>(j*k), array_idx);
+                my_array_octet->set_byte_value(static_cast<uint8_t>(j * k), array_idx);
             }
         }
         //staticData.my_union().complex().my_array_octet()[i][j][k] = j*k;
     }
     complex->return_loaned_value(my_array_octet);
 
-    DynamicData *my_array_struct = complex->loan_value(complex->get_member_id_by_name("my_array_struct"));
+    DynamicData* my_array_struct = complex->loan_value(complex->get_member_id_by_name("my_array_struct"));
     for (int i = 0; i < 5; ++i)
     {
-        DynamicData *tempBasic = DynamicDataFactory::get_instance()->create_data(GetBasicStructType());
+        DynamicData* tempBasic = DynamicDataFactory::get_instance()->create_data(GetBasicStructType());
         tempBasic->set_bool_value(i % 2 == 1, tempBasic->get_member_id_by_name("my_bool"));
         tempBasic->set_byte_value(static_cast<uint8_t>(i), tempBasic->get_member_id_by_name("my_octet"));
         tempBasic->set_int16_value(static_cast<int16_t>(-i), tempBasic->get_member_id_by_name("my_int16"));
@@ -1832,9 +1897,9 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_C)
         tempBasic->set_uint16_value(static_cast<uint16_t>(i), tempBasic->get_member_id_by_name("my_uint16"));
         tempBasic->set_uint32_value(i, tempBasic->get_member_id_by_name("my_uint32"));
         tempBasic->set_uint64_value(i * 10005, tempBasic->get_member_id_by_name("my_uint64"));
-        tempBasic->set_float32_value(i*5.5f, tempBasic->get_member_id_by_name("my_float32"));
-        tempBasic->set_float64_value(i*8.8, tempBasic->get_member_id_by_name("my_float64"));
-        tempBasic->set_float128_value(i*10.0, tempBasic->get_member_id_by_name("my_float128"));
+        tempBasic->set_float32_value(i * 5.5f, tempBasic->get_member_id_by_name("my_float32"));
+        tempBasic->set_float64_value(i * 8.8, tempBasic->get_member_id_by_name("my_float64"));
+        tempBasic->set_float128_value(i * 10.0, tempBasic->get_member_id_by_name("my_float128"));
         tempBasic->set_char8_value('J', tempBasic->get_member_id_by_name("my_char"));
         tempBasic->set_char16_value(L'C', tempBasic->get_member_id_by_name("my_wchar"));
         tempBasic->set_string_value("JC@eProsima", tempBasic->get_member_id_by_name("my_string"));
@@ -1849,7 +1914,7 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_C)
     MemberId vId;
     MemberId ssId;
     MemberId sId;
-    DynamicData *my_map_octet_short = complex->loan_value(complex->get_member_id_by_name("my_map_octet_short"));
+    DynamicData* my_map_octet_short = complex->loan_value(complex->get_member_id_by_name("my_map_octet_short"));
     key_oct->set_byte_value(0);
     my_map_octet_short->insert_map_data(key_oct.get(), kId, vId);
     my_map_octet_short->set_int16_value((short)1340, vId);
@@ -1863,7 +1928,7 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_C)
 
     DynamicTypeBuilder_ptr long_builder = m_factory->create_int32_builder();
     DynamicData_ptr key(DynamicDataFactory::get_instance()->create_data(long_builder->build()));
-    DynamicData *my_map_long_struct = complex->loan_value(complex->get_member_id_by_name("my_map_long_struct"));
+    DynamicData* my_map_long_struct = complex->loan_value(complex->get_member_id_by_name("my_map_long_struct"));
 
     //DynamicData *mas3 = my_array_struct->loan_value(3);
     key = DynamicDataFactory::get_instance()->create_data(long_builder->build());
@@ -1889,7 +1954,7 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_C)
     key = DynamicDataFactory::get_instance()->create_data(long_builder->build());
     key->set_int32_value(1000);
     my_map_long_struct->insert_map_data(key.get(), kId, vId);
-    DynamicData *mas3 = my_map_long_struct->loan_value(vId);
+    DynamicData* mas3 = my_map_long_struct->loan_value(vId);
     int i = 3;
     mas3->set_bool_value(i % 2 == 1, mas3->get_member_id_by_name("my_bool"));
     mas3->set_byte_value(static_cast<uint8_t>(i), mas3->get_member_id_by_name("my_octet"));
@@ -1899,9 +1964,9 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_C)
     mas3->set_uint16_value(static_cast<uint8_t>(i), mas3->get_member_id_by_name("my_uint16"));
     mas3->set_uint32_value(i, mas3->get_member_id_by_name("my_uint32"));
     mas3->set_uint64_value(i * 10005, mas3->get_member_id_by_name("my_uint64"));
-    mas3->set_float32_value(i*5.5f, mas3->get_member_id_by_name("my_float32"));
-    mas3->set_float64_value(i*8.8, mas3->get_member_id_by_name("my_float64"));
-    mas3->set_float128_value(i*10.0, mas3->get_member_id_by_name("my_float128"));
+    mas3->set_float32_value(i * 5.5f, mas3->get_member_id_by_name("my_float32"));
+    mas3->set_float64_value(i * 8.8, mas3->get_member_id_by_name("my_float64"));
+    mas3->set_float128_value(i * 10.0, mas3->get_member_id_by_name("my_float128"));
     mas3->set_char8_value('J', mas3->get_member_id_by_name("my_char"));
     mas3->set_char16_value(L'C', mas3->get_member_id_by_name("my_wchar"));
     mas3->set_string_value("JC@eProsima", mas3->get_member_id_by_name("my_string"));
@@ -1912,26 +1977,26 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_C)
     // staticData.my_union().complex().my_map_long_struct()[55] = staticData.my_union().complex().my_basic_struct();
     complex->return_loaned_value(my_map_long_struct);
 
-    DynamicData *my_map_long_seq_octet = complex->loan_value(complex->get_member_id_by_name("my_map_long_seq_octet"));
+    DynamicData* my_map_long_seq_octet = complex->loan_value(complex->get_member_id_by_name("my_map_long_seq_octet"));
     //std::vector my_vector_octet = {1, 2, 3, 4, 5};
     //MemberId id;
     /*DynamicTypeBuilder_ptr octet_builder = m_factory->create_byte_builder();
-    types::DynamicTypeBuilder_ptr seqOctet_builder = m_factory->create_sequence_builder(octet_builder.get());
-    types::DynamicType_ptr seqSeqOctet_builder = m_factory->create_sequence_builder(seqOctet_builder.get())->build();
-    DynamicData *dataSeqOctet = seqOctet_builder->build();
-    DynamicData *dataSeqSeqOctet = seqSeqOctet_builder->build();
-    dataSeqOctet->insert_sequence_data(id);
-    dataSeqOctet->set_byte_value(1, id);
-    dataSeqOctet->insert_sequence_data(id);
-    dataSeqOctet->set_byte_value(2, id);
-    dataSeqOctet->insert_sequence_data(id);
-    dataSeqOctet->set_byte_value(3, id);
-    dataSeqOctet->insert_sequence_data(id);
-    dataSeqOctet->set_byte_value(4, id);
-    dataSeqOctet->insert_sequence_data(id);
-    dataSeqOctet->set_byte_value(5, id);
-    dataSeqSeqOctet->insert_sequence_data(id);
-    dataSeqSeqOctet->set_complex_value(dataSeqOctet, id);*/
+       types::DynamicTypeBuilder_ptr seqOctet_builder = m_factory->create_sequence_builder(octet_builder.get());
+       types::DynamicType_ptr seqSeqOctet_builder = m_factory->create_sequence_builder(seqOctet_builder.get())->build();
+       DynamicData *dataSeqOctet = seqOctet_builder->build();
+       DynamicData *dataSeqSeqOctet = seqSeqOctet_builder->build();
+       dataSeqOctet->insert_sequence_data(id);
+       dataSeqOctet->set_byte_value(1, id);
+       dataSeqOctet->insert_sequence_data(id);
+       dataSeqOctet->set_byte_value(2, id);
+       dataSeqOctet->insert_sequence_data(id);
+       dataSeqOctet->set_byte_value(3, id);
+       dataSeqOctet->insert_sequence_data(id);
+       dataSeqOctet->set_byte_value(4, id);
+       dataSeqOctet->insert_sequence_data(id);
+       dataSeqOctet->set_byte_value(5, id);
+       dataSeqSeqOctet->insert_sequence_data(id);
+       dataSeqSeqOctet->set_complex_value(dataSeqOctet, id);*/
     // insert_map_data(DynamicData_ptr key, MemberId& outKeyId, MemberId& outValueId);
     // TODO De la muerte para Juan Carlos - Esto no es NADA práctico...
 
@@ -1992,8 +2057,8 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_C)
     //staticData.my_union().complex().my_map_long_seq_octet()[0].push_back(my_vector_octet);
     complex->return_loaned_value(my_map_long_seq_octet);
 
-    DynamicData *my_map_long_octet_array_500 =
-        complex->loan_value(complex->get_member_id_by_name("my_map_long_octet_array_500"));
+    DynamicData* my_map_long_octet_array_500 =
+            complex->loan_value(complex->get_member_id_by_name("my_map_long_octet_array_500"));
 
     key = DynamicDataFactory::get_instance()->create_data(long_builder->build());
     key->set_int32_value(0);
@@ -2020,24 +2085,32 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_C)
     my_map_long_octet_array_500->return_loaned_value(oct_array_500);
     complex->return_loaned_value(my_map_long_octet_array_500);
 
-    complex->set_string_value("Bv7EMffURwGNqePoujdSfkF9PXN9TH125X5nGpNLfzya53tZtNJdgMROlYdZnTE1SLWzBdIU7ZyjjGvsGHkmuJUROwVPcNa9q5dRUV3KZAKNx1exL7BjhqIgQFconhd", complex->get_member_id_by_name("my_small_string_8"));
-    complex->set_wstring_value(L"AgzñgXsI9pXbWjYLDvvn8JUFWhxZhk9t92rdsTqylvdpqtXA6hy9dHkoBTgmF2c", complex->get_member_id_by_name("my_small_string_16"));
-    complex->set_string_value("hYE5vjcLJe6ML5DmoqQwh9ns866dAbnjkVKIKu2VF6lbkvh91ZOG2enEcdoRa8T43hR0Ym0k7tI621EQGufvzmLqxKCPgiXSp2zUTTmIWtn4fM8tC3aP1Yd0dKvn0tDobyp6p3156KvxqG3BKQ6VjFiHlMFoEyz8pjCclhXLl2cfAi97sQzXLUoPYUC5BWKyQTrA2JF6HXZM6vrbw5dc3B4AOJNGdPJ9ai6weF43h1RhnXE9MOFxPNoQnJ8gqSXYbMtpG6ZzqhUyoz0XhFDt7EOqXIgvc9SCejQTVMPeRcF5Zy57hrYZiKrCQqFWidS4BdfEAkuwESgBmEpEFOpZotwDt0TGDaLktSt3dKRsURO6TpuZ2nZNdiEJyc597ZjjQXtyKU7OCyRRqllzAnHEtoU3zd3OLTOvT5uk32N1Y64tpUte63De2EMwDNYb2eGAQfATdSt8VcGBOzJQjsmrMwMumtk48JzXXLxjo6s2vl2rNK9WQM1", complex->get_member_id_by_name("my_large_string_8"));
-    complex->set_wstring_value(L"nosYBfFr1s3t8rUsuUrVCWFi6moDk7GULFj6XnkebIDkjl3n2ykKxUIaLj3qNNUx0ny8DvFbdfxZBdMhBNW3fHbKrig4GkHnN1JoEo0ACiPxrARusDs3xKzvaQQrls6lVUFAUXzDOtw5f2CNVJKiruGjXUO2Lq5Mmy8ygW3eUiTlueAHA2dRXXryOFi47jS3DkmBH4aAOKcmR27KhhJnXaY0gWy3XdSnaGQNB3XvbmxQ7xXDsf1wz860WMEKP3VhdOLsmS6tKCb4sshuOlmUSyTggY7vNoxfpG1EUFP5iPro9E0tHLLdHlWf2NwU8OXCYx6KKEbs5pFMvgEstnQglsdTk0lOv6riaFkFOwx83gW1l6Pg4eXjacnJKoVh1pOeZxULLZpCECw8yRZ9z4JPHxh2C7ytkCHMKp9O4MwQwYvvvgWWLWfJgb7Ecy2tgvWLpNDzgkFrEFhaCTKitChlG422CnLSsXvTBNnF52sULH6rcwOVx3mbhqte3ld3fObtAuH3zPzjOF4vVbvUXxgZh1Zx1cey0iGfnhOZHUfUwJ3Qv0WZNcuVLvMMhhg85A3620b84MAIc2UoW9Hl4BIT7pHo41ApF0DxIPJL0QdIdAOjn0JTPZqAhoHVBQoYvivPHftk5Crd1a1J8L7hSs0s4uSQKAMTKDxy3gKLaGAg277h4iEsEZRCI4RPlPTo9nZ48s8OO2KzqrUbMkoPSTgaJEXq8GsozAzh0wtL4P3gPeHO5nQzoytoXAkiXoPph0GaTLiahYQksYeK1eVQADDqZPXC55teXKKdX4aomCufr1ZizgzkGwAmnsFmhmBSF0gvbm56NDaUVT0UqXxKxAfRjkILeWR1mW8jfn6RYJH3IWiHxEfyB23rr78NySfgzIchhrm7jEFtmwPpKPKAwzajLv0HpkrtTr38YwWeT5LzHokFAQEc6l3aWdJWapVyt9wX89dEkmPPG9torCV2ddjyF4jAKsxKvzU4pCxV6B3m16IIdnksemJ0xG8iKh4ZPsX", complex->get_member_id_by_name("my_large_string_16"));
+    complex->set_string_value(
+        "Bv7EMffURwGNqePoujdSfkF9PXN9TH125X5nGpNLfzya53tZtNJdgMROlYdZnTE1SLWzBdIU7ZyjjGvsGHkmuJUROwVPcNa9q5dRUV3KZAKNx1exL7BjhqIgQFconhd", complex->get_member_id_by_name(
+            "my_small_string_8"));
+    complex->set_wstring_value(L"AgzñgXsI9pXbWjYLDvvn8JUFWhxZhk9t92rdsTqylvdpqtXA6hy9dHkoBTgmF2c", complex->get_member_id_by_name(
+                "my_small_string_16"));
+    complex->set_string_value(
+        "hYE5vjcLJe6ML5DmoqQwh9ns866dAbnjkVKIKu2VF6lbkvh91ZOG2enEcdoRa8T43hR0Ym0k7tI621EQGufvzmLqxKCPgiXSp2zUTTmIWtn4fM8tC3aP1Yd0dKvn0tDobyp6p3156KvxqG3BKQ6VjFiHlMFoEyz8pjCclhXLl2cfAi97sQzXLUoPYUC5BWKyQTrA2JF6HXZM6vrbw5dc3B4AOJNGdPJ9ai6weF43h1RhnXE9MOFxPNoQnJ8gqSXYbMtpG6ZzqhUyoz0XhFDt7EOqXIgvc9SCejQTVMPeRcF5Zy57hrYZiKrCQqFWidS4BdfEAkuwESgBmEpEFOpZotwDt0TGDaLktSt3dKRsURO6TpuZ2nZNdiEJyc597ZjjQXtyKU7OCyRRqllzAnHEtoU3zd3OLTOvT5uk32N1Y64tpUte63De2EMwDNYb2eGAQfATdSt8VcGBOzJQjsmrMwMumtk48JzXXLxjo6s2vl2rNK9WQM1", complex->get_member_id_by_name(
+            "my_large_string_8"));
+    complex->set_wstring_value(
+        L"nosYBfFr1s3t8rUsuUrVCWFi6moDk7GULFj6XnkebIDkjl3n2ykKxUIaLj3qNNUx0ny8DvFbdfxZBdMhBNW3fHbKrig4GkHnN1JoEo0ACiPxrARusDs3xKzvaQQrls6lVUFAUXzDOtw5f2CNVJKiruGjXUO2Lq5Mmy8ygW3eUiTlueAHA2dRXXryOFi47jS3DkmBH4aAOKcmR27KhhJnXaY0gWy3XdSnaGQNB3XvbmxQ7xXDsf1wz860WMEKP3VhdOLsmS6tKCb4sshuOlmUSyTggY7vNoxfpG1EUFP5iPro9E0tHLLdHlWf2NwU8OXCYx6KKEbs5pFMvgEstnQglsdTk0lOv6riaFkFOwx83gW1l6Pg4eXjacnJKoVh1pOeZxULLZpCECw8yRZ9z4JPHxh2C7ytkCHMKp9O4MwQwYvvvgWWLWfJgb7Ecy2tgvWLpNDzgkFrEFhaCTKitChlG422CnLSsXvTBNnF52sULH6rcwOVx3mbhqte3ld3fObtAuH3zPzjOF4vVbvUXxgZh1Zx1cey0iGfnhOZHUfUwJ3Qv0WZNcuVLvMMhhg85A3620b84MAIc2UoW9Hl4BIT7pHo41ApF0DxIPJL0QdIdAOjn0JTPZqAhoHVBQoYvivPHftk5Crd1a1J8L7hSs0s4uSQKAMTKDxy3gKLaGAg277h4iEsEZRCI4RPlPTo9nZ48s8OO2KzqrUbMkoPSTgaJEXq8GsozAzh0wtL4P3gPeHO5nQzoytoXAkiXoPph0GaTLiahYQksYeK1eVQADDqZPXC55teXKKdX4aomCufr1ZizgzkGwAmnsFmhmBSF0gvbm56NDaUVT0UqXxKxAfRjkILeWR1mW8jfn6RYJH3IWiHxEfyB23rr78NySfgzIchhrm7jEFtmwPpKPKAwzajLv0HpkrtTr38YwWeT5LzHokFAQEc6l3aWdJWapVyt9wX89dEkmPPG9torCV2ddjyF4jAKsxKvzU4pCxV6B3m16IIdnksemJ0xG8iKh4ZPsX", complex->get_member_id_by_name(
+            "my_large_string_16"));
 
-    DynamicData *my_array_string = complex->loan_value(complex->get_member_id_by_name("my_array_string"));
+    DynamicData* my_array_string = complex->loan_value(complex->get_member_id_by_name("my_array_string"));
     for (unsigned int j = 0; j < 5; ++j)
     {
         for (unsigned int k = 0; k < 5; ++k)
         {
             MemberId array_idx = my_array_string->get_array_index({ j, k });
-            my_array_string->set_string_value("Ee4rH8nSX1xnWrlDqDJjKWtWntMia9RrZqZPznr0yIDjeroWxUUzpPVV8UK4qUF4eilYR3Dz42", array_idx);
+            my_array_string->set_string_value(
+                "Ee4rH8nSX1xnWrlDqDJjKWtWntMia9RrZqZPznr0yIDjeroWxUUzpPVV8UK4qUF4eilYR3Dz42", array_idx);
             //staticData.my_union().complex().my_array_string()[i][j]("Ee4rH8nSX1xnWrlDqDJjKWtWntMia9RrZqZPznr0yIDjeroWxUUzpPVV8UK4qUF4eilYR3Dz42");
         }
     }
     complex->return_loaned_value(my_array_string);
 
-    DynamicData *multi_alias_array_42 = complex->loan_value(complex->get_member_id_by_name("multi_alias_array_42"));
+    DynamicData* multi_alias_array_42 = complex->loan_value(complex->get_member_id_by_name("multi_alias_array_42"));
     for (int j = 0; j < 42; ++j)
     {
         multi_alias_array_42->set_enum_value(j % 3, j);
@@ -2045,23 +2118,23 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_C)
     }
     complex->return_loaned_value(multi_alias_array_42);
 
-    DynamicData *my_array_arrays = complex->loan_value(complex->get_member_id_by_name("my_array_arrays"));
+    DynamicData* my_array_arrays = complex->loan_value(complex->get_member_id_by_name("my_array_arrays"));
     for (unsigned int j = 0; j < 5; ++j)
     {
-        DynamicData *myMiniArray = my_array_arrays->loan_value(j);
+        DynamicData* myMiniArray = my_array_arrays->loan_value(j);
         for (unsigned int k = 0; k < 2; ++k)
         {
-            myMiniArray->set_int32_value(j*k, k);
+            myMiniArray->set_int32_value(j * k, k);
             //staticData.my_union().complex().my_array_arrays()[i][j](i*j);
         }
         my_array_arrays->return_loaned_value(myMiniArray);
     }
     complex->return_loaned_value(my_array_arrays);
 
-    DynamicData *my_sequences_array = complex->loan_value(complex->get_member_id_by_name("my_sequences_array"));
+    DynamicData* my_sequences_array = complex->loan_value(complex->get_member_id_by_name("my_sequences_array"));
     for (int j = 0; j < 23; ++j)
     {
-        DynamicData *seq = DynamicDataFactory::get_instance()->create_data(GetMySequenceLongType());
+        DynamicData* seq = DynamicDataFactory::get_instance()->create_data(GetMySequenceLongType());
         seq->insert_sequence_data(id);
         seq->set_int32_value(j, id);
         seq->insert_sequence_data(id);
@@ -2078,7 +2151,7 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_C)
     my_union->return_loaned_value(complex);
     dynData->return_loaned_value(my_union);
 
-    DynamicData *my_union_2 = dynData->loan_value(dynData->get_member_id_by_name("my_union_2"));
+    DynamicData* my_union_2 = dynData->loan_value(dynData->get_member_id_by_name("my_union_2"));
     my_union_2->set_int32_value(156, my_union_2->get_member_id_by_name("tres"));
 
     dynData->return_loaned_value(my_union_2);
@@ -2090,54 +2163,54 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_B_C)
     ASSERT_TRUE(pubsubType.serialize(dynData.get(), &payload));
     ASSERT_TRUE(payload.length == payloadSize);
     /*
-    std::cout << "BEGIN" << std::endl;
-    for (uint32_t j = 0; j < payload.length; j += 100)
-    {
-    std::cout << std::endl;
-    for (uint32_t k = 0; k < 100; k++)
-    {
-    if (j + k < payload.length)
-    {
-    if ((int)payload.data[j + k] == 204)
-    {
-    std::cout << 0 << " ";
-    }
-    else
-    {
-    std::cout << (int)payload.data[j + k] << " ";
-    }
-    }
-    }
-    }
-    std::cout << "END" << std::endl;
-    */
+       std::cout << "BEGIN" << std::endl;
+       for (uint32_t j = 0; j < payload.length; j += 100)
+       {
+       std::cout << std::endl;
+       for (uint32_t k = 0; k < 100; k++)
+       {
+       if (j + k < payload.length)
+       {
+       if ((int)payload.data[j + k] == 204)
+       {
+       std::cout << 0 << " ";
+       }
+       else
+       {
+       std::cout << (int)payload.data[j + k] << " ";
+       }
+       }
+       }
+       }
+       std::cout << "END" << std::endl;
+     */
     CompleteStructPubSubType pbComplete;
     uint32_t payloadSize2 = static_cast<uint32_t>(m_StaticType.getSerializedSizeProvider(&staticData)());
     SerializedPayload_t stPayload(payloadSize2);
     ASSERT_TRUE(pbComplete.serialize(&staticData, &stPayload));
     ASSERT_TRUE(stPayload.length == payloadSize2);
     /*
-    std::cout << "BEGIN" << std::endl;
-    for (uint32_t j = 0; j < stPayload.length; j += 100)
-    {
-    std::cout << std::endl;
-    for (uint32_t k = 0; k < 100; k++)
-    {
-    if (j + k < stPayload.length)
-    {
-    if ((int)stPayload.data[j + k] == 204)
-    {
-    std::cout << 0 << " ";
-    }
-    else
-    {
-    std::cout << (int)stPayload.data[j + k] << " ";
-    }
-    }
-    }
-    }
-    std::cout << "END" << std::endl;
-    */
+       std::cout << "BEGIN" << std::endl;
+       for (uint32_t j = 0; j < stPayload.length; j += 100)
+       {
+       std::cout << std::endl;
+       for (uint32_t k = 0; k < 100; k++)
+       {
+       if (j + k < stPayload.length)
+       {
+       if ((int)stPayload.data[j + k] == 204)
+       {
+       std::cout << 0 << " ";
+       }
+       else
+       {
+       std::cout << (int)stPayload.data[j + k] << " ";
+       }
+       }
+       }
+       }
+       std::cout << "END" << std::endl;
+     */
     types::DynamicData_ptr dynDataFromDynamic(DynamicDataFactory::get_instance()->create_data(m_DynAutoType));
     ASSERT_TRUE(pubsubType.deserialize(&payload, dynDataFromDynamic.get()));
 
@@ -2168,8 +2241,8 @@ TEST_F(DynamicComplexTypesTests, Data_Comparison_with_Keys)
     staticData.basic().my_wstring(L" Working");
     //staticData.key(88);
 
-    DynamicData *dynData = DynamicDataFactory::get_instance()->create_data(GetKeyedStructType());
-    DynamicData *basic = dynData->loan_value(dynData->get_member_id_by_name("basic"));
+    DynamicData* dynData = DynamicDataFactory::get_instance()->create_data(GetKeyedStructType());
+    DynamicData* basic = dynData->loan_value(dynData->get_member_id_by_name("basic"));
     basic->set_bool_value(true, basic->get_member_id_by_name("my_bool"));
     basic->set_byte_value(100, basic->get_member_id_by_name("my_octet"));
     basic->set_int16_value(-12000, basic->get_member_id_by_name("my_int16"));
@@ -2222,15 +2295,22 @@ TEST_F(DynamicComplexTypesTests, TypeInformation)
     ASSERT_TRUE(info->complete().typeid_with_size().type_id()._d() == EK_COMPLETE);
     ASSERT_TRUE(info->complete().dependent_typeid_count() == 2);
     ASSERT_TRUE(info->complete().typeid_with_size().typeobject_serialized_size()
-        == TypeObject::getCdrSerializedSize(*compl_obj));
+            == TypeObject::getCdrSerializedSize(*compl_obj));
     const TypeInformation* enum_info = TypeObjectFactory::get_instance()->get_type_information("MyAliasEnum");
     ASSERT_TRUE(enum_info->minimal().typeid_with_size().type_id()._d() == EK_MINIMAL);
     const TypeInformation* bool_info = TypeObjectFactory::get_instance()->get_type_information("bool");
     ASSERT_TRUE(bool_info->minimal().typeid_with_size().type_id()._d() == TK_BOOLEAN);
     ASSERT_TRUE(bool_info->minimal().typeid_with_size().typeobject_serialized_size() == 0);
+
+    const TypeObject* key_obj = TypeObjectFactory::get_instance()->get_type_object("key");
+    ASSERT_EQ(key_obj->minimal()._d(), TK_ANNOTATION);
+    key_obj = TypeObjectFactory::get_instance()->get_type_object("Key");
+    ASSERT_EQ(key_obj->minimal()._d(), TK_ANNOTATION);
 }
 
-int main(int argc, char **argv)
+int main(
+        int argc,
+        char** argv)
 {
     eprosima::fastdds::dds::Log::SetVerbosity(eprosima::fastdds::dds::Log::Info);
 


### PR DESCRIPTION
`TypeObjectFactory` currently only supports `@key`, but not `@Key`. This PR fixes this.