### PR TITLE
Fix locks used in MockConsumer [13303]

### DIFF
--- a/test/unittest/logging/mock/MockConsumer.h
+++ b/test/unittest/logging/mock/MockConsumer.h
@@ -68,6 +68,14 @@ public:
         return cv_;
     }
 
+    template<typename Pred>
+    void wait(
+            Pred pred)
+    {
+        std::unique_lock<std::mutex> lock(mMutex);
+        cv_.wait(lock, pred);
+    }
+
     void clear_entries()
     {
         std::unique_lock<std::mutex> guard(mMutex);

--- a/test/unittest/logging/mock/MockConsumer.h
+++ b/test/unittest/logging/mock/MockConsumer.h
@@ -58,16 +58,6 @@ public:
         return mEntriesConsumed;
     }
 
-    size_t ConsumedEntriesSize_nts() const
-    {
-        return mEntriesConsumed.size();
-    }
-
-    std::condition_variable& cv()
-    {
-        return cv_;
-    }
-
     template<typename Pred>
     void wait(
             Pred pred)

--- a/test/unittest/logging/mock/MockConsumer.h
+++ b/test/unittest/logging/mock/MockConsumer.h
@@ -47,7 +47,7 @@ public:
         {
             std::unique_lock<std::mutex> guard(mMutex);
             mEntriesConsumed.push_back(entry);
-            cv_.notify_one();
+            cv_.notify_all();
         }
         StdoutConsumer::Consume(entry);
     }
@@ -89,6 +89,7 @@ public:
     {
         std::unique_lock<std::mutex> guard(mMutex);
         mEntriesConsumed.clear();
+        cv_.notify_all();
     }
 
 private:

--- a/test/unittest/logging/mock/MockConsumer.h
+++ b/test/unittest/logging/mock/MockConsumer.h
@@ -76,6 +76,15 @@ public:
         cv_.wait(lock, pred);
     }
 
+    void wait_for_at_least_entries(
+            size_t num_entries)
+    {
+        return wait([this, num_entries]() -> bool
+                       {
+                           return mEntriesConsumed.size() >= num_entries;
+                       });
+    }
+
     void clear_entries()
     {
         std::unique_lock<std::mutex> guard(mMutex);

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantMockTests.cpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantMockTests.cpp
@@ -42,11 +42,7 @@ public:
     void helper_block_for_at_least_entries(
             uint32_t amount)
     {
-        std::unique_lock<std::mutex> lck(*mutex_);
-        mock_consumer_->cv().wait(lck, [this, amount]
-                {
-                    return mock_consumer_->ConsumedEntriesSize_nts() >= amount;
-                });
+        mock_consumer_->wait_for_at_least_entries(amount);
     }
 
     eprosima::fastdds::dds::MockConsumer* mock_consumer_;

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantMockTests.cpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantMockTests.cpp
@@ -47,21 +47,6 @@ public:
 
     eprosima::fastdds::dds::MockConsumer* mock_consumer_;
 
-    mutable std::mutex* mutex_;
-
-protected:
-
-    void SetUp() override
-    {
-        mutex_ = new std::mutex();
-    }
-
-    void TearDown() override
-    {
-        delete mutex_;
-        mutex_ = nullptr;
-    }
-
 };
 
 class DomainParticipantImplTest : public DomainParticipantImpl

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantTests.cpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantTests.cpp
@@ -141,21 +141,6 @@ public:
 
     eprosima::fastdds::dds::MockConsumer* mock_consumer_;
 
-    mutable std::mutex* mutex_;
-
-protected:
-
-    void SetUp() override
-    {
-        mutex_ = new std::mutex();
-    }
-
-    void TearDown() override
-    {
-        delete mutex_;
-        mutex_ = nullptr;
-    }
-
 };
 
 /*

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantTests.cpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantTests.cpp
@@ -136,11 +136,7 @@ public:
     void helper_block_for_at_least_entries(
             uint32_t amount)
     {
-        std::unique_lock<std::mutex> lck(*mutex_);
-        mock_consumer_->cv().wait(lck, [this, amount]
-                {
-                    return mock_consumer_->ConsumedEntriesSize_nts() >= amount;
-                });
+        mock_consumer_->wait_for_at_least_entries(amount);
     }
 
     eprosima::fastdds::dds::MockConsumer* mock_consumer_;

--- a/test/unittest/xmlparser/XMLElementParserTests.cpp
+++ b/test/unittest/xmlparser/XMLElementParserTests.cpp
@@ -61,11 +61,7 @@ public:
     void helper_block_for_at_least_entries(
             uint32_t amount)
     {
-        std::unique_lock<std::mutex> lck(*xml_mutex_);
-        mock_consumer->cv().wait(lck, [this, amount]
-                {
-                    return mock_consumer->ConsumedEntriesSize_nts() >= amount;
-                });
+        mock_consumer->wait_for_at_least_entries(amount);
     }
 
     MockConsumer* mock_consumer;

--- a/test/unittest/xmlparser/XMLElementParserTests.cpp
+++ b/test/unittest/xmlparser/XMLElementParserTests.cpp
@@ -66,21 +66,6 @@ public:
 
     MockConsumer* mock_consumer;
 
-    mutable std::mutex* xml_mutex_;
-
-protected:
-
-    void SetUp() override
-    {
-        xml_mutex_ = new std::mutex();
-    }
-
-    void TearDown() override
-    {
-        delete xml_mutex_;
-        xml_mutex_ = nullptr;
-    }
-
 };
 
 /*

--- a/test/unittest/xmlparser/XMLEndpointParserTests.cpp
+++ b/test/unittest/xmlparser/XMLEndpointParserTests.cpp
@@ -59,11 +59,7 @@ public:
     void helper_block_for_at_least_entries(
             uint32_t amount)
     {
-        std::unique_lock<std::mutex> lck(*xml_mutex_);
-        mock_consumer->cv().wait(lck, [this, amount]
-                {
-                    return mock_consumer->ConsumedEntriesSize_nts() >= amount;
-                });
+        mock_consumer->wait_for_at_least_entries(amount);
     }
 
     eprosima::fastdds::dds::MockConsumer* mock_consumer;

--- a/test/unittest/xmlparser/XMLEndpointParserTests.cpp
+++ b/test/unittest/xmlparser/XMLEndpointParserTests.cpp
@@ -64,22 +64,18 @@ public:
 
     eprosima::fastdds::dds::MockConsumer* mock_consumer;
 
-    mutable std::mutex* xml_mutex_;
     XMLEndpointParser* mp_edpXML;
 
 protected:
 
     void SetUp() override
     {
-        xml_mutex_ = new std::mutex();
         mp_edpXML = new xmlparser::XMLEndpointParser();
     }
 
     void TearDown() override
     {
-        delete xml_mutex_;
         delete mp_edpXML;
-        xml_mutex_ = nullptr;
         mp_edpXML = nullptr;
     }
 

--- a/test/unittest/xmlparser/XMLParserTests.hpp
+++ b/test/unittest/xmlparser/XMLParserTests.hpp
@@ -73,19 +73,4 @@ public:
 
     eprosima::fastdds::dds::MockConsumer* mock_consumer;
 
-    mutable std::mutex* xml_mutex_;
-
-protected:
-
-    void SetUp() override
-    {
-        xml_mutex_ = new std::mutex();
-    }
-
-    void TearDown() override
-    {
-        delete xml_mutex_;
-        xml_mutex_ = nullptr;
-    }
-
 };

--- a/test/unittest/xmlparser/XMLParserTests.hpp
+++ b/test/unittest/xmlparser/XMLParserTests.hpp
@@ -68,11 +68,7 @@ public:
     void helper_block_for_at_least_entries(
             uint32_t amount)
     {
-        std::unique_lock<std::mutex> lck(*xml_mutex_);
-        mock_consumer->cv().wait(lck, [this, amount]
-                {
-                    return mock_consumer->ConsumedEntriesSize_nts() >= amount;
-                });
+        mock_consumer->wait_for_at_least_entries(amount);
     }
 
     eprosima::fastdds::dds::MockConsumer* mock_consumer;


### PR DESCRIPTION
The class used on unit tests for checking behavior regarding the log messages is wrongly used.
A reference to its condition_variable is obtained and then used with a different mutex.

This PR fixes this by adding a generic `wait` method receiving a predicate, as long as a `wait_for_at_least_entries` method, which is the most common use in the unit tests.

The `cv()` getter and `ConsumedEntriesSize_nts()` methods are removed, to ensure we don't have incorrect behaviour.