### PR TITLE
Change the order of destruction to prevent use of released objects [14737]

### DIFF
--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -312,9 +312,7 @@ StatefulWriter::~StatefulWriter()
 {
     logInfo(RTPS_WRITER, "StatefulWriter destructor");
 
-    // This must be the first action, because free CacheChange_t from async thread.
-    deinit();
-
+    // Disable timed events, because their callbacks use cache changes
     if (disable_positive_acks_)
     {
         delete(ack_event_);
@@ -326,6 +324,9 @@ StatefulWriter::~StatefulWriter()
         delete(nack_response_event_);
         nack_response_event_ = nullptr;
     }
+
+    // This must be the next action, because free CacheChange_t from async thread.
+    deinit();
 
     // Stop all active proxies and pass them to the pool
     {

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -325,7 +325,13 @@ StatefulWriter::~StatefulWriter()
         nack_response_event_ = nullptr;
     }
 
-    // This must be the next action, because free CacheChange_t from async thread.
+    if (periodic_hb_event_ != nullptr)
+    {
+        delete(periodic_hb_event_);
+        periodic_hb_event_ = nullptr;
+    }
+
+    // This must be the next action, as it frees CacheChange_t from the async thread.
     deinit();
 
     // Stop all active proxies and pass them to the pool
@@ -352,13 +358,6 @@ StatefulWriter::~StatefulWriter()
             remote_reader->stop();
             matched_readers_pool_.push_back(remote_reader);
         }
-    }
-
-    // Destroy heartbeat event
-    if (periodic_hb_event_ != nullptr)
-    {
-        delete(periodic_hb_event_);
-        periodic_hb_event_ = nullptr;
     }
 
     // Delete all proxies in the pool


### PR DESCRIPTION
Signed-off-by: Artem Shumov <agshumov@sberautotech.ru>

<!-- Provide a general summary of your changes in the Title above -->
This PR changes the order of destruction of StatefulWriter members. 
We need to disable all timed events before calling function deinit(), because deinit() [releases all cache changes](https://github.com/shumov-ag/Fast-DDS/blob/6b55651b6edfaf0a201fce26e1861ceef84696a4/src/cpp/rtps/writer/RTPSWriter.cpp#L158-L161) but callbacks of the timed events still use them.

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- *N/A*: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A*: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- *N/A*: New feature has been added to the `versions.md` file (if applicable).
- *N/A*: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
