### PR TITLE
 [14237] Fixing flow controller TSan lock-order-inversion reports <feature/tsan/fixes>

### DIFF
--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -323,7 +323,8 @@ void BuiltinProtocols::announceRTPSParticipantState()
 
 void BuiltinProtocols::stopRTPSParticipantAnnouncement()
 {
-    assert(mp_PDP);
+    // note that participants created with DiscoveryProtocol::NONE
+    // may not have mp_PDP available
 
     if (mp_PDP)
     {

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -315,7 +315,7 @@ void BuiltinProtocols::announceRTPSParticipantState()
     {
         mp_PDP->announceParticipantState(false);
     }
-    else
+    else if (m_att.discovery_config.discoveryProtocol != DiscoveryProtocol_t::NONE)
     {
         logError(RTPS_EDP, "Trying to use BuiltinProtocols interfaces before initBuiltinProtocols call");
     }
@@ -330,7 +330,7 @@ void BuiltinProtocols::stopRTPSParticipantAnnouncement()
     {
         mp_PDP->stopParticipantAnnouncement();
     }
-    else
+    else if (m_att.discovery_config.discoveryProtocol != DiscoveryProtocol_t::NONE)
     {
         logError(RTPS_EDP, "Trying to use BuiltinProtocols interfaces before initBuiltinProtocols call");
     }
@@ -344,7 +344,7 @@ void BuiltinProtocols::resetRTPSParticipantAnnouncement()
     {
         mp_PDP->resetParticipantAnnouncement();
     }
-    else
+    else if (m_att.discovery_config.discoveryProtocol != DiscoveryProtocol_t::NONE)
     {
         logError(RTPS_EDP, "Trying to use BuiltinProtocols interfaces before initBuiltinProtocols call");
     }

--- a/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp
+++ b/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp
@@ -1325,8 +1325,8 @@ private:
 
                 fastrtps::rtps::LocatorSelectorSender& locator_selector =
                         current_writer->get_async_locator_selector();
-                locator_selector.lock();
                 async_mode.group.sender(current_writer, &locator_selector);
+                locator_selector.lock();
 
                 // Remove previously from queue, because deliver_sample_nts could call FlowController::remove_sample()
                 // provoking a deadlock.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This addresses the most common deadlock TSan report in Fast-DDS test suite (reported 317 times).
Now all `DataWriters` use a default asynchronous flow controller.
The associated asynchronous thread traverses the collection of pending changes to send.
For each change the `RTPSMessageSenderInterface` associated with the `DataWriter` is set into the `FlowController` auxiliary `RTPSMessageGroup`.
+ Before calling the `RTPSMessageGroup` setter the new `RTPSMessageSenderInterface` is locked (A).
+ The `RTPSMessageGroup` setter flushes pending messages before change the `RTPSMessageSenderInterface` locking the former `RTPSMessageSenderInterface` (B).

TSan reports that if the next change in the collection is delivered to A then we will lock B &rarr; A.
Note that this is not an issue because, despite been possible to have several `FlowController`s (each one with a devoted asynchronous thread), only one of them can be associated with a `DataWriter/RTPSMessageSenderInterface`. That makes an actual deadlock impossible.

Mitigation:
+ Add to the TSan's suppressions list. Not very elegant though.
+ Flush() the `FlowController`'s message group after each cache processing.
+ Don't lock the `RTPSMessageSenderInterface` before calling the `RTPSMessageGroup` setter.

I've chosen the last option:
+ It's safe because the `RTPSMessageSenderInterface` is not modified inside the setter.
+ Manually flushing may multiply the number of messages if several consecutive changes have the same destination.

<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

Merge after https://github.com/eProsima/Fast-DDS/pull/2565

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] NA Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] NA Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] NA Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] NA New feature has been added to the `versions.md` file (if applicable).
- [ ] NA New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->

## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
