### PR TITLE
Refs 13882. Fixes for _UNICODE macro on Visual Studio

### DIFF
--- a/src/cpp/utils/StringMatching.cpp
+++ b/src/cpp/utils/StringMatching.cpp
@@ -101,7 +101,7 @@ bool StringMatching::matchPattern(
         const char* pattern,
         const char* str)
 {
-    if (PathMatchSpec(str, pattern))
+    if (PathMatchSpecA(str, pattern))
     {
         return true;
     }
@@ -112,11 +112,11 @@ bool StringMatching::matchString(
         const char* str1,
         const char* str2)
 {
-    if (PathMatchSpec(str1, str2))
+    if (PathMatchSpecA(str1, str2))
     {
         return true;
     }
-    if (PathMatchSpec(str2, str1))
+    if (PathMatchSpecA(str2, str1))
     {
         return true;
     }

--- a/src/cpp/utils/SystemInfo.cpp
+++ b/src/cpp/utils/SystemInfo.cpp
@@ -104,7 +104,7 @@ ReturnCode_t SystemInfo::get_username(
 #define INFO_BUFFER_SIZE 32767
     char user[INFO_BUFFER_SIZE];
     DWORD bufCharCount = INFO_BUFFER_SIZE;
-    if (!GetUserName(user, &bufCharCount))
+    if (!GetUserNameA(user, &bufCharCount))
     {
         return ReturnCode_t::RETCODE_ERROR;
     }


### PR DESCRIPTION
Select the right windows API functions independently of the `_UNICODE` preprocessor definition.
This addresses the issue https://github.com/eProsima/Fast-DDS/issues/2501