### PR TITLE
Removing unused macro to avoid naming clashes

### DIFF
--- a/include/fastrtps/xmlparser/XMLParserCommon.h
+++ b/include/fastrtps/xmlparser/XMLParserCommon.h
@@ -19,9 +19,6 @@ namespace eprosima {
 namespace fastrtps {
 namespace xmlparser {
 
-#define draw(ident, text, ...) for (uint8_t i = ident + 1; i > 0; --i)(i == 1) ? printf(text, ## __VA_ARGS__) : printf( \
-        "\t")
-
 /**
  * Enum class XMLP_ret, used to provide a strongly typed result from the operations within this module.
  * @ingroup XMLPARSER_MODULE


### PR DESCRIPTION
As discussed in issue #1997 this macro was clashing with function from the Gtk3 UI library. As it is not needed it was proposed by MiguelCompany to remove it.