### PR TITLE
Fix not caught exception in XMLDynamicParser [13462]

### DIFF
--- a/src/cpp/rtps/xmlparser/XMLDynamicParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLDynamicParser.cpp
@@ -981,7 +981,15 @@ p_dynamictypebuilder_t XMLParser::parseXMLMemberDynamicType(
         uint32_t length = types::MAX_ELEMENTS_COUNT;
         if (lengthStr != nullptr)
         {
-            length = static_cast<uint32_t>(std::stoi(lengthStr));
+            try
+            {
+                length = static_cast<uint32_t>(std::stoi(lengthStr));
+            }
+            catch (const std::exception&)
+            {
+                logError(XMLPARSER, "Error parsing member sequence length in line " << p_root->GetLineNum());
+                return nullptr;
+            }
         }
 
         if (!isArray)
@@ -1057,7 +1065,15 @@ p_dynamictypebuilder_t XMLParser::parseXMLMemberDynamicType(
         uint32_t length = types::MAX_ELEMENTS_COUNT;
         if (lengthStr != nullptr)
         {
-            length = static_cast<uint32_t>(std::stoi(lengthStr));
+            try
+            {
+                length = static_cast<uint32_t>(std::stoi(lengthStr));
+            }
+            catch (const std::exception&)
+            {
+                logError(XMLPARSER, "Error parsing map member sequence length in line " << p_root->GetLineNum())
+                return nullptr;
+            }
         }
 
         if (!isArray)

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -56,6 +56,7 @@ TEST_F(XMLParserTests, regressions)
 
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/12736.xml", root));
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/13418.xml", root));
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/13454.xml", root));
 }
 
 TEST_F(XMLParserTests, NoFile)

--- a/test/unittest/xmlparser/regressions/13454.xml
+++ b/test/unittest/xmlparser/regressions/13454.xml
@@ -1,0 +1,2 @@
+á8dd~pJe<types><type><typedef type="float128" sequenceMaxLength="=Û"îÚÚÚÚÚÚÚÚÚÚÚÚÚÚÚÚÚÚÚÚÚÚÚÚÚÚÚÚÚame=">Ìpee/s"/>o7ö</type>!</types>>
+</types></jds></ju


### PR DESCRIPTION
XMLDynamicParser uses `stoi()` without a try/catch statement. With a wrong XML attribute value a exception is launched without being caught.

This will fix oss-fuzz 43525