### PR TITLE
Use BOUND_UNLIMITED on Dynamic Types

### DIFF
--- a/include/fastrtps/types/DynamicTypeBuilderFactory.h
+++ b/include/fastrtps/types/DynamicTypeBuilderFactory.h
@@ -36,9 +36,6 @@ class DynamicType;
 class DynamicType_ptr;
 class AnnotationParameterValue;
 
-//! A special value indicating an unlimited quantity
-constexpr uint32_t BOUND_UNLIMITED = 0;
-
 class DynamicTypeBuilderFactory
 {
 protected:

--- a/include/fastrtps/types/TypesBase.h
+++ b/include/fastrtps/types/TypesBase.h
@@ -38,6 +38,9 @@ class Cdr;
 namespace fastrtps {
 namespace types {
 
+//! A special value indicating an unlimited quantity
+constexpr uint32_t BOUND_UNLIMITED = 0;
+
 using eprosima::fastrtps::rtps::octet;
 
 using OctetSeq = std::vector<octet>;

--- a/src/cpp/dynamic-types/DynamicData.cpp
+++ b/src/cpp/dynamic-types/DynamicData.cpp
@@ -23,8 +23,6 @@
 #include <fastdds/dds/log/Log.hpp>
 #include <fastcdr/Cdr.h>
 
-#include <dds/core/LengthUnlimited.hpp>
-
 #include <locale>
 #include <codecvt>
 
@@ -3523,7 +3521,7 @@ ReturnCode_t DynamicData::set_bool_value(
                 uint64_value_ = 0;
             }
         }
-        else if (type_->get_bounds() == ::dds::core::LENGTH_UNLIMITED || id < type_->get_bounds())
+        else if (type_->get_bounds() == BOUND_UNLIMITED || id < type_->get_bounds())
         {
             if (value)
             {
@@ -3596,7 +3594,7 @@ ReturnCode_t DynamicData::set_bool_value(
                 }
                 return ReturnCode_t::RETCODE_OK;
             }
-            else if (type_->get_bounds() == ::dds::core::LENGTH_UNLIMITED || id < type_->get_bounds())
+            else if (type_->get_bounds() == BOUND_UNLIMITED || id < type_->get_bounds())
             {
                 auto m_id = descriptors_.find(id);
                 MemberDescriptor* member = m_id->second;
@@ -4747,7 +4745,7 @@ ReturnCode_t DynamicData::insert_complex_value(
 {
     if (get_kind() == TK_SEQUENCE && type_->get_element_type()->equals(value->type_.get()))
     {
-        if (type_->get_bounds() == ::dds::core::LENGTH_UNLIMITED || get_item_count() < type_->get_bounds())
+        if (type_->get_bounds() == BOUND_UNLIMITED || get_item_count() < type_->get_bounds())
         {
 #ifdef DYNAMIC_TYPES_CHECKING
             outId = static_cast<MemberId>(complex_values_.size());
@@ -4778,7 +4776,7 @@ ReturnCode_t DynamicData::insert_complex_value(
 {
     if (get_kind() == TK_SEQUENCE && type_->get_element_type()->equals(value->type_.get()))
     {
-        if (type_->get_bounds() == ::dds::core::LENGTH_UNLIMITED || get_item_count() < type_->get_bounds())
+        if (type_->get_bounds() == BOUND_UNLIMITED || get_item_count() < type_->get_bounds())
         {
 #ifdef DYNAMIC_TYPES_CHECKING
             outId = static_cast<MemberId>(complex_values_.size());
@@ -4809,7 +4807,7 @@ ReturnCode_t DynamicData::insert_complex_value(
 {
     if (get_kind() == TK_SEQUENCE && type_->get_element_type()->equals(value->type_.get()))
     {
-        if (type_->get_bounds() == ::dds::core::LENGTH_UNLIMITED || get_item_count() < type_->get_bounds())
+        if (type_->get_bounds() == BOUND_UNLIMITED || get_item_count() < type_->get_bounds())
         {
 #ifdef DYNAMIC_TYPES_CHECKING
             outId = static_cast<MemberId>(complex_values_.size());
@@ -4840,7 +4838,7 @@ ReturnCode_t DynamicData::insert_sequence_data(
     outId = MEMBER_ID_INVALID;
     if (get_kind() == TK_SEQUENCE)
     {
-        if (type_->get_bounds() == ::dds::core::LENGTH_UNLIMITED || get_item_count() < type_->get_bounds())
+        if (type_->get_bounds() == BOUND_UNLIMITED || get_item_count() < type_->get_bounds())
         {
 #ifdef DYNAMIC_TYPES_CHECKING
             DynamicData* new_element = DynamicDataFactory::get_instance()->create_data(type_->get_element_type());
@@ -4908,7 +4906,7 @@ ReturnCode_t DynamicData::insert_map_data(
 {
     if (get_kind() == TK_MAP && type_->get_key_element_type()->equals(key->type_.get()))
     {
-        if (type_->get_bounds() == ::dds::core::LENGTH_UNLIMITED || get_item_count() < type_->get_bounds())
+        if (type_->get_bounds() == BOUND_UNLIMITED || get_item_count() < type_->get_bounds())
         {
 #ifdef DYNAMIC_TYPES_CHECKING
             for (auto it = complex_values_.begin(); it != complex_values_.end(); ++it)
@@ -4971,7 +4969,7 @@ ReturnCode_t DynamicData::insert_map_data(
     if (get_kind() == TK_MAP && type_->get_key_element_type()->equals(key->type_.get()) &&
             type_->get_element_type()->equals(value->type_.get()))
     {
-        if (type_->get_bounds() == ::dds::core::LENGTH_UNLIMITED || get_item_count() < type_->get_bounds())
+        if (type_->get_bounds() == BOUND_UNLIMITED || get_item_count() < type_->get_bounds())
         {
 #ifdef DYNAMIC_TYPES_CHECKING
             for (auto it = complex_values_.begin(); it != complex_values_.end(); ++it)
@@ -5032,7 +5030,7 @@ ReturnCode_t DynamicData::insert_map_data(
     if (get_kind() == TK_MAP && type_->get_key_element_type()->equals(key->type_.get()) &&
             type_->get_element_type()->equals(value->type_.get()))
     {
-        if (type_->get_bounds() == ::dds::core::LENGTH_UNLIMITED || get_item_count() < type_->get_bounds())
+        if (type_->get_bounds() == BOUND_UNLIMITED || get_item_count() < type_->get_bounds())
         {
 #ifdef DYNAMIC_TYPES_CHECKING
             for (auto it = complex_values_.begin(); it != complex_values_.end(); ++it)

--- a/src/cpp/dynamic-types/DynamicType.cpp
+++ b/src/cpp/dynamic-types/DynamicType.cpp
@@ -20,8 +20,6 @@
 #include <fastrtps/types/DynamicTypeMember.h>
 #include <fastdds/dds/log/Log.hpp>
 
-#include <dds/core/LengthUnlimited.hpp>
-
 namespace eprosima {
 namespace fastrtps {
 namespace types {
@@ -413,7 +411,7 @@ uint32_t DynamicType::get_bounds(
     {
         return descriptor_->get_bounds(index);
     }
-    return ::dds::core::LENGTH_UNLIMITED;
+    return BOUND_UNLIMITED;
 }
 
 uint32_t DynamicType::get_bounds_size() const
@@ -458,7 +456,7 @@ uint32_t DynamicType::get_total_bounds() const
     {
         return descriptor_->get_total_bounds();
     }
-    return ::dds::core::LENGTH_UNLIMITED;
+    return BOUND_UNLIMITED;
 }
 
 bool DynamicType::has_children() const

--- a/src/cpp/dynamic-types/TypeDescriptor.cpp
+++ b/src/cpp/dynamic-types/TypeDescriptor.cpp
@@ -19,8 +19,6 @@
 #include <fastdds/dds/log/Log.hpp>
 #include <fastrtps/types/TypesBase.h>
 
-#include <dds/core/LengthUnlimited.hpp>
-
 namespace eprosima {
 namespace fastrtps {
 namespace types {
@@ -164,7 +162,7 @@ uint32_t TypeDescriptor::get_bounds(
     else
     {
         logError(DYN_TYPES, "Error getting bounds value. Index out of range.");
-        return ::dds::core::LENGTH_UNLIMITED;
+        return BOUND_UNLIMITED;
     }
 }
 
@@ -209,7 +207,7 @@ uint32_t TypeDescriptor::get_total_bounds() const
         }
         return bounds;
     }
-    return ::dds::core::LENGTH_UNLIMITED;
+    return BOUND_UNLIMITED;
 }
 
 bool TypeDescriptor::is_consistent() const

--- a/test/unittest/dynamic_types/DynamicTypesTests.cpp
+++ b/test/unittest/dynamic_types/DynamicTypesTests.cpp
@@ -32,8 +32,6 @@
 #include "idl/BasicTypeObject.h"
 #include <tinyxml2.h>
 
-#include <dds/core/LengthUnlimited.hpp>
-
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 using namespace eprosima::fastrtps::types;
@@ -330,7 +328,7 @@ TEST_F(DynamicTypesTests, DynamicTypeBuilderFactory_unit_tests)
         ASSERT_TRUE(DynamicDataFactory::get_instance()->delete_data(data2) == ReturnCode_t::RETCODE_OK);
 
         created_builder =
-                DynamicTypeBuilderFactory::get_instance()->create_string_builder(::dds::core::LENGTH_UNLIMITED);
+                DynamicTypeBuilderFactory::get_instance()->create_string_builder(BOUND_UNLIMITED);
         ASSERT_TRUE(created_builder != nullptr);
         type = created_builder->build();
         ASSERT_TRUE(type != nullptr);
@@ -346,8 +344,7 @@ TEST_F(DynamicTypesTests, DynamicTypeBuilderFactory_unit_tests)
         ASSERT_TRUE(DynamicDataFactory::get_instance()->delete_data(data) == ReturnCode_t::RETCODE_OK);
         ASSERT_TRUE(DynamicDataFactory::get_instance()->delete_data(data2) == ReturnCode_t::RETCODE_OK);
 
-        created_builder = DynamicTypeBuilderFactory::get_instance()->create_wstring_builder(
-            ::dds::core::LENGTH_UNLIMITED);
+        created_builder = DynamicTypeBuilderFactory::get_instance()->create_wstring_builder(BOUND_UNLIMITED);
         ASSERT_TRUE(created_builder != nullptr);
         type = created_builder->build();
         ASSERT_TRUE(type != nullptr);


### PR DESCRIPTION
In order to remove the dependency on `#include <dds/core/LengthUnlimited.hpp>`, this PR changes references to `::dds::core::LENGTH_UNLIMITED` into `eprosima::fastrtps::types::BOUND_UNLIMITED`