### PR TITLE
Disable DataReader on destruction [12870]

### DIFF
--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -287,6 +287,8 @@ void DataReaderImpl::disable()
 
 DataReaderImpl::~DataReaderImpl()
 {
+    // Disable the datareader to prevent receiving data in the middle of deleting it
+    disable();
     delete lifespan_timer_;
     delete deadline_timer_;
 

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -314,7 +314,6 @@ ReturnCode_t SubscriberImpl::delete_datareader(
                 return ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;
             }
 
-            reader_impl->set_listener(nullptr);
             it->second.erase(dr_it);
             if (it->second.empty())
             {

--- a/src/cpp/rtps/reader/RTPSReader.cpp
+++ b/src/cpp/rtps/reader/RTPSReader.cpp
@@ -208,6 +208,7 @@ ReaderListener* RTPSReader::getListener() const
 bool RTPSReader::setListener(
         ReaderListener* target)
 {
+    std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
     mp_listener = target;
     return true;
 }


### PR DESCRIPTION
This PR disables the `DataReader` on destruction. This is because, as reported in #2307 , it could be the case that a data sample is received while deleting a `DataReader`, which before could end up in a situation in which the underlying `RTPSReader` was accessed when it had been already deleted. To avoid this case, the first thing done on the destruction of the `DataReader` is to disable it, which sets the `DataReader` and `RTPSReader` listeners to `nullptr`, thus preventing receiving a data sample on upper layers.

Closes #2307 