### PR TITLE
Remove `#include <condition_variable>` from `Log.hpp` [12720]

### DIFF
--- a/include/fastdds/dds/log/Log.hpp
+++ b/include/fastdds/dds/log/Log.hpp
@@ -15,7 +15,6 @@
 #ifndef _FASTDDS_DDS_LOG_LOG_HPP_
 #define _FASTDDS_DDS_LOG_LOG_HPP_
 
-#include <fastrtps/utils/DBQueue.h>
 #include <fastrtps/fastrtps_dll.h>
 #include <thread>
 #include <sstream>
@@ -153,36 +152,6 @@ public:
             Log::Kind);
 
 private:
-
-    struct Resources
-    {
-        fastrtps::DBQueue<Entry> logs;
-        std::vector<std::unique_ptr<LogConsumer>> consumers;
-        std::unique_ptr<std::thread> logging_thread;
-
-        // Condition variable segment.
-        std::condition_variable cv;
-        std::mutex cv_mutex;
-        bool logging;
-        bool work;
-        int current_loop;
-
-        // Context configuration.
-        std::mutex config_mutex;
-        bool filenames;
-        bool functions;
-        std::unique_ptr<std::regex> category_filter;
-        std::unique_ptr<std::regex> filename_filter;
-        std::unique_ptr<std::regex> error_string_filter;
-
-        std::atomic<Log::Kind> verbosity;
-
-        Resources();
-
-        ~Resources();
-    };
-
-    static struct Resources resources_;
 
     // Applies transformations to the entries compliant with the options selected (such as
     // erasure of certain context information, or filtering by category. Returns false

--- a/include/fastdds/rtps/writer/LocatorSelectorSender.hpp
+++ b/include/fastdds/rtps/writer/LocatorSelectorSender.hpp
@@ -5,6 +5,8 @@
 #include <fastdds/rtps/messages/RTPSMessageSenderInterface.hpp>
 #include <fastrtps/utils/collections/ResourceLimitedVector.hpp>
 
+#include <mutex>
+
 namespace eprosima {
 namespace fastrtps {
 namespace rtps {

--- a/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
+++ b/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
@@ -23,6 +23,8 @@
 #include <fastrtps/rtps/attributes/HistoryAttributes.h>
 #include <fastrtps/utils/TimedMutex.hpp>
 
+#include <mutex>
+
 #include <gmock/gmock.h>
 
 namespace eprosima {

--- a/test/unittest/logging/mock/MockConsumer.h
+++ b/test/unittest/logging/mock/MockConsumer.h
@@ -20,6 +20,7 @@
 #include <thread>
 #include <mutex>
 #include <vector>
+#include <condition_variable>
 
 namespace eprosima {
 namespace fastdds {
@@ -86,4 +87,3 @@ private:
 } // namespace eprosima
 
 #endif // ifndef MOCK_LOG_CONSUMER_H
-


### PR DESCRIPTION
`Log.hpp` header file is used everywhere. It's include `<condition_variable>` and `<mutex>`. This is incompatible with making a C# wrapper. This PR moves these included headers to `Log.cpp`.