### PR TITLE
[12754] Add participant locators if new network interfaces are found

### DIFF
--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -345,9 +345,10 @@ ReturnCode_t DomainParticipantImpl::set_qos(
         return ReturnCode_t::RETCODE_IMMUTABLE_POLICY;
     }
 
+    bool qos_should_be_updated = set_qos(qos_, qos_to_set, !enabled);
     if (enabled)
     {
-        if (set_qos(qos_, qos_to_set, !enabled))
+        if (qos_should_be_updated)
         {
             // Notify the participant that there is a QoS update
             fastrtps::rtps::RTPSParticipantAttributes patt;

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -345,12 +345,19 @@ ReturnCode_t DomainParticipantImpl::set_qos(
         return ReturnCode_t::RETCODE_IMMUTABLE_POLICY;
     }
 
-    if (set_qos(qos_, qos_to_set, !enabled) && enabled)
+    if (enabled)
     {
-        // Notify the participant that there is a QoS update
-        fastrtps::rtps::RTPSParticipantAttributes patt;
-        set_attributes_from_qos(patt, qos_);
-        rtps_participant_->update_attributes(patt);
+        if (set_qos(qos_, qos_to_set, !enabled))
+        {
+            // Notify the participant that there is a QoS update
+            fastrtps::rtps::RTPSParticipantAttributes patt;
+            set_attributes_from_qos(patt, qos_);
+            rtps_participant_->update_attributes(patt);
+        }
+        else
+        {
+            rtps_participant_->update_attributes(rtps_participant_->getRTPSParticipantAttributes());
+        }
     }
 
     return ReturnCode_t::RETCODE_OK;

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -357,6 +357,7 @@ ReturnCode_t DomainParticipantImpl::set_qos(
         }
         else
         {
+            // Trigger update of network interfaces by calling update_attributes
             rtps_participant_->update_attributes(rtps_participant_->getRTPSParticipantAttributes());
         }
     }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -244,9 +244,6 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     if (m_att.builtin.metatrafficMulticastLocatorList.empty() && m_att.builtin.metatrafficUnicastLocatorList.empty())
     {
         get_default_metatraffic_locators(metatraffic_multicast_port, metatraffic_unicast_port);
-        std::cout << m_att.getName() << " created with NO default metatraffic Locator List, adding Locators:\n\t"
-                                                    << m_att.builtin.metatrafficMulticastLocatorList << "\n\t"
-                                                    << m_att.builtin.metatrafficUnicastLocatorList << std::endl;
     }
     else
     {
@@ -301,9 +298,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         /* INSERT DEFAULT UNICAST LOCATORS FOR THE PARTICIPANT */
         get_default_unicast_locators();
         logInfo(RTPS_PARTICIPANT, m_att.getName() << " Created with NO default Unicast Locator List, adding Locators:"
-                                                    << m_att.defaultUnicastLocatorList);
-        std::cout << m_att.getName() << " created with NO default Unicast Locator List, adding Locators:"
-                                                    << m_att.defaultUnicastLocatorList << std::endl;
+                                                  << m_att.defaultUnicastLocatorList);
     }
     else
     {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -298,7 +298,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         /* INSERT DEFAULT UNICAST LOCATORS FOR THE PARTICIPANT */
         get_default_unicast_locators();
         logInfo(RTPS_PARTICIPANT, m_att.getName() << " Created with NO default Unicast Locator List, adding Locators:"
-                                                    << m_att.defaultUnicastLocatorList);
+                                                  << m_att.defaultUnicastLocatorList);
     }
     else
     {
@@ -1177,7 +1177,7 @@ void RTPSParticipantImpl::update_attributes(
         if (!(default_unicast_locator_list == m_att.defaultUnicastLocatorList))
         {
             logInfo(RTPS_PARTICIPANT, m_att.getName() << " updated default unicast locator list, current locators: "
-                                                        << m_att.defaultUnicastLocatorList);
+                                                      << m_att.defaultUnicastLocatorList);
         }
     }
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1152,7 +1152,7 @@ bool RTPSParticipantImpl::registerReader(
 void RTPSParticipantImpl::update_attributes(
         const RTPSParticipantAttributes& patt)
 {
-    // Check if new interfaces has been added
+    // Check if new interfaces have been added
     if (patt.builtin.metatrafficMulticastLocatorList.empty() && patt.builtin.metatrafficUnicastLocatorList.empty())
     {
         LocatorList_t metatraffic_multicast_locator_list = m_att.builtin.metatrafficMulticastLocatorList;

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -699,6 +699,21 @@ private:
             bool enable,
             const Functor& callback);
 
+    /**
+     * Get default metatraffic locators when not provided by the user.
+     * 
+     * @param [in] metatraffic_multicast_port well known multicast metatraffic port following DDS standard
+     * @param [in] metatraffic_unicast_port well known unicast metatraffic port following DDS standard
+     */
+    void get_default_metatraffic_locators(
+            uint32_t metatraffic_multicast_port,
+            uint32_t metatraffic_unicast_port);
+
+    /**
+     * Get default unicast locators when not provided by the user.
+     */
+    void get_default_unicast_locators();
+
 public:
 
     const RTPSParticipantAttributes& getRTPSParticipantAttributes() const

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -701,7 +701,7 @@ private:
 
     /**
      * Get default metatraffic locators when not provided by the user.
-     * 
+     *
      * @param [in] metatraffic_multicast_port well known multicast metatraffic port following DDS standard
      * @param [in] metatraffic_unicast_port well known unicast metatraffic port following DDS standard
      */


### PR DESCRIPTION
Currently only network interfaces found when launching Fast DDS are taken into account. This PR adds new participant locators if new network interfaces are detected. In order to trigger the check, the user must call `DomainParticipant::set_qos`. If some user is using the RTPS layer directly, the feature can also be triggered by calling `RTPSParticipant::update_attributes`.

This PR only includes the implementation. Another PR to the same intermediary branch will also include the tests.

Related PRs:
* #2336 
* eProsima/Fast-DDS-docs#301
