### PR TITLE
[10843] Correctly protect endpoints collections

### DIFF
--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -460,6 +460,7 @@ void RTPSParticipantImpl::disable()
         block.disable();
     }
 
+    std::unique_lock<std::recursive_mutex> lock(*mp_mutex);
     while (m_userReaderList.size() > 0)
     {
         deleteUserEndpoint(static_cast<Endpoint*>(*m_userReaderList.begin()));
@@ -469,6 +470,7 @@ void RTPSParticipantImpl::disable()
     {
         deleteUserEndpoint(static_cast<Endpoint*>(*m_userWriterList.begin()));
     }
+    lock.unlock();
 
     delete(mp_builtinProtocols);
     mp_builtinProtocols = nullptr;
@@ -751,10 +753,12 @@ bool RTPSParticipantImpl::create_writer(
         }
     }
 
-    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
+    std::unique_lock<std::mutex> lock(endpoints_list_mutex);
     m_allWriterList.push_back(SWriter);
+    lock.unlock();
     if (!is_builtin)
     {
+        std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
         m_userWriterList.push_back(SWriter);
     }
     *writer_out = SWriter;
@@ -886,10 +890,12 @@ bool RTPSParticipantImpl::create_reader(
         }
     }
 
-    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
+    std::unique_lock<std::mutex> lock(endpoints_list_mutex);
     m_allReaderList.push_back(SReader);
+    lock.unlock();
     if (!is_builtin)
     {
+        std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
         m_userReaderList.push_back(SReader);
     }
     *reader_out = SReader;
@@ -1098,9 +1104,7 @@ bool RTPSParticipantImpl::createReader(
 RTPSReader* RTPSParticipantImpl::find_local_reader(
         const GUID_t& reader_guid)
 {
-    // As this is only called from RTPSDomainImpl::find_local_reader, and it has
-    // the domain mutex taken, there is no need to take the participant mutex
-    // std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
+    std::lock_guard<std::mutex> guard(endpoints_list_mutex);
 
     for (auto reader : m_allReaderList)
     {
@@ -1116,9 +1120,7 @@ RTPSReader* RTPSParticipantImpl::find_local_reader(
 RTPSWriter* RTPSParticipantImpl::find_local_writer(
         const GUID_t& writer_guid)
 {
-    // As this is only called from RTPSDomainImpl::find_local_reader, and it has
-    // the domain mutex taken, there is no need to take the participant mutex
-    // std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
+    std::lock_guard<std::mutex> guard(endpoints_list_mutex);
 
     for (auto writer : m_allWriterList)
     {
@@ -1354,6 +1356,7 @@ bool RTPSParticipantImpl::existsEntityId(
         const EntityId_t& ent,
         EndpointKind_t kind) const
 {
+    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
     if (kind == WRITER)
     {
         for (std::vector<RTPSWriter*>::const_iterator it = m_userWriterList.begin(); it != m_userWriterList.end(); ++it)
@@ -1609,45 +1612,55 @@ bool RTPSParticipantImpl::deleteUserEndpoint(
     {
         if (p_endpoint->getAttributes().endpointKind == WRITER)
         {
-            std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
-            for (auto wit = m_userWriterList.begin(); wit != m_userWriterList.end(); ++wit)
             {
-                if ((*wit)->getGuid().entityId == p_endpoint->getGuid().entityId) //Found it
+                std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
+                for (auto wit = m_userWriterList.begin(); wit != m_userWriterList.end(); ++wit)
                 {
-                    m_userWriterList.erase(wit);
-                    found_in_users = true;
-                    break;
+                    if ((*wit)->getGuid().entityId == p_endpoint->getGuid().entityId) //Found it
+                    {
+                        m_userWriterList.erase(wit);
+                        found_in_users = true;
+                        break;
+                    }
                 }
             }
-            for (auto wit = m_allWriterList.begin(); wit != m_allWriterList.end(); ++wit)
             {
-                if ((*wit)->getGuid().entityId == p_endpoint->getGuid().entityId) //Found it
+                std::lock_guard<std::mutex> lock(endpoints_list_mutex);
+                for (auto wit = m_allWriterList.begin(); wit != m_allWriterList.end(); ++wit)
                 {
-                    m_allWriterList.erase(wit);
-                    found = true;
-                    break;
+                    if ((*wit)->getGuid().entityId == p_endpoint->getGuid().entityId) //Found it
+                    {
+                        m_allWriterList.erase(wit);
+                        found = true;
+                        break;
+                    }
                 }
             }
         }
         else
         {
-            std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
-            for (auto rit = m_userReaderList.begin(); rit != m_userReaderList.end(); ++rit)
             {
-                if ((*rit)->getGuid().entityId == p_endpoint->getGuid().entityId) //Found it
+                std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
+                for (auto rit = m_userReaderList.begin(); rit != m_userReaderList.end(); ++rit)
                 {
-                    m_userReaderList.erase(rit);
-                    found_in_users = true;
-                    break;
+                    if ((*rit)->getGuid().entityId == p_endpoint->getGuid().entityId) //Found it
+                    {
+                        m_userReaderList.erase(rit);
+                        found_in_users = true;
+                        break;
+                    }
                 }
             }
-            for (auto rit = m_allReaderList.begin(); rit != m_allReaderList.end(); ++rit)
             {
-                if ((*rit)->getGuid().entityId == p_endpoint->getGuid().entityId) //Found it
+                std::lock_guard<std::mutex> lock(endpoints_list_mutex);
+                for (auto rit = m_allReaderList.begin(); rit != m_allReaderList.end(); ++rit)
                 {
-                    m_allReaderList.erase(rit);
-                    found = true;
-                    break;
+                    if ((*rit)->getGuid().entityId == p_endpoint->getGuid().entityId) //Found it
+                    {
+                        m_allReaderList.erase(rit);
+                        found = true;
+                        break;
+                    }
                 }
             }
         }
@@ -2269,6 +2282,7 @@ bool RTPSParticipantImpl::register_in_writer(
         std::shared_ptr<fastdds::statistics::IListener> listener,
         GUID_t writer_guid)
 {
+    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
     bool res = false;
 
     if ( GUID_t::unknown() == writer_guid )
@@ -2295,6 +2309,7 @@ bool RTPSParticipantImpl::register_in_reader(
         std::shared_ptr<fastdds::statistics::IListener> listener,
         GUID_t reader_guid)
 {
+    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
     bool res = false;
 
     if ( GUID_t::unknown() == reader_guid )
@@ -2320,7 +2335,7 @@ bool RTPSParticipantImpl::register_in_reader(
 bool RTPSParticipantImpl::unregister_in_writer(
         std::shared_ptr<fastdds::statistics::IListener> listener)
 {
-    std::lock_guard<std::recursive_mutex> guard(*getParticipantMutex());
+    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
     bool res = true;
 
     for ( auto writer : m_userWriterList)
@@ -2337,7 +2352,7 @@ bool RTPSParticipantImpl::unregister_in_writer(
 bool RTPSParticipantImpl::unregister_in_reader(
         std::shared_ptr<fastdds::statistics::IListener> listener)
 {
-    std::lock_guard<std::recursive_mutex> guard(*getParticipantMutex());
+    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
     bool res = true;
 
     for ( auto reader : m_userReaderList)

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -460,17 +460,18 @@ void RTPSParticipantImpl::disable()
         block.disable();
     }
 
-    std::unique_lock<std::recursive_mutex> lock(*mp_mutex);
-    while (m_userReaderList.size() > 0)
     {
-        deleteUserEndpoint(static_cast<Endpoint*>(*m_userReaderList.begin()));
-    }
+        std::lock_guard<std::recursive_mutex> lock(*mp_mutex);
+        while (m_userReaderList.size() > 0)
+        {
+            deleteUserEndpoint(static_cast<Endpoint*>(*m_userReaderList.begin()));
+        }
 
-    while (m_userWriterList.size() > 0)
-    {
-        deleteUserEndpoint(static_cast<Endpoint*>(*m_userWriterList.begin()));
+        while (m_userWriterList.size() > 0)
+        {
+            deleteUserEndpoint(static_cast<Endpoint*>(*m_userWriterList.begin()));
+        }
     }
-    lock.unlock();
 
     delete(mp_builtinProtocols);
     mp_builtinProtocols = nullptr;
@@ -753,9 +754,10 @@ bool RTPSParticipantImpl::create_writer(
         }
     }
 
-    std::unique_lock<std::mutex> lock(endpoints_list_mutex);
-    m_allWriterList.push_back(SWriter);
-    lock.unlock();
+    {
+        std::lock_guard<std::mutex> lock(endpoints_list_mutex);
+        m_allWriterList.push_back(SWriter);
+    }
     if (!is_builtin)
     {
         std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
@@ -890,9 +892,10 @@ bool RTPSParticipantImpl::create_reader(
         }
     }
 
-    std::unique_lock<std::mutex> lock(endpoints_list_mutex);
-    m_allReaderList.push_back(SReader);
-    lock.unlock();
+    {
+        std::lock_guard<std::mutex> lock(endpoints_list_mutex);
+        m_allReaderList.push_back(SReader);
+    }
     if (!is_builtin)
     {
         std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
@@ -1250,7 +1253,7 @@ void RTPSParticipantImpl::update_attributes(
         m_att.userData = patt.userData;
 
         {
-            std::unique_lock<std::recursive_mutex> lock(*pdp->getMutex());
+            std::lock_guard<std::recursive_mutex> lock(*pdp->getMutex());
 
             // Update user data
             auto local_participant_proxy_data = pdp->getLocalParticipantProxyData();
@@ -1582,7 +1585,7 @@ bool RTPSParticipantImpl::createReceiverResources(
 void RTPSParticipantImpl::createSenderResources(
         const LocatorList_t& locator_list)
 {
-    std::unique_lock<std::timed_mutex> lock(m_send_resources_mutex_);
+    std::lock_guard<std::timed_mutex> lock(m_send_resources_mutex_);
 
     for (auto it_loc = locator_list.begin(); it_loc != locator_list.end(); ++it_loc)
     {
@@ -1593,7 +1596,7 @@ void RTPSParticipantImpl::createSenderResources(
 void RTPSParticipantImpl::createSenderResources(
         const Locator_t& locator)
 {
-    std::unique_lock<std::timed_mutex> lock(m_send_resources_mutex_);
+    std::lock_guard<std::timed_mutex> lock(m_send_resources_mutex_);
 
     m_network_Factory.build_send_resources(send_resource_list_, locator);
 }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -521,6 +521,8 @@ private:
     Semaphore* mp_ResourceSemaphore;
     //!Id counter to correctly assign the ids to writers and readers.
     uint32_t IdCounter;
+    //! Mutex to safely access endpoints collections
+    std::mutex endpoints_list_mutex;
     //!Writer List.
     std::vector<RTPSWriter*> m_allWriterList;
     //!Reader List

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -493,7 +493,7 @@ bool StatefulWriter::intraprocess_heartbeat(
     bool returned_value = false;
 
     std::lock_guard<RecursiveTimedMutex> guardW(mp_mutex);
-    RTPSReader* reader = RTPSDomainImpl::find_local_reader(reader_proxy->guid());
+    RTPSReader* reader = reader_proxy->local_reader();
 
     if (reader)
     {

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -493,7 +493,7 @@ bool StatefulWriter::intraprocess_heartbeat(
     bool returned_value = false;
 
     std::lock_guard<RecursiveTimedMutex> guardW(mp_mutex);
-    RTPSReader* reader = reader_proxy->local_reader();
+    RTPSReader* reader = RTPSDomainImpl::find_local_reader(reader_proxy->guid());
 
     if (reader)
     {


### PR DESCRIPTION
This PR closes #1819. It also replaces #1823.

I have tried the regression test proposed in that PR but it does not seem to provoke the data race condition and the segmentation fault. However, the test is prone to failure due to discovery issues. Thus, I have not introduced it in this PR (if the reviewer considers it is of interest I can update this PR). There is no regression test because forcing the failure is not straight forward nor easy. However, the benefits of correctly protecting the access to the collections are too great compare to a regression test. My opinion is that this fix should be merged.