### PR TITLE
[14386] Fix oss-fuzz 43650

### DIFF
--- a/src/cpp/rtps/xmlparser/XMLDynamicParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLDynamicParser.cpp
@@ -341,9 +341,17 @@ XMLP_ret XMLParser::parseXMLAliasDynamicType(
         if (valueBuilder != nullptr)
         {
             const char* name = p_root->Attribute(NAME);
-            p_dynamictypebuilder_t typeBuilder =
-                    types::DynamicTypeBuilderFactory::get_instance()->create_alias_builder(valueBuilder, name);
-            XMLProfileManager::insertDynamicTypeByName(name, typeBuilder);
+            if (name != nullptr)
+            {
+                p_dynamictypebuilder_t typeBuilder =
+                        types::DynamicTypeBuilderFactory::get_instance()->create_alias_builder(valueBuilder, name);
+                XMLProfileManager::insertDynamicTypeByName(name, typeBuilder);
+            }
+            else
+            {
+                logError(XMLPARSER, "Error parsing alias type: No name attribute given.");
+                ret = XMLP_ret::XML_ERROR;
+            }
         }
         else
         {

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -57,6 +57,7 @@ TEST_F(XMLParserTests, regressions)
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/12736.xml", root));
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/13418.xml", root));
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/13454.xml", root));
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/13513.xml", root));
 }
 
 TEST_F(XMLParserTests, NoFile)

--- a/test/unittest/xmlparser/regressions/13513.xml
+++ b/test/unittest/xmlparser/regressions/13513.xml
@@ -1,0 +1,1 @@
+<types><type><typedef type="int8"/></type></types>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Fixed a null-dereference on XML parser

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
@Mergifyio backport 2.5.x 2.3.x 2.1.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
