### PR TITLE
[14147] Fix documentation installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,7 +404,7 @@ if(BUILD_DOCUMENTATION)
     ### ReadTheDocs ########################
     if(NOT CHECK_DOCUMENTATION)
         add_custom_target(readthedocs
-            COMMAND "${CURL_EXE}" "https://fast-dds.docs.eprosima.com/_/downloads/en/v${PROJECT_VERSION}/htmlzip/" "--output" "eprosima-fast-rtps.zip"
+            COMMAND "${CURL_EXE}" "https://fast-dds.docs.eprosima.com/_/downloads/en/v${PROJECT_VERSION}/htmlzip/" "--silent" "--output" "eprosima-fast-rtps.zip"
             COMMAND "${UNZIP_EXE}" "eprosima-fast-rtps.zip" -d "${PROJECT_BINARY_DIR}/doc/"
             COMMAND ${CMAKE_COMMAND} -E remove_directory "${PROJECT_BINARY_DIR}/doc/manual"
             COMMAND ${CMAKE_COMMAND} -E rename "${PROJECT_BINARY_DIR}/doc/eprosima-fast-rtps-v${PROJECT_VERSION}" "${PROJECT_BINARY_DIR}/doc/manual"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,11 +353,11 @@ if(BUILD_DOCUMENTATION)
     endif()
 
     if(NOT CHECK_DOCUMENTATION)
-        find_program(WGET_EXE wget)
-        if(WGET_EXE)
-            message(STATUS "Found WGet: ${WGET_EXE}")
+        find_program(CURL_EXE curl)
+        if(CURL_EXE)
+            message(STATUS "Found cURL: ${CURL_EXE}")
         else()
-            message(FATAL_ERROR "wget is needed to build the documentation. Please install it correctly")
+            message(FATAL_ERROR "curl is needed to build the documentation. Please install it correctly")
         endif()
         find_program(UNZIP_EXE unzip)
         if(UNZIP_EXE)
@@ -404,7 +404,7 @@ if(BUILD_DOCUMENTATION)
     ### ReadTheDocs ########################
     if(NOT CHECK_DOCUMENTATION)
         add_custom_target(readthedocs
-            COMMAND "${WGET_EXE}" "https://media.readthedocs.org/htmlzip/eprosima-fast-rtps/v${PROJECT_VERSION}/eprosima-fast-rtps.zip"
+            COMMAND "${CURL_EXE}" "https://fast-dds.docs.eprosima.com/_/downloads/en/v${PROJECT_VERSION}/htmlzip/" "--output" "eprosima-fast-rtps.zip"
             COMMAND "${UNZIP_EXE}" "eprosima-fast-rtps.zip" -d "${PROJECT_BINARY_DIR}/doc/"
             COMMAND ${CMAKE_COMMAND} -E remove_directory "${PROJECT_BINARY_DIR}/doc/manual"
             COMMAND ${CMAKE_COMMAND} -E rename "${PROJECT_BINARY_DIR}/doc/eprosima-fast-rtps-v${PROJECT_VERSION}" "${PROJECT_BINARY_DIR}/doc/manual"


### PR DESCRIPTION
Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>

<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

CMake option `BUILD_DOCUMENTATION` downloads using `wget` the Readthedocs ZIP file from an URL that does not have the latest documentation. Changing to this other URL solves the problem: https://fast-dds.docs.eprosima.com/_/downloads/en/v2.6.0/htmlzip/, though instead of using `wget`, `curl` must be used.

I have tested it in Ubuntu 20.04. I suggest the reviewer to check that it also works as expected in Windows. To test this PR run:

```
colcon build --packages-select fastrtps --cmake-args -DBUILD_DOCUMENTATION=ON
```

In case of using a `colcon.meta` file, ensure that CMake option `CHECK_DOCUMENTATION` is disabled (by default CMake option `EPROSIMA_BUILD` sets the later to `ON`).

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
* *N/A* The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
* *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
* *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
* *N/A* Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
* *N/A* Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
* *N/A* Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
* *N/A* Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
* *N/A* New feature has been added to the `versions.md` file (if applicable).
* *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
