### PR TITLE
Removing existing fuzzer from orig. location

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -504,11 +504,6 @@ if(MSVC OR MSVC_IDE)
     endif()
 endif()
 
-if(DEFINED ENV{LIB_FUZZING_ENGINE})
-  add_executable(fuzz_processCDRMsg rtps/messages/fuzz_processCDRMsg.cpp)
-  target_link_libraries(fuzz_processCDRMsg ${PROJECT_NAME} $ENV{LIB_FUZZING_ENGINE})
-endif()
-
 ###############################################################################
 # Packaging
 ###############################################################################


### PR DESCRIPTION
This is a follow-up from #2273, where the fuzzer was moved.

It removes the reference to the old location from the CMake files.

Signed-off-by: Federico Maggi <federico@maggi.cc>