### PR TITLE
Avoid payload reservation and copy when change is going to be rejected by history [13120]

### DIFF
--- a/include/fastdds/rtps/history/ReaderHistory.h
+++ b/include/fastdds/rtps/history/ReaderHistory.h
@@ -61,7 +61,7 @@ public:
      *
      * @pre change should not be present in the history
      *
-     * @return Whether a call to received_change will succeed when called with the same arguments. 
+     * @return Whether a call to received_change will succeed when called with the same arguments.
      */
     RTPS_DllAPI virtual bool can_change_be_added_nts(
             const CacheChange_t* change,

--- a/include/fastdds/rtps/history/ReaderHistory.h
+++ b/include/fastdds/rtps/history/ReaderHistory.h
@@ -63,9 +63,9 @@ public:
      *
      * @return Whether a call to received_change will succeed when called with the same arguments. 
      */
-    RTPS_DllAPI virtual bool can_change_be_added(
+    RTPS_DllAPI virtual bool can_change_be_added_nts(
             const CacheChange_t* change,
-            size_t unknown_missing_changes_up_to);
+            size_t unknown_missing_changes_up_to) const;
 
     /**
      * Virtual method that is called when a new change is received.

--- a/include/fastdds/rtps/history/ReaderHistory.h
+++ b/include/fastdds/rtps/history/ReaderHistory.h
@@ -53,6 +53,21 @@ public:
     RTPS_DllAPI ~ReaderHistory() override;
 
     /**
+     * Check if a new change can be added to this history.
+     *
+     * @param change                         Pointer to the change to be added.
+     * @param unknown_missing_changes_up_to  The number of changes from the same writer with a lower sequence number
+     *                                       that could potentially be received in the future.
+     *
+     * @pre change should not be present in the history
+     *
+     * @return Whether a call to received_change will succeed when called with the same arguments. 
+     */
+    RTPS_DllAPI virtual bool can_change_be_added(
+            const CacheChange_t* change,
+            size_t unknown_missing_changes_up_to);
+
+    /**
      * Virtual method that is called when a new change is received.
      * In this implementation this method just calls add_change. The user can overload this method in case
      * he needs to perform additional checks before adding the change.
@@ -61,7 +76,7 @@ public:
      */
     RTPS_DllAPI virtual bool received_change(
             CacheChange_t* change,
-            size_t);
+            size_t unknown_missing_changes_up_to);
 
     /**
      * Called when a fragmented change is received completely by the Subscriber. Will find its instance and store it.

--- a/include/fastdds/rtps/history/ReaderHistory.h
+++ b/include/fastdds/rtps/history/ReaderHistory.h
@@ -55,9 +55,11 @@ public:
     /**
      * Check if a new change can be added to this history.
      *
-     * @param change                         Pointer to the change to be added.
-     * @param unknown_missing_changes_up_to  The number of changes from the same writer with a lower sequence number
-     *                                       that could potentially be received in the future.
+     * @param [in]  change                         Pointer to the change to be added.
+     * @param [in]  unknown_missing_changes_up_to  The number of changes from the same writer with a lower sequence
+     *                                             number that could potentially be received in the future.
+     * @param [out] will_never_be_accepted         When the method returns @c false, this parameter will inform
+     *                                             whether the change could be accepted in the future or not.
      *
      * @pre change should not be present in the history
      *
@@ -65,7 +67,8 @@ public:
      */
     RTPS_DllAPI virtual bool can_change_be_added_nts(
             const CacheChange_t* change,
-            size_t unknown_missing_changes_up_to) const;
+            size_t unknown_missing_changes_up_to,
+            bool& will_never_be_accepted) const;
 
     /**
      * Virtual method that is called when a new change is received.

--- a/include/fastdds/rtps/history/ReaderHistory.h
+++ b/include/fastdds/rtps/history/ReaderHistory.h
@@ -55,7 +55,8 @@ public:
     /**
      * Check if a new change can be added to this history.
      *
-     * @param [in]  change                         Pointer to the change to be added.
+     * @param [in]  writer_guid                    GUID of the writer where the change came from.
+     * @param [in]  total_payload_size             Total payload size of the incoming change.
      * @param [in]  unknown_missing_changes_up_to  The number of changes from the same writer with a lower sequence
      *                                             number that could potentially be received in the future.
      * @param [out] will_never_be_accepted         When the method returns @c false, this parameter will inform
@@ -66,7 +67,8 @@ public:
      * @return Whether a call to received_change will succeed when called with the same arguments.
      */
     RTPS_DllAPI virtual bool can_change_be_added_nts(
-            const CacheChange_t* change,
+            const GUID_t& writer_guid,
+            uint32_t total_payload_size,
             size_t unknown_missing_changes_up_to,
             bool& will_never_be_accepted) const;
 

--- a/include/fastdds/rtps/reader/StatefulReader.h
+++ b/include/fastdds/rtps/reader/StatefulReader.h
@@ -171,7 +171,8 @@ public:
      */
     bool change_received(
             CacheChange_t* a_change,
-            WriterProxy* prox);
+            WriterProxy* prox,
+            size_t unknown_missing_changes_up_to);
 
     /**
      * Get the RTPS participant

--- a/include/fastrtps/subscriber/SubscriberHistory.h
+++ b/include/fastrtps/subscriber/SubscriberHistory.h
@@ -83,7 +83,7 @@ public:
      *
      * @pre change should not be present in the history
      *
-     * @return Whether a call to received_change will succeed when called with the same arguments. 
+     * @return Whether a call to received_change will succeed when called with the same arguments.
      */
     bool can_change_be_added_nts(
             const rtps::CacheChange_t* change,

--- a/include/fastrtps/subscriber/SubscriberHistory.h
+++ b/include/fastrtps/subscriber/SubscriberHistory.h
@@ -77,9 +77,11 @@ public:
     /**
      * Check if a new change can be added to this history.
      *
-     * @param change                         Pointer to the change to be added.
-     * @param unknown_missing_changes_up_to  The number of changes from the same writer with a lower sequence number
-     *                                       that could potentially be received in the future.
+     * @param [in]  change                         Pointer to the change to be added.
+     * @param [in]  unknown_missing_changes_up_to  The number of changes from the same writer with a lower sequence
+     *                                             number that could potentially be received in the future.
+     * @param [out] will_never_be_accepted         When the method returns @c false, this parameter will inform
+     *                                             whether the change could be accepted in the future or not.
      *
      * @pre change should not be present in the history
      *
@@ -87,7 +89,8 @@ public:
      */
     bool can_change_be_added_nts(
             const rtps::CacheChange_t* change,
-            size_t unknown_missing_changes_up_to) const override;
+            size_t unknown_missing_changes_up_to,
+            bool& will_never_be_accepted) const override;
 
     /**
      * Called when a change is received by the Subscriber. Will add the change to the history.

--- a/include/fastrtps/subscriber/SubscriberHistory.h
+++ b/include/fastrtps/subscriber/SubscriberHistory.h
@@ -75,6 +75,21 @@ public:
             bool release = true) override;
 
     /**
+     * Check if a new change can be added to this history.
+     *
+     * @param change                         Pointer to the change to be added.
+     * @param unknown_missing_changes_up_to  The number of changes from the same writer with a lower sequence number
+     *                                       that could potentially be received in the future.
+     *
+     * @pre change should not be present in the history
+     *
+     * @return Whether a call to received_change will succeed when called with the same arguments. 
+     */
+    bool can_change_be_added(
+            const rtps::CacheChange_t* change,
+            size_t unknown_missing_changes_up_to) override;
+
+    /**
      * Called when a change is received by the Subscriber. Will add the change to the history.
      * @pre Change should not be already present in the history.
      * @param[in] change The received change

--- a/include/fastrtps/subscriber/SubscriberHistory.h
+++ b/include/fastrtps/subscriber/SubscriberHistory.h
@@ -85,9 +85,9 @@ public:
      *
      * @return Whether a call to received_change will succeed when called with the same arguments. 
      */
-    bool can_change_be_added(
+    bool can_change_be_added_nts(
             const rtps::CacheChange_t* change,
-            size_t unknown_missing_changes_up_to) override;
+            size_t unknown_missing_changes_up_to) const override;
 
     /**
      * Called when a change is received by the Subscriber. Will add the change to the history.

--- a/include/fastrtps/subscriber/SubscriberHistory.h
+++ b/include/fastrtps/subscriber/SubscriberHistory.h
@@ -77,7 +77,8 @@ public:
     /**
      * Check if a new change can be added to this history.
      *
-     * @param [in]  change                         Pointer to the change to be added.
+     * @param [in]  writer_guid                    GUID of the writer where the change came from.
+     * @param [in]  total_payload_size             Total payload size of the incoming change.
      * @param [in]  unknown_missing_changes_up_to  The number of changes from the same writer with a lower sequence
      *                                             number that could potentially be received in the future.
      * @param [out] will_never_be_accepted         When the method returns @c false, this parameter will inform
@@ -88,7 +89,8 @@ public:
      * @return Whether a call to received_change will succeed when called with the same arguments.
      */
     bool can_change_be_added_nts(
-            const rtps::CacheChange_t* change,
+            const rtps::GUID_t& writer_guid,
+            uint32_t total_payload_size,
             size_t unknown_missing_changes_up_to,
             bool& will_never_be_accepted) const override;
 

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -137,6 +137,15 @@ SubscriberHistory::~SubscriberHistory()
     }
 }
 
+bool SubscriberHistory::can_change_be_added(
+        const CacheChange_t* change,
+        size_t unknown_missing_changes_up_to)
+{
+    bool ret_val = (KEEP_ALL_HISTORY_QOS != history_qos_.kind) || 
+        (m_changes.size() + unknown_missing_changes_up_to < static_cast<size_t>(resource_limited_qos_.max_samples));
+    return ret_val && ReaderHistory::can_change_be_added(change, unknown_missing_changes_up_to);
+}
+
 bool SubscriberHistory::received_change(
         CacheChange_t* a_change,
         size_t unknown_missing_changes_up_to)

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -139,11 +139,17 @@ SubscriberHistory::~SubscriberHistory()
 
 bool SubscriberHistory::can_change_be_added_nts(
         const CacheChange_t* change,
-        size_t unknown_missing_changes_up_to) const
+        size_t unknown_missing_changes_up_to,
+        bool& will_never_be_accepted) const
 {
-    bool ret_val = (KEEP_ALL_HISTORY_QOS != history_qos_.kind) ||
-            (m_changes.size() + unknown_missing_changes_up_to < static_cast<size_t>(resource_limited_qos_.max_samples));
-    return ret_val && ReaderHistory::can_change_be_added_nts(change, unknown_missing_changes_up_to);
+    if (!ReaderHistory::can_change_be_added_nts(change, unknown_missing_changes_up_to, will_never_be_accepted))
+    {
+        return false;
+    }
+
+    will_never_be_accepted = false;
+    return (KEEP_ALL_HISTORY_QOS != history_qos_.kind) ||
+           (m_changes.size() + unknown_missing_changes_up_to < static_cast<size_t>(resource_limited_qos_.max_samples));
 }
 
 bool SubscriberHistory::received_change(

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -138,11 +138,13 @@ SubscriberHistory::~SubscriberHistory()
 }
 
 bool SubscriberHistory::can_change_be_added_nts(
-        const CacheChange_t* change,
+        const rtps::GUID_t& writer_guid,
+        uint32_t total_payload_size,
         size_t unknown_missing_changes_up_to,
         bool& will_never_be_accepted) const
 {
-    if (!ReaderHistory::can_change_be_added_nts(change, unknown_missing_changes_up_to, will_never_be_accepted))
+    if (!ReaderHistory::can_change_be_added_nts(writer_guid, total_payload_size, unknown_missing_changes_up_to,
+            will_never_be_accepted))
     {
         return false;
     }

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -141,8 +141,8 @@ bool SubscriberHistory::can_change_be_added_nts(
         const CacheChange_t* change,
         size_t unknown_missing_changes_up_to) const
 {
-    bool ret_val = (KEEP_ALL_HISTORY_QOS != history_qos_.kind) || 
-        (m_changes.size() + unknown_missing_changes_up_to < static_cast<size_t>(resource_limited_qos_.max_samples));
+    bool ret_val = (KEEP_ALL_HISTORY_QOS != history_qos_.kind) ||
+            (m_changes.size() + unknown_missing_changes_up_to < static_cast<size_t>(resource_limited_qos_.max_samples));
     return ret_val && ReaderHistory::can_change_be_added_nts(change, unknown_missing_changes_up_to);
 }
 

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -137,13 +137,13 @@ SubscriberHistory::~SubscriberHistory()
     }
 }
 
-bool SubscriberHistory::can_change_be_added(
+bool SubscriberHistory::can_change_be_added_nts(
         const CacheChange_t* change,
-        size_t unknown_missing_changes_up_to)
+        size_t unknown_missing_changes_up_to) const
 {
     bool ret_val = (KEEP_ALL_HISTORY_QOS != history_qos_.kind) || 
         (m_changes.size() + unknown_missing_changes_up_to < static_cast<size_t>(resource_limited_qos_.max_samples));
-    return ret_val && ReaderHistory::can_change_be_added(change, unknown_missing_changes_up_to);
+    return ret_val && ReaderHistory::can_change_be_added_nts(change, unknown_missing_changes_up_to);
 }
 
 bool SubscriberHistory::received_change(

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -318,7 +318,7 @@ void EDPSimple::processPersistentData(
                     return;
                 }
 
-                if (!reader.first->change_received(change_to_add, nullptr))
+                if (!reader.first->change_received(change_to_add, nullptr, 0))
                 {
                     logInfo(RTPS_EDP, "EDPServer couldn't process database data not add change "
                         << change_to_add->sequenceNumber);

--- a/src/cpp/rtps/history/ReaderHistory.cpp
+++ b/src/cpp/rtps/history/ReaderHistory.cpp
@@ -43,6 +43,30 @@ ReaderHistory::~ReaderHistory()
 {
 }
 
+bool ReaderHistory::can_change_be_added(
+        const CacheChange_t* change,
+        size_t unknown_missing_changes_up_to)
+{
+    static_cast<void>(unknown_missing_changes_up_to);
+
+    if (m_att.memoryPolicy == PREALLOCATED_MEMORY_MODE && change->serializedPayload.length > m_att.payloadMaxSize)
+    {
+        logError(RTPS_READER_HISTORY,
+            "Change payload size of '" << change->serializedPayload.length <<
+            "' bytes is larger than the history payload size of '" << m_att.payloadMaxSize <<
+            "' bytes and cannot be resized.");
+        return false;
+    }
+
+    if (change->writerGUID == c_Guid_Unknown)
+    {
+        logError(RTPS_READER_HISTORY, "The Writer GUID_t must be defined");
+        return false;
+    }
+
+    return true;
+}
+
 bool ReaderHistory::received_change(
         CacheChange_t* change,
         size_t)

--- a/src/cpp/rtps/history/ReaderHistory.cpp
+++ b/src/cpp/rtps/history/ReaderHistory.cpp
@@ -52,9 +52,9 @@ bool ReaderHistory::can_change_be_added_nts(
     if (m_att.memoryPolicy == PREALLOCATED_MEMORY_MODE && change->serializedPayload.length > m_att.payloadMaxSize)
     {
         logError(RTPS_READER_HISTORY,
-            "Change payload size of '" << change->serializedPayload.length <<
-            "' bytes is larger than the history payload size of '" << m_att.payloadMaxSize <<
-            "' bytes and cannot be resized.");
+                "Change payload size of '" << change->serializedPayload.length <<
+                "' bytes is larger than the history payload size of '" << m_att.payloadMaxSize <<
+                "' bytes and cannot be resized.");
         return false;
     }
 

--- a/src/cpp/rtps/history/ReaderHistory.cpp
+++ b/src/cpp/rtps/history/ReaderHistory.cpp
@@ -43,9 +43,9 @@ ReaderHistory::~ReaderHistory()
 {
 }
 
-bool ReaderHistory::can_change_be_added(
+bool ReaderHistory::can_change_be_added_nts(
         const CacheChange_t* change,
-        size_t unknown_missing_changes_up_to)
+        size_t unknown_missing_changes_up_to) const
 {
     static_cast<void>(unknown_missing_changes_up_to);
 

--- a/src/cpp/rtps/history/ReaderHistory.cpp
+++ b/src/cpp/rtps/history/ReaderHistory.cpp
@@ -44,7 +44,8 @@ ReaderHistory::~ReaderHistory()
 }
 
 bool ReaderHistory::can_change_be_added_nts(
-        const CacheChange_t* change,
+        const GUID_t& writer_guid,
+        uint32_t total_payload_size,
         size_t unknown_missing_changes_up_to,
         bool& will_never_be_accepted) const
 {
@@ -52,17 +53,17 @@ bool ReaderHistory::can_change_be_added_nts(
 
     will_never_be_accepted = false;
 
-    if (m_att.memoryPolicy == PREALLOCATED_MEMORY_MODE && change->serializedPayload.length > m_att.payloadMaxSize)
+    if (m_att.memoryPolicy == PREALLOCATED_MEMORY_MODE && total_payload_size > m_att.payloadMaxSize)
     {
         logError(RTPS_READER_HISTORY,
-                "Change payload size of '" << change->serializedPayload.length <<
+                "Change payload size of '" << total_payload_size <<
                 "' bytes is larger than the history payload size of '" << m_att.payloadMaxSize <<
                 "' bytes and cannot be resized.");
         will_never_be_accepted = true;
         return false;
     }
 
-    if (change->writerGUID == c_Guid_Unknown)
+    if (writer_guid == c_Guid_Unknown)
     {
         logError(RTPS_READER_HISTORY, "The Writer GUID_t must be defined");
         will_never_be_accepted = true;

--- a/src/cpp/rtps/history/ReaderHistory.cpp
+++ b/src/cpp/rtps/history/ReaderHistory.cpp
@@ -45,9 +45,12 @@ ReaderHistory::~ReaderHistory()
 
 bool ReaderHistory::can_change_be_added_nts(
         const CacheChange_t* change,
-        size_t unknown_missing_changes_up_to) const
+        size_t unknown_missing_changes_up_to,
+        bool& will_never_be_accepted) const
 {
     static_cast<void>(unknown_missing_changes_up_to);
+
+    will_never_be_accepted = false;
 
     if (m_att.memoryPolicy == PREALLOCATED_MEMORY_MODE && change->serializedPayload.length > m_att.payloadMaxSize)
     {
@@ -55,12 +58,14 @@ bool ReaderHistory::can_change_be_added_nts(
                 "Change payload size of '" << change->serializedPayload.length <<
                 "' bytes is larger than the history payload size of '" << m_att.payloadMaxSize <<
                 "' bytes and cannot be resized.");
+        will_never_be_accepted = true;
         return false;
     }
 
     if (change->writerGUID == c_Guid_Unknown)
     {
         logError(RTPS_READER_HISTORY, "The Writer GUID_t must be defined");
+        will_never_be_accepted = true;
         return false;
     }
 

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -456,7 +456,8 @@ bool StatefulReader::processDataMsg(
 
             size_t unknown_missing_changes_up_to = pWP ? pWP->unknown_missing_changes_up_to(change->sequenceNumber) : 0;
             bool will_never_be_accepted = false;
-            if (!mp_history->can_change_be_added_nts(change, unknown_missing_changes_up_to, will_never_be_accepted))
+            if (!mp_history->can_change_be_added_nts(change->writerGUID, change->serializedPayload.length,
+                    unknown_missing_changes_up_to, will_never_be_accepted))
             {
                 if (will_never_be_accepted && pWP)
                 {

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -562,6 +562,17 @@ bool StatefulReader::processDataFragMsg(
                     IDSTRING "Trying to add fragment " << incomingChange->sequenceNumber.to64long() << " TO reader: " <<
                     getGuid().entityId);
 
+            size_t changes_up_to = pWP->unknown_missing_changes_up_to(incomingChange->sequenceNumber);
+            bool will_never_be_accepted = false;
+            if (!mp_history->can_change_be_added_nts(incomingChange->writerGUID, sampleSize, changes_up_to, will_never_be_accepted))
+            {
+                if (will_never_be_accepted)
+                {
+                    pWP->irrelevant_change_set(incomingChange->sequenceNumber);
+                }
+                return false;
+            }
+
             CacheChange_t* change_to_add = incomingChange;
 
             CacheChange_t* change_created = nullptr;
@@ -595,7 +606,6 @@ bool StatefulReader::processDataFragMsg(
             // If this is the first time we have received fragments for this change, add it to history
             if (change_created != nullptr)
             {
-                size_t changes_up_to = pWP->unknown_missing_changes_up_to(change_created->sequenceNumber);
                 if (!change_received(change_created, pWP, changes_up_to))
                 {
 

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -446,58 +446,63 @@ bool StatefulReader::processDataMsg(
             logInfo(RTPS_MSG_IN,
                     IDSTRING "Trying to add change " << change->sequenceNumber << " TO reader: " << getGuid().entityId);
 
-            // Ask the pool for a cache change
-            CacheChange_t* change_to_add = nullptr;
-            if (!change_pool_->reserve_cache(change_to_add))
+            size_t unknown_missing_changes_up_to = pWP ? pWP->unknown_missing_changes_up_to(change->sequenceNumber) : 0;
+            if (mp_history->can_change_be_added(change, unknown_missing_changes_up_to))
             {
-                logError(RTPS_MSG_IN, IDSTRING "Problem reserving CacheChange in reader: " << m_guid);
-                return false;
-            }
-
-            // Copy metadata to reserved change
-            change_to_add->copy_not_memcpy(change);
-
-            // Ask payload pool to copy the payload
-            IPayloadPool* payload_owner = change->payload_owner();
-
-            if (is_datasharing_compatible_ && datasharing_listener_->writer_is_matched(change->writerGUID))
-            {
-                // We may receive the change from the listener (with owner a ReaderPool) or intraprocess (with owner a WriterPool)
-                ReaderPool* datasharing_pool = dynamic_cast<ReaderPool*>(payload_owner);
-                if (!datasharing_pool)
+                // Ask the pool for a cache change
+                CacheChange_t* change_to_add = nullptr;
+                if (!change_pool_->reserve_cache(change_to_add))
                 {
-                    datasharing_pool = datasharing_listener_->get_pool_for_writer(change->writerGUID).get();
+                    logError(RTPS_MSG_IN, IDSTRING "Problem reserving CacheChange in reader: " << m_guid);
+                    return false;
                 }
-                if (!datasharing_pool)
+
+                // Copy metadata to reserved change
+                change_to_add->copy_not_memcpy(change);
+
+                // Ask payload pool to copy the payload
+                IPayloadPool* payload_owner = change->payload_owner();
+
+                if (is_datasharing_compatible_ && datasharing_listener_->writer_is_matched(change->writerGUID))
                 {
-                    logWarning(RTPS_MSG_IN, IDSTRING "Problem copying DataSharing CacheChange from writer "
-                            << change->writerGUID);
+                    // We may receive the change from the listener (with owner a ReaderPool) or intraprocess (with owner a WriterPool)
+                    ReaderPool* datasharing_pool = dynamic_cast<ReaderPool*>(payload_owner);
+                    if (!datasharing_pool)
+                    {
+                        datasharing_pool = datasharing_listener_->get_pool_for_writer(change->writerGUID).get();
+                    }
+                    if (!datasharing_pool)
+                    {
+                        logWarning(RTPS_MSG_IN, IDSTRING "Problem copying DataSharing CacheChange from writer "
+                                << change->writerGUID);
+                        change_pool_->release_cache(change_to_add);
+                        return false;
+                    }
+                    datasharing_pool->get_payload(change->serializedPayload, payload_owner, *change_to_add);
+                }
+                else if (payload_pool_->get_payload(change->serializedPayload, payload_owner, *change_to_add))
+                {
+                    change->payload_owner(payload_owner);
+                }
+                else
+                {
+                    logWarning(RTPS_MSG_IN, IDSTRING "Problem copying CacheChange, received data is: "
+                            << change->serializedPayload.length << " bytes and max size in reader "
+                            << m_guid << " is "
+                            << (fixed_payload_size_ > 0 ? fixed_payload_size_ : std::numeric_limits<uint32_t>::max()));
                     change_pool_->release_cache(change_to_add);
                     return false;
                 }
-                datasharing_pool->get_payload(change->serializedPayload, payload_owner, *change_to_add);
-            }
-            else if (payload_pool_->get_payload(change->serializedPayload, payload_owner, *change_to_add))
-            {
-                change->payload_owner(payload_owner);
-            }
-            else
-            {
-                logWarning(RTPS_MSG_IN, IDSTRING "Problem copying CacheChange, received data is: "
-                        << change->serializedPayload.length << " bytes and max size in reader "
-                        << m_guid << " is "
-                        << (fixed_payload_size_ > 0 ? fixed_payload_size_ : std::numeric_limits<uint32_t>::max()));
-                change_pool_->release_cache(change_to_add);
-                return false;
-            }
 
-            // Perform reception of cache change
-            if (!change_received(change_to_add, pWP))
-            {
-                logInfo(RTPS_MSG_IN, IDSTRING "Change " << change_to_add->sequenceNumber << " not added to history");
-                change_to_add->payload_owner()->release_payload(*change_to_add);
-                change_pool_->release_cache(change_to_add);
-                return false;
+                // Perform reception of cache change
+                if (!change_received(change_to_add, pWP))
+                {
+                    logInfo(RTPS_MSG_IN,
+                            IDSTRING "Change " << change_to_add->sequenceNumber << " not added to history");
+                    change_to_add->payload_owner()->release_payload(*change_to_add);
+                    change_pool_->release_cache(change_to_add);
+                    return false;
+                }
             }
         }
 

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -455,8 +455,13 @@ bool StatefulReader::processDataMsg(
                     IDSTRING "Trying to add change " << change->sequenceNumber << " TO reader: " << getGuid().entityId);
 
             size_t unknown_missing_changes_up_to = pWP ? pWP->unknown_missing_changes_up_to(change->sequenceNumber) : 0;
-            if (!mp_history->can_change_be_added_nts(change, unknown_missing_changes_up_to))
+            bool will_never_be_accepted = false;
+            if (!mp_history->can_change_be_added_nts(change, unknown_missing_changes_up_to, will_never_be_accepted))
             {
+                if (will_never_be_accepted && pWP)
+                {
+                    pWP->irrelevant_change_set(change->sequenceNumber);
+                }
                 return false;
             }
 

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -445,10 +445,10 @@ bool StatefulReader::processDataMsg(
         {
             // Always assert liveliness on scope exit
             auto assert_liveliness_lambda = [&lock, this, change](void*)
-            {
-                lock.unlock(); // Avoid deadlock with LivelinessManager.
-                assert_writer_liveliness(change->writerGUID);
-            };
+                    {
+                        lock.unlock(); // Avoid deadlock with LivelinessManager.
+                        assert_writer_liveliness(change->writerGUID);
+                    };
             std::unique_ptr<void, decltype(assert_liveliness_lambda)> p{ this, assert_liveliness_lambda };
 
             logInfo(RTPS_MSG_IN,
@@ -543,10 +543,10 @@ bool StatefulReader::processDataFragMsg(
     {
         // Always assert liveliness on scope exit
         auto assert_liveliness_lambda = [&lock, this, incomingChange](void*)
-        {
-            lock.unlock(); // Avoid deadlock with LivelinessManager.
-            assert_writer_liveliness(incomingChange->writerGUID);
-        };
+                {
+                    lock.unlock(); // Avoid deadlock with LivelinessManager.
+                    assert_writer_liveliness(incomingChange->writerGUID);
+                };
         std::unique_ptr<void, decltype(assert_liveliness_lambda)> p{ this, assert_liveliness_lambda };
 
         // Check if CacheChange was received.

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -495,7 +495,7 @@ bool StatefulReader::processDataMsg(
                 }
 
                 // Perform reception of cache change
-                if (!change_received(change_to_add, pWP))
+                if (!change_received(change_to_add, pWP, unknown_missing_changes_up_to))
                 {
                     logInfo(RTPS_MSG_IN,
                             IDSTRING "Change " << change_to_add->sequenceNumber << " not added to history");
@@ -574,7 +574,8 @@ bool StatefulReader::processDataFragMsg(
             // If this is the first time we have received fragments for this change, add it to history
             if (change_created != nullptr)
             {
-                if (!change_received(change_created, pWP))
+                size_t changes_up_to = pWP->unknown_missing_changes_up_to(change_created->sequenceNumber);
+                if (!change_received(change_created, pWP, changes_up_to))
                 {
 
                     logInfo(RTPS_MSG_IN,
@@ -801,7 +802,8 @@ bool StatefulReader::change_removed_by_history(
 
 bool StatefulReader::change_received(
         CacheChange_t* a_change,
-        WriterProxy* prox)
+        WriterProxy* prox,
+        size_t unknown_missing_changes_up_to)
 {
     //First look for WriterProxy in case is not provided
     if (prox == nullptr)
@@ -851,9 +853,6 @@ bool StatefulReader::change_received(
             }
         }
     }
-
-    // TODO (Miguel C): Refactor this inside WriterProxy
-    size_t unknown_missing_changes_up_to = prox->unknown_missing_changes_up_to(a_change->sequenceNumber);
 
     // NOTE: Depending on QoS settings, one change can be removed from history
     // inside the call to mp_history->received_change

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -852,6 +852,10 @@ bool StatefulReader::change_received(
                 return false;
             }
         }
+        else
+        {
+            unknown_missing_changes_up_to = prox->unknown_missing_changes_up_to(a_change->sequenceNumber);
+        }
     }
 
     // NOTE: Depending on QoS settings, one change can be removed from history

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -564,7 +564,8 @@ bool StatefulReader::processDataFragMsg(
 
             size_t changes_up_to = pWP->unknown_missing_changes_up_to(incomingChange->sequenceNumber);
             bool will_never_be_accepted = false;
-            if (!mp_history->can_change_be_added_nts(incomingChange->writerGUID, sampleSize, changes_up_to, will_never_be_accepted))
+            if (!mp_history->can_change_be_added_nts(incomingChange->writerGUID, sampleSize, changes_up_to,
+                    will_never_be_accepted))
             {
                 if (will_never_be_accepted)
                 {

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -447,7 +447,7 @@ bool StatefulReader::processDataMsg(
                     IDSTRING "Trying to add change " << change->sequenceNumber << " TO reader: " << getGuid().entityId);
 
             size_t unknown_missing_changes_up_to = pWP ? pWP->unknown_missing_changes_up_to(change->sequenceNumber) : 0;
-            if (mp_history->can_change_be_added(change, unknown_missing_changes_up_to))
+            if (mp_history->can_change_be_added_nts(change, unknown_missing_changes_up_to))
             {
                 // Ask the pool for a cache change
                 CacheChange_t* change_to_add = nullptr;

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -447,62 +447,64 @@ bool StatefulReader::processDataMsg(
                     IDSTRING "Trying to add change " << change->sequenceNumber << " TO reader: " << getGuid().entityId);
 
             size_t unknown_missing_changes_up_to = pWP ? pWP->unknown_missing_changes_up_to(change->sequenceNumber) : 0;
-            if (mp_history->can_change_be_added_nts(change, unknown_missing_changes_up_to))
+            if (!mp_history->can_change_be_added_nts(change, unknown_missing_changes_up_to))
             {
-                // Ask the pool for a cache change
-                CacheChange_t* change_to_add = nullptr;
-                if (!change_pool_->reserve_cache(change_to_add))
-                {
-                    logError(RTPS_MSG_IN, IDSTRING "Problem reserving CacheChange in reader: " << m_guid);
-                    return false;
-                }
+                return false;
+            }
 
-                // Copy metadata to reserved change
-                change_to_add->copy_not_memcpy(change);
+            // Ask the pool for a cache change
+            CacheChange_t* change_to_add = nullptr;
+            if (!change_pool_->reserve_cache(change_to_add))
+            {
+                logError(RTPS_MSG_IN, IDSTRING "Problem reserving CacheChange in reader: " << m_guid);
+                return false;
+            }
 
-                // Ask payload pool to copy the payload
-                IPayloadPool* payload_owner = change->payload_owner();
+            // Copy metadata to reserved change
+            change_to_add->copy_not_memcpy(change);
 
-                if (is_datasharing_compatible_ && datasharing_listener_->writer_is_matched(change->writerGUID))
+            // Ask payload pool to copy the payload
+            IPayloadPool* payload_owner = change->payload_owner();
+
+            if (is_datasharing_compatible_ && datasharing_listener_->writer_is_matched(change->writerGUID))
+            {
+                // We may receive the change from the listener (with owner a ReaderPool) or intraprocess (with owner a WriterPool)
+                ReaderPool* datasharing_pool = dynamic_cast<ReaderPool*>(payload_owner);
+                if (!datasharing_pool)
                 {
-                    // We may receive the change from the listener (with owner a ReaderPool) or intraprocess (with owner a WriterPool)
-                    ReaderPool* datasharing_pool = dynamic_cast<ReaderPool*>(payload_owner);
-                    if (!datasharing_pool)
-                    {
-                        datasharing_pool = datasharing_listener_->get_pool_for_writer(change->writerGUID).get();
-                    }
-                    if (!datasharing_pool)
-                    {
-                        logWarning(RTPS_MSG_IN, IDSTRING "Problem copying DataSharing CacheChange from writer "
-                                << change->writerGUID);
-                        change_pool_->release_cache(change_to_add);
-                        return false;
-                    }
-                    datasharing_pool->get_payload(change->serializedPayload, payload_owner, *change_to_add);
+                    datasharing_pool = datasharing_listener_->get_pool_for_writer(change->writerGUID).get();
                 }
-                else if (payload_pool_->get_payload(change->serializedPayload, payload_owner, *change_to_add))
+                if (!datasharing_pool)
                 {
-                    change->payload_owner(payload_owner);
-                }
-                else
-                {
-                    logWarning(RTPS_MSG_IN, IDSTRING "Problem copying CacheChange, received data is: "
-                            << change->serializedPayload.length << " bytes and max size in reader "
-                            << m_guid << " is "
-                            << (fixed_payload_size_ > 0 ? fixed_payload_size_ : std::numeric_limits<uint32_t>::max()));
+                    logWarning(RTPS_MSG_IN, IDSTRING "Problem copying DataSharing CacheChange from writer "
+                            << change->writerGUID);
                     change_pool_->release_cache(change_to_add);
                     return false;
                 }
+                datasharing_pool->get_payload(change->serializedPayload, payload_owner, *change_to_add);
+            }
+            else if (payload_pool_->get_payload(change->serializedPayload, payload_owner, *change_to_add))
+            {
+                change->payload_owner(payload_owner);
+            }
+            else
+            {
+                logWarning(RTPS_MSG_IN, IDSTRING "Problem copying CacheChange, received data is: "
+                        << change->serializedPayload.length << " bytes and max size in reader "
+                        << m_guid << " is "
+                        << (fixed_payload_size_ > 0 ? fixed_payload_size_ : std::numeric_limits<uint32_t>::max()));
+                change_pool_->release_cache(change_to_add);
+                return false;
+            }
 
-                // Perform reception of cache change
-                if (!change_received(change_to_add, pWP, unknown_missing_changes_up_to))
-                {
-                    logInfo(RTPS_MSG_IN,
-                            IDSTRING "Change " << change_to_add->sequenceNumber << " not added to history");
-                    change_to_add->payload_owner()->release_payload(*change_to_add);
-                    change_pool_->release_cache(change_to_add);
-                    return false;
-                }
+            // Perform reception of cache change
+            if (!change_received(change_to_add, pWP, unknown_missing_changes_up_to))
+            {
+                logInfo(RTPS_MSG_IN,
+                        IDSTRING "Change " << change_to_add->sequenceNumber << " not added to history");
+                change_to_add->payload_owner()->release_payload(*change_to_add);
+                change_pool_->release_cache(change_to_add);
+                return false;
             }
         }
 

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -410,7 +410,8 @@ bool StatelessReader::processDataMsg(
         if (!thereIsUpperRecordOf(change->writerGUID, change->sequenceNumber))
         {
             bool will_never_be_accepted = false;
-            if (!mp_history->can_change_be_added_nts(change, 0, will_never_be_accepted))
+            if (!mp_history->can_change_be_added_nts(change->writerGUID, change->serializedPayload.length, 0,
+                    will_never_be_accepted))
             {
                 if (will_never_be_accepted)
                 {

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -518,11 +518,21 @@ bool StatelessReader::processDataFragMsg(
                 logInfo(RTPS_MSG_IN, IDSTRING "Trying to add fragment " << incomingChange->sequenceNumber.to64long() <<
                         " TO reader: " << m_guid);
 
-                // Early return if we already know abount a greater sequence number
+                // Early return if we already know about a greater sequence number
                 CacheChange_t* work_change = writer.fragmented_change;
                 if (work_change != nullptr && work_change->sequenceNumber > incomingChange->sequenceNumber)
                 {
                     return true;
+                }
+
+                bool will_never_be_accepted = false;
+                if (!mp_history->can_change_be_added_nts(writer_guid, sampleSize, 0, will_never_be_accepted))
+                {
+                    if (will_never_be_accepted)
+                    {
+                        update_last_notified(writer_guid, incomingChange->sequenceNumber);
+                    }
+                    return false;
                 }
 
                 CacheChange_t* change_to_add = incomingChange;

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -399,7 +399,7 @@ bool StatelessReader::processDataMsg(
         logInfo(RTPS_MSG_IN, IDSTRING "Trying to add change " << change->sequenceNumber << " TO reader: " << m_guid);
 
         // Check rejection by history
-        if (mp_history->can_change_be_added(change, 0) &&
+        if (mp_history->can_change_be_added_nts(change, 0) &&
                 !thereIsUpperRecordOf(change->writerGUID, change->sequenceNumber))
         {
             // Ask the pool for a cache change

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -398,10 +398,10 @@ bool StatelessReader::processDataMsg(
     {
         // Always assert liveliness on scope exit
         auto assert_liveliness_lambda = [&lock, this, change](void*)
-        {
-            lock.unlock(); // Avoid deadlock with LivelinessManager.
-            assert_writer_liveliness(change->writerGUID);
-        };
+                {
+                    lock.unlock(); // Avoid deadlock with LivelinessManager.
+                    assert_writer_liveliness(change->writerGUID);
+                };
         std::unique_ptr<void, decltype(assert_liveliness_lambda)> p{ this, assert_liveliness_lambda };
 
         logInfo(RTPS_MSG_IN, IDSTRING "Trying to add change " << change->sequenceNumber << " TO reader: " << m_guid);
@@ -497,10 +497,10 @@ bool StatelessReader::processDataFragMsg(
         {
             // Always assert liveliness on scope exit
             auto assert_liveliness_lambda = [&lock, this, &writer_guid](void*)
-            {
-                lock.unlock(); // Avoid deadlock with LivelinessManager.
-                assert_writer_liveliness(writer_guid);
-            };
+                    {
+                        lock.unlock(); // Avoid deadlock with LivelinessManager.
+                        assert_writer_liveliness(writer_guid);
+                    };
             std::unique_ptr<void, decltype(assert_liveliness_lambda)> p{ this, assert_liveliness_lambda };
 
             // Datasharing communication will never send fragments

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -409,8 +409,13 @@ bool StatelessReader::processDataMsg(
         // Check rejection by history
         if (!thereIsUpperRecordOf(change->writerGUID, change->sequenceNumber))
         {
-            if (!mp_history->can_change_be_added_nts(change, 0))
+            bool will_never_be_accepted = false;
+            if (!mp_history->can_change_be_added_nts(change, 0, will_never_be_accepted))
             {
+                if (will_never_be_accepted)
+                {
+                    update_last_notified(change->writerGUID, change->sequenceNumber);
+                }
                 return false;
             }
 

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -399,9 +399,13 @@ bool StatelessReader::processDataMsg(
         logInfo(RTPS_MSG_IN, IDSTRING "Trying to add change " << change->sequenceNumber << " TO reader: " << m_guid);
 
         // Check rejection by history
-        if (mp_history->can_change_be_added_nts(change, 0) &&
-                !thereIsUpperRecordOf(change->writerGUID, change->sequenceNumber))
+        if (!thereIsUpperRecordOf(change->writerGUID, change->sequenceNumber))
         {
+            if (!mp_history->can_change_be_added_nts(change, 0))
+            {
+                return false;
+            }
+
             // Ask the pool for a cache change
             CacheChange_t* change_to_add = nullptr;
             if (!change_pool_->reserve_cache(change_to_add))

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -398,65 +398,70 @@ bool StatelessReader::processDataMsg(
     {
         logInfo(RTPS_MSG_IN, IDSTRING "Trying to add change " << change->sequenceNumber << " TO reader: " << m_guid);
 
-        // Ask the pool for a cache change
-        CacheChange_t* change_to_add = nullptr;
-        if (!change_pool_->reserve_cache(change_to_add))
+        // Check rejection by history
+        if (mp_history->can_change_be_added(change, 0) &&
+                !thereIsUpperRecordOf(change->writerGUID, change->sequenceNumber))
         {
-            logError(RTPS_MSG_IN, IDSTRING "Problem reserving CacheChange in reader: " << m_guid);
-            return false;
-        }
-
-        // Copy metadata to reserved change
-        change_to_add->copy_not_memcpy(change);
-
-        // Ask payload pool to copy the payload
-        IPayloadPool* payload_owner = change->payload_owner();
-
-        bool is_datasharing = std::any_of(matched_writers_.begin(), matched_writers_.end(),
-                        [&change](const RemoteWriterInfo_t& writer)
-                        {
-                            return (writer.guid == change->writerGUID) && (writer.is_datasharing);
-                        });
-
-        if (is_datasharing)
-        {
-            //We may receive the change from the listener (with owner a ReaderPool) or intraprocess (with owner a WriterPool)
-            ReaderPool* datasharing_pool = dynamic_cast<ReaderPool*>(payload_owner);
-            if (!datasharing_pool)
+            // Ask the pool for a cache change
+            CacheChange_t* change_to_add = nullptr;
+            if (!change_pool_->reserve_cache(change_to_add))
             {
-                datasharing_pool = datasharing_listener_->get_pool_for_writer(change->writerGUID).get();
+                logError(RTPS_MSG_IN, IDSTRING "Problem reserving CacheChange in reader: " << m_guid);
+                return false;
             }
-            if (!datasharing_pool)
+
+            // Copy metadata to reserved change
+            change_to_add->copy_not_memcpy(change);
+
+            // Ask payload pool to copy the payload
+            IPayloadPool* payload_owner = change->payload_owner();
+
+            bool is_datasharing = std::any_of(matched_writers_.begin(), matched_writers_.end(),
+                            [&change](const RemoteWriterInfo_t& writer)
+                            {
+                                return (writer.guid == change->writerGUID) && (writer.is_datasharing);
+                            });
+
+            if (is_datasharing)
             {
-                logWarning(RTPS_MSG_IN, IDSTRING "Problem copying DataSharing CacheChange from writer "
-                        << change->writerGUID);
+                //We may receive the change from the listener (with owner a ReaderPool) or intraprocess (with owner a WriterPool)
+                ReaderPool* datasharing_pool = dynamic_cast<ReaderPool*>(payload_owner);
+                if (!datasharing_pool)
+                {
+                    datasharing_pool = datasharing_listener_->get_pool_for_writer(change->writerGUID).get();
+                }
+                if (!datasharing_pool)
+                {
+                    logWarning(RTPS_MSG_IN, IDSTRING "Problem copying DataSharing CacheChange from writer "
+                            << change->writerGUID);
+                    change_pool_->release_cache(change_to_add);
+                    return false;
+                }
+
+                datasharing_pool->get_payload(change->serializedPayload, payload_owner, *change_to_add);
+            }
+            else if (payload_pool_->get_payload(change->serializedPayload, payload_owner, *change_to_add))
+            {
+                change->payload_owner(payload_owner);
+            }
+            else
+            {
+                logWarning(RTPS_MSG_IN, IDSTRING "Problem copying CacheChange, received data is: "
+                        << change->serializedPayload.length << " bytes and max size in reader "
+                        << m_guid << " is "
+                        << (fixed_payload_size_ > 0 ? fixed_payload_size_ : std::numeric_limits<uint32_t>::max()));
                 change_pool_->release_cache(change_to_add);
                 return false;
             }
 
-            datasharing_pool->get_payload(change->serializedPayload, payload_owner, *change_to_add);
-        }
-        else if (payload_pool_->get_payload(change->serializedPayload, payload_owner, *change_to_add))
-        {
-            change->payload_owner(payload_owner);
-        }
-        else
-        {
-            logWarning(RTPS_MSG_IN, IDSTRING "Problem copying CacheChange, received data is: "
-                    << change->serializedPayload.length << " bytes and max size in reader "
-                    << m_guid << " is "
-                    << (fixed_payload_size_ > 0 ? fixed_payload_size_ : std::numeric_limits<uint32_t>::max()));
-            change_pool_->release_cache(change_to_add);
-            return false;
-        }
-
-        // Perform reception of cache change
-        if (!change_received(change_to_add))
-        {
-            logInfo(RTPS_MSG_IN, IDSTRING "MessageReceiver not add change " << change_to_add->sequenceNumber);
-            change_to_add->payload_owner()->release_payload(*change_to_add);
-            change_pool_->release_cache(change_to_add);
-            return false;
+            // Perform reception of cache change
+            if (!change_received(change_to_add))
+            {
+                logInfo(RTPS_MSG_IN, IDSTRING "MessageReceiver not add change " << change_to_add->sequenceNumber);
+                change_to_add->payload_owner()->release_payload(*change_to_add);
+                change_pool_->release_cache(change_to_add);
+                return false;
+            }
         }
 
         lock.unlock(); // Avoid deadlock with LivelinessManager.

--- a/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
+++ b/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
@@ -73,7 +73,8 @@ public:
     }
 
     virtual bool can_change_be_added_nts(
-            const CacheChange_t*,
+            const GUID_t&,
+            uint32_t,
             size_t,
             bool&) const
     {

--- a/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
+++ b/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
@@ -72,9 +72,9 @@ public:
         return ret;
     }
 
-    virtual bool can_change_be_added(
+    virtual bool can_change_be_added_nts(
             const CacheChange_t*,
-            size_t)
+            size_t) const
     {
         return true;
     }

--- a/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
+++ b/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
@@ -72,6 +72,13 @@ public:
         return ret;
     }
 
+    virtual bool can_change_be_added(
+            const CacheChange_t*,
+            size_t)
+    {
+        return true;
+    }
+
     virtual bool received_change(
             CacheChange_t*,
             size_t)

--- a/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
+++ b/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
@@ -74,7 +74,8 @@ public:
 
     virtual bool can_change_be_added_nts(
             const CacheChange_t*,
-            size_t) const
+            size_t,
+            bool&) const
     {
         return true;
     }


### PR DESCRIPTION
This PR adds a mechanism on ReaderHistory to check if a new change will be accepted into it. This allows the code on `processDataMsg` to avoid copying the change information (and, possibly, its payload) for a sample that is going to be rejected