### PR TITLE
[14385] Avoid data race on UDPChannelResource

### DIFF
--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
@@ -115,11 +115,6 @@ void TCPChannelResourceBasic::disconnect()
                     try
                     {
                         socket->cancel();
-
-                        // This method was added on the version 1.12.0
-#if ASIO_VERSION >= 101200 && (!defined(_WIN32_WINNT) || _WIN32_WINNT >= 0x0603)
-                        socket->release();
-#endif // if ASIO_VERSION >= 101200 && (!defined(_WIN32_WINNT) || _WIN32_WINNT >= 0x0603)
                         socket->close();
                     }
                     catch (std::exception&)

--- a/src/cpp/rtps/transport/UDPChannelResource.cpp
+++ b/src/cpp/rtps/transport/UDPChannelResource.cpp
@@ -45,6 +45,9 @@ UDPChannelResource::UDPChannelResource(
 UDPChannelResource::~UDPChannelResource()
 {
     message_receiver_ = nullptr;
+
+    asio::error_code ec;
+    socket()->close(ec);
 }
 
 void UDPChannelResource::perform_listen_operation(

--- a/src/cpp/rtps/transport/UDPChannelResource.cpp
+++ b/src/cpp/rtps/transport/UDPChannelResource.cpp
@@ -120,8 +120,11 @@ void UDPChannelResource::release()
     // in Windows and Linux anyways, which is what we want.
     asio::error_code ec;
     socket()->shutdown(asio::socket_base::shutdown_type::shutdown_receive, ec);
-    // On OSX shutdown does not unblock the listening thread, but close does.
+
+#if defined(__APPLE__)
+    // On OSX shutdown does not seem to unblock the listening thread, but close does.
     socket()->close();
+#endif
 }
 
 } // namespace rtps

--- a/src/cpp/rtps/transport/UDPChannelResource.cpp
+++ b/src/cpp/rtps/transport/UDPChannelResource.cpp
@@ -124,7 +124,7 @@ void UDPChannelResource::release()
 #if defined(__APPLE__)
     // On OSX shutdown does not seem to unblock the listening thread, but close does.
     socket()->close();
-#endif
+#endif // if defined(__APPLE__)
 }
 
 } // namespace rtps


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR moves the close operation over the UDP socket from `UDPChannelResource::release` to the destructor of `UDPChannelResource`.

As the destructor is called after calling `UDPChannelResource::clear`, the receiving thread would have been already joined, so the thread sanitizer should not complain.

As a bonus, I introduced a small change on `TCPChannelResourceBasic::disconnect` that I think is responsible for leaving TCP sockets on a FIN_2 state sometimes.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
@Mergifyio backport 2.5.x 2.3.x 2.1.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
