### PR TITLE
[14467] Fixing event thread shutdown <feature/tsan/fixes>

### DIFF
--- a/include/fastdds/rtps/resources/ResourceEvent.h
+++ b/include/fastdds/rtps/resources/ResourceEvent.h
@@ -52,6 +52,8 @@ public:
      */
     void init_thread();
 
+    void stop_thread();
+
     /*!
      * @brief This method informs that a TimedEventImpl has been created.
      *

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -486,6 +486,8 @@ void RTPSParticipantImpl::disable()
         }
     }
 
+    mp_event_thr.stop_thread();
+
     delete(mp_builtinProtocols);
     mp_builtinProtocols = nullptr;
 }

--- a/src/cpp/rtps/resources/ResourceEvent.cpp
+++ b/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -41,11 +41,16 @@ ResourceEvent::~ResourceEvent()
     assert(pending_timers_.empty());
     assert(timers_count_ == 0);
 
+    stop_thread();
+}
+
+void ResourceEvent::stop_thread()
+{
     logInfo(RTPS_PARTICIPANT, "Removing event thread");
     if (thread_.joinable())
     {
         {
-            std::unique_lock<TimedMutex> lock(mutex_);
+            std::lock_guard<TimedMutex> guard(mutex_);
             stop_.store(true);
             cv_.notify_one();
         }
@@ -56,11 +61,10 @@ ResourceEvent::~ResourceEvent()
 void ResourceEvent::register_timer(
         TimedEventImpl* /*event*/)
 {
-    assert(!stop_.load());
-
-    std::lock_guard<TimedMutex> lock(mutex_);
-
-    ++timers_count_;
+    {
+        std::lock_guard<TimedMutex> lock(mutex_);
+        ++timers_count_;
+    }
 
     // Notify the execution thread that something changed
     cv_.notify_one();
@@ -69,14 +73,12 @@ void ResourceEvent::register_timer(
 void ResourceEvent::unregister_timer(
         TimedEventImpl* event)
 {
-    assert(!stop_.load());
-
     std::unique_lock<TimedMutex> lock(mutex_);
 
     cv_manipulation_.wait(lock, [&]()
-            {
-                return allow_vector_manipulation_;
-            });
+        {
+            return allow_vector_manipulation_;
+        });
 
     bool should_notify = false;
     std::vector<TimedEventImpl*>::iterator it;
@@ -191,6 +193,13 @@ void ResourceEvent::event_service()
         allow_vector_manipulation_ = false;
         resize_collections();
     }
+
+    // Thread being stopped. Allow other threads to manipulate the timer collections.
+    {
+        std::lock_guard<TimedMutex> guard(mutex_);
+        allow_vector_manipulation_ = true;
+    }
+    cv_manipulation_.notify_all();
 }
 
 void ResourceEvent::sort_timers()
@@ -274,6 +283,7 @@ void ResourceEvent::init_thread()
     std::lock_guard<TimedMutex> lock(mutex_);
 
     allow_vector_manipulation_ = false;
+    stop_.store(false);
     resize_collections();
 
     thread_ = std::thread(&ResourceEvent::event_service, this);

--- a/src/cpp/rtps/resources/ResourceEvent.cpp
+++ b/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -76,9 +76,9 @@ void ResourceEvent::unregister_timer(
     std::unique_lock<TimedMutex> lock(mutex_);
 
     cv_manipulation_.wait(lock, [&]()
-        {
-            return allow_vector_manipulation_;
-        });
+            {
+                return allow_vector_manipulation_;
+            });
 
     bool should_notify = false;
     std::vector<TimedEventImpl*>::iterator it;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Closing participant's event thread sooner on participant removal to prevent data races.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] NA New feature has been added to the `versions.md` file (if applicable).
- [ ] NA New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
