### PR TITLE
MessageReceiver refactor to fix deadlocks [14069] <master>

### DIFF
--- a/.github/workflows/thread-sanitizer.yaml
+++ b/.github/workflows/thread-sanitizer.yaml
@@ -89,13 +89,10 @@ jobs:
           cd ws
           git clone https://github.com/eProsima/Fast-DDS.git
           cd Fast-DDS
-<<<<<<< HEAD
-=======
           git fetch origin ${{ github.ref }}:merge-branch
           git checkout merge-branch
           echo "Modified files against destination branch"
           git diff --name-only HEAD~1
->>>>>>> b14962a01... Fixed unknown ref error during checkout in workflow execution (#2644)
           git remote add efork https://github.com/MiguelBarro/Fast-DDS.git
           git fetch efork
           git merge --no-edit efork/bugfix/add_sanitizer_support | Out-Null

--- a/.github/workflows/thread-sanitizer.yaml
+++ b/.github/workflows/thread-sanitizer.yaml
@@ -21,7 +21,7 @@ jobs:
     name: Sanitizer Evaluation
     runs-on: ubuntu-latest
     steps:
-      - name: Download the sanitazers cmake module and apply some fixes
+      - name: Download the sanitizers cmake module and apply some fixes
         run: |
           git config --global user.email "dummy@mail.com"
           git config --global user.name "dummy"
@@ -98,7 +98,7 @@ jobs:
 >>>>>>> b14962a01... Fixed unknown ref error during checkout in workflow execution (#2644)
           git remote add efork https://github.com/MiguelBarro/Fast-DDS.git
           git fetch efork
-          git merge --no-edit efork/bugfix/add_sanitizer_support
+          git merge --no-edit efork/bugfix/add_sanitizer_support | Out-Null
 
       - name: Build & install Fast-DDS
         run: |

--- a/.github/workflows/thread-sanitizer.yaml
+++ b/.github/workflows/thread-sanitizer.yaml
@@ -89,6 +89,13 @@ jobs:
           cd ws
           git clone https://github.com/eProsima/Fast-DDS.git
           cd Fast-DDS
+<<<<<<< HEAD
+=======
+          git fetch origin ${{ github.ref }}:merge-branch
+          git checkout merge-branch
+          echo "Modified files against destination branch"
+          git diff --name-only HEAD~1
+>>>>>>> b14962a01... Fixed unknown ref error during checkout in workflow execution (#2644)
           git remote add efork https://github.com/MiguelBarro/Fast-DDS.git
           git fetch efork
           git merge --no-edit efork/bugfix/add_sanitizer_support

--- a/include/fastdds/rtps/messages/MessageReceiver.h
+++ b/include/fastdds/rtps/messages/MessageReceiver.h
@@ -20,11 +20,11 @@
 #define _FASTDDS_RTPS_MESSAGERECEIVER_H_
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
-#include <fastdds/rtps/common/all_common.h>
-
 #include <functional>
-#include <fastrtps/utils/shared_mutex.hpp>
 #include <unordered_map>
+
+#include <fastdds/rtps/common/all_common.h>
+#include <fastrtps/utils/shared_mutex.hpp>
 
 namespace eprosima {
 namespace fastrtps {

--- a/include/fastdds/rtps/messages/MessageReceiver.h
+++ b/include/fastdds/rtps/messages/MessageReceiver.h
@@ -22,9 +22,9 @@
 
 #include <fastdds/rtps/common/all_common.h>
 
-#include <unordered_map>
-#include <mutex>
 #include <functional>
+#include <shared_mutex>
+#include <unordered_map>
 
 namespace eprosima {
 namespace fastrtps {
@@ -73,7 +73,7 @@ public:
 
 private:
 
-    std::mutex mtx_;
+    mutable std::shared_mutex mtx_;
     std::vector<RTPSWriter*> associated_writers_;
     std::unordered_map<EntityId_t, std::vector<RTPSReader*>> associated_readers_;
 
@@ -130,7 +130,7 @@ private:
      */
     bool readSubmessageHeader(
             CDRMessage_t* msg,
-            SubmessageHeader_t* smh);
+            SubmessageHeader_t* smh) const;
 
     /**
      * Find if there is a reader (in associated_readers_) that will accept a msg directed
@@ -138,7 +138,7 @@ private:
      */
     bool willAReaderAcceptMsgDirectedTo(
             const EntityId_t& readerID,
-            RTPSReader*& first_reader);
+            RTPSReader*& first_reader) const;
 
     /**
      * Find all readers (in associated_readers_), with the given entity ID, and call the
@@ -147,7 +147,7 @@ private:
     template<typename Functor>
     void findAllReaders(
             const EntityId_t& readerID,
-            const Functor& callback);
+            const Functor& callback) const;
 
     /**@name Processing methods.
      * These methods are designed to read a part of the message
@@ -169,19 +169,19 @@ private:
      */
     bool proc_Submsg_Data(
             CDRMessage_t* msg,
-            SubmessageHeader_t* smh);
+            SubmessageHeader_t* smh) const;
     bool proc_Submsg_DataFrag(
             CDRMessage_t* msg,
-            SubmessageHeader_t* smh);
-    bool proc_Submsg_Acknack(
-            CDRMessage_t* msg,
-            SubmessageHeader_t* smh);
+            SubmessageHeader_t* smh) const;
     bool proc_Submsg_Heartbeat(
             CDRMessage_t* msg,
-            SubmessageHeader_t* smh);
+            SubmessageHeader_t* smh) const;
+    bool proc_Submsg_Acknack(
+            CDRMessage_t* msg,
+            SubmessageHeader_t* smh) const;
     bool proc_Submsg_Gap(
             CDRMessage_t* msg,
-            SubmessageHeader_t* smh);
+            SubmessageHeader_t* smh) const;
     bool proc_Submsg_InfoTS(
             CDRMessage_t* msg,
             SubmessageHeader_t* smh);
@@ -193,10 +193,10 @@ private:
             SubmessageHeader_t* smh);
     bool proc_Submsg_NackFrag(
             CDRMessage_t* msg,
-            SubmessageHeader_t* smh);
+            SubmessageHeader_t* smh) const;
     bool proc_Submsg_HeartbeatFrag(
             CDRMessage_t* msg,
-            SubmessageHeader_t* smh);
+            SubmessageHeader_t* smh) const;
     ///@}
 
 
@@ -258,7 +258,7 @@ private:
     void notify_network_statistics(
             const Locator_t& source_locator,
             const Locator_t& reception_locator,
-            CDRMessage_t* msg);
+            CDRMessage_t* msg) const;
 
 };
 

--- a/include/fastdds/rtps/messages/MessageReceiver.h
+++ b/include/fastdds/rtps/messages/MessageReceiver.h
@@ -23,7 +23,7 @@
 #include <fastdds/rtps/common/all_common.h>
 
 #include <functional>
-#include <shared_mutex>
+#include <fastrtps/utils/shared_mutex.hpp>
 #include <unordered_map>
 
 namespace eprosima {
@@ -73,7 +73,7 @@ public:
 
 private:
 
-    mutable std::shared_mutex mtx_;
+    mutable eprosima::shared_mutex mtx_;
     std::vector<RTPSWriter*> associated_writers_;
     std::unordered_map<EntityId_t, std::vector<RTPSReader*>> associated_readers_;
 

--- a/include/fastrtps/utils/shared_mutex.hpp
+++ b/include/fastrtps/utils/shared_mutex.hpp
@@ -8,8 +8,15 @@
 #ifndef _UTILS_SHARED_MUTEX_HPP_
 #define _UTILS_SHARED_MUTEX_HPP_
 
-// detect if STL version is available, note that __cplusplus is not reliable on MSVC
-#if (__cplusplus < 201402) || (defined(_MSC_VER) && _MSC_VER < 1900 )
+#if defined(__has_include) && __has_include(<version>)
+#   include <version>
+#endif
+
+// Detect if the share_mutex feature is available
+#if defined(__has_include) && __has_include(<version>) && !defined(__cpp_lib_shared_mutex) || \
+/* deprecated procedure if the good one is not available*/ \
+( !(defined(__has_include) && __has_include(<version>)) && \
+  !(defined(HAVE_CXX17) && HAVE_CXX17) &&  __cplusplus < 201703 )
 
 #include <mutex>
 #include <condition_variable>
@@ -347,7 +354,8 @@ shared_lock<Mutex>::try_lock()
 namespace eprosima {
 
 using shared_mutex = std::shared_mutex;
-using shared_lock = std::shared_lock;
+template< class Mutex >
+using shared_lock = std::shared_lock<Mutex>;
 
 } //namespace eprosima
 

--- a/include/fastrtps/utils/shared_mutex.hpp
+++ b/include/fastrtps/utils/shared_mutex.hpp
@@ -1,0 +1,269 @@
+// Copyright Howard Hinnant 2007-2010. Distributed under the Boost
+// Software License, Version 1.0. (see http://www.boost.org/LICENSE_1_0.txt)
+
+/**
+ * @file shared_mutex.hpp
+ */
+
+#ifndef _UTILS_SHARED_MUTEX_HPP_
+#define _UTILS_SHARED_MUTEX_HPP_
+
+// detect if STL version is available, note that __cplusplus is not reliable on MSVC
+#if (__cplusplus < 201402) || (defined(_MSC_VER) && _MSC_VER < 1900 )
+
+#include <mutex>
+#include <condition_variable>
+#include <climits>
+#include <system_error>
+
+namespace eprosima {
+
+class shared_mutex
+{
+    typedef std::mutex              mutex_t;
+    typedef std::condition_variable cond_t;
+    typedef unsigned                count_t;
+
+    mutex_t mut_;
+    cond_t  gate1_;
+    cond_t  gate2_;
+    count_t state_;
+
+    static const count_t write_entered_ = 1U << (sizeof(count_t)*CHAR_BIT - 1);
+    static const count_t n_readers_ = ~write_entered_;
+
+public:
+    shared_mutex()
+        : state_(0)
+    {
+    }
+
+    ~shared_mutex()
+    {
+        std::lock_guard<mutex_t> _(mut_);
+    }
+
+    shared_mutex(const shared_mutex&) = delete;
+    shared_mutex& operator=(const shared_mutex&) = delete;
+
+// Exclusive ownership
+
+    void lock()
+    {
+        std::unique_lock<mutex_t> lk(mut_);
+        while (state_ & write_entered_)
+            gate1_.wait(lk);
+        state_ |= write_entered_;
+        while (state_ & n_readers_)
+            gate2_.wait(lk);
+    }
+
+    bool try_lock()
+    {
+        std::unique_lock<mutex_t> lk(mut_);
+        if (state_ == 0)
+        {
+            state_ = write_entered_;
+            return true;
+        }
+        return false;
+    }
+
+    void unlock()
+    {
+        std::lock_guard<mutex_t> _(mut_);
+        state_ = 0;
+        gate1_.notify_all();
+    }
+
+// Shared ownership
+
+    void lock_shared()
+    {
+        std::unique_lock<mutex_t> lk(mut_);
+        while ((state_ & write_entered_) || (state_ & n_readers_) == n_readers_)
+            gate1_.wait(lk);
+        count_t num_readers = (state_ & n_readers_) + 1;
+        state_ &= ~n_readers_;
+        state_ |= num_readers;
+    }
+
+    bool try_lock_shared()
+    {
+        std::unique_lock<mutex_t> lk(mut_);
+        count_t num_readers = state_ & n_readers_;
+        if (!(state_ & write_entered_) && num_readers != n_readers_)
+        {
+            ++num_readers;
+            state_ &= ~n_readers_;
+            state_ |= num_readers;
+            return true;
+        }
+        return false;
+    }
+
+    void unlock_shared()
+    {
+        std::lock_guard<mutex_t> _(mut_);
+        count_t num_readers = (state_ & n_readers_) - 1;
+        state_ &= ~n_readers_;
+        state_ |= num_readers;
+        if (state_ & write_entered_)
+        {
+            if (num_readers == 0)
+                gate2_.notify_one();
+        }
+        else
+        {
+            if (num_readers == n_readers_ - 1)
+                gate1_.notify_one();
+        }
+    }
+};
+
+template <class Mutex>
+class shared_lock
+{
+public:
+    typedef Mutex mutex_type;
+
+private:
+    mutex_type* m_;
+    bool owns_;
+
+    struct __nat {int _;};
+
+public:
+    shared_lock()
+        : m_(nullptr), owns_(false) {}
+
+    explicit shared_lock(mutex_type& m)
+        : m_(&m), owns_(true)
+        {m_->lock_shared();}
+
+    shared_lock(mutex_type& m, std::defer_lock_t)
+        : m_(&m), owns_(false) {}
+
+    shared_lock(mutex_type& m, std::try_to_lock_t)
+        : m_(&m), owns_(m.try_lock_shared()) {}
+
+    shared_lock(mutex_type& m, std::adopt_lock_t)
+        : m_(&m), owns_(true) {}
+
+    template <class Clock, class Duration>
+        shared_lock(mutex_type& m,
+                    const std::chrono::time_point<Clock, Duration>& abs_time)
+        : m_(&m), owns_(m.try_lock_shared_until(abs_time)) {}
+    template <class Rep, class Period>
+        shared_lock(mutex_type& m,
+                    const std::chrono::duration<Rep, Period>& rel_time)
+        : m_(&m), owns_(m.try_lock_shared_for(rel_time)) {}
+
+    ~shared_lock()
+    {
+        if (owns_)
+            m_->unlock_shared();
+    }
+
+    shared_lock(shared_lock const&) = delete;
+    shared_lock& operator=(shared_lock const&) = delete;
+
+    shared_lock(shared_lock&& sl)
+        : m_(sl.m_), owns_(sl.owns_)
+        {sl.m_ = nullptr; sl.owns_ = false;}
+
+    shared_lock& operator=(shared_lock&& sl)
+    {
+        if (owns_)
+            m_->unlock_shared();
+        m_ = sl.m_;
+        owns_ = sl.owns_;
+        sl.m_ = nullptr;
+        sl.owns_ = false;
+        return *this;
+    }
+
+    explicit shared_lock(std::unique_lock<mutex_type>&& ul)
+        : m_(ul.mutex()), owns_(ul.owns_lock())
+    {
+        if (owns_)
+            m_->unlock_and_lock_shared();
+        ul.release();
+    }
+
+    void lock();
+    bool try_lock();
+    template <class Rep, class Period>
+        bool try_lock_for(const std::chrono::duration<Rep, Period>& rel_time)
+        {
+            return try_lock_until(std::chrono::steady_clock::now() + rel_time);
+        }
+    template <class Clock, class Duration>
+        bool
+        try_lock_until(
+                      const std::chrono::time_point<Clock, Duration>& abs_time);
+    void unlock();
+
+    void swap(shared_lock&& u)
+    {
+        std::swap(m_, u.m_);
+        std::swap(owns_, u.owns_);
+    }
+
+    mutex_type* release()
+    {
+        mutex_type* r = m_;
+        m_ = nullptr;
+        owns_ = false;
+        return r;
+    }
+    bool owns_lock() const {return owns_;}
+    operator int __nat::* () const {return owns_ ? &__nat::_ : 0;}
+    mutex_type* mutex() const {return m_;}
+
+};
+
+template <class Mutex>
+void
+shared_lock<Mutex>::lock()
+{
+    if (m_ == nullptr)
+        throw std::system_error(std::error_code(EPERM, std::system_category()),
+                                    "shared_lock::lock: references null mutex");
+    if (owns_)
+        throw std::system_error(std::error_code(EDEADLK, std::system_category()),
+                                           "shared_lock::lock: already locked");
+    m_->lock_shared();
+    owns_ = true;
+}
+
+template <class Mutex>
+bool
+shared_lock<Mutex>::try_lock()
+{
+    if (m_ == nullptr)
+        throw std::system_error(std::error_code(EPERM, std::system_category()),
+                                "shared_lock::try_lock: references null mutex");
+    if (owns_)
+        throw std::system_error(std::error_code(EDEADLK, std::system_category()),
+                                       "shared_lock::try_lock: already locked");
+    owns_ = m_->try_lock_shared();
+    return owns_;
+}
+
+} //namespace eprosima
+
+#else // fallback to STL
+
+#include <shared_mutex>
+
+namespace eprosima {
+
+using shared_mutex = std::shared_mutex;
+using shared_lock = std::shared_lock;
+
+} //namespace eprosima
+
+#endif
+
+#endif // _UTILS_SHARED_MUTEX_HPP_

--- a/include/fastrtps/utils/shared_mutex.hpp
+++ b/include/fastrtps/utils/shared_mutex.hpp
@@ -10,13 +10,13 @@
 
 #if defined(__has_include) && __has_include(<version>)
 #   include <version>
-#endif
+#endif // if defined(__has_include) && __has_include(<version>)
 
 // Detect if the share_mutex feature is available
 #if defined(__has_include) && __has_include(<version>) && !defined(__cpp_lib_shared_mutex) || \
-/* deprecated procedure if the good one is not available*/ \
-( !(defined(__has_include) && __has_include(<version>)) && \
-  !(defined(HAVE_CXX17) && HAVE_CXX17) &&  __cplusplus < 201703 )
+    /* deprecated procedure if the good one is not available*/ \
+    ( !(defined(__has_include) && __has_include(<version>)) && \
+    !(defined(HAVE_CXX17) && HAVE_CXX17) &&  __cplusplus < 201703 )
 
 #include <mutex>
 #include <condition_variable>

--- a/include/fastrtps/utils/shared_mutex.hpp
+++ b/include/fastrtps/utils/shared_mutex.hpp
@@ -20,19 +20,20 @@ namespace eprosima {
 
 class shared_mutex
 {
-    typedef std::mutex              mutex_t;
+    typedef std::mutex mutex_t;
     typedef std::condition_variable cond_t;
-    typedef unsigned                count_t;
+    typedef unsigned count_t;
 
     mutex_t mut_;
-    cond_t  gate1_;
-    cond_t  gate2_;
+    cond_t gate1_;
+    cond_t gate2_;
     count_t state_;
 
-    static const count_t write_entered_ = 1U << (sizeof(count_t)*CHAR_BIT - 1);
+    static const count_t write_entered_ = 1U << (sizeof(count_t) * CHAR_BIT - 1);
     static const count_t n_readers_ = ~write_entered_;
 
 public:
+
     shared_mutex()
         : state_(0)
     {
@@ -43,19 +44,25 @@ public:
         std::lock_guard<mutex_t> _(mut_);
     }
 
-    shared_mutex(const shared_mutex&) = delete;
-    shared_mutex& operator=(const shared_mutex&) = delete;
+    shared_mutex(
+            const shared_mutex&) = delete;
+    shared_mutex& operator =(
+            const shared_mutex&) = delete;
 
-// Exclusive ownership
+    // Exclusive ownership
 
     void lock()
     {
         std::unique_lock<mutex_t> lk(mut_);
         while (state_ & write_entered_)
+        {
             gate1_.wait(lk);
+        }
         state_ |= write_entered_;
         while (state_ & n_readers_)
+        {
             gate2_.wait(lk);
+        }
     }
 
     bool try_lock()
@@ -76,13 +83,15 @@ public:
         gate1_.notify_all();
     }
 
-// Shared ownership
+    // Shared ownership
 
     void lock_shared()
     {
         std::unique_lock<mutex_t> lk(mut_);
         while ((state_ & write_entered_) || (state_ & n_readers_) == n_readers_)
+        {
             gate1_.wait(lk);
+        }
         count_t num_readers = (state_ & n_readers_) + 1;
         state_ &= ~n_readers_;
         state_ |= num_readers;
@@ -111,71 +120,124 @@ public:
         if (state_ & write_entered_)
         {
             if (num_readers == 0)
+            {
                 gate2_.notify_one();
+            }
         }
         else
         {
             if (num_readers == n_readers_ - 1)
+            {
                 gate1_.notify_one();
+            }
         }
     }
+
 };
 
 template <class Mutex>
 class shared_lock
 {
 public:
+
     typedef Mutex mutex_type;
 
 private:
+
     mutex_type* m_;
     bool owns_;
 
-    struct __nat {int _;};
+    struct __nat
+    {
+        int _;
+    };
 
 public:
+
     shared_lock()
-        : m_(nullptr), owns_(false) {}
+        : m_(nullptr)
+        , owns_(false)
+    {
+    }
 
-    explicit shared_lock(mutex_type& m)
-        : m_(&m), owns_(true)
-        {m_->lock_shared();}
+    explicit shared_lock(
+            mutex_type& m)
+        : m_(&m)
+        , owns_(true)
+    {
+        m_->lock_shared();
+    }
 
-    shared_lock(mutex_type& m, std::defer_lock_t)
-        : m_(&m), owns_(false) {}
+    shared_lock(
+            mutex_type& m,
+            std::defer_lock_t)
+        : m_(&m)
+        , owns_(false)
+    {
+    }
 
-    shared_lock(mutex_type& m, std::try_to_lock_t)
-        : m_(&m), owns_(m.try_lock_shared()) {}
+    shared_lock(
+            mutex_type& m,
+            std::try_to_lock_t)
+        : m_(&m)
+        , owns_(m.try_lock_shared())
+    {
+    }
 
-    shared_lock(mutex_type& m, std::adopt_lock_t)
-        : m_(&m), owns_(true) {}
+    shared_lock(
+            mutex_type& m,
+            std::adopt_lock_t)
+        : m_(&m)
+        , owns_(true)
+    {
+    }
 
     template <class Clock, class Duration>
-        shared_lock(mutex_type& m,
-                    const std::chrono::time_point<Clock, Duration>& abs_time)
-        : m_(&m), owns_(m.try_lock_shared_until(abs_time)) {}
+    shared_lock(
+            mutex_type& m,
+            const std::chrono::time_point<Clock, Duration>& abs_time)
+        : m_(&m)
+        , owns_(m.try_lock_shared_until(abs_time))
+    {
+    }
+
     template <class Rep, class Period>
-        shared_lock(mutex_type& m,
-                    const std::chrono::duration<Rep, Period>& rel_time)
-        : m_(&m), owns_(m.try_lock_shared_for(rel_time)) {}
+    shared_lock(
+            mutex_type& m,
+            const std::chrono::duration<Rep, Period>& rel_time)
+        : m_(&m)
+        , owns_(m.try_lock_shared_for(rel_time))
+    {
+    }
 
     ~shared_lock()
     {
         if (owns_)
+        {
             m_->unlock_shared();
+        }
     }
 
-    shared_lock(shared_lock const&) = delete;
-    shared_lock& operator=(shared_lock const&) = delete;
+    shared_lock(
+            shared_lock const&) = delete;
+    shared_lock& operator =(
+            shared_lock const&) = delete;
 
-    shared_lock(shared_lock&& sl)
-        : m_(sl.m_), owns_(sl.owns_)
-        {sl.m_ = nullptr; sl.owns_ = false;}
+    shared_lock(
+            shared_lock&& sl)
+        : m_(sl.m_)
+        , owns_(sl.owns_)
+    {
+        sl.m_ = nullptr; sl.owns_ = false;
+    }
 
-    shared_lock& operator=(shared_lock&& sl)
+    shared_lock& operator =(
+            shared_lock&& sl)
     {
         if (owns_)
+        {
             m_->unlock_shared();
+        }
         m_ = sl.m_;
         owns_ = sl.owns_;
         sl.m_ = nullptr;
@@ -183,28 +245,35 @@ public:
         return *this;
     }
 
-    explicit shared_lock(std::unique_lock<mutex_type>&& ul)
-        : m_(ul.mutex()), owns_(ul.owns_lock())
+    explicit shared_lock(
+            std::unique_lock<mutex_type>&& ul)
+        : m_(ul.mutex())
+        , owns_(ul.owns_lock())
     {
         if (owns_)
+        {
             m_->unlock_and_lock_shared();
+        }
         ul.release();
     }
 
     void lock();
     bool try_lock();
     template <class Rep, class Period>
-        bool try_lock_for(const std::chrono::duration<Rep, Period>& rel_time)
-        {
-            return try_lock_until(std::chrono::steady_clock::now() + rel_time);
-        }
+    bool try_lock_for(
+            const std::chrono::duration<Rep, Period>& rel_time)
+    {
+        return try_lock_until(std::chrono::steady_clock::now() + rel_time);
+    }
+
     template <class Clock, class Duration>
-        bool
-        try_lock_until(
-                      const std::chrono::time_point<Clock, Duration>& abs_time);
+    bool
+    try_lock_until(
+            const std::chrono::time_point<Clock, Duration>& abs_time);
     void unlock();
 
-    void swap(shared_lock&& u)
+    void swap(
+            shared_lock&& u)
     {
         std::swap(m_, u.m_);
         std::swap(owns_, u.owns_);
@@ -217,9 +286,19 @@ public:
         owns_ = false;
         return r;
     }
-    bool owns_lock() const {return owns_;}
-    operator int __nat::* () const {return owns_ ? &__nat::_ : 0;}
-    mutex_type* mutex() const {return m_;}
+
+    bool owns_lock() const
+    {
+        return owns_;
+    }
+
+    operator int __nat::* () const {
+        return owns_ ? &__nat::_ : 0;
+    }
+    mutex_type* mutex() const
+    {
+        return m_;
+    }
 
 };
 
@@ -228,11 +307,15 @@ void
 shared_lock<Mutex>::lock()
 {
     if (m_ == nullptr)
+    {
         throw std::system_error(std::error_code(EPERM, std::system_category()),
-                                    "shared_lock::lock: references null mutex");
+                      "shared_lock::lock: references null mutex");
+    }
     if (owns_)
+    {
         throw std::system_error(std::error_code(EDEADLK, std::system_category()),
-                                           "shared_lock::lock: already locked");
+                      "shared_lock::lock: already locked");
+    }
     m_->lock_shared();
     owns_ = true;
 }
@@ -242,11 +325,15 @@ bool
 shared_lock<Mutex>::try_lock()
 {
     if (m_ == nullptr)
+    {
         throw std::system_error(std::error_code(EPERM, std::system_category()),
-                                "shared_lock::try_lock: references null mutex");
+                      "shared_lock::try_lock: references null mutex");
+    }
     if (owns_)
+    {
         throw std::system_error(std::error_code(EDEADLK, std::system_category()),
-                                       "shared_lock::try_lock: already locked");
+                      "shared_lock::try_lock: already locked");
+    }
     owns_ = m_->try_lock_shared();
     return owns_;
 }
@@ -264,6 +351,6 @@ using shared_lock = std::shared_lock;
 
 } //namespace eprosima
 
-#endif
+#endif // if (__cplusplus < 201402) || (defined(_MSC_VER) && _MSC_VER < 1900 )
 
 #endif // _UTILS_SHARED_MUTEX_HPP_

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -21,7 +21,6 @@
 
 #include <cassert>
 #include <limits>
-#include <mutex>
 
 #include <fastdds/core/policy/ParameterList.hpp>
 #include <fastdds/dds/log/Log.hpp>
@@ -222,7 +221,7 @@ void MessageReceiver::process_data_fragment_message_without_security(
 void MessageReceiver::associateEndpoint(
         Endpoint* to_add)
 {
-    std::lock_guard<std::mutex> guard(mtx_);
+    std::lock_guard<std::shared_mutex> guard(mtx_);
     if (to_add->getAttributes().endpointKind == WRITER)
     {
         const auto writer = dynamic_cast<RTPSWriter*>(to_add);
@@ -266,7 +265,7 @@ void MessageReceiver::associateEndpoint(
 void MessageReceiver::removeEndpoint(
         Endpoint* to_remove)
 {
-    std::lock_guard<std::mutex> guard(mtx_);
+    std::lock_guard<std::shared_mutex> guard(mtx_);
 
     if (to_remove->getAttributes().endpointKind == WRITER)
     {
@@ -317,53 +316,63 @@ void MessageReceiver::processCDRMsg(
         const Locator_t& reception_locator,
         CDRMessage_t* msg)
 {
-    if (msg->length < RTPSMESSAGE_HEADER_SIZE)
-    {
-        logWarning(RTPS_MSG_IN, IDSTRING "Received message too short, ignoring");
-        return;
-    }
-
-    reset();
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     GuidPrefix_t participantGuidPrefix;
 #else
     GuidPrefix_t participantGuidPrefix = participant_->getGuid().guidPrefix;
 #endif // ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    dest_guid_prefix_ = participantGuidPrefix;
-
-    msg->pos = 0; //Start reading at 0
-
-    //Once everything is set, the reading begins:
-    if (!checkRTPSHeader(msg))
-    {
-        return;
-    }
-
-    notify_network_statistics(source_locator, reception_locator, msg);
 
 #if HAVE_SECURITY
     security::SecurityManager& security = participant_->security_manager();
     CDRMessage_t* auxiliary_buffer = &crypto_msg_;
-
-    int decode_ret = security.decode_rtps_message(*msg, *auxiliary_buffer, source_guid_prefix_);
-
-    if (decode_ret < 0)
-    {
-        return;
-    }
-
-    if (decode_ret == 0)
-    {
-        // The original CDRMessage buffer (msg) now points to the proprietary temporary buffer crypto_msg_.
-        // The auxiliary buffer now points to the propietary temporary buffer crypto_submsg_.
-        // This way each decoded sub-message will be processed using the crypto_submsg_ buffer.
-        msg = auxiliary_buffer;
-        auxiliary_buffer = &crypto_submsg_;
-    }
+    int decode_ret = 0;
 #endif // if HAVE_SECURITY
 
+    {
+        std::lock_guard<std::shared_mutex> guard(mtx_);
+
+        if (msg->length < RTPSMESSAGE_HEADER_SIZE)
+        {
+            logWarning(RTPS_MSG_IN, IDSTRING "Received message too short, ignoring");
+            return;
+        }
+
+        reset();
+
+        dest_guid_prefix_ = participantGuidPrefix;
+
+        msg->pos = 0; //Start reading at 0
+
+        //Once everything is set, the reading begins:
+        if (!checkRTPSHeader(msg))
+        {
+            return;
+        }
+
+        notify_network_statistics(source_locator, reception_locator, msg);
+
+#if HAVE_SECURITY
+        decode_ret = security.decode_rtps_message(*msg, *auxiliary_buffer, source_guid_prefix_);
+
+        if (decode_ret < 0)
+        {
+            return;
+        }
+
+        if (decode_ret == 0)
+        {
+            // The original CDRMessage buffer (msg) now points to the proprietary temporary buffer crypto_msg_.
+            // The auxiliary buffer now points to the propietary temporary buffer crypto_submsg_.
+            // This way each decoded sub-message will be processed using the crypto_submsg_ buffer.
+            msg = auxiliary_buffer;
+            auxiliary_buffer = &crypto_submsg_;
+        }
+#endif // if HAVE_SECURITY
+    }
+
     // Loop until there are no more submessages
+    // Each submessage processing method choses the lock kind required
     bool valid;
     SubmessageHeader_t submsgh; //Current submessage header
 
@@ -563,7 +572,7 @@ bool MessageReceiver::checkRTPSHeader(
 
 bool MessageReceiver::readSubmessageHeader(
         CDRMessage_t* msg,
-        SubmessageHeader_t* smh)
+        SubmessageHeader_t* smh) const
 {
     if (msg->length - msg->pos < 4)
     {
@@ -604,7 +613,7 @@ bool MessageReceiver::readSubmessageHeader(
 
 bool MessageReceiver::willAReaderAcceptMsgDirectedTo(
         const EntityId_t& readerID,
-        RTPSReader*& first_reader)
+        RTPSReader*& first_reader) const
 {
     first_reader = nullptr;
     if (associated_readers_.empty())
@@ -644,7 +653,7 @@ bool MessageReceiver::willAReaderAcceptMsgDirectedTo(
 template<typename Functor>
 void MessageReceiver::findAllReaders(
         const EntityId_t& readerID,
-        const Functor& callback)
+        const Functor& callback) const
 {
     if (readerID != c_EntityId_Unknown)
     {
@@ -674,9 +683,9 @@ void MessageReceiver::findAllReaders(
 
 bool MessageReceiver::proc_Submsg_Data(
         CDRMessage_t* msg,
-        SubmessageHeader_t* smh)
+        SubmessageHeader_t* smh) const
 {
-    std::lock_guard<std::mutex> guard(mtx_);
+    std::shared_lock<std::shared_mutex> guard(mtx_);
 
     //READ and PROCESS
     if (smh->submessageLength < RTPSMESSAGE_DATA_MIN_LENGTH)
@@ -844,9 +853,9 @@ bool MessageReceiver::proc_Submsg_Data(
 
 bool MessageReceiver::proc_Submsg_DataFrag(
         CDRMessage_t* msg,
-        SubmessageHeader_t* smh)
+        SubmessageHeader_t* smh) const
 {
-    std::lock_guard<std::mutex> guard(mtx_);
+    std::shared_lock<std::shared_mutex> guard(mtx_);
 
     //READ and PROCESS
     if (smh->submessageLength < RTPSMESSAGE_DATA_MIN_LENGTH)
@@ -1019,8 +1028,10 @@ bool MessageReceiver::proc_Submsg_DataFrag(
 
 bool MessageReceiver::proc_Submsg_Heartbeat(
         CDRMessage_t* msg,
-        SubmessageHeader_t* smh)
+        SubmessageHeader_t* smh) const
 {
+    std::shared_lock<std::shared_mutex> guard(mtx_);
+
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     bool finalFlag = (smh->flags & BIT(1)) != 0;
     bool livelinessFlag = (smh->flags & BIT(2)) != 0;
@@ -1057,7 +1068,6 @@ bool MessageReceiver::proc_Submsg_Heartbeat(
         return false;
     }
 
-    std::lock_guard<std::mutex> guard(mtx_);
     //Look for the correct reader and writers:
     findAllReaders(readerGUID.entityId,
             [&writerGUID, &HBCount, &firstSN, &lastSN, finalFlag, livelinessFlag](RTPSReader* reader)
@@ -1070,8 +1080,10 @@ bool MessageReceiver::proc_Submsg_Heartbeat(
 
 bool MessageReceiver::proc_Submsg_Acknack(
         CDRMessage_t* msg,
-        SubmessageHeader_t* smh)
+        SubmessageHeader_t* smh) const
 {
+    std::shared_lock<std::shared_mutex> guard(mtx_);
+
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     bool finalFlag = (smh->flags & BIT(1)) != 0;
     //Assign message endianness
@@ -1090,7 +1102,6 @@ bool MessageReceiver::proc_Submsg_Acknack(
     writerGUID.guidPrefix = dest_guid_prefix_;
     CDRMessage::readEntityId(msg, &writerGUID.entityId);
 
-
     SequenceNumberSet_t SNSet = CDRMessage::readSequenceNumberSet(msg);
     uint32_t Ackcount;
     if (!CDRMessage::readUInt32(msg, &Ackcount))
@@ -1099,7 +1110,6 @@ bool MessageReceiver::proc_Submsg_Acknack(
         return false;
     }
 
-    std::lock_guard<std::mutex> guard(mtx_);
     //Look for the correct writer to use the acknack
     for (RTPSWriter* it : associated_writers_)
     {
@@ -1120,8 +1130,10 @@ bool MessageReceiver::proc_Submsg_Acknack(
 
 bool MessageReceiver::proc_Submsg_Gap(
         CDRMessage_t* msg,
-        SubmessageHeader_t* smh)
+        SubmessageHeader_t* smh) const
 {
+    std::shared_lock<std::shared_mutex> guard(mtx_);
+
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     //Assign message endianness
     if (endiannessFlag)
@@ -1147,7 +1159,6 @@ bool MessageReceiver::proc_Submsg_Gap(
         return false;
     }
 
-    std::lock_guard<std::mutex> guard(mtx_);
     findAllReaders(readerGUID.entityId,
             [&writerGUID, &gapStart, &gapList](RTPSReader* reader)
             {
@@ -1161,6 +1172,8 @@ bool MessageReceiver::proc_Submsg_InfoTS(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh)
 {
+    std::lock_guard<std::shared_mutex> guard(mtx_);
+
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     bool timeFlag = (smh->flags & BIT(1)) != 0;
     //Assign message endianness
@@ -1189,6 +1202,8 @@ bool MessageReceiver::proc_Submsg_InfoDST(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh)
 {
+    std::lock_guard<std::shared_mutex> guard(mtx_);
+
     bool endiannessFlag = (smh->flags & BIT(0)) != 0u;
     //bool timeFlag = smh->flags & BIT(1) ? true : false;
     //Assign message endianness
@@ -1214,6 +1229,8 @@ bool MessageReceiver::proc_Submsg_InfoSRC(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh)
 {
+    std::lock_guard<std::shared_mutex> guard(mtx_);
+
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     //bool timeFlag = smh->flags & BIT(1) ? true : false;
     //Assign message endianness
@@ -1241,8 +1258,10 @@ bool MessageReceiver::proc_Submsg_InfoSRC(
 
 bool MessageReceiver::proc_Submsg_NackFrag(
         CDRMessage_t* msg,
-        SubmessageHeader_t* smh)
+        SubmessageHeader_t* smh) const
 {
+    std::shared_lock<std::shared_mutex> guard(mtx_);
+
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     //Assign message endianness
     if (endiannessFlag)
@@ -1274,7 +1293,6 @@ bool MessageReceiver::proc_Submsg_NackFrag(
         return false;
     }
 
-    std::lock_guard<std::mutex> guard(mtx_);
     //Look for the correct writer to use the acknack
     for (RTPSWriter* it : associated_writers_)
     {
@@ -1295,8 +1313,10 @@ bool MessageReceiver::proc_Submsg_NackFrag(
 
 bool MessageReceiver::proc_Submsg_HeartbeatFrag(
         CDRMessage_t* msg,
-        SubmessageHeader_t* smh)
+        SubmessageHeader_t* smh) const
 {
+    std::shared_lock<std::shared_mutex> guard(mtx_);
+
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     //Assign message endianness
     if (endiannessFlag)
@@ -1344,7 +1364,7 @@ bool MessageReceiver::proc_Submsg_HeartbeatFrag(
 void MessageReceiver::notify_network_statistics(
         const Locator_t& source_locator,
         const Locator_t& reception_locator,
-        CDRMessage_t* msg)
+        CDRMessage_t* msg) const
 {
     static_cast<void>(source_locator);
     static_cast<void>(reception_locator);

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -316,6 +316,12 @@ void MessageReceiver::processCDRMsg(
         const Locator_t& reception_locator,
         CDRMessage_t* msg)
 {
+    if (msg->length < RTPSMESSAGE_HEADER_SIZE)
+    {
+        logWarning(RTPS_MSG_IN, IDSTRING "Received message too short, ignoring");
+        return;
+    }
+
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     GuidPrefix_t participantGuidPrefix;
 #else
@@ -330,12 +336,6 @@ void MessageReceiver::processCDRMsg(
 
     {
         std::lock_guard<eprosima::shared_mutex> guard(mtx_);
-
-        if (msg->length < RTPSMESSAGE_HEADER_SIZE)
-        {
-            logWarning(RTPS_MSG_IN, IDSTRING "Received message too short, ignoring");
-            return;
-        }
 
         reset();
 

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -24,9 +24,9 @@
 
 #include <fastdds/core/policy/ParameterList.hpp>
 #include <fastdds/dds/log/Log.hpp>
-
 #include <fastdds/rtps/reader/RTPSReader.h>
 #include <fastdds/rtps/writer/RTPSWriter.h>
+#include <fastrtps/utils/shared_mutex.hpp>
 
 #include <rtps/participant/RTPSParticipantImpl.h>
 #include <statistics/rtps/StatisticsBase.hpp>
@@ -316,7 +316,6 @@ void MessageReceiver::processCDRMsg(
         const Locator_t& reception_locator,
         CDRMessage_t* msg)
 {
-
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     GuidPrefix_t participantGuidPrefix;
 #else

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -221,7 +221,7 @@ void MessageReceiver::process_data_fragment_message_without_security(
 void MessageReceiver::associateEndpoint(
         Endpoint* to_add)
 {
-    std::lock_guard<std::shared_mutex> guard(mtx_);
+    std::lock_guard<eprosima::shared_mutex> guard(mtx_);
     if (to_add->getAttributes().endpointKind == WRITER)
     {
         const auto writer = dynamic_cast<RTPSWriter*>(to_add);
@@ -265,7 +265,7 @@ void MessageReceiver::associateEndpoint(
 void MessageReceiver::removeEndpoint(
         Endpoint* to_remove)
 {
-    std::lock_guard<std::shared_mutex> guard(mtx_);
+    std::lock_guard<eprosima::shared_mutex> guard(mtx_);
 
     if (to_remove->getAttributes().endpointKind == WRITER)
     {
@@ -330,7 +330,7 @@ void MessageReceiver::processCDRMsg(
 #endif // if HAVE_SECURITY
 
     {
-        std::lock_guard<std::shared_mutex> guard(mtx_);
+        std::lock_guard<eprosima::shared_mutex> guard(mtx_);
 
         if (msg->length < RTPSMESSAGE_HEADER_SIZE)
         {
@@ -685,7 +685,7 @@ bool MessageReceiver::proc_Submsg_Data(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh) const
 {
-    std::shared_lock<std::shared_mutex> guard(mtx_);
+    eprosima::shared_lock<eprosima::shared_mutex> guard(mtx_);
 
     //READ and PROCESS
     if (smh->submessageLength < RTPSMESSAGE_DATA_MIN_LENGTH)
@@ -855,7 +855,7 @@ bool MessageReceiver::proc_Submsg_DataFrag(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh) const
 {
-    std::shared_lock<std::shared_mutex> guard(mtx_);
+    eprosima::shared_lock<eprosima::shared_mutex> guard(mtx_);
 
     //READ and PROCESS
     if (smh->submessageLength < RTPSMESSAGE_DATA_MIN_LENGTH)
@@ -1030,7 +1030,7 @@ bool MessageReceiver::proc_Submsg_Heartbeat(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh) const
 {
-    std::shared_lock<std::shared_mutex> guard(mtx_);
+    eprosima::shared_lock<eprosima::shared_mutex> guard(mtx_);
 
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     bool finalFlag = (smh->flags & BIT(1)) != 0;
@@ -1082,7 +1082,7 @@ bool MessageReceiver::proc_Submsg_Acknack(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh) const
 {
-    std::shared_lock<std::shared_mutex> guard(mtx_);
+    eprosima::shared_lock<eprosima::shared_mutex> guard(mtx_);
 
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     bool finalFlag = (smh->flags & BIT(1)) != 0;
@@ -1132,7 +1132,7 @@ bool MessageReceiver::proc_Submsg_Gap(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh) const
 {
-    std::shared_lock<std::shared_mutex> guard(mtx_);
+    eprosima::shared_lock<eprosima::shared_mutex> guard(mtx_);
 
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     //Assign message endianness
@@ -1172,7 +1172,7 @@ bool MessageReceiver::proc_Submsg_InfoTS(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh)
 {
-    std::lock_guard<std::shared_mutex> guard(mtx_);
+    std::lock_guard<eprosima::shared_mutex> guard(mtx_);
 
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     bool timeFlag = (smh->flags & BIT(1)) != 0;
@@ -1202,7 +1202,7 @@ bool MessageReceiver::proc_Submsg_InfoDST(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh)
 {
-    std::lock_guard<std::shared_mutex> guard(mtx_);
+    std::lock_guard<eprosima::shared_mutex> guard(mtx_);
 
     bool endiannessFlag = (smh->flags & BIT(0)) != 0u;
     //bool timeFlag = smh->flags & BIT(1) ? true : false;
@@ -1229,7 +1229,7 @@ bool MessageReceiver::proc_Submsg_InfoSRC(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh)
 {
-    std::lock_guard<std::shared_mutex> guard(mtx_);
+    std::lock_guard<eprosima::shared_mutex> guard(mtx_);
 
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     //bool timeFlag = smh->flags & BIT(1) ? true : false;
@@ -1260,7 +1260,7 @@ bool MessageReceiver::proc_Submsg_NackFrag(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh) const
 {
-    std::shared_lock<std::shared_mutex> guard(mtx_);
+    eprosima::shared_lock<eprosima::shared_mutex> guard(mtx_);
 
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     //Assign message endianness
@@ -1315,7 +1315,7 @@ bool MessageReceiver::proc_Submsg_HeartbeatFrag(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh) const
 {
-    std::shared_lock<std::shared_mutex> guard(mtx_);
+    eprosima::shared_lock<eprosima::shared_mutex> guard(mtx_);
 
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     //Assign message endianness


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
For sanitizer CI see https://github.com/eProsima/Fast-DDS/pull/2565

This refactor promotes the mutex to shared mutex in order to prevent deadlocks due to interaction with participant mutexes.

A) std::mutex MessageReceives::mtx_
B) std::recursive_mutex* RTPSParticipantImpl::mp_mutex 
C) std::mutex RTPSParticipantImpl::m_receiverResourcelistMutex

`MessageReceiver::associateEndpoint(C > A)` takes A while C is taken at `RTPSParticipantImpl::assignEndpoint2LocatorList()`

`EDP::pairing_writer_proxy_with_any_local_reader(A > B)` takes B while A is taken in `MessageReceiver::process_data_message_without_security()`

`RTPSParticipantImpl::deleteUserEndpoint(B > C)` takes C while B is taken in `RTPSParticipantImpl::disable()`

This is the first use of `shared_mutex` in Fast-DDS. Because it's a C++17 feature a public domain implementation is included in our utils folder to support old compilers.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] [Sanitizer] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] NA Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] NA Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] NA New feature has been added to the `versions.md` file (if applicable).
- [ ] NA New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.