### PR TITLE
[14091] Fix update remote server locators when enabling statistics

### DIFF
--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1285,7 +1285,10 @@ void RTPSParticipantImpl::update_attributes(
             createSenderResources(m_att.builtin.metatrafficMulticastLocatorList);
             createSenderResources(m_att.builtin.metatrafficUnicastLocatorList);
             createSenderResources(m_att.defaultUnicastLocatorList);
-            createSenderResources(modified_locators);
+            if (!modified_locators.empty())
+            {
+                createSenderResources(modified_locators);
+            }
 
             // Update remote servers list
             if (m_att.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::CLIENT ||

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1214,6 +1214,7 @@ void RTPSParticipantImpl::update_attributes(
     {
         update_pdp = true;
         std::vector<GUID_t> modified_servers;
+        LocatorList_t modified_locators;
         // Check that the remote servers list is consistent: all the already known remote servers must be included in
         // the list and either new remote servers are added or remote server listening locator is modified.
         for (auto existing_server : m_att.builtin.discovery_config.m_DiscoveryServers)
@@ -1237,6 +1238,7 @@ void RTPSParticipantImpl::update_attributes(
                         if (!locator_contained)
                         {
                             modified_servers.emplace_back(incoming_server.GetParticipant());
+                            modified_locators.push_back(incoming_locator);
                             logInfo(RTPS_QOS_CHECK,
                                     "DS Server: " << incoming_server.guidPrefix << " has modified its locators: "
                                                   << incoming_locator << " being added")
@@ -1283,6 +1285,7 @@ void RTPSParticipantImpl::update_attributes(
             createSenderResources(m_att.builtin.metatrafficMulticastLocatorList);
             createSenderResources(m_att.builtin.metatrafficUnicastLocatorList);
             createSenderResources(m_att.defaultUnicastLocatorList);
+            createSenderResources(modified_locators);
 
             // Update remote servers list
             if (m_att.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::CLIENT ||


### PR DESCRIPTION
Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>

<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

If Fast DDS is compile with Statistics (`-DFASTDDS_STATISTICS=ON`) and in Debug, when updating the remote server locator and assertion in `OutputTrafficManager::set_statistics_message_data` fails. This is due to the new locator not being added to the `collection_` member of this class. New locators are added when calling to the specific transport `OpenOutputChannel`. This PR ensures that it is called before announcing the new Participant state, preventing the assertion to fail.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
* **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->

This feature is tested with the tests included in eProsima/Discovery-Server#52. Running these tests with Fast DDS compiled as described before will fail.

* **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
* **N/A** Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->

Changes does not affect the test suite. `RTPSParticipantImpl::update_attributes` is called in only a few tests. Changes only affect if there are modified locators (if the feature is being used) and this feature is not tested in Fast DDS suite but in the Discovery Server suite.

- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
* **N/A** Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
* **N/A** New feature has been added to the `versions.md` file (if applicable).
* **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
