### PR TITLE
DBQueue move Push and Pop methods [14537]

### DIFF
--- a/include/fastrtps/utils/DBQueue.h
+++ b/include/fastrtps/utils/DBQueue.h
@@ -85,7 +85,7 @@ public:
    }
 
    //! Return the front element in the foreground queue by moving it and erase it from the queue.
-   T FrontAndPop() const
+   T FrontAndPop()
    {
       std::unique_lock<std::mutex> guard(mForegroundMutex);
 

--- a/include/fastrtps/utils/DBQueue.h
+++ b/include/fastrtps/utils/DBQueue.h
@@ -21,131 +21,137 @@
 #include <condition_variable>
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 
 /**
  * Double buffered, threadsafe queue for MPSC (multi-producer, single-consumer) comms.
  */
 template<class T>
-class DBQueue {
+class DBQueue
+{
 
 public:
-   DBQueue():
-      mForegroundQueue(&mQueueAlpha),
-      mBackgroundQueue(&mQueueBeta)
-   {}
 
-   //! Clears foreground queue and swaps queues.
-   void Swap()
-   {
-      std::unique_lock<std::mutex> fgGuard(mForegroundMutex);
-      std::unique_lock<std::mutex> bgGuard(mBackgroundMutex);
+    DBQueue()
+        : mForegroundQueue(&mQueueAlpha)
+        , mBackgroundQueue(&mQueueBeta)
+    {
+    }
 
-      // Clear the foreground queue.
-      std::queue<T>().swap(*mForegroundQueue);
+    //! Clears foreground queue and swaps queues.
+    void Swap()
+    {
+        std::unique_lock<std::mutex> fgGuard(mForegroundMutex);
+        std::unique_lock<std::mutex> bgGuard(mBackgroundMutex);
 
-      auto* swap       = mBackgroundQueue;
-      mBackgroundQueue = mForegroundQueue;
-      mForegroundQueue = swap;
-   }
+        // Clear the foreground queue.
+        std::queue<T>().swap(*mForegroundQueue);
 
-   //! Pushes to the background queue. Copy constructor.
-   void Push(const T& item)
-   {
-      std::unique_lock<std::mutex> guard(mBackgroundMutex);
-      mBackgroundQueue->push(item);
-   }
+        auto* swap       = mBackgroundQueue;
+        mBackgroundQueue = mForegroundQueue;
+        mForegroundQueue = swap;
+    }
 
-   //! Pushes to the background queue. Move constructor.
-   void Push(T&& item)
-   {
-      std::unique_lock<std::mutex> guard(mBackgroundMutex);
-      mBackgroundQueue->push(std::move(item));
-   }
+    //! Pushes to the background queue. Copy constructor.
+    void Push(
+            const T& item)
+    {
+        std::unique_lock<std::mutex> guard(mBackgroundMutex);
+        mBackgroundQueue->push(item);
+    }
 
-   //! Returns a reference to the front element
-   //! in the foregrund queue.
-   T& Front()
-   {
-      std::unique_lock<std::mutex> guard(mForegroundMutex);
-      return mForegroundQueue->front();
-   }
+    //! Pushes to the background queue. Move constructor.
+    void Push(
+            T&& item)
+    {
+        std::unique_lock<std::mutex> guard(mBackgroundMutex);
+        mBackgroundQueue->push(std::move(item));
+    }
 
-   const T& Front() const
-   {
-      std::unique_lock<std::mutex> guard(mForegroundMutex);
-      return mForegroundQueue->front();
-   }
+    //! Returns a reference to the front element
+    //! in the foregrund queue.
+    T& Front()
+    {
+        std::unique_lock<std::mutex> guard(mForegroundMutex);
+        return mForegroundQueue->front();
+    }
 
-   //! Pops from the foreground queue.
-   void Pop()
-   {
-      std::unique_lock<std::mutex> guard(mForegroundMutex);
-      mForegroundQueue->pop();
-   }
+    const T& Front() const
+    {
+        std::unique_lock<std::mutex> guard(mForegroundMutex);
+        return mForegroundQueue->front();
+    }
 
-   //! Return the front element in the foreground queue by moving it and erase it from the queue.
-   T FrontAndPop()
-   {
-      std::unique_lock<std::mutex> guard(mForegroundMutex);
+    //! Pops from the foreground queue.
+    void Pop()
+    {
+        std::unique_lock<std::mutex> guard(mForegroundMutex);
+        mForegroundQueue->pop();
+    }
 
-      // Get value by moving the internal queue reference to a new value
-      T value = std::move(mForegroundQueue->front());
-      // At this point mForegroundQueue contains a non valid element, but mutex is taken and next instruction erase it
+    //! Return the front element in the foreground queue by moving it and erase it from the queue.
+    T FrontAndPop()
+    {
+        std::unique_lock<std::mutex> guard(mForegroundMutex);
 
-      // Pop value from queue
-      mForegroundQueue->pop();
+        // Get value by moving the internal queue reference to a new value
+        T value = std::move(mForegroundQueue->front());
+        // At this point mForegroundQueue contains a non valid element, but mutex is taken and next instruction erase it
 
-      // Return value (as it has been created in this scope, it will not be copied but moved or directly forwarded)
-      return value;
-   }
+        // Pop value from queue
+        mForegroundQueue->pop();
 
-   //! Reports whether the foreground queue is empty.
-   bool Empty() const
-   {
-      std::unique_lock<std::mutex> guard(mForegroundMutex);
-      return mForegroundQueue->empty();
-   }
+        // Return value (as it has been created in this scope, it will not be copied but moved or directly forwarded)
+        return value;
+    }
 
-   //! Reports whether the both queues are empty.
-   bool BothEmpty() const
-   {
-      std::unique_lock<std::mutex> guard(mForegroundMutex);
-      std::unique_lock<std::mutex> bgGuard(mBackgroundMutex);
-      return mForegroundQueue->empty() && mBackgroundQueue->empty();
-   }
+    //! Reports whether the foreground queue is empty.
+    bool Empty() const
+    {
+        std::unique_lock<std::mutex> guard(mForegroundMutex);
+        return mForegroundQueue->empty();
+    }
 
-   //! Reports the size of the foreground queue.
-   size_t Size() const
-   {
-      std::unique_lock<std::mutex> guard(mForegroundMutex);
-      return mForegroundQueue->size();
-   }
+    //! Reports whether the both queues are empty.
+    bool BothEmpty() const
+    {
+        std::unique_lock<std::mutex> guard(mForegroundMutex);
+        std::unique_lock<std::mutex> bgGuard(mBackgroundMutex);
+        return mForegroundQueue->empty() && mBackgroundQueue->empty();
+    }
 
-   //! Clears foreground and background.
-   void Clear()
-   {
-      std::unique_lock<std::mutex> fgGuard(mForegroundMutex);
-      std::unique_lock<std::mutex> bgGuard(mBackgroundMutex);
-      std::queue<T>().swap(*mForegroundQueue);
-      std::queue<T>().swap(*mBackgroundQueue);
-   }
+    //! Reports the size of the foreground queue.
+    size_t Size() const
+    {
+        std::unique_lock<std::mutex> guard(mForegroundMutex);
+        return mForegroundQueue->size();
+    }
+
+    //! Clears foreground and background.
+    void Clear()
+    {
+        std::unique_lock<std::mutex> fgGuard(mForegroundMutex);
+        std::unique_lock<std::mutex> bgGuard(mBackgroundMutex);
+        std::queue<T>().swap(*mForegroundQueue);
+        std::queue<T>().swap(*mBackgroundQueue);
+    }
 
 private:
-   // Underlying queues
-   std::queue<T> mQueueAlpha;
-   std::queue<T> mQueueBeta;
 
-   // Front and background queue references (double buffering)
-   std::queue<T>* mForegroundQueue;
-   std::queue<T>* mBackgroundQueue;
+    // Underlying queues
+    std::queue<T> mQueueAlpha;
+    std::queue<T> mQueueBeta;
 
-   mutable std::mutex mForegroundMutex;
-   mutable std::mutex mBackgroundMutex;
+    // Front and background queue references (double buffering)
+    std::queue<T>* mForegroundQueue;
+    std::queue<T>* mBackgroundQueue;
+
+    mutable std::mutex mForegroundMutex;
+    mutable std::mutex mBackgroundMutex;
 };
 
 
 } // namespace fastrtps
 } // namespace eprosima
 
-#endif
+#endif // ifndef DBQUEUE_H

--- a/src/cpp/fastdds/log/Log.cpp
+++ b/src/cpp/fastdds/log/Log.cpp
@@ -173,15 +173,16 @@ void Log::run()
             while (!resources_.logs.Empty())
             {
                 std::unique_lock<std::mutex> configGuard(resources_.config_mutex);
-                if (preprocess(resources_.logs.Front()))
+
+                // This value is moved and not copied
+                Entry value_dequeue = resources_.logs.FrontAndPop();
+                if (preprocess(value_dequeue))
                 {
                     for (auto& consumer : resources_.consumers)
                     {
-                        consumer->Consume(resources_.logs.Front());
+                        consumer->Consume(value_dequeue);
                     }
                 }
-
-                resources_.logs.Pop();
             }
         }
         guard.lock();

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -84,18 +84,18 @@ std::vector<fastrtps::rtps::CacheChange_t*> DiscoveryDataBase::clear()
     /* Clear receive queues. Set changes inside to release */
     while (!pdp_data_queue_.Empty())
     {
-        DiscoveryPDPDataQueueInfo data_queue_info = pdp_data_queue_.Front();
+        // This moves the value, do not copy it
+        DiscoveryPDPDataQueueInfo data_queue_info = pdp_data_queue_.FrontAndPop();
         changes_to_release_.push_back(data_queue_info.change());
-        pdp_data_queue_.Pop();
     }
     pdp_data_queue_.Clear(
 
         );
     while (!edp_data_queue_.Empty())
     {
-        DiscoveryEDPDataQueueInfo data_queue_info = edp_data_queue_.Front();
+        // This moves the value, do not copy it
+        DiscoveryEDPDataQueueInfo data_queue_info = edp_data_queue_.FrontAndPop();
         changes_to_release_.push_back(data_queue_info.change());
-        edp_data_queue_.Pop();
     }
     edp_data_queue_.Clear();
 
@@ -468,8 +468,8 @@ void DiscoveryDataBase::process_pdp_data_queue()
     // Process all messages in the queque
     while (!pdp_data_queue_.Empty())
     {
-        // Process each message with Front()
-        DiscoveryPDPDataQueueInfo data_queue_info = pdp_data_queue_.Front();
+        // Process each message with FrontAndPop(). Move it, do not copy it
+        DiscoveryPDPDataQueueInfo data_queue_info = pdp_data_queue_.FrontAndPop();
 
         // If the change is a DATA(p)
         if (data_queue_info.change()->kind == eprosima::fastrtps::rtps::ALIVE)
@@ -486,9 +486,6 @@ void DiscoveryDataBase::process_pdp_data_queue()
                     " received from: " << data_queue_info.change()->writerGUID);
             process_dispose_participant_(data_queue_info.change());
         }
-
-        // Pop the message from the queue
-        pdp_data_queue_.Pop();
     }
 }
 
@@ -514,8 +511,8 @@ bool DiscoveryDataBase::process_edp_data_queue()
     // Process all messages in the queque
     while (!edp_data_queue_.Empty())
     {
-        // Process each message with Front()
-        DiscoveryEDPDataQueueInfo data_queue_info = edp_data_queue_.Front();
+        // Process each message with FrontAndPop(). Move it, do not copy it
+        DiscoveryEDPDataQueueInfo data_queue_info = edp_data_queue_.FrontAndPop();
         change = data_queue_info.change();
         topic_name = data_queue_info.topic();
 
@@ -554,9 +551,6 @@ bool DiscoveryDataBase::process_edp_data_queue()
                 process_dispose_reader_(change);
             }
         }
-
-        // Pop the message from the queue
-        edp_data_queue_.Pop();
     }
 
     return is_dirty_topic;

--- a/src/cpp/rtps/transport/shared_mem/SharedMemLog.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemLog.hpp
@@ -386,12 +386,13 @@ private:
                 while (!resources_.logs.Empty())
                 {
                     std::unique_lock<std::mutex> configGuard(resources_.config_mutex);
+
+                    // This value is moved and not copied
+                    auto value_dequeue = resources_.logs.FrontAndPop();
                     for (auto& consumer : resources_.consumers)
                     {
-                        consumer->Consume(resources_.logs.Front());
+                        consumer->Consume(value_dequeue);
                     }
-
-                    resources_.logs.Pop();
                 }
             }
             guard.lock();


### PR DESCRIPTION
<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
Implement new methods in DBQueue class so it allows to move elements TO the queue and FROM the queue, avoiding copy of big objects.

Methods implemented:
- Push(T&&) move an element to the queue
- FrontAndPop() get the first element from the queue by moving it and remove it from the queue

<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [ ] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
