### PR TITLE
Enable memory protection on DataSharing readers [13457]

### DIFF
--- a/examples/C++/DDS/ZeroCopyExample/LoanableHelloWorldSubscriber.cxx
+++ b/examples/C++/DDS/ZeroCopyExample/LoanableHelloWorldSubscriber.cxx
@@ -126,7 +126,7 @@ void LoanableHelloWorldSubscriber::SubListener::on_subscription_matched(
 void LoanableHelloWorldSubscriber::SubListener::on_data_available(
         DataReader* reader)
 {
-    FASTDDS_SEQUENCE(DataSeq, LoanableHelloWorld);
+    FASTDDS_CONST_SEQUENCE(DataSeq, LoanableHelloWorld);
 
     DataSeq data;
     SampleInfoSeq infos;

--- a/include/fastdds/dds/core/LoanableSequence.hpp
+++ b/include/fastdds/dds/core/LoanableSequence.hpp
@@ -22,6 +22,7 @@
 #include <cassert>
 #include <cstdint>
 #include <vector>
+#include <type_traits>
 
 #include <fastdds/dds/core/LoanableTypedCollection.hpp>
 #include <fastdds/dds/log/Log.hpp>
@@ -57,8 +58,8 @@ namespace dds {
  *         the sequence is loaning the buffer. The sequence should not be destroyed until the loan is returned.
  *     @li A sequence with a zero maximum always has has_ownership == true
  */
-template<typename T>
-class LoanableSequence : public LoanableTypedCollection<T>
+template<typename T, typename _NonConstEnabler = std::true_type>
+class LoanableSequence : public LoanableTypedCollection<T, _NonConstEnabler>
 {
 public:
 

--- a/include/fastdds/dds/core/LoanableSequence.hpp
+++ b/include/fastdds/dds/core/LoanableSequence.hpp
@@ -227,6 +227,7 @@ private:
 
 // Macro to easily declare a LoanableSequence for a data type
 #define FASTDDS_SEQUENCE(FooSeq, Foo) using FooSeq = eprosima::fastdds::dds::LoanableSequence<Foo>
-#define FASTDDS_CONST_SEQUENCE(FooSeq, Foo) using FooSeq = eprosima::fastdds::dds::LoanableSequence<Foo, std::false_type>
+#define FASTDDS_CONST_SEQUENCE(FooSeq, Foo) using FooSeq = eprosima::fastdds::dds::LoanableSequence<Foo, \
+                    std::false_type>
 
 #endif // _FASTDDS_DDS_CORE_LOANABLESEQUENCE_HPP_

--- a/include/fastdds/dds/core/LoanableSequence.hpp
+++ b/include/fastdds/dds/core/LoanableSequence.hpp
@@ -227,5 +227,6 @@ private:
 
 // Macro to easily declare a LoanableSequence for a data type
 #define FASTDDS_SEQUENCE(FooSeq, Foo) using FooSeq = eprosima::fastdds::dds::LoanableSequence<Foo>
+#define FASTDDS_CONST_SEQUENCE(FooSeq, Foo) using FooSeq = eprosima::fastdds::dds::LoanableSequence<Foo, std::false_type>
 
 #endif // _FASTDDS_DDS_CORE_LOANABLESEQUENCE_HPP_

--- a/include/fastdds/dds/core/LoanableTypedCollection.hpp
+++ b/include/fastdds/dds/core/LoanableTypedCollection.hpp
@@ -22,6 +22,7 @@
 #include <cassert>
 #include <cstdint>
 #include <stdexcept>
+#include <type_traits>
 
 #include <fastdds/dds/core/LoanableCollection.hpp>
 
@@ -34,7 +35,7 @@ namespace dds {
  *
  * This is an abstract class. See @ref LoanableSequence for details.
  */
-template<typename T>
+template<typename T, typename _NonConstEnabler = std::true_type>
 class LoanableTypedCollection : public LoanableCollection
 {
 public:
@@ -54,7 +55,8 @@ public:
      *
      * @return a reference to the element at position @c n
      */
-    T& operator [](
+    template <typename Enabler = _NonConstEnabler>
+    typename std::enable_if<Enabler::value, T>::type& operator [](
             size_type n)
     {
         if (n >= length_)

--- a/src/cpp/rtps/DataSharing/ReaderPool.hpp
+++ b/src/cpp/rtps/DataSharing/ReaderPool.hpp
@@ -94,7 +94,7 @@ public:
         try
         {
             local_segment = std::unique_ptr<T>(
-                new T(boost::interprocess::open_only,
+                new T(boost::interprocess::open_read_only,
                 segment_name_.c_str()));
         }
         catch (const std::exception& e)

--- a/src/cpp/utils/shared_memory/SharedMemSegment.hpp
+++ b/src/cpp/utils/shared_memory/SharedMemSegment.hpp
@@ -273,6 +273,15 @@ public:
     }
 
     SharedSegment(
+            boost::interprocess::open_read_only_t,
+            const std::string& name)
+        : SharedSegmentBase(name)
+    {
+        segment_ = std::unique_ptr<managed_shared_memory_type>(
+            new managed_shared_memory_type(boost::interprocess::open_read_only, name.c_str()));
+    }
+
+    SharedSegment(
             boost::interprocess::open_or_create_t,
             const std::string& name,
             size_t size)


### PR DESCRIPTION
This PR adds several safety protection mechanisms on DataReader entities using data-sharing.

First, the readers will open the shared history on read-only mode.
Second, a new FASTDDS_CONST_SEQUENCE macro to define a sequence that only has the `const` version of the `[]` operator.

Should fix #2385