### PR TITLE
[12819] Fully support dynamic addition od remote servers in deprecated API

### DIFF
--- a/src/cpp/fastrtps_deprecated/Domain.cpp
+++ b/src/cpp/fastrtps_deprecated/Domain.cpp
@@ -218,6 +218,7 @@ void Domain::getDefaultParticipantAttributes(
 {
     if (false == default_xml_profiles_loaded)
     {
+        SystemInfo::set_environment_file();
         XMLProfileManager::loadDefaultXMLFile();
         default_xml_profiles_loaded = true;
     }
@@ -262,6 +263,7 @@ void Domain::getDefaultPublisherAttributes(
 {
     if (false == default_xml_profiles_loaded)
     {
+        SystemInfo::set_environment_file();
         XMLProfileManager::loadDefaultXMLFile();
         default_xml_profiles_loaded = true;
     }
@@ -274,6 +276,7 @@ void Domain::getDefaultSubscriberAttributes(
 {
     if (false == default_xml_profiles_loaded)
     {
+        SystemInfo::set_environment_file();
         XMLProfileManager::loadDefaultXMLFile();
         default_xml_profiles_loaded = true;
     }
@@ -409,6 +412,7 @@ bool Domain::loadXMLProfilesFile(
 {
     if (false == default_xml_profiles_loaded)
     {
+        SystemInfo::set_environment_file();
         XMLProfileManager::loadDefaultXMLFile();
         default_xml_profiles_loaded = true;
     }


### PR DESCRIPTION
Currently this feature is not working with ROS 2 Foxy because the RMW implementation is still using the deprecated API.

No tests have been added because this API is already deprecated.

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>