### PR TITLE
Cleanup on several APIs [14031]

### DIFF
--- a/include/fastdds/dds/core/status/IncompatibleQosStatus.hpp
+++ b/include/fastdds/dds/core/status/IncompatibleQosStatus.hpp
@@ -34,6 +34,9 @@ namespace dds {
 struct QosPolicyCount
 {
     //!Constructor
+    QosPolicyCount() = default;
+
+    //!Constructor
     QosPolicyCount(
             QosPolicyId_t id,
             int32_t c)

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -187,7 +187,16 @@ public:
     RTPS_DllAPI ReturnCode_t write_w_timestamp(
             void* data,
             const InstanceHandle_t& handle,
+            const fastrtps::Time_t& timestamp);
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+    FASTDDS_DEPRECATED_UNTIL(3, "eprosima::fastdds::dds:DataWriter::write_w_timestamp()",
+            "In favor of version using eprosima::fastrtps::Time_t.")
+    RTPS_DllAPI ReturnCode_t write_w_timestamp(
+            void* data,
+            const InstanceHandle_t& handle,
             const fastrtps::rtps::Time_t& timestamp);
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
     /*!
      * @brief Informs that the application will be modifying a particular instance.
@@ -223,7 +232,15 @@ public:
      */
     RTPS_DllAPI InstanceHandle_t register_instance_w_timestamp(
             void* instance,
+            const fastrtps::Time_t& timestamp);
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+    FASTDDS_DEPRECATED_UNTIL(3, "eprosima::fastdds::dds:DataWriter::register_instance_w_timestamp()",
+            "In favor of version using eprosima::fastrtps::Time_t.")
+    RTPS_DllAPI InstanceHandle_t register_instance_w_timestamp(
+            void* instance,
             const fastrtps::rtps::Time_t& timestamp);
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
     /*!
      * @brief This operation reverses the action of `register_instance`.
@@ -264,7 +281,16 @@ public:
     RTPS_DllAPI ReturnCode_t unregister_instance_w_timestamp(
             void* instance,
             const InstanceHandle_t& handle,
+            const fastrtps::Time_t& timestamp);
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+    FASTDDS_DEPRECATED_UNTIL(3, "eprosima::fastdds::dds:DataWriter::unregister_instance_w_timestamp()",
+            "In favor of version using eprosima::fastrtps::Time_t.")
+    RTPS_DllAPI ReturnCode_t unregister_instance_w_timestamp(
+            void* instance,
+            const InstanceHandle_t& handle,
             const fastrtps::rtps::Time_t& timestamp);
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
     /**
      * NOT YET IMPLEMENTED

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -483,13 +483,15 @@ public:
      * This operation may return RETCODE_TIMEOUT and RETCODE_OUT_OF_RESOURCES under the same circumstances described
      * for the @ref write operation.
      *
-     * @param data Pointer to the data.
-     * @param handle InstanceHandle_t
+     * @param instance  Sample used to deduce instance's key in case of `handle` parameter is HANDLE_NIL.
+     * @param handle Instance's key to be disposed.
+     * @param timestamp Time_t used to set the source_timestamp.
      * @return RTPS_DllAPI
      */
     RTPS_DllAPI ReturnCode_t dispose_w_timestamp(
-            void* data,
-            const InstanceHandle_t& handle);
+            void* instance,
+            const InstanceHandle_t& handle,
+            const fastrtps::Time_t& timestamp);
     /**
      * @brief Returns the liveliness lost status
      *

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -532,7 +532,7 @@ public:
      */
     RTPS_DllAPI ReturnCode_t get_matched_subscription_data(
             builtin::SubscriptionBuiltinTopicData& subscription_data,
-            const fastrtps::rtps::InstanceHandle_t& subscription_handle) const;
+            const InstanceHandle_t& subscription_handle) const;
 
     /**
      * @brief Fills the given vector with the InstanceHandle_t of matched DataReaders
@@ -541,7 +541,14 @@ public:
      * @return RETCODE_OK
      */
     RTPS_DllAPI ReturnCode_t get_matched_subscriptions(
-            std::vector<fastrtps::rtps::InstanceHandle_t*>& subscription_handles) const;
+            std::vector<InstanceHandle_t>& subscription_handles) const;
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+    FASTDDS_DEPRECATED_UNTIL(3, "eprosima::fastdds::dds:DataWriter::get_matched_subscriptions()",
+            "In favor of version using std::vector<fastrtps::rtps::InstanceHandle_t>.")
+    RTPS_DllAPI ReturnCode_t get_matched_subscriptions(
+            std::vector<InstanceHandle_t*>& subscription_handles) const;
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
     /**
      * @brief Clears the DataWriter history

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -972,7 +972,7 @@ public:
      * @return RETCODE_OK
      */
     RTPS_DllAPI ReturnCode_t get_matched_publications(
-            std::vector<fastrtps::rtps::InstanceHandle_t>& publication_handles) const;
+            std::vector<InstanceHandle_t>& publication_handles) const;
 
     /**
      * @brief This operation creates a ReadCondition. The returned ReadCondition will be attached and belong to the

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -130,6 +130,8 @@ public:
             const fastrtps::Duration_t& timeout);
 
     /**
+     * NOT YET IMPLEMENTED
+     *
      * @brief Method to block the current thread until an unread message is available.
      *
      * @param[in] max_wait Max blocking time for this operation.

--- a/src/cpp/fastdds/publisher/DataWriter.cpp
+++ b/src/cpp/fastdds/publisher/DataWriter.cpp
@@ -314,7 +314,7 @@ ReturnCode_t DataWriter::assert_liveliness()
 
 ReturnCode_t DataWriter::get_matched_subscription_data(
         builtin::SubscriptionBuiltinTopicData& subscription_data,
-        const fastrtps::rtps::InstanceHandle_t& subscription_handle) const
+        const InstanceHandle_t& subscription_handle) const
 {
     static_cast<void> (subscription_data);
     static_cast<void> (subscription_handle);
@@ -325,7 +325,17 @@ ReturnCode_t DataWriter::get_matched_subscription_data(
 }
 
 ReturnCode_t DataWriter::get_matched_subscriptions(
-        std::vector<fastrtps::rtps::InstanceHandle_t*>& subscription_handles) const
+        std::vector<InstanceHandle_t>& subscription_handles) const
+{
+    static_cast<void> (subscription_handles);
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+    /*
+       return impl_->get_matched_subscription_data(subscription_handles);
+     */
+}
+
+ReturnCode_t DataWriter::get_matched_subscriptions(
+        std::vector<InstanceHandle_t*>& subscription_handles) const
 {
     static_cast<void> (subscription_handles);
     return ReturnCode_t::RETCODE_UNSUPPORTED;

--- a/src/cpp/fastdds/publisher/DataWriter.cpp
+++ b/src/cpp/fastdds/publisher/DataWriter.cpp
@@ -101,6 +101,17 @@ ReturnCode_t DataWriter::write(
 ReturnCode_t DataWriter::write_w_timestamp(
         void* data,
         const InstanceHandle_t& handle,
+        const fastrtps::Time_t& timestamp)
+{
+    static_cast<void> (data);
+    static_cast<void> (handle);
+    static_cast<void> (timestamp);
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
+ReturnCode_t DataWriter::write_w_timestamp(
+        void* data,
+        const InstanceHandle_t& handle,
         const fastrtps::rtps::Time_t& timestamp)
 {
     static_cast<void> (data);
@@ -113,6 +124,16 @@ InstanceHandle_t DataWriter::register_instance(
         void* instance)
 {
     return impl_->register_instance(instance);
+}
+
+InstanceHandle_t DataWriter::register_instance_w_timestamp(
+        void* instance,
+        const fastrtps::Time_t& timestamp)
+{
+    static_cast<void> (instance);
+    static_cast<void> (timestamp);
+    logWarning(DATA_WRITER, "register_instance_w_timestamp method not yet implemented")
+    return HANDLE_NIL;
 }
 
 InstanceHandle_t DataWriter::register_instance_w_timestamp(
@@ -130,6 +151,17 @@ ReturnCode_t DataWriter::unregister_instance(
         const InstanceHandle_t& handle)
 {
     return impl_->unregister_instance(instance, handle);
+}
+
+ReturnCode_t DataWriter::unregister_instance_w_timestamp(
+        void* instance,
+        const InstanceHandle_t& handle,
+        const fastrtps::Time_t& timestamp)
+{
+    static_cast<void> (instance);
+    static_cast<void> (handle);
+    static_cast<void> (timestamp);
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
 }
 
 ReturnCode_t DataWriter::unregister_instance_w_timestamp(

--- a/src/cpp/fastdds/publisher/DataWriter.cpp
+++ b/src/cpp/fastdds/publisher/DataWriter.cpp
@@ -199,6 +199,17 @@ ReturnCode_t DataWriter::dispose(
     return impl_->unregister_instance(data, handle, true);
 }
 
+ReturnCode_t DataWriter::dispose_w_timestamp(
+        void* instance,
+        const InstanceHandle_t& handle,
+        const fastrtps::Time_t& timestamp)
+{
+    static_cast<void> (instance);
+    static_cast<void> (handle);
+    static_cast<void> (timestamp);
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
 const fastrtps::rtps::GUID_t& DataWriter::guid() const
 {
     return impl_->guid();

--- a/src/cpp/fastdds/subscriber/DataReader.cpp
+++ b/src/cpp/fastdds/subscriber/DataReader.cpp
@@ -375,7 +375,7 @@ ReturnCode_t DataReader::get_matched_publication_data(
 }
 
 ReturnCode_t DataReader::get_matched_publications(
-        std::vector<fastrtps::rtps::InstanceHandle_t>& publication_handles) const
+        std::vector<InstanceHandle_t>& publication_handles) const
 {
     static_cast<void> (publication_handles);
     return ReturnCode_t::RETCODE_UNSUPPORTED;

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -1343,14 +1343,14 @@ TEST_F(DataWriterUnsupportedTests, UnsupportedDataWriterMethods)
 
     {
         InstanceHandle_t handle;
-        fastrtps::rtps::Time_t timestamp;
+        fastrtps::Time_t timestamp;
         EXPECT_EQ(
             ReturnCode_t::RETCODE_UNSUPPORTED,
             data_writer->write_w_timestamp(nullptr /* data */, handle, timestamp));
     }
 
     {
-        fastrtps::rtps::Time_t timestamp;
+        fastrtps::Time_t timestamp;
         EXPECT_EQ(
             HANDLE_NIL,
             data_writer->register_instance_w_timestamp(nullptr /* instance */, timestamp));
@@ -1358,14 +1358,14 @@ TEST_F(DataWriterUnsupportedTests, UnsupportedDataWriterMethods)
 
     {
         InstanceHandle_t handle;
-        fastrtps::rtps::Time_t timestamp;
+        fastrtps::Time_t timestamp;
         EXPECT_EQ(
             ReturnCode_t::RETCODE_UNSUPPORTED,
             data_writer->unregister_instance_w_timestamp(nullptr /* instance */, handle, timestamp));
     }
 
 
-    std::vector<fastrtps::rtps::InstanceHandle_t*> subscription_handles;
+    std::vector<InstanceHandle_t> subscription_handles;
     EXPECT_EQ(ReturnCode_t::RETCODE_UNSUPPORTED, data_writer->get_matched_subscriptions(subscription_handles));
 
     fastrtps::rtps::InstanceHandle_t key_handle;

--- a/versions.md
+++ b/versions.md
@@ -1,12 +1,15 @@
 Version 2.6.0
 -------------
 
-* New TransportInterface and NetworkFactory API to allow updating the network interfaces at runtime (ABI breaks on RPTS
+* New TransportInterface and NetworkFactory API to allow updating the network interfaces at runtime (ABI breaks on RTPS
   and transport layers)
 * Removed dll export for constructors and destructors of factory created entities (breaks ABI)
 * Allow modifying the remote server locator in runtime.
 * Add physical information in DATA[p] using properties
 * Extension of `DISCOVERY_TOPIC` to include physical information about the discovered entity (ABI break)
+* Added methods getting `fastrtps::Time_t` as parameters instead of `fastrtps::rtps::Time_t`.
+* Changed signature of eprosima::fastdds::dds::DataWriter::dispose_w_timestamp. (ABI break).
+* Added method getting `std::vector<InstanceHandle_t>&` instead of `std::vector<InstanceHandle_t*>&`.
 
 Version 2.5.0
 -------------

--- a/versions.md
+++ b/versions.md
@@ -7,9 +7,11 @@ Version 2.6.0
 * Allow modifying the remote server locator in runtime.
 * Add physical information in DATA[p] using properties
 * Extension of `DISCOVERY_TOPIC` to include physical information about the discovered entity (ABI break)
-* Added methods getting `fastrtps::Time_t` as parameters instead of `fastrtps::rtps::Time_t`.
-* Changed signature of eprosima::fastdds::dds::DataWriter::dispose_w_timestamp. (ABI break).
-* Added method getting `std::vector<InstanceHandle_t>&` instead of `std::vector<InstanceHandle_t*>&`.
+* Added methods getting `fastrtps::Time_t` as parameters instead of `fastrtps::rtps::Time_t` (API extension, API
+  deprecations).
+* Changed signature of eprosima::fastdds::dds::DataWriter::dispose_w_timestamp (ABI break).
+* Added method getting `std::vector<InstanceHandle_t>&` instead of `std::vector<InstanceHandle_t*>&` (API extension, API
+  deprecations).
 
 Version 2.5.0
 -------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
DataWriter API should use `fastrtps::Time_t` instead of `fastrtps::rtps::Time_t`.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [ ] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] *N/A* Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
