### PR TITLE
[14430] Fix freezes in the RTPS level when transferring large files

### DIFF
--- a/include/fastdds/rtps/writer/ChangeForReader.h
+++ b/include/fastdds/rtps/writer/ChangeForReader.h
@@ -133,7 +133,7 @@ public:
         if (unsent_fragments_.empty())
         {
             base = highest_sent_fragment_ + 1u;
-            max = highest_sent_fragment_ + 1u;
+            max = highest_sent_fragment_;
         }
         else
         {
@@ -141,6 +141,11 @@ public:
             max = unsent_fragments_.max();
             assert(!unsent_fragments_.is_set(base));
             base = unsent_fragments_.min();
+
+            if (max < highest_sent_fragment_)
+            {
+                max = highest_sent_fragment_;
+            }
         }
 
         if (max < change_->getFragmentCount())

--- a/include/fastdds/rtps/writer/ChangeForReader.h
+++ b/include/fastdds/rtps/writer/ChangeForReader.h
@@ -150,16 +150,25 @@ public:
     {
         unsent_fragments_.remove(sentFragment);
 
-        if (!unsent_fragments_.empty() && unsent_fragments_.max() < change_->getFragmentCount())
+        FragmentNumber_t base;
+        FragmentNumber_t max;
+        if (unsent_fragments_.empty())
         {
-            FragmentNumber_t base = unsent_fragments_.base();
-            FragmentNumber_t max = unsent_fragments_.max();
+            base = sentFragment + 1u;
+            max = sentFragment;
+        }
+        else
+        {
+            base = unsent_fragments_.base();
+            max = unsent_fragments_.max();
             assert(!unsent_fragments_.is_set(base));
-
-            // Update base to first bit set
             base = unsent_fragments_.min();
-            unsent_fragments_.base_update(base);
+        }
 
+        if (max < change_->getFragmentCount())
+        {
+            // Update base to first bit set
+            unsent_fragments_.base_update(base);
             // Add all possible fragments
             unsent_fragments_.add_range(max + 1u, change_->getFragmentCount() + 1u);
         }

--- a/include/fastdds/rtps/writer/ChangeForReader.h
+++ b/include/fastdds/rtps/writer/ChangeForReader.h
@@ -54,20 +54,7 @@ class ChangeForReader_t
 
 public:
 
-    ChangeForReader_t() = delete;
-
-    ChangeForReader_t(
-            const ChangeForReader_t& ch)
-        : status_(ch.status_)
-        , seq_num_(ch.seq_num_)
-        , change_(ch.change_)
-        , unsent_fragments_(ch.unsent_fragments_)
-    {
-    }
-
-    //TODO(Ricardo) Temporal
-    //ChangeForReader_t(const CacheChange_t* change) : status_(UNSENT),
-    ChangeForReader_t(
+    explicit ChangeForReader_t(
             CacheChange_t* change)
         : status_(UNSENT)
         , seq_num_(change->sequenceNumber)
@@ -78,20 +65,6 @@ public:
             unsent_fragments_.base(1u);
             unsent_fragments_.add_range(1u, change->getFragmentCount() + 1u);
         }
-    }
-
-    ~ChangeForReader_t()
-    {
-    }
-
-    ChangeForReader_t& operator =(
-            const ChangeForReader_t& ch)
-    {
-        status_ = ch.status_;
-        seq_num_ = ch.seq_num_;
-        change_ = ch.change_;
-        unsent_fragments_ = ch.unsent_fragments_;
-        return *this;
     }
 
     /**

--- a/include/fastdds/rtps/writer/ChangeForReader.h
+++ b/include/fastdds/rtps/writer/ChangeForReader.h
@@ -178,7 +178,7 @@ public:
             const FragmentNumberSet_t& unsentFragments)
     {
         FragmentNumber_t other_base = unsentFragments.base();
-        if (other_base < unsent_fragments_.base())
+        if (unsent_fragments_.empty() || other_base < unsent_fragments_.base())
         {
             unsent_fragments_.base_update(other_base);
         }

--- a/include/fastdds/rtps/writer/ChangeForReader.h
+++ b/include/fastdds/rtps/writer/ChangeForReader.h
@@ -150,12 +150,17 @@ public:
     {
         unsent_fragments_.remove(sentFragment);
 
+        if (sentFragment > highest_sent_fragment_)
+        {
+            highest_sent_fragment_ = sentFragment;
+        }
+
         FragmentNumber_t base;
         FragmentNumber_t max;
         if (unsent_fragments_.empty())
         {
-            base = sentFragment + 1u;
-            max = sentFragment;
+            base = highest_sent_fragment_ + 1u;
+            max = highest_sent_fragment_ + 1u;
         }
         else
         {
@@ -212,7 +217,10 @@ private:
 
     FragmentNumberSet_t unsent_fragments_;
 
-    //! Indicates if was delivered at least one time.
+    //! Highest fragment number sent at least once.
+    FragmentNumber_t highest_sent_fragment_ = 0;
+
+    //! Indicates if was delivered at least once.
     bool delivered_ = false;
 };
 

--- a/test/blackbox/common/BlackboxTestsPubSubFragments.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubFragments.cpp
@@ -86,10 +86,12 @@ protected:
             bool reliable,
             bool volatile_reader,
             bool volatile_writer,
-            bool small_fragments)
+            bool small_fragments,
+            uint32_t loss_rate = 0)
     {
         PubSubReader<Data1mbPubSubType> reader(topic_name);
         PubSubWriter<Data1mbPubSubType> writer(topic_name);
+        uint32_t fragment_count = 0;
 
         reader
                 .socket_buffer_size(1048576) // accomodate large and fast fragments
@@ -104,12 +106,31 @@ protected:
 
         ASSERT_TRUE(reader.isInitialized());
 
-        if (small_fragments)
+        if (small_fragments || 0 < loss_rate)
         {
-            auto testTransport = std::make_shared<UDPv4TransportDescriptor>();
-            testTransport->sendBufferSize = 1024;
-            testTransport->maxMessageSize = 1024;
+            auto testTransport = std::make_shared<test_UDPv4TransportDescriptor>();
+
             testTransport->receiveBufferSize = 65536;
+            if (small_fragments)
+            {
+                testTransport->sendBufferSize = 1024;
+                testTransport->maxMessageSize = 1024;
+            }
+            if (0 < loss_rate)
+            {
+                testTransport->drop_data_frag_messages_filter_ =
+                        [&fragment_count, loss_rate](eprosima::fastrtps::rtps::CDRMessage_t& msg)->bool
+                        {
+                            ++fragment_count;
+                            if (fragment_count >= loss_rate)
+                            {
+                                fragment_count = 0;
+                            }
+
+                            return 1ul == fragment_count;
+                        };
+            }
+
             writer.disable_builtin_transport();
             writer.add_user_transport_to_pparams(testTransport);
         }
@@ -228,6 +249,12 @@ TEST_P(PubSubFragments, PubSubAsReliableTransientLocalData300kbSmallFragments)
     do_fragment_test(TEST_TOPIC_NAME, data, false, true, false, false, true);
 }
 
+TEST_P(PubSubFragments, PubSubAsReliableTransientLocalData300kbSmallFragmentsLossy)
+{
+    auto data = default_data300kb_data_generator();
+    do_fragment_test(TEST_TOPIC_NAME, data, false, true, false, false, true, 260);
+}
+
 TEST_P(PubSubFragments, AsyncPubSubAsNonReliableData300kb)
 {
     auto data = default_data300kb_data_generator();
@@ -298,6 +325,12 @@ TEST_P(PubSubFragments, AsyncPubSubAsReliableTransientLocalData300kbSmallFragmen
 {
     auto data = default_data300kb_data_generator();
     do_fragment_test(TEST_TOPIC_NAME, data, true, true, false, false, true);
+}
+
+TEST_P(PubSubFragments, AsyncPubSubAsReliableTransientLocalData300kbSmallFragmentsLossy)
+{
+    auto data = default_data300kb_data_generator();
+    do_fragment_test(TEST_TOPIC_NAME, data, true, true, false, false, true, 260);
 }
 
 class PubSubFragmentsLimited : public testing::TestWithParam<eprosima::fastdds::rtps::FlowControllerSchedulerPolicy>

--- a/test/blackbox/common/BlackboxTestsPubSubFragments.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubFragments.cpp
@@ -121,6 +121,8 @@ protected:
                 testTransport->drop_data_frag_messages_filter_ =
                         [&fragment_count, loss_rate](eprosima::fastrtps::rtps::CDRMessage_t& msg)->bool
                         {
+                            static_cast<void>(msg);
+
                             ++fragment_count;
                             if (fragment_count >= loss_rate)
                             {

--- a/test/unittest/rtps/writer/ReaderProxyTests.cpp
+++ b/test/unittest/rtps/writer/ReaderProxyTests.cpp
@@ -148,6 +148,132 @@ TEST(ReaderProxyTests, requested_changes_set_test)
     rproxy.requested_changes_set(set, gap_builder, {0, 1});
 }
 
+bool mark_next_fragment_sent(
+        ReaderProxy& rproxy,
+        SequenceNumber_t sequence_number,
+        FragmentNumber_t expected_fragment)
+{
+    FragmentNumber_t next_fragment{expected_fragment};
+    SequenceNumber_t gap_seq;
+    bool need_reactivate_periodic_heartbeat;
+    rproxy.change_is_unsent(sequence_number, next_fragment, gap_seq, need_reactivate_periodic_heartbeat);
+    if (next_fragment != expected_fragment)
+    {
+        return false;
+    }
+
+    bool was_last_fragment;
+    return rproxy.mark_fragment_as_sent_for_change(sequence_number, next_fragment, was_last_fragment);
+}
+
+TEST(ReaderProxyTests, process_nack_frag_single_fragment_test)
+{
+    StatefulWriter writerMock;
+    WriterTimes wTimes;
+    RemoteLocatorsAllocationAttributes alloc;
+    ReaderProxy rproxy(wTimes, alloc, &writerMock);
+    CacheChange_t seq;
+    seq.sequenceNumber = {0, 1};
+    seq.serializedPayload.length = 100000;
+    seq.setFragmentSize(100);
+
+    RTPSMessageGroup message_group(nullptr, false);
+    RTPSGapBuilder gap_builder(message_group);
+
+    ReaderProxyData reader_attributes(0, 0);
+    reader_attributes.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+    rproxy.start(reader_attributes);
+
+    ChangeForReader_t change(&seq);
+    rproxy.add_change(change, true, false);
+
+    SequenceNumberSet_t sequence_number_set({0, 1});
+    sequence_number_set.add({0, 1});
+    rproxy.from_unsent_to_status(seq.sequenceNumber, UNACKNOWLEDGED, false, false);
+    rproxy.requested_changes_set(sequence_number_set, gap_builder, seq.sequenceNumber);
+
+    // The number of sent fragments should be higher than the FragmentNumberSet_t size.
+    constexpr FragmentNumber_t NUMBER_OF_SENT_FRAGMENTS = 259;
+
+    for (auto i = 1u; i <= NUMBER_OF_SENT_FRAGMENTS; ++i)
+    {
+        ASSERT_TRUE(mark_next_fragment_sent(rproxy, seq.sequenceNumber, i));
+    }
+
+    // Set the change status to UNSENT.
+    rproxy.perform_acknack_response(nullptr);
+
+    // The difference between the latest sent fragment and an undelivered fragment should also be higher than
+    // the FragmentNumberSet_t size.
+    constexpr FragmentNumber_t UNDELIVERED_FRAGMENT = 3;
+
+    FragmentNumberSet_t fragment_set(UNDELIVERED_FRAGMENT);
+    fragment_set.add(UNDELIVERED_FRAGMENT);
+    rproxy.process_nack_frag({}, 1, seq.sequenceNumber, fragment_set);
+
+    ASSERT_TRUE(mark_next_fragment_sent(rproxy, seq.sequenceNumber, UNDELIVERED_FRAGMENT));
+    ASSERT_TRUE(mark_next_fragment_sent(rproxy, seq.sequenceNumber, UNDELIVERED_FRAGMENT + 1u));
+}
+
+TEST(ReaderProxyTests, process_nack_frag_multiple_fragments_test)
+{
+    StatefulWriter writerMock;
+    WriterTimes wTimes;
+    RemoteLocatorsAllocationAttributes alloc;
+    ReaderProxy rproxy(wTimes, alloc, &writerMock);
+    CacheChange_t seq;
+    seq.sequenceNumber = {0, 1};
+    seq.serializedPayload.length = 100000;
+    seq.setFragmentSize(100);
+
+    RTPSMessageGroup message_group(nullptr, false);
+    RTPSGapBuilder gap_builder(message_group);
+
+    ReaderProxyData reader_attributes(0, 0);
+    reader_attributes.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+    rproxy.start(reader_attributes);
+
+    ChangeForReader_t change(&seq);
+    rproxy.add_change(change, true, false);
+
+    SequenceNumberSet_t sequence_number_set({0, 1});
+    sequence_number_set.add({0, 1});
+    rproxy.from_unsent_to_status(seq.sequenceNumber, UNACKNOWLEDGED, false, false);
+    rproxy.requested_changes_set(sequence_number_set, gap_builder, seq.sequenceNumber);
+
+    // The number of sent fragments should be higher than the FragmentNumberSet_t size.
+    constexpr FragmentNumber_t NUMBER_OF_SENT_FRAGMENTS = 259;
+
+    for (auto i = 1u; i <= NUMBER_OF_SENT_FRAGMENTS; ++i)
+    {
+        ASSERT_TRUE(mark_next_fragment_sent(rproxy, seq.sequenceNumber, i));
+    }
+
+    // Set the change status to UNSENT.
+    rproxy.perform_acknack_response(nullptr);
+
+    std::vector<FragmentNumber_t> undelivered_fragments = {3, 6, 8};
+
+    FragmentNumberSet_t undelivered_fragment_set(undelivered_fragments.front());
+    for (auto fragment : undelivered_fragments)
+    {
+        undelivered_fragment_set.add(fragment);
+    }
+    rproxy.process_nack_frag({}, 1, seq.sequenceNumber, undelivered_fragment_set);
+
+    // Check that all undelivered fragments are chosen first for sending.
+    for (auto fragment : undelivered_fragments)
+    {
+        ASSERT_TRUE(mark_next_fragment_sent(rproxy, seq.sequenceNumber, fragment));
+    }
+
+    // After the last undelivered fragment is sent, fragments for sent go sequentially.
+    for (auto i = 1u; i < 3u; i++)
+    {
+        ASSERT_TRUE(mark_next_fragment_sent(rproxy, seq.sequenceNumber, undelivered_fragments.back() + i));
+    }
+}
+
 } // namespace rtps
 } // namespace fastrtps
 } // namespace eprosima


### PR DESCRIPTION
Signed-off-by: Igor Abdrakhimov <abdrahimov@arrival.com>

<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

When sending large files (>16 MB), the transfer may hang on the RTPS level. This happens because of how `ChangeForReader_t` handles fragments.

### Details

The issue appears when on `ChangeForReader_t::markFragmentsAsUnsent` call, if `unsentFragments` contains only one fragment and this fragment is less than `unsent_fragments_.base_` by >255 fragments.
Then on a `ChangeForReader_t::markFragmentsAsSent` call, `unsent_fragments_` becomes empty. So, `base_update` and `add_range` won't be called for `unsent_fragments_`.
Which leads to `ChangeForReader_t::get_next_unsent_fragment` reporting that all fragments are sent.

Now, a hang will happen if a Reader request for an unsent change which is greater than the previously requested fragment by >255 fragments. Surprisingly, it happens more than I'd expect.

### Notes

While fixing this issue, a couple of other things caught my attention.

1. When I transfer ~100 MB of data, a Reader always requests for few fragments starting from the 6th fragment. This happens because  of this statement in `StatefulReader::processDataFragMsg`:
    ```
    work_change->setFragmentSize(change_to_add->getFragmentSize(), true);
    ```
    It takes ~2 ms on my system. During this period, a socket buffer fills up and few UDP packets are lost. Increasing a buffer might help, but on some systems and for larger data this period might be much higher, so I don't think it's a good solution.
    This issue may seem minor, but it causes the next issue.

2. If an unsent fragment is less than the last sent fragment by >255 fragments, a Writer will resend all fragments again, starting with the undelivered one. On my local experiments, 10% of losses lead to 250% of data being transferred because of this issue.
Considering that the incoming data is handled synchronously, any delay (caused by system overload, for example) can cause a significant increase of the network traffic.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
