### PR TITLE
Remove constructor exports for factory created entities [13947]

### DIFF
--- a/include/fastdds/dds/core/Entity.hpp
+++ b/include/fastdds/dds/core/Entity.hpp
@@ -171,7 +171,7 @@ public:
      *
      * @param mask StatusMask (default: all)
      */
-    RTPS_DllAPI DomainEntity(
+    DomainEntity(
             const StatusMask& mask = StatusMask::all())
         : Entity(mask)
     {

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -93,7 +93,7 @@ public:
     /**
      * @brief Destructor
      */
-    RTPS_DllAPI virtual ~DomainParticipant();
+    virtual ~DomainParticipant();
 
     // Superclass methods
 
@@ -891,7 +891,7 @@ public:
 
 protected:
 
-    RTPS_DllAPI DomainParticipant(
+    DomainParticipant(
             const StatusMask& mask = StatusMask::all());
 
     DomainParticipantImpl* impl_;

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -77,11 +77,11 @@ protected:
      * Create a data writer, assigning its pointer to the associated implementation.
      * Don't use directly, create DataWriter using create_datawriter from Publisher.
      */
-    RTPS_DllAPI DataWriter(
+    DataWriter(
             DataWriterImpl* impl,
             const StatusMask& mask = StatusMask::all());
 
-    RTPS_DllAPI DataWriter(
+    DataWriter(
             Publisher* pub,
             Topic* topic,
             const DataWriterQos& qos = DATAWRITER_QOS_DEFAULT,
@@ -121,7 +121,7 @@ public:
         CONSTRUCTED_LOAN_INITIALIZATION
     };
 
-    RTPS_DllAPI virtual ~DataWriter();
+    virtual ~DataWriter();
 
     /**
      * @brief This operation enables the DataWriter

--- a/include/fastdds/dds/publisher/Publisher.hpp
+++ b/include/fastdds/dds/publisher/Publisher.hpp
@@ -70,11 +70,11 @@ protected:
      * Create a publisher, assigning its pointer to the associated implementation.
      * Don't use directly, create Publisher using create_publisher from DomainParticipant.
      */
-    RTPS_DllAPI Publisher(
+    Publisher(
             PublisherImpl* p,
             const StatusMask& mask = StatusMask::all());
 
-    RTPS_DllAPI Publisher(
+    Publisher(
             DomainParticipant* dp,
             const PublisherQos& qos = PUBLISHER_QOS_DEFAULT,
             PublisherListener* listener = nullptr,
@@ -85,7 +85,7 @@ public:
     /**
      * @brief Destructor
      */
-    RTPS_DllAPI virtual ~Publisher();
+    virtual ~Publisher();
 
     /**
      * @brief This operation enables the Publisher

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -93,11 +93,11 @@ protected:
      * Create a data reader, assigning its pointer to the associated implementation.
      * Don't use directly, create DataReader using create_datareader from Subscriber.
      */
-    RTPS_DllAPI DataReader(
+    DataReader(
             DataReaderImpl* impl,
             const StatusMask& mask = StatusMask::all());
 
-    RTPS_DllAPI DataReader(
+    DataReader(
             Subscriber* s,
             TopicDescription* topic,
             const DataReaderQos& qos,
@@ -109,7 +109,7 @@ public:
     /**
      * @brief Destructor.
      */
-    RTPS_DllAPI virtual ~DataReader();
+    virtual ~DataReader();
 
     /**
      * @brief This operation enables the DataReader.

--- a/include/fastdds/dds/subscriber/Subscriber.hpp
+++ b/include/fastdds/dds/subscriber/Subscriber.hpp
@@ -75,11 +75,11 @@ protected:
      * Create a subscriber, assigning its pointer to the associated implementation.
      * Don't use directly, create Subscriber using create_subscriber from DomainParticipant.
      */
-    RTPS_DllAPI Subscriber(
+    Subscriber(
             SubscriberImpl* pimpl,
             const StatusMask& mask = StatusMask::all());
 
-    RTPS_DllAPI Subscriber(
+    Subscriber(
             DomainParticipant* dp,
             const SubscriberQos& qos = SUBSCRIBER_QOS_DEFAULT,
             SubscriberListener* listener = nullptr,
@@ -90,7 +90,7 @@ public:
     /**
      * @brief Destructor
      */
-    RTPS_DllAPI virtual ~Subscriber()
+    virtual ~Subscriber()
     {
     }
 

--- a/include/fastdds/dds/topic/Topic.hpp
+++ b/include/fastdds/dds/topic/Topic.hpp
@@ -59,13 +59,13 @@ class Topic : public DomainEntity, public TopicDescription
      * Create a topic, assigning its pointer to the associated implementation.
      * Don't use directly, create Topic using create_topic from DomainParticipant.
      */
-    RTPS_DllAPI Topic(
+    Topic(
             const std::string& topic_name,
             const std::string& type_name,
             TopicImpl* p,
             const StatusMask& mask = StatusMask::all());
 
-    RTPS_DllAPI Topic(
+    Topic(
             DomainParticipant* dp,
             const std::string& topic_name,
             const std::string& type_name,
@@ -78,7 +78,7 @@ public:
     /**
      * @brief Destructor
      */
-    RTPS_DllAPI virtual ~Topic();
+    virtual ~Topic();
 
     /**
      * @brief Getter for the DomainParticipant

--- a/versions.md
+++ b/versions.md
@@ -3,6 +3,7 @@ Version 2.6.0
 
 * New TransportInterface and NetworkFactory API to allow updating the network interfaces at runtime (ABI breaks on RPTS
   and transport layers)
+* Removed dll export for constructors and destructors of factory created entities (breaks ABI)
 
 Version 2.5.0
 -------------


### PR DESCRIPTION
## Description

Added missing exports required by the SWIG wrapper used in the python bindings.

<!-- despite of been a bugfix we cannot backport due ABI break @Mergifyio backport 2.5.x 2.4.x 2.3.x 2.1.x -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] n/a Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [ ] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] n/a New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
