### PR TITLE
[14234] Add support for hexadecimal values to DDSSQLFilter

### DIFF
--- a/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterExpressionParser.cpp
+++ b/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterExpressionParser.cpp
@@ -56,6 +56,7 @@ using selector = parse_tree::selector <
     literal_value_processor::on<
         true_value,
         false_value,
+        hex_value,
         integer_value,
         float_value,
         char_value,

--- a/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterExpressionParserImpl/literal_values.hpp
+++ b/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterExpressionParserImpl/literal_values.hpp
@@ -38,17 +38,17 @@ struct literal_value_processor
             n->value->kind = DDSFilterValue::ValueKind::BOOLEAN;
             n->value->boolean_value = false;
         }
-        else if (n->is<integer_value>())
+        else if (n->is<integer_value>() || n->is<hex_value>())
         {
             if (n->m_begin.data[0] == '-')
             {
                 n->value->kind = DDSFilterValue::ValueKind::SIGNED_INTEGER;
-                n->value->signed_integer_value = std::stoll(n->content());
+                n->value->signed_integer_value = std::stoll(n->content(), nullptr, 0);
             }
             else
             {
                 n->value->kind = DDSFilterValue::ValueKind::UNSIGNED_INTEGER;
-                n->value->unsigned_integer_value = std::stoull(n->content());
+                n->value->unsigned_integer_value = std::stoull(n->content(), nullptr, 0);
             }
         }
         else if (n->is<float_value>())

--- a/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterGrammar.hpp
+++ b/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterGrammar.hpp
@@ -57,6 +57,7 @@ struct integer_value : seq< opt< sign >, integer > {};
 struct fractional : seq< dot_op, integer > {};
 struct exponent : seq< one< 'e', 'E' >, integer_value > {};
 struct float_value : seq < opt< sign >, integer, sor < exponent, seq< fractional, opt< exponent > > > > {};
+struct hex_value : seq< opt< sign >, one< '0' >, one< 'x', 'X' >, plus< xdigit > > {};
 
 // PARAMETER
 struct parameter_value : seq< one< '%' >, digit, opt< digit > > {};
@@ -80,7 +81,7 @@ struct match_op : pad< sor< TAO_PEGTL_KEYWORD("MATCH"), TAO_PEGTL_KEYWORD("match
 struct rel_op : sor< match_op, like_op, ne_op, le_op, ge_op, lt_op, gt_op, eq_op > {};
 
 // Parameter, Range
-struct Literal : sor< boolean_value, float_value, integer_value, char_value, string_value > {};
+struct Literal : sor< boolean_value, float_value, hex_value, integer_value, char_value, string_value > {};
 struct Parameter : sor< Literal, parameter_value > {};
 struct Range : seq< Parameter, and_op, Parameter > {};
 

--- a/test/unittest/dds/topic/DDSSQLFilter/DDSSQLFilterTests.cpp
+++ b/test/unittest/dds/topic/DDSSQLFilter/DDSSQLFilterTests.cpp
@@ -261,6 +261,8 @@ TEST_F(DDSSQLFilterTests, type_compatibility_like)
             // Integer values
             {"1", bad_code},
             {"-1", bad_code},
+            {"0x10", bad_code},
+            {"-0x10", bad_code},
             // Floating point values
             {"1.0", bad_code},
             {"-1.0", bad_code},
@@ -351,6 +353,8 @@ TEST_F(DDSSQLFilterTests, type_compatibility_match)
             // Integer values
             {"1", bad_code},
             {"-1", bad_code},
+            {"0x10", bad_code},
+            {"-0x10", bad_code},
             // Floating point values
             {"1.0", bad_code},
             {"-1.0", bad_code},
@@ -450,6 +454,8 @@ TEST_F(DDSSQLFilterTests, type_compatibility_compare)
             // Integer values
             {"1", "INT"},
             {"-1", "INT"},
+            {"0x10", "INT"},
+            {"-0x10", "INT"},
             // Floating point values
             {"1.0", "FLOAT"},
             {"-1.0", "FLOAT"},
@@ -1608,6 +1614,11 @@ static std::vector<DDSSQLFilterValueParams> get_test_filtered_value_promotion_in
     input.samples_filtered.assign({true, true, true, true, true});
     inputs.push_back(input);
 
+    input.test_case_name = "bool_field_signed_hex_constant";
+    input.expression = "bool_field > -0x1";
+    input.samples_filtered.assign({true, true, true, true, true});
+    inputs.push_back(input);
+
     input.test_case_name = "bool_field_uint8_field";
     input.expression = "bool_field < uint8_field";
     input.samples_filtered.assign({false, true, true, true, true});
@@ -1630,6 +1641,11 @@ static std::vector<DDSSQLFilterValueParams> get_test_filtered_value_promotion_in
 
     input.test_case_name = "bool_field_unsigned_int_constant";
     input.expression = "bool_field < 1";
+    input.samples_filtered.assign({true, true, false, false, false});
+    inputs.push_back(input);
+
+    input.test_case_name = "bool_field_unsigned_hex_constant";
+    input.expression = "bool_field < 0x1";
     input.samples_filtered.assign({true, true, false, false, false});
     inputs.push_back(input);
 
@@ -1715,13 +1731,23 @@ static std::vector<DDSSQLFilterValueParams> get_test_filtered_value_promotion_in
     input.samples_filtered.assign({true, true, true, false, false});
     inputs.push_back(input);
 
-    input.test_case_name = "int32_field_unsigned_int_constant";
-    input.expression = "int32_field < 1";
+    input.test_case_name = "int16_field_unsigned_hex_constant";
+    input.expression = "int16_field < 0x1";
+    input.samples_filtered.assign({true, true, true, false, false});
+    inputs.push_back(input);
+
+    input.test_case_name = "int32_field_unsigned_hex_constant";
+    input.expression = "int32_field < 0x1";
     input.samples_filtered.assign({true, true, true, false, false});
     inputs.push_back(input);
 
     input.test_case_name = "int64_field_unsigned_int_constant";
     input.expression = "int64_field < 1";
+    input.samples_filtered.assign({true, true, true, false, false});
+    inputs.push_back(input);
+
+    input.test_case_name = "int64_field_unsigned_hex_constant";
+    input.expression = "int64_field < 0x1";
     input.samples_filtered.assign({true, true, true, false, false});
     inputs.push_back(input);
 
@@ -1873,6 +1899,11 @@ static std::vector<DDSSQLFilterValueParams> get_test_filtered_value_promotion_in
     input.samples_filtered.assign({true, true, true, true, true});
     inputs.push_back(input);
 
+    input.test_case_name = "enum_field_signed_hex_constant";
+    input.expression = "enum_field > -0x1";
+    input.samples_filtered.assign({true, true, true, true, true});
+    inputs.push_back(input);
+
     // ENUM - UINT promotions
     input.test_case_name = "enum_field_uint8_field";
     input.expression = "enum_field >= uint8_field";
@@ -1896,6 +1927,11 @@ static std::vector<DDSSQLFilterValueParams> get_test_filtered_value_promotion_in
 
     input.test_case_name = "enum_field_unsigned_int_constant";
     input.expression = "enum_field > 1";
+    input.samples_filtered.assign({false, false, true, true, true});
+    inputs.push_back(input);
+
+    input.test_case_name = "enum_field_unsigned_hex_constant";
+    input.expression = "enum_field > 0x1";
     input.samples_filtered.assign({false, false, true, true, true});
     inputs.push_back(input);
 

--- a/test/unittest/dds/topic/DDSSQLFilter/DDSSQLFilterTests.cpp
+++ b/test/unittest/dds/topic/DDSSQLFilter/DDSSQLFilterTests.cpp
@@ -261,8 +261,8 @@ TEST_F(DDSSQLFilterTests, type_compatibility_like)
             // Integer values
             {"1", bad_code},
             {"-1", bad_code},
-            {"0x10", bad_code},
-            {"-0x10", bad_code},
+            {"0x1F", bad_code},
+            {"-0x1f", bad_code},
             // Floating point values
             {"1.0", bad_code},
             {"-1.0", bad_code},
@@ -353,8 +353,8 @@ TEST_F(DDSSQLFilterTests, type_compatibility_match)
             // Integer values
             {"1", bad_code},
             {"-1", bad_code},
-            {"0x10", bad_code},
-            {"-0x10", bad_code},
+            {"0xab", bad_code},
+            {"-0xCd", bad_code},
             // Floating point values
             {"1.0", bad_code},
             {"-1.0", bad_code},
@@ -454,8 +454,8 @@ TEST_F(DDSSQLFilterTests, type_compatibility_compare)
             // Integer values
             {"1", "INT"},
             {"-1", "INT"},
-            {"0x10", "INT"},
-            {"-0x10", "INT"},
+            {"0xabcdef", "INT"},
+            {"-0xFEEDBAC0", "INT"},
             // Floating point values
             {"1.0", "FLOAT"},
             {"-1.0", "FLOAT"},


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
Just what the title says. Extend DDSSQLFilter unit tests, and add support for hexadecimal constant values.
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
@mergifyio backport 2.5.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [x] *N/A* New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
Related documentation PR: eProsima/Fast-DDS-docs#361


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
