### PR TITLE
Remove UDP transport from the shared memory example

### DIFF
--- a/examples/C++/DDS/HelloWorldExampleSharedMem/HelloWorldPublisher.cpp
+++ b/examples/C++/DDS/HelloWorldExampleSharedMem/HelloWorldPublisher.cpp
@@ -53,17 +53,12 @@ bool HelloWorldPublisher::init()
     pqos.wire_protocol().builtin.discovery_config.leaseDuration = eprosima::fastrtps::c_TimeInfinite;
     pqos.name("Participant_pub");
 
-    // SharedMem transport configuration
+    // Explicit configuration of SharedMem transport
     pqos.transport().use_builtin_transports = false;
 
     auto shm_transport = std::make_shared<SharedMemTransportDescriptor>();
     shm_transport->segment_size(2 * 1024 * 1024);
     pqos.transport().user_transports.push_back(shm_transport);
-
-    // UDP
-    auto udp_transport = std::make_shared<UDPv4TransportDescriptor>();
-    //udp_transport->interfaceWhiteList.push_back("127.0.0.1");
-    pqos.transport().user_transports.push_back(udp_transport);
 
     participant_ = DomainParticipantFactory::get_instance()->create_participant(0, pqos);
 

--- a/examples/C++/DDS/HelloWorldExampleSharedMem/HelloWorldSubscriber.cpp
+++ b/examples/C++/DDS/HelloWorldExampleSharedMem/HelloWorldSubscriber.cpp
@@ -48,17 +48,12 @@ bool HelloWorldSubscriber::init()
     pqos.wire_protocol().builtin.discovery_config.leaseDuration = eprosima::fastrtps::c_TimeInfinite;
     pqos.name("Participant_sub");
 
-    // SharedMem transport configuration
+    // Explicit configuration of SharedMem transport
     pqos.transport().use_builtin_transports = false;
 
     auto sm_transport = std::make_shared<SharedMemTransportDescriptor>();
     sm_transport->segment_size(2 * 1024 * 1024);
     pqos.transport().user_transports.push_back(sm_transport);
-
-    // UDP
-    auto udp_transport = std::make_shared<UDPv4TransportDescriptor>();
-    //udp_transport->interfaceWhiteList.push_back("127.0.0.1");
-    pqos.transport().user_transports.push_back(udp_transport);
 
     participant_ = DomainParticipantFactory::get_instance()->create_participant(0, pqos);
 


### PR DESCRIPTION
The shared memory example is adding 2 transport layers, shared memory + UDP.
The UDP will not be used if a shared memory transport layer conditions are met and this is a unique shared memory example.
I find it confusing as a user that the shared memory example also configure UDP, it looks like a mandatory step for shared memory and it's not.

Consider using this PR to remove it and make the example clearer.