### PR TITLE
Fixing wrong usage of condition_variable [13542]

### DIFF
--- a/test/blackbox/common/RTPSBlackboxTestsPersistenceNonIntraprocess.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsPersistenceNonIntraprocess.cpp
@@ -131,20 +131,10 @@ protected:
     std::string db_file_name_reader_;
     GuidPrefix_t guid_prefix_;
 
-    void block(
-            std::function<bool()> checker)
-    {
-        std::unique_lock<std::mutex> lock(mutex_);
-        mock_consumer_->cv().wait(lock, checker);
-    }
-
     std::vector<Log::Entry> helper_block_for_at_least_entries(
             uint32_t amount)
     {
-        block([this, amount]() -> bool
-                {
-                    return mock_consumer_->ConsumedEntries().size() >= amount;
-                });
+        mock_consumer_->wait(amount);
         return mock_consumer_->ConsumedEntries();
     }
 
@@ -191,9 +181,6 @@ protected:
         std::remove(db_file_name_writer_.c_str());
     }
 
-private:
-
-    std::mutex mutex_;
 };
 
 TEST_F(PersistenceNonIntraprocess, InconsistentAcknackReceived)

--- a/test/blackbox/common/mock/BlackboxMockConsumer.h
+++ b/test/blackbox/common/mock/BlackboxMockConsumer.h
@@ -51,9 +51,14 @@ public:
         cv_.notify_all();
     }
 
-    std::condition_variable& cv()
+    void wait(
+            uint32_t amount)
     {
-        return cv_;
+        std::unique_lock<std::mutex> lock(mMutex);
+        cv_.wait(lock, [this, amount]() -> bool
+                {
+                    return mEntriesConsumed.size() >= amount;
+                });
     }
 
 private:
@@ -68,4 +73,3 @@ private:
 } // namespace eprosima
 
 #endif // ifndef MOCK_BLACKBOX_LOG_CONSUMER_H
-


### PR DESCRIPTION
In a blackbock tests a condition_variable is being notified locking a mutex but for waiting process another mutex is used.