### PR TITLE
Avoid logWarning when environment file filename is empty [13302]

### DIFF
--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -122,7 +122,7 @@ RTPSParticipant* RTPSDomain::createParticipant(
             // Create filewatch
             RTPSDomainImpl::file_watch_handle_ = SystemInfo::watch_file(filename, RTPSDomainImpl::file_watch_callback);
         }
-        else
+        else if (!filename.empty())
         {
             logWarning(RTPS_PARTICIPANT, filename + " does not exist. File watching not initialized.");
         }

--- a/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
@@ -99,7 +99,9 @@ public:
  * @param expected_logs The number of expected logs (error or warning) matching
  *                      ".*does not exist. File watching not initialized."
  */
-void env_file_warning(const char* env_file_name, size_t expected_logs)
+void env_file_warning(
+        const char* env_file_name,
+        size_t expected_logs)
 {
     /* Set environment variable */
 #ifdef _WIN32

--- a/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
@@ -26,6 +26,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdlib>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -127,8 +128,7 @@ void env_file_warning(const char* env_file_name, size_t expected_logs)
     EXPECT_EQ(helper_consumer->ConsumedEntries().size(), expected_logs);
 
     /* Clean-up */
-    helper_consumer->ClearEntries(); // This calls to ClearConsumers, which deletes the registered consumer
-    Log::Reset();
+    Log::Reset();  // This calls to ClearConsumers, which deletes the registered consumer
 }
 
 TEST_P(PubSubBasic, PubSubAsNonReliableHelloworld)
@@ -809,7 +809,7 @@ TEST_P(PubSubBasic, ReliableTransientLocalTwoWritersConsecutives)
 /*
  * Check that setting FASTDDS_ENVIRONMENT_FILE to an unexisting file issues 1 logWarning
  */
-TEST_P(PubSubBasic, EnvFileWarningWrongFile)
+TEST(PubSubBasic, EnvFileWarningWrongFile)
 {
     env_file_warning("unexisting_file", 1);
 }
@@ -817,7 +817,7 @@ TEST_P(PubSubBasic, EnvFileWarningWrongFile)
 /*
  * Check that setting FASTDDS_ENVIRONMENT_FILE to an empty string issues 0 logWarning
  */
-TEST_P(PubSubBasic, EnvFileWarningEmpty)
+TEST(PubSubBasic, EnvFileWarningEmpty)
 {
     env_file_warning("", 0);
 }

--- a/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
@@ -14,16 +14,21 @@
 
 #include "BlackboxTests.hpp"
 
+#include "mock/BlackboxMockConsumer.h"
 #include "PubSubParticipant.hpp"
 #include "PubSubReader.hpp"
 #include "PubSubWriter.hpp"
-#include "ReqRepAsReliableHelloWorldRequester.hpp"
 #include "ReqRepAsReliableHelloWorldReplier.hpp"
+#include "ReqRepAsReliableHelloWorldRequester.hpp"
+
+#include <fastdds/dds/log/Log.hpp>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 
 #include <gtest/gtest.h>
 
+#include <string>
 #include <tuple>
+#include <vector>
 
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
@@ -80,6 +85,51 @@ public:
     }
 
 };
+
+/**
+ * @brief Test function for EnvFileWarning* tests
+ *
+ * Sets environment variable @c FASTDDS_ENVIRONMENT_FILE to @c env_file_name, and then initializes a DomainParticipant,
+ * using a custom log consumer to check how many logWarnings matching
+ * ".*does not exist. File watching not initialized." are issued, comparing that number with @c expected_logs.
+ * Finally, it resets the log module
+ *
+ * @param env_file_name The value to assign to @c FASTDDS_ENVIRONMENT_FILE
+ * @param expected_logs The number of expected logs (error or warning) matching
+ *                      ".*does not exist. File watching not initialized."
+ */
+void env_file_warning(const char* env_file_name, size_t expected_logs)
+{
+    /* Set environment variable */
+#ifdef _WIN32
+    _putenv_s("FASTDDS_ENVIRONMENT_FILE", env_file_name);
+#else
+    setenv("FASTDDS_ENVIRONMENT_FILE", env_file_name, 1);
+#endif // _WIN32
+
+    using namespace eprosima::fastdds::dds;
+    /* Set up log */
+    BlackboxMockConsumer* helper_consumer = new BlackboxMockConsumer();
+    Log::ClearConsumers();  // Remove default consumers
+    Log::RegisterConsumer(std::unique_ptr<LogConsumer>(helper_consumer)); // Registering a consumer transfer ownership
+    // Filter specific message
+    Log::SetVerbosity(Log::Kind::Warning);
+    Log::SetCategoryFilter(std::regex("RTPS_PARTICIPANT"));
+    Log::SetErrorStringFilter(std::regex(".*does not exist. File watching not initialized."));
+
+    /* Create and enable DomainParticipant */
+    PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
+    reader.init();
+    EXPECT_TRUE(reader.isInitialized());
+
+    /* Check logs */
+    Log::Flush();
+    EXPECT_EQ(helper_consumer->ConsumedEntries().size(), expected_logs);
+
+    /* Clean-up */
+    helper_consumer->ClearEntries(); // This calls to ClearConsumers, which deletes the registered consumer
+    Log::Reset();
+}
 
 TEST_P(PubSubBasic, PubSubAsNonReliableHelloworld)
 {
@@ -754,6 +804,22 @@ TEST_P(PubSubBasic, ReliableTransientLocalTwoWritersConsecutives)
         writer.history_depth(10).reliability(RELIABLE_RELIABILITY_QOS);
         two_consecutive_writers(reader, writer, true);
     }
+}
+
+/*
+ * Check that setting FASTDDS_ENVIRONMENT_FILE to an unexisting file issues 1 logWarning
+ */
+TEST_P(PubSubBasic, EnvFileWarningWrongFile)
+{
+    env_file_warning("unexisting_file", 1);
+}
+
+/*
+ * Check that setting FASTDDS_ENVIRONMENT_FILE to an empty string issues 0 logWarning
+ */
+TEST_P(PubSubBasic, EnvFileWarningEmpty)
+{
+    env_file_warning("", 0);
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P

--- a/test/blackbox/common/mock/BlackboxMockConsumer.h
+++ b/test/blackbox/common/mock/BlackboxMockConsumer.h
@@ -42,6 +42,12 @@ public:
         return mEntriesConsumed;
     }
 
+    void ClearEntries()
+    {
+        std::unique_lock<std::mutex> guard(mMutex);
+        mEntriesConsumed.clear();
+    }
+
     std::condition_variable& cv()
     {
         return cv_;

--- a/test/blackbox/common/mock/BlackboxMockConsumer.h
+++ b/test/blackbox/common/mock/BlackboxMockConsumer.h
@@ -16,8 +16,10 @@
 #define MOCK_BLACKBOX_LOG_CONSUMER_H
 
 #include <fastdds/dds/log/Log.hpp>
-#include <thread>
+
+#include <condition_variable>
 #include <mutex>
+#include <thread>
 #include <vector>
 
 namespace eprosima {
@@ -33,7 +35,7 @@ public:
     {
         std::unique_lock<std::mutex> guard(mMutex);
         mEntriesConsumed.push_back(entry);
-        cv_.notify_one();
+        cv_.notify_all();
     }
 
     const std::vector<Log::Entry> ConsumedEntries() const
@@ -42,10 +44,11 @@ public:
         return mEntriesConsumed;
     }
 
-    void ClearEntries()
+    void clear_entries()
     {
         std::unique_lock<std::mutex> guard(mMutex);
         mEntriesConsumed.clear();
+        cv_.notify_all();
     }
 
     std::condition_variable& cv()


### PR DESCRIPTION
This PR avoids a `logWarning` that was issued whenever `DomainParticipantFactory::load_profiles()` was called for the first time without setting `FASTDDS_ENVIRONMENT_FILE` environment variable or setting it to `""`. It also adds a regression test and a test that checks that the `logWarning` is indeed issued if `FASTDDS_ENVIRONMENT_FILE` is set to an non-existing file.