### PR TITLE
Fix publishing on physical data topic [14124]

### DIFF
--- a/include/fastdds/rtps/builtin/discovery/participant/PDP.h
+++ b/include/fastdds/rtps/builtin/discovery/participant/PDP.h
@@ -105,13 +105,6 @@ public:
      */
     bool enable();
 
-    /**
-     * @brief Check whether this PDP is enabled
-     *
-     * @return true if already enabled; false otherwise
-     */
-    bool is_enabled();
-
     virtual bool init(
             RTPSParticipantImpl* part) = 0;
 
@@ -415,7 +408,7 @@ protected:
     //!To protect callbacks (ParticipantProxyData&)
     std::mutex callback_mtx_;
     //!Tell if object is enabled
-    std::atomic<bool> enabled_ = {false};
+    std::atomic<bool> enabled_ {false};
 
     /**
      * Adds an entry to the collection of participant proxy information.

--- a/include/fastdds/rtps/builtin/discovery/participant/PDP.h
+++ b/include/fastdds/rtps/builtin/discovery/participant/PDP.h
@@ -21,6 +21,7 @@
 #define _FASTDDS_RTPS_PDP_H_
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
+#include <atomic>
 #include <mutex>
 #include <functional>
 
@@ -97,7 +98,19 @@ public:
     bool initPDP(
             RTPSParticipantImpl* part);
 
+    /**
+     * @brief Enable the Participant Discovery Protocol
+     *
+     * @return true if enabled correctly, or if already enabled; false otherwise
+     */
     bool enable();
+
+    /**
+     * @brief Check whether this PDP is enabled
+     *
+     * @return true if already enabled; false otherwise
+     */
+    bool is_enabled();
 
     virtual bool init(
             RTPSParticipantImpl* part) = 0;
@@ -402,7 +415,7 @@ protected:
     //!To protect callbacks (ParticipantProxyData&)
     std::mutex callback_mtx_;
     //!Tell if object is enabled
-    bool enable_ = false;
+    std::atomic<bool> enabled_ = {false};
 
     /**
      * Adds an entry to the collection of participant proxy information.

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -308,7 +308,10 @@ void BuiltinProtocols::stopRTPSParticipantAnnouncement()
 
     if (mp_PDP)
     {
-        mp_PDP->stopParticipantAnnouncement();
+        if (mp_PDP->is_enabled())
+        {
+            mp_PDP->stopParticipantAnnouncement();
+        }
     }
     else
     {

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -308,10 +308,7 @@ void BuiltinProtocols::stopRTPSParticipantAnnouncement()
 
     if (mp_PDP)
     {
-        if (mp_PDP->is_enabled())
-        {
-            mp_PDP->stopParticipantAnnouncement();
-        }
+        mp_PDP->stopParticipantAnnouncement();
     }
     else
     {

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -408,6 +408,12 @@ bool PDP::initPDP(
 
 bool PDP::enable()
 {
+    // It is safe to call enable() on already enable PDPs
+    if (enabled_)
+    {
+        return true;
+    }
+
     // Create lease events on already created proxy data objects
     for (ParticipantProxyData* pool_item : participant_proxies_pool_)
     {
@@ -430,7 +436,7 @@ bool PDP::enable()
 
     set_initial_announcement_interval();
 
-    enable_  = true;
+    enabled_.store(true);
     // Notify "self-discovery"
     getRTPSParticipant()->on_entity_discovery(mp_RTPSParticipant->getGuid(),
             get_participant_proxy_data(mp_RTPSParticipant->getGuid().guidPrefix)->m_properties);
@@ -438,12 +444,17 @@ bool PDP::enable()
     return mp_RTPSParticipant->enableReader(mp_PDPReader);
 }
 
+bool PDP::is_enabled()
+{
+    return enabled_.load();
+}
+
 void PDP::announceParticipantState(
         bool new_change,
         bool dispose,
         WriteParams& wparams)
 {
-    if (enable_)
+    if (enabled_)
     {
         // logInfo(RTPS_PDP, "Announcing RTPSParticipant State (new change: " << new_change << ")");
         CacheChange_t* change = nullptr;

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -549,7 +549,7 @@ void PDP::announceParticipantState(
 
 void PDP::stopParticipantAnnouncement()
 {
-    if (enabled_)
+    if (resend_participant_info_event_)
     {
         resend_participant_info_event_->cancel_timer();
     }
@@ -557,7 +557,10 @@ void PDP::stopParticipantAnnouncement()
 
 void PDP::resetParticipantAnnouncement()
 {
-    resend_participant_info_event_->restart_timer();
+    if (resend_participant_info_event_)
+    {
+        resend_participant_info_event_->restart_timer();
+    }
 }
 
 bool PDP::has_reader_proxy_data(

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -444,11 +444,6 @@ bool PDP::enable()
     return mp_RTPSParticipant->enableReader(mp_PDPReader);
 }
 
-bool PDP::is_enabled()
-{
-    return enabled_.load();
-}
-
 void PDP::announceParticipantState(
         bool new_change,
         bool dispose,
@@ -554,7 +549,10 @@ void PDP::announceParticipantState(
 
 void PDP::stopParticipantAnnouncement()
 {
-    resend_participant_info_event_->cancel_timer();
+    if (enabled_)
+    {
+        resend_participant_info_event_->cancel_timer();
+    }
 }
 
 void PDP::resetParticipantAnnouncement()

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -410,7 +410,7 @@ void PDPClient::announceParticipantState(
         bool dispose,
         WriteParams& )
 {
-    if (enable_)
+    if (enabled_)
     {
         /*
            Protect writer sequence number. Make sure in order to prevent AB BA deadlock that the

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -538,7 +538,7 @@ void PDPServer::announceParticipantState(
         bool dispose /* = false */,
         WriteParams& )
 {
-    if (enable_)
+    if (enabled_)
     {
         logInfo(RTPS_PDP_SERVER,
                 "Announcing Server " << mp_RTPSParticipant->getGuid() << " (new change: " << new_change << ")");

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -210,7 +210,7 @@ void PDPSimple::announceParticipantState(
         bool dispose,
         WriteParams& wp)
 {
-    if (enable_)
+    if (enabled_)
     {
         PDP::announceParticipantState(new_change, dispose, wp);
 

--- a/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.cpp
@@ -203,11 +203,11 @@ ReturnCode_t DomainParticipantImpl::disable_statistics_datawriter(
 ReturnCode_t DomainParticipantImpl::enable()
 {
     ReturnCode_t ret = efd::DomainParticipantImpl::enable();
-    create_statistics_builtin_entities();
 
     if (ReturnCode_t::RETCODE_OK == ret)
     {
         rtps_participant_->add_statistics_listener(statistics_listener_, participant_statistics_mask);
+        create_statistics_builtin_entities();
     }
 
     return ret;

--- a/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.cpp
@@ -202,8 +202,8 @@ ReturnCode_t DomainParticipantImpl::disable_statistics_datawriter(
 
 ReturnCode_t DomainParticipantImpl::enable()
 {
-    create_statistics_builtin_entities();
     ReturnCode_t ret = efd::DomainParticipantImpl::enable();
+    create_statistics_builtin_entities();
 
     if (ReturnCode_t::RETCODE_OK == ret)
     {

--- a/src/cpp/statistics/rtps/StatisticsBase.cpp
+++ b/src/cpp/statistics/rtps/StatisticsBase.cpp
@@ -492,7 +492,7 @@ void StatisticsParticipantImpl::on_entity_discovery(
      *
      */
     auto get_physical_property_value =
-            [](const dds::ParameterPropertyList_t& properties, const std::string& property_name)
+            [](const dds::ParameterPropertyList_t& properties, const std::string& property_name) -> std::string
             {
                 auto property = std::find_if(
                     properties.begin(),

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -1,0 +1,114 @@
+// Copyright 2022 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <fastdds/dds/domain/DomainParticipant.hpp>
+#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
+#include <fastdds/dds/domain/qos/DomainParticipantFactoryQos.hpp>
+#include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
+#include <fastdds/dds/publisher/DataWriter.hpp>
+#include <fastdds/dds/publisher/Publisher.hpp>
+#include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
+#include <fastdds/dds/publisher/qos/PublisherQos.hpp>
+#include <fastdds/dds/subscriber/DataReader.hpp>
+#include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
+#include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
+#include <fastdds/dds/subscriber/Subscriber.hpp>
+#include <fastdds/dds/topic/qos/TopicQos.hpp>
+#include <fastdds/dds/topic/Topic.hpp>
+#include <fastdds/dds/topic/TypeSupport.hpp>
+#include <fastrtps/types/TypesBase.h>
+
+#include "BlackboxTests.hpp"
+#include "../types/HelloWorldPubSubTypes.h"
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+
+using ReturnCode_t = eprosima::fastrtps::types::ReturnCode_t;
+
+/**
+ * This test checks whether it is safe to delete not enabled DDS entities *
+ */
+TEST(DDSBasic, DeleteDisabledEntities)
+{
+    // Set DomainParticipantFactory to create disabled entities
+    DomainParticipantFactoryQos factory_qos;
+    factory_qos.entity_factory().autoenable_created_entities = false;
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_NE(nullptr, factory);
+    factory->set_qos(factory_qos);
+    DomainParticipantFactoryQos factory_qos_check;
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, factory->get_qos(factory_qos_check));
+    ASSERT_EQ(false, factory_qos_check.entity_factory().autoenable_created_entities);
+
+    // Create a disabled DomainParticipant, setting it to in turn create disable entities
+    DomainParticipantQos participant_qos;
+    participant_qos.entity_factory().autoenable_created_entities = false;
+    DomainParticipant* participant = factory->create_participant((uint32_t)GET_PID() % 230, participant_qos);
+    ASSERT_NE(nullptr, participant);
+    DomainParticipantQos participant_qos_check;
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, participant->get_qos(participant_qos_check));
+    ASSERT_EQ(false, participant_qos_check.entity_factory().autoenable_created_entities);
+
+    // Create a disabled Publisher, setting it to in turn create disable entities
+    PublisherQos publisher_qos;
+    publisher_qos.entity_factory().autoenable_created_entities = false;
+    Publisher* publisher = participant->create_publisher(publisher_qos);
+    ASSERT_NE(nullptr, publisher);
+    PublisherQos publisher_qos_check;
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, publisher->get_qos(publisher_qos_check));
+    ASSERT_EQ(false, publisher_qos_check.entity_factory().autoenable_created_entities);
+
+    // Create a disabled Subscriber, setting it to in turn create disable entities
+    SubscriberQos subscriber_qos;
+    subscriber_qos.entity_factory().autoenable_created_entities = false;
+    Subscriber* subscriber = participant->create_subscriber(subscriber_qos);
+    ASSERT_NE(nullptr, subscriber);
+    SubscriberQos subscriber_qos_check;
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, subscriber->get_qos(subscriber_qos_check));
+    ASSERT_EQ(false, subscriber_qos_check.entity_factory().autoenable_created_entities);
+
+    // Register type
+    TypeSupport type_support;
+    type_support.reset(new HelloWorldPubSubType());
+    type_support.register_type(participant);
+    ASSERT_NE(nullptr, type_support);
+
+    // Create Topic
+    Topic* topic = participant->create_topic("HelloWorld", type_support.get_type_name(), TOPIC_QOS_DEFAULT);
+    ASSERT_NE(nullptr, topic);
+
+    // Create a disabled DataWriter
+    DataWriter* datawriter = publisher->create_datawriter(topic, DATAWRITER_QOS_DEFAULT);
+    ASSERT_NE(nullptr, datawriter);
+
+    // Create a disabled DataReader
+    DataReader* datareader = subscriber->create_datareader(topic, DATAREADER_QOS_DEFAULT);
+    ASSERT_NE(nullptr, datareader);
+
+    // Delete all entities
+    publisher->delete_datawriter(datawriter);
+    subscriber->delete_datareader(datareader);
+    participant->delete_publisher(publisher);
+    participant->delete_subscriber(subscriber);
+    participant->delete_topic(topic);
+    factory->delete_participant(participant);
+}
+
+} // namespace dds
+} // namespace fastdds
+} // namespace eprosima


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

#2171 introduced a separation between initialization and enabling of `BuiltinProtocols`.
This had the side effect of the statistics' physical data not to be published, since the data was generated and added to the writer history only once on the creation of the corresponding `DataWriter`, which was performed prior to enabling the `DomainParticipantImpl`.
This lead to the `RTPSWriter` not to being created, as there was not `RTPSParticipant` (created when enabling the `DomainParticipantImpl`).
This PR fixes this behaviour by always enabling the `DomainParticipantImpl` before creating the statistics `DataWriter`s.

Furthermore, #2171 also introduced a regression in which removing a not enabled `RTPSParticipant` results in accessing a `nullptr` and therefore into a segmentation fault. This PR fixes this regression by checking whether the `PDP` instance is enabled within the call to `PDP::stopParticipantAnnouncement()`, which is the member function accessing to a `TimedEvent*`, which in turn is set to `nullptr` on non-enabled `PDP`s.
Moreover, the PR adds a regression test to ensure that it is always safe to remove a not enabled `RTPSParticipant`.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [x] *N/a* New feature has been added to the `versions.md` file (if applicable).
- [x] *N/a* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
