### PR TITLE
Fix incomplete `set_qos` making not working set a default entity qos [13836]

### DIFF
--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -2052,6 +2052,14 @@ public:
         std::swap(*this, reset);
     }
 
+    bool operator ==(
+            const PublishModeQosPolicy& b) const
+    {
+        return (this->kind == b.kind) &&
+               0 == strcmp(flow_controller_name, b.flow_controller_name) &&
+               QosPolicy::operator ==(b);
+    }
+
 };
 
 /**

--- a/include/fastdds/dds/domain/qos/DomainParticipantQos.hpp
+++ b/include/fastdds/dds/domain/qos/DomainParticipantQos.hpp
@@ -281,7 +281,7 @@ public:
     /**
      * Setter for the Participant name
      *
-     * @return value New name to be set
+     * @param value New name to be set
      */
     void name(
             const fastrtps::string_255& value)

--- a/include/fastdds/rtps/common/Time_t.h
+++ b/include/fastdds/rtps/common/Time_t.h
@@ -23,10 +23,6 @@
 #include <cstdint>
 #include <iostream>
 
-// defines to avoid the "static initialization order fiasco"
-#define TIME_T_INFINITE_SECONDS 0x7fffffff
-#define TIME_T_INFINITE_NANOSECONDS 0xffffffff
-
 namespace eprosima {
 namespace fastrtps {
 
@@ -36,6 +32,9 @@ namespace fastrtps {
  */
 struct RTPS_DllAPI Time_t
 {
+    static constexpr int32_t INFINITE_SECONDS = 0x7fffffff;
+    static constexpr uint32_t INFINITE_NANOSECONDS = 0xffffffffu;
+
     int32_t seconds;
     uint32_t nanosec;
 
@@ -663,13 +662,17 @@ static inline Time_t operator -(
 #endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 //! Time_t (Duration_t) representing an infinite time. DONT USE IT IN CONSTRUCTORS
-const Time_t c_TimeInfinite{TIME_T_INFINITE_SECONDS, TIME_T_INFINITE_NANOSECONDS};
+const Time_t c_TimeInfinite{Time_t::INFINITE_SECONDS, Time_t::INFINITE_NANOSECONDS};
 //! Time_t (Duration_t) representing a zero time. DONT USE IT IN CONSTRUCTORS
 const Time_t c_TimeZero{0, 0};
 //! Time_t (Duration_t) representing an invalid time. DONT USE IT IN CONSTRUCTORS
-const Time_t c_TimeInvalid{-1, TIME_T_INFINITE_NANOSECONDS};
+const Time_t c_TimeInvalid{-1, Time_t::INFINITE_NANOSECONDS};
 
 } // namespace fastrtps
 } // namespace eprosima
+
+// defines to avoid the "static initialization order fiasco"
+#define TIME_T_INFINITE_SECONDS (eprosima::fastrtps::Time_t::INFINITE_SECONDS)
+#define TIME_T_INFINITE_NANOSECONDS (eprosima::fastrtps::Time_t::INFINITE_NANOSECONDS)
 
 #endif /* _FASTDDS_RTPS_TIME_T_H_ */

--- a/include/fastrtps/utils/collections/ResourceLimitedContainerConfig.hpp
+++ b/include/fastrtps/utils/collections/ResourceLimitedContainerConfig.hpp
@@ -26,6 +26,8 @@
 namespace eprosima {
 namespace fastrtps {
 
+#define dummy_avoid_winmax
+
 /**
  * Specifies the configuration of a resource limited collection.
  * @ingroup UTILITIES_MODULE
@@ -35,7 +37,7 @@ struct ResourceLimitedContainerConfig
 
     ResourceLimitedContainerConfig(
             size_t ini = 0,
-            size_t max = (std::numeric_limits<size_t>::max)(),
+            size_t max = std::numeric_limits<size_t>::max dummy_avoid_winmax (),
             size_t inc = 1u)
         : initial(ini)
         , maximum(max)
@@ -46,7 +48,7 @@ struct ResourceLimitedContainerConfig
     //! Number of elements to be preallocated in the collection.
     size_t initial = 0;
     //! Maximum number of elements allowed in the collection.
-    size_t maximum = (std::numeric_limits<size_t>::max)();
+    size_t maximum = std::numeric_limits<size_t>::max dummy_avoid_winmax ();
     //! Number of items to add when capacity limit is reached.
     size_t increment = 1u;
 
@@ -69,7 +71,8 @@ struct ResourceLimitedContainerConfig
     inline static ResourceLimitedContainerConfig dynamic_allocation_configuration(
             size_t increment = 1u)
     {
-        return ResourceLimitedContainerConfig(0u, (std::numeric_limits<size_t>::max)(), increment ? increment : 1u);
+        return ResourceLimitedContainerConfig(0u,
+                       std::numeric_limits<size_t>::max dummy_avoid_winmax (), increment ? increment : 1u);
     }
 
 };

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1472,6 +1472,10 @@ void DataWriterImpl::set_qos(
     {
         to.throughput_controller() = from.throughput_controller();
     }
+    if (is_default && !(to.data_sharing() == from.data_sharing()))
+    {
+        to.data_sharing() = from.data_sharing();
+    }
 }
 
 ReturnCode_t DataWriterImpl::check_qos(

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1423,6 +1423,11 @@ void DataReaderImpl::set_qos(
     {
         to.reader_resource_limits() = from.reader_resource_limits();
     }
+
+    if (first_time && !(to.data_sharing() == from.data_sharing()))
+    {
+        to.data_sharing() = from.data_sharing();
+    }
 }
 
 fastrtps::TopicAttributes DataReaderImpl::topic_attributes() const

--- a/src/cpp/rtps/common/Time_t.cpp
+++ b/src/cpp/rtps/common/Time_t.cpp
@@ -61,6 +61,9 @@ static void current_time_since_unix_epoch(
 namespace eprosima {
 namespace fastrtps {
 
+constexpr int32_t Time_t::INFINITE_SECONDS;
+constexpr uint32_t Time_t::INFINITE_NANOSECONDS;
+
 Time_t::Time_t()
 {
     seconds = 0;

--- a/test/unittest/dds/publisher/PublisherTests.cpp
+++ b/test/unittest/dds/publisher/PublisherTests.cpp
@@ -196,14 +196,213 @@ TEST(PublisherTests, ChangeDefaultDataWriterQos)
     publisher->get_default_datawriter_qos(qos);
     ASSERT_EQ(qos, DATAWRITER_QOS_DEFAULT);
 
-    qos.deadline().period = 260;
+    // .durability
+    qos.durability().kind = eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS;
+    // .durability_service
+    qos.durability_service().history_kind = eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS;
+    qos.durability_service().history_depth = 10;
+    qos.durability_service().max_samples = 5;
+    qos.durability_service().max_instances = 20;
+    qos.durability_service().max_samples_per_instance = 30;
+    // .deadline
+    qos.deadline().period.seconds = 10;
+    qos.deadline().period.nanosec = 20;
+    // .latency_budget
+    qos.latency_budget().duration.seconds = 20;
+    qos.latency_budget().duration.nanosec = 30;
+    // .liveliness
+    qos.liveliness().kind = eprosima::fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS;
+    qos.liveliness().lease_duration.seconds = 40;
+    qos.liveliness().lease_duration.nanosec = 61;
+    qos.liveliness().announcement_period.seconds = 30;
+    qos.liveliness().announcement_period.nanosec = 50;
+    // .reliability
+    qos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
+    qos.reliability().max_blocking_time.seconds = 100;
+    qos.reliability().max_blocking_time.nanosec = eprosima::fastrtps::Time_t::INFINITE_NANOSECONDS;
+    // .destination_order
+    qos.destination_order().kind = eprosima::fastdds::dds::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS;
+    // .history
+    qos.history().kind = eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS;
+    qos.history().depth = 1000;
+    // .resource_limits
+    qos.resource_limits().max_samples = 3000;
+    qos.resource_limits().max_instances = 100;
+    qos.resource_limits().max_samples_per_instance = 500;
+    qos.resource_limits().allocated_samples = 50;
+    qos.resource_limits().extra_samples = 2;
+    // .transport_priority
+    qos.transport_priority().value = 10;
+    // .lifespan
+    qos.lifespan().duration.seconds = 10;
+    qos.lifespan().duration.nanosec = 33;
+    // .user_data
+    qos.user_data().push_back(0);
+    qos.user_data().push_back(1);
+    qos.user_data().push_back(2);
+    qos.user_data().push_back(3);
+    // .ownership
+    qos.ownership().kind = eprosima::fastdds::dds::EXCLUSIVE_OWNERSHIP_QOS;
+    // .ownership_strength
+    qos.ownership_strength().value = 30;
+    // .writer_data_lifecycle
+    qos.writer_data_lifecycle().autodispose_unregistered_instances = false;
+    // .publish_mode
+    qos.publish_mode().kind = eprosima::fastdds::dds::ASYNCHRONOUS_PUBLISH_MODE;
+    qos.publish_mode().flow_controller_name = "Prueba";
+
+    // .properties
+    eprosima::fastrtps::rtps::Property property;
+    property.name("Property1");
+    property.value("Value1");
+    qos.properties().properties().push_back(property);
+    property.name("Property2");
+    property.value("Value2");
+    qos.properties().properties().push_back(property);
+    // .reliable_writer_qos
+    qos.reliable_writer_qos().times.initialHeartbeatDelay.seconds = 2;
+    qos.reliable_writer_qos().times.initialHeartbeatDelay.nanosec = 15;
+    qos.reliable_writer_qos().times.heartbeatPeriod.seconds = 3;
+    qos.reliable_writer_qos().times.heartbeatPeriod.nanosec = 16;
+    qos.reliable_writer_qos().times.nackResponseDelay.seconds = 4;
+    qos.reliable_writer_qos().times.nackResponseDelay.nanosec = 17;
+    qos.reliable_writer_qos().times.nackSupressionDuration.seconds = 5;
+    qos.reliable_writer_qos().times.nackSupressionDuration.nanosec = 18;
+    qos.reliable_writer_qos().disable_positive_acks.enabled = true;
+    qos.reliable_writer_qos().disable_positive_acks.duration.seconds = 13;
+    qos.reliable_writer_qos().disable_positive_acks.duration.nanosec = 320;
+    qos.reliable_writer_qos().disable_heartbeat_piggyback = true;
+    // .endpoint
+    qos.endpoint().user_defined_id = 1;
+    qos.endpoint().entity_id = 2;
+    qos.endpoint().history_memory_policy = eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+    // . writer_resource_limits
+    qos.writer_resource_limits().matched_subscriber_allocation.initial = 30;
+    qos.writer_resource_limits().matched_subscriber_allocation.maximum = 300;
+    qos.writer_resource_limits().matched_subscriber_allocation.increment = 400;
+    // . data_sharing
+    qos.data_sharing().on("/");
 
     ASSERT_TRUE(publisher->set_default_datawriter_qos(qos) == ReturnCode_t::RETCODE_OK);
     DataWriterQos wqos;
     publisher->get_default_datawriter_qos(wqos);
 
+    // .durability
+    ASSERT_EQ(eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS, wqos.durability().kind);
+    // .durability_service
+    ASSERT_EQ(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS, wqos.durability_service().history_kind);
+    ASSERT_EQ(10, wqos.durability_service().history_depth);
+    ASSERT_EQ(5, wqos.durability_service().max_samples);
+    ASSERT_EQ(20, wqos.durability_service().max_instances);
+    ASSERT_EQ(30, wqos.durability_service().max_samples_per_instance);
+    // .deadline
+    ASSERT_EQ(10, wqos.deadline().period.seconds);
+    ASSERT_EQ(20, wqos.deadline().period.nanosec);
+    // .latency_budget
+    ASSERT_EQ(20, wqos.latency_budget().duration.seconds);
+    ASSERT_EQ(30, wqos.latency_budget().duration.nanosec);
+    // .liveliness
+    ASSERT_EQ(eprosima::fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS, wqos.liveliness().kind);
+    ASSERT_EQ(40, wqos.liveliness().lease_duration.seconds);
+    ASSERT_EQ(61, wqos.liveliness().lease_duration.nanosec);
+    ASSERT_EQ(30, wqos.liveliness().announcement_period.seconds);
+    ASSERT_EQ(50, wqos.liveliness().announcement_period.nanosec);
+    // .reliability
+    ASSERT_EQ(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS, wqos.reliability().kind);
+    ASSERT_EQ(100, wqos.reliability().max_blocking_time.seconds);
+    ASSERT_EQ(eprosima::fastrtps::Time_t::INFINITE_NANOSECONDS, wqos.reliability().max_blocking_time.nanosec);
+    // .destination_order
+    ASSERT_EQ(eprosima::fastdds::dds::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS, wqos.destination_order().kind);
+    // .history
+    ASSERT_EQ(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS, wqos.history().kind);
+    ASSERT_EQ(1000, wqos.history().depth);
+    // .resource_limits
+    ASSERT_EQ(3000, wqos.resource_limits().max_samples);
+    ASSERT_EQ(100, wqos.resource_limits().max_instances);
+    ASSERT_EQ(500, wqos.resource_limits().max_samples_per_instance);
+    ASSERT_EQ(50, wqos.resource_limits().allocated_samples);
+    ASSERT_EQ(2, wqos.resource_limits().extra_samples);
+    // .transport_priority
+    ASSERT_EQ(10, wqos.transport_priority().value);
+    // .lifespan
+    ASSERT_EQ(10, wqos.lifespan().duration.seconds);
+    ASSERT_EQ(33, wqos.lifespan().duration.nanosec);
+    // .user_data
+    size_t count = 1;
+    for (auto user_value : wqos.user_data())
+    {
+        switch (count)
+        {
+            case 1:
+                ASSERT_EQ(0, user_value);
+                break;
+            case 2:
+                ASSERT_EQ(1, user_value);
+                break;
+            case 3:
+                ASSERT_EQ(2, user_value);
+                break;
+            case 4:
+                ASSERT_EQ(3, user_value);
+                break;
+            default:
+                ASSERT_TRUE(false);
+        }
+        ++count;
+    }
+    // .ownership
+    ASSERT_EQ(eprosima::fastdds::dds::EXCLUSIVE_OWNERSHIP_QOS, wqos.ownership().kind);
+    // .ownership_strength
+    ASSERT_EQ(30, wqos.ownership_strength().value);
+    // .writer_data_lifecycle
+    ASSERT_FALSE(wqos.writer_data_lifecycle().autodispose_unregistered_instances);
+    // .publish_mode
+    ASSERT_EQ(eprosima::fastdds::dds::ASYNCHRONOUS_PUBLISH_MODE, wqos.publish_mode().kind);
+    ASSERT_EQ(0, strcmp(wqos.publish_mode().flow_controller_name, "Prueba"));
+    count = 1;
+    for (auto prop : wqos.properties().properties())
+    {
+        switch (count)
+        {
+            case 1:
+                ASSERT_EQ(0, prop.name().compare("Property1"));
+                ASSERT_EQ(0, prop.value().compare("Value1"));
+                break;
+            case 2:
+                ASSERT_EQ(0, prop.name().compare("Property2"));
+                ASSERT_EQ(0, prop.value().compare("Value2"));
+                break;
+            default:
+                ASSERT_TRUE(false);
+        }
+        ++count;
+    }
+    // .reliable_writer_qos
+    ASSERT_EQ(2, wqos.reliable_writer_qos().times.initialHeartbeatDelay.seconds);
+    ASSERT_EQ(15, wqos.reliable_writer_qos().times.initialHeartbeatDelay.nanosec);
+    ASSERT_EQ(3, wqos.reliable_writer_qos().times.heartbeatPeriod.seconds);
+    ASSERT_EQ(16, wqos.reliable_writer_qos().times.heartbeatPeriod.nanosec);
+    ASSERT_EQ(4, wqos.reliable_writer_qos().times.nackResponseDelay.seconds);
+    ASSERT_EQ(17, wqos.reliable_writer_qos().times.nackResponseDelay.nanosec);
+    ASSERT_EQ(5, wqos.reliable_writer_qos().times.nackSupressionDuration.seconds);
+    ASSERT_EQ(18, wqos.reliable_writer_qos().times.nackSupressionDuration.nanosec);
+    ASSERT_TRUE(wqos.reliable_writer_qos().disable_positive_acks.enabled);
+    ASSERT_EQ(13, wqos.reliable_writer_qos().disable_positive_acks.duration.seconds);
+    ASSERT_EQ(320, wqos.reliable_writer_qos().disable_positive_acks.duration.nanosec);
+    ASSERT_TRUE(wqos.reliable_writer_qos().disable_heartbeat_piggyback);
+    // .endpoint
+    ASSERT_EQ(1, wqos.endpoint().user_defined_id);
+    ASSERT_EQ(2, wqos.endpoint().entity_id);
+    ASSERT_EQ(eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE, wqos.endpoint().history_memory_policy);
+    // . writer_resource_limits
+    ASSERT_EQ(30, wqos.writer_resource_limits().matched_subscriber_allocation.initial);
+    ASSERT_EQ(300, wqos.writer_resource_limits().matched_subscriber_allocation.maximum);
+    ASSERT_EQ(400, wqos.writer_resource_limits().matched_subscriber_allocation.increment);
+    // . data_sharing
+    ASSERT_EQ(eprosima::fastdds::dds::ON, wqos.data_sharing().kind());
+    ASSERT_EQ(0, wqos.data_sharing().shm_directory().compare("/"));
+
     ASSERT_TRUE(qos == wqos);
-    ASSERT_EQ(wqos.deadline().period, 260);
 
     ASSERT_TRUE(participant->delete_publisher(publisher) == ReturnCode_t::RETCODE_OK);
     ASSERT_TRUE(DomainParticipantFactory::get_instance()->delete_participant(participant) == ReturnCode_t::RETCODE_OK);

--- a/test/unittest/dds/publisher/PublisherTests.cpp
+++ b/test/unittest/dds/publisher/PublisherTests.cpp
@@ -353,7 +353,7 @@ TEST(PublisherTests, ChangeDefaultDataWriterQos)
     // .ownership
     EXPECT_EQ(eprosima::fastdds::dds::EXCLUSIVE_OWNERSHIP_QOS, wqos.ownership().kind);
     // .ownership_strength
-    EXPECT_EQ(30, wqos.ownership_strength().value);
+    EXPECT_EQ(30u, wqos.ownership_strength().value);
     // .writer_data_lifecycle
     EXPECT_FALSE(wqos.writer_data_lifecycle().autodispose_unregistered_instances);
     // .publish_mode

--- a/test/unittest/dds/publisher/PublisherTests.cpp
+++ b/test/unittest/dds/publisher/PublisherTests.cpp
@@ -323,7 +323,7 @@ TEST(PublisherTests, ChangeDefaultDataWriterQos)
     EXPECT_EQ(50, wqos.resource_limits().allocated_samples);
     EXPECT_EQ(2, wqos.resource_limits().extra_samples);
     // .transport_priority
-    EXPECT_EQ(10, wqos.transport_priority().value);
+    EXPECT_EQ(10u, wqos.transport_priority().value);
     // .lifespan
     EXPECT_EQ(10, wqos.lifespan().duration.seconds);
     EXPECT_EQ(33u, wqos.lifespan().duration.nanosec);

--- a/test/unittest/dds/publisher/PublisherTests.cpp
+++ b/test/unittest/dds/publisher/PublisherTests.cpp
@@ -206,16 +206,16 @@ TEST(PublisherTests, ChangeDefaultDataWriterQos)
     qos.durability_service().max_samples_per_instance = 30;
     // .deadline
     qos.deadline().period.seconds = 10;
-    qos.deadline().period.nanosec = 20;
+    qos.deadline().period.nanosec = 20u;
     // .latency_budget
     qos.latency_budget().duration.seconds = 20;
-    qos.latency_budget().duration.nanosec = 30;
+    qos.latency_budget().duration.nanosec = 30u;
     // .liveliness
     qos.liveliness().kind = eprosima::fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS;
     qos.liveliness().lease_duration.seconds = 40;
-    qos.liveliness().lease_duration.nanosec = 61;
+    qos.liveliness().lease_duration.nanosec = 61u;
     qos.liveliness().announcement_period.seconds = 30;
-    qos.liveliness().announcement_period.nanosec = 50;
+    qos.liveliness().announcement_period.nanosec = 50u;
     // .reliability
     qos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
     qos.reliability().max_blocking_time.seconds = 100;
@@ -235,7 +235,7 @@ TEST(PublisherTests, ChangeDefaultDataWriterQos)
     qos.transport_priority().value = 10;
     // .lifespan
     qos.lifespan().duration.seconds = 10;
-    qos.lifespan().duration.nanosec = 33;
+    qos.lifespan().duration.nanosec = 33u;
     // .user_data
     qos.user_data().push_back(0);
     qos.user_data().push_back(1);
@@ -261,16 +261,16 @@ TEST(PublisherTests, ChangeDefaultDataWriterQos)
     qos.properties().properties().push_back(property);
     // .reliable_writer_qos
     qos.reliable_writer_qos().times.initialHeartbeatDelay.seconds = 2;
-    qos.reliable_writer_qos().times.initialHeartbeatDelay.nanosec = 15;
+    qos.reliable_writer_qos().times.initialHeartbeatDelay.nanosec = 15u;
     qos.reliable_writer_qos().times.heartbeatPeriod.seconds = 3;
-    qos.reliable_writer_qos().times.heartbeatPeriod.nanosec = 16;
+    qos.reliable_writer_qos().times.heartbeatPeriod.nanosec = 16u;
     qos.reliable_writer_qos().times.nackResponseDelay.seconds = 4;
-    qos.reliable_writer_qos().times.nackResponseDelay.nanosec = 17;
+    qos.reliable_writer_qos().times.nackResponseDelay.nanosec = 17u;
     qos.reliable_writer_qos().times.nackSupressionDuration.seconds = 5;
-    qos.reliable_writer_qos().times.nackSupressionDuration.nanosec = 18;
+    qos.reliable_writer_qos().times.nackSupressionDuration.nanosec = 18u;
     qos.reliable_writer_qos().disable_positive_acks.enabled = true;
     qos.reliable_writer_qos().disable_positive_acks.duration.seconds = 13;
-    qos.reliable_writer_qos().disable_positive_acks.duration.nanosec = 320;
+    qos.reliable_writer_qos().disable_positive_acks.duration.nanosec = 320u;
     qos.reliable_writer_qos().disable_heartbeat_piggyback = true;
     // .endpoint
     qos.endpoint().user_defined_id = 1;
@@ -297,16 +297,16 @@ TEST(PublisherTests, ChangeDefaultDataWriterQos)
     EXPECT_EQ(30, wqos.durability_service().max_samples_per_instance);
     // .deadline
     EXPECT_EQ(10, wqos.deadline().period.seconds);
-    EXPECT_EQ(20, wqos.deadline().period.nanosec);
+    EXPECT_EQ(20u, wqos.deadline().period.nanosec);
     // .latency_budget
     EXPECT_EQ(20, wqos.latency_budget().duration.seconds);
-    EXPECT_EQ(30, wqos.latency_budget().duration.nanosec);
+    EXPECT_EQ(30u, wqos.latency_budget().duration.nanosec);
     // .liveliness
     EXPECT_EQ(eprosima::fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS, wqos.liveliness().kind);
     EXPECT_EQ(40, wqos.liveliness().lease_duration.seconds);
-    EXPECT_EQ(61, wqos.liveliness().lease_duration.nanosec);
+    EXPECT_EQ(61u, wqos.liveliness().lease_duration.nanosec);
     EXPECT_EQ(30, wqos.liveliness().announcement_period.seconds);
-    EXPECT_EQ(50, wqos.liveliness().announcement_period.nanosec);
+    EXPECT_EQ(50u, wqos.liveliness().announcement_period.nanosec);
     // .reliability
     EXPECT_EQ(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS, wqos.reliability().kind);
     EXPECT_EQ(100, wqos.reliability().max_blocking_time.seconds);
@@ -326,7 +326,7 @@ TEST(PublisherTests, ChangeDefaultDataWriterQos)
     EXPECT_EQ(10, wqos.transport_priority().value);
     // .lifespan
     EXPECT_EQ(10, wqos.lifespan().duration.seconds);
-    EXPECT_EQ(33, wqos.lifespan().duration.nanosec);
+    EXPECT_EQ(33u, wqos.lifespan().duration.nanosec);
     // .user_data
     size_t count = 1;
     for (auto user_value : wqos.user_data())
@@ -379,16 +379,16 @@ TEST(PublisherTests, ChangeDefaultDataWriterQos)
     }
     // .reliable_writer_qos
     EXPECT_EQ(2, wqos.reliable_writer_qos().times.initialHeartbeatDelay.seconds);
-    EXPECT_EQ(15, wqos.reliable_writer_qos().times.initialHeartbeatDelay.nanosec);
+    EXPECT_EQ(15u, wqos.reliable_writer_qos().times.initialHeartbeatDelay.nanosec);
     EXPECT_EQ(3, wqos.reliable_writer_qos().times.heartbeatPeriod.seconds);
-    EXPECT_EQ(16, wqos.reliable_writer_qos().times.heartbeatPeriod.nanosec);
+    EXPECT_EQ(16u, wqos.reliable_writer_qos().times.heartbeatPeriod.nanosec);
     EXPECT_EQ(4, wqos.reliable_writer_qos().times.nackResponseDelay.seconds);
-    EXPECT_EQ(17, wqos.reliable_writer_qos().times.nackResponseDelay.nanosec);
+    EXPECT_EQ(17u, wqos.reliable_writer_qos().times.nackResponseDelay.nanosec);
     EXPECT_EQ(5, wqos.reliable_writer_qos().times.nackSupressionDuration.seconds);
-    EXPECT_EQ(18, wqos.reliable_writer_qos().times.nackSupressionDuration.nanosec);
+    EXPECT_EQ(18u, wqos.reliable_writer_qos().times.nackSupressionDuration.nanosec);
     EXPECT_TRUE(wqos.reliable_writer_qos().disable_positive_acks.enabled);
     EXPECT_EQ(13, wqos.reliable_writer_qos().disable_positive_acks.duration.seconds);
-    EXPECT_EQ(320, wqos.reliable_writer_qos().disable_positive_acks.duration.nanosec);
+    EXPECT_EQ(320u, wqos.reliable_writer_qos().disable_positive_acks.duration.nanosec);
     EXPECT_TRUE(wqos.reliable_writer_qos().disable_heartbeat_piggyback);
     // .endpoint
     EXPECT_EQ(1, wqos.endpoint().user_defined_id);

--- a/test/unittest/dds/publisher/PublisherTests.cpp
+++ b/test/unittest/dds/publisher/PublisherTests.cpp
@@ -288,45 +288,45 @@ TEST(PublisherTests, ChangeDefaultDataWriterQos)
     publisher->get_default_datawriter_qos(wqos);
 
     // .durability
-    ASSERT_EQ(eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS, wqos.durability().kind);
+    EXPECT_EQ(eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS, wqos.durability().kind);
     // .durability_service
-    ASSERT_EQ(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS, wqos.durability_service().history_kind);
-    ASSERT_EQ(10, wqos.durability_service().history_depth);
-    ASSERT_EQ(5, wqos.durability_service().max_samples);
-    ASSERT_EQ(20, wqos.durability_service().max_instances);
-    ASSERT_EQ(30, wqos.durability_service().max_samples_per_instance);
+    EXPECT_EQ(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS, wqos.durability_service().history_kind);
+    EXPECT_EQ(10, wqos.durability_service().history_depth);
+    EXPECT_EQ(5, wqos.durability_service().max_samples);
+    EXPECT_EQ(20, wqos.durability_service().max_instances);
+    EXPECT_EQ(30, wqos.durability_service().max_samples_per_instance);
     // .deadline
-    ASSERT_EQ(10, wqos.deadline().period.seconds);
-    ASSERT_EQ(20, wqos.deadline().period.nanosec);
+    EXPECT_EQ(10, wqos.deadline().period.seconds);
+    EXPECT_EQ(20, wqos.deadline().period.nanosec);
     // .latency_budget
-    ASSERT_EQ(20, wqos.latency_budget().duration.seconds);
-    ASSERT_EQ(30, wqos.latency_budget().duration.nanosec);
+    EXPECT_EQ(20, wqos.latency_budget().duration.seconds);
+    EXPECT_EQ(30, wqos.latency_budget().duration.nanosec);
     // .liveliness
-    ASSERT_EQ(eprosima::fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS, wqos.liveliness().kind);
-    ASSERT_EQ(40, wqos.liveliness().lease_duration.seconds);
-    ASSERT_EQ(61, wqos.liveliness().lease_duration.nanosec);
-    ASSERT_EQ(30, wqos.liveliness().announcement_period.seconds);
-    ASSERT_EQ(50, wqos.liveliness().announcement_period.nanosec);
+    EXPECT_EQ(eprosima::fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS, wqos.liveliness().kind);
+    EXPECT_EQ(40, wqos.liveliness().lease_duration.seconds);
+    EXPECT_EQ(61, wqos.liveliness().lease_duration.nanosec);
+    EXPECT_EQ(30, wqos.liveliness().announcement_period.seconds);
+    EXPECT_EQ(50, wqos.liveliness().announcement_period.nanosec);
     // .reliability
-    ASSERT_EQ(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS, wqos.reliability().kind);
-    ASSERT_EQ(100, wqos.reliability().max_blocking_time.seconds);
-    ASSERT_EQ(eprosima::fastrtps::Time_t::INFINITE_NANOSECONDS, wqos.reliability().max_blocking_time.nanosec);
+    EXPECT_EQ(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS, wqos.reliability().kind);
+    EXPECT_EQ(100, wqos.reliability().max_blocking_time.seconds);
+    EXPECT_EQ(eprosima::fastrtps::Time_t::INFINITE_NANOSECONDS, wqos.reliability().max_blocking_time.nanosec);
     // .destination_order
-    ASSERT_EQ(eprosima::fastdds::dds::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS, wqos.destination_order().kind);
+    EXPECT_EQ(eprosima::fastdds::dds::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS, wqos.destination_order().kind);
     // .history
-    ASSERT_EQ(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS, wqos.history().kind);
-    ASSERT_EQ(1000, wqos.history().depth);
+    EXPECT_EQ(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS, wqos.history().kind);
+    EXPECT_EQ(1000, wqos.history().depth);
     // .resource_limits
-    ASSERT_EQ(3000, wqos.resource_limits().max_samples);
-    ASSERT_EQ(100, wqos.resource_limits().max_instances);
-    ASSERT_EQ(500, wqos.resource_limits().max_samples_per_instance);
-    ASSERT_EQ(50, wqos.resource_limits().allocated_samples);
-    ASSERT_EQ(2, wqos.resource_limits().extra_samples);
+    EXPECT_EQ(3000, wqos.resource_limits().max_samples);
+    EXPECT_EQ(100, wqos.resource_limits().max_instances);
+    EXPECT_EQ(500, wqos.resource_limits().max_samples_per_instance);
+    EXPECT_EQ(50, wqos.resource_limits().allocated_samples);
+    EXPECT_EQ(2, wqos.resource_limits().extra_samples);
     // .transport_priority
-    ASSERT_EQ(10, wqos.transport_priority().value);
+    EXPECT_EQ(10, wqos.transport_priority().value);
     // .lifespan
-    ASSERT_EQ(10, wqos.lifespan().duration.seconds);
-    ASSERT_EQ(33, wqos.lifespan().duration.nanosec);
+    EXPECT_EQ(10, wqos.lifespan().duration.seconds);
+    EXPECT_EQ(33, wqos.lifespan().duration.nanosec);
     // .user_data
     size_t count = 1;
     for (auto user_value : wqos.user_data())
@@ -334,75 +334,75 @@ TEST(PublisherTests, ChangeDefaultDataWriterQos)
         switch (count)
         {
             case 1:
-                ASSERT_EQ(0, user_value);
+                EXPECT_EQ(0, user_value);
                 break;
             case 2:
-                ASSERT_EQ(1, user_value);
+                EXPECT_EQ(1, user_value);
                 break;
             case 3:
-                ASSERT_EQ(2, user_value);
+                EXPECT_EQ(2, user_value);
                 break;
             case 4:
-                ASSERT_EQ(3, user_value);
+                EXPECT_EQ(3, user_value);
                 break;
             default:
-                ASSERT_TRUE(false);
+                EXPECT_TRUE(false);
         }
         ++count;
     }
     // .ownership
-    ASSERT_EQ(eprosima::fastdds::dds::EXCLUSIVE_OWNERSHIP_QOS, wqos.ownership().kind);
+    EXPECT_EQ(eprosima::fastdds::dds::EXCLUSIVE_OWNERSHIP_QOS, wqos.ownership().kind);
     // .ownership_strength
-    ASSERT_EQ(30, wqos.ownership_strength().value);
+    EXPECT_EQ(30, wqos.ownership_strength().value);
     // .writer_data_lifecycle
-    ASSERT_FALSE(wqos.writer_data_lifecycle().autodispose_unregistered_instances);
+    EXPECT_FALSE(wqos.writer_data_lifecycle().autodispose_unregistered_instances);
     // .publish_mode
-    ASSERT_EQ(eprosima::fastdds::dds::ASYNCHRONOUS_PUBLISH_MODE, wqos.publish_mode().kind);
-    ASSERT_EQ(0, strcmp(wqos.publish_mode().flow_controller_name, "Prueba"));
+    EXPECT_EQ(eprosima::fastdds::dds::ASYNCHRONOUS_PUBLISH_MODE, wqos.publish_mode().kind);
+    EXPECT_EQ(0, strcmp(wqos.publish_mode().flow_controller_name, "Prueba"));
     count = 1;
     for (auto prop : wqos.properties().properties())
     {
         switch (count)
         {
             case 1:
-                ASSERT_EQ(0, prop.name().compare("Property1"));
-                ASSERT_EQ(0, prop.value().compare("Value1"));
+                EXPECT_EQ(0, prop.name().compare("Property1"));
+                EXPECT_EQ(0, prop.value().compare("Value1"));
                 break;
             case 2:
-                ASSERT_EQ(0, prop.name().compare("Property2"));
-                ASSERT_EQ(0, prop.value().compare("Value2"));
+                EXPECT_EQ(0, prop.name().compare("Property2"));
+                EXPECT_EQ(0, prop.value().compare("Value2"));
                 break;
             default:
-                ASSERT_TRUE(false);
+                EXPECT_TRUE(false);
         }
         ++count;
     }
     // .reliable_writer_qos
-    ASSERT_EQ(2, wqos.reliable_writer_qos().times.initialHeartbeatDelay.seconds);
-    ASSERT_EQ(15, wqos.reliable_writer_qos().times.initialHeartbeatDelay.nanosec);
-    ASSERT_EQ(3, wqos.reliable_writer_qos().times.heartbeatPeriod.seconds);
-    ASSERT_EQ(16, wqos.reliable_writer_qos().times.heartbeatPeriod.nanosec);
-    ASSERT_EQ(4, wqos.reliable_writer_qos().times.nackResponseDelay.seconds);
-    ASSERT_EQ(17, wqos.reliable_writer_qos().times.nackResponseDelay.nanosec);
-    ASSERT_EQ(5, wqos.reliable_writer_qos().times.nackSupressionDuration.seconds);
-    ASSERT_EQ(18, wqos.reliable_writer_qos().times.nackSupressionDuration.nanosec);
-    ASSERT_TRUE(wqos.reliable_writer_qos().disable_positive_acks.enabled);
-    ASSERT_EQ(13, wqos.reliable_writer_qos().disable_positive_acks.duration.seconds);
-    ASSERT_EQ(320, wqos.reliable_writer_qos().disable_positive_acks.duration.nanosec);
-    ASSERT_TRUE(wqos.reliable_writer_qos().disable_heartbeat_piggyback);
+    EXPECT_EQ(2, wqos.reliable_writer_qos().times.initialHeartbeatDelay.seconds);
+    EXPECT_EQ(15, wqos.reliable_writer_qos().times.initialHeartbeatDelay.nanosec);
+    EXPECT_EQ(3, wqos.reliable_writer_qos().times.heartbeatPeriod.seconds);
+    EXPECT_EQ(16, wqos.reliable_writer_qos().times.heartbeatPeriod.nanosec);
+    EXPECT_EQ(4, wqos.reliable_writer_qos().times.nackResponseDelay.seconds);
+    EXPECT_EQ(17, wqos.reliable_writer_qos().times.nackResponseDelay.nanosec);
+    EXPECT_EQ(5, wqos.reliable_writer_qos().times.nackSupressionDuration.seconds);
+    EXPECT_EQ(18, wqos.reliable_writer_qos().times.nackSupressionDuration.nanosec);
+    EXPECT_TRUE(wqos.reliable_writer_qos().disable_positive_acks.enabled);
+    EXPECT_EQ(13, wqos.reliable_writer_qos().disable_positive_acks.duration.seconds);
+    EXPECT_EQ(320, wqos.reliable_writer_qos().disable_positive_acks.duration.nanosec);
+    EXPECT_TRUE(wqos.reliable_writer_qos().disable_heartbeat_piggyback);
     // .endpoint
-    ASSERT_EQ(1, wqos.endpoint().user_defined_id);
-    ASSERT_EQ(2, wqos.endpoint().entity_id);
-    ASSERT_EQ(eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE, wqos.endpoint().history_memory_policy);
+    EXPECT_EQ(1, wqos.endpoint().user_defined_id);
+    EXPECT_EQ(2, wqos.endpoint().entity_id);
+    EXPECT_EQ(eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE, wqos.endpoint().history_memory_policy);
     // . writer_resource_limits
-    ASSERT_EQ(30, wqos.writer_resource_limits().matched_subscriber_allocation.initial);
-    ASSERT_EQ(300, wqos.writer_resource_limits().matched_subscriber_allocation.maximum);
-    ASSERT_EQ(400, wqos.writer_resource_limits().matched_subscriber_allocation.increment);
+    EXPECT_EQ(30, wqos.writer_resource_limits().matched_subscriber_allocation.initial);
+    EXPECT_EQ(300, wqos.writer_resource_limits().matched_subscriber_allocation.maximum);
+    EXPECT_EQ(400, wqos.writer_resource_limits().matched_subscriber_allocation.increment);
     // . data_sharing
-    ASSERT_EQ(eprosima::fastdds::dds::ON, wqos.data_sharing().kind());
-    ASSERT_EQ(0, wqos.data_sharing().shm_directory().compare("/"));
+    EXPECT_EQ(eprosima::fastdds::dds::ON, wqos.data_sharing().kind());
+    EXPECT_EQ(0, wqos.data_sharing().shm_directory().compare("/"));
 
-    ASSERT_TRUE(qos == wqos);
+    EXPECT_TRUE(qos == wqos);
 
     ASSERT_TRUE(participant->delete_publisher(publisher) == ReturnCode_t::RETCODE_OK);
     ASSERT_TRUE(DomainParticipantFactory::get_instance()->delete_participant(participant) == ReturnCode_t::RETCODE_OK);

--- a/test/unittest/dds/subscriber/SubscriberTests.cpp
+++ b/test/unittest/dds/subscriber/SubscriberTests.cpp
@@ -368,32 +368,32 @@ TEST(SubscriberTests, ChangeDefaultDataReaderQos)
     subscriber->get_default_datareader_qos(wqos);
 
     // .durability
-    ASSERT_EQ(eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS, wqos.durability().kind);
+    EXPECT_EQ(eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS, wqos.durability().kind);
     // .deadline
-    ASSERT_EQ(10, wqos.deadline().period.seconds);
-    ASSERT_EQ(20, wqos.deadline().period.nanosec);
+    EXPECT_EQ(10, wqos.deadline().period.seconds);
+    EXPECT_EQ(20, wqos.deadline().period.nanosec);
     // .latency_budget
-    ASSERT_EQ(20, wqos.latency_budget().duration.seconds);
-    ASSERT_EQ(30, wqos.latency_budget().duration.nanosec);
+    EXPECT_EQ(20, wqos.latency_budget().duration.seconds);
+    EXPECT_EQ(30, wqos.latency_budget().duration.nanosec);
     // .liveliness
-    ASSERT_EQ(eprosima::fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS, wqos.liveliness().kind);
-    ASSERT_EQ(40, wqos.liveliness().lease_duration.seconds);
-    ASSERT_EQ(61, wqos.liveliness().lease_duration.nanosec);
-    ASSERT_EQ(30, wqos.liveliness().announcement_period.seconds);
-    ASSERT_EQ(50, wqos.liveliness().announcement_period.nanosec);
+    EXPECT_EQ(eprosima::fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS, wqos.liveliness().kind);
+    EXPECT_EQ(40, wqos.liveliness().lease_duration.seconds);
+    EXPECT_EQ(61, wqos.liveliness().lease_duration.nanosec);
+    EXPECT_EQ(30, wqos.liveliness().announcement_period.seconds);
+    EXPECT_EQ(50, wqos.liveliness().announcement_period.nanosec);
     // .reliability
-    ASSERT_EQ(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS, wqos.reliability().kind);
+    EXPECT_EQ(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS, wqos.reliability().kind);
     // .destination_order
-    ASSERT_EQ(eprosima::fastdds::dds::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS, wqos.destination_order().kind);
+    EXPECT_EQ(eprosima::fastdds::dds::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS, wqos.destination_order().kind);
     // . history
-    ASSERT_EQ(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS, wqos.history().kind);
-    ASSERT_EQ(1000, wqos.history().depth);
+    EXPECT_EQ(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS, wqos.history().kind);
+    EXPECT_EQ(1000, wqos.history().depth);
     // .resource_limits
-    ASSERT_EQ(3000, wqos.resource_limits().max_samples);
-    ASSERT_EQ(100, wqos.resource_limits().max_instances);
-    ASSERT_EQ(500, wqos.resource_limits().max_samples_per_instance);
-    ASSERT_EQ(50, wqos.resource_limits().allocated_samples);
-    ASSERT_EQ(2, wqos.resource_limits().extra_samples);
+    EXPECT_EQ(3000, wqos.resource_limits().max_samples);
+    EXPECT_EQ(100, wqos.resource_limits().max_instances);
+    EXPECT_EQ(500, wqos.resource_limits().max_samples_per_instance);
+    EXPECT_EQ(50, wqos.resource_limits().allocated_samples);
+    EXPECT_EQ(2, wqos.resource_limits().extra_samples);
     // .user_data
     size_t count = 1;
     for (auto user_value : wqos.user_data())
@@ -401,59 +401,59 @@ TEST(SubscriberTests, ChangeDefaultDataReaderQos)
         switch (count)
         {
             case 1:
-                ASSERT_EQ(0, user_value);
+                EXPECT_EQ(0, user_value);
                 break;
             case 2:
-                ASSERT_EQ(1, user_value);
+                EXPECT_EQ(1, user_value);
                 break;
             case 3:
-                ASSERT_EQ(2, user_value);
+                EXPECT_EQ(2, user_value);
                 break;
             case 4:
-                ASSERT_EQ(3, user_value);
+                EXPECT_EQ(3, user_value);
                 break;
             default:
-                ASSERT_TRUE(false);
+                EXPECT_TRUE(false);
         }
         ++count;
     }
     // .ownership
-    ASSERT_EQ(eprosima::fastdds::dds::EXCLUSIVE_OWNERSHIP_QOS, wqos.ownership().kind);
+    EXPECT_EQ(eprosima::fastdds::dds::EXCLUSIVE_OWNERSHIP_QOS, wqos.ownership().kind);
     // .time_based_filter
-    ASSERT_EQ(eprosima::fastrtps::Time_t::INFINITE_SECONDS, wqos.time_based_filter().minimum_separation.seconds);
-    ASSERT_EQ(eprosima::fastrtps::Time_t::INFINITE_NANOSECONDS, wqos.time_based_filter().minimum_separation.nanosec);
+    EXPECT_EQ(eprosima::fastrtps::Time_t::INFINITE_SECONDS, wqos.time_based_filter().minimum_separation.seconds);
+    EXPECT_EQ(eprosima::fastrtps::Time_t::INFINITE_NANOSECONDS, wqos.time_based_filter().minimum_separation.nanosec);
     // .reader_data_lifecycle
-    ASSERT_EQ(100, wqos.reader_data_lifecycle().autopurge_disposed_samples_delay.seconds);
-    ASSERT_EQ(30000, wqos.reader_data_lifecycle().autopurge_disposed_samples_delay.nanosec);
-    ASSERT_EQ(30000, wqos.reader_data_lifecycle().autopurge_no_writer_samples_delay.seconds);
-    ASSERT_EQ(100, wqos.reader_data_lifecycle().autopurge_no_writer_samples_delay.nanosec);
+    EXPECT_EQ(100, wqos.reader_data_lifecycle().autopurge_disposed_samples_delay.seconds);
+    EXPECT_EQ(30000, wqos.reader_data_lifecycle().autopurge_disposed_samples_delay.nanosec);
+    EXPECT_EQ(30000, wqos.reader_data_lifecycle().autopurge_no_writer_samples_delay.seconds);
+    EXPECT_EQ(100, wqos.reader_data_lifecycle().autopurge_no_writer_samples_delay.nanosec);
     // .lifespan
-    ASSERT_EQ(10, wqos.lifespan().duration.seconds);
-    ASSERT_EQ(33, wqos.lifespan().duration.nanosec);
+    EXPECT_EQ(10, wqos.lifespan().duration.seconds);
+    EXPECT_EQ(33, wqos.lifespan().duration.nanosec);
     // .durability_service
-    ASSERT_EQ(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS, wqos.durability_service().history_kind);
-    ASSERT_EQ(10, wqos.durability_service().history_depth);
-    ASSERT_EQ(5, wqos.durability_service().max_samples);
-    ASSERT_EQ(20, wqos.durability_service().max_instances);
-    ASSERT_EQ(30, wqos.durability_service().max_samples_per_instance);
+    EXPECT_EQ(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS, wqos.durability_service().history_kind);
+    EXPECT_EQ(10, wqos.durability_service().history_depth);
+    EXPECT_EQ(5, wqos.durability_service().max_samples);
+    EXPECT_EQ(20, wqos.durability_service().max_instances);
+    EXPECT_EQ(30, wqos.durability_service().max_samples_per_instance);
     // .reliable_reader_qos
-    ASSERT_EQ(34, wqos.reliable_reader_qos().times.initialAcknackDelay.seconds);
-    ASSERT_EQ(32, wqos.reliable_reader_qos().times.initialAcknackDelay.nanosec);
-    ASSERT_EQ(432, wqos.reliable_reader_qos().times.heartbeatResponseDelay.seconds);
-    ASSERT_EQ(43, wqos.reliable_reader_qos().times.heartbeatResponseDelay.nanosec);
-    ASSERT_TRUE(wqos.reliable_reader_qos().disable_positive_ACKs.enabled);
-    ASSERT_EQ(13, wqos.reliable_reader_qos().disable_positive_ACKs.duration.seconds);
-    ASSERT_EQ(320, wqos.reliable_reader_qos().disable_positive_ACKs.duration.nanosec);
+    EXPECT_EQ(34, wqos.reliable_reader_qos().times.initialAcknackDelay.seconds);
+    EXPECT_EQ(32, wqos.reliable_reader_qos().times.initialAcknackDelay.nanosec);
+    EXPECT_EQ(432, wqos.reliable_reader_qos().times.heartbeatResponseDelay.seconds);
+    EXPECT_EQ(43, wqos.reliable_reader_qos().times.heartbeatResponseDelay.nanosec);
+    EXPECT_TRUE(wqos.reliable_reader_qos().disable_positive_ACKs.enabled);
+    EXPECT_EQ(13, wqos.reliable_reader_qos().disable_positive_ACKs.duration.seconds);
+    EXPECT_EQ(320, wqos.reliable_reader_qos().disable_positive_ACKs.duration.nanosec);
     // .type_consistency
-    ASSERT_EQ(XML_DATA_REPRESENTATION, wqos.type_consistency().representation.m_value.at(0));
-    ASSERT_EQ(XCDR_DATA_REPRESENTATION, wqos.type_consistency().representation.m_value.at(1));
-    ASSERT_FALSE(wqos.type_consistency().type_consistency.m_ignore_sequence_bounds);
-    ASSERT_FALSE(wqos.type_consistency().type_consistency.m_ignore_string_bounds);
-    ASSERT_TRUE(wqos.type_consistency().type_consistency.m_ignore_member_names);
-    ASSERT_TRUE(wqos.type_consistency().type_consistency.m_prevent_type_widening);
-    ASSERT_TRUE(wqos.type_consistency().type_consistency.m_force_type_validation);
+    EXPECT_EQ(XML_DATA_REPRESENTATION, wqos.type_consistency().representation.m_value.at(0));
+    EXPECT_EQ(XCDR_DATA_REPRESENTATION, wqos.type_consistency().representation.m_value.at(1));
+    EXPECT_FALSE(wqos.type_consistency().type_consistency.m_ignore_sequence_bounds);
+    EXPECT_FALSE(wqos.type_consistency().type_consistency.m_ignore_string_bounds);
+    EXPECT_TRUE(wqos.type_consistency().type_consistency.m_ignore_member_names);
+    EXPECT_TRUE(wqos.type_consistency().type_consistency.m_prevent_type_widening);
+    EXPECT_TRUE(wqos.type_consistency().type_consistency.m_force_type_validation);
     // .expects_inline_qos
-    ASSERT_TRUE(wqos.expects_inline_qos());
+    EXPECT_TRUE(wqos.expects_inline_qos());
     // .properties
     count = 1;
     for (auto prop : wqos.properties().properties())
@@ -461,38 +461,38 @@ TEST(SubscriberTests, ChangeDefaultDataReaderQos)
         switch (count)
         {
             case 1:
-                ASSERT_EQ(0, prop.name().compare("Property1"));
-                ASSERT_EQ(0, prop.value().compare("Value1"));
+                EXPECT_EQ(0, prop.name().compare("Property1"));
+                EXPECT_EQ(0, prop.value().compare("Value1"));
                 break;
             case 2:
-                ASSERT_EQ(0, prop.name().compare("Property2"));
-                ASSERT_EQ(0, prop.value().compare("Value2"));
+                EXPECT_EQ(0, prop.name().compare("Property2"));
+                EXPECT_EQ(0, prop.value().compare("Value2"));
                 break;
             default:
-                ASSERT_TRUE(false);
+                EXPECT_TRUE(false);
         }
         ++count;
     }
     // .endpoint
-    ASSERT_EQ(1, wqos.endpoint().user_defined_id);
-    ASSERT_EQ(2, wqos.endpoint().entity_id);
-    ASSERT_EQ(eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE, wqos.endpoint().history_memory_policy);
+    EXPECT_EQ(1, wqos.endpoint().user_defined_id);
+    EXPECT_EQ(2, wqos.endpoint().entity_id);
+    EXPECT_EQ(eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE, wqos.endpoint().history_memory_policy);
     // .reader_resource_limits
-    ASSERT_EQ(30, wqos.reader_resource_limits().matched_publisher_allocation.initial);
-    ASSERT_EQ(300, wqos.reader_resource_limits().matched_publisher_allocation.maximum);
-    ASSERT_EQ(4, wqos.reader_resource_limits().matched_publisher_allocation.increment);
-    ASSERT_EQ(40, wqos.reader_resource_limits().sample_infos_allocation.initial);
-    ASSERT_EQ(400, wqos.reader_resource_limits().sample_infos_allocation.maximum);
-    ASSERT_EQ(5, wqos.reader_resource_limits().sample_infos_allocation.increment);
-    ASSERT_EQ(50, wqos.reader_resource_limits().outstanding_reads_allocation.initial);
-    ASSERT_EQ(500, wqos.reader_resource_limits().outstanding_reads_allocation.maximum);
-    ASSERT_EQ(6, wqos.reader_resource_limits().outstanding_reads_allocation.increment);
-    ASSERT_EQ(33, wqos.reader_resource_limits().max_samples_per_read);
+    EXPECT_EQ(30, wqos.reader_resource_limits().matched_publisher_allocation.initial);
+    EXPECT_EQ(300, wqos.reader_resource_limits().matched_publisher_allocation.maximum);
+    EXPECT_EQ(4, wqos.reader_resource_limits().matched_publisher_allocation.increment);
+    EXPECT_EQ(40, wqos.reader_resource_limits().sample_infos_allocation.initial);
+    EXPECT_EQ(400, wqos.reader_resource_limits().sample_infos_allocation.maximum);
+    EXPECT_EQ(5, wqos.reader_resource_limits().sample_infos_allocation.increment);
+    EXPECT_EQ(50, wqos.reader_resource_limits().outstanding_reads_allocation.initial);
+    EXPECT_EQ(500, wqos.reader_resource_limits().outstanding_reads_allocation.maximum);
+    EXPECT_EQ(6, wqos.reader_resource_limits().outstanding_reads_allocation.increment);
+    EXPECT_EQ(33, wqos.reader_resource_limits().max_samples_per_read);
     // .data_sharing
-    ASSERT_EQ(eprosima::fastdds::dds::ON, wqos.data_sharing().kind());
-    ASSERT_EQ(0, wqos.data_sharing().shm_directory().compare("/"));
+    EXPECT_EQ(eprosima::fastdds::dds::ON, wqos.data_sharing().kind());
+    EXPECT_EQ(0, wqos.data_sharing().shm_directory().compare("/"));
 
-    ASSERT_EQ(qos, wqos);
+    EXPECT_EQ(qos, wqos);
 
     ASSERT_TRUE(participant->delete_subscriber(subscriber) == ReturnCode_t::RETCODE_OK);
     ASSERT_TRUE(DomainParticipantFactory::get_instance()->delete_participant(participant) == ReturnCode_t::RETCODE_OK);

--- a/test/unittest/dds/subscriber/SubscriberTests.cpp
+++ b/test/unittest/dds/subscriber/SubscriberTests.cpp
@@ -268,16 +268,16 @@ TEST(SubscriberTests, ChangeDefaultDataReaderQos)
     qos.durability().kind = eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS;
     // .deadline
     qos.deadline().period.seconds = 10;
-    qos.deadline().period.nanosec = 20;
+    qos.deadline().period.nanosec = 20u;
     // .latency_budget
     qos.latency_budget().duration.seconds = 20;
-    qos.latency_budget().duration.nanosec = 30;
+    qos.latency_budget().duration.nanosec = 30u;
     // .liveliness
     qos.liveliness().kind = eprosima::fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS;
     qos.liveliness().lease_duration.seconds = 40;
-    qos.liveliness().lease_duration.nanosec = 61;
+    qos.liveliness().lease_duration.nanosec = 61u;
     qos.liveliness().announcement_period.seconds = 30;
-    qos.liveliness().announcement_period.nanosec = 50;
+    qos.liveliness().announcement_period.nanosec = 50u;
     // .reliability
     qos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
     // .destination_order
@@ -303,12 +303,12 @@ TEST(SubscriberTests, ChangeDefaultDataReaderQos)
     qos.time_based_filter().minimum_separation.nanosec = eprosima::fastrtps::Time_t::INFINITE_NANOSECONDS;
     // .reader_data_lifecycle
     qos.reader_data_lifecycle().autopurge_disposed_samples_delay.seconds = 100;
-    qos.reader_data_lifecycle().autopurge_disposed_samples_delay.nanosec = 30000;
+    qos.reader_data_lifecycle().autopurge_disposed_samples_delay.nanosec = 30000u;
     qos.reader_data_lifecycle().autopurge_no_writer_samples_delay.seconds = 30000;
-    qos.reader_data_lifecycle().autopurge_no_writer_samples_delay.nanosec = 100;
+    qos.reader_data_lifecycle().autopurge_no_writer_samples_delay.nanosec = 100u;
     // .lifespan
     qos.lifespan().duration.seconds = 10;
-    qos.lifespan().duration.nanosec = 33;
+    qos.lifespan().duration.nanosec = 33u;
     // .durability_service
     qos.durability_service().history_kind = eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS;
     qos.durability_service().history_depth = 10;
@@ -317,12 +317,12 @@ TEST(SubscriberTests, ChangeDefaultDataReaderQos)
     qos.durability_service().max_samples_per_instance = 30;
     // .reliable_reader_qos
     qos.reliable_reader_qos().times.initialAcknackDelay.seconds = 34;
-    qos.reliable_reader_qos().times.initialAcknackDelay.nanosec = 32;
+    qos.reliable_reader_qos().times.initialAcknackDelay.nanosec = 32u;
     qos.reliable_reader_qos().times.heartbeatResponseDelay.seconds = 432;
-    qos.reliable_reader_qos().times.heartbeatResponseDelay.nanosec = 43;
+    qos.reliable_reader_qos().times.heartbeatResponseDelay.nanosec = 43u;
     qos.reliable_reader_qos().disable_positive_ACKs.enabled = true;
     qos.reliable_reader_qos().disable_positive_ACKs.duration.seconds = 13;
-    qos.reliable_reader_qos().disable_positive_ACKs.duration.nanosec = 320;
+    qos.reliable_reader_qos().disable_positive_ACKs.duration.nanosec = 320u;
     // .type_consistency
     qos.type_consistency().representation.m_value.push_back(XML_DATA_REPRESENTATION);
     qos.type_consistency().representation.m_value.push_back(XCDR_DATA_REPRESENTATION);
@@ -371,16 +371,16 @@ TEST(SubscriberTests, ChangeDefaultDataReaderQos)
     EXPECT_EQ(eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS, wqos.durability().kind);
     // .deadline
     EXPECT_EQ(10, wqos.deadline().period.seconds);
-    EXPECT_EQ(20, wqos.deadline().period.nanosec);
+    EXPECT_EQ(20u, wqos.deadline().period.nanosec);
     // .latency_budget
     EXPECT_EQ(20, wqos.latency_budget().duration.seconds);
-    EXPECT_EQ(30, wqos.latency_budget().duration.nanosec);
+    EXPECT_EQ(30u, wqos.latency_budget().duration.nanosec);
     // .liveliness
     EXPECT_EQ(eprosima::fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS, wqos.liveliness().kind);
     EXPECT_EQ(40, wqos.liveliness().lease_duration.seconds);
-    EXPECT_EQ(61, wqos.liveliness().lease_duration.nanosec);
+    EXPECT_EQ(61u, wqos.liveliness().lease_duration.nanosec);
     EXPECT_EQ(30, wqos.liveliness().announcement_period.seconds);
-    EXPECT_EQ(50, wqos.liveliness().announcement_period.nanosec);
+    EXPECT_EQ(50u, wqos.liveliness().announcement_period.nanosec);
     // .reliability
     EXPECT_EQ(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS, wqos.reliability().kind);
     // .destination_order
@@ -424,12 +424,12 @@ TEST(SubscriberTests, ChangeDefaultDataReaderQos)
     EXPECT_EQ(eprosima::fastrtps::Time_t::INFINITE_NANOSECONDS, wqos.time_based_filter().minimum_separation.nanosec);
     // .reader_data_lifecycle
     EXPECT_EQ(100, wqos.reader_data_lifecycle().autopurge_disposed_samples_delay.seconds);
-    EXPECT_EQ(30000, wqos.reader_data_lifecycle().autopurge_disposed_samples_delay.nanosec);
+    EXPECT_EQ(30000u, wqos.reader_data_lifecycle().autopurge_disposed_samples_delay.nanosec);
     EXPECT_EQ(30000, wqos.reader_data_lifecycle().autopurge_no_writer_samples_delay.seconds);
-    EXPECT_EQ(100, wqos.reader_data_lifecycle().autopurge_no_writer_samples_delay.nanosec);
+    EXPECT_EQ(100u, wqos.reader_data_lifecycle().autopurge_no_writer_samples_delay.nanosec);
     // .lifespan
     EXPECT_EQ(10, wqos.lifespan().duration.seconds);
-    EXPECT_EQ(33, wqos.lifespan().duration.nanosec);
+    EXPECT_EQ(33u, wqos.lifespan().duration.nanosec);
     // .durability_service
     EXPECT_EQ(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS, wqos.durability_service().history_kind);
     EXPECT_EQ(10, wqos.durability_service().history_depth);
@@ -438,12 +438,12 @@ TEST(SubscriberTests, ChangeDefaultDataReaderQos)
     EXPECT_EQ(30, wqos.durability_service().max_samples_per_instance);
     // .reliable_reader_qos
     EXPECT_EQ(34, wqos.reliable_reader_qos().times.initialAcknackDelay.seconds);
-    EXPECT_EQ(32, wqos.reliable_reader_qos().times.initialAcknackDelay.nanosec);
+    EXPECT_EQ(32u, wqos.reliable_reader_qos().times.initialAcknackDelay.nanosec);
     EXPECT_EQ(432, wqos.reliable_reader_qos().times.heartbeatResponseDelay.seconds);
-    EXPECT_EQ(43, wqos.reliable_reader_qos().times.heartbeatResponseDelay.nanosec);
+    EXPECT_EQ(43u, wqos.reliable_reader_qos().times.heartbeatResponseDelay.nanosec);
     EXPECT_TRUE(wqos.reliable_reader_qos().disable_positive_ACKs.enabled);
     EXPECT_EQ(13, wqos.reliable_reader_qos().disable_positive_ACKs.duration.seconds);
-    EXPECT_EQ(320, wqos.reliable_reader_qos().disable_positive_ACKs.duration.nanosec);
+    EXPECT_EQ(320u, wqos.reliable_reader_qos().disable_positive_ACKs.duration.nanosec);
     // .type_consistency
     EXPECT_EQ(XML_DATA_REPRESENTATION, wqos.type_consistency().representation.m_value.at(0));
     EXPECT_EQ(XCDR_DATA_REPRESENTATION, wqos.type_consistency().representation.m_value.at(1));

--- a/test/unittest/dds/subscriber/SubscriberTests.cpp
+++ b/test/unittest/dds/subscriber/SubscriberTests.cpp
@@ -264,15 +264,220 @@ TEST(SubscriberTests, ChangeDefaultDataReaderQos)
     subscriber->get_default_datareader_qos(qos);
     ASSERT_EQ(qos, DATAREADER_QOS_DEFAULT);
 
-    qos.reliability().kind = BEST_EFFORT_RELIABILITY_QOS;
+    // .durability
+    qos.durability().kind = eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS;
+    // .deadline
+    qos.deadline().period.seconds = 10;
+    qos.deadline().period.nanosec = 20;
+    // .latency_budget
+    qos.latency_budget().duration.seconds = 20;
+    qos.latency_budget().duration.nanosec = 30;
+    // .liveliness
+    qos.liveliness().kind = eprosima::fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS;
+    qos.liveliness().lease_duration.seconds = 40;
+    qos.liveliness().lease_duration.nanosec = 61;
+    qos.liveliness().announcement_period.seconds = 30;
+    qos.liveliness().announcement_period.nanosec = 50;
+    // .reliability
+    qos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
+    // .destination_order
+    qos.destination_order().kind = eprosima::fastdds::dds::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS;
+    // . history
+    qos.history().kind = eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS;
+    qos.history().depth = 1000;
+    // .resource_limits
+    qos.resource_limits().max_samples = 3000;
+    qos.resource_limits().max_instances = 100;
+    qos.resource_limits().max_samples_per_instance = 500;
+    qos.resource_limits().allocated_samples = 50;
+    qos.resource_limits().extra_samples = 2;
+    // .user_data
+    qos.user_data().push_back(0);
+    qos.user_data().push_back(1);
+    qos.user_data().push_back(2);
+    qos.user_data().push_back(3);
+    // .ownership
+    qos.ownership().kind = eprosima::fastdds::dds::EXCLUSIVE_OWNERSHIP_QOS;
+    // .time_based_filter
+    qos.time_based_filter().minimum_separation.seconds = eprosima::fastrtps::Time_t::INFINITE_SECONDS;
+    qos.time_based_filter().minimum_separation.nanosec = eprosima::fastrtps::Time_t::INFINITE_NANOSECONDS;
+    // .reader_data_lifecycle
+    qos.reader_data_lifecycle().autopurge_disposed_samples_delay.seconds = 100;
+    qos.reader_data_lifecycle().autopurge_disposed_samples_delay.nanosec = 30000;
+    qos.reader_data_lifecycle().autopurge_no_writer_samples_delay.seconds = 30000;
+    qos.reader_data_lifecycle().autopurge_no_writer_samples_delay.nanosec = 100;
+    // .lifespan
+    qos.lifespan().duration.seconds = 10;
+    qos.lifespan().duration.nanosec = 33;
+    // .durability_service
+    qos.durability_service().history_kind = eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS;
+    qos.durability_service().history_depth = 10;
+    qos.durability_service().max_samples = 5;
+    qos.durability_service().max_instances = 20;
+    qos.durability_service().max_samples_per_instance = 30;
+    // .reliable_reader_qos
+    qos.reliable_reader_qos().times.initialAcknackDelay.seconds = 34;
+    qos.reliable_reader_qos().times.initialAcknackDelay.nanosec = 32;
+    qos.reliable_reader_qos().times.heartbeatResponseDelay.seconds = 432;
+    qos.reliable_reader_qos().times.heartbeatResponseDelay.nanosec = 43;
+    qos.reliable_reader_qos().disable_positive_ACKs.enabled = true;
+    qos.reliable_reader_qos().disable_positive_ACKs.duration.seconds = 13;
+    qos.reliable_reader_qos().disable_positive_ACKs.duration.nanosec = 320;
+    // TODO .type_consistency
+    // .expects_inline_qos
+    qos.expects_inline_qos(true);
+    // .properties
+    eprosima::fastrtps::rtps::Property property;
+    property.name("Property1");
+    property.value("Value1");
+    qos.properties().properties().push_back(property);
+    property.name("Property2");
+    property.value("Value2");
+    qos.properties().properties().push_back(property);
+
+    // .endpoint
+    qos.endpoint().user_defined_id = 1;
+    qos.endpoint().entity_id = 2;
+    qos.endpoint().history_memory_policy = eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+
+    // .reader_resource_limits
+    qos.reader_resource_limits().matched_publisher_allocation.initial = 30;
+    qos.reader_resource_limits().matched_publisher_allocation.maximum = 300;
+    qos.reader_resource_limits().matched_publisher_allocation.increment = 4;
+    qos.reader_resource_limits().sample_infos_allocation.initial = 40;
+    qos.reader_resource_limits().sample_infos_allocation.maximum = 400;
+    qos.reader_resource_limits().sample_infos_allocation.increment = 5;
+    qos.reader_resource_limits().outstanding_reads_allocation.initial = 50;
+    qos.reader_resource_limits().outstanding_reads_allocation.maximum = 500;
+    qos.reader_resource_limits().outstanding_reads_allocation.increment = 6;
+    qos.reader_resource_limits().max_samples_per_read = 33;
+
+    // .data_sharing
+    qos.data_sharing().on("/");
 
     ASSERT_TRUE(subscriber->set_default_datareader_qos(qos) == ReturnCode_t::RETCODE_OK);
 
     DataReaderQos wqos;
     subscriber->get_default_datareader_qos(wqos);
 
+    // .durability
+    ASSERT_EQ(eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS, wqos.durability().kind);
+    // .deadline
+    ASSERT_EQ(10, wqos.deadline().period.seconds);
+    ASSERT_EQ(20, wqos.deadline().period.nanosec);
+    // .latency_budget
+    ASSERT_EQ(20, wqos.latency_budget().duration.seconds);
+    ASSERT_EQ(30, wqos.latency_budget().duration.nanosec);
+    // .liveliness
+    ASSERT_EQ(eprosima::fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS, wqos.liveliness().kind);
+    ASSERT_EQ(40, wqos.liveliness().lease_duration.seconds);
+    ASSERT_EQ(61, wqos.liveliness().lease_duration.nanosec);
+    ASSERT_EQ(30, wqos.liveliness().announcement_period.seconds);
+    ASSERT_EQ(50, wqos.liveliness().announcement_period.nanosec);
+    // .reliability
+    ASSERT_EQ(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS, wqos.reliability().kind);
+    // .destination_order
+    ASSERT_EQ(eprosima::fastdds::dds::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS, wqos.destination_order().kind);
+    // . history
+    ASSERT_EQ(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS, wqos.history().kind);
+    ASSERT_EQ(1000, wqos.history().depth);
+    // .resource_limits
+    ASSERT_EQ(3000, wqos.resource_limits().max_samples);
+    ASSERT_EQ(100, wqos.resource_limits().max_instances);
+    ASSERT_EQ(500, wqos.resource_limits().max_samples_per_instance);
+    ASSERT_EQ(50, wqos.resource_limits().allocated_samples);
+    ASSERT_EQ(2, wqos.resource_limits().extra_samples);
+    // .user_data
+    size_t count = 1;
+    for (auto user_value : wqos.user_data())
+    {
+        switch (count)
+        {
+            case 1:
+                ASSERT_EQ(0, user_value);
+                break;
+            case 2:
+                ASSERT_EQ(1, user_value);
+                break;
+            case 3:
+                ASSERT_EQ(2, user_value);
+                break;
+            case 4:
+                ASSERT_EQ(3, user_value);
+                break;
+            default:
+                ASSERT_TRUE(false);
+        }
+        ++count;
+    }
+    // .ownership
+    ASSERT_EQ(eprosima::fastdds::dds::EXCLUSIVE_OWNERSHIP_QOS, wqos.ownership().kind);
+    // .time_based_filter
+    ASSERT_EQ(eprosima::fastrtps::Time_t::INFINITE_SECONDS, wqos.time_based_filter().minimum_separation.seconds);
+    ASSERT_EQ(eprosima::fastrtps::Time_t::INFINITE_NANOSECONDS, wqos.time_based_filter().minimum_separation.nanosec);
+    // .reader_data_lifecycle
+    ASSERT_EQ(100, wqos.reader_data_lifecycle().autopurge_disposed_samples_delay.seconds);
+    ASSERT_EQ(30000, wqos.reader_data_lifecycle().autopurge_disposed_samples_delay.nanosec);
+    ASSERT_EQ(30000, wqos.reader_data_lifecycle().autopurge_no_writer_samples_delay.seconds);
+    ASSERT_EQ(100, wqos.reader_data_lifecycle().autopurge_no_writer_samples_delay.nanosec);
+    // .lifespan
+    ASSERT_EQ(10, wqos.lifespan().duration.seconds);
+    ASSERT_EQ(33, wqos.lifespan().duration.nanosec);
+    // .durability_service
+    ASSERT_EQ(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS, wqos.durability_service().history_kind);
+    ASSERT_EQ(10, wqos.durability_service().history_depth);
+    ASSERT_EQ(5, wqos.durability_service().max_samples);
+    ASSERT_EQ(20, wqos.durability_service().max_instances);
+    ASSERT_EQ(30, wqos.durability_service().max_samples_per_instance);
+    // .reliable_reader_qos
+    ASSERT_EQ(34, wqos.reliable_reader_qos().times.initialAcknackDelay.seconds);
+    ASSERT_EQ(32, wqos.reliable_reader_qos().times.initialAcknackDelay.nanosec);
+    ASSERT_EQ(432, wqos.reliable_reader_qos().times.heartbeatResponseDelay.seconds);
+    ASSERT_EQ(43, wqos.reliable_reader_qos().times.heartbeatResponseDelay.nanosec);
+    ASSERT_TRUE(wqos.reliable_reader_qos().disable_positive_ACKs.enabled);
+    ASSERT_EQ(13, wqos.reliable_reader_qos().disable_positive_ACKs.duration.seconds);
+    ASSERT_EQ(320, wqos.reliable_reader_qos().disable_positive_ACKs.duration.nanosec);
+    // .expects_inline_qos
+    ASSERT_TRUE(wqos.expects_inline_qos());
+    // .properties
+    count = 1;
+    for (auto prop : wqos.properties().properties())
+    {
+        switch (count)
+        {
+            case 1:
+                ASSERT_EQ(0, prop.name().compare("Property1"));
+                ASSERT_EQ(0, prop.value().compare("Value1"));
+                break;
+            case 2:
+                ASSERT_EQ(0, prop.name().compare("Property2"));
+                ASSERT_EQ(0, prop.value().compare("Value2"));
+                break;
+            default:
+                ASSERT_TRUE(false);
+        }
+        ++count;
+    }
+    // .endpoint
+    ASSERT_EQ(1, wqos.endpoint().user_defined_id);
+    ASSERT_EQ(2, wqos.endpoint().entity_id);
+    ASSERT_EQ(eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE, wqos.endpoint().history_memory_policy);
+    // .reader_resource_limits
+    ASSERT_EQ(30, wqos.reader_resource_limits().matched_publisher_allocation.initial);
+    ASSERT_EQ(300, wqos.reader_resource_limits().matched_publisher_allocation.maximum);
+    ASSERT_EQ(4, wqos.reader_resource_limits().matched_publisher_allocation.increment);
+    ASSERT_EQ(40, wqos.reader_resource_limits().sample_infos_allocation.initial);
+    ASSERT_EQ(400, wqos.reader_resource_limits().sample_infos_allocation.maximum);
+    ASSERT_EQ(5, wqos.reader_resource_limits().sample_infos_allocation.increment);
+    ASSERT_EQ(50, wqos.reader_resource_limits().outstanding_reads_allocation.initial);
+    ASSERT_EQ(500, wqos.reader_resource_limits().outstanding_reads_allocation.maximum);
+    ASSERT_EQ(6, wqos.reader_resource_limits().outstanding_reads_allocation.increment);
+    ASSERT_EQ(33, wqos.reader_resource_limits().max_samples_per_read);
+    // .data_sharing
+    ASSERT_EQ(eprosima::fastdds::dds::ON, wqos.data_sharing().kind());
+    ASSERT_EQ(0, wqos.data_sharing().shm_directory().compare("/"));
+
     ASSERT_EQ(qos, wqos);
-    ASSERT_EQ(wqos.reliability().kind, BEST_EFFORT_RELIABILITY_QOS);
 
     ASSERT_TRUE(participant->delete_subscriber(subscriber) == ReturnCode_t::RETCODE_OK);
     ASSERT_TRUE(DomainParticipantFactory::get_instance()->delete_participant(participant) == ReturnCode_t::RETCODE_OK);

--- a/test/unittest/dds/subscriber/SubscriberTests.cpp
+++ b/test/unittest/dds/subscriber/SubscriberTests.cpp
@@ -323,7 +323,14 @@ TEST(SubscriberTests, ChangeDefaultDataReaderQos)
     qos.reliable_reader_qos().disable_positive_ACKs.enabled = true;
     qos.reliable_reader_qos().disable_positive_ACKs.duration.seconds = 13;
     qos.reliable_reader_qos().disable_positive_ACKs.duration.nanosec = 320;
-    // TODO .type_consistency
+    // .type_consistency
+    qos.type_consistency().representation.m_value.push_back(XML_DATA_REPRESENTATION);
+    qos.type_consistency().representation.m_value.push_back(XCDR_DATA_REPRESENTATION);
+    qos.type_consistency().type_consistency.m_ignore_sequence_bounds = false;
+    qos.type_consistency().type_consistency.m_ignore_string_bounds = false;
+    qos.type_consistency().type_consistency.m_ignore_member_names = true;
+    qos.type_consistency().type_consistency.m_prevent_type_widening = true;
+    qos.type_consistency().type_consistency.m_force_type_validation = true;
     // .expects_inline_qos
     qos.expects_inline_qos(true);
     // .properties
@@ -437,6 +444,14 @@ TEST(SubscriberTests, ChangeDefaultDataReaderQos)
     ASSERT_TRUE(wqos.reliable_reader_qos().disable_positive_ACKs.enabled);
     ASSERT_EQ(13, wqos.reliable_reader_qos().disable_positive_ACKs.duration.seconds);
     ASSERT_EQ(320, wqos.reliable_reader_qos().disable_positive_ACKs.duration.nanosec);
+    // .type_consistency
+    ASSERT_EQ(XML_DATA_REPRESENTATION, wqos.type_consistency().representation.m_value.at(0));
+    ASSERT_EQ(XCDR_DATA_REPRESENTATION, wqos.type_consistency().representation.m_value.at(1));
+    ASSERT_FALSE(wqos.type_consistency().type_consistency.m_ignore_sequence_bounds);
+    ASSERT_FALSE(wqos.type_consistency().type_consistency.m_ignore_string_bounds);
+    ASSERT_TRUE(wqos.type_consistency().type_consistency.m_ignore_member_names);
+    ASSERT_TRUE(wqos.type_consistency().type_consistency.m_prevent_type_widening);
+    ASSERT_TRUE(wqos.type_consistency().type_consistency.m_force_type_validation);
     // .expects_inline_qos
     ASSERT_TRUE(wqos.expects_inline_qos());
     // .properties


### PR DESCRIPTION
There are missing things which not make work well setting a default qos for DataWriters and DataReaders. This PR fixes this and also add/extend a regression test.

Also comes with minor changes to make work Swig when generating Python bindings.