### PR TITLE
Ensure correct boost singleton destruction order [13288]

### DIFF
--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -32,7 +32,7 @@
 #include <statistics/fastdds/domain/DomainParticipantImpl.hpp>
 #include <utils/SystemInfo.hpp>
 
- // We include boost through this internal header, to ensure we use our custom boost config file
+// We include boost through this internal header, to ensure we use our custom boost config file
 #include <utils/shared_memory/SharedMemSegment.hpp>
 #include <boost/interprocess/sync/interprocess_mutex.hpp>
 
@@ -119,6 +119,7 @@ DomainParticipantFactory* DomainParticipantFactory::get_instance()
         {
             boost::interprocess::interprocess_mutex mtx;
         }
+
     };
     static AuxiliaryBoostFunctor boost_functor;
 

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -32,8 +32,9 @@
 #include <statistics/fastdds/domain/DomainParticipantImpl.hpp>
 #include <utils/SystemInfo.hpp>
 
-
-
+ // We include boost through this internal header, to ensure we use our custom boost config file
+#include <utils/shared_memory/SharedMemSegment.hpp>
+#include <boost/interprocess/sync/interprocess_mutex.hpp>
 
 using namespace eprosima::fastrtps::xmlparser;
 
@@ -101,6 +102,26 @@ DomainParticipantFactory::~DomainParticipantFactory()
 
 DomainParticipantFactory* DomainParticipantFactory::get_instance()
 {
+    /*
+     * The first time an interprocess synchronization object is created by boost, a singleton is instantiated and
+     * its destructor is registered with std::atexit(&atexit_work).
+     *
+     * We need to ensure that the boost singleton is destroyed after the instance of DomainParticipantFactory, to
+     * ensure that the interprocess objects keep working until all the participants are destroyed.
+     *
+     * We achieve this behavior by having an static instance of an auxiliary struct that instantiates a synchornization
+     * object on the constructor, just to ensure that the boost singleton is instantiated before the
+     * DomainParticipantFactory.
+     */
+    struct AuxiliaryBoostFunctor
+    {
+        AuxiliaryBoostFunctor()
+        {
+            boost::interprocess::interprocess_mutex mtx;
+        }
+    };
+    static AuxiliaryBoostFunctor boost_functor;
+
     // Keep a reference to the topic payload pool to avoid it to be destroyed before our own instance
     using pool_registry_ref = eprosima::fastrtps::rtps::TopicPayloadPoolRegistry::reference;
     static pool_registry_ref topic_pool_registry = eprosima::fastrtps::rtps::TopicPayloadPoolRegistry::instance();

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -109,7 +109,7 @@ DomainParticipantFactory* DomainParticipantFactory::get_instance()
      * We need to ensure that the boost singleton is destroyed after the instance of DomainParticipantFactory, to
      * ensure that the interprocess objects keep working until all the participants are destroyed.
      *
-     * We achieve this behavior by having an static instance of an auxiliary struct that instantiates a synchornization
+     * We achieve this behavior by having an static instance of an auxiliary struct that instantiates a synchronization
      * object on the constructor, just to ensure that the boost singleton is instantiated before the
      * DomainParticipantFactory.
      */

--- a/test/unittest/dds/status/CMakeLists.txt
+++ b/test/unittest/dds/status/CMakeLists.txt
@@ -125,9 +125,12 @@ add_executable(ListenerTests ${LISTENERTESTS_SOURCE})
 target_compile_definitions(ListenerTests PRIVATE FASTRTPS_NO_LIB
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
+    ASIO_DISABLE_VISIBILITY
+    SQLITE_WIN32_GETVERSIONEX=0
     $<$<AND:$<BOOL:${ANDROID}>,$<NOT:$<BOOL:${HAVE_CXX14}>>,$<NOT:$<BOOL:${HAVE_CXX1Y}>>>:ASIO_DISABLE_STD_STRING_VIEW>
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    $<$<BOOL:${WIN32}>:_ENABLE_ATOMIC_ALIGNMENT_FIX>
     )
 target_include_directories(ListenerTests PRIVATE
     ${Asio_INCLUDE_DIR}
@@ -160,12 +163,15 @@ target_include_directories(ListenerTests PRIVATE
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/WLP
     ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
     ${PROJECT_SOURCE_DIR}/src/cpp
+    ${THIRDPARTY_BOOST_INCLUDE_DIR}
     )
 
 target_link_libraries(ListenerTests fastcdr foonathan_memory
     ${TINYXML2_LIBRARY}
     GTest::gmock
-    ${CMAKE_DL_LIBS})
+    ${CMAKE_DL_LIBS}
+    ${THIRDPARTY_BOOST_LINK_LIBS}
+    )
 if(MSVC OR MSVC_IDE)
     target_link_libraries(ListenerTests iphlpapi Shlwapi ws2_32)
 endif()


### PR DESCRIPTION
The first time an interprocess synchronization object is created by boost, a singleton is instantiated and its destructor is registered with std::atexit(&atexit_work).

This PR ensures that singleton is created before the DomainParticipantFactory instance so that it is destroyed after all the participants have been deleted.