### PR TITLE
[14349] Fix inconsistent ReaderProxy state on intra-process

### DIFF
--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -462,7 +462,7 @@ void ReaderProxy::from_unsent_to_status(
     {
         assert(changes_for_reader_.begin() == it);
         changes_for_reader_.erase(it);
-        changes_low_mark_ = seq_num;
+        acked_changes_set(seq_num + 1);
         return;
     }
 
@@ -563,6 +563,12 @@ void ReaderProxy::change_has_been_removed(
 
     // Element may not be in the container when marked as irrelevant.
     changes_for_reader_.erase(chit);
+
+    // When removing the next-to-be-acknowledged, we should auto-acknowledge it.
+    if ((changes_low_mark_ + 1) == seq_num)
+    {
+        acked_changes_set(seq_num + 1);
+    }
 }
 
 bool ReaderProxy::has_unacknowledged(

--- a/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
@@ -808,6 +808,42 @@ TEST_P(PubSubBasic, ReliableTransientLocalTwoWritersConsecutives)
     }
 }
 
+// Regression test for redmine issue #14346
+TEST_P(PubSubBasic, ReliableHelloworldLateJoinersStress)
+{
+    if (enable_datasharing)
+    {
+        GTEST_SKIP() << "Data-sharing needs data reception for acknowledgement";
+    }
+
+    constexpr unsigned int num_iterations = 10;
+
+    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+    writer.history_depth(10).init();
+    ASSERT_TRUE(writer.isInitialized());
+
+    std::vector<std::unique_ptr<PubSubReader<HelloWorldPubSubType>>> readers;
+
+    for (unsigned int i = 0; i < num_iterations; ++i)
+    {
+        readers.emplace_back(new PubSubReader<HelloWorldPubSubType>(TEST_TOPIC_NAME));
+        const auto& new_reader = readers.back();
+
+        new_reader->reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+                .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
+                .history_depth(10)
+                .init();
+        ASSERT_TRUE(new_reader->isInitialized()) << " on iteration " << i;
+        new_reader->wait_discovery();
+        writer.wait_discovery(i + 1);
+
+        auto data = default_helloworld_data_generator();
+        writer.send(data);
+        EXPECT_TRUE(data.empty()) << " on iteration " << i;
+        ASSERT_TRUE(writer.waitForAllAcked(std::chrono::seconds(5))) << " on iteration " << i;
+    }
+}
+
 /*
  * Check that setting FASTDDS_ENVIRONMENT_FILE to an unexisting file issues 1 logWarning
  */


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
When adding samples to a full history on a reliable DataWriter, just after a new transient-local reader has been discovered, the ReaderProxy of the newly discovered reader ends up in an inconsistent state, where all the samples are marked as ACKNOWLEDGED, but the low_mark stays on the sequence number of the first historical change.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
@Mergifyio backport 2.5.x 2.3.x 2.1.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] **N/A** Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [x] **N/A** New feature has been added to the `versions.md` file (if applicable).
- [x] **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
