### PR TITLE
Updating content filter interfaces [13272]

### DIFF
--- a/include/fastdds/dds/topic/IContentFilterFactory.hpp
+++ b/include/fastdds/dds/topic/IContentFilterFactory.hpp
@@ -40,7 +40,7 @@ struct IContentFilterFactory
     virtual ReturnCode_t create_content_filter(
             const char* filter_class_name,
             const char* type_name,
-            const TopicDataType* type_description,
+            const TopicDataType* data_type,
             const char* filter_expression,
             const ParameterSeq& filter_parameters,
             IContentFilter*& filter_instance) = 0;

--- a/include/fastdds/dds/topic/IContentFilterFactory.hpp
+++ b/include/fastdds/dds/topic/IContentFilterFactory.hpp
@@ -23,9 +23,9 @@
 
 #include <fastdds/dds/core/LoanableTypedCollection.hpp>
 #include <fastdds/dds/topic/IContentFilter.hpp>
+#include <fastdds/dds/topic/TopicDataType.hpp>
 
 #include <fastrtps/types/TypesBase.h>
-#include <fastrtps/types/TypeDescriptor.h>
 
 namespace eprosima {
 namespace fastdds {
@@ -40,7 +40,7 @@ struct IContentFilterFactory
     virtual ReturnCode_t create_content_filter(
             const char* filter_class_name,
             const char* type_name,
-            const TypeDescriptor* type_description,
+            const TopicDataType* type_description,
             const char* filter_expression,
             const ParameterSeq& filter_parameters,
             IContentFilter*& filter_instance) = 0;

--- a/include/fastdds/dds/topic/TopicDataType.hpp
+++ b/include/fastdds/dds/topic/TopicDataType.hpp
@@ -27,7 +27,6 @@
 #include <fastdds/rtps/common/InstanceHandle.h>
 
 #include <fastrtps/fastrtps_dll.h>
-#include <fastrtps/types/TypeDescriptor.h>
 #include <fastrtps/utils/md5.h>
 
 // This version of TypeSupport has `is_bounded()`
@@ -38,9 +37,6 @@
 
 // This version of TypeSupport has `construct_sample()`
 #define TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
-
-// This version of TypeSupport has `get_descriptor()`
-#define TOPIC_DATA_TYPE_API_HAS_GET_DESCRIPTOR
 
 namespace eprosima {
 namespace fastrtps {
@@ -64,8 +60,6 @@ class TypeSupport;
 class TopicDataType
 {
 public:
-
-    using TypeDescriptor = eprosima::fastrtps::types::TypeDescriptor;
 
     /**
      * @brief Constructor
@@ -310,16 +304,6 @@ public:
     {
         static_cast<void>(memory);
         return false;
-    }
-
-    /**
-     * Get the structure representing the description of the type
-     *
-     * @return pointer to the type descriptor
-     */
-    RTPS_DllAPI virtual inline const TypeDescriptor* get_desciptor() const
-    {
-        return nullptr;
     }
 
     //! Maximum serialized size of the type in bytes.

--- a/include/fastdds/dds/topic/TypeSupport.hpp
+++ b/include/fastdds/dds/topic/TypeSupport.hpp
@@ -237,16 +237,6 @@ public:
         return get()->is_plain();
     }
 
-    /**
-     * Get the structure representing the description of the type
-     *
-     * @return pointer to the type descriptor
-     */
-    RTPS_DllAPI virtual inline const TopicDataType::TypeDescriptor* get_desciptor() const
-    {
-        return get()->get_desciptor();
-    }
-
     RTPS_DllAPI bool operator !=(
             std::nullptr_t) const
     {

--- a/include/fastrtps/types/DynamicPubSubType.h
+++ b/include/fastrtps/types/DynamicPubSubType.h
@@ -65,8 +65,6 @@ public:
             void* data,
             eprosima::fastrtps::rtps::SerializedPayload_t* payload) override;
 
-    RTPS_DllAPI const TypeDescriptor* get_desciptor() const override;
-
     RTPS_DllAPI void CleanDynamicType();
 
     RTPS_DllAPI DynamicType_ptr GetDynamicType() const;

--- a/src/cpp/dynamic-types/DynamicPubSubType.cpp
+++ b/src/cpp/dynamic-types/DynamicPubSubType.cpp
@@ -200,11 +200,6 @@ bool DynamicPubSubType::serialize(
     return true;
 }
 
-const TypeDescriptor* DynamicPubSubType::get_desciptor() const
-{
-    return nullptr == dynamic_type_ ? nullptr : dynamic_type_->get_descriptor();
-}
-
 void DynamicPubSubType::UpdateDynamicTypeInfo()
 {
     if (dynamic_type_ != nullptr)

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -502,7 +502,6 @@ ContentFilteredTopic* DomainParticipantImpl::create_contentfilteredtopic(
     TopicImpl* topic_impl = dynamic_cast<TopicImpl*>(related_topic->get_impl());
     assert(nullptr != topic_impl);
     const TypeSupport& type = topic_impl->get_type();
-    const IContentFilterFactory::TypeDescriptor* type_descriptor = type->get_desciptor();
     LoanableSequence<const char*>::size_type n_params;
     n_params = static_cast<LoanableSequence<const char*>::size_type>(expression_parameters.size());
     LoanableSequence<const char*> filter_parameters(n_params);
@@ -516,7 +515,7 @@ ContentFilteredTopic* DomainParticipantImpl::create_contentfilteredtopic(
     IContentFilter* filter_instance = nullptr;
     if (ReturnCode_t::RETCODE_OK !=
             filter_factory->create_content_filter(filter_class_name, related_topic->get_type_name().c_str(),
-            type_descriptor, filter_expression.c_str(), filter_parameters, filter_instance))
+            type.get(), filter_expression.c_str(), filter_parameters, filter_instance))
     {
         logError(PARTICIPANT, "Could not create filter of class " << filter_class_name << " for expression \"" <<
                 filter_expression);


### PR DESCRIPTION
After some internal discussions about the design, this PR updates the following interfaces:

**IContentFilterFactory**
* Method `create_content_filter` receives `TopicDataType` instead of `TopicDescriptor`
* Removed `type_descriptor` getter from `TopicDataType`
