### PR TITLE
Allow zero-valued InstanceHandle_t [12942]

### DIFF
--- a/include/fastdds/rtps/common/InstanceHandle.h
+++ b/include/fastdds/rtps/common/InstanceHandle.h
@@ -34,42 +34,42 @@ using KeyHash_t = std::array<octet, 16>;
 struct RTPS_DllAPI InstanceHandleValue_t
 {
     octet& operator [] (
-            size_t i)
+            size_t i) noexcept
     {
         has_been_set_ = true;
         return value_[i];
     }
 
     octet operator [] (
-            size_t i) const
+            size_t i) const noexcept
     {
         return value_[i];
     }
 
-    operator octet* ()
+    operator octet* () noexcept
     {
         has_been_set_ = true;
         return value_.data();
     }
 
-    operator const octet* () const
+    operator const octet* () const noexcept
     {
         return value_.data();
     }
 
-    bool has_been_set() const
+    bool has_been_set() const noexcept
     {
         return has_been_set_;
     }
 
     bool operator == (
-            const InstanceHandleValue_t& other) const
+            const InstanceHandleValue_t& other) const noexcept
     {
         return (has_been_set_ == other.has_been_set_) && (value_ == other.value_);
     }
 
     bool operator < (
-            const InstanceHandleValue_t& other) const
+            const InstanceHandleValue_t& other) const noexcept
     {
         if (has_been_set_)
         {
@@ -96,13 +96,13 @@ struct RTPS_DllAPI InstanceHandle_t
     //!Value
     InstanceHandleValue_t value;
 
-    InstanceHandle_t() = default;
+    InstanceHandle_t() noexcept = default;
 
     InstanceHandle_t(
-            const InstanceHandle_t& ihandle) = default;
+            const InstanceHandle_t& ihandle) noexcept = default;
 
     InstanceHandle_t(
-            const GUID_t& guid)
+            const GUID_t& guid) noexcept
     {
         *this = guid;
     }
@@ -112,14 +112,14 @@ struct RTPS_DllAPI InstanceHandle_t
      * @param ihandle Instance handle to copy the data from
      */
     InstanceHandle_t& operator =(
-            const InstanceHandle_t& ihandle) = default;
+            const InstanceHandle_t& ihandle) noexcept = default;
 
     /**
      * Assignment operator
      * @param guid GUID to copy the data from
      */
     InstanceHandle_t& operator =(
-            const GUID_t& guid)
+            const GUID_t& guid) noexcept
     {
         octet* dst = value;
         memcpy(dst, guid.guidPrefix.value, 12);
@@ -131,13 +131,13 @@ struct RTPS_DllAPI InstanceHandle_t
      * Know if the instance handle is defined
      * @return True if the values are not zero.
      */
-    bool isDefined() const
+    bool isDefined() const noexcept
     {
         return value.has_been_set();
     }
 
     // TODO Review this conversion once InstanceHandle_t is implemented as DDS standard defines
-    explicit operator const GUID_t&() const
+    explicit operator const GUID_t&() const noexcept
     {
         return *reinterpret_cast<const GUID_t*>(this);
     }
@@ -156,14 +156,14 @@ const InstanceHandle_t c_InstanceHandle_Unknown;
  */
 inline bool operator ==(
         const InstanceHandle_t& ihandle1,
-        const InstanceHandle_t& ihandle2)
+        const InstanceHandle_t& ihandle2) noexcept
 {
     return ihandle1.value == ihandle2.value;
 }
 
 inline bool operator !=(
         const InstanceHandle_t& ihandle1,
-        const InstanceHandle_t& ihandle2)
+        const InstanceHandle_t& ihandle2) noexcept
 {
     return !(ihandle1 == ihandle2);
 }
@@ -177,7 +177,7 @@ inline bool operator !=(
  */
 inline void iHandle2GUID(
         GUID_t& guid,
-        const InstanceHandle_t& ihandle)
+        const InstanceHandle_t& ihandle) noexcept
 {
     const octet* value = ihandle.value;
     memcpy(guid.guidPrefix.value, value, 12);
@@ -190,7 +190,7 @@ inline void iHandle2GUID(
  * @return GUID_t
  */
 inline GUID_t iHandle2GUID(
-        const InstanceHandle_t& ihandle)
+        const InstanceHandle_t& ihandle) noexcept
 {
     GUID_t guid;
     iHandle2GUID(guid, ihandle);
@@ -199,7 +199,7 @@ inline GUID_t iHandle2GUID(
 
 inline bool operator <(
         const InstanceHandle_t& h1,
-        const InstanceHandle_t& h2)
+        const InstanceHandle_t& h2) noexcept
 {
     return h1.value < h2.value;
 }

--- a/include/fastdds/rtps/common/InstanceHandle.h
+++ b/include/fastdds/rtps/common/InstanceHandle.h
@@ -62,6 +62,23 @@ struct RTPS_DllAPI InstanceHandleValue_t
         return has_been_set_;
     }
 
+    bool operator == (
+            const InstanceHandleValue_t& other) const
+    {
+        return (has_been_set_ == other.has_been_set_) && (value_ == other.value_);
+    }
+
+    bool operator < (
+            const InstanceHandleValue_t& other) const
+    {
+        if (has_been_set_)
+        {
+            return other.has_been_set_ && value_ < other.value_;
+        }
+
+        return other.has_been_set_;
+    }
+
 private:
 
     //! Hash value
@@ -184,12 +201,7 @@ inline bool operator <(
         const InstanceHandle_t& h1,
         const InstanceHandle_t& h2)
 {
-    if (h1.isDefined())
-    {
-        return h2.isDefined() && memcmp(h1.value, h2.value, 16) < 0;
-    }
-
-    return h2.isDefined();
+    return h1.value < h2.value;
 }
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC

--- a/include/fastdds/rtps/common/InstanceHandle.h
+++ b/include/fastdds/rtps/common/InstanceHandle.h
@@ -31,6 +31,45 @@ namespace rtps {
 
 using KeyHash_t = std::array<octet, 16>;
 
+struct RTPS_DllAPI InstanceHandleValue_t
+{
+    octet& operator [] (
+            size_t i)
+    {
+        has_been_set_ = true;
+        return value_[i];
+    }
+
+    octet operator [] (
+            size_t i) const
+    {
+        return value_[i];
+    }
+
+    operator octet* ()
+    {
+        has_been_set_ = true;
+        return value_.data();
+    }
+
+    operator const octet* () const
+    {
+        return value_.data();
+    }
+
+    bool has_been_set() const
+    {
+        return has_been_set_;
+    }
+
+private:
+
+    //! Hash value
+    KeyHash_t value_ { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    //! Flag indicating if value_ has been modified since the creation of this object
+    bool has_been_set_ = false;
+};
+
 /**
  * Struct InstanceHandle_t, used to contain the key for WITH_KEY topics.
  * @ingroup COMMON_MODULE

--- a/include/fastdds/rtps/common/InstanceHandle.h
+++ b/include/fastdds/rtps/common/InstanceHandle.h
@@ -19,6 +19,8 @@
 #ifndef _FASTDDS_RTPS_INSTANCEHANDLE_H_
 #define _FASTDDS_RTPS_INSTANCEHANDLE_H_
 
+#include <array>
+
 #include <fastrtps/fastrtps_dll.h>
 #include <fastdds/rtps/common/Types.h>
 #include <fastdds/rtps/common/Guid.h>
@@ -26,6 +28,8 @@
 namespace eprosima {
 namespace fastrtps {
 namespace rtps {
+
+using KeyHash_t = std::array<octet, 16>;
 
 /**
  * Struct InstanceHandle_t, used to contain the key for WITH_KEY topics.

--- a/include/fastdds/rtps/common/InstanceHandle.h
+++ b/include/fastdds/rtps/common/InstanceHandle.h
@@ -33,6 +33,18 @@ using KeyHash_t = std::array<octet, 16>;
 
 struct RTPS_DllAPI InstanceHandleValue_t
 {
+    /**
+     * Write access indexing operator.
+     *
+     * Provides a reference to the byte value at position @c i.
+     *
+     * @param [in] i index of the byte to return.
+     *
+     * @post Method has_been_set() returns @c true.
+     *
+     * @remark Do not use this method to check if this value has been set.
+     *         Use method has_been_set() instead.
+     */
     octet& operator [] (
             size_t i) noexcept
     {
@@ -40,34 +52,71 @@ struct RTPS_DllAPI InstanceHandleValue_t
         return value_[i];
     }
 
+    /**
+     * Read access indexing operator.
+     *
+     * Provides the byte value at position @c i.
+     *
+     * @param [in] i index of the byte to return.
+     *
+     * @remark Do not use this method to check if this value has been set.
+     *         Use method has_been_set() instead.
+     */
     octet operator [] (
             size_t i) const noexcept
     {
         return value_[i];
     }
 
+    /**
+     * Write access pointer cast operator.
+     *
+     * Provides a pointer to the start of the raw data.
+     *
+     * @post Method has_been_set() returns @c true.
+     *
+     * @remark Do not use this method to check if this value has been set.
+     *         Use method has_been_set() instead.
+     */
     operator octet* () noexcept
     {
         has_been_set_ = true;
         return value_.data();
     }
 
+    /**
+     * Read access pointer cast operator.
+     *
+     * Provides a pointer to the start of the raw data.
+     *
+     * @remark Do not use this method to check if this value has been set.
+     *         Use method has_been_set() instead.
+     */
     operator const octet* () const noexcept
     {
         return value_.data();
     }
 
+    /**
+     * Return whether any of the write access operators of this value has been used.
+     */
     bool has_been_set() const noexcept
     {
         return has_been_set_;
     }
 
+    /**
+     * Equality comparison operator.
+     */
     bool operator == (
             const InstanceHandleValue_t& other) const noexcept
     {
         return (has_been_set_ == other.has_been_set_) && (value_ == other.value_);
     }
 
+    /**
+     * Less than comparisor operator.
+     */
     bool operator < (
             const InstanceHandleValue_t& other) const noexcept
     {

--- a/include/fastdds/rtps/common/InstanceHandle.h
+++ b/include/fastdds/rtps/common/InstanceHandle.h
@@ -82,7 +82,7 @@ struct RTPS_DllAPI InstanceHandleValue_t
 private:
 
     //! Hash value
-    KeyHash_t value_ { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    KeyHash_t value_ {};
     //! Flag indicating if value_ has been modified since the creation of this object
     bool has_been_set_ = false;
 };

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -151,7 +151,7 @@ protected:
     {
         FooType data;
 
-        data.index(1);
+        data.index(0);
         type_.get_key(&data, &handle_ok_);
 
         data.index(2);
@@ -512,7 +512,7 @@ protected:
 
         // Send data
         DataType data;
-        data.index(1);
+        data.index(0);
         EXPECT_EQ(ReturnCode_t::RETCODE_OK, data_writer_->write(&data, HANDLE_NIL));
 
         // Wait for data to arrive and check OK should be returned
@@ -883,7 +883,7 @@ TEST_F(DataReaderTests, return_loan)
     EXPECT_EQ(ok_code, reader2->enable());
 
     FooType data;
-    data.index(1);
+    data.index(0);
 
     // Send a bunch of samples
     for (int32_t i = 0; i < num_samples; ++i)
@@ -1030,7 +1030,7 @@ TEST_F(DataReaderTests, resource_limits)
     create_entities(nullptr, reader_qos, SUBSCRIBER_QOS_DEFAULT, writer_qos);
 
     FooType data;
-    data.index(1);
+    data.index(0);
 
     // Send a bunch of samples
     for (int32_t i = 0; i < num_samples; ++i)
@@ -1232,7 +1232,7 @@ TEST_F(DataReaderTests, read_unread)
     create_entities(nullptr, reader_qos, SUBSCRIBER_QOS_DEFAULT, writer_qos);
 
     FooType data;
-    data.index(1);
+    data.index(0);
     data.message()[1] = '\0';
 
     // Send a bunch of samples
@@ -1527,7 +1527,7 @@ TEST_F(DataReaderTests, Deserialization_errors)
     create_entities(nullptr, reader_qos, SUBSCRIBER_QOS_DEFAULT, writer_qos);
 
     FooType data;
-    data.index(1);
+    data.index(0);
     data.message()[1] = '\0';
 
     // Check deserialization errors without loans
@@ -1780,7 +1780,7 @@ TEST_F(DataReaderTests, check_key_history_wholesomeness_on_unmatch)
     FooType sample;
     std::array<char, 256> msg = {"checking robustness"};
 
-    sample.index(1);
+    sample.index(0);
     sample.message(msg);
 
     ASSERT_TRUE(data_writer_->write(&sample));
@@ -2053,7 +2053,7 @@ TEST_F(DataReaderTests, read_samples_with_future_changes)
     std::this_thread::sleep_for(std::chrono::milliseconds(100)); // Wait discovery
 
     FooType data;
-    data.index(1);
+    data.index(0);
     data.message()[0] = '\0';
     data.message()[1] = '\0';
 

--- a/versions.md
+++ b/versions.md
@@ -1,6 +1,7 @@
 Forthcoming
 -----------
 
+* Allow zero-valued InstanceHandle_t (ABI break)
 * 
 
 Version 2.4.0


### PR DESCRIPTION
This should fix #2306 by adding a specific validity field to `InstanceHandle_t`. This means the solution is not ABI compatible with the current code. That's why I added this to v2.5.0 milestone.