### PR TITLE
[14018] Support lowercase keywords on SQL filter

### DIFF
--- a/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterGrammar.hpp
+++ b/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterGrammar.hpp
@@ -48,8 +48,8 @@ struct string_content : star< not_one< '\'', '\r', '\n'> > {};
 struct string_value : seq< open_quote, string_content, close_quote > {};
 
 // BOOLEANVALUE
-struct false_value : pad< TAO_PEGTL_KEYWORD("FALSE"), space > {};
-struct true_value : pad< TAO_PEGTL_KEYWORD("TRUE"), space > {};
+struct false_value : pad< sor< TAO_PEGTL_KEYWORD("FALSE"), TAO_PEGTL_KEYWORD("false") >, space > {};
+struct true_value : pad< sor< TAO_PEGTL_KEYWORD("TRUE"), TAO_PEGTL_KEYWORD("true") >, space > {};
 struct boolean_value : sor<false_value, true_value> {};
 
 // INTEGERVALUE, FLOATVALUE
@@ -62,11 +62,11 @@ struct float_value : seq < opt< sign >, integer, sor < exponent, seq< fractional
 struct parameter_value : seq< one< '%' >, digit, opt< digit > > {};
 
 // Keyword based operators
-struct and_op : pad< TAO_PEGTL_KEYWORD("AND"), space > {};
-struct or_op : pad< TAO_PEGTL_KEYWORD("OR"), space> {};
-struct not_op : pad< TAO_PEGTL_KEYWORD("NOT"), space> {};
-struct between_op : pad< TAO_PEGTL_KEYWORD("BETWEEN"), space> {};
-struct not_between_op : pad< TAO_PEGTL_KEYWORD("NOT BETWEEN"), space> {};
+struct and_op : pad< sor< TAO_PEGTL_KEYWORD("AND"), TAO_PEGTL_KEYWORD("and") >, space > {};
+struct or_op : pad< sor< TAO_PEGTL_KEYWORD("OR"), TAO_PEGTL_KEYWORD("or") >, space> {};
+struct not_op : pad< sor< TAO_PEGTL_KEYWORD("NOT"), TAO_PEGTL_KEYWORD("not") >, space> {};
+struct between_op : pad< sor< TAO_PEGTL_KEYWORD("BETWEEN"), TAO_PEGTL_KEYWORD("between") >, space> {};
+struct not_between_op : pad< sor< TAO_PEGTL_KEYWORD("NOT BETWEEN"), TAO_PEGTL_KEYWORD("not between") >, space> {};
 
 // RelOp
 struct eq_op : pad< one<'='>, space> {};


### PR DESCRIPTION
## Description
This PR improves DDSSQLFilter by including lowercase `and`, `or`, `not`, `between`, `not between`, `true`, and `false`.

Apart from updating the unit tests to include checks for the lowercase keywords, t has an improvement on `test_compound_or` to check for 'not between' operator, for which no test was present.

@mergifyio backport 2.5.x

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [X] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [X] *N/A* New feature has been added to the `versions.md` file (if applicable).
- [X] *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->

## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
