### PR TITLE
Fix warning when converting string to Time_t.

### DIFF
--- a/include/fastdds/rtps/common/Time_t.h
+++ b/include/fastdds/rtps/common/Time_t.h
@@ -375,7 +375,7 @@ inline std::istream& operator >>(
     {
         char point;
         int32_t sec = 0;
-        int32_t nano = 0;
+        uint32_t nano = 0;
         std::ios_base::iostate excp_mask = input.exceptions();
 
         try
@@ -388,6 +388,7 @@ inline std::istream& operator >>(
             if ( point != '.' || nano > 1000000000 )
             {
                 input.setstate(std::ios_base::failbit);
+                nano = 0;
             }
         }
         catch (std::ios_base::failure& )


### PR DESCRIPTION
The Time_t nanosec() method requires a uint32_t to be passed in.
But the previous code was using an int32_t for the nanoseconds,
which was causing a warning in some compilers.  Fix this by
using a uint32_t for the nano variable.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Note that I targeted this at the 2.3.x branch, which is where I noticed it (using ROS 2 Rolling).  I'm happy to retarget it to master if preferred (though I'll then ask for a backport to 2.3.x).