### PR TITLE
Fix strict realtime feature [13838]

### DIFF
--- a/include/fastdds/rtps/history/History.h
+++ b/include/fastdds/rtps/history/History.h
@@ -103,7 +103,7 @@ public:
     RTPS_DllAPI inline void release_Cache(
             CacheChange_t* ch)
     {
-        do_release_cache(ch);
+        do_release_cache(ch, std::chrono::steady_clock::now() + std::chrono::hours(24));
     }
 
     /**
@@ -139,11 +139,14 @@ public:
      * No Thread Safe
      * @param removal iterator to the CacheChange_t to remove.
      * @param release defaults to true and hints if the CacheChange_t should return to the pool
+     * @param max_blocking_time Maximum time the function can be blocked
      * @return iterator to the next CacheChange_t or end iterator.
      */
     RTPS_DllAPI virtual iterator remove_change_nts(
             const_iterator removal,
-            bool release = true);
+            bool release = true,
+            std::chrono::steady_clock::time_point max_blocking_time = std::chrono::steady_clock::now() +
+            std::chrono::hours(24));
 
     /**
      * Remove all changes from the History
@@ -297,7 +300,8 @@ protected:
             uint32_t size) = 0;
 
     RTPS_DllAPI virtual void do_release_cache(
-            CacheChange_t* ch) = 0;
+            CacheChange_t* ch,
+            const std::chrono::steady_clock::time_point& max_blocking_time) = 0;
 
 };
 

--- a/include/fastdds/rtps/history/IPayloadPool.h
+++ b/include/fastdds/rtps/history/IPayloadPool.h
@@ -23,6 +23,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <chrono>
 
 namespace eprosima {
 namespace fastrtps {
@@ -52,6 +53,8 @@ public:
      *                               Should be greater than 0.
      * @param [in,out] cache_change  Cache change to assign the payload to
      *
+     * @param [in]     max_blocking_time Maximum time the function can be blocked.
+     *
      * @returns whether the operation succeeded or not
      *
      * @pre Fields @c writerGUID and @c sequenceNumber of @c cache_change are either:
@@ -65,7 +68,8 @@ public:
      */
     virtual bool get_payload(
             uint32_t size,
-            CacheChange_t& cache_change) = 0;
+            CacheChange_t& cache_change,
+            const std::chrono::steady_clock::time_point& max_blocking_time) = 0;
 
     /**
      * @brief Assign a serialized payload to a new sample.
@@ -114,6 +118,8 @@ public:
      *
      * @param [in,out] cache_change  Cache change to assign the payload to
      *
+     * @param [in]     max_blocking_time Maximum time the function can be blocked.
+     *
      * @returns whether the operation succeeded or not
      *
      * @pre @li Field @c payload_owner of @c cache_change equals this
@@ -121,7 +127,9 @@ public:
      * @post @li Field @c payload_owner of @c cache_change is @c nullptr
      */
     virtual bool release_payload(
-            CacheChange_t& cache_change) = 0;
+            CacheChange_t& cache_change,
+            std::chrono::steady_clock::time_point max_blocking_time =
+            std::chrono::steady_clock::now() + std::chrono::hours(24)) = 0;
 };
 
 } /* namespace rtps */

--- a/include/fastdds/rtps/history/ReaderHistory.h
+++ b/include/fastdds/rtps/history/ReaderHistory.h
@@ -111,11 +111,14 @@ public:
      * No Thread Safe
      * @param removal iterator to the change for removal
      * @param release specifies if the change must be returned to the pool
+     * @param max_blocking_time Maximum time the function can be blocked
      * @return iterator to the next change if any
      */
     RTPS_DllAPI iterator remove_change_nts(
             const_iterator removal,
-            bool release = true) override;
+            bool release = true,
+            std::chrono::steady_clock::time_point max_blocking_time = std::chrono::steady_clock::now() +
+            std::chrono::hours(24)) override;
 
     /**
      * Criteria to search a specific CacheChange_t on history
@@ -172,7 +175,8 @@ protected:
             uint32_t size) override;
 
     RTPS_DllAPI void do_release_cache(
-            CacheChange_t* ch) override;
+            CacheChange_t* ch,
+            const std::chrono::steady_clock::time_point& max_blocking_time) override;
 
     template<typename Pred>
     inline void remove_changes_with_pred(

--- a/include/fastdds/rtps/history/WriterHistory.h
+++ b/include/fastdds/rtps/history/WriterHistory.h
@@ -80,7 +80,9 @@ public:
      */
     RTPS_DllAPI iterator remove_change_nts(
             const_iterator removal,
-            bool release = true) override;
+            bool release = true,
+            std::chrono::steady_clock::time_point max_blocking_time = std::chrono::steady_clock::now() +
+            std::chrono::hours(24)) override;
 
     /**
      * Criteria to search a specific CacheChange_t on history
@@ -122,7 +124,8 @@ protected:
             uint32_t size) override;
 
     RTPS_DllAPI void do_release_cache(
-            CacheChange_t* ch) override;
+            CacheChange_t* ch,
+            const std::chrono::steady_clock::time_point& maximum_blocking_time) override;
 
     bool add_change_(
             CacheChange_t* a_change,

--- a/include/fastdds/rtps/messages/RTPSMessageGroup.h
+++ b/include/fastdds/rtps/messages/RTPSMessageGroup.h
@@ -83,11 +83,14 @@ public:
      * Constructs a RTPSMessageGroup allowing to allocate its own buffer.
      * @param participant Pointer to the participant sending data.
      * @param internal_buffer true indicates this object to allocate its own buffer. false indicates to get a buffer
+     * @param max_blocking_time_point Future time point where blocking send should end.
      * from the participant.
      */
     RTPSMessageGroup(
             RTPSParticipantImpl* participant,
-            bool internal_buffer = false);
+            bool internal_buffer = false,
+            std::chrono::steady_clock::time_point max_blocking_time_point =
+            std::chrono::steady_clock::now() + std::chrono::hours(24));
 
     /**
      * Basic constructor.
@@ -312,8 +315,6 @@ private:
      #endif // if HAVE_SECURITY
 
     std::chrono::steady_clock::time_point max_blocking_time_point_;
-
-    bool max_blocking_time_is_set_ = false;
 
     std::unique_ptr<RTPSMessageGroup_t> send_buffer_;
 

--- a/include/fastdds/rtps/reader/RTPSReader.h
+++ b/include/fastdds/rtps/reader/RTPSReader.h
@@ -211,7 +211,8 @@ public:
      * Release a cacheChange.
      */
     RTPS_DllAPI void releaseCache(
-            CacheChange_t* change);
+            CacheChange_t* change,
+            const std::chrono::steady_clock::time_point& max_blocking_time);
 
     /**
      * Read the next unread CacheChange_t from the history

--- a/include/fastdds/rtps/writer/LocatorSelectorSender.hpp
+++ b/include/fastdds/rtps/writer/LocatorSelectorSender.hpp
@@ -4,8 +4,7 @@
 #include <fastdds/rtps/common/LocatorSelector.hpp>
 #include <fastdds/rtps/messages/RTPSMessageSenderInterface.hpp>
 #include <fastrtps/utils/collections/ResourceLimitedVector.hpp>
-
-#include <mutex>
+#include <fastrtps/utils/TimedMutex.hpp>
 
 namespace eprosima {
 namespace fastrtps {
@@ -95,6 +94,18 @@ public:
         mutex_.unlock();
     }
 
+    /*!
+     * Try to lock the object.
+     *
+     * This kind of object needs to be locked because could be used outside the writer's mutex.
+     */
+    template <class Clock, class Duration>
+    bool try_lock_until(
+            const std::chrono::time_point<Clock, Duration>& abs_time)
+    {
+        return mutex_.try_lock_until(abs_time);
+    }
+
     fastrtps::rtps::LocatorSelector locator_selector;
 
     ResourceLimitedVector<GUID_t> all_remote_readers;
@@ -105,7 +116,7 @@ private:
 
     RTPSWriter& writer_;
 
-    std::recursive_mutex mutex_;
+    RecursiveTimedMutex mutex_;
 };
 
 } // namespace rtps

--- a/include/fastdds/rtps/writer/RTPSWriter.h
+++ b/include/fastdds/rtps/writer/RTPSWriter.h
@@ -120,7 +120,8 @@ public:
     RTPS_DllAPI CacheChange_t* new_change(
             const std::function<uint32_t()>& dataCdrSerializedSize,
             ChangeKind_t changeKind,
-            InstanceHandle_t handle = c_InstanceHandle_Unknown);
+            InstanceHandle_t handle = c_InstanceHandle_Unknown,
+            const std::chrono::steady_clock::time_point max_blocking_time = std::chrono::steady_clock::now() + std::chrono::hours(24));
 
     RTPS_DllAPI CacheChange_t* new_change(
             ChangeKind_t changeKind,
@@ -131,6 +132,8 @@ public:
      *
      * @param change Pointer to the cache change to be released.
      *
+     * @param[in] max_blocking_time Maximum time the function can be blocked.
+     *
      * @returns whether the operation succeeded or not
      *
      * @pre
@@ -140,7 +143,8 @@ public:
      * @post memory pointed to by @c change is not accessed
      */
     RTPS_DllAPI bool release_change(
-            CacheChange_t* change);
+            CacheChange_t* change,
+            const std::chrono::steady_clock::time_point& max_blocking_time);
 
     /**
      * Add a matched reader.

--- a/include/fastdds/rtps/writer/ReaderProxy.h
+++ b/include/fastdds/rtps/writer/ReaderProxy.h
@@ -177,12 +177,14 @@ public:
      * @param seq_num Sequence number of the change to update.
      * @param status Status to apply.
      * @param restart_nack_supression Whether nack supression event should be restarted or not.
+     * @param max_blocking_time Maximum time the function can be blocked.
      * @param delivered true if change was able to be delivered to its addressees. false otherwise.
      */
     void from_unsent_to_status(
             const SequenceNumber_t& seq_num,
             ChangeForReaderStatus_t status,
             bool restart_nack_supression,
+            const std::chrono::steady_clock::time_point& max_blocking_time,
             bool delivered = true);
 
     /**

--- a/include/fastdds/rtps/writer/StatefulWriter.h
+++ b/include/fastdds/rtps/writer/StatefulWriter.h
@@ -26,7 +26,7 @@
 #include <fastdds/rtps/history/IChangePool.h>
 #include <fastdds/rtps/history/IPayloadPool.h>
 #include <fastrtps/utils/collections/ResourceLimitedVector.hpp>
-#include <condition_variable>
+#include <fastrtps/utils/TimedConditionVariable.hpp>
 #include <mutex>
 
 namespace eprosima {
@@ -123,10 +123,10 @@ private:
 
     // TODO Join this mutex when main mutex would not be recursive.
     std::mutex all_acked_mutex_;
-    std::condition_variable all_acked_cond_;
+    fastrtps::TimedConditionVariable all_acked_cond_;
     // TODO Also remove when main mutex not recursive.
     bool all_acked_;
-    std::condition_variable_any may_remove_change_cond_;
+    fastrtps::TimedConditionVariable may_remove_change_cond_;
     unsigned int may_remove_change_;
 
 public:
@@ -443,10 +443,12 @@ private:
     void send_heartbeat_to_all_readers();
 
     void deliver_sample_to_intraprocesses(
-            CacheChange_t* change);
+            CacheChange_t* change,
+            const std::chrono::time_point<std::chrono::steady_clock>& max_blocking_time);
 
     void deliver_sample_to_datasharing(
-            CacheChange_t* change);
+            CacheChange_t* change,
+            const std::chrono::time_point<std::chrono::steady_clock>& max_blocking_time);
 
     DeliveryRetCode deliver_sample_to_network(
             CacheChange_t* change,

--- a/include/fastdds/rtps/writer/StatelessWriter.h
+++ b/include/fastdds/rtps/writer/StatelessWriter.h
@@ -27,8 +27,8 @@
 #include <fastdds/rtps/writer/ReaderLocator.h>
 #include <fastdds/rtps/writer/RTPSWriter.h>
 #include <fastrtps/utils/collections/ResourceLimitedVector.hpp>
+#include <fastrtps/utils/TimedConditionVariable.hpp>
 
-#include <condition_variable>
 #include <list>
 #include <memory>
 #include <mutex>
@@ -226,7 +226,7 @@ private:
     LocatorList_t fixed_locators_;
     ResourceLimitedVector<std::unique_ptr<ReaderLocator>> matched_remote_readers_;
 
-    std::condition_variable_any unsent_changes_cond_;
+    TimedConditionVariable unsent_changes_cond_;
 
     uint64_t current_sequence_number_sent_ = 0;
 

--- a/include/fastrtps/attributes/LibrarySettingsAttributes.h
+++ b/include/fastrtps/attributes/LibrarySettingsAttributes.h
@@ -38,19 +38,26 @@ class LibrarySettingsAttributes
 {
 public:
 
-    LibrarySettingsAttributes() {
+    LibrarySettingsAttributes()
+    {
     }
 
-    virtual ~LibrarySettingsAttributes() {
+    virtual ~LibrarySettingsAttributes()
+    {
     }
 
-    bool operator==(
+    bool operator ==(
             const LibrarySettingsAttributes& b) const
     {
         return (intraprocess_delivery == b.intraprocess_delivery);
     }
 
-    IntraprocessDeliveryType intraprocess_delivery = INTRAPROCESS_FULL;
+    IntraprocessDeliveryType intraprocess_delivery =
+#if HAVE_STRICT_REALTIME
+            INTRAPROCESS_OFF;
+#else
+            INTRAPROCESS_FULL;
+#endif // if HAVE_STRICT_REALTIME
 };
 
 }  // namespace fastrtps

--- a/include/fastrtps/subscriber/SubscriberHistory.h
+++ b/include/fastrtps/subscriber/SubscriberHistory.h
@@ -70,7 +70,9 @@ public:
      */
     iterator remove_change_nts(
             const_iterator removal,
-            bool release = true) override;
+            bool release = true,
+            std::chrono::steady_clock::time_point max_blocking_time = std::chrono::steady_clock::now() +
+            std::chrono::hours(24)) override;
 
     /**
      * Check if a new change can be added to this history.

--- a/include/fastrtps/utils/TimedConditionVariable.hpp
+++ b/include/fastrtps/utils/TimedConditionVariable.hpp
@@ -42,12 +42,14 @@
 #if HAVE_STRICT_REALTIME && defined(__unix__)
 #include <pthread.h>
 
-#define CV_INIT_(x) pthread_cond_init(x, NULL);
+#define CV_INIT_(x) pthread_condattr_init(&cv_attr_); \
+    pthread_condattr_setclock(&cv_attr_, CLOCK_MONOTONIC); \
+    pthread_cond_init(x, &cv_attr_);
 #define CV_WAIT_(cv, x) pthread_cond_wait(&cv, x)
 #define CV_TIMEDWAIT_(cv, x, y) pthread_cond_timedwait(&cv, x, y)
 #define CV_SIGNAL_(cv) pthread_cond_signal(&cv)
 #define CV_BROADCAST_(cv) pthread_cond_broadcast(&cv)
-#define CV_T_ pthread_cond_t
+#define CV_T_ pthread_condattr_t cv_attr_; pthread_cond_t
 #else
 #include <condition_variable>
 #endif // if HAVE_STRICT_REALTIME && defined(__unix__)
@@ -99,7 +101,7 @@ public:
         struct timespec max_wait = {
             0, 0
         };
-        clock_gettime(CLOCK_REALTIME, &max_wait);
+        clock_gettime(CLOCK_MONOTONIC, &max_wait);
         nsecs = nsecs + std::chrono::nanoseconds(max_wait.tv_nsec);
         auto secs = std::chrono::duration_cast<std::chrono::seconds>(nsecs);
         nsecs -= secs;
@@ -111,6 +113,24 @@ public:
         }
 
         return ret_value;
+    }
+
+    template<typename Mutex>
+    bool wait_for(
+            std::unique_lock<Mutex>& lock,
+            const std::chrono::nanoseconds& max_blocking_time)
+    {
+        auto nsecs = max_blocking_time;
+        struct timespec max_wait = {
+            0, 0
+        };
+        clock_gettime(CLOCK_MONOTONIC, &max_wait);
+        nsecs = nsecs + std::chrono::nanoseconds(max_wait.tv_nsec);
+        auto secs = std::chrono::duration_cast<std::chrono::seconds>(nsecs);
+        nsecs -= secs;
+        max_wait.tv_sec += secs.count();
+        max_wait.tv_nsec = (long)nsecs.count();
+        return (CV_TIMEDWAIT_(cv_, lock.mutex()->native_handle(), &max_wait) == 0);
     }
 
     template<typename Mutex>

--- a/src/cpp/fastdds/core/condition/StatusConditionImpl.cpp
+++ b/src/cpp/fastdds/core/condition/StatusConditionImpl.cpp
@@ -106,6 +106,7 @@ void StatusConditionImpl::set_status(
     if (lock.try_lock_until(max_blocking_time))
 #else
     std::lock_guard<fastrtps::TimedMutex> guard(mutex_);
+    static_cast<void>(max_blocking_time);
 #endif // if HAVE_STRICT_REALTIME
     {
         status_ &= ~status;

--- a/src/cpp/fastdds/core/condition/StatusConditionImpl.hpp
+++ b/src/cpp/fastdds/core/condition/StatusConditionImpl.hpp
@@ -19,10 +19,9 @@
 #ifndef _FASTDDS_CORE_CONDITION_STATUSCONDITIONIMPL_HPP_
 #define _FASTDDS_CORE_CONDITION_STATUSCONDITIONIMPL_HPP_
 
-#include <mutex>
-
 #include <fastdds/dds/core/status/StatusMask.hpp>
 #include <fastrtps/types/TypesBase.h>
+#include <fastrtps/utils/TimedMutex.hpp>
 
 #include <fastdds/core/condition/ConditionNotifier.hpp>
 
@@ -94,9 +93,18 @@ struct StatusConditionImpl
             const StatusMask& status,
             bool trigger_value);
 
+    /**
+     * @brief Timed function which sets the trigger value of a specific status without triggering.
+     * @param status The status for which to change the trigger value
+     * @param max_blocking_time Maximum time the function can be blocked.
+     */
+    void set_status(
+            const StatusMask& status,
+            const std::chrono::steady_clock::time_point& max_blocking_time);
+
 private:
 
-    mutable std::mutex mutex_;
+    mutable fastrtps::TimedMutex mutex_;
     StatusMask mask_{};
     StatusMask status_{};
     ConditionNotifier* notifier_;

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -499,7 +499,8 @@ protected:
     template<typename SizeFunctor>
     bool get_free_payload_from_pool(
             const SizeFunctor& size_getter,
-            PayloadInfo_t& payload)
+            PayloadInfo_t& payload,
+            const std::chrono::time_point<std::chrono::steady_clock>& max_blocking_time)
     {
         CacheChange_t change;
         if (!payload_pool_)
@@ -508,7 +509,7 @@ protected:
         }
 
         uint32_t size = fixed_payload_size_ ? fixed_payload_size_ : size_getter();
-        if (!payload_pool_->get_payload(size, change))
+        if (!payload_pool_->get_payload(size, change, max_blocking_time))
         {
             return false;
         }

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -615,10 +615,10 @@ ReturnCode_t DataReaderImpl::read_or_take_next_sample(
         return ReturnCode_t::RETCODE_NOT_ENABLED;
     }
 
-#if HAVE_STRICT_REALTIME
-    std::unique_lock<RecursiveTimedMutex> lock(reader_->getMutex(), std::defer_lock);
     auto max_blocking_time = std::chrono::steady_clock::now() +
             std::chrono::microseconds(::TimeConv::Time_t2MicroSecondsInt64(qos_.reliability().max_blocking_time));
+#if HAVE_STRICT_REALTIME
+    std::unique_lock<RecursiveTimedMutex> lock(reader_->getMutex(), std::defer_lock);
     if (!lock.try_lock_until(max_blocking_time))
     {
         return ReturnCode_t::RETCODE_TIMEOUT;

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -442,10 +442,10 @@ ReturnCode_t DataReaderImpl::read_or_take(
         return code;
     }
 
-#if HAVE_STRICT_REALTIME
-    std::unique_lock<RecursiveTimedMutex> lock(reader_->getMutex(), std::defer_lock);
     auto max_blocking_time = std::chrono::steady_clock::now() +
             std::chrono::microseconds(::TimeConv::Time_t2MicroSecondsInt64(qos_.reliability().max_blocking_time));
+#if HAVE_STRICT_REALTIME
+    std::unique_lock<RecursiveTimedMutex> lock(reader_->getMutex(), std::defer_lock);
     if (!lock.try_lock_until(max_blocking_time))
     {
         return ReturnCode_t::RETCODE_TIMEOUT;

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -435,8 +435,10 @@ protected:
             SampleInfo* info,
             bool should_take);
 
-    void set_read_communication_status(
-            bool trigger_value);
+    void set_read_communication_status_triggering();
+
+    void set_read_communication_status_no_triggering(
+            const std::chrono::steady_clock::time_point& max_blocking_time);
 
     void update_subscription_matched_status(
             const SubscriptionMatchedStatus& status);

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
@@ -97,7 +97,8 @@ struct ReadTakeCommand
     }
 
     bool add_instance(
-            bool take_samples)
+            bool take_samples,
+            const std::chrono::steady_clock::time_point& max_blocking_time)
     {
         // Advance to the first instance with a valid state
         if (!go_to_first_valid_instance())
@@ -132,7 +133,7 @@ struct ReadTakeCommand
                 if (remove_change)
                 {
                     // Remove from history
-                    history_.remove_change_sub(change, it);
+                    history_.remove_change_sub(change, it, max_blocking_time);
 
                     // Current iterator will point to change next to the one removed. Avoid incrementing.
                     continue;
@@ -166,7 +167,7 @@ struct ReadTakeCommand
                     if (remove_change || (added && take_samples))
                     {
                         // Remove from history
-                        history_.remove_change_sub(change, it);
+                        history_.remove_change_sub(change, it, max_blocking_time);
 
                         // Current iterator will point to change next to the one removed. Avoid incrementing.
                         continue;

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
@@ -432,7 +432,8 @@ bool DataReaderHistory::remove_change_sub(
 
 bool DataReaderHistory::remove_change_sub(
         CacheChange_t* change,
-        DataReaderInstance::ChangeCollection::iterator& it)
+        DataReaderInstance::ChangeCollection::iterator& it,
+        const std::chrono::steady_clock::time_point& max_blocking_time)
 {
     if (mp_reader == nullptr || mp_mutex == nullptr)
     {
@@ -470,7 +471,7 @@ bool DataReaderHistory::remove_change_sub(
     }
 
     m_isHistoryFull = false;
-    ReaderHistory::remove_change_nts(chit);
+    ReaderHistory::remove_change_nts(chit, true, max_blocking_time);
 
     return true;
 }
@@ -583,7 +584,8 @@ void DataReaderHistory::check_and_remove_instance(
 
 ReaderHistory::iterator DataReaderHistory::remove_change_nts(
         ReaderHistory::const_iterator removal,
-        bool release)
+        bool release,
+        std::chrono::steady_clock::time_point max_blocking_time)
 {
     if (removal != changesEnd())
     {
@@ -603,7 +605,7 @@ ReaderHistory::iterator DataReaderHistory::remove_change_nts(
     }
 
     // call the base class
-    return ReaderHistory::remove_change_nts(removal, release);
+    return ReaderHistory::remove_change_nts(removal, release, max_blocking_time);
 }
 
 bool DataReaderHistory::completed_change(

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
@@ -86,7 +86,9 @@ public:
      */
     iterator remove_change_nts(
             const_iterator removal,
-            bool release = true) override;
+            bool release = true,
+            std::chrono::steady_clock::time_point max_blocking_time = std::chrono::steady_clock::now() +
+            std::chrono::hours(24)) override;
 
     /**
      * Check if a new change can be added to this history.
@@ -148,11 +150,13 @@ public:
      * This method is called to remove a change from the SubscriberHistory.
      * @param [in]     change Pointer to the CacheChange_t.
      * @param [in,out] it     Iterator pointing to change on input. Will point to next valid change on output.
+     * @param [in]     maximum_blocking_time Maximum time the function can be blocked.
      * @return True if removed.
      */
     bool remove_change_sub(
             CacheChange_t* change,
-            DataReaderInstance::ChangeCollection::iterator& it);
+            DataReaderInstance::ChangeCollection::iterator& it,
+            const std::chrono::steady_clock::time_point& maximum_blocking_time);
 
     /**
      * Called when a writer is unmatched from the reader holding this history.

--- a/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.cpp
+++ b/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.cpp
@@ -182,7 +182,7 @@ bool PublisherImpl::create_new_change_with_params(
                 if (!mp_type->serialize(data, &ch->serializedPayload))
                 {
                     logWarning(RTPS_WRITER, "RTPSWriter:Serialization returns false"; );
-                    mp_writer->release_change(ch);
+                    mp_writer->release_change(ch, max_blocking_time);
                     return false;
                 }
             }
@@ -190,7 +190,7 @@ bool PublisherImpl::create_new_change_with_params(
             InstanceHandle_t change_handle = ch->instanceHandle;
             if (!this->m_history.add_pub_change(ch, wparams, lock, max_blocking_time))
             {
-                mp_writer->release_change(ch);
+                mp_writer->release_change(ch, max_blocking_time);
                 return false;
             }
 

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -695,7 +695,8 @@ bool SubscriberHistory::get_next_deadline(
 
 ReaderHistory::iterator SubscriberHistory::remove_change_nts(
         ReaderHistory::const_iterator removal,
-        bool release)
+        bool release,
+        std::chrono::steady_clock::time_point max_blocking_time)
 {
     CacheChange_t* p_sample = nullptr;
 
@@ -714,7 +715,7 @@ ReaderHistory::iterator SubscriberHistory::remove_change_nts(
     }
 
     // call the base class
-    return ReaderHistory::remove_change_nts(removal, release);
+    return ReaderHistory::remove_change_nts(removal, release, max_blocking_time);
 }
 
 bool SubscriberHistory::completed_change(

--- a/src/cpp/rtps/DataSharing/DataSharingPayloadPool.cpp
+++ b/src/cpp/rtps/DataSharing/DataSharingPayloadPool.cpp
@@ -28,7 +28,8 @@ namespace fastrtps {
 namespace rtps {
 
 bool DataSharingPayloadPool::release_payload(
-        CacheChange_t& cache_change)
+        CacheChange_t& cache_change,
+        std::chrono::steady_clock::time_point)
 {
     cache_change.serializedPayload.length = 0;
     cache_change.serializedPayload.pos = 0;

--- a/src/cpp/rtps/DataSharing/DataSharingPayloadPool.hpp
+++ b/src/cpp/rtps/DataSharing/DataSharingPayloadPool.hpp
@@ -53,7 +53,9 @@ public:
     ~DataSharingPayloadPool() = default;
 
     virtual bool release_payload(
-            CacheChange_t& cache_change) override;
+            CacheChange_t& cache_change,
+            std::chrono::steady_clock::time_point max_blocking_time =
+            std::chrono::steady_clock::now() + std::chrono::hours(24)) override;
 
     static std::shared_ptr<DataSharingPayloadPool> get_reader_pool(
             bool is_reader_volatile);

--- a/src/cpp/rtps/DataSharing/ReaderPool.hpp
+++ b/src/cpp/rtps/DataSharing/ReaderPool.hpp
@@ -44,7 +44,8 @@ public:
 
     bool get_payload(
             uint32_t /*size*/,
-            CacheChange_t& /*cache_change*/) override
+            CacheChange_t& /*cache_change*/,
+            const std::chrono::time_point<std::chrono::steady_clock>&) override
     {
         // Only WriterPool can return new payloads
         return false;
@@ -74,11 +75,13 @@ public:
     }
 
     bool release_payload(
-            CacheChange_t& cache_change) override
+            CacheChange_t& cache_change,
+            std::chrono::steady_clock::time_point max_blocking_time =
+            std::chrono::steady_clock::now() + std::chrono::hours(24)) override
     {
         assert(cache_change.payload_owner() == this);
 
-        return DataSharingPayloadPool::release_payload(cache_change);
+        return DataSharingPayloadPool::release_payload(cache_change, max_blocking_time);
     }
 
     template <typename T>

--- a/src/cpp/rtps/DataSharing/WriterPool.hpp
+++ b/src/cpp/rtps/DataSharing/WriterPool.hpp
@@ -61,7 +61,8 @@ public:
 
     bool get_payload(
             uint32_t /*size*/,
-            CacheChange_t& cache_change) override
+            CacheChange_t& cache_change,
+            const std::chrono::time_point<std::chrono::steady_clock>&) override
     {
         if (free_payloads_.empty())
         {
@@ -98,7 +99,7 @@ public:
         }
         else
         {
-            if (get_payload(data.length, cache_change))
+            if (get_payload(data.length, cache_change, std::chrono::steady_clock::now() + std::chrono::hours(24)))
             {
                 if (!cache_change.serializedPayload.copy(&data, true))
                 {
@@ -120,7 +121,9 @@ public:
     }
 
     bool release_payload(
-            CacheChange_t& cache_change) override
+            CacheChange_t& cache_change,
+            std::chrono::steady_clock::time_point max_blocking_time =
+            std::chrono::steady_clock::now() + std::chrono::hours(24)) override
     {
         assert(cache_change.payload_owner() == this);
 
@@ -136,7 +139,7 @@ public:
         }
         logInfo(DATASHARING_PAYLOADPOOL, "Change released with SN " << cache_change.sequenceNumber);
 
-        return DataSharingPayloadPool::release_payload(cache_change);
+        return DataSharingPayloadPool::release_payload(cache_change, max_blocking_time);
     }
 
     template <typename T>

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
@@ -267,7 +267,8 @@ bool EDPServer::removeLocalReader(
             else
             {
                 // If the database doesn't take the ownership, then return the CacheChante_t to the pool.
-                get_pdp()->mp_PDPWriter->release_change(change);
+                get_pdp()->mp_PDPWriter->release_change(change,
+                        std::chrono::steady_clock::now() + std::chrono::hours(24));
             }
             return true;
         }
@@ -327,7 +328,8 @@ bool EDPServer::removeLocalWriter(
             else
             {
                 // If the database doesn't take the ownership, then return the CacheChante_t to the pool.
-                get_pdp()->mp_PDPWriter->release_change(change);
+                get_pdp()->mp_PDPWriter->release_change(change,
+                        std::chrono::steady_clock::now() + std::chrono::hours(24));
             }
             return true;
         }
@@ -374,14 +376,16 @@ bool EDPServer::processLocalWriterProxyData(
         else
         {
             // If the database doesn't take the ownership, then return the CacheChante_t to the pool.
-            get_pdp()->mp_PDPWriter->release_change(change);
+            get_pdp()->mp_PDPWriter->release_change(change,
+                    std::chrono::steady_clock::now() + std::chrono::hours(24));
         }
         // Return whether the DATA(w) was generated correctly
         return ret_val;
     }
 
     // Return the change to the pool and return false
-    get_pdp()->mp_PDPWriter->release_change(change);
+    get_pdp()->mp_PDPWriter->release_change(change,
+            std::chrono::steady_clock::now() + std::chrono::hours(24));
     return false;
 }
 
@@ -424,14 +428,16 @@ bool EDPServer::processLocalReaderProxyData(
         else
         {
             // If the database doesn't take the ownership, then return the CacheChante_t to the pool.
-            get_pdp()->mp_PDPWriter->release_change(change);
+            get_pdp()->mp_PDPWriter->release_change(change,
+                    std::chrono::steady_clock::now() + std::chrono::hours(24));
         }
         // Return whether the DATA(w) was generated correctly
         return ret_val;
     }
 
     // Return the change to the pool and return false
-    get_pdp()->mp_PDPWriter->release_change(change);
+    get_pdp()->mp_PDPWriter->release_change(change,
+            std::chrono::steady_clock::now() + std::chrono::hours(24));
     return false;
 }
 

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners.cpp
@@ -141,7 +141,8 @@ void EDPServerPUBListener::onNewCacheChangeAdded(
         else
         {
             // If the database doesn't take the ownership, then return the CacheChante_t to the pool.
-            reader->releaseCache(change);
+            reader->releaseCache(change,
+                    std::chrono::steady_clock::now() + std::chrono::hours(24));
         }
     }
     logInfo(RTPS_EDP_LISTENER,
@@ -255,7 +256,8 @@ void EDPServerSUBListener::onNewCacheChangeAdded(
         else
         {
             // If the database doesn't take the ownership, then return the CacheChante_t to the pool.
-            reader->releaseCache(change);
+            reader->releaseCache(change,
+                    std::chrono::steady_clock::now() + std::chrono::hours(24));
         }
     }
 

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -283,7 +283,8 @@ void EDPSimple::processPersistentData(
                         << change->serializedPayload.length << " bytes and max size in EDPServer reader"
                         << " is " << change_to_add->serializedPayload.max_size);
 
-                    reader.first->releaseCache(change_to_add);
+                    reader.first->releaseCache(change_to_add,
+                    std::chrono::steady_clock::now() + std::chrono::hours(24));
                     return;
                 }
 
@@ -291,7 +292,8 @@ void EDPSimple::processPersistentData(
                 {
                     logInfo(RTPS_EDP, "EDPServer couldn't process database data not add change "
                         << change_to_add->sequenceNumber);
-                    reader.first->releaseCache(change_to_add);
+                    reader.first->releaseCache(change_to_add,
+                    std::chrono::steady_clock::now() + std::chrono::hours(24));
                 }
 
                 // change_to_add would be released within change_received

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -491,7 +491,8 @@ void PDPClient::announceParticipantState(
         }
 
         // free change
-        mp_PDPWriter->release_change(change);
+        mp_PDPWriter->release_change(change,
+                std::chrono::steady_clock::now() + std::chrono::hours(24));
     }
     else
     {

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -645,7 +645,8 @@ void PDPServer::announceParticipantState(
                 {
                     // Already there, dispose
                     logError(RTPS_PDP_SERVER, "DiscoveryDatabase already initialized with local DATA(p) on creation");
-                    mp_PDPWriter->release_change(change);
+                    mp_PDPWriter->release_change(change,
+                            std::chrono::steady_clock::now() + std::chrono::hours(24));
                 }
             }
             // Doesn't make sense to send the DATA directly if it hasn't been introduced in the history yet (missing
@@ -715,7 +716,8 @@ void PDPServer::announceParticipantState(
             {
                 // Dispose if already there
                 // It may happen if the participant is not removed fast enough
-                mp_PDPWriter->release_change(change);
+                mp_PDPWriter->release_change(change,
+                        std::chrono::steady_clock::now() + std::chrono::hours(24));
                 return;
             }
         }
@@ -799,7 +801,8 @@ bool PDPServer::remove_remote_participant(
             else
             {
                 // if the database doesn't take the ownership remove
-                mp_PDPReader->releaseCache(pC);
+                mp_PDPReader->releaseCache(pC,
+                        std::chrono::steady_clock::now() + std::chrono::hours(24));
             }
         }
     }
@@ -1126,7 +1129,8 @@ void PDPServer::process_changes_release_(
                 // Normally Data(Up) will not be in history except in Own Server destruction
                 if (!remove_change_from_writer_history(mp_PDPWriter, mp_PDPWriterHistory, ch))
                 {
-                    mp_PDPWriter->release_change(ch);
+                    mp_PDPWriter->release_change(ch,
+                            std::chrono::steady_clock::now() + std::chrono::hours(24));
                 }
             }
             else if (discovery_db_.is_writer(ch))
@@ -1138,7 +1142,8 @@ void PDPServer::process_changes_release_(
                             edp->publications_writer_.second,
                             ch))
                 {
-                    edp->publications_writer_.first->release_change(ch);
+                    edp->publications_writer_.first->release_change(ch,
+                            std::chrono::steady_clock::now() + std::chrono::hours(24));
                 }
             }
             else if (discovery_db_.is_reader(ch))
@@ -1150,7 +1155,8 @@ void PDPServer::process_changes_release_(
                             edp->subscriptions_writer_.second,
                             ch))
                 {
-                    edp->subscriptions_writer_.first->release_change(ch);
+                    edp->subscriptions_writer_.first->release_change(ch,
+                            std::chrono::steady_clock::now() + std::chrono::hours(24));
                 }
             }
             else
@@ -1169,7 +1175,8 @@ void PDPServer::process_changes_release_(
             if (discovery_db_.is_participant(ch))
             {
                 remove_change_from_writer_history(mp_PDPWriter, mp_PDPWriterHistory, ch, false);
-                mp_PDPReader->releaseCache(ch);
+                mp_PDPReader->releaseCache(ch,
+                        std::chrono::steady_clock::now() + std::chrono::hours(24));
             }
             else if (discovery_db_.is_writer(ch))
             {
@@ -1178,7 +1185,8 @@ void PDPServer::process_changes_release_(
                     edp->publications_writer_.second,
                     ch,
                     false);
-                edp->publications_reader_.first->releaseCache(ch);
+                edp->publications_reader_.first->releaseCache(ch,
+                        std::chrono::steady_clock::now() + std::chrono::hours(24));
             }
             else if (discovery_db_.is_reader(ch))
             {
@@ -1187,7 +1195,8 @@ void PDPServer::process_changes_release_(
                     edp->subscriptions_writer_.second,
                     ch,
                     false);
-                edp->subscriptions_reader_.first->releaseCache(ch);
+                edp->subscriptions_reader_.first->releaseCache(ch,
+                        std::chrono::steady_clock::now() + std::chrono::hours(24));
             }
             else
             {

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
@@ -271,7 +271,8 @@ void PDPServerListener::onNewCacheChangeAdded(
                 else
                 {
                     // If the database doesn't take the ownership, then return the CacheChante_t to the pool.
-                    pdp_reader->releaseCache(change.release());
+                    pdp_reader->releaseCache(change.release(),
+                            std::chrono::steady_clock::now() + std::chrono::hours(24));
                 }
 
             }

--- a/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp
+++ b/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp
@@ -321,7 +321,7 @@ struct FlowControllerLimitedAsyncPublishMode : public FlowControllerAsyncPublish
 
         if (lapse < period_ms)
         {
-            if (cv.wait_for(lock, period_ms - lapse))
+            if (std::cv_status::no_timeout == cv.wait_for(lock, period_ms - lapse))
             {
                 reset_limit = false;
             }

--- a/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp
+++ b/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp
@@ -1109,6 +1109,7 @@ private:
         std::unique_lock<fastrtps::TimedMutex> lock(async_mode.changes_interested_mutex, std::defer_lock);
         if (lock.try_lock_until(max_blocking_time))
 #else
+        static_cast<void>(max_blocking_time);
         std::unique_lock<fastrtps::TimedMutex> lock(async_mode.changes_interested_mutex);
 #endif // if HAVE_STRICT_REALTIME{
         {
@@ -1215,6 +1216,7 @@ private:
             std::unique_lock<fastrtps::TimedMutex> lock(async_mode.changes_interested_mutex, std::defer_lock);
             if (lock.try_lock_until(max_blocking_time))
 #else
+            static_cast<void>(max_blocking_time);
             std::unique_lock<fastrtps::TimedMutex> lock(async_mode.changes_interested_mutex);
 #endif // if HAVE_STRICT_REALTIME{
             {

--- a/src/cpp/rtps/history/BasicPayloadPool.hpp
+++ b/src/cpp/rtps/history/BasicPayloadPool.hpp
@@ -59,7 +59,8 @@ public:
                                 [&payload_pool, &config](
                                     CacheChange_t* change)
                                 {
-                                    if (payload_pool->get_payload(config.payload_initial_size, *change))
+                                    if (payload_pool->get_payload(config.payload_initial_size, *change,
+                                    std::chrono::steady_clock::now() + std::chrono::hours(24)))
                                     {
                                         payload_pool->release_payload(*change);
                                     }

--- a/src/cpp/rtps/history/BasicPayloadPool_impl/Base.hpp
+++ b/src/cpp/rtps/history/BasicPayloadPool_impl/Base.hpp
@@ -20,7 +20,8 @@ class BaseImpl : public IPayloadPool
 {
     bool get_payload(
             uint32_t size,
-            CacheChange_t& cache_change) override
+            CacheChange_t& cache_change,
+            const std::chrono::steady_clock::time_point&) override
     {
         cache_change.serializedPayload.reserve(size);
         cache_change.payload_owner(this);
@@ -44,7 +45,9 @@ class BaseImpl : public IPayloadPool
     }
 
     bool release_payload(
-            CacheChange_t& cache_change) override
+            CacheChange_t& cache_change,
+            std::chrono::steady_clock::time_point =
+            std::chrono::steady_clock::now() + std::chrono::hours(24)) override
     {
         assert(cache_change.payload_owner() == this);
 

--- a/src/cpp/rtps/history/BasicPayloadPool_impl/Dynamic.hpp
+++ b/src/cpp/rtps/history/BasicPayloadPool_impl/Dynamic.hpp
@@ -22,7 +22,9 @@ class Impl<DYNAMIC_RESERVE_MEMORY_MODE> : public BaseImpl
 public:
 
     bool release_payload(
-            CacheChange_t& cache_change) override
+            CacheChange_t& cache_change,
+            std::chrono::steady_clock::time_point =
+            std::chrono::steady_clock::now() + std::chrono::hours(24)) override
     {
         assert(cache_change.payload_owner() == this);
 

--- a/src/cpp/rtps/history/BasicPayloadPool_impl/Preallocated.hpp
+++ b/src/cpp/rtps/history/BasicPayloadPool_impl/Preallocated.hpp
@@ -30,7 +30,8 @@ public:
 
     bool get_payload(
             uint32_t /* size */,
-            CacheChange_t& cache_change) override
+            CacheChange_t& cache_change,
+            const std::chrono::time_point<std::chrono::steady_clock>&) override
     {
         cache_change.serializedPayload.reserve(payload_size_);
         cache_change.payload_owner(this);

--- a/src/cpp/rtps/history/BasicPayloadPool_impl/PreallocatedWithRealloc.hpp
+++ b/src/cpp/rtps/history/BasicPayloadPool_impl/PreallocatedWithRealloc.hpp
@@ -30,7 +30,8 @@ public:
 
     bool get_payload(
             uint32_t size,
-            CacheChange_t& cache_change) override
+            CacheChange_t& cache_change,
+            const std::chrono::time_point<std::chrono::steady_clock>&) override
     {
         cache_change.serializedPayload.reserve(std::max(size, min_payload_size_));
         cache_change.payload_owner(this);

--- a/src/cpp/rtps/history/History.cpp
+++ b/src/cpp/rtps/history/History.cpp
@@ -70,7 +70,8 @@ bool History::matches_change(
 
 History::iterator History::remove_change_nts(
         const_iterator removal,
-        bool release)
+        bool release,
+        std::chrono::steady_clock::time_point max_blocking_time)
 {
     if (nullptr == mp_mutex)
     {
@@ -88,7 +89,7 @@ History::iterator History::remove_change_nts(
 
     if (release)
     {
-        do_release_cache(change);
+        do_release_cache(change, max_blocking_time);
     }
 
     return m_changes.erase(removal);

--- a/src/cpp/rtps/history/ReaderHistory.cpp
+++ b/src/cpp/rtps/history/ReaderHistory.cpp
@@ -131,7 +131,8 @@ bool ReaderHistory::matches_change(
 
 History::iterator ReaderHistory::remove_change_nts(
         const_iterator removal,
-        bool release)
+        bool release,
+        std::chrono::steady_clock::time_point max_blocking_time)
 {
     if ( mp_reader == nullptr || mp_mutex == nullptr)
     {
@@ -152,7 +153,7 @@ History::iterator ReaderHistory::remove_change_nts(
     mp_reader->change_removed_by_history(change);
     if (release)
     {
-        mp_reader->releaseCache(change);
+        mp_reader->releaseCache(change, max_blocking_time);
     }
 
     return ret_val;
@@ -253,9 +254,10 @@ bool ReaderHistory::do_reserve_cache(
 }
 
 void ReaderHistory::do_release_cache(
-        CacheChange_t* ch)
+        CacheChange_t* ch,
+        const std::chrono::steady_clock::time_point& max_blocking_time)
 {
-    mp_reader->releaseCache(ch);
+    mp_reader->releaseCache(ch, max_blocking_time);
 }
 
 } /* namespace rtps */

--- a/src/cpp/rtps/history/TopicPayloadPool.cpp
+++ b/src/cpp/rtps/history/TopicPayloadPool.cpp
@@ -53,6 +53,7 @@ bool TopicPayloadPool::do_get_payload(
         return false;
     }
 #else
+    static_cast<void>(max_blocking_time);
     std::unique_lock<TimedMutex> lock(mutex_);
 #endif // HAVE_STRICT_REALTIME
 
@@ -154,6 +155,7 @@ bool TopicPayloadPool::release_payload(
         std::unique_lock<fastrtps::TimedMutex> lock(mutex_, std::defer_lock);
         if (lock.try_lock_until(max_blocking_time))
 #else
+        static_cast<void>(max_blocking_time);
         std::unique_lock<TimedMutex> lock(mutex_);
 #endif // if HAVE_STRICT_REALTIME{
         {

--- a/src/cpp/rtps/history/TopicPayloadPoolRegistry_impl/TopicPayloadPoolProxy.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPoolRegistry_impl/TopicPayloadPoolProxy.hpp
@@ -57,9 +57,10 @@ public:
 
     bool get_payload(
             uint32_t size,
-            CacheChange_t& cache_change) override
+            CacheChange_t& cache_change,
+            const std::chrono::steady_clock::time_point& max_blocking_time) override
     {
-        return inner_pool_->get_payload(size, cache_change);
+        return inner_pool_->get_payload(size, cache_change, max_blocking_time);
     }
 
     bool get_payload(
@@ -71,9 +72,11 @@ public:
     }
 
     bool release_payload(
-            CacheChange_t& cache_change) override
+            CacheChange_t& cache_change,
+            std::chrono::steady_clock::time_point max_blocking_time =
+            std::chrono::steady_clock::now() + std::chrono::hours(24)) override
     {
-        return inner_pool_->release_payload(cache_change);
+        return inner_pool_->release_payload(cache_change, max_blocking_time);
     }
 
     bool reserve_history(

--- a/src/cpp/rtps/history/TopicPayloadPool_impl/Dynamic.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPool_impl/Dynamic.hpp
@@ -52,6 +52,7 @@ public:
                 std::unique_lock<fastrtps::TimedMutex> lock(mutex_, std::defer_lock);
                 if (lock.try_lock_until(max_blocking_time))
 #else
+                static_cast<void>(max_blocking_time);
                 std::unique_lock<TimedMutex> lock(mutex_);
 #endif // if HAVE_STRICT_REALTIME{
                 {

--- a/src/cpp/rtps/history/TopicPayloadPool_impl/DynamicReusable.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPool_impl/DynamicReusable.hpp
@@ -29,9 +29,10 @@ class DynamicReusableTopicPayloadPool : public TopicPayloadPool
 {
     bool get_payload(
             uint32_t size,
-            CacheChange_t& cache_change) override
+            CacheChange_t& cache_change,
+            const std::chrono::time_point<std::chrono::steady_clock>& max_blocking_time) override
     {
-        return (size > 0u) && do_get_payload(size, cache_change, true);
+        return (size > 0u) && do_get_payload(size, cache_change, true, max_blocking_time);
     }
 
 protected:

--- a/src/cpp/rtps/history/TopicPayloadPool_impl/Preallocated.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPool_impl/Preallocated.hpp
@@ -39,9 +39,10 @@ public:
 
     bool get_payload(
             uint32_t /* size */,
-            CacheChange_t& cache_change) override
+            CacheChange_t& cache_change,
+            const std::chrono::steady_clock::time_point& max_blocking_time) override
     {
-        return do_get_payload(payload_size_, cache_change, false);
+        return do_get_payload(payload_size_, cache_change, false, max_blocking_time);
     }
 
     bool reserve_history(
@@ -53,7 +54,7 @@ public:
             return false;
         }
 
-        std::lock_guard<std::mutex> lock(mutex_);
+        std::lock_guard<TimedMutex> lock(mutex_);
         minimum_pool_size_ += config.initial_size;
         reserve(minimum_pool_size_, payload_size_);
         return true;
@@ -64,7 +65,7 @@ public:
             bool is_reader) override
     {
         {
-            std::lock_guard<std::mutex> lock(mutex_);
+            std::lock_guard<TimedMutex> lock(mutex_);
             minimum_pool_size_ -= config.initial_size;
         }
 

--- a/src/cpp/rtps/history/TopicPayloadPool_impl/PreallocatedWithRealloc.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPool_impl/PreallocatedWithRealloc.hpp
@@ -39,9 +39,10 @@ public:
 
     bool get_payload(
             uint32_t size,
-            CacheChange_t& cache_change) override
+            CacheChange_t& cache_change,
+            const std::chrono::time_point<std::chrono::steady_clock>& max_blocking_time) override
     {
-        return do_get_payload(std::max(size, min_payload_size_), cache_change, true);
+        return do_get_payload(std::max(size, min_payload_size_), cache_change, true, max_blocking_time);
     }
 
     bool reserve_history(
@@ -53,7 +54,7 @@ public:
             return false;
         }
 
-        std::lock_guard<std::mutex> lock(mutex_);
+        std::lock_guard<TimedMutex> lock(mutex_);
         minimum_pool_size_ += config.initial_size;
         reserve(minimum_pool_size_, min_payload_size_);
         return true;
@@ -64,7 +65,7 @@ public:
             bool is_reader) override
     {
         {
-            std::lock_guard<std::mutex> lock(mutex_);
+            std::lock_guard<TimedMutex> lock(mutex_);
             minimum_pool_size_ -= config.initial_size;
         }
 

--- a/src/cpp/rtps/history/WriterHistory.cpp
+++ b/src/cpp/rtps/history/WriterHistory.cpp
@@ -143,7 +143,8 @@ bool WriterHistory::matches_change(
 
 History::iterator WriterHistory::remove_change_nts(
         const_iterator removal,
-        bool release)
+        bool release,
+        std::chrono::steady_clock::time_point max_blocking_time)
 {
     if (mp_writer == nullptr || mp_mutex == nullptr)
     {
@@ -168,7 +169,7 @@ History::iterator WriterHistory::remove_change_nts(
     // Release from pools
     if ( release )
     {
-        mp_writer->release_change(change);
+        mp_writer->release_change(change, max_blocking_time);
     }
 
     return ret_val;
@@ -187,7 +188,7 @@ bool WriterHistory::remove_change(
 
     if (nullptr != p )
     {
-        mp_writer->release_change(p);
+        mp_writer->release_change(p, std::chrono::steady_clock::now() + std::chrono::hours(24));
         return true;
     }
 
@@ -257,9 +258,10 @@ bool WriterHistory::do_reserve_cache(
 }
 
 void WriterHistory::do_release_cache(
-        CacheChange_t* ch)
+        CacheChange_t* ch,
+        const std::chrono::steady_clock::time_point& max_blocking_time)
 {
-    mp_writer->release_change(ch);
+    mp_writer->release_change(ch, max_blocking_time);
 }
 
 void WriterHistory::set_fragments(

--- a/src/cpp/rtps/messages/SendBuffersManager.cpp
+++ b/src/cpp/rtps/messages/SendBuffersManager.cpp
@@ -100,7 +100,7 @@ std::unique_ptr<RTPSMessageGroup_t> SendBuffersManager::get_buffer(
         else
         {
             logInfo(RTPS_PARTICIPANT, "Waiting for send buffer");
-            if (!available_cv_.wait_until(lock, max_blocking_time))
+            if (std::cv_status::timeout == available_cv_.wait_until(lock, max_blocking_time))
             {
                 throw RTPSMessageGroup::timeout();
             }

--- a/src/cpp/rtps/messages/SendBuffersManager.hpp
+++ b/src/cpp/rtps/messages/SendBuffersManager.hpp
@@ -22,11 +22,11 @@
 
 #include "RTPSMessageGroup_t.hpp"
 #include <fastdds/rtps/common/GuidPrefix_t.hpp>
+#include <fastrtps/utils/TimedMutex.hpp>
+#include <fastrtps/utils/TimedConditionVariable.hpp>
 
 #include <vector>              // std::vector
 #include <memory>              // std::unique_ptr
-#include <mutex>               // std::mutex
-#include <condition_variable>  // std::condition_variable
 
 
 namespace eprosima {
@@ -68,10 +68,12 @@ public:
     /**
      * Get one buffer from the pool.
      * @param participant Pointer to the participant asking for a buffer.
+     * @param max_blocking_time Maximum time the function can be blocked.
      * @return unique pointer to a send buffer.
      */
     std::unique_ptr<RTPSMessageGroup_t> get_buffer(
-            const RTPSParticipantImpl* participant);
+            const RTPSParticipantImpl* participant,
+            const std::chrono::steady_clock::time_point& max_blocking_time);
 
     /**
      * Return one buffer to the pool.
@@ -86,7 +88,7 @@ private:
             const RTPSParticipantImpl* participant);
 
     //!Protects all data
-    std::mutex mutex_;
+    TimedMutex mutex_;
     //!Send buffers pool
     std::vector<std::unique_ptr<RTPSMessageGroup_t>> pool_;
     //!Raw buffer shared by the buffers created inside init()
@@ -96,13 +98,13 @@ private:
     //!Whether we allow n_created_ to grow beyond the pool_ capacity.
     bool allow_growing_ = true;
     //!To wait for a buffer to be returned to the pool.
-    std::condition_variable available_cv_;
+    TimedConditionVariable available_cv_;
 };
 
 } /* namespace rtps */
 } /* namespace fastrtps */
 } /* namespace eprosima */
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 #endif // RTPS_MESSAGES_SENDBUFFERSMANAGER_HPP

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -150,7 +150,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         descriptor.receiveBufferSize = m_att.listenSocketBufferSize;
         m_network_Factory.RegisterTransport(&descriptor, &m_att.properties);
 
-#if defined(SHM_TRANSPORT_BUILTIN) && not defined(HAVE_STRICT_REALTIME)
+#if defined(SHM_TRANSPORT_BUILTIN) && !defined(HAVE_STRICT_REALTIME)
         SharedMemTransportDescriptor shm_transport;
         // We assume (Linux) UDP doubles the user socket buffer size in kernel, so
         // the equivalent segment size in SHM would be socket buffer size x 2

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -150,7 +150,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         descriptor.receiveBufferSize = m_att.listenSocketBufferSize;
         m_network_Factory.RegisterTransport(&descriptor, &m_att.properties);
 
-#ifdef SHM_TRANSPORT_BUILTIN
+#if defined(SHM_TRANSPORT_BUILTIN) && not defined(HAVE_STRICT_REALTIME)
         SharedMemTransportDescriptor shm_transport;
         // We assume (Linux) UDP doubles the user socket buffer size in kernel, so
         // the equivalent segment size in SHM would be socket buffer size x 2
@@ -2006,9 +2006,10 @@ void RTPSParticipantImpl::set_check_type_function(
     type_check_fn_ = std::move(check_type);
 }
 
-std::unique_ptr<RTPSMessageGroup_t> RTPSParticipantImpl::get_send_buffer()
+std::unique_ptr<RTPSMessageGroup_t> RTPSParticipantImpl::get_send_buffer(
+        const std::chrono::steady_clock::time_point& max_blocking_time)
 {
-    return send_buffers_->get_buffer(this);
+    return send_buffers_->get_buffer(this, max_blocking_time);
 }
 
 void RTPSParticipantImpl::return_send_buffer(

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -469,7 +469,8 @@ public:
         return false;
     }
 
-    std::unique_ptr<RTPSMessageGroup_t> get_send_buffer();
+    std::unique_ptr<RTPSMessageGroup_t> get_send_buffer(
+            const std::chrono::steady_clock::time_point& max_blocking_time);
     void return_send_buffer(
             std::unique_ptr <RTPSMessageGroup_t>&& buffer);
 

--- a/src/cpp/rtps/persistence/SQLite3PersistenceService.cpp
+++ b/src/cpp/rtps/persistence/SQLite3PersistenceService.cpp
@@ -287,7 +287,7 @@ bool SQLite3PersistenceService::load_writer_from_storage(
             SampleIdentity identity;
             identity.writer_guid(writer_guid);
             identity.sequence_number(sn);
-            if (!payload_pool->get_payload(size, *change))
+            if (!payload_pool->get_payload(size, *change, std::chrono::steady_clock::now() + std::chrono::hours(24)))
             {
                 change_pool->release_cache(change);
                 continue;

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -594,7 +594,7 @@ bool StatefulReader::processDataFragMsg(
                 {
                     if (work_change->serializedPayload.max_size < sampleSize)
                     {
-                        releaseCache(work_change);
+                        releaseCache(work_change, std::chrono::steady_clock::now() + std::chrono::hours(24));
                         work_change = nullptr;
                     }
                     else
@@ -622,7 +622,7 @@ bool StatefulReader::processDataFragMsg(
                     logInfo(RTPS_MSG_IN,
                             IDSTRING "MessageReceiver not add change " << change_created->sequenceNumber.to64long());
 
-                    releaseCache(change_created);
+                    releaseCache(change_created, std::chrono::steady_clock::now() + std::chrono::hours(24));
                     work_change = nullptr;
                 }
             }

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -559,7 +559,7 @@ bool StatelessReader::processDataFragMsg(
                         else
                         {
                             // Release change, and let it be reserved later
-                            releaseCache(work_change);
+                            releaseCache(work_change, std::chrono::steady_clock::now() + std::chrono::hours(24));
                             work_change = nullptr;
                         }
                     }
@@ -572,7 +572,7 @@ bool StatelessReader::processDataFragMsg(
                     {
                         if (work_change->serializedPayload.max_size < sampleSize)
                         {
-                            releaseCache(work_change);
+                            releaseCache(work_change, std::chrono::steady_clock::now() + std::chrono::hours(24));
                             work_change = nullptr;
                         }
                         else
@@ -604,7 +604,7 @@ bool StatelessReader::processDataFragMsg(
                     if (data_filter_ && !data_filter_->is_relevant(*change_completed, m_guid))
                     {
                         update_last_notified(change_completed->writerGUID, change_completed->sequenceNumber);
-                        releaseCache(change_completed);
+                        releaseCache(change_completed, std::chrono::steady_clock::now() + std::chrono::hours(24));
                     }
                     else if (!change_received(change_completed))
                     {
@@ -613,7 +613,7 @@ bool StatelessReader::processDataFragMsg(
                                 change_completed->sequenceNumber.to64long());
 
                         // Release CacheChange_t.
-                        releaseCache(change_completed);
+                        releaseCache(change_completed, std::chrono::steady_clock::now() + std::chrono::hours(24));
                     }
                 }
             }

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -2118,13 +2118,15 @@ void SecurityManager::exchange_participant_crypto(
                 // Send
                 if (!participant_volatile_message_secure_writer_history_->add_change(change))
                 {
-                    participant_volatile_message_secure_writer_->release_change(change);
+                    participant_volatile_message_secure_writer_->release_change(change,
+                            std::chrono::steady_clock::now() + std::chrono::hours(24));
                     logError(SECURITY, "WriterHistory cannot add the CacheChange_t");
                 }
             }
             else
             {
-                participant_volatile_message_secure_writer_->release_change(change);
+                participant_volatile_message_secure_writer_->release_change(change,
+                        std::chrono::steady_clock::now() + std::chrono::hours(24));
                 logError(SECURITY, "Cannot serialize ParticipantGenericMessage");
             }
         }
@@ -2907,13 +2909,15 @@ bool SecurityManager::discovered_reader(
                                         }
                                         else
                                         {
-                                            participant_volatile_message_secure_writer_->release_change(change);
+                                            participant_volatile_message_secure_writer_->release_change(change,
+                                                    std::chrono::steady_clock::now() + std::chrono::hours(24));
                                             logError(SECURITY, "WriterHistory cannot add the CacheChange_t");
                                         }
                                     }
                                     else
                                     {
-                                        participant_volatile_message_secure_writer_->release_change(change);
+                                        participant_volatile_message_secure_writer_->release_change(change,
+                                                std::chrono::steady_clock::now() + std::chrono::hours(24));
                                         logError(SECURITY, "Cannot serialize ParticipantGenericMessage");
                                     }
                                 }
@@ -3240,13 +3244,15 @@ bool SecurityManager::discovered_writer(
                                         }
                                         else
                                         {
-                                            participant_volatile_message_secure_writer_->release_change(change);
+                                            participant_volatile_message_secure_writer_->release_change(change,
+                                                    std::chrono::steady_clock::now() + std::chrono::hours(24));
                                             logError(SECURITY, "WriterHistory cannot add the CacheChange_t");
                                         }
                                     }
                                     else
                                     {
-                                        participant_volatile_message_secure_writer_->release_change(change);
+                                        participant_volatile_message_secure_writer_->release_change(change,
+                                                std::chrono::steady_clock::now() + std::chrono::hours(24));
                                         logError(SECURITY, "Cannot serialize ParticipantGenericMessage");
                                     }
                                 }

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -438,6 +438,7 @@ void ReaderProxy::from_unsent_to_status(
         const SequenceNumber_t& seq_num,
         ChangeForReaderStatus_t status,
         bool restart_nack_supression,
+        const std::chrono::steady_clock::time_point& max_blocking_time,
         bool delivered)
 {
     // This function must not be called by a best-effort reader.
@@ -447,7 +448,7 @@ void ReaderProxy::from_unsent_to_status(
     if (restart_nack_supression && is_remote_and_reliable())
     {
         assert(timers_enabled_.load());
-        nack_supression_event_->restart_timer();
+        nack_supression_event_->restart_timer(max_blocking_time);
     }
 
     // Called when delivering an UNSENT sample, the seq_number must exists in the ReaderProxy.

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -328,7 +328,7 @@ void StatelessWriter::unsent_change_added_to_history(
         logInfo(RTPS_WRITER, "No reader to add change.");
         if (mp_listener != nullptr)
         {
-            mp_listener->onWriterChangeReceivedByAll(this, change);
+            mp_listener->onWriterChangeReceivedByAll(this, change); // TODO (richiware) realtime
         }
     }
 

--- a/test/blackbox/common/RTPSBlackboxTestsPools.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsPools.cpp
@@ -97,7 +97,8 @@ public:
 
     bool get_payload(
             uint32_t size,
-            CacheChange_t& cache_change) override
+            CacheChange_t& cache_change,
+            const std::chrono::time_point<std::chrono::steady_clock>&) override
     {
         std::lock_guard<std::mutex> lock(mutex_);
         return do_get_payload(size, cache_change);
@@ -151,7 +152,9 @@ public:
     }
 
     bool release_payload(
-            CacheChange_t& cache_change) override
+            CacheChange_t& cache_change,
+            std::chrono::steady_clock::time_point =
+            std::chrono::steady_clock::now() + std::chrono::hours(24)) override
     {
         std::lock_guard<std::mutex> lock(mutex_);
 

--- a/test/mock/rtps/DataSharingPayloadPool/rtps/DataSharing/DataSharingPayloadPool.hpp
+++ b/test/mock/rtps/DataSharingPayloadPool/rtps/DataSharing/DataSharingPayloadPool.hpp
@@ -38,7 +38,8 @@ public:
 
     bool get_payload(
             uint32_t size,
-            CacheChange_t& cache_change) override
+            CacheChange_t& cache_change,
+            const std::chrono::time_point<std::chrono::steady_clock>&) override
     {
         cache_change.serializedPayload.data = new octet[size];
         cache_change.serializedPayload.max_size = size;
@@ -64,7 +65,9 @@ public:
     }
 
     bool release_payload(
-            CacheChange_t& cache_change) override
+            CacheChange_t& cache_change,
+            std::chrono::steady_clock::time_point =
+            std::chrono::steady_clock::now() + std::chrono::hours(24)) override
     {
         delete[] cache_change.serializedPayload.data;
         cache_change.serializedPayload.max_size = 0;
@@ -117,7 +120,7 @@ public:
     bool get_next_unread_payload(
             CacheChange_t& cache_change)
     {
-        return get_payload(1, cache_change);
+        return get_payload(1, cache_change, std::chrono::steady_clock::now() + std::chrono::hours(24));
     }
 
     uint32_t advance(

--- a/test/mock/rtps/RTPSMessageGroup/fastdds/rtps/messages/RTPSMessageGroup.h
+++ b/test/mock/rtps/RTPSMessageGroup/fastdds/rtps/messages/RTPSMessageGroup.h
@@ -20,6 +20,8 @@
 #ifndef _FASTDDS_RTPS_RTPSMESSAGEGROUP_H_
 #define _FASTDDS_RTPS_RTPSMESSAGEGROUP_H_
 
+#include <chrono>
+
 #include <gmock/gmock.h>
 
 namespace eprosima {
@@ -34,6 +36,18 @@ class RTPSMessageGroup
 {
 public:
 
+    class timeout : public std::runtime_error
+    {
+    public:
+
+        timeout()
+            : std::runtime_error("timeout")
+        {
+        }
+
+        virtual ~timeout() = default;
+    };
+
     RTPSMessageGroup(
             RTPSParticipantImpl*,
             bool)
@@ -43,7 +57,8 @@ public:
     RTPSMessageGroup(
             RTPSParticipantImpl*,
             Endpoint*,
-            const RTPSMessageSenderInterface*)
+            const RTPSMessageSenderInterface*,
+            std::chrono::steady_clock::time_point)
     {
     }
 

--- a/test/mock/rtps/RTPSReader/fastdds/rtps/reader/RTPSReader.h
+++ b/test/mock/rtps/RTPSReader/fastdds/rtps/reader/RTPSReader.h
@@ -107,7 +107,9 @@ public:
 
     MOCK_METHOD2(reserveCache, bool (CacheChange_t** a_change, uint32_t dataCdrSerializedSize));
 
-    MOCK_METHOD1(releaseCache, void (CacheChange_t* a_change));
+    MOCK_METHOD2(releaseCache, void (
+                CacheChange_t* a_change,
+                const std::chrono::steady_clock::time_point& max_blocking_time));
 
     MOCK_METHOD0(expectsInlineQos, bool());
 

--- a/test/mock/rtps/RTPSWriter/fastdds/rtps/writer/RTPSWriter.h
+++ b/test/mock/rtps/RTPSWriter/fastdds/rtps/writer/RTPSWriter.h
@@ -114,7 +114,9 @@ public:
             const std::function<uint32_t()>&,
             ChangeKind_t));
 
-    MOCK_METHOD1(release_change, void(CacheChange_t*));
+    MOCK_METHOD2(release_change, void(
+                CacheChange_t*, 
+        const std::chrono::steady_clock::time_point& max_blocking_time));
 
     MOCK_METHOD1(set_separate_sending, void(bool));
 

--- a/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
+++ b/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
@@ -127,7 +127,9 @@ public:
 
     virtual iterator remove_change_nts(
             const_iterator removal,
-            bool release = true)
+            bool release = true,
+            std::chrono::steady_clock::time_point = std::chrono::steady_clock::now() +
+            std::chrono::hours(24))
     {
         (void)release;
         return m_changes.erase(removal);

--- a/test/mock/rtps/TopicPayloadPoolProxy/rtps/history/TopicPayloadPoolRegistry_impl/TopicPayloadPoolProxy.hpp
+++ b/test/mock/rtps/TopicPayloadPoolProxy/rtps/history/TopicPayloadPoolRegistry_impl/TopicPayloadPoolProxy.hpp
@@ -87,9 +87,10 @@ public:
 
     bool get_payload(
             uint32_t size,
-            CacheChange_t& cache_change) override
+            CacheChange_t& cache_change,
+            const std::chrono::steady_clock::time_point& max_blocking_time) override
     {
-        return inner_pool_->get_payload(size, cache_change);
+        return inner_pool_->get_payload(size, cache_change, max_blocking_time);
     }
 
     bool get_payload(
@@ -101,9 +102,11 @@ public:
     }
 
     bool release_payload(
-            CacheChange_t& cache_change) override
+            CacheChange_t& cache_change,
+            std::chrono::steady_clock::time_point max_blocking_time =
+            std::chrono::steady_clock::now() + std::chrono::hours(24)) override
     {
-        return inner_pool_->release_payload(cache_change);
+        return inner_pool_->release_payload(cache_change, max_blocking_time);
     }
 
     bool reserve_history(

--- a/test/realtime/CMakeLists.txt
+++ b/test/realtime/CMakeLists.txt
@@ -3,7 +3,7 @@ add_subdirectory(mutex_testing_tool)
 set(USER_THREAD_NONBLOCKED_TEST UserThreadNonBlockedTest.cpp)
 
 add_executable(user_thread_nonblocked_test ${USER_THREAD_NONBLOCKED_TEST})
-target_compile_definitions(DDSSimpleCommunicationSubscriber PRIVATE
+target_compile_definitions(user_thread_nonblocked_test PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )

--- a/test/realtime/mutex_testing_tool/Mutex.cpp
+++ b/test/realtime/mutex_testing_tool/Mutex.cpp
@@ -23,7 +23,8 @@
 #include <dlfcn.h>
 #include <ctime>
 
-int pthread_mutex_lock(pthread_mutex_t* mutex)
+int pthread_mutex_lock(
+        pthread_mutex_t* mutex)
 {
     pid_t pid = eprosima::fastrtps::g_tmutex_thread_pid;
 
@@ -35,15 +36,17 @@ int pthread_mutex_lock(pthread_mutex_t* mutex)
         }
     }
 
-    if(eprosima::fastrtps::g_origin_lock_func == nullptr)
+    if (eprosima::fastrtps::g_origin_lock_func == nullptr)
     {
-        eprosima::fastrtps::g_origin_lock_func = (int(*)(pthread_mutex_t*))dlsym(RTLD_NEXT, "pthread_mutex_lock");
+        eprosima::fastrtps::g_origin_lock_func = (int (*)(pthread_mutex_t*))dlsym(RTLD_NEXT, "pthread_mutex_lock");
     }
 
     return (*eprosima::fastrtps::g_origin_lock_func)(mutex);
 }
 
-int pthread_mutex_timedlock(pthread_mutex_t* mutex, const struct timespec* abs_timeout)
+int pthread_mutex_timedlock(
+        pthread_mutex_t* mutex,
+        const struct timespec* abs_timeout)
 {
     pid_t pid = eprosima::fastrtps::g_tmutex_thread_pid;
 
@@ -55,10 +58,10 @@ int pthread_mutex_timedlock(pthread_mutex_t* mutex, const struct timespec* abs_t
         }
     }
 
-    if(eprosima::fastrtps::g_origin_timedlock_func == nullptr)
+    if (eprosima::fastrtps::g_origin_timedlock_func == nullptr)
     {
         eprosima::fastrtps::g_origin_timedlock_func =
-            (int(*)(pthread_mutex_t*, const struct timespec*))dlsym(RTLD_NEXT, "pthread_mutex_timedlock");
+                (int (*)(pthread_mutex_t*, const struct timespec*))dlsym(RTLD_NEXT, "pthread_mutex_timedlock");
     }
 
     return (*eprosima::fastrtps::g_origin_timedlock_func)(mutex, abs_timeout);

--- a/test/realtime/mutex_testing_tool/TMutex.cpp
+++ b/test/realtime/mutex_testing_tool/TMutex.cpp
@@ -20,8 +20,11 @@
 #include "TMutex.hpp"
 
 #include <array>
+#include <string>
 #include <algorithm>
 #include <cassert>
+#include <execinfo.h>
+#include <cstring>
 
 // TODO contar que solo bloquea una vez y nunca mas despues de timeout.
 // TODO si se bloquea el dos, que no se bloqueen los posteriores
@@ -32,25 +35,46 @@ namespace eprosima {
 namespace fastrtps {
 
 std::atomic<pid_t> g_tmutex_thread_pid(0);
+// *INDENT-OFF* Uncrustify parse this as a function declaration instead of a function pointer.
 int (*g_origin_lock_func)(pthread_mutex_t*){nullptr};
 int (*g_origin_timedlock_func)(pthread_mutex_t*, const struct timespec*){nullptr};
+// *INDENT-ON*
 
 typedef struct
 {
     LockType type;
     pthread_mutex_t* mutex;
     uint32_t count;
+    std::string backtrace;
 } tmutex_record;
 
 constexpr size_t g_tmutex_records_max_length = 30;
-std::array<tmutex_record, g_tmutex_records_max_length>  g_tmutex_records{{{LockType::LOCK, nullptr, 0}}};
+std::array<tmutex_record, g_tmutex_records_max_length>  g_tmutex_records{{{LockType::LOCK, nullptr, 0, ""}}};
 int32_t g_tmutex_records_end = -1;
 
-int32_t tmutex_find_record(pthread_mutex_t* mutex)
+std::string get_backtrace_line()
+{
+    void* bt[1024];
+    int bt_size = backtrace(bt, 1024);
+    char**    bt_syms = backtrace_symbols(bt, bt_size);
+    for (int i = 3; i < bt_size; i++)
+    {
+        size_t len = strlen(bt_syms[i]);
+        std::string trace(bt_syms[i], len);
+        if (std::string::npos != trace.find("eprosima7"))
+        {
+            return trace;
+        }
+    }
+    return "";
+}
+
+int32_t tmutex_find_record(
+        pthread_mutex_t* mutex)
 {
     int32_t returned_position = -1;
 
-    for(int32_t position = 0; position <= g_tmutex_records_end; ++position)
+    for (int32_t position = 0; position <= g_tmutex_records_end; ++position)
     {
         if (mutex == g_tmutex_records[position].mutex)
         {
@@ -69,7 +93,7 @@ void eprosima::fastrtps::tmutex_start_recording()
 {
     assert(0 == g_tmutex_thread_pid);
     g_tmutex_thread_pid = GET_TID();
-    g_tmutex_records = {{{LockType::LOCK, nullptr, 0}}};
+    g_tmutex_records = {{{LockType::LOCK, nullptr, 0, ""}}};
     g_tmutex_records_end = -1;
 }
 
@@ -79,7 +103,9 @@ void eprosima::fastrtps::tmutex_stop_recording()
     g_tmutex_thread_pid = 0;
 }
 
-void eprosima::fastrtps::tmutex_record_mutex_(LockType type, pthread_mutex_t* mutex)
+void eprosima::fastrtps::tmutex_record_mutex_(
+        LockType type,
+        pthread_mutex_t* mutex)
 {
     assert(0 < g_tmutex_thread_pid);
 
@@ -92,6 +118,7 @@ void eprosima::fastrtps::tmutex_record_mutex_(LockType type, pthread_mutex_t* mu
         position = ++g_tmutex_records_end;
         g_tmutex_records[position].type = type;
         g_tmutex_records[position].mutex = mutex;
+        g_tmutex_records[position].backtrace = get_backtrace_line();
     }
 
     ++g_tmutex_records[position].count;
@@ -107,12 +134,12 @@ size_t eprosima::fastrtps::tmutex_get_num_lock_type()
 {
     size_t counter = 0;
 
-    if(-1 < g_tmutex_records_end)
+    if (-1 < g_tmutex_records_end)
     {
         std::for_each(g_tmutex_records.begin(), g_tmutex_records.begin() + g_tmutex_records_end + 1,
                 [&](const tmutex_record& record)
                 {
-                    if(record.type == LockType::LOCK)
+                    if (record.type == LockType::LOCK)
                     {
                         ++counter;
                     }
@@ -126,12 +153,12 @@ size_t eprosima::fastrtps::tmutex_get_num_timedlock_type()
 {
     size_t counter = 0;
 
-    if(-1 < g_tmutex_records_end)
+    if (-1 < g_tmutex_records_end)
     {
         std::for_each(g_tmutex_records.begin(), g_tmutex_records.begin() + g_tmutex_records_end + 1,
                 [&](const tmutex_record& record)
                 {
-                    if(record.type == LockType::TIMED_LOCK)
+                    if (record.type == LockType::TIMED_LOCK)
                     {
                         ++counter;
                     }
@@ -141,24 +168,38 @@ size_t eprosima::fastrtps::tmutex_get_num_timedlock_type()
     return counter;
 }
 
-pthread_mutex_t* eprosima::fastrtps::tmutex_get_mutex(const size_t index)
+pthread_mutex_t* eprosima::fastrtps::tmutex_get_mutex(
+        const size_t index)
 {
     assert(index <= size_t(g_tmutex_records_end));
     return g_tmutex_records[index].mutex;
 }
 
-void eprosima::fastrtps::tmutex_lock_mutex(const size_t index)
+void eprosima::fastrtps::tmutex_lock_mutex(
+        const size_t index)
 {
     assert(index <= size_t(g_tmutex_records_end));
 
-    if(g_origin_lock_func != nullptr)
+    if (g_origin_lock_func != nullptr)
     {
-        (*g_origin_lock_func)(g_tmutex_records[index].mutex);
+        int ret_value = (*g_origin_lock_func)(g_tmutex_records[index].mutex);
+        (void)ret_value;
+        assert(0 == ret_value);
     }
 }
 
-void eprosima::fastrtps::tmutex_unlock_mutex(const size_t index)
+void eprosima::fastrtps::tmutex_unlock_mutex(
+        const size_t index)
 {
     assert(index <= size_t(g_tmutex_records_end));
-    pthread_mutex_unlock(g_tmutex_records[index].mutex);
+    int ret_value = pthread_mutex_unlock(g_tmutex_records[index].mutex);
+    (void)ret_value;
+    assert(0 == ret_value);
+}
+
+const char* eprosima::fastrtps::tmux_get_mutex_trace(
+        size_t index)
+{
+    assert(index <= size_t(g_tmutex_records_end));
+    return g_tmutex_records[index].backtrace.c_str();
 }

--- a/test/realtime/mutex_testing_tool/TMutex.hpp
+++ b/test/realtime/mutex_testing_tool/TMutex.hpp
@@ -36,7 +36,7 @@ using pid_t = int;
 #define GET_TID() syscall(SYS_gettid)
 #else
 #error "SYS_gettid unavailable on this system"
-#endif
+#endif // ifdef SYS_gettid
 
 #endif //_WIN32
 
@@ -55,10 +55,13 @@ enum LockType : int32_t
 extern std::atomic<pid_t> g_tmutex_thread_pid;
 
 //! Store the original pthread_mutex_lock function
-extern int (*g_origin_lock_func)(pthread_mutex_t*);
+extern int (* g_origin_lock_func)(
+        pthread_mutex_t*);
 
 //! Store the original pthread_mutex_timedlock function
-extern int (*g_origin_timedlock_func)(pthread_mutex_t*, const struct timespec*);
+extern int (* g_origin_timedlock_func)(
+        pthread_mutex_t*,
+        const struct timespec*);
 
 /*!
  * @brief Records all mutexes used by the thread that calls this function.
@@ -75,26 +78,31 @@ void tmutex_stop_recording();
  * @param[in] type Type of the lock used by the mutex.
  * @param[in] mutex Pointer of the mutex to be recorded.
  */
-void tmutex_record_mutex_(LockType type, pthread_mutex_t* mutex);
+void tmutex_record_mutex_(
+        LockType type,
+        pthread_mutex_t* mutex);
 
 /*!
  * @brief Gets the pointer of the selected recorded mutex.
  * @param[in] index Position of the recorded mutex.
  * @return Pointer to the selected mutex.
  */
-pthread_mutex_t* tmutex_get_mutex(size_t index);
+pthread_mutex_t* tmutex_get_mutex(
+        size_t index);
 
 /*!
  * @brief Locks the selected recorded mutex.
  * @param[in] index Position of the recorded mutex.
  */
-void tmutex_lock_mutex(size_t index);
+void tmutex_lock_mutex(
+        size_t index);
 
 /*!
  * @brief Unlocks the selected recorded mutex.
  * @param[in] index Position of the recorded mutex.
  */
-void tmutex_unlock_mutex(size_t index);
+void tmutex_unlock_mutex(
+        size_t index);
 
 /*!
  * @brief Returns the number of mutex recorded.
@@ -113,6 +121,14 @@ size_t tmutex_get_num_lock_type();
  * @return Number of mutex.
  */
 size_t tmutex_get_num_timedlock_type();
+
+/*!
+ * @brief Return the backtrace where the lock was done.
+ * @param[in] index Position of the recorded mutex.
+ * @return String with the backtrace info.
+ */
+const char* tmux_get_mutex_trace(
+        size_t index);
 
 } //namespace fastrtps
 } //namespace eprosima

--- a/test/unittest/rtps/history/BasicPoolsTests.cpp
+++ b/test/unittest/rtps/history/BasicPoolsTests.cpp
@@ -68,7 +68,7 @@ protected:
             return false;
         }
 
-        if (!payload_pool_->get_payload(data_size, *change))
+        if (!payload_pool_->get_payload(data_size, *change, std::chrono::steady_clock::now() + std::chrono::hours(24)))
         {
             change_pool_->release_cache(change);
             return false;

--- a/test/unittest/rtps/history/ReaderHistoryTests.cpp
+++ b/test/unittest/rtps/history/ReaderHistoryTests.cpp
@@ -95,7 +95,7 @@ TEST_F(ReaderHistoryTests, add_and_remove_changes)
 {
     EXPECT_CALL(*readerMock, change_removed_by_history(_)).Times(num_changes).
             WillRepeatedly(Return(true));
-    EXPECT_CALL(*readerMock, releaseCache(_)).Times(num_changes);
+    EXPECT_CALL(*readerMock, releaseCache(_, _)).Times(num_changes);
 
     for (uint32_t i = 0; i < num_changes; i++)
     {
@@ -113,7 +113,7 @@ TEST_F(ReaderHistoryTests, add_and_remove_changes)
 TEST_F(ReaderHistoryTests, remove_empty_history)
 {
     EXPECT_CALL(*readerMock, change_removed_by_history(_)).Times(0);
-    EXPECT_CALL(*readerMock, releaseCache(_)).Times(0);
+    EXPECT_CALL(*readerMock, releaseCache(_, _)).Times(0);
 
     CacheChange_t* ch = new CacheChange_t();
     ch->writerGUID = GUID_t(GuidPrefix_t::unknown(), 1U);
@@ -126,7 +126,7 @@ TEST_F(ReaderHistoryTests, remove_empty_history)
 TEST_F(ReaderHistoryTests, remove_null_cache_change)
 {
     EXPECT_CALL(*readerMock, change_removed_by_history(_)).Times(0);
-    EXPECT_CALL(*readerMock, releaseCache(_)).Times(0);
+    EXPECT_CALL(*readerMock, releaseCache(_, _)).Times(0);
 
     CacheChange_t* ch = nullptr;
     ASSERT_FALSE(history->remove_change(ch));
@@ -209,7 +209,7 @@ TEST_F(ReaderHistoryTests, remove_changes_with_guid)
 
     EXPECT_CALL(*readerMock, change_removed_by_history(_)).Times(2).
             WillRepeatedly(Return(true));
-    EXPECT_CALL(*readerMock, releaseCache(_)).Times(2);
+    EXPECT_CALL(*readerMock, releaseCache(_, _)).Times(2);
 
     ASSERT_EQ(history->getHistorySize(), num_changes);
     GUID_t w1 = GUID_t(GuidPrefix_t::unknown(), 1U);

--- a/test/unittest/rtps/history/TopicPayloadPoolTests.cpp
+++ b/test/unittest/rtps/history/TopicPayloadPoolTests.cpp
@@ -154,7 +154,8 @@ protected:
             CacheChange_t* ch = new CacheChange_t();
             cache_changes.push_back(ch);
 
-            ASSERT_TRUE(pool->get_payload(data_size, *ch));
+            ASSERT_TRUE(pool->get_payload(data_size, *ch, std::chrono::steady_clock::now() + std::chrono::hours(
+                        24)));
             ASSERT_NE(ch->serializedPayload.data, nullptr);
 
             switch (memory_policy)
@@ -180,13 +181,15 @@ protected:
             CacheChange_t* ch = new CacheChange_t();
             cache_changes.push_back(ch);
 
-            ASSERT_TRUE(pool->get_payload(payload_size, *ch));
+            ASSERT_TRUE(pool->get_payload(payload_size, *ch, std::chrono::steady_clock::now() + std::chrono::hours(
+                        24)));
         }
         else
         {
             CacheChange_t* ch = new CacheChange_t();
 
-            ASSERT_FALSE(pool->get_payload(payload_size, *ch));
+            ASSERT_FALSE(pool->get_payload(payload_size, *ch, std::chrono::steady_clock::now() + std::chrono::hours(
+                        24)));
             delete ch;
         }
 

--- a/test/unittest/rtps/persistence/PersistenceTests.cpp
+++ b/test/unittest/rtps/persistence/PersistenceTests.cpp
@@ -32,7 +32,8 @@ class NoOpPayloadPool : public IPayloadPool
 {
     virtual bool get_payload(
             uint32_t,
-            CacheChange_t&) override
+            CacheChange_t&,
+            const std::chrono::time_point<std::chrono::steady_clock>&) override
     {
         return true;
     }
@@ -46,7 +47,9 @@ class NoOpPayloadPool : public IPayloadPool
     }
 
     virtual bool release_payload(
-            CacheChange_t&) override
+            CacheChange_t&,
+            std::chrono::steady_clock::time_point =
+            std::chrono::steady_clock::now() + std::chrono::hours(24)) override
     {
         return true;
     }

--- a/test/unittest/rtps/writer/RTPSWriterTests.cpp
+++ b/test/unittest/rtps/writer/RTPSWriterTests.cpp
@@ -35,7 +35,8 @@ public:
 
     bool get_payload(
             uint32_t size,
-            CacheChange_t& cache_change) override
+            CacheChange_t& cache_change,
+            const std::chrono::time_point<std::chrono::steady_clock>&) override
     {
         bool result = get_payload_delegate(size, cache_change);
         if (result)
@@ -66,7 +67,9 @@ public:
             bool(SerializedPayload_t & data, IPayloadPool * &data_owner, CacheChange_t & cache_change));
 
     bool release_payload (
-            CacheChange_t& cache_change) override
+            CacheChange_t& cache_change,
+            std::chrono::steady_clock::time_point =
+            std::chrono::steady_clock::now() + std::chrono::hours(24)) override
     {
         bool result = release_payload_delegate(cache_change);
         if (result)
@@ -144,7 +147,8 @@ void pool_initialization_test (
             .Times(1)
             .WillOnce(Return(true));
 
-    writer->release_change(ch);
+    writer->release_change(ch,
+            std::chrono::steady_clock::now() + std::chrono::hours(24));
 
     RTPSDomain::removeRTPSWriter(writer);
     RTPSDomain::removeRTPSParticipant(participant);


### PR DESCRIPTION
Some logical paths from user thread lose the strict realtime feature. This was caused by new features implemented. This PR adds strict realtime again.

Needs #2473 merged first.