### PR TITLE
Fix flaky test: incompatible qos conditions [13582]

### DIFF
--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -721,7 +721,7 @@ public:
     }
 
     void incompatible_qos(
-            eprosima::fastdds::dds::OfferedIncompatibleQosStatus status)
+            eprosima::fastdds::dds::RequestedIncompatibleQosStatus status)
     {
         std::unique_lock<std::mutex> lock(incompatible_qos_mutex_);
         times_incompatible_qos_ += status.total_count_change;

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -724,7 +724,7 @@ public:
             eprosima::fastdds::dds::OfferedIncompatibleQosStatus status)
     {
         std::unique_lock<std::mutex> lock(incompatible_qos_mutex_);
-        times_incompatible_qos_++;
+        times_incompatible_qos_ += status.total_count_change;
         last_incompatible_qos_ = status.last_policy_id;
         incompatible_qos_cv_.notify_one();
     }
@@ -1926,12 +1926,10 @@ protected:
                 if (status.alive_count_change == 1)
                 {
                     reader_.liveliness_recovered();
-
                 }
                 else if (status.not_alive_count_change == 1)
                 {
                     reader_.liveliness_lost();
-
                 }
             }
 


### PR DESCRIPTION
Sometimes the `DDSStatus.IncompatibleQosConditions` test fails due to `PubSubReader::incompatible_qos()` not taking into account `total_count_changes`, and instead only increasing the variable `times_incompatible_qos_` by one each time the Waitset returns. This PR corrects `PubSubReader::incompatible_qos()` so it uses `times_incompatible_qos_`.