### PR TITLE
[12529] Fix file watch initialization

### DIFF
--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -19,9 +19,10 @@
 #include <fastdds/rtps/RTPSDomain.h>
 
 #include <chrono>
-#include <thread>
 #include <cstdlib>
 #include <regex>
+#include <string>
+#include <thread>
 
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/rtps/history/WriterHistory.h>
@@ -115,11 +116,15 @@ RTPSParticipant* RTPSDomain::createParticipant(
     // Only the first time, initialize environment file watch if the corresponding environment variable is set
     if (!RTPSDomainImpl::file_watch_handle_)
     {
-        if (!SystemInfo::get_environment_file().empty())
+        std::string filename = SystemInfo::get_environment_file();
+        if (!filename.empty() && SystemInfo::file_exists(filename))
         {
             // Create filewatch
-            RTPSDomainImpl::file_watch_handle_ = SystemInfo::watch_file(SystemInfo::get_environment_file(),
-                            RTPSDomainImpl::file_watch_callback);
+            RTPSDomainImpl::file_watch_handle_ = SystemInfo::watch_file(filename, RTPSDomainImpl::file_watch_callback);
+        }
+        else
+        {
+            logWarning(RTPS_PARTICIPANT, filename + " does not exist. File watching not initialized.");
         }
     }
 

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -663,6 +663,7 @@ TEST(ParticipantTests, RemoteServersListConfiguration)
     server.metatrafficUnicastLocatorList.push_back(locator);
     get_server_client_default_guidPrefix(1, server.guidPrefix);
     output.push_back(server);
+#ifndef __APPLE__
     std::this_thread::sleep_for(std::chrono::milliseconds(1100));
     file.open(filename);
     file << "{\"ROS_DISCOVERY_SERVER\": \"84.22.253.128:8888;192.168.1.133:64863;localhost:1234\"}";
@@ -670,6 +671,7 @@ TEST(ParticipantTests, RemoteServersListConfiguration)
     std::this_thread::sleep_for(std::chrono::milliseconds(1100));
     get_rtps_attributes(participant, attributes);
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, output);
+#endif // APPLE
     result_qos = participant->get_qos();
     EXPECT_EQ(ReturnCode_t::RETCODE_OK, participant->set_qos(result_qos));
     EXPECT_EQ(ReturnCode_t::RETCODE_OK, DomainParticipantFactory::get_instance()->delete_participant(participant));
@@ -748,7 +750,9 @@ TEST(ParticipantTests, RemoteServersListConfiguration)
     get_rtps_attributes(participant, attributes);
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, qos_output);
     // Capture log warning
+#ifndef __APPLE__
     helper_wait_for_at_least_entries(mockConsumer, 1);
+#endif // APPLE
     result_qos = participant->get_qos();
     EXPECT_EQ(ReturnCode_t::RETCODE_OK, participant->set_qos(result_qos));
     EXPECT_EQ(ReturnCode_t::RETCODE_OK, DomainParticipantFactory::get_instance()->delete_participant(participant));
@@ -789,6 +793,7 @@ TEST(ParticipantTests, RemoteServersListConfiguration)
     participant = DomainParticipantFactory::get_instance()->create_participant(0, qos);
     ASSERT_NE(nullptr, participant);
     // Try adding a new remote server
+#ifndef __APPLE__
     std::this_thread::sleep_for(std::chrono::milliseconds(1100));
     file.open(filename);
     file << "{\"ROS_DISCOVERY_SERVER\": \"172.17.0.5:4321;192.168.1.133:64863\"}";
@@ -796,6 +801,7 @@ TEST(ParticipantTests, RemoteServersListConfiguration)
     std::this_thread::sleep_for(std::chrono::milliseconds(1100));
     get_rtps_attributes(participant, attributes);
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, output);
+#endif // APPLE
     result_qos = participant->get_qos();
     EXPECT_EQ(ReturnCode_t::RETCODE_OK, participant->set_qos(result_qos));
     EXPECT_EQ(ReturnCode_t::RETCODE_OK, DomainParticipantFactory::get_instance()->delete_participant(participant));
@@ -822,6 +828,7 @@ TEST(ParticipantTests, RemoteServersListConfiguration)
     // Add new server through environment file
     // Even though the server added previously through the environment file is being pinged, it is not really being
     // checked because it is not included in the attributes.
+#ifndef __APPLE__
     std::this_thread::sleep_for(std::chrono::milliseconds(1100));
     file.open(filename);
     file << "{\"ROS_DISCOVERY_SERVER\": \"172.17.0.5:4321;;192.168.1.133:64863\"}";
@@ -871,6 +878,7 @@ TEST(ParticipantTests, RemoteServersListConfiguration)
     output.push_back(server);
     get_rtps_attributes(participant, attributes);
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, output);
+#endif // APPLE
     result_qos = participant->get_qos();
     EXPECT_EQ(ReturnCode_t::RETCODE_OK, participant->set_qos(result_qos));
     EXPECT_EQ(ReturnCode_t::RETCODE_OK, DomainParticipantFactory::get_instance()->delete_participant(participant));

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -937,6 +937,7 @@ TEST(ParticipantTests, ServerParticipantCorrectRemoteServerListConfiguration)
     // Add new server through environment file
     // Even though the server added previously through the environment file is being pinged, it is not really being
     // checked because it is not included in the attributes.
+    DomainParticipantQos result_qos;
 #ifndef __APPLE__
     std::this_thread::sleep_for(std::chrono::milliseconds(1100));
     file.open(filename);
@@ -965,7 +966,7 @@ TEST(ParticipantTests, ServerParticipantCorrectRemoteServerListConfiguration)
     output.push_back(server);
     get_rtps_attributes(participant, attributes);
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, output);
-    DomainParticipantQos result_qos = participant->get_qos();
+    result_qos = participant->get_qos();
     EXPECT_EQ(ReturnCode_t::RETCODE_OK, participant->set_qos(result_qos));
     // Add new server using API
     result_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.push_back(server);

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -744,10 +744,13 @@ TEST(ParticipantTests, ClientParticipantRemoteServerListConfiguration)
 
 /**
  * SERVER Participant without initial remote server list set by QoS.
- * The environment variable applies and adds those remote servers to the list.
+ * The environment variable applies and adds those remote servers to the list even though the attributes are not
+ * updated.
  */
 TEST(ParticipantTests, ServerParticipantEnvironmentConfiguration)
 {
+    set_environment_variable();
+
     DomainParticipantQos server_qos;
     server_qos.wire_protocol().builtin.discovery_config.discoveryProtocol = fastrtps::rtps::DiscoveryProtocol::SERVER;
     // Listening locator: requirement for SERVERs

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -535,6 +535,7 @@ public:
     {
         return impl_;
     }
+
 };
 
 void get_rtps_attributes(
@@ -727,7 +728,7 @@ TEST(ParticipantTests, RemoteServersListConfiguration)
     /* 6. SERVER Participant with initial server with inconsistent GUID prefix. Dynamic addition of servers failure */
     // Write environment file
     std::cout << "6. SERVER Participant with initial server with inconsistent GUID prefix"
-            << std::endl;
+              << std::endl;
     file.open(filename);
     file << "{\"ROS_DISCOVERY_SERVER\": \"84.22.253.128:8888;;localhost:1234\"}";
     file.close();
@@ -758,7 +759,7 @@ TEST(ParticipantTests, RemoteServersListConfiguration)
     // the one pinged.
     // However, the locator which is checked in order to add a new server is the one set by QoS.
     std::cout << "7. SERVER Participant: same remote server, different locators"
-            << std::endl;
+              << std::endl;
     qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.clear();
     server.clear();
     server.ReadguidPrefix(rtps::DEFAULT_ROS2_SERVER_GUIDPREFIX);


### PR DESCRIPTION
If the `FASTDDS_ENVIRONMENT_FILE` environment variable is set but the file does not exist, Fast DDS breaks. This PR fixes this issue and adds also a test to check different Discovery Server configurations.