### PR TITLE
Add support for octet vectors on XML parser [14011]

### DIFF
--- a/include/fastrtps/xmlparser/XMLParser.h
+++ b/include/fastrtps/xmlparser/XMLParser.h
@@ -521,7 +521,7 @@ protected:
 
     RTPS_DllAPI static XMLP_ret getXMLOctetVector(
             tinyxml2::XMLElement* elem,
-            std::vector<rtps::octet>& octetVector,
+            std::vector<rtps::octet>& octet_vector,
             uint8_t ident);
 
     RTPS_DllAPI static XMLP_ret getXMLInt(

--- a/resources/xsd/fastRTPS_profiles.xsd
+++ b/resources/xsd/fastRTPS_profiles.xsd
@@ -652,7 +652,7 @@
     <xs:complexType name="disablePositiveAcksQosPolicyType">
         <xs:all>
             <xs:element name="enabled" type="boolType"/>
-            <xs:element name="duration" type="durationType"/>
+            <xs:element name="duration" type="durationType" minOccurs="0"/>
         </xs:all>
     </xs:complexType>
 

--- a/resources/xsd/fastRTPS_profiles.xsd
+++ b/resources/xsd/fastRTPS_profiles.xsd
@@ -120,9 +120,11 @@
         </xs:all>
     </xs:complexType>
 
-    <xs:simpleType name="octetVectorType">
-        <xs:restriction base="xs:string"/><!-- std::vector<octet> -->
-    </xs:simpleType>
+    <xs:complexType name="octetVectorType">
+        <xs:all>
+            <xs:element name="value" type="xs:string"/>
+        </xs:all>
+    </xs:complexType>
 
     <xs:complexType name="propertyType">
         <xs:all>
@@ -538,12 +540,6 @@
         </xs:all>
     </xs:complexType>
 
-    <xs:complexType name="userDataQosPolicyType">
-        <xs:all>
-            <xs:element name="dataVec" type="octetVectorType"/>
-        </xs:all>
-    </xs:complexType>
-
     <xs:complexType name="timeBasedFilterQosPolicyType">
         <xs:all>
             <xs:element name="minimum_separation" type="durationType"/>
@@ -610,18 +606,6 @@
         </xs:all>
     </xs:complexType>
 
-    <xs:complexType name="topicDataQosPolicyType">
-        <xs:all>
-            <xs:element name="value" type="octetVectorType"/>
-        </xs:all>
-    </xs:complexType>
-
-    <xs:complexType name="groupDataQosPolicyType">
-        <xs:all>
-            <xs:element name="value" type="octetVectorType"/>
-        </xs:all>
-    </xs:complexType>
-
     <xs:simpleType name="publishModeQosKindType">
         <xs:restriction base="xs:string">
             <xs:enumeration value="SYNCHRONOUS"/>
@@ -681,15 +665,15 @@
             <xs:element name="liveliness" type="livelinessQosPolicyType" minOccurs="0"/>
             <xs:element name="reliability" type="reliabilityQosPolicyType" minOccurs="0"/>
             <xs:element name="lifespan" type="lifespanQosPolicyType" minOccurs="0"/>
-            <xs:element name="userData" type="userDataQosPolicyType" minOccurs="0"/>
+            <xs:element name="userData" type="octetVectorType" minOccurs="0"/>
             <xs:element name="timeBasedFilter" type="timeBasedFilterQosPolicyType" minOccurs="0"/>
             <xs:element name="ownership" type="ownershipQosPolicyType" minOccurs="0"/>
             <xs:element name="ownershipStrength" type="ownershipStrengthQosPolicyType" minOccurs="0"/>
             <xs:element name="destinationOrder" type="destinationOrderQosPolicyType" minOccurs="0"/>
             <xs:element name="presentation" type="presentationQosPolicyType" minOccurs="0"/>
             <xs:element name="partition" type="partitionQosPolicyType" minOccurs="0"/>
-            <xs:element name="topicData" type="topicDataQosPolicyType" minOccurs="0"/>
-            <xs:element name="groupData" type="groupDataQosPolicyType" minOccurs="0"/>
+            <xs:element name="topicData" type="octetVectorType" minOccurs="0"/>
+            <xs:element name="groupData" type="octetVectorType" minOccurs="0"/>
             <xs:element name="publishMode" type="publishModeQosPolicyType" minOccurs="0"/>
             <xs:element name="data_sharing" type="dataSharingQosPolicyType" minOccurs="0"/>
             <xs:element name="disablePositiveAcks" type="disablePositiveAcksQosPolicyType" minOccurs="0"/>
@@ -706,14 +690,14 @@
             <xs:element name="liveliness" type="livelinessQosPolicyType" minOccurs="0"/>
             <xs:element name="reliability" type="reliabilityQosPolicyType" minOccurs="0"/>
             <xs:element name="lifespan" type="lifespanQosPolicyType" minOccurs="0"/>
-            <xs:element name="userData" type="userDataQosPolicyType" minOccurs="0"/>
+            <xs:element name="userData" type="octetVectorType" minOccurs="0"/>
             <xs:element name="timeBasedFilter" type="timeBasedFilterQosPolicyType" minOccurs="0"/>
             <xs:element name="ownership" type="ownershipQosPolicyType" minOccurs="0"/>
             <xs:element name="destinationOrder" type="destinationOrderQosPolicyType" minOccurs="0"/>
             <xs:element name="presentation" type="presentationQosPolicyType" minOccurs="0"/>
             <xs:element name="partition" type="partitionQosPolicyType" minOccurs="0"/>
-            <xs:element name="topicData" type="topicDataQosPolicyType" minOccurs="0"/>
-            <xs:element name="groupData" type="groupDataQosPolicyType" minOccurs="0"/>
+            <xs:element name="topicData" type="octetVectorType" minOccurs="0"/>
+            <xs:element name="groupData" type="octetVectorType" minOccurs="0"/>
             <xs:element name="data_sharing" type="dataSharingQosPolicyType" minOccurs="0"/>
             <xs:element name="disablePositiveAcks" type="disablePositiveAcksQosPolicyType" minOccurs="0"/>
         </xs:all>

--- a/src/cpp/rtps/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLElementParser.cpp
@@ -3325,7 +3325,7 @@ XMLP_ret XMLParser::getXMLOctetVector(
                 }
 
                 // Add octet in vector.
-                octet_vector.push_back(o);
+                octet_vector.push_back(static_cast<octet>(o));
 
                 if (!ss.eof())
                 {

--- a/src/cpp/rtps/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLElementParser.cpp
@@ -3310,12 +3310,7 @@ XMLP_ret XMLParser::getXMLOctetVector(
             std::string text = p_aux0->GetText();
             std::istringstream ss(text);
 
-            // Detect if it is in hexadecimal
-            if (2 < text.size() && '0' == text.at(0) &&
-                    ('x' == text.at(1) || 'X' == text.at(1)))
-            {
-                ss >> std::hex;
-            }
+            ss >> std::hex;
 
             while (!ss.eof())
             {
@@ -3337,9 +3332,9 @@ XMLP_ret XMLParser::getXMLOctetVector(
                     char c = 0;
                     ss >> c;
 
-                    if (!ss || ',' != c)
+                    if (!ss || '.' != c)
                     {
-                        logError(XMLPARSER, "Expected a ',' separator on line " << p_aux0->GetLineNum());
+                        logError(XMLPARSER, "Expected a '.' separator on line " << p_aux0->GetLineNum());
                         ret_value = XMLP_ret::XML_ERROR;
                         break;
                     }

--- a/src/cpp/rtps/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLElementParser.cpp
@@ -1177,22 +1177,18 @@ XMLP_ret XMLParser::getXMLWriterQosPolicies(
                 return XMLP_ret::XML_ERROR;
             }
         }
-        else if (strcmp(name, DURABILITY_SRV) == 0 || strcmp(name, USER_DATA) == 0 ||
+        else if (strcmp(name, DURABILITY_SRV) == 0 ||
                 strcmp(name, TIME_FILTER) == 0 || strcmp(name, OWNERSHIP) == 0 ||
                 strcmp(name, OWNERSHIP_STRENGTH) == 0 || strcmp(name, DEST_ORDER) == 0 ||
-                strcmp(name, PRESENTATION) == 0 || strcmp(name, TOPIC_DATA) == 0 ||
-                strcmp(name, GROUP_DATA) == 0)
+                strcmp(name, PRESENTATION) == 0)
         {
             // TODO: Do not supported for now
             //if (nullptr != (p_aux = elem->FirstChildElement(    DURABILITY_SRV))) getXMLDurabilityServiceQos(p_aux, ident);
-            //if (nullptr != (p_aux = elem->FirstChildElement(         USER_DATA))) getXMLUserDataQos(p_aux, ident);
             //if (nullptr != (p_aux = elem->FirstChildElement(       TIME_FILTER))) getXMLTimeBasedFilterQos(p_aux, ident);
             //if (nullptr != (p_aux = elem->FirstChildElement(         OWNERSHIP))) getXMLOwnershipQos(p_aux, ident);
             //if (nullptr != (p_aux = elem->FirstChildElement(OWNERSHIP_STRENGTH))) getXMLOwnershipStrengthQos(p_aux, ident);
             //if (nullptr != (p_aux = elem->FirstChildElement(        DEST_ORDER))) getXMLDestinationOrderQos(p_aux, ident);
             //if (nullptr != (p_aux = elem->FirstChildElement(      PRESENTATION))) getXMLPresentationQos(p_aux, ident);
-            //if (nullptr != (p_aux = elem->FirstChildElement(        TOPIC_DATA))) getXMLTopicDataQos(p_aux, ident);
-            //if (nullptr != (p_aux = elem->FirstChildElement(        GROUP_DATA))) getXMLGroupDataQos(p_aux, ident);
             logError(XMLPARSER, "Quality of Service '" << p_aux0->Value() << "' do not supported for now");
         }
         else if (strcmp(name, DATA_SHARING) == 0)
@@ -1207,6 +1203,30 @@ XMLP_ret XMLParser::getXMLWriterQosPolicies(
         {
             // Disable heartbeat piggyback
             if (XMLP_ret::XML_OK != getXMLBool(p_aux0, &qos.disable_heartbeat_piggyback, ident))
+            {
+                return XMLP_ret::XML_ERROR;
+            }
+        }
+        else if (0 == strcmp(name, USER_DATA))
+        {
+            // userData
+            if (XMLP_ret::XML_OK != getXMLOctetVector(p_aux0, qos.m_userData.data_vec(), ident))
+            {
+                return XMLP_ret::XML_ERROR;
+            }
+        }
+        else if (0 == strcmp(name, TOPIC_DATA))
+        {
+            // userData
+            if (XMLP_ret::XML_OK != getXMLOctetVector(p_aux0, qos.m_topicData.data_vec(), ident))
+            {
+                return XMLP_ret::XML_ERROR;
+            }
+        }
+        else if (0 == strcmp(name, GROUP_DATA))
+        {
+            // userData
+            if (XMLP_ret::XML_OK != getXMLOctetVector(p_aux0, qos.m_groupData.data_vec(), ident))
             {
                 return XMLP_ret::XML_ERROR;
             }
@@ -1317,27 +1337,47 @@ XMLP_ret XMLParser::getXMLReaderQosPolicies(
                 return XMLP_ret::XML_ERROR;
             }
         }
-        else if (strcmp(name, DURABILITY_SRV) == 0 || strcmp(name, USER_DATA) == 0 ||
+        else if (strcmp(name, DURABILITY_SRV) == 0 ||
                 strcmp(name, TIME_FILTER) == 0 || strcmp(name, OWNERSHIP) == 0 ||
                 strcmp(name, OWNERSHIP_STRENGTH) == 0 || strcmp(name, DEST_ORDER) == 0 ||
-                strcmp(name, PRESENTATION) == 0 || strcmp(name, TOPIC_DATA) == 0 ||
-                strcmp(name, GROUP_DATA) == 0)
+                strcmp(name, PRESENTATION) == 0)
         {
             // TODO: Do not supported for now
             //if (nullptr != (p_aux = elem->FirstChildElement(    DURABILITY_SRV))) getXMLDurabilityServiceQos(p_aux, ident);
-            //if (nullptr != (p_aux = elem->FirstChildElement(         USER_DATA))) getXMLUserDataQos(p_aux, ident);
             //if (nullptr != (p_aux = elem->FirstChildElement(       TIME_FILTER))) getXMLTimeBasedFilterQos(p_aux, ident);
             //if (nullptr != (p_aux = elem->FirstChildElement(         OWNERSHIP))) getXMLOwnershipQos(p_aux, ident);
             //if (nullptr != (p_aux = elem->FirstChildElement(        DEST_ORDER))) getXMLDestinationOrderQos(p_aux, ident);
             //if (nullptr != (p_aux = elem->FirstChildElement(      PRESENTATION))) getXMLPresentationQos(p_aux, ident);
-            //if (nullptr != (p_aux = elem->FirstChildElement(        TOPIC_DATA))) getXMLTopicDataQos(p_aux, ident);
-            //if (nullptr != (p_aux = elem->FirstChildElement(        GROUP_DATA))) getXMLGroupDataQos(p_aux, ident);
             logError(XMLPARSER, "Quality of Service '" << p_aux0->Value() << "' do not supported for now");
         }
         else if (strcmp(name, DATA_SHARING) == 0)
         {
             //data sharing
             if (XMLP_ret::XML_OK != getXMLDataSharingQos(p_aux0, qos.data_sharing, ident))
+            {
+                return XMLP_ret::XML_ERROR;
+            }
+        }
+        else if (0 == strcmp(name, USER_DATA))
+        {
+            // userData
+            if (XMLP_ret::XML_OK != getXMLOctetVector(p_aux0, qos.m_userData.data_vec(), ident))
+            {
+                return XMLP_ret::XML_ERROR;
+            }
+        }
+        else if (0 == strcmp(name, TOPIC_DATA))
+        {
+            // userData
+            if (XMLP_ret::XML_OK != getXMLOctetVector(p_aux0, qos.m_topicData.data_vec(), ident))
+            {
+                return XMLP_ret::XML_ERROR;
+            }
+        }
+        else if (0 == strcmp(name, GROUP_DATA))
+        {
+            // userData
+            if (XMLP_ret::XML_OK != getXMLOctetVector(p_aux0, qos.m_groupData.data_vec(), ident))
             {
                 return XMLP_ret::XML_ERROR;
             }
@@ -3243,15 +3283,77 @@ XMLP_ret XMLParser::getXMLPropertiesPolicy(
     return XMLP_ret::XML_OK;
 }
 
-// TODO
 XMLP_ret XMLParser::getXMLOctetVector(
         tinyxml2::XMLElement* elem,
-        std::vector<octet>& /*octetVector*/,
+        std::vector<octet>& octet_vector,
         uint8_t /*ident*/)
 {
-    (void)(elem);
-    logError(XMLPARSER, "octetVector do not supported for now");
-    return XMLP_ret::XML_ERROR;
+    if (nullptr == elem)
+    {
+        logError(XMLPARSER, "preconditions error");
+        return XMLP_ret::XML_ERROR;
+    }
+
+    tinyxml2::XMLElement* p_aux0 = nullptr;
+    XMLP_ret ret_value = XMLP_ret::XML_OK;
+    size_t num_elems = 0;
+
+    for (p_aux0 = elem->FirstChildElement(); nullptr != p_aux0; p_aux0 = p_aux0->NextSiblingElement())
+    {
+        if (1 < ++num_elems)
+        {
+            logError(XMLPARSER, "More than one tag on " << p_aux0->GetLineNum());
+            ret_value = XMLP_ret::XML_ERROR;
+        }
+        if (0 == strcmp(p_aux0->Name(), VALUE))
+        {
+            std::string text = p_aux0->GetText();
+            std::istringstream ss(text);
+
+            // Detect if it is in hexadecimal
+            if (2 < text.size() && '0' == text.at(0) &&
+                    ('x' == text.at(1) || 'X' == text.at(1)))
+            {
+                ss >> std::hex;
+            }
+
+            while (!ss.eof())
+            {
+                uint16_t o = 0;
+                ss >> o;
+
+                if (!ss || std::numeric_limits<octet>::max() < o)
+                {
+                    logError(XMLPARSER, "Expected an octet value on line " << p_aux0->GetLineNum());
+                    ret_value = XMLP_ret::XML_ERROR;
+                    break;
+                }
+
+                // Add octet in vector.
+                octet_vector.push_back(o);
+
+                if (!ss.eof())
+                {
+                    char c = 0;
+                    ss >> c;
+
+                    if (!ss || ',' != c)
+                    {
+                        logError(XMLPARSER, "Expected a ',' separator on line " << p_aux0->GetLineNum());
+                        ret_value = XMLP_ret::XML_ERROR;
+                        break;
+                    }
+                }
+            }
+        }
+        else
+        {
+            logError(XMLPARSER, "Invalid tag with name of " << p_aux0->Name() << " on line " << p_aux0->GetLineNum());
+            ret_value = XMLP_ret::XML_ERROR;
+        }
+    }
+
+    return ret_value;
 }
 
 XMLP_ret XMLParser::getXMLInt(

--- a/src/cpp/rtps/xmlparser/XMLParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLParser.cpp
@@ -1831,12 +1831,11 @@ XMLP_ret XMLParser::fillDataNode(
                 return XMLP_ret::XML_ERROR;
             }
         }
-        else if (strcmp(name, USER_DATA) == 0)
+        else if (0 == strcmp(name, USER_DATA))
         {
             // userData
             if (XMLP_ret::XML_OK != getXMLOctetVector(p_aux0, participant_node.get()->rtps.userData, ident))
             {
-                // Not supported for now - returns Error
                 return XMLP_ret::XML_ERROR;
             }
         }

--- a/test/unittest/xmlparser/XMLElementParserTests.cpp
+++ b/test/unittest/xmlparser/XMLElementParserTests.cpp
@@ -127,12 +127,11 @@ TEST_F(XMLParserTests, getXMLLifespanQos)
 
 /*
  * This test checks the proper parsing of an octet vecotr xml element, and negative cases.
- * 1. Correct parsing of a valid element with decimal numbers.
- * 2. Correct parsing of a valid element with hexadecimal numbers.
- * 3. Check an bad element with a wrong separator.
+ * 1. Correct parsing of a valid element with hexadecimal numbers.
+ * 2. Check an bad element with a wrong separator.
  * 3. Check an bad element with a wrong number.
- * 3. Check an bad element with a number too high.
- * 4. Check an  empty xml definition.
+ * 4. Check an bad element with a number too high.
+ * 5. Check an  empty xml definition.
  */
 TEST_F(XMLParserTests, getXMLOctetVector)
 {
@@ -150,16 +149,8 @@ TEST_F(XMLParserTests, getXMLOctetVector)
             ";
     char xml[500];
 
-    // Valid XML with decimal numbers
-    sprintf(xml, xml_p, "1,2,3,4,5");
-    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
-    titleElement = xml_doc.RootElement();
-    EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLOctetVector_wrapper(titleElement, octet_vector, ident));
-    ASSERT_EQ(octet_vector, std::vector<octet>({1, 2, 3, 4, 5}));
-    octet_vector.clear();
-
     // Valid XML with hexadecimal numbers
-    sprintf(xml, xml_p, "0x10,0x20,0x30,0x40,0x50");
+    sprintf(xml, xml_p, "10.20.30.40.50");
     ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
     titleElement = xml_doc.RootElement();
     EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLOctetVector_wrapper(titleElement, octet_vector, ident));
@@ -181,7 +172,7 @@ TEST_F(XMLParserTests, getXMLOctetVector)
     octet_vector.clear();
 
     // Invalid XML with too high number
-    sprintf(xml, xml_p, "1,256,3");
+    sprintf(xml, xml_p, "1,1F1,3");
     ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
     titleElement = xml_doc.RootElement();
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLOctetVector_wrapper(titleElement, octet_vector, ident));

--- a/test/unittest/xmlparser/XMLElementParserTests.cpp
+++ b/test/unittest/xmlparser/XMLElementParserTests.cpp
@@ -172,7 +172,7 @@ TEST_F(XMLParserTests, getXMLOctetVector)
     octet_vector.clear();
 
     // Invalid XML with too high number
-    sprintf(xml, xml_p, "1,1F1,3");
+    sprintf(xml, xml_p, "1.1F1.3");
     ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
     titleElement = xml_doc.RootElement();
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLOctetVector_wrapper(titleElement, octet_vector, ident));

--- a/test/unittest/xmlparser/XMLElementParserTests.cpp
+++ b/test/unittest/xmlparser/XMLElementParserTests.cpp
@@ -165,7 +165,7 @@ TEST_F(XMLParserTests, getXMLOctetVector)
     octet_vector.clear();
 
     // Invalid XML with wrong number
-    sprintf(xml, xml_p, "1,h,3");
+    sprintf(xml, xml_p, "1.h.3");
     ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
     titleElement = xml_doc.RootElement();
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLOctetVector_wrapper(titleElement, octet_vector, ident));

--- a/test/unittest/xmlparser/XMLElementParserTests.cpp
+++ b/test/unittest/xmlparser/XMLElementParserTests.cpp
@@ -126,6 +126,69 @@ TEST_F(XMLParserTests, getXMLLifespanQos)
 }
 
 /*
+ * This test checks the proper parsing of an octet vecotr xml element, and negative cases.
+ * 1. Correct parsing of a valid element with decimal numbers.
+ * 2. Correct parsing of a valid element with hexadecimal numbers.
+ * 3. Check an bad element with a wrong separator.
+ * 3. Check an bad element with a wrong number.
+ * 3. Check an bad element with a number too high.
+ * 4. Check an  empty xml definition.
+ */
+TEST_F(XMLParserTests, getXMLOctetVector)
+{
+    uint8_t ident = 1;
+    std::vector<octet> octet_vector;
+    tinyxml2::XMLDocument xml_doc;
+    tinyxml2::XMLElement* titleElement;
+
+    // Parametrized XML
+    const char* xml_p =
+            "\
+            <root>\
+                <value>%s</value>\
+            </root>\
+            ";
+    char xml[500];
+
+    // Valid XML with decimal numbers
+    sprintf(xml, xml_p, "1,2,3,4,5");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLOctetVector_wrapper(titleElement, octet_vector, ident));
+    ASSERT_EQ(octet_vector, std::vector<octet>({1, 2, 3, 4, 5}));
+    octet_vector.clear();
+
+    // Valid XML with hexadecimal numbers
+    sprintf(xml, xml_p, "0x10,0x20,0x30,0x40,0x50");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLOctetVector_wrapper(titleElement, octet_vector, ident));
+    ASSERT_EQ(octet_vector, std::vector<octet>({0x10, 0x20, 0x30, 0x40, 0x50}));
+    octet_vector.clear();
+
+    // Invalid XML with wrong separator
+    sprintf(xml, xml_p, "1,2.3");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLOctetVector_wrapper(titleElement, octet_vector, ident));
+    octet_vector.clear();
+
+    // Invalid XML with wrong number
+    sprintf(xml, xml_p, "1,h,3");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLOctetVector_wrapper(titleElement, octet_vector, ident));
+    octet_vector.clear();
+
+    // Invalid XML with too high number
+    sprintf(xml, xml_p, "1,256,3");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLOctetVector_wrapper(titleElement, octet_vector, ident));
+    octet_vector.clear();
+}
+
+/*
  * This test checks the proper parsing of the <disablePositiveACKs> xml element to DisablePositiveACKsQosPolicy,
  * and negative cases.
  * 1. Correct parsing of a valid element.
@@ -1296,6 +1359,9 @@ TEST_F(XMLParserTests, getXMLInitialAnnouncementsConfig_NegativeClauses)
  * 6. Check an empty definition of <deadline> xml element.
  * 7. Check an empty definition of <disablePositiveAcks> xml element.
  * 8. Check an empty definition of <latencyBudget> xml element.
+ * 9. Check an wrong definition of <userData> xml element.
+ * 10. Check an wrong definition of <topicData> xml element.
+ * 11. Check an wrong definition of <groupData> xml element.
  * 9. Check a wrong xml element definition inside <qos>
  */
 TEST_F(XMLParserTests, getXMLWriterReaderQosPolicies)
@@ -1388,6 +1454,42 @@ TEST_F(XMLParserTests, getXMLWriterReaderQosPolicies)
     titleElement = xml_doc.RootElement();
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLReaderQosPolicies_wrapper(titleElement, rqos, ident));
 
+    // Check an wrong definition of <userData> xml element.
+    sprintf(xml, xml_p, "<userData><bad_element></bad_element></userData>");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLWriterQosPolicies_wrapper(titleElement, wqos, ident));
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLReaderQosPolicies_wrapper(titleElement, rqos, ident));
+    sprintf(xml, xml_p, "<userData><value>1</value><value>2</value></userData>");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLWriterQosPolicies_wrapper(titleElement, wqos, ident));
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLReaderQosPolicies_wrapper(titleElement, rqos, ident));
+
+    // Check an wrong definition of <topicData> xml element.
+    sprintf(xml, xml_p, "<topicData><bad_element></bad_element></topicData>");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLWriterQosPolicies_wrapper(titleElement, wqos, ident));
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLReaderQosPolicies_wrapper(titleElement, rqos, ident));
+    sprintf(xml, xml_p, "<topicData><value>1</value><value>2</value></topicData>");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLWriterQosPolicies_wrapper(titleElement, wqos, ident));
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLReaderQosPolicies_wrapper(titleElement, rqos, ident));
+
+    // Check an wrong definition of <groupData> xml element.
+    sprintf(xml, xml_p, "<groupData><bad_element></bad_element></groupData>");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLWriterQosPolicies_wrapper(titleElement, wqos, ident));
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLReaderQosPolicies_wrapper(titleElement, rqos, ident));
+    sprintf(xml, xml_p, "<groupData><value>1</value><value>2</value></groupData>");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLWriterQosPolicies_wrapper(titleElement, wqos, ident));
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLReaderQosPolicies_wrapper(titleElement, rqos, ident));
+
     // Check a wrong xml element definition inside <qos>
     sprintf(xml, xml_p, "<bad_element></bad_element>");
     ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
@@ -1399,14 +1501,11 @@ TEST_F(XMLParserTests, getXMLWriterReaderQosPolicies)
 /*
  * This test checks that there is a logError when setting up a non supported <data_writer>/<data_reader> qos
  * 1. Check that there is a logError when trying to set up the <durabilityService> Qos.
- * 2. Check that there is a logError when trying to set up the <userData> Qos.
  * 3. Check that there is a logError when trying to set up the <timeBasedFilter> Qos.
  * 4. Check that there is a logError when trying to set up the <ownership> Qos.
  * 5. Check that there is a logError when trying to set up the <ownershipStrength> Qos.
  * 6. Check that there is a logError when trying to set up the <destinationOrder> Qos.
  * 7. Check that there is a logError when trying to set up the <presentation> Qos.
- * 8. Check that there is a logError when trying to set up the <topicData> Qos.
- * 9. Check that there is a logError when trying to set up the <groupData> Qos.
  */
 TEST_F(XMLParserTests, getXMLWriterReaderUnsupportedQosPolicies)
 {
@@ -1433,13 +1532,6 @@ TEST_F(XMLParserTests, getXMLWriterReaderUnsupportedQosPolicies)
 
     // Check that there is a logError when trying to set up the <durabilityService> Qos.
     sprintf(xml, xml_p, "<durabilityService></durabilityService>");
-    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
-    titleElement = xml_doc.RootElement();
-    EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLWriterQosPolicies_wrapper(titleElement, wqos, ident));
-    EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLReaderQosPolicies_wrapper(titleElement, rqos, ident));
-
-    // Check that there is a logError when trying to set up the <userData> Qos.
-    sprintf(xml, xml_p, "<userData></userData>");
     ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
     titleElement = xml_doc.RootElement();
     EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLWriterQosPolicies_wrapper(titleElement, wqos, ident));
@@ -1480,21 +1572,7 @@ TEST_F(XMLParserTests, getXMLWriterReaderUnsupportedQosPolicies)
     EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLWriterQosPolicies_wrapper(titleElement, wqos, ident));
     EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLReaderQosPolicies_wrapper(titleElement, rqos, ident));
 
-    // Check that there is a logError when trying to set up the <topicData> Qos.
-    sprintf(xml, xml_p, "<topicData></topicData>");
-    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
-    titleElement = xml_doc.RootElement();
-    EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLWriterQosPolicies_wrapper(titleElement, wqos, ident));
-    EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLReaderQosPolicies_wrapper(titleElement, rqos, ident));
-
-    // Check that there is a logError when trying to set up the <groupData> Qos.
-    sprintf(xml, xml_p, "<groupData></groupData>");
-    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
-    titleElement = xml_doc.RootElement();
-    EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLWriterQosPolicies_wrapper(titleElement, wqos, ident));
-    EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLReaderQosPolicies_wrapper(titleElement, rqos, ident));
-
-    helper_block_for_at_least_entries(18);
+    helper_block_for_at_least_entries(12);
     auto consumed_entries = mock_consumer->ConsumedEntries();
     // Expect 18 log errors.
     uint32_t num_errors = 0;
@@ -1505,7 +1583,7 @@ TEST_F(XMLParserTests, getXMLWriterReaderUnsupportedQosPolicies)
             num_errors++;
         }
     }
-    EXPECT_EQ(num_errors, 18u);
+    EXPECT_EQ(num_errors, 12u);
 }
 
 /*
@@ -3159,41 +3237,6 @@ TEST_F(XMLParserTests, getXMLEnum_NegativeClauses)
         titleElement = xml_doc.RootElement();
         EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLEnum_wrapper(titleElement, &e, ident));
     }
-}
-
-/*
- * This function is not implemented, so this test checks fulfillment of the XMLElementParser coverage
- * 1. Check an error message is received
- */
-TEST_F(XMLParserTests, getXMLOctetVector_NegativeClauses)
-{
-    uint8_t indent = 1;
-    std::vector<octet> v;
-    tinyxml2::XMLDocument xml_doc;
-    tinyxml2::XMLElement* titleElement;
-    const char* xml = "</void>";
-
-    mock_consumer = new MockConsumer();
-
-    Log::RegisterConsumer(std::unique_ptr<LogConsumer>(mock_consumer));
-    Log::SetCategoryFilter(std::regex("(XMLPARSER)"));
-
-    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
-    titleElement = xml_doc.RootElement();
-    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLOctetVector_wrapper(titleElement, v, indent));
-
-    helper_block_for_at_least_entries(1);
-    auto consumed_entries = mock_consumer->ConsumedEntries();
-    // Expect 1 log error.
-    uint32_t num_errors = 0;
-    for (const auto& entry : consumed_entries)
-    {
-        if (entry.kind == Log::Kind::Error)
-        {
-            num_errors++;
-        }
-    }
-    EXPECT_EQ(num_errors, 1u);
 }
 
 /*

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -415,7 +415,7 @@ TEST_F(XMLParserTests, Data)
     EXPECT_EQ(rtps_atts.throughputController.periodMillisecs, 45u);
     EXPECT_EQ(rtps_atts.useBuiltinTransports, true);
     EXPECT_EQ(std::string(rtps_atts.getName()), "test_name");
-    EXPECT_EQ(rtps_atts.userData, std::vector<octet>({0x56, 0x30, 0x0, 0x1}));
+    EXPECT_EQ(rtps_atts.userData, std::vector<octet>({0x56, 0x30, 0x0, 0xce}));
 }
 
 TEST_F(XMLParserTests, DataBuffer)
@@ -509,7 +509,7 @@ TEST_F(XMLParserTests, DataBuffer)
     EXPECT_EQ(rtps_atts.throughputController.periodMillisecs, 45u);
     EXPECT_EQ(rtps_atts.useBuiltinTransports, true);
     EXPECT_EQ(std::string(rtps_atts.getName()), "test_name");
-    EXPECT_EQ(rtps_atts.userData, std::vector<octet>({0x56, 0x30, 0x0, 0x1}));
+    EXPECT_EQ(rtps_atts.userData, std::vector<octet>({0x56, 0x30, 0x0, 0xce}));
 }
 
 /*

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -415,6 +415,7 @@ TEST_F(XMLParserTests, Data)
     EXPECT_EQ(rtps_atts.throughputController.periodMillisecs, 45u);
     EXPECT_EQ(rtps_atts.useBuiltinTransports, true);
     EXPECT_EQ(std::string(rtps_atts.getName()), "test_name");
+    EXPECT_EQ(rtps_atts.userData, std::vector<octet>({0x56, 0x30, 0x0, 0x1}));
 }
 
 TEST_F(XMLParserTests, DataBuffer)
@@ -508,6 +509,7 @@ TEST_F(XMLParserTests, DataBuffer)
     EXPECT_EQ(rtps_atts.throughputController.periodMillisecs, 45u);
     EXPECT_EQ(rtps_atts.useBuiltinTransports, true);
     EXPECT_EQ(std::string(rtps_atts.getName()), "test_name");
+    EXPECT_EQ(rtps_atts.userData, std::vector<octet>({0x56, 0x30, 0x0, 0x1}));
 }
 
 /*
@@ -1374,6 +1376,7 @@ TEST_F(XMLParserTests, fillDataNodeParticipantNegativeClauses)
             "<userTransports><bad_element></bad_element></userTransports>",
             "<useBuiltinTransports><bad_element></bad_element></useBuiltinTransports>",
             "<propertiesPolicy><bad_element></bad_element></propertiesPolicy>",
+            "<userData><bad_element></bad_element></userData>",
             "<allocation><bad_element></bad_element></allocation>",
             "<bad_element></bad_element>"
         };
@@ -1388,54 +1391,6 @@ TEST_F(XMLParserTests, fillDataNodeParticipantNegativeClauses)
 
         }
     }
-
-}
-
-/*
- * This test checks the return of the unsupported cases of the fillDataNode given a ParticipantAttributes DataNode
- * 1. Check passing a a UserData parameter.
- * 2. Check that it outputs a Log Error when reading an unsupported element.
- */
-TEST_F(XMLParserTests, fillDataNodeParticipantUnsupported)
-{
-    tinyxml2::XMLDocument xml_doc;
-    tinyxml2::XMLElement* titleElement;
-
-    up_participant_t participant_atts{new ParticipantAttributes};
-    up_node_participant_t participant_node{new node_participant_t{NodeType::PARTICIPANT, std::move(participant_atts)}};
-
-    mock_consumer = new eprosima::fastdds::dds::MockConsumer();
-    Log::RegisterConsumer(std::unique_ptr<LogConsumer>(mock_consumer));
-    Log::SetCategoryFilter(std::regex("(XMLPARSER)"));
-
-    // Unsupported fields
-    const char* xml =
-            "\
-            <participant profile_name=\"domainparticipant_profile_name\">\
-                <rtps>\
-                    <userData>data</userData>\
-                </rtps>\
-            </participant>\
-            ";
-
-    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
-    titleElement = xml_doc.RootElement();
-    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(titleElement, *participant_node));
-
-    helper_block_for_at_least_entries(1);
-    auto consumed_entries = mock_consumer->ConsumedEntries();
-    // Expect 1 log error.
-    uint32_t num_errors = 0;
-    for (const auto& entry : consumed_entries)
-    {
-        if (entry.kind == Log::Kind::Error)
-        {
-            num_errors++;
-        }
-    }
-
-    EXPECT_EQ(num_errors, 1u);
-
 }
 
 /*

--- a/test/unittest/xmlparser/test_xml_profiles.xml
+++ b/test/unittest/xmlparser/test_xml_profiles.xml
@@ -135,7 +135,7 @@
                 <useBuiltinTransports>true</useBuiltinTransports>
                 <name>test_name</name>
                 <userData>
-                    <value>0x56,0x30,0x0,0x1</value>
+                    <value>56.30.0.CE</value>
                 </userData>
             </rtps>
         </participant>
@@ -188,13 +188,13 @@
                     <kind>ASYNCHRONOUS</kind>
                 </publishMode>
                 <userData>
-                    <value>56,30,0,1</value>
+                    <value>56.30.0.1</value>
                 </userData>
                 <topicData>
-                    <value>5,3,1,0</value>
+                    <value>5.3.1.0</value>
                 </topicData>
                 <groupData>
-                    <value>5,3,1,0,254</value>
+                    <value>5.3.1.0.F1</value>
                 </groupData>
             </qos>
             <times>
@@ -305,13 +305,13 @@
                     </names>
                 </partition>
                 <userData>
-                    <value>56,30,0,1</value>
+                    <value>56.30.0.1</value>
                 </userData>
                 <topicData>
-                    <value>5,3,1,0</value>
+                    <value>5.3.1.0</value>
                 </topicData>
                 <groupData>
-                    <value>5,3,1,0,254</value>
+                    <value>5.3.1.0.F1</value>
                 </groupData>
             </qos>
             <times>

--- a/test/unittest/xmlparser/test_xml_profiles.xml
+++ b/test/unittest/xmlparser/test_xml_profiles.xml
@@ -134,6 +134,9 @@
                 </throughputController>
                 <useBuiltinTransports>true</useBuiltinTransports>
                 <name>test_name</name>
+                <userData>
+                    <value>0x56,0x30,0x0,0x1</value>
+                </userData>
             </rtps>
         </participant>
 
@@ -184,6 +187,15 @@
                 <publishMode>
                     <kind>ASYNCHRONOUS</kind>
                 </publishMode>
+                <userData>
+                    <value>56,30,0,1</value>
+                </userData>
+                <topicData>
+                    <value>5,3,1,0</value>
+                </topicData>
+                <groupData>
+                    <value>5,3,1,0,254</value>
+                </groupData>
             </qos>
             <times>
                 <initialHeartbeatDelay>
@@ -292,6 +304,15 @@
                         <name>partition_name_f</name>
                     </names>
                 </partition>
+                <userData>
+                    <value>56,30,0,1</value>
+                </userData>
+                <topicData>
+                    <value>5,3,1,0</value>
+                </topicData>
+                <groupData>
+                    <value>5,3,1,0,254</value>
+                </groupData>
             </qos>
             <times>
                 <initialAcknackDelay>


### PR DESCRIPTION
## Description
Add support of parsing octet vector with XML parser, as `user_data`, `topic_data` and `group_data`.

## Contributor Checklist
- [x] Commit messages follow the project guidelines.
- [x] The code follows the style guidelines of this project.
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [x] *N/A* New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
