### PR TITLE
Set recommended DataReaderQos to PREALLOCATED_WITH_REALLOC [14006]

### DIFF
--- a/src/cpp/statistics/fastdds/subscriber/qos/DataReaderQos.cpp
+++ b/src/cpp/statistics/fastdds/subscriber/qos/DataReaderQos.cpp
@@ -19,6 +19,7 @@
 #include <fastdds/statistics/dds/subscriber/qos/DataReaderQos.hpp>
 
 #include <fastdds/dds/core/policy/QosPolicies.hpp>
+#include <fastdds/rtps/resources/ResourceManagement.h>
 
 namespace eprosima {
 namespace fastdds {
@@ -27,11 +28,14 @@ namespace dds {
 
 DataReaderQos::DataReaderQos()
 {
-    // Specific implementation for recommended statistics DataReaderQos
+    /* Specific implementation for recommended statistics DataReaderQos */
     reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
     durability().kind = eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS;
     history().kind = eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS;
     history().depth = 100;
+    // Setting history memory policy to PREALLOCATED_WITH_REALLOC_MEMORY_MODE allows for future type
+    // extension with backwards compatibility
+    endpoint().history_memory_policy = eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
 }
 
 } // dds


### PR DESCRIPTION
Signed-off-by: Eduardo Ponz <eduardoponz@eprosima.com>

<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR sets the recommend Statistics DataReaderQos history memory policy to `PREALLOCATED_WITH_REALLOC_MEMORY_MODE` to allow future statistics data type extensions,
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
@Mergifyio backport 2.3.x 2.4.x 2.5.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [x] *N/A* New feature has been added to the `versions.md` file (if applicable).
- [x] *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
