### PR TITLE
Fix clock used by TimedConditionVariable

### DIFF
--- a/include/fastrtps/utils/TimedConditionVariable.hpp
+++ b/include/fastrtps/utils/TimedConditionVariable.hpp
@@ -42,12 +42,14 @@
 #if HAVE_STRICT_REALTIME && defined(__unix__)
 #include <pthread.h>
 
-#define CV_INIT_(x) pthread_cond_init(x, NULL);
+#define CV_INIT_(x) pthread_condattr_init(&cv_attr_); \
+    pthread_condattr_setclock(&cv_attr_, CLOCK_MONOTONIC); \
+    pthread_cond_init(x, &cv_attr_);
 #define CV_WAIT_(cv, x) pthread_cond_wait(&cv, x)
 #define CV_TIMEDWAIT_(cv, x, y) pthread_cond_timedwait(&cv, x, y)
 #define CV_SIGNAL_(cv) pthread_cond_signal(&cv)
 #define CV_BROADCAST_(cv) pthread_cond_broadcast(&cv)
-#define CV_T_ pthread_cond_t
+#define CV_T_ pthread_condattr_t cv_attr_; pthread_cond_t
 #else
 #include <condition_variable>
 #endif // if HAVE_STRICT_REALTIME && defined(__unix__)
@@ -99,7 +101,7 @@ public:
         struct timespec max_wait = {
             0, 0
         };
-        clock_gettime(CLOCK_REALTIME, &max_wait);
+        clock_gettime(CLOCK_MONOTONIC, &max_wait);
         nsecs = nsecs + std::chrono::nanoseconds(max_wait.tv_nsec);
         auto secs = std::chrono::duration_cast<std::chrono::seconds>(nsecs);
         nsecs -= secs;

--- a/test/realtime/CMakeLists.txt
+++ b/test/realtime/CMakeLists.txt
@@ -3,7 +3,7 @@ add_subdirectory(mutex_testing_tool)
 set(USER_THREAD_NONBLOCKED_TEST UserThreadNonBlockedTest.cpp)
 
 add_executable(user_thread_nonblocked_test ${USER_THREAD_NONBLOCKED_TEST})
-target_compile_definitions(DDSSimpleCommunicationSubscriber PRIVATE
+target_compile_definitions(user_thread_nonblocked_test PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -15,4 +15,12 @@ add_gtest(NAME UserThreadNonBlockedTest COMMAND user_thread_nonblocked_test SOUR
     "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:mutex_testing_tool_preload>"
     "LD_PRELOAD=$<TARGET_FILE_NAME:mutex_testing_tool_preload>"
     LABELS "NoMemoryCheck"
+    )
+
+set(TIMED_CONDITION_VARIABLE_UNIT_TEST_SOURCE TimedConditionVariableUnitTest.cpp)
+
+add_executable(TimedConditionVariableUnitTest ${TIMED_CONDITION_VARIABLE_UNIT_TEST_SOURCE})
+target_link_libraries(TimedConditionVariableUnitTest fastrtps GTest::gtest)
+add_gtest(NAME TimedConditionVariableUnitTest COMMAND TimedConditionVariableUnitTest
+    SOURCES ${TIMED_CONDITION_VARIABLE_UNIT_TEST_SOURCE}
     )

--- a/test/realtime/TimedConditionVariableUnitTest.cpp
+++ b/test/realtime/TimedConditionVariableUnitTest.cpp
@@ -1,0 +1,45 @@
+#include <fastrtps/utils/TimedConditionVariable.hpp>
+
+#include <chrono>
+
+#include <gtest/gtest.h>
+
+TEST(TimedConditionVariable, wait_for)
+{
+    eprosima::fastrtps::TimedConditionVariable cv;
+    std::timed_mutex mutex;
+    std::unique_lock<std::timed_mutex> lock(mutex);
+
+    std::chrono::steady_clock::time_point initial = std::chrono::steady_clock::now();
+
+    ASSERT_FALSE(cv.wait_for(lock, std::chrono::nanoseconds(2000000000), []() -> bool
+            {
+                return false;
+            }));
+    std::chrono::steady_clock::time_point final = std::chrono::steady_clock::now();
+    ASSERT_LE(std::chrono::seconds(1), final - initial);
+}
+
+TEST(TimedConditionVariable, wait_until)
+{
+    eprosima::fastrtps::TimedConditionVariable cv;
+    std::timed_mutex mutex;
+    std::unique_lock<std::timed_mutex> lock(mutex);
+
+    std::chrono::steady_clock::time_point initial = std::chrono::steady_clock::now();
+
+    ASSERT_FALSE(cv.wait_until(lock, initial + std::chrono::seconds(2), []() -> bool
+            {
+                return false;
+            }));
+    std::chrono::steady_clock::time_point final = std::chrono::steady_clock::now();
+    ASSERT_LE(std::chrono::seconds(1), final - initial);
+}
+
+int main(
+        int argc,
+        char** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
When compiled with `STRICT_REALTIME`, a custom condition variable is used: TimedConditionVariable. This uses internally a `pthread_cond_t`  which by default uses `CLOCK_REALTIME`. But FastDDS uses `steady_clock` (`CLOCK_MONOTONIC`) and therefore `wait_until()`function return immediately. This PR fixes this configuring `pthread_cond_t` to use `CLOCK_MONOTONIC`.