### PR TITLE
[14361] Improve ParticipantTests with ContentFilteredTopic 

### DIFF
--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -3021,6 +3021,10 @@ TEST(ParticipantTests, DeleteContainedEntities)
     Topic* topic_bar = participant->create_topic("bartopic", type.get_type_name(), TOPIC_QOS_DEFAULT);
     ASSERT_NE(topic_bar, nullptr);
 
+    ContentFilteredTopic* content_filtered_topic_bar = participant->create_contentfilteredtopic("contentfilteredtopic",
+            topic_bar, "", {});
+    ASSERT_NE(content_filtered_topic_bar, nullptr);
+
     DataReader* data_reader_bar = subscriber->create_datareader(topic_bar, DATAREADER_QOS_DEFAULT);
     ASSERT_NE(data_reader_bar, nullptr);
 
@@ -3127,6 +3131,8 @@ TEST(ParticipantTests, DeleteContainedEntities)
     EXPECT_FALSE(participant->contains_entity(subscriber_handle));
     EXPECT_FALSE(participant->contains_entity(topic_foo_handle));
     EXPECT_FALSE(participant->contains_entity(topic_bar_handle));
+    // ContentFilteredTopic is not considered an entity
+    EXPECT_EQ(participant->lookup_topicdescription("contentfilteredtopic"), nullptr);
 
     ASSERT_EQ(retcode, ReturnCode_t::RETCODE_OK);
 

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -1895,7 +1895,7 @@ TEST(ParticipantTests, DeleteTopicInUse)
     Topic* topic = participant->create_topic("footopic", "footype", TOPIC_QOS_DEFAULT);
 
     ContentFilteredTopic* content_filtered_topic = participant->create_contentfilteredtopic("contentfilteredtopic",
-            topic, "", {});
+                    topic, "", {});
     ASSERT_NE(content_filtered_topic, nullptr);
 
     Subscriber* subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
@@ -3022,7 +3022,7 @@ TEST(ParticipantTests, DeleteContainedEntities)
     ASSERT_NE(topic_bar, nullptr);
 
     ContentFilteredTopic* content_filtered_topic_bar = participant->create_contentfilteredtopic("contentfilteredtopic",
-            topic_bar, "", {});
+                    topic_bar, "", {});
     ASSERT_NE(content_filtered_topic_bar, nullptr);
 
     DataReader* data_reader_bar = subscriber->create_datareader(topic_bar, DATAREADER_QOS_DEFAULT);

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -1894,6 +1894,10 @@ TEST(ParticipantTests, DeleteTopicInUse)
 
     Topic* topic = participant->create_topic("footopic", "footype", TOPIC_QOS_DEFAULT);
 
+    ContentFilteredTopic* content_filtered_topic = participant->create_contentfilteredtopic("contentfilteredtopic",
+            topic, "", {});
+    ASSERT_NE(content_filtered_topic, nullptr);
+
     Subscriber* subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
     ASSERT_NE(subscriber, nullptr);
 
@@ -1903,6 +1907,8 @@ TEST(ParticipantTests, DeleteTopicInUse)
     ASSERT_EQ(participant->delete_topic(topic), ReturnCode_t::RETCODE_PRECONDITION_NOT_MET);
 
     ASSERT_EQ(subscriber->delete_datareader(data_reader), ReturnCode_t::RETCODE_OK);
+    ASSERT_EQ(participant->delete_topic(topic), ReturnCode_t::RETCODE_PRECONDITION_NOT_MET);
+    ASSERT_EQ(participant->delete_contentfilteredtopic(content_filtered_topic), ReturnCode_t::RETCODE_OK);
     ASSERT_EQ(participant->delete_topic(topic), ReturnCode_t::RETCODE_OK);
     ASSERT_EQ(participant->delete_subscriber(subscriber), ReturnCode_t::RETCODE_OK);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

#2521 added ContentFilteredTopics into Fast DDS. Some DomainParticipant unit tests were not updated taking into account this new feature. This PR improves two of these tests:

* DeleteTopicInUse: check that even if no endpoints are created in the Topic, Topic deletion fails if there is a ContentFilteredTopic created using this specific Topic.
* DeleteContainedEntities: check that `DomainParticipant::delete_contained_entities` also takes charge of gracefully deleting the ContentFilteredTopic allowing the Topic to be deleted as well.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
@Mergifyio backport 2.5.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
* **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
* **N/A** Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
* **N/A** New feature has been added to the `versions.md` file (if applicable).
* **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
