### PR TITLE
[14139] Fix partition validation checks on EDP

### DIFF
--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
@@ -63,6 +63,12 @@ namespace rtps {
 using reader_map_helper = utilities::collections::map_size_helper<GUID_t, SubscriptionMatchedStatus>;
 using writer_map_helper = utilities::collections::map_size_helper<GUID_t, PublicationMatchedStatus>;
 
+static bool is_partition_empty(
+        const fastdds::dds::Partition_t& partition)
+{
+    return partition.size() <= 1 && 0 == strlen(partition.name());
+}
+
 EDP::EDP(
         PDP* p,
         RTPSParticipantImpl* part)
@@ -721,7 +727,7 @@ bool EDP::valid_matching(
         for (auto rnameit = rdata->m_qos.m_partition.begin();
                 rnameit != rdata->m_qos.m_partition.end(); ++rnameit)
         {
-            if (rnameit->size() == 0)
+            if (is_partition_empty(*rnameit))
             {
                 matched = true;
                 break;
@@ -733,7 +739,7 @@ bool EDP::valid_matching(
         for (auto wnameit = wdata->m_qos.m_partition.begin();
                 wnameit !=  wdata->m_qos.m_partition.end(); ++wnameit)
         {
-            if (wnameit->size() == 0)
+            if (is_partition_empty(*wnameit))
             {
                 matched = true;
                 break;
@@ -947,7 +953,7 @@ bool EDP::valid_matching(
         for (auto rnameit = wdata->m_qos.m_partition.begin();
                 rnameit != wdata->m_qos.m_partition.end(); ++rnameit)
         {
-            if (rnameit->size() == 0)
+            if (is_partition_empty(*rnameit))
             {
                 matched = true;
                 break;
@@ -959,7 +965,7 @@ bool EDP::valid_matching(
         for (auto wnameit = rdata->m_qos.m_partition.begin();
                 wnameit !=  rdata->m_qos.m_partition.end(); ++wnameit)
         {
-            if (wnameit->size() == 0)
+            if (is_partition_empty(*wnameit))
             {
                 matched = true;
                 break;

--- a/test/unittest/rtps/discovery/EdpTests.cpp
+++ b/test/unittest/rtps/discovery/EdpTests.cpp
@@ -251,6 +251,16 @@ TEST_F(EdpTests, CheckPartitionCompatibility)
     rdata->m_qos.m_partition.clear();
     rdata->m_qos.m_partition.push_back("Partition");
     check_expectations(true);
+
+    // Matching empty list against empty partition
+    wdata->m_qos.m_partition.clear();
+    rdata->m_qos.m_partition.clear();
+    rdata->m_qos.m_partition.push_back("");
+    check_expectations(true);
+    wdata->m_qos.m_partition.clear();
+    wdata->m_qos.m_partition.push_back("");
+    rdata->m_qos.m_partition.clear();
+    check_expectations(true);
 }
 
 TEST_F(EdpTests, CheckDurabilityCompatibility)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
It was discovered that an endpoint with an empty partition list was not correctly matching with an endpoint having an empty string on its partition list.

This PR adds a test for that case and fixes the issue.
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
@Mergifyio backport 2.5.x 2.4.x 2.3.x 2.1.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] *N/A* Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [x] *N/A* New feature has been added to the `versions.md` file (if applicable).
- [x] *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->

## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
