### PR TITLE
Add participant locators if new network interfaces are found [12753]

### DIFF
--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -345,9 +345,10 @@ ReturnCode_t DomainParticipantImpl::set_qos(
         return ReturnCode_t::RETCODE_IMMUTABLE_POLICY;
     }
 
+    bool qos_should_be_updated = set_qos(qos_, qos_to_set, !enabled);
     if (enabled)
     {
-        if (set_qos(qos_, qos_to_set, !enabled))
+        if (qos_should_be_updated)
         {
             // Notify the participant that there is a QoS update
             fastrtps::rtps::RTPSParticipantAttributes patt;

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -345,12 +345,19 @@ ReturnCode_t DomainParticipantImpl::set_qos(
         return ReturnCode_t::RETCODE_IMMUTABLE_POLICY;
     }
 
-    if (set_qos(qos_, qos_to_set, !enabled) && enabled)
+    if (enabled)
     {
-        // Notify the participant that there is a QoS update
-        fastrtps::rtps::RTPSParticipantAttributes patt;
-        set_attributes_from_qos(patt, qos_);
-        rtps_participant_->update_attributes(patt);
+        if (set_qos(qos_, qos_to_set, !enabled))
+        {
+            // Notify the participant that there is a QoS update
+            fastrtps::rtps::RTPSParticipantAttributes patt;
+            set_attributes_from_qos(patt, qos_);
+            rtps_participant_->update_attributes(patt);
+        }
+        else
+        {
+            rtps_participant_->update_attributes(rtps_participant_->getRTPSParticipantAttributes());
+        }
     }
 
     return ReturnCode_t::RETCODE_OK;

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -357,6 +357,7 @@ ReturnCode_t DomainParticipantImpl::set_qos(
         }
         else
         {
+            // Trigger update of network interfaces by calling update_attributes
             rtps_participant_->update_attributes(rtps_participant_->getRTPSParticipantAttributes());
         }
     }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -244,9 +244,6 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     if (m_att.builtin.metatrafficMulticastLocatorList.empty() && m_att.builtin.metatrafficUnicastLocatorList.empty())
     {
         get_default_metatraffic_locators(metatraffic_multicast_port, metatraffic_unicast_port);
-        std::cout << m_att.getName() << " created with NO default metatraffic Locator List, adding Locators:\n\t"
-                                                    << m_att.builtin.metatrafficMulticastLocatorList << "\n\t"
-                                                    << m_att.builtin.metatrafficUnicastLocatorList << std::endl;
     }
     else
     {
@@ -301,9 +298,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         /* INSERT DEFAULT UNICAST LOCATORS FOR THE PARTICIPANT */
         get_default_unicast_locators();
         logInfo(RTPS_PARTICIPANT, m_att.getName() << " Created with NO default Unicast Locator List, adding Locators:"
-                                                    << m_att.defaultUnicastLocatorList);
-        std::cout << m_att.getName() << " created with NO default Unicast Locator List, adding Locators:"
-                                                    << m_att.defaultUnicastLocatorList << std::endl;
+                                                  << m_att.defaultUnicastLocatorList);
     }
     else
     {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -298,7 +298,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         /* INSERT DEFAULT UNICAST LOCATORS FOR THE PARTICIPANT */
         get_default_unicast_locators();
         logInfo(RTPS_PARTICIPANT, m_att.getName() << " Created with NO default Unicast Locator List, adding Locators:"
-                                                    << m_att.defaultUnicastLocatorList);
+                                                  << m_att.defaultUnicastLocatorList);
     }
     else
     {
@@ -1177,7 +1177,7 @@ void RTPSParticipantImpl::update_attributes(
         if (!(default_unicast_locator_list == m_att.defaultUnicastLocatorList))
         {
             logInfo(RTPS_PARTICIPANT, m_att.getName() << " updated default unicast locator list, current locators: "
-                                                        << m_att.defaultUnicastLocatorList);
+                                                      << m_att.defaultUnicastLocatorList);
         }
     }
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -243,7 +243,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     /* INSERT DEFAULT MANDATORY MULTICAST LOCATORS HERE */
     if (m_att.builtin.metatrafficMulticastLocatorList.empty() && m_att.builtin.metatrafficUnicastLocatorList.empty())
     {
-        get_default_metatraffic_locators(metatraffic_multicast_port, metatraffic_unicast_port);
+        get_default_metatraffic_locators();
     }
     else
     {
@@ -315,7 +315,6 @@ RTPSParticipantImpl::RTPSParticipantImpl(
                 {
                     m_network_Factory.fill_default_locator_port(domain_id_, loc, m_att, true);
                 });
-        m_network_Factory.NormalizeLocators(m_att.defaultMulticastLocatorList);
     }
 
 #if HAVE_SECURITY
@@ -1159,11 +1158,7 @@ void RTPSParticipantImpl::update_attributes(
         LocatorList_t metatraffic_multicast_locator_list = m_att.builtin.metatrafficMulticastLocatorList;
         LocatorList_t metatraffic_unicast_locator_list = m_att.builtin.metatrafficUnicastLocatorList;
 
-        uint32_t metatraffic_multicast_port = m_att.port.getMulticastPort(domain_id_);
-        uint32_t metatraffic_unicast_port = m_att.port.getUnicastPort(domain_id_,
-                        static_cast<uint32_t>(m_att.participantID));
-
-        get_default_metatraffic_locators(metatraffic_multicast_port, metatraffic_unicast_port);
+        get_default_metatraffic_locators();
 
         if (!(metatraffic_multicast_locator_list == m_att.builtin.metatrafficMulticastLocatorList) ||
                 !(metatraffic_unicast_locator_list == m_att.builtin.metatrafficUnicastLocatorList))
@@ -2208,10 +2203,12 @@ void RTPSParticipantImpl::environment_file_has_changed()
     }
 }
 
-void RTPSParticipantImpl::get_default_metatraffic_locators(
-        uint32_t metatraffic_multicast_port,
-        uint32_t metatraffic_unicast_port)
+void RTPSParticipantImpl::get_default_metatraffic_locators()
 {
+    uint32_t metatraffic_multicast_port = m_att.port.getMulticastPort(domain_id_);
+    uint32_t metatraffic_unicast_port = m_att.port.getUnicastPort(domain_id_,
+                    static_cast<uint32_t>(m_att.participantID));
+
     m_network_Factory.getDefaultMetatrafficMulticastLocators(m_att.builtin.metatrafficMulticastLocatorList,
             metatraffic_multicast_port);
     m_network_Factory.NormalizeLocators(m_att.builtin.metatrafficMulticastLocatorList);

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1152,7 +1152,7 @@ bool RTPSParticipantImpl::registerReader(
 void RTPSParticipantImpl::update_attributes(
         const RTPSParticipantAttributes& patt)
 {
-    // Check if new interfaces has been added
+    // Check if new interfaces have been added
     if (patt.builtin.metatrafficMulticastLocatorList.empty() && patt.builtin.metatrafficUnicastLocatorList.empty())
     {
         LocatorList_t metatraffic_multicast_locator_list = m_att.builtin.metatrafficMulticastLocatorList;

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -699,6 +699,21 @@ private:
             bool enable,
             const Functor& callback);
 
+    /**
+     * Get default metatraffic locators when not provided by the user.
+     * 
+     * @param [in] metatraffic_multicast_port well known multicast metatraffic port following DDS standard
+     * @param [in] metatraffic_unicast_port well known unicast metatraffic port following DDS standard
+     */
+    void get_default_metatraffic_locators(
+            uint32_t metatraffic_multicast_port,
+            uint32_t metatraffic_unicast_port);
+
+    /**
+     * Get default unicast locators when not provided by the user.
+     */
+    void get_default_unicast_locators();
+
 public:
 
     const RTPSParticipantAttributes& getRTPSParticipantAttributes() const

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -701,13 +701,8 @@ private:
 
     /**
      * Get default metatraffic locators when not provided by the user.
-     *
-     * @param [in] metatraffic_multicast_port well known multicast metatraffic port following DDS standard
-     * @param [in] metatraffic_unicast_port well known unicast metatraffic port following DDS standard
      */
-    void get_default_metatraffic_locators(
-            uint32_t metatraffic_multicast_port,
-            uint32_t metatraffic_unicast_port);
+    void get_default_metatraffic_locators();
 
     /**
      * Get default unicast locators when not provided by the user.

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -701,7 +701,7 @@ private:
 
     /**
      * Get default metatraffic locators when not provided by the user.
-     * 
+     *
      * @param [in] metatraffic_multicast_port well known multicast metatraffic port following DDS standard
      * @param [in] metatraffic_unicast_port well known unicast metatraffic port following DDS standard
      */

--- a/src/cpp/rtps/transport/test_UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.cpp
@@ -18,6 +18,7 @@
 #include <functional>
 
 #include <asio.hpp>
+#include <fastrtps/utils/IPLocator.h>
 
 using namespace std;
 
@@ -221,7 +222,11 @@ bool test_UDPv4Transport::send(
         bool only_multicast_purpose,
         const std::chrono::microseconds& timeout)
 {
-    if (packet_should_drop(send_buffer, send_buffer_size))
+    if (packet_should_drop(send_buffer, send_buffer_size) ||
+            // If there are no interfaces (simulate_no_interfaces), only multicast and localhost traffic is sent
+            (simulate_no_interfaces &&
+            !fastrtps::rtps::IPLocator::isMulticast(remote_locator) &&
+            !fastrtps::rtps::IPLocator::isLocal(remote_locator)))
     {
         statistics_info_.set_statistics_message_data(remote_locator, send_buffer, send_buffer_size);
         log_drop(send_buffer, send_buffer_size);

--- a/src/cpp/rtps/transport/test_UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.cpp
@@ -153,6 +153,28 @@ void test_UDPv4Transport::get_ips(
     }
 }
 
+LocatorList test_UDPv4Transport::NormalizeLocator(
+        const Locator& locator)
+{
+    if (!simulate_no_interfaces)
+    {
+        return UDPv4Transport::NormalizeLocator(locator);
+    }
+
+    LocatorList list;
+    if (fastrtps::rtps::IPLocator::isAny(locator))
+    {
+        Locator newloc(locator);
+        fastrtps::rtps::IPLocator::setIPv4(newloc, "127.0.0.1");
+        list.push_back(newloc);
+    }
+    else
+    {
+        list.push_back(locator);
+    }
+    return list;
+}
+
 bool test_UDPv4Transport::send(
         const octet* send_buffer,
         uint32_t send_buffer_size,

--- a/src/cpp/rtps/transport/test_UDPv4Transport.h
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.h
@@ -17,10 +17,10 @@
 
 #include <vector>
 
-#include <fastdds/rtps/transport/test_UDPv4TransportDescriptor.h>
+#include <fastdds/rtps/common/SequenceNumber.h>
 #include <fastdds/rtps/messages/RTPS_messages.h>
 #include <fastdds/rtps/messages/CDRMessage.h>
-#include <fastdds/rtps/common/SequenceNumber.h>
+#include <fastdds/rtps/transport/test_UDPv4TransportDescriptor.h>
 #include <rtps/transport/UDPv4Transport.h>
 
 
@@ -48,6 +48,9 @@ public:
             fastrtps::rtps::LocatorsIterator* destination_locators_end,
             bool only_multicast_purpose,
             const std::chrono::steady_clock::time_point& max_blocking_time_point) override;
+
+    virtual LocatorList NormalizeLocator(
+            const Locator& locator) override;
 
     RTPS_DllAPI static bool test_UDPv4Transport_ShutdownAllNetwork;
     // Handle to a persistent log of dropped packets. Defaults to length 0 (no logging) to prevent wasted resources.

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -1513,6 +1513,11 @@ public:
         return matched_ > 0;
     }
 
+    unsigned int get_matched() const
+    {
+        return matched_;
+    }
+
     void set_xml_filename(
             const std::string& name)
     {

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -1383,6 +1383,11 @@ public:
         datawriter_profile_ = profile;
     }
 
+    void participant_set_qos()
+    {
+        participant_->set_qos(participant_qos_);
+    }
+
 #if HAVE_SQLITE3
     PubSubWriter& make_persistent(
             const std::string& filename,

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -1338,6 +1338,11 @@ public:
         return matched_ > 0;
     }
 
+    unsigned int get_matched() const
+    {
+        return matched_;
+    }
+
     unsigned int missed_deadlines() const
     {
         return listener_.missed_deadlines();

--- a/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
@@ -1207,6 +1207,11 @@ public:
         return matched_ > 0;
     }
 
+    unsigned int get_matched() const
+    {
+        return matched_;
+    }
+
 private:
 
     const eprosima::fastrtps::rtps::GUID_t& participant_guid() const

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
@@ -1148,6 +1148,11 @@ public:
         return matched_ > 0;
     }
 
+    unsigned int get_matched() const
+    {
+        return matched_;
+    }
+
     unsigned int missed_deadlines() const
     {
         return listener_.missed_deadlines();

--- a/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
@@ -174,12 +174,12 @@ TEST(DDSDiscovery, AddDiscoveryServerToList)
 
 /**
  * This test checks the addition of network interfaces at run-time.
- * 
+ *
  * After launching the reader with the network interfaces enabled,
  * the writer is launched with the transport simulating that there
  * are no interfaces.
  * No participant discovery occurs.
- * 
+ *
  * In a second step, the flag to simulate no interfaces is disabled and
  * DomainParticipant::set_qos() called to add the "new" interfaces.
  * Discovery is succesful and communication is established.

--- a/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
@@ -178,7 +178,7 @@ TEST(DDSDiscovery, AddDiscoveryServerToList)
  * After launching the reader with the network interfaces enabled,
  * the writer is launched with the transport simulating that there
  * are no interfaces.
- * No participant discovery occurs.
+ * No participant discovery occurs, nor is communication established.
  *
  * In a second step, the flag to simulate no interfaces is disabled and
  * DomainParticipant::set_qos() called to add the "new" interfaces.
@@ -205,10 +205,10 @@ TEST(DDSDiscovery, DDSNetworkInterfaceChangesAtRunTime)
     // no discovery
     datawriter.wait_discovery(std::chrono::seconds(3));
     datareader.wait_discovery(std::chrono::seconds(3));
-
     EXPECT_EQ(datawriter.get_matched(), 0u);
     EXPECT_EQ(datareader.get_matched(), 0u);
 
+    // send data
     auto complete_data = default_helloworld_data_generator();
     size_t samples = complete_data.size();
 
@@ -217,6 +217,7 @@ TEST(DDSDiscovery, DDSNetworkInterfaceChangesAtRunTime)
     datawriter.send(complete_data);
     EXPECT_TRUE(complete_data.empty());
 
+    // no data received
     EXPECT_EQ(datareader.block_for_all(std::chrono::seconds(3)), 0);
 
     // enable interfaces
@@ -229,6 +230,7 @@ TEST(DDSDiscovery, DDSNetworkInterfaceChangesAtRunTime)
     ASSERT_EQ(datawriter.get_matched(), 1u);
     ASSERT_EQ(datareader.get_matched(), 1u);
 
+    // data received
     EXPECT_EQ(datareader.block_for_all(std::chrono::seconds(3)), samples);
 
     datareader.destroy();

--- a/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
@@ -626,7 +626,7 @@ TEST(RTPS, RTPSNetworkInterfaceChangesAtRunTime)
     ASSERT_EQ(reader.get_matched(), 1u);
 
     reader.block_for_all();
-    EXPECT_EQ(reader.getReceivedCount(), samples);
+    EXPECT_EQ(reader.getReceivedCount(), static_cast<unsigned int>(samples));
 
     reader.destroy();
     writer.destroy();

--- a/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
@@ -569,6 +569,18 @@ TEST_P(RTPS, RTPSAsReliableTransientLocalTwoWritersConsecutives)
     writer.destroy();
 }
 
+/**
+ * This test checks the addition of network interfaces at run-time.
+ * 
+ * After launching the reader with the network interfaces enabled,
+ * the writer is launched with the transport simulating that there
+ * are no interfaces.
+ * No participant discovery occurs.
+ * 
+ * In a second step, the flag to simulate no interfaces is disabled and
+ * RTPSParticipant::update_attributes() called to add the "new" interfaces.
+ * Discovery is succesful and communication is established.
+ */
 TEST(RTPS, RTPSNetworkInterfaceChangesAtRunTime)
 {
     RTPSWithRegistrationReader<HelloWorldType> reader(TEST_TOPIC_NAME);

--- a/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
@@ -571,12 +571,12 @@ TEST_P(RTPS, RTPSAsReliableTransientLocalTwoWritersConsecutives)
 
 /**
  * This test checks the addition of network interfaces at run-time.
- * 
+ *
  * After launching the reader with the network interfaces enabled,
  * the writer is launched with the transport simulating that there
  * are no interfaces.
  * No participant discovery occurs.
- * 
+ *
  * In a second step, the flag to simulate no interfaces is disabled and
  * RTPSParticipant::update_attributes() called to add the "new" interfaces.
  * Discovery is succesful and communication is established.

--- a/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
@@ -569,7 +569,7 @@ TEST_P(RTPS, RTPSAsReliableTransientLocalTwoWritersConsecutives)
     writer.destroy();
 }
 
-TEST_P(RTPS, RTPSNetworkInterfaceChangesAtRunTime)
+TEST(RTPS, RTPSNetworkInterfaceChangesAtRunTime)
 {
     RTPSWithRegistrationReader<HelloWorldType> reader(TEST_TOPIC_NAME);
     RTPSWithRegistrationWriter<HelloWorldType> writer(TEST_TOPIC_NAME);

--- a/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
@@ -575,7 +575,7 @@ TEST_P(RTPS, RTPSAsReliableTransientLocalTwoWritersConsecutives)
  * After launching the reader with the network interfaces enabled,
  * the writer is launched with the transport simulating that there
  * are no interfaces.
- * No participant discovery occurs.
+ * No participant discovery occurs, nor is communication established.
  *
  * In a second step, the flag to simulate no interfaces is disabled and
  * RTPSParticipant::update_attributes() called to add the "new" interfaces.
@@ -599,10 +599,10 @@ TEST(RTPS, RTPSNetworkInterfaceChangesAtRunTime)
     // no discovery
     writer.wait_discovery(std::chrono::seconds(3));
     reader.wait_discovery(std::chrono::seconds(3));
-
     EXPECT_EQ(writer.get_matched(), 0u);
     EXPECT_EQ(reader.get_matched(), 0u);
 
+    // send data
     auto complete_data = default_helloworld_data_generator();
     size_t samples = complete_data.size();
 
@@ -612,6 +612,7 @@ TEST(RTPS, RTPSNetworkInterfaceChangesAtRunTime)
     writer.send(complete_data);
     EXPECT_TRUE(complete_data.empty());
 
+    // no data received
     reader.block_for_all(std::chrono::seconds(3));
     EXPECT_EQ(reader.getReceivedCount(), 0u);
 
@@ -625,6 +626,7 @@ TEST(RTPS, RTPSNetworkInterfaceChangesAtRunTime)
     ASSERT_EQ(writer.get_matched(), 1u);
     ASSERT_EQ(reader.get_matched(), 1u);
 
+    // data received
     reader.block_for_all();
     EXPECT_EQ(reader.getReceivedCount(), static_cast<unsigned int>(samples));
 

--- a/test/blackbox/common/RTPSWithRegistrationReader.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationReader.hpp
@@ -365,7 +365,7 @@ public:
 
     unsigned int getReceivedCount() const
     {
-        return current_received_count_;
+        return static_cast<unsigned int>(current_received_count_);
     }
 
     /*** Function to change QoS ***/

--- a/test/blackbox/common/RTPSWithRegistrationWriter.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationWriter.hpp
@@ -407,9 +407,9 @@ public:
         return *this;
     }
 
-    bool is_matched() const
+    uint32_t get_matched() const
     {
-        return matched_ > 0;
+        return matched_;
     }
 
     void participant_update_attributes()
@@ -433,7 +433,7 @@ private:
     bool initialized_;
     std::mutex mutex_;
     std::condition_variable cv_;
-    unsigned int matched_;
+    uint32_t matched_;
     type_support type_;
     std::shared_ptr<eprosima::fastrtps::rtps::IPayloadPool> payload_pool_;
     bool has_payload_pool_ = false;


### PR DESCRIPTION
Currently only network interfaces found when launching Fast DDS are taken into account. This PR adds new participant locators if new network interfaces are detected. In order to trigger the check, the user must call `DomainParticipant::set_qos`. If some user is using the RTPS layer directly, the feature can also be triggered by calling `RTPSParticipant::update_attributes`.

This PR includes both the implementation and the Blackbox tests at RTPS and DDS level. It also completes test API, both in the Entities as in the Transport layer.

Related PRs:
* eProsima/Fast-DDS-docs#301