### PR TITLE
Suppress OpenSSL 3.0 warnings.

### DIFF
--- a/src/cpp/security/authentication/PKIDH.cpp
+++ b/src/cpp/security/authentication/PKIDH.cpp
@@ -16,6 +16,10 @@
  * @file PKIDH.cpp
  */
 
+// TODO This isn't a proper fix for compatibility with OpenSSL 3.0, but
+// suppresses the warnings until true OpenSSL 3.0 APIs can be used.
+#define OPENSSL_API_COMPAT 10101
+
 #include <security/authentication/PKIDH.h>
 #include <security/authentication/PKIIdentityHandle.h>
 #include <fastdds/rtps/security/logging/Logging.h>


### PR DESCRIPTION
This is a temporary fix until the code can be refactored to
use real OpenSSL 3.0 APIs.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Note that this should also be forward-ported to the master branch, as the same warning is there.