### PR TITLE
[13340] Bugfix/windows installer/static linking

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -445,7 +445,6 @@ target_link_libraries(${PROJECT_NAME} ${PRIVACY} fastcdr foonathan_memory
     $<$<BOOL:${WIN32}>:iphlpapi$<SEMICOLON>Shlwapi>
     ${THIRDPARTY_BOOST_LINK_LIBS}
     PRIVATE eProsima_atomic
-    $<$<BOOL:${LibP11_FOUND}>:eProsima_p11>  # $<TARGET_NAME_IF_EXISTS:eProsima_p11>
     )
 
 if(MSVC OR MSVC_IDE)


### PR DESCRIPTION
CMake always makes static libraries transitive targets even if they are marked as PRIVATE, that is, CMake will never bundle Fast-DDS static library with OpenSSL, tinyxml or pkcs11.

People have found ways to work around it through custom CMake commands [see here](https://cristianadam.eu/20190501/bundling-together-static-libraries-with-cmake/).

We took an easier workaround on the third parties by including the actual sources into the Fast-DDS project.

The Bugfix plainly removes the Fast-DDS dependency because it's only useful on the tests. Note the OpenSSL engine loads the pkcs11 module dynamically thus no linking is required.
