### PR TITLE
Refs 14322 Refactor SecurityManager synchronization <master>

### DIFF
--- a/.github/workflows/thread-sanitizer.yaml
+++ b/.github/workflows/thread-sanitizer.yaml
@@ -89,13 +89,10 @@ jobs:
           cd ws
           git clone https://github.com/eProsima/Fast-DDS.git
           cd Fast-DDS
-<<<<<<< HEAD
-=======
           git fetch origin ${{ github.ref }}:merge-branch
           git checkout merge-branch
           echo "Modified files against destination branch"
           git diff --name-only HEAD~1
->>>>>>> b14962a01... Fixed unknown ref error during checkout in workflow execution (#2644)
           git remote add efork https://github.com/MiguelBarro/Fast-DDS.git
           git fetch efork
           git merge --no-edit efork/bugfix/add_sanitizer_support | Out-Null

--- a/.github/workflows/thread-sanitizer.yaml
+++ b/.github/workflows/thread-sanitizer.yaml
@@ -21,7 +21,7 @@ jobs:
     name: Sanitizer Evaluation
     runs-on: ubuntu-latest
     steps:
-      - name: Download the sanitazers cmake module and apply some fixes
+      - name: Download the sanitizers cmake module and apply some fixes
         run: |
           git config --global user.email "dummy@mail.com"
           git config --global user.name "dummy"
@@ -98,7 +98,7 @@ jobs:
 >>>>>>> b14962a01... Fixed unknown ref error during checkout in workflow execution (#2644)
           git remote add efork https://github.com/MiguelBarro/Fast-DDS.git
           git fetch efork
-          git merge --no-edit efork/bugfix/add_sanitizer_support
+          git merge --no-edit efork/bugfix/add_sanitizer_support | Out-Null
 
       - name: Build & install Fast-DDS
         run: |

--- a/.github/workflows/thread-sanitizer.yaml
+++ b/.github/workflows/thread-sanitizer.yaml
@@ -89,6 +89,13 @@ jobs:
           cd ws
           git clone https://github.com/eProsima/Fast-DDS.git
           cd Fast-DDS
+<<<<<<< HEAD
+=======
+          git fetch origin ${{ github.ref }}:merge-branch
+          git checkout merge-branch
+          echo "Modified files against destination branch"
+          git diff --name-only HEAD~1
+>>>>>>> b14962a01... Fixed unknown ref error during checkout in workflow execution (#2644)
           git remote add efork https://github.com/MiguelBarro/Fast-DDS.git
           git fetch efork
           git merge --no-edit efork/bugfix/add_sanitizer_support

--- a/include/fastdds/dds/core/condition/StatusCondition.hpp
+++ b/include/fastdds/dds/core/condition/StatusCondition.hpp
@@ -43,7 +43,7 @@ class Entity;
  * @brief The StatusCondition class is a specific Condition that is associated with each Entity.
  *
  */
-class StatusCondition : public Condition
+class StatusCondition final : public Condition
 {
 public:
 

--- a/include/fastdds/rtps/messages/MessageReceiver.h
+++ b/include/fastdds/rtps/messages/MessageReceiver.h
@@ -20,11 +20,11 @@
 #define _FASTDDS_RTPS_MESSAGERECEIVER_H_
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
-#include <fastdds/rtps/common/all_common.h>
-
 #include <functional>
-#include <fastrtps/utils/shared_mutex.hpp>
 #include <unordered_map>
+
+#include <fastdds/rtps/common/all_common.h>
+#include <fastrtps/utils/shared_mutex.hpp>
 
 namespace eprosima {
 namespace fastrtps {

--- a/include/fastdds/rtps/messages/MessageReceiver.h
+++ b/include/fastdds/rtps/messages/MessageReceiver.h
@@ -22,9 +22,9 @@
 
 #include <fastdds/rtps/common/all_common.h>
 
-#include <unordered_map>
-#include <mutex>
 #include <functional>
+#include <shared_mutex>
+#include <unordered_map>
 
 namespace eprosima {
 namespace fastrtps {
@@ -73,7 +73,7 @@ public:
 
 private:
 
-    std::mutex mtx_;
+    mutable std::shared_mutex mtx_;
     std::vector<RTPSWriter*> associated_writers_;
     std::unordered_map<EntityId_t, std::vector<RTPSReader*>> associated_readers_;
 
@@ -130,7 +130,7 @@ private:
      */
     bool readSubmessageHeader(
             CDRMessage_t* msg,
-            SubmessageHeader_t* smh);
+            SubmessageHeader_t* smh) const;
 
     /**
      * Find if there is a reader (in associated_readers_) that will accept a msg directed
@@ -138,7 +138,7 @@ private:
      */
     bool willAReaderAcceptMsgDirectedTo(
             const EntityId_t& readerID,
-            RTPSReader*& first_reader);
+            RTPSReader*& first_reader) const;
 
     /**
      * Find all readers (in associated_readers_), with the given entity ID, and call the
@@ -147,7 +147,7 @@ private:
     template<typename Functor>
     void findAllReaders(
             const EntityId_t& readerID,
-            const Functor& callback);
+            const Functor& callback) const;
 
     /**@name Processing methods.
      * These methods are designed to read a part of the message
@@ -169,19 +169,19 @@ private:
      */
     bool proc_Submsg_Data(
             CDRMessage_t* msg,
-            SubmessageHeader_t* smh);
+            SubmessageHeader_t* smh) const;
     bool proc_Submsg_DataFrag(
             CDRMessage_t* msg,
-            SubmessageHeader_t* smh);
-    bool proc_Submsg_Acknack(
-            CDRMessage_t* msg,
-            SubmessageHeader_t* smh);
+            SubmessageHeader_t* smh) const;
     bool proc_Submsg_Heartbeat(
             CDRMessage_t* msg,
-            SubmessageHeader_t* smh);
+            SubmessageHeader_t* smh) const;
+    bool proc_Submsg_Acknack(
+            CDRMessage_t* msg,
+            SubmessageHeader_t* smh) const;
     bool proc_Submsg_Gap(
             CDRMessage_t* msg,
-            SubmessageHeader_t* smh);
+            SubmessageHeader_t* smh) const;
     bool proc_Submsg_InfoTS(
             CDRMessage_t* msg,
             SubmessageHeader_t* smh);
@@ -193,10 +193,10 @@ private:
             SubmessageHeader_t* smh);
     bool proc_Submsg_NackFrag(
             CDRMessage_t* msg,
-            SubmessageHeader_t* smh);
+            SubmessageHeader_t* smh) const;
     bool proc_Submsg_HeartbeatFrag(
             CDRMessage_t* msg,
-            SubmessageHeader_t* smh);
+            SubmessageHeader_t* smh) const;
     ///@}
 
 
@@ -258,7 +258,7 @@ private:
     void notify_network_statistics(
             const Locator_t& source_locator,
             const Locator_t& reception_locator,
-            CDRMessage_t* msg);
+            CDRMessage_t* msg) const;
 
 };
 

--- a/include/fastdds/rtps/messages/MessageReceiver.h
+++ b/include/fastdds/rtps/messages/MessageReceiver.h
@@ -23,7 +23,7 @@
 #include <fastdds/rtps/common/all_common.h>
 
 #include <functional>
-#include <shared_mutex>
+#include <fastrtps/utils/shared_mutex.hpp>
 #include <unordered_map>
 
 namespace eprosima {
@@ -73,7 +73,7 @@ public:
 
 private:
 
-    mutable std::shared_mutex mtx_;
+    mutable eprosima::shared_mutex mtx_;
     std::vector<RTPSWriter*> associated_writers_;
     std::unordered_map<EntityId_t, std::vector<RTPSReader*>> associated_readers_;
 

--- a/include/fastdds/rtps/security/accesscontrol/AccessControl.h
+++ b/include/fastdds/rtps/security/accesscontrol/AccessControl.h
@@ -51,7 +51,6 @@ public:
             const RTPSParticipantAttributes& participant_attr,
             SecurityException& exception) = 0;
 
-
     virtual bool get_permissions_token(
             PermissionsToken** permissions_token,
             const PermissionsHandle& handle,
@@ -68,6 +67,9 @@ public:
 
     virtual bool return_permissions_credential_token(
             PermissionsCredentialToken* token,
+            SecurityException& exception) = 0;
+
+    virtual PermissionsHandle* get_permissions_handle(
             SecurityException& exception) = 0;
 
     virtual bool return_permissions_handle(

--- a/include/fastdds/rtps/security/authentication/Authentication.h
+++ b/include/fastdds/rtps/security/authentication/Authentication.h
@@ -50,208 +50,223 @@ class Authentication;
 
 class AuthenticationListener
 {
-    virtual bool on_revoke_identity(Authentication& plugin,
+    virtual bool on_revoke_identity(
+            Authentication& plugin,
             const IdentityHandle& handle,
             SecurityException& exception) = 0;
 };
 
 class Authentication
 {
-    public:
+public:
 
-        virtual ~Authentication() = default;
+    virtual ~Authentication() = default;
 
-        /*!
-         * @brief Validates the identity of the local RTPSParticipant.
-         * @param local_identity_handle (out) A handle that can be used to locally refer to the Authenticated
-         * Participant in subsequent interactions with the Authentication plugin.
-         * @param adjusted_participant_key (out) The GUID_t that the implementation shall use to uniquely identify the
-         * RTPSParticipant on the network.
-         * @param domain_id The Domain Id of the RTPSParticipant.
-         * @param participant_attr The RTPSParticipantAttributes of the RTPSParticipant.
-         * @param candidate_participant_key The GUID_t that the DDS implementation would have used to uniquely identify
-         * the RTPSParticipant if the Security plugins were not enabled.
-         * @param exception (out) A SecurityException object.
-         * @return Validation status.
-         */
-        virtual ValidationResult_t validate_local_identity(IdentityHandle** local_identity_handle,
-                GUID_t& adjusted_participant_key,
-                const uint32_t domain_id,
-                const RTPSParticipantAttributes& participant_attr,
-                const GUID_t& candidate_participant_key,
-                SecurityException& exception) = 0;
+    /*!
+     * @brief Validates the identity of the local RTPSParticipant.
+     * @param local_identity_handle (out) A handle that can be used to locally refer to the Authenticated
+     * Participant in subsequent interactions with the Authentication plugin.
+     * @param adjusted_participant_key (out) The GUID_t that the implementation shall use to uniquely identify the
+     * RTPSParticipant on the network.
+     * @param domain_id The Domain Id of the RTPSParticipant.
+     * @param participant_attr The RTPSParticipantAttributes of the RTPSParticipant.
+     * @param candidate_participant_key The GUID_t that the DDS implementation would have used to uniquely identify
+     * the RTPSParticipant if the Security plugins were not enabled.
+     * @param exception (out) A SecurityException object.
+     * @return Validation status.
+     */
+    virtual ValidationResult_t validate_local_identity(
+            IdentityHandle** local_identity_handle,
+            GUID_t& adjusted_participant_key,
+            const uint32_t domain_id,
+            const RTPSParticipantAttributes& participant_attr,
+            const GUID_t& candidate_participant_key,
+            SecurityException& exception) = 0;
 
-        /*!
-         * @brief Initiates the process of validating the identity of the discovered remote RTPSParticipant, represented
-         * as an IdentityToken object.
-         * @param remote_identity_handle (out) A handle that can be used to locally refer to the remote Authenticated
-         * Participant in subsequent interactions with the AuthenticationPlugin.
-         * @param local_identity_handle A handle to the local RTPSParticipant requesting the remote participant to be
-         * validate.
-         * @param remote_identity_token A token received as part of ParticipantProxyData, representing the
-         * identity of the remote DomainParticipant.
-         * @param remote_participant_key
-         * @param exception (out) A SecurityException object.
-         * @result Validation status.
-         */
-        virtual ValidationResult_t validate_remote_identity(IdentityHandle** remote_identity_handle,
-                const IdentityHandle& local_identity_handle,
-                const IdentityToken& remote_identity_token,
-                const GUID_t& remote_participant_key,
-                SecurityException& exception) = 0;
+    /*!
+     * @brief Initiates the process of validating the identity of the discovered remote RTPSParticipant, represented
+     * as an IdentityToken object.
+     * @param remote_identity_handle (out) A handle that can be used to locally refer to the remote Authenticated
+     * Participant in subsequent interactions with the AuthenticationPlugin.
+     * @param local_identity_handle A handle to the local RTPSParticipant requesting the remote participant to be
+     * validate.
+     * @param remote_identity_token A token received as part of ParticipantProxyData, representing the
+     * identity of the remote DomainParticipant.
+     * @param remote_participant_key
+     * @param exception (out) A SecurityException object.
+     * @result Validation status.
+     */
+    virtual ValidationResult_t validate_remote_identity(
+            IdentityHandle** remote_identity_handle,
+            const IdentityHandle& local_identity_handle,
+            const IdentityToken& remote_identity_token,
+            const GUID_t& remote_participant_key,
+            SecurityException& exception) = 0;
 
-        /*!
-         * @brief This operation is used to initiate a handshake.
-         * @param handshake_handle (out) A handle returned by the Authentication plugin used to keep the state of the
-         * handshake.
-         * @param handshake_message (out) A HandshakeMessageToken to be sent using the BuiltinParticipantMessageWriter.
-         * @param initiator_identity_handle Handle to the local participant that originated the handshake.
-         * @param replier_identity_handle Handle to the remote participant whose identity is being validated.
-         * @param cdr_participant_data Participant's data.
-         * @param exception (out) A SecurityException object.
-         * @result Validation status.
-         */
-        virtual ValidationResult_t begin_handshake_request(HandshakeHandle** handshake_handle,
-                HandshakeMessageToken** handshake_message,
-                const IdentityHandle& initiator_identity_handle,
-                IdentityHandle& replier_identity_handle,
-                const CDRMessage_t& cdr_participant_data,
-                SecurityException& exception) = 0;
+    /*!
+     * @brief This operation is used to initiate a handshake.
+     * @param handshake_handle (out) A handle returned by the Authentication plugin used to keep the state of the
+     * handshake.
+     * @param handshake_message (out) A HandshakeMessageToken to be sent using the BuiltinParticipantMessageWriter.
+     * @param initiator_identity_handle Handle to the local participant that originated the handshake.
+     * @param replier_identity_handle Handle to the remote participant whose identity is being validated.
+     * @param cdr_participant_data Participant's data.
+     * @param exception (out) A SecurityException object.
+     * @result Validation status.
+     */
+    virtual ValidationResult_t begin_handshake_request(
+            HandshakeHandle** handshake_handle,
+            HandshakeMessageToken** handshake_message,
+            const IdentityHandle& initiator_identity_handle,
+            IdentityHandle& replier_identity_handle,
+            const CDRMessage_t& cdr_participant_data,
+            SecurityException& exception) = 0;
 
-        /*!
-         * @brief This operation shall be invoked by the implementation in reaction to the reception of the initial
-         * handshake message that originated on a RTPSParticipant that called the begin_handshake_request operation.
-         * @param handshake_handle (out) A handle returned by the Authentication Plugin used to keep the state of the
-         * handshake.
-         * @param handshake_message_out (out) A HandshakeMessageToken containing a message to be sent using the
-         * BuiltinParticipantMessageWriter.
-         * @param handshake_message_in A HandshakeMessageToken containing a message received from the
-         * BuiltinParticipantMessageReader.
-         * @param initiator_identity_handle Handle to the remote participant that originated the handshake.
-         * @param replier_identity_handle Handle to the local participant that is initiaing the handshake.
-         * @param cdr_participant_data Participant's CDRMessage.
-         * @param exception A SecurityException object.
-         * @result Validation status.
-         */
-        virtual ValidationResult_t begin_handshake_reply(
-                HandshakeHandle** handshake_handle,
-                HandshakeMessageToken** handshake_message_out,
-                HandshakeMessageToken&& handshake_message_in,
-                IdentityHandle& initiator_identity_handle,
-                const IdentityHandle& replier_identity_handle,
-                const CDRMessage_t& cdr_participant_data,
-                SecurityException& exception) = 0;
+    /*!
+     * @brief This operation shall be invoked by the implementation in reaction to the reception of the initial
+     * handshake message that originated on a RTPSParticipant that called the begin_handshake_request operation.
+     * @param handshake_handle (out) A handle returned by the Authentication Plugin used to keep the state of the
+     * handshake.
+     * @param handshake_message_out (out) A HandshakeMessageToken containing a message to be sent using the
+     * BuiltinParticipantMessageWriter.
+     * @param handshake_message_in A HandshakeMessageToken containing a message received from the
+     * BuiltinParticipantMessageReader.
+     * @param initiator_identity_handle Handle to the remote participant that originated the handshake.
+     * @param replier_identity_handle Handle to the local participant that is initiaing the handshake.
+     * @param cdr_participant_data Participant's CDRMessage.
+     * @param exception A SecurityException object.
+     * @result Validation status.
+     */
+    virtual ValidationResult_t begin_handshake_reply(
+            HandshakeHandle** handshake_handle,
+            HandshakeMessageToken** handshake_message_out,
+            HandshakeMessageToken&& handshake_message_in,
+            IdentityHandle& initiator_identity_handle,
+            const IdentityHandle& replier_identity_handle,
+            const CDRMessage_t& cdr_participant_data,
+            SecurityException& exception) = 0;
 
-        /*!
-         * @brief This operation is used to continue a handshake.
-         * @param handshake_message_out (out) A HandshakeMessageToken containing the message_data that should be
-         * place in a ParticipantStatelessMessage to be sent using the BuiltinParticipantMessageWriter.
-         * @param handshake_message_in The HandshakeMessageToken contained in the message_data attribute of the
-         * ParticipantStatelessMessage received.
-         * @param handshake_handle Handle returned by a correspoing previous call to begin_handshake_request or
-         * begin_handshake_reply.
-         * @param exception A SecurityException object.
-         * @return Validation status.
-         */
-        virtual ValidationResult_t process_handshake(
-                HandshakeMessageToken** handshake_message_out,
-                HandshakeMessageToken&& handshake_message_in,
-                HandshakeHandle& handshake_handle,
-                SecurityException& exception) = 0;
+    /*!
+     * @brief This operation is used to continue a handshake.
+     * @param handshake_message_out (out) A HandshakeMessageToken containing the message_data that should be
+     * place in a ParticipantStatelessMessage to be sent using the BuiltinParticipantMessageWriter.
+     * @param handshake_message_in The HandshakeMessageToken contained in the message_data attribute of the
+     * ParticipantStatelessMessage received.
+     * @param handshake_handle Handle returned by a correspoing previous call to begin_handshake_request or
+     * begin_handshake_reply.
+     * @param exception A SecurityException object.
+     * @return Validation status.
+     */
+    virtual ValidationResult_t process_handshake(
+            HandshakeMessageToken** handshake_message_out,
+            HandshakeMessageToken&& handshake_message_in,
+            HandshakeHandle& handshake_handle,
+            SecurityException& exception) = 0;
 
-        /*!
-         * @brief Retrieve the SecretHandle resulting with a successfully completed handshake.
-         * @param handshake_handle Handle returned bu a corresponding previous call to begin_handshake_request or
-         * begin_handshake_reply, which has successfully complete the handshake operations.
-         * @param exception SecurityException object
-         * @return SecretHandle.
-         */
-        virtual std::shared_ptr<SecretHandle> get_shared_secret(
-                const HandshakeHandle& handshake_handle,
-                SecurityException& exception) const = 0;
+    /*!
+     * @brief Retrieve the SecretHandle resulting with a successfully completed handshake.
+     * @param handshake_handle Handle returned bu a corresponding previous call to begin_handshake_request or
+     * begin_handshake_reply, which has successfully complete the handshake operations.
+     * @param exception SecurityException object
+     * @return SecretHandle.
+     */
+    virtual std::shared_ptr<SecretHandle> get_shared_secret(
+            const HandshakeHandle& handshake_handle,
+            SecurityException& exception) const = 0;
 
-        /*!
-         * @brief Sets the AuthenticationListener that the Authentication plugin will use to notify the infrastructure
-         * of events relevant to the Authentication of RTPSParticipants.
-         * @param listener An AuthenticationListener object to be attached to the Authentication object.
-         * @param exception (out) A SecurityException object.
-         */
-        virtual bool set_listener(AuthenticationListener* listener,
-                SecurityException& exception) = 0;
+    /*!
+     * @brief Sets the AuthenticationListener that the Authentication plugin will use to notify the infrastructure
+     * of events relevant to the Authentication of RTPSParticipants.
+     * @param listener An AuthenticationListener object to be attached to the Authentication object.
+     * @param exception (out) A SecurityException object.
+     */
+    virtual bool set_listener(
+            AuthenticationListener* listener,
+            SecurityException& exception) = 0;
 
-        virtual bool get_identity_token(IdentityToken** identity_token,
-                const IdentityHandle& handle,
-                SecurityException& exception) = 0;
+    virtual bool get_identity_token(
+            IdentityToken** identity_token,
+            const IdentityHandle& handle,
+            SecurityException& exception) = 0;
 
-        /*!
-         * @brief Returns the IdentityToken object to the plugin so it can be disposed of.
-         * @param token An IdentityToken issued by the plugin on a prior call to get_identity_token.
-         * @param exception (out) A SecurityException object.
-         */
-        virtual bool return_identity_token(IdentityToken* token,
-                SecurityException& exception) = 0;
+    /*!
+     * @brief Returns the IdentityToken object to the plugin so it can be disposed of.
+     * @param token An IdentityToken issued by the plugin on a prior call to get_identity_token.
+     * @param exception (out) A SecurityException object.
+     */
+    virtual bool return_identity_token(
+            IdentityToken* token,
+            SecurityException& exception) = 0;
 
-        /*!
-         * @brief Returns the Handshakehandle object to the plugin so it can be disposed of.
-         * @param handshake_handle A HandshakeHandle issued by the plugin on a prior call to begin_handshake_request or
-         * begin_handshake_reply.
-         * @param exception (out) A SecurityException object.
-         */
-        virtual bool return_handshake_handle(HandshakeHandle* handshake_handle,
-                SecurityException& exception) = 0;
+    /*!
+     * @brief Returns the Handshakehandle object to the plugin so it can be disposed of.
+     * @param handshake_handle A HandshakeHandle issued by the plugin on a prior call to begin_handshake_request or
+     * begin_handshake_reply.
+     * @param exception (out) A SecurityException object.
+     */
+    virtual bool return_handshake_handle(
+            HandshakeHandle* handshake_handle,
+            SecurityException& exception) = 0;
 
-        /*!
-         * @brief Creates and IdentityHandle for the handshake process
-         * @param exception (out) A SecurityException object.
-         * @return the new handle or nullptr on failure
-         */
-        virtual IdentityHandle* get_identity_handle(
-                SecurityException& exception) = 0;
+    /*!
+     * @brief Creates and IdentityHandle for the handshake process
+     * @param exception (out) A SecurityException object.
+     * @return the new handle or nullptr on failure
+     */
+    virtual IdentityHandle* get_identity_handle(
+            SecurityException& exception) = 0;
 
-        /*!
-         * @brief Returns the IdentityHandle object to the plugin so it can be disposed of.
-         * @param identity_handle An IdentityHandle issued by the plugin on a prior call to validate_local_identity or
-         * validate_remote_identity.
-         * @param exception (out) A SecurityException object.
-         */
-        virtual bool return_identity_handle(IdentityHandle* identity_handle,
-                SecurityException& exception) = 0;
+    /*!
+     * @brief Returns the IdentityHandle object to the plugin so it can be disposed of.
+     * @param identity_handle An IdentityHandle issued by the plugin on a prior call to validate_local_identity or
+     * validate_remote_identity.
+     * @param exception (out) A SecurityException object.
+     */
+    virtual bool return_identity_handle(
+            IdentityHandle* identity_handle,
+            SecurityException& exception) = 0;
 
-        /*!
-         * @brief Returns the SecretHandle object to the plugin so it can be disposed of.
-         * @param sharedsecret_handle An SharedSecretHandle issued by the plugin on a prior call to get_shared_secret.
-         * @param exception (out) A SecurityException object.
-         */
-        virtual bool return_sharedsecret_handle(std::shared_ptr<SecretHandle>& sharedsecret_handle,
-                SecurityException& exception) const = 0;
+    /*!
+     * @brief Returns the SecretHandle object to the plugin so it can be disposed of.
+     * @param sharedsecret_handle An SharedSecretHandle issued by the plugin on a prior call to get_shared_secret.
+     * @param exception (out) A SecurityException object.
+     */
+    virtual bool return_sharedsecret_handle(
+            std::shared_ptr<SecretHandle>& sharedsecret_handle,
+            SecurityException& exception) const = 0;
 
-        virtual bool set_permissions_credential_and_token(IdentityHandle& identity_handle,
-                PermissionsCredentialToken& permissions_credential_token,
-                SecurityException& ex) = 0;
+    virtual bool set_permissions_credential_and_token(
+            IdentityHandle& identity_handle,
+            PermissionsCredentialToken& permissions_credential_token,
+            SecurityException& ex) = 0;
 
-        virtual bool get_authenticated_peer_credential_token(PermissionsCredentialToken **token,
-                const IdentityHandle& identity_handle, SecurityException& exception) = 0;
+    virtual bool get_authenticated_peer_credential_token(
+            PermissionsCredentialToken** token,
+            const IdentityHandle& identity_handle,
+            SecurityException& exception) = 0;
 
-        virtual bool return_authenticated_peer_credential_token(PermissionsCredentialToken* token,
-                SecurityException& ex) = 0;
+    virtual bool return_authenticated_peer_credential_token(
+            PermissionsCredentialToken* token,
+            SecurityException& ex) = 0;
 
-        bool set_logger(Logging* logger,
-             SecurityException& /*exception*/)
-        {
-            logger_ = logger;
-            return true;
-        }
+    bool set_logger(
+            Logging* logger,
+            SecurityException& /*exception*/)
+    {
+        logger_ = logger;
+        return true;
+    }
 
-    protected:
+protected:
 
-        const Logging* get_logger() const
-        {
-            return logger_;
-        }
+    const Logging* get_logger() const
+    {
+        return logger_;
+    }
 
-    private:
+private:
 
-        Logging* logger_ = nullptr;
+    Logging* logger_ = nullptr;
 };
 
 } //namespace security

--- a/include/fastdds/rtps/security/authentication/Authentication.h
+++ b/include/fastdds/rtps/security/authentication/Authentication.h
@@ -160,13 +160,13 @@ class Authentication
                 SecurityException& exception) = 0;
 
         /*!
-         * @brief Retrieve the SharedSecretHandle resulting with a successfully completed handshake.
+         * @brief Retrieve the SecretHandle resulting with a successfully completed handshake.
          * @param handshake_handle Handle returned bu a corresponding previous call to begin_handshake_request or
          * begin_handshake_reply, which has successfully complete the handshake operations.
          * @param exception SecurityException object
-         * @return SharedSecretHandle.
+         * @return SecretHandle.
          */
-        virtual std::shared_ptr<SharedSecretHandle> get_shared_secret(
+        virtual std::shared_ptr<SecretHandle> get_shared_secret(
                 const HandshakeHandle& handshake_handle,
                 SecurityException& exception) const = 0;
 
@@ -201,6 +201,14 @@ class Authentication
                 SecurityException& exception) = 0;
 
         /*!
+         * @brief Creates and IdentityHandle for the handshake process
+         * @param exception (out) A SecurityException object.
+         * @return the new handle or nullptr on failure
+         */
+        virtual IdentityHandle* get_identity_handle(
+                SecurityException& exception) = 0;
+
+        /*!
          * @brief Returns the IdentityHandle object to the plugin so it can be disposed of.
          * @param identity_handle An IdentityHandle issued by the plugin on a prior call to validate_local_identity or
          * validate_remote_identity.
@@ -210,11 +218,11 @@ class Authentication
                 SecurityException& exception) = 0;
 
         /*!
-         * @brief Returns the SharedSecretHandle object to the plugin so it can be disposed of.
+         * @brief Returns the SecretHandle object to the plugin so it can be disposed of.
          * @param sharedsecret_handle An SharedSecretHandle issued by the plugin on a prior call to get_shared_secret.
          * @param exception (out) A SecurityException object.
          */
-        virtual bool return_sharedsecret_handle(std::shared_ptr<SharedSecretHandle>& sharedsecret_handle,
+        virtual bool return_sharedsecret_handle(std::shared_ptr<SecretHandle>& sharedsecret_handle,
                 SecurityException& exception) const = 0;
 
         virtual bool set_permissions_credential_and_token(IdentityHandle& identity_handle,

--- a/include/fastdds/rtps/security/authentication/Authentication.h
+++ b/include/fastdds/rtps/security/authentication/Authentication.h
@@ -166,9 +166,9 @@ class Authentication
          * @param exception SecurityException object
          * @return SharedSecretHandle.
          */
-        virtual SharedSecretHandle* get_shared_secret(
+        virtual std::shared_ptr<SharedSecretHandle> get_shared_secret(
                 const HandshakeHandle& handshake_handle,
-                SecurityException& exception) = 0;
+                SecurityException& exception) const = 0;
 
         /*!
          * @brief Sets the AuthenticationListener that the Authentication plugin will use to notify the infrastructure
@@ -214,8 +214,8 @@ class Authentication
          * @param sharedsecret_handle An SharedSecretHandle issued by the plugin on a prior call to get_shared_secret.
          * @param exception (out) A SecurityException object.
          */
-        virtual bool return_sharedsecret_handle(SharedSecretHandle* sharedsecret_handle,
-                SecurityException& exception) = 0;
+        virtual bool return_sharedsecret_handle(std::shared_ptr<SharedSecretHandle>& sharedsecret_handle,
+                SecurityException& exception) const = 0;
 
         virtual bool set_permissions_credential_and_token(IdentityHandle& identity_handle,
                 PermissionsCredentialToken& permissions_credential_token,

--- a/include/fastdds/rtps/security/common/Handle.h
+++ b/include/fastdds/rtps/security/common/Handle.h
@@ -133,6 +133,8 @@ typedef Handle IdentityHandle;
 
 typedef Handle PermissionsHandle;
 
+typedef Handle SecretHandle;
+
 typedef Handle ParticipantCryptoHandle;
 typedef Handle EntityCryptoHandle;
 typedef Handle DatawriterCryptoHandle;

--- a/include/fastdds/rtps/security/common/Handle.h
+++ b/include/fastdds/rtps/security/common/Handle.h
@@ -28,24 +28,30 @@ namespace security {
 
 class Handle : public std::enable_shared_from_this<Handle>
 {
-    public:
+public:
 
-        const std::string& get_class_id() const
-        {
-            return class_id_;
-        }
+    const std::string& get_class_id() const
+    {
+        return class_id_;
+    }
 
-        virtual bool nil() const = 0;
+    virtual bool nil() const = 0;
 
-    protected:
+protected:
 
-        Handle(const std::string& class_id) : class_id_(class_id) {};
+    Handle(
+            const std::string& class_id)
+        : class_id_(class_id)
+    {
+    }
 
-        virtual ~Handle(){}
+    virtual ~Handle()
+    {
+    }
 
-    private:
+private:
 
-        std::string class_id_;
+    std::string class_id_;
 };
 
 template<typename T, typename F>
@@ -53,78 +59,99 @@ class HandleImpl : public Handle
 {
     friend F;
 
-    protected:
+protected:
 
-        HandleImpl() : Handle(T::class_id_), impl_(new T) {}
+    HandleImpl()
+        : Handle(T::class_id_)
+        , impl_(new T)
+    {
+    }
 
-        virtual ~HandleImpl() = default;
+    virtual ~HandleImpl() = default;
 
-    public:
+public:
 
-        typedef T type;
+    typedef T type;
 
-        static HandleImpl<T,F>& narrow(Handle& handle)
+    static HandleImpl<T, F>& narrow(
+            Handle& handle)
+    {
+        if (handle.get_class_id().compare(T::class_id_) == 0)
         {
-            if(handle.get_class_id().compare(T::class_id_) == 0)
-                return reinterpret_cast<HandleImpl<T,F>&>(handle);
-
-            return HandleImpl<T,F>::nil_handle;
+            return reinterpret_cast<HandleImpl<T, F>&>(handle);
         }
 
-        static const HandleImpl<T,F>& narrow(const Handle& handle)
-        {
-            if(handle.get_class_id().compare(T::class_id_) == 0)
-                return reinterpret_cast<const HandleImpl<T,F>&>(handle);
+        return HandleImpl<T, F>::nil_handle;
+    }
 
-            return HandleImpl<T,F>::nil_handle;
+    static const HandleImpl<T, F>& narrow(
+            const Handle& handle)
+    {
+        if (handle.get_class_id().compare(T::class_id_) == 0)
+        {
+            return reinterpret_cast<const HandleImpl<T, F>&>(handle);
         }
 
-        bool nil() const override
-        {
-            return impl_ ? false : true;
-        }
+        return HandleImpl<T, F>::nil_handle;
+    }
 
-        T* operator*()
-        {
-            return impl_.get();
-        }
+    bool nil() const override
+    {
+        return impl_ ? false : true;
+    }
 
-        const T* operator*() const
-        {
-            return impl_.get();
-        }
+    T* operator *()
+    {
+        return impl_.get();
+    }
 
-        T* operator->()
-        {
-            return impl_.get();
-        }
+    const T* operator *() const
+    {
+        return impl_.get();
+    }
 
-        const T* operator->() const
-        {
-            return impl_.get();
-        }
+    T* operator ->()
+    {
+        return impl_.get();
+    }
 
-        static HandleImpl<T,F> nil_handle;
+    const T* operator ->() const
+    {
+        return impl_.get();
+    }
 
-    private:
+    static HandleImpl<T, F> nil_handle;
 
-        explicit HandleImpl(bool) : Handle(T::class_id_) {}
+private:
 
-        std::unique_ptr<T> impl_;
+    explicit HandleImpl(
+            bool)
+        : Handle(T::class_id_)
+    {
+    }
+
+    std::unique_ptr<T> impl_;
 };
 
 template<typename T, typename F>
-HandleImpl<T,F> HandleImpl<T,F>::nil_handle(true);
+HandleImpl<T, F> HandleImpl<T, F>::nil_handle(true);
 
 class NilHandle : public Handle
 {
-    public:
+public:
 
-        NilHandle() : Handle("nil_handle") {}
+    NilHandle()
+        : Handle("nil_handle")
+    {
+    }
 
-        virtual ~NilHandle() = default;
+    virtual ~NilHandle() = default;
 
-        bool nil() const override { return true; }
+    bool nil() const override
+    {
+        return true;
+    }
+
 };
 
 

--- a/include/fastdds/rtps/security/common/SharedSecretHandle.h
+++ b/include/fastdds/rtps/security/common/SharedSecretHandle.h
@@ -119,7 +119,9 @@ class SharedSecret
         std::vector<BinaryData> data_;
 };
 
-typedef HandleImpl<SharedSecret> SharedSecretHandle;
+class PKIDH;
+
+typedef HandleImpl<SharedSecret, PKIDH> SharedSecretHandle;
 
 class SharedSecretHelper
 {

--- a/include/fastdds/rtps/security/common/SharedSecretHandle.h
+++ b/include/fastdds/rtps/security/common/SharedSecretHandle.h
@@ -127,9 +127,7 @@ class SharedSecretHelper
 {
     public:
 
-        static std::vector<uint8_t>* find_data_value(SharedSecret& sharedsecret, const std::string& name);
-
-        static const std::vector<uint8_t>* find_data_value(const SharedSecret& sharedsecret, const std::string& name);
+        static const std::vector<uint8_t>* find_data_value(const SecretHandle& sharedsecret, const std::string& name);
 };
 
 } //namespace security

--- a/include/fastdds/rtps/security/common/SharedSecretHandle.h
+++ b/include/fastdds/rtps/security/common/SharedSecretHandle.h
@@ -29,94 +29,116 @@ namespace security {
 
 class SharedSecret
 {
+public:
+
+    class BinaryData
+    {
     public:
 
-        class BinaryData
+        BinaryData()
         {
-            public:
+        }
 
-                BinaryData() {}
+        BinaryData(
+                const BinaryData& data)
+            : name_(data.name_)
+            , value_(data.value_)
+        {
+        }
 
-                BinaryData(const BinaryData& data) :
-                    name_(data.name_),
-                    value_(data.value_) {}
+        BinaryData(
+                BinaryData&& data)
+            : name_(std::move(data.name_))
+            , value_(std::move(data.value_))
+        {
+        }
 
-                BinaryData(BinaryData&& data) :
-                    name_(std::move(data.name_)),
-                    value_(std::move(data.value_)) {}
+        BinaryData(
+                const std::string& name,
+                const std::vector<uint8_t>& value)
+            : name_(name)
+            , value_(value)
+        {
+        }
 
-                BinaryData(const std::string& name,
-                        const std::vector<uint8_t>& value) :
-                    name_(name), value_(value) {}
+        BinaryData(
+                std::string&& name,
+                std::vector<uint8_t>&& value)
+            : name_(std::move(name))
+            , value_(std::move(value))
+        {
+        }
 
-                BinaryData(std::string&& name,
-                        std::vector<uint8_t>&& value) :
-                    name_(std::move(name)), value_(std::move(value)) {}
+        BinaryData& operator =(
+                const BinaryData& data)
+        {
+            name_ = data.name_;
+            value_ = data.value_;
+            return *this;
+        }
 
-                BinaryData& operator=(const BinaryData& data)
-                {
-                    name_ = data.name_;
-                    value_ = data.value_;
-                    return *this;
-                }
+        BinaryData& operator =(
+                BinaryData&& data)
+        {
+            name_ = std::move(data.name_);
+            value_ = std::move(data.value_);
+            return *this;
+        }
 
-                BinaryData& operator=(BinaryData&& data)
-                {
-                    name_ = std::move(data.name_);
-                    value_ = std::move(data.value_);
-                    return *this;
-                }
+        void name(
+                const std::string& name)
+        {
+            name_ = name;
+        }
 
-                void name(const std::string& name)
-                {
-                    name_ = name;
-                }
+        void name(
+                std::string&& name)
+        {
+            name_ = std::move(name);
+        }
 
-                void name(std::string&& name)
-                {
-                    name_ = std::move(name);
-                }
+        const std::string& name() const
+        {
+            return name_;
+        }
 
-                const std::string& name() const
-                {
-                    return name_;
-                }
+        std::string& name()
+        {
+            return name_;
+        }
 
-                std::string& name()
-                {
-                    return name_;
-                }
+        void value(
+                const std::vector<uint8_t>& value)
+        {
+            value_ = value;
+        }
 
-                void value(const std::vector<uint8_t>& value)
-                {
-                    value_ = value;
-                }
+        void value(
+                std::vector<uint8_t>&& value)
+        {
+            value_ = std::move(value);
+        }
 
-                void value(std::vector<uint8_t>&& value)
-                {
-                    value_ = std::move(value);
-                }
+        const std::vector<uint8_t>& value() const
+        {
+            return value_;
+        }
 
-                const std::vector<uint8_t>& value() const
-                {
-                    return value_;
-                }
+        std::vector<uint8_t>& value()
+        {
+            return value_;
+        }
 
-                std::vector<uint8_t>& value()
-                {
-                    return value_;
-                }
+    private:
 
-            private:
+        std::string name_;
 
-                std::string name_;
+        std::vector<uint8_t> value_;
+    };
 
-                std::vector<uint8_t> value_;
-        };
+    static const char* const class_id_;
 
-        static const char* const class_id_;
-
-        std::vector<BinaryData> data_;
+    std::vector<BinaryData> data_;
 };
 
 class PKIDH;
@@ -125,9 +147,11 @@ typedef HandleImpl<SharedSecret, PKIDH> SharedSecretHandle;
 
 class SharedSecretHelper
 {
-    public:
+public:
 
-        static const std::vector<uint8_t>* find_data_value(const SecretHandle& sharedsecret, const std::string& name);
+    static const std::vector<uint8_t>* find_data_value(
+            const SecretHandle& sharedsecret,
+            const std::string& name);
 };
 
 } //namespace security

--- a/include/fastdds/rtps/security/cryptography/CryptoKeyFactory.h
+++ b/include/fastdds/rtps/security/cryptography/CryptoKeyFactory.h
@@ -144,25 +144,78 @@ public:
             SecurityException& exception) = 0;
 
     /**
-     * Releases resources associated with a DataWriter. The Crypto Handle becomes unusable after this
+     * Releases resources associated with a DataWriter. The Crypto Handle may become unusable after this
      * @param datawriter_crypto_handle Belonging to the DataWriter that awaits termination
      * @param exception (out) Security exception
      * @return TRUE is successful
      */
     virtual bool unregister_datawriter(
-            DatawriterCryptoHandle* datawriter_crypto_handle,
+            std::shared_ptr<DatawriterCryptoHandle>& datawriter_crypto_handle,
             SecurityException& exception) = 0;
 
     /**
-     * Releases resources associated with a DataReader. The Crypto Handle becomes unusable after this
+     * Convenient override for raw pointers arguments.
+     * @param datawriter_crypto_handle Belonging to the DataWriter that awaits termination
+     * @param exception (out) Security exception
+     * @return TRUE is successful
+     */
+    bool unregister_datawriter(
+            DatawriterCryptoHandle* datawriter_crypto_handle,
+            SecurityException& exception)
+    {
+
+        if (nullptr == datawriter_crypto_handle)
+        {
+            return false;
+        }
+
+        try
+        {
+            auto temp = datawriter_crypto_handle->shared_from_this();
+            return unregister_datawriter(temp, exception);
+        }
+        catch(std::bad_weak_ptr&)
+        {
+            return false;
+        }
+    }
+
+    /**
+     * Releases resources associated with a DataReader. The Crypto Handle may become unusable after this
      * @param datareader_crypto_handle Belonging to the DataReader that awaits termination
      * @param exception (out) Security exception
      * @return TRUE is successful
      */
     virtual bool unregister_datareader(
-            DatareaderCryptoHandle* datareader_crypto_handle,
+            std::shared_ptr<DatareaderCryptoHandle>& datareader_crypto_handle,
             SecurityException& exception) = 0;
 
+    /**
+     * Convenient override for raw pointers arguments.
+     * @param datareader_crypto_handle Belonging to the DataWriter that awaits termination
+     * @param exception (out) Security exception
+     * @return TRUE is successful
+     */
+    bool unregister_datareader(
+            DatareaderCryptoHandle* datareader_crypto_handle,
+            SecurityException& exception)
+    {
+
+        if (nullptr == datareader_crypto_handle)
+        {
+            return false;
+        }
+
+        try
+        {
+            auto temp = datareader_crypto_handle->shared_from_this();
+            return unregister_datareader(temp, exception);
+        }
+        catch(std::bad_weak_ptr&)
+        {
+            return false;
+        }
+    }
 
 };
 

--- a/include/fastdds/rtps/security/cryptography/CryptoKeyFactory.h
+++ b/include/fastdds/rtps/security/cryptography/CryptoKeyFactory.h
@@ -174,7 +174,7 @@ public:
             auto temp = datawriter_crypto_handle->shared_from_this();
             return unregister_datawriter(temp, exception);
         }
-        catch(std::bad_weak_ptr&)
+        catch (std::bad_weak_ptr&)
         {
             return false;
         }
@@ -211,7 +211,7 @@ public:
             auto temp = datareader_crypto_handle->shared_from_this();
             return unregister_datareader(temp, exception);
         }
-        catch(std::bad_weak_ptr&)
+        catch (std::bad_weak_ptr&)
         {
             return false;
         }

--- a/include/fastdds/rtps/security/cryptography/CryptoKeyFactory.h
+++ b/include/fastdds/rtps/security/cryptography/CryptoKeyFactory.h
@@ -68,7 +68,7 @@ public:
             const ParticipantCryptoHandle& local_participant_crypto_handle,
             const IdentityHandle& remote_participant_identity,
             const PermissionsHandle& remote_participant_permissions,
-            const SharedSecretHandle& shared_secret,
+            const SecretHandle& shared_secret,
             SecurityException& exception) = 0;
 
     /**
@@ -99,7 +99,7 @@ public:
     virtual DatareaderCryptoHandle* register_matched_remote_datareader(
             DatawriterCryptoHandle& local_datawriter_crypto_handle,
             ParticipantCryptoHandle& remote_participant_crypto,
-            const SharedSecretHandle& shared_secret,
+            const SecretHandle& shared_secret,
             const bool relay_only,
             SecurityException& exception) = 0;
 
@@ -130,7 +130,7 @@ public:
     virtual DatawriterCryptoHandle* register_matched_remote_datawriter(
             DatareaderCryptoHandle& local_datareader_crypto_handle,
             ParticipantCryptoHandle& remote_participant_crypt,
-            const SharedSecretHandle& shared_secret,
+            const SecretHandle& shared_secret,
             SecurityException& exception) = 0;
 
     /**

--- a/include/fastdds/rtps/security/cryptography/CryptoKeyFactory.h
+++ b/include/fastdds/rtps/security/cryptography/CryptoKeyFactory.h
@@ -22,6 +22,8 @@
 #include <fastdds/rtps/security/accesscontrol/EndpointSecurityAttributes.h>
 #include <fastdds/rtps/security/accesscontrol/ParticipantSecurityAttributes.h>
 
+#include <memory>
+
 namespace eprosima {
 namespace fastrtps {
 namespace rtps {
@@ -45,7 +47,7 @@ public:
      * @param exception (out) Security exception
      * @return ParticipantCryptoHandle with generated key material
      */
-    virtual ParticipantCryptoHandle* register_local_participant(
+    virtual std::shared_ptr<ParticipantCryptoHandle> register_local_participant(
             const IdentityHandle& participant_identity,
             const PermissionsHandle& participant_permissions,
             const PropertySeq& participant_properties,
@@ -62,7 +64,7 @@ public:
      * @param exception (out) Security exception
      * @return ParticipantCryptoHandle with generated key material
      */
-    virtual ParticipantCryptoHandle* register_matched_remote_participant(
+    virtual std::shared_ptr<ParticipantCryptoHandle> register_matched_remote_participant(
             const ParticipantCryptoHandle& local_participant_crypto_handle,
             const IdentityHandle& remote_participant_identity,
             const PermissionsHandle& remote_participant_permissions,
@@ -138,7 +140,7 @@ public:
      * @return TRUE is successful
      */
     virtual bool unregister_participant(
-            ParticipantCryptoHandle* participant_crypto_handle,
+            std::shared_ptr<ParticipantCryptoHandle>& participant_crypto_handle,
             SecurityException& exception) = 0;
 
     /**

--- a/include/fastdds/rtps/security/cryptography/CryptoTransform.h
+++ b/include/fastdds/rtps/security/cryptography/CryptoTransform.h
@@ -18,11 +18,11 @@
 #ifndef _FASTDDS_RTPS_SECURITY_CRYPTOGRAPHY_CRYPTOTRANSFORM_H_
 #define _FASTDDS_RTPS_SECURITY_CRYPTOGRAPHY_CRYPTOTRANSFORM_H_
 
+#include <memory>
+
 #include <fastdds/rtps/security/cryptography/CryptoTypes.h>
 #include <fastdds/rtps/common/CDRMessage_t.h>
 #include <fastdds/rtps/common/SerializedPayload.h>
-
-#include <memory>
 
 namespace eprosima {
 namespace fastrtps {

--- a/include/fastdds/rtps/security/cryptography/CryptoTransform.h
+++ b/include/fastdds/rtps/security/cryptography/CryptoTransform.h
@@ -22,6 +22,8 @@
 #include <fastdds/rtps/common/CDRMessage_t.h>
 #include <fastdds/rtps/common/SerializedPayload.h>
 
+#include <memory>
+
 namespace eprosima {
 namespace fastrtps {
 namespace rtps {
@@ -63,7 +65,7 @@ public:
             CDRMessage_t& encoded_rtps_submessage,
             const CDRMessage_t& plain_rtps_submessage,
             DatawriterCryptoHandle& sending_datawriter_crypto,
-            std::vector<DatareaderCryptoHandle*>& receiving_datareader_crypto_list,
+            std::vector<std::shared_ptr<DatareaderCryptoHandle>>& receiving_datareader_crypto_list,
             SecurityException& exception) = 0;
 
     /**
@@ -79,7 +81,7 @@ public:
             CDRMessage_t& encoded_rtps_submessage,
             const CDRMessage_t& plain_rtps_submessage,
             DatareaderCryptoHandle& sending_datareader_crypto,
-            std::vector<DatawriterCryptoHandle*>& receiving_datawriter_crypto_list,
+            std::vector<std::shared_ptr<DatawriterCryptoHandle>>& receiving_datawriter_crypto_list,
             SecurityException& exception) = 0;
 
     /**
@@ -95,7 +97,7 @@ public:
             CDRMessage_t& encoded_rtps_message,
             const CDRMessage_t& plain_rtps_message,
             ParticipantCryptoHandle& sending_crypto,
-            std::vector<ParticipantCryptoHandle*>& receiving_crypto_list,
+            std::vector<std::shared_ptr<ParticipantCryptoHandle>>& receiving_crypto_list,
             SecurityException& exception) = 0;
 
     /**

--- a/include/fastdds/rtps/security/cryptography/Cryptography.h
+++ b/include/fastdds/rtps/security/cryptography/Cryptography.h
@@ -34,17 +34,13 @@ class Cryptography
 {
 public:
 
-    Cryptography(): m_cryptokeyexchange(nullptr), m_cryptokeyfactory(nullptr),
-    m_cryptotransform(nullptr), m_logger(nullptr) {}
+    Cryptography() = default;
+    virtual ~Cryptography() = default;
 
-    virtual ~Cryptography() {}
-
-    /* Specializations should add functions to access the private members */
-    CryptoKeyExchange* cryptkeyexchange() { return m_cryptokeyexchange; }
-
-    CryptoKeyFactory* cryptokeyfactory() { return m_cryptokeyfactory; }
-
-    CryptoTransform* cryptotransform() { return m_cryptotransform; }
+    /* Specializations should add functions to access the different modules */
+    virtual CryptoKeyExchange* cryptokeyexchange() = 0;
+    virtual CryptoKeyFactory* cryptokeyfactory() = 0;
+    virtual CryptoTransform* cryptotransform() = 0;
 
     bool set_logger(
             Logging* logger,
@@ -60,10 +56,6 @@ protected:
     {
         return m_logger;
     }
-
-    CryptoKeyExchange *m_cryptokeyexchange;
-    CryptoKeyFactory *m_cryptokeyfactory;
-    CryptoTransform *m_cryptotransform;
 
 private:
 

--- a/include/fastdds/rtps/security/cryptography/Cryptography.h
+++ b/include/fastdds/rtps/security/cryptography/Cryptography.h
@@ -59,7 +59,7 @@ protected:
 
 private:
 
-    Logging *m_logger;
+    Logging* m_logger;
 };
 
 } //namespace security

--- a/include/fastrtps/config/doxygen_modules.h
+++ b/include/fastrtps/config/doxygen_modules.h
@@ -115,7 +115,6 @@
 
 #endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
-
 /** @defgroup UTILITIES_MODULE Shared Utilities
  * @ingroup FASTRTPS_GENERAL_API
  * Shared utilities that can be used by one or more classes in different modules. They are not strictly part of the RTPS implementation

--- a/include/fastrtps/config/doxygen_modules.h
+++ b/include/fastrtps/config/doxygen_modules.h
@@ -61,7 +61,7 @@
 
 /** @defgroup NETWORK_MODULE Network Module
  * @ingroup RTPS_MODULE
- * Includes the elements necessary to interface between the 
+ * Includes the elements necessary to interface between the
  * transport layer and the FastRTPS library.
  */
 
@@ -106,6 +106,11 @@
 /** @defgroup LIVELINESS_MODULE Liveliness Module
  * @ingroup MANAGEMENT_MODULE
  * This module contains the classes associated with the Writer Liveliness Protocols.
+ */
+
+/** @defgroup SECURITY_MODULE Security Module
+ * @ingroup MANAGEMENT_MODULE
+ * This module contains the classes associated with DDS Security (see https://www.omg.org/spec/DDS-SECURITY/)
  */
 
 #endif

--- a/include/fastrtps/config/doxygen_modules.h
+++ b/include/fastrtps/config/doxygen_modules.h
@@ -21,14 +21,14 @@
 
 //Description of doxygen modules, not used in actual code.
 
- /*!
+/*!
  * @defgroup FASTRTPS_GENERAL_API eProsima Fast RTPS API Reference
  * @brief eProsima Fast RTPS API grouped in modules.
  */
 
 
 
- /*!
+/*!
  * @defgroup RTPS_MODULE RTPS
  * @ingroup FASTRTPS_GENERAL_API
  * @brief RTPS API
@@ -113,7 +113,7 @@
  * This module contains the classes associated with DDS Security (see https://www.omg.org/spec/DDS-SECURITY/)
  */
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 
 /** @defgroup UTILITIES_MODULE Shared Utilities
@@ -140,6 +140,6 @@
 /**
  * @namespace eprosima::fastrtps::rtps::TimeConv Auxiliary methods to convert to Time_t to more manageable types.
  *  @ingroup UTILITIES_MODULE
-  */
+ */
 
 #endif /* RTPS_DOXYGEN_MODULES_H_ */

--- a/include/fastrtps/utils/shared_mutex.hpp
+++ b/include/fastrtps/utils/shared_mutex.hpp
@@ -8,8 +8,15 @@
 #ifndef _UTILS_SHARED_MUTEX_HPP_
 #define _UTILS_SHARED_MUTEX_HPP_
 
-// detect if STL version is available, note that __cplusplus is not reliable on MSVC
-#if (__cplusplus < 201402) || (defined(_MSC_VER) && _MSC_VER < 1900 )
+#if defined(__has_include) && __has_include(<version>)
+#   include <version>
+#endif
+
+// Detect if the share_mutex feature is available
+#if defined(__has_include) && __has_include(<version>) && !defined(__cpp_lib_shared_mutex) || \
+/* deprecated procedure if the good one is not available*/ \
+( !(defined(__has_include) && __has_include(<version>)) && \
+  !(defined(HAVE_CXX17) && HAVE_CXX17) &&  __cplusplus < 201703 )
 
 #include <mutex>
 #include <condition_variable>
@@ -347,7 +354,8 @@ shared_lock<Mutex>::try_lock()
 namespace eprosima {
 
 using shared_mutex = std::shared_mutex;
-using shared_lock = std::shared_lock;
+template< class Mutex >
+using shared_lock = std::shared_lock<Mutex>;
 
 } //namespace eprosima
 

--- a/include/fastrtps/utils/shared_mutex.hpp
+++ b/include/fastrtps/utils/shared_mutex.hpp
@@ -1,0 +1,269 @@
+// Copyright Howard Hinnant 2007-2010. Distributed under the Boost
+// Software License, Version 1.0. (see http://www.boost.org/LICENSE_1_0.txt)
+
+/**
+ * @file shared_mutex.hpp
+ */
+
+#ifndef _UTILS_SHARED_MUTEX_HPP_
+#define _UTILS_SHARED_MUTEX_HPP_
+
+// detect if STL version is available, note that __cplusplus is not reliable on MSVC
+#if (__cplusplus < 201402) || (defined(_MSC_VER) && _MSC_VER < 1900 )
+
+#include <mutex>
+#include <condition_variable>
+#include <climits>
+#include <system_error>
+
+namespace eprosima {
+
+class shared_mutex
+{
+    typedef std::mutex              mutex_t;
+    typedef std::condition_variable cond_t;
+    typedef unsigned                count_t;
+
+    mutex_t mut_;
+    cond_t  gate1_;
+    cond_t  gate2_;
+    count_t state_;
+
+    static const count_t write_entered_ = 1U << (sizeof(count_t)*CHAR_BIT - 1);
+    static const count_t n_readers_ = ~write_entered_;
+
+public:
+    shared_mutex()
+        : state_(0)
+    {
+    }
+
+    ~shared_mutex()
+    {
+        std::lock_guard<mutex_t> _(mut_);
+    }
+
+    shared_mutex(const shared_mutex&) = delete;
+    shared_mutex& operator=(const shared_mutex&) = delete;
+
+// Exclusive ownership
+
+    void lock()
+    {
+        std::unique_lock<mutex_t> lk(mut_);
+        while (state_ & write_entered_)
+            gate1_.wait(lk);
+        state_ |= write_entered_;
+        while (state_ & n_readers_)
+            gate2_.wait(lk);
+    }
+
+    bool try_lock()
+    {
+        std::unique_lock<mutex_t> lk(mut_);
+        if (state_ == 0)
+        {
+            state_ = write_entered_;
+            return true;
+        }
+        return false;
+    }
+
+    void unlock()
+    {
+        std::lock_guard<mutex_t> _(mut_);
+        state_ = 0;
+        gate1_.notify_all();
+    }
+
+// Shared ownership
+
+    void lock_shared()
+    {
+        std::unique_lock<mutex_t> lk(mut_);
+        while ((state_ & write_entered_) || (state_ & n_readers_) == n_readers_)
+            gate1_.wait(lk);
+        count_t num_readers = (state_ & n_readers_) + 1;
+        state_ &= ~n_readers_;
+        state_ |= num_readers;
+    }
+
+    bool try_lock_shared()
+    {
+        std::unique_lock<mutex_t> lk(mut_);
+        count_t num_readers = state_ & n_readers_;
+        if (!(state_ & write_entered_) && num_readers != n_readers_)
+        {
+            ++num_readers;
+            state_ &= ~n_readers_;
+            state_ |= num_readers;
+            return true;
+        }
+        return false;
+    }
+
+    void unlock_shared()
+    {
+        std::lock_guard<mutex_t> _(mut_);
+        count_t num_readers = (state_ & n_readers_) - 1;
+        state_ &= ~n_readers_;
+        state_ |= num_readers;
+        if (state_ & write_entered_)
+        {
+            if (num_readers == 0)
+                gate2_.notify_one();
+        }
+        else
+        {
+            if (num_readers == n_readers_ - 1)
+                gate1_.notify_one();
+        }
+    }
+};
+
+template <class Mutex>
+class shared_lock
+{
+public:
+    typedef Mutex mutex_type;
+
+private:
+    mutex_type* m_;
+    bool owns_;
+
+    struct __nat {int _;};
+
+public:
+    shared_lock()
+        : m_(nullptr), owns_(false) {}
+
+    explicit shared_lock(mutex_type& m)
+        : m_(&m), owns_(true)
+        {m_->lock_shared();}
+
+    shared_lock(mutex_type& m, std::defer_lock_t)
+        : m_(&m), owns_(false) {}
+
+    shared_lock(mutex_type& m, std::try_to_lock_t)
+        : m_(&m), owns_(m.try_lock_shared()) {}
+
+    shared_lock(mutex_type& m, std::adopt_lock_t)
+        : m_(&m), owns_(true) {}
+
+    template <class Clock, class Duration>
+        shared_lock(mutex_type& m,
+                    const std::chrono::time_point<Clock, Duration>& abs_time)
+        : m_(&m), owns_(m.try_lock_shared_until(abs_time)) {}
+    template <class Rep, class Period>
+        shared_lock(mutex_type& m,
+                    const std::chrono::duration<Rep, Period>& rel_time)
+        : m_(&m), owns_(m.try_lock_shared_for(rel_time)) {}
+
+    ~shared_lock()
+    {
+        if (owns_)
+            m_->unlock_shared();
+    }
+
+    shared_lock(shared_lock const&) = delete;
+    shared_lock& operator=(shared_lock const&) = delete;
+
+    shared_lock(shared_lock&& sl)
+        : m_(sl.m_), owns_(sl.owns_)
+        {sl.m_ = nullptr; sl.owns_ = false;}
+
+    shared_lock& operator=(shared_lock&& sl)
+    {
+        if (owns_)
+            m_->unlock_shared();
+        m_ = sl.m_;
+        owns_ = sl.owns_;
+        sl.m_ = nullptr;
+        sl.owns_ = false;
+        return *this;
+    }
+
+    explicit shared_lock(std::unique_lock<mutex_type>&& ul)
+        : m_(ul.mutex()), owns_(ul.owns_lock())
+    {
+        if (owns_)
+            m_->unlock_and_lock_shared();
+        ul.release();
+    }
+
+    void lock();
+    bool try_lock();
+    template <class Rep, class Period>
+        bool try_lock_for(const std::chrono::duration<Rep, Period>& rel_time)
+        {
+            return try_lock_until(std::chrono::steady_clock::now() + rel_time);
+        }
+    template <class Clock, class Duration>
+        bool
+        try_lock_until(
+                      const std::chrono::time_point<Clock, Duration>& abs_time);
+    void unlock();
+
+    void swap(shared_lock&& u)
+    {
+        std::swap(m_, u.m_);
+        std::swap(owns_, u.owns_);
+    }
+
+    mutex_type* release()
+    {
+        mutex_type* r = m_;
+        m_ = nullptr;
+        owns_ = false;
+        return r;
+    }
+    bool owns_lock() const {return owns_;}
+    operator int __nat::* () const {return owns_ ? &__nat::_ : 0;}
+    mutex_type* mutex() const {return m_;}
+
+};
+
+template <class Mutex>
+void
+shared_lock<Mutex>::lock()
+{
+    if (m_ == nullptr)
+        throw std::system_error(std::error_code(EPERM, std::system_category()),
+                                    "shared_lock::lock: references null mutex");
+    if (owns_)
+        throw std::system_error(std::error_code(EDEADLK, std::system_category()),
+                                           "shared_lock::lock: already locked");
+    m_->lock_shared();
+    owns_ = true;
+}
+
+template <class Mutex>
+bool
+shared_lock<Mutex>::try_lock()
+{
+    if (m_ == nullptr)
+        throw std::system_error(std::error_code(EPERM, std::system_category()),
+                                "shared_lock::try_lock: references null mutex");
+    if (owns_)
+        throw std::system_error(std::error_code(EDEADLK, std::system_category()),
+                                       "shared_lock::try_lock: already locked");
+    owns_ = m_->try_lock_shared();
+    return owns_;
+}
+
+} //namespace eprosima
+
+#else // fallback to STL
+
+#include <shared_mutex>
+
+namespace eprosima {
+
+using shared_mutex = std::shared_mutex;
+using shared_lock = std::shared_lock;
+
+} //namespace eprosima
+
+#endif
+
+#endif // _UTILS_SHARED_MUTEX_HPP_

--- a/include/fastrtps/utils/shared_mutex.hpp
+++ b/include/fastrtps/utils/shared_mutex.hpp
@@ -10,13 +10,13 @@
 
 #if defined(__has_include) && __has_include(<version>)
 #   include <version>
-#endif
+#endif // if defined(__has_include) && __has_include(<version>)
 
 // Detect if the share_mutex feature is available
 #if defined(__has_include) && __has_include(<version>) && !defined(__cpp_lib_shared_mutex) || \
-/* deprecated procedure if the good one is not available*/ \
-( !(defined(__has_include) && __has_include(<version>)) && \
-  !(defined(HAVE_CXX17) && HAVE_CXX17) &&  __cplusplus < 201703 )
+    /* deprecated procedure if the good one is not available*/ \
+    ( !(defined(__has_include) && __has_include(<version>)) && \
+    !(defined(HAVE_CXX17) && HAVE_CXX17) &&  __cplusplus < 201703 )
 
 #include <mutex>
 #include <condition_variable>

--- a/include/fastrtps/utils/shared_mutex.hpp
+++ b/include/fastrtps/utils/shared_mutex.hpp
@@ -20,19 +20,20 @@ namespace eprosima {
 
 class shared_mutex
 {
-    typedef std::mutex              mutex_t;
+    typedef std::mutex mutex_t;
     typedef std::condition_variable cond_t;
-    typedef unsigned                count_t;
+    typedef unsigned count_t;
 
     mutex_t mut_;
-    cond_t  gate1_;
-    cond_t  gate2_;
+    cond_t gate1_;
+    cond_t gate2_;
     count_t state_;
 
-    static const count_t write_entered_ = 1U << (sizeof(count_t)*CHAR_BIT - 1);
+    static const count_t write_entered_ = 1U << (sizeof(count_t) * CHAR_BIT - 1);
     static const count_t n_readers_ = ~write_entered_;
 
 public:
+
     shared_mutex()
         : state_(0)
     {
@@ -43,19 +44,25 @@ public:
         std::lock_guard<mutex_t> _(mut_);
     }
 
-    shared_mutex(const shared_mutex&) = delete;
-    shared_mutex& operator=(const shared_mutex&) = delete;
+    shared_mutex(
+            const shared_mutex&) = delete;
+    shared_mutex& operator =(
+            const shared_mutex&) = delete;
 
-// Exclusive ownership
+    // Exclusive ownership
 
     void lock()
     {
         std::unique_lock<mutex_t> lk(mut_);
         while (state_ & write_entered_)
+        {
             gate1_.wait(lk);
+        }
         state_ |= write_entered_;
         while (state_ & n_readers_)
+        {
             gate2_.wait(lk);
+        }
     }
 
     bool try_lock()
@@ -76,13 +83,15 @@ public:
         gate1_.notify_all();
     }
 
-// Shared ownership
+    // Shared ownership
 
     void lock_shared()
     {
         std::unique_lock<mutex_t> lk(mut_);
         while ((state_ & write_entered_) || (state_ & n_readers_) == n_readers_)
+        {
             gate1_.wait(lk);
+        }
         count_t num_readers = (state_ & n_readers_) + 1;
         state_ &= ~n_readers_;
         state_ |= num_readers;
@@ -111,71 +120,124 @@ public:
         if (state_ & write_entered_)
         {
             if (num_readers == 0)
+            {
                 gate2_.notify_one();
+            }
         }
         else
         {
             if (num_readers == n_readers_ - 1)
+            {
                 gate1_.notify_one();
+            }
         }
     }
+
 };
 
 template <class Mutex>
 class shared_lock
 {
 public:
+
     typedef Mutex mutex_type;
 
 private:
+
     mutex_type* m_;
     bool owns_;
 
-    struct __nat {int _;};
+    struct __nat
+    {
+        int _;
+    };
 
 public:
+
     shared_lock()
-        : m_(nullptr), owns_(false) {}
+        : m_(nullptr)
+        , owns_(false)
+    {
+    }
 
-    explicit shared_lock(mutex_type& m)
-        : m_(&m), owns_(true)
-        {m_->lock_shared();}
+    explicit shared_lock(
+            mutex_type& m)
+        : m_(&m)
+        , owns_(true)
+    {
+        m_->lock_shared();
+    }
 
-    shared_lock(mutex_type& m, std::defer_lock_t)
-        : m_(&m), owns_(false) {}
+    shared_lock(
+            mutex_type& m,
+            std::defer_lock_t)
+        : m_(&m)
+        , owns_(false)
+    {
+    }
 
-    shared_lock(mutex_type& m, std::try_to_lock_t)
-        : m_(&m), owns_(m.try_lock_shared()) {}
+    shared_lock(
+            mutex_type& m,
+            std::try_to_lock_t)
+        : m_(&m)
+        , owns_(m.try_lock_shared())
+    {
+    }
 
-    shared_lock(mutex_type& m, std::adopt_lock_t)
-        : m_(&m), owns_(true) {}
+    shared_lock(
+            mutex_type& m,
+            std::adopt_lock_t)
+        : m_(&m)
+        , owns_(true)
+    {
+    }
 
     template <class Clock, class Duration>
-        shared_lock(mutex_type& m,
-                    const std::chrono::time_point<Clock, Duration>& abs_time)
-        : m_(&m), owns_(m.try_lock_shared_until(abs_time)) {}
+    shared_lock(
+            mutex_type& m,
+            const std::chrono::time_point<Clock, Duration>& abs_time)
+        : m_(&m)
+        , owns_(m.try_lock_shared_until(abs_time))
+    {
+    }
+
     template <class Rep, class Period>
-        shared_lock(mutex_type& m,
-                    const std::chrono::duration<Rep, Period>& rel_time)
-        : m_(&m), owns_(m.try_lock_shared_for(rel_time)) {}
+    shared_lock(
+            mutex_type& m,
+            const std::chrono::duration<Rep, Period>& rel_time)
+        : m_(&m)
+        , owns_(m.try_lock_shared_for(rel_time))
+    {
+    }
 
     ~shared_lock()
     {
         if (owns_)
+        {
             m_->unlock_shared();
+        }
     }
 
-    shared_lock(shared_lock const&) = delete;
-    shared_lock& operator=(shared_lock const&) = delete;
+    shared_lock(
+            shared_lock const&) = delete;
+    shared_lock& operator =(
+            shared_lock const&) = delete;
 
-    shared_lock(shared_lock&& sl)
-        : m_(sl.m_), owns_(sl.owns_)
-        {sl.m_ = nullptr; sl.owns_ = false;}
+    shared_lock(
+            shared_lock&& sl)
+        : m_(sl.m_)
+        , owns_(sl.owns_)
+    {
+        sl.m_ = nullptr; sl.owns_ = false;
+    }
 
-    shared_lock& operator=(shared_lock&& sl)
+    shared_lock& operator =(
+            shared_lock&& sl)
     {
         if (owns_)
+        {
             m_->unlock_shared();
+        }
         m_ = sl.m_;
         owns_ = sl.owns_;
         sl.m_ = nullptr;
@@ -183,28 +245,35 @@ public:
         return *this;
     }
 
-    explicit shared_lock(std::unique_lock<mutex_type>&& ul)
-        : m_(ul.mutex()), owns_(ul.owns_lock())
+    explicit shared_lock(
+            std::unique_lock<mutex_type>&& ul)
+        : m_(ul.mutex())
+        , owns_(ul.owns_lock())
     {
         if (owns_)
+        {
             m_->unlock_and_lock_shared();
+        }
         ul.release();
     }
 
     void lock();
     bool try_lock();
     template <class Rep, class Period>
-        bool try_lock_for(const std::chrono::duration<Rep, Period>& rel_time)
-        {
-            return try_lock_until(std::chrono::steady_clock::now() + rel_time);
-        }
+    bool try_lock_for(
+            const std::chrono::duration<Rep, Period>& rel_time)
+    {
+        return try_lock_until(std::chrono::steady_clock::now() + rel_time);
+    }
+
     template <class Clock, class Duration>
-        bool
-        try_lock_until(
-                      const std::chrono::time_point<Clock, Duration>& abs_time);
+    bool
+    try_lock_until(
+            const std::chrono::time_point<Clock, Duration>& abs_time);
     void unlock();
 
-    void swap(shared_lock&& u)
+    void swap(
+            shared_lock&& u)
     {
         std::swap(m_, u.m_);
         std::swap(owns_, u.owns_);
@@ -217,9 +286,19 @@ public:
         owns_ = false;
         return r;
     }
-    bool owns_lock() const {return owns_;}
-    operator int __nat::* () const {return owns_ ? &__nat::_ : 0;}
-    mutex_type* mutex() const {return m_;}
+
+    bool owns_lock() const
+    {
+        return owns_;
+    }
+
+    operator int __nat::* () const {
+        return owns_ ? &__nat::_ : 0;
+    }
+    mutex_type* mutex() const
+    {
+        return m_;
+    }
 
 };
 
@@ -228,11 +307,15 @@ void
 shared_lock<Mutex>::lock()
 {
     if (m_ == nullptr)
+    {
         throw std::system_error(std::error_code(EPERM, std::system_category()),
-                                    "shared_lock::lock: references null mutex");
+                      "shared_lock::lock: references null mutex");
+    }
     if (owns_)
+    {
         throw std::system_error(std::error_code(EDEADLK, std::system_category()),
-                                           "shared_lock::lock: already locked");
+                      "shared_lock::lock: already locked");
+    }
     m_->lock_shared();
     owns_ = true;
 }
@@ -242,11 +325,15 @@ bool
 shared_lock<Mutex>::try_lock()
 {
     if (m_ == nullptr)
+    {
         throw std::system_error(std::error_code(EPERM, std::system_category()),
-                                "shared_lock::try_lock: references null mutex");
+                      "shared_lock::try_lock: references null mutex");
+    }
     if (owns_)
+    {
         throw std::system_error(std::error_code(EDEADLK, std::system_category()),
-                                       "shared_lock::try_lock: already locked");
+                      "shared_lock::try_lock: already locked");
+    }
     owns_ = m_->try_lock_shared();
     return owns_;
 }
@@ -264,6 +351,6 @@ using shared_lock = std::shared_lock;
 
 } //namespace eprosima
 
-#endif
+#endif // if (__cplusplus < 201402) || (defined(_MSC_VER) && _MSC_VER < 1900 )
 
 #endif // _UTILS_SHARED_MUTEX_HPP_

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -315,7 +315,7 @@ void BuiltinProtocols::announceRTPSParticipantState()
     {
         mp_PDP->announceParticipantState(false);
     }
-    else
+    else if (m_att.discovery_config.discoveryProtocol != DiscoveryProtocol_t::NONE)
     {
         logError(RTPS_EDP, "Trying to use BuiltinProtocols interfaces before initBuiltinProtocols call");
     }
@@ -323,13 +323,14 @@ void BuiltinProtocols::announceRTPSParticipantState()
 
 void BuiltinProtocols::stopRTPSParticipantAnnouncement()
 {
-    assert(mp_PDP);
+    // note that participants created with DiscoveryProtocol::NONE
+    // may not have mp_PDP available
 
     if (mp_PDP)
     {
         mp_PDP->stopParticipantAnnouncement();
     }
-    else
+    else if (m_att.discovery_config.discoveryProtocol != DiscoveryProtocol_t::NONE)
     {
         logError(RTPS_EDP, "Trying to use BuiltinProtocols interfaces before initBuiltinProtocols call");
     }
@@ -343,7 +344,7 @@ void BuiltinProtocols::resetRTPSParticipantAnnouncement()
     {
         mp_PDP->resetParticipantAnnouncement();
     }
-    else
+    else if (m_att.discovery_config.discoveryProtocol != DiscoveryProtocol_t::NONE)
     {
         logError(RTPS_EDP, "Trying to use BuiltinProtocols interfaces before initBuiltinProtocols call");
     }

--- a/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp
+++ b/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp
@@ -1325,8 +1325,8 @@ private:
 
                 fastrtps::rtps::LocatorSelectorSender& locator_selector =
                         current_writer->get_async_locator_selector();
-                locator_selector.lock();
                 async_mode.group.sender(current_writer, &locator_selector);
+                locator_selector.lock();
 
                 // Remove previously from queue, because deliver_sample_nts could call FlowController::remove_sample()
                 // provoking a deadlock.

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -21,7 +21,6 @@
 
 #include <cassert>
 #include <limits>
-#include <mutex>
 
 #include <fastdds/core/policy/ParameterList.hpp>
 #include <fastdds/dds/log/Log.hpp>
@@ -222,7 +221,7 @@ void MessageReceiver::process_data_fragment_message_without_security(
 void MessageReceiver::associateEndpoint(
         Endpoint* to_add)
 {
-    std::lock_guard<std::mutex> guard(mtx_);
+    std::lock_guard<std::shared_mutex> guard(mtx_);
     if (to_add->getAttributes().endpointKind == WRITER)
     {
         const auto writer = dynamic_cast<RTPSWriter*>(to_add);
@@ -266,7 +265,7 @@ void MessageReceiver::associateEndpoint(
 void MessageReceiver::removeEndpoint(
         Endpoint* to_remove)
 {
-    std::lock_guard<std::mutex> guard(mtx_);
+    std::lock_guard<std::shared_mutex> guard(mtx_);
 
     if (to_remove->getAttributes().endpointKind == WRITER)
     {
@@ -317,53 +316,63 @@ void MessageReceiver::processCDRMsg(
         const Locator_t& reception_locator,
         CDRMessage_t* msg)
 {
-    if (msg->length < RTPSMESSAGE_HEADER_SIZE)
-    {
-        logWarning(RTPS_MSG_IN, IDSTRING "Received message too short, ignoring");
-        return;
-    }
-
-    reset();
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     GuidPrefix_t participantGuidPrefix;
 #else
     GuidPrefix_t participantGuidPrefix = participant_->getGuid().guidPrefix;
 #endif // ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    dest_guid_prefix_ = participantGuidPrefix;
-
-    msg->pos = 0; //Start reading at 0
-
-    //Once everything is set, the reading begins:
-    if (!checkRTPSHeader(msg))
-    {
-        return;
-    }
-
-    notify_network_statistics(source_locator, reception_locator, msg);
 
 #if HAVE_SECURITY
     security::SecurityManager& security = participant_->security_manager();
     CDRMessage_t* auxiliary_buffer = &crypto_msg_;
-
-    int decode_ret = security.decode_rtps_message(*msg, *auxiliary_buffer, source_guid_prefix_);
-
-    if (decode_ret < 0)
-    {
-        return;
-    }
-
-    if (decode_ret == 0)
-    {
-        // The original CDRMessage buffer (msg) now points to the proprietary temporary buffer crypto_msg_.
-        // The auxiliary buffer now points to the propietary temporary buffer crypto_submsg_.
-        // This way each decoded sub-message will be processed using the crypto_submsg_ buffer.
-        msg = auxiliary_buffer;
-        auxiliary_buffer = &crypto_submsg_;
-    }
+    int decode_ret = 0;
 #endif // if HAVE_SECURITY
 
+    {
+        std::lock_guard<std::shared_mutex> guard(mtx_);
+
+        if (msg->length < RTPSMESSAGE_HEADER_SIZE)
+        {
+            logWarning(RTPS_MSG_IN, IDSTRING "Received message too short, ignoring");
+            return;
+        }
+
+        reset();
+
+        dest_guid_prefix_ = participantGuidPrefix;
+
+        msg->pos = 0; //Start reading at 0
+
+        //Once everything is set, the reading begins:
+        if (!checkRTPSHeader(msg))
+        {
+            return;
+        }
+
+        notify_network_statistics(source_locator, reception_locator, msg);
+
+#if HAVE_SECURITY
+        decode_ret = security.decode_rtps_message(*msg, *auxiliary_buffer, source_guid_prefix_);
+
+        if (decode_ret < 0)
+        {
+            return;
+        }
+
+        if (decode_ret == 0)
+        {
+            // The original CDRMessage buffer (msg) now points to the proprietary temporary buffer crypto_msg_.
+            // The auxiliary buffer now points to the propietary temporary buffer crypto_submsg_.
+            // This way each decoded sub-message will be processed using the crypto_submsg_ buffer.
+            msg = auxiliary_buffer;
+            auxiliary_buffer = &crypto_submsg_;
+        }
+#endif // if HAVE_SECURITY
+    }
+
     // Loop until there are no more submessages
+    // Each submessage processing method choses the lock kind required
     bool valid;
     SubmessageHeader_t submsgh; //Current submessage header
 
@@ -563,7 +572,7 @@ bool MessageReceiver::checkRTPSHeader(
 
 bool MessageReceiver::readSubmessageHeader(
         CDRMessage_t* msg,
-        SubmessageHeader_t* smh)
+        SubmessageHeader_t* smh) const
 {
     if (msg->length - msg->pos < 4)
     {
@@ -604,7 +613,7 @@ bool MessageReceiver::readSubmessageHeader(
 
 bool MessageReceiver::willAReaderAcceptMsgDirectedTo(
         const EntityId_t& readerID,
-        RTPSReader*& first_reader)
+        RTPSReader*& first_reader) const
 {
     first_reader = nullptr;
     if (associated_readers_.empty())
@@ -644,7 +653,7 @@ bool MessageReceiver::willAReaderAcceptMsgDirectedTo(
 template<typename Functor>
 void MessageReceiver::findAllReaders(
         const EntityId_t& readerID,
-        const Functor& callback)
+        const Functor& callback) const
 {
     if (readerID != c_EntityId_Unknown)
     {
@@ -674,9 +683,9 @@ void MessageReceiver::findAllReaders(
 
 bool MessageReceiver::proc_Submsg_Data(
         CDRMessage_t* msg,
-        SubmessageHeader_t* smh)
+        SubmessageHeader_t* smh) const
 {
-    std::lock_guard<std::mutex> guard(mtx_);
+    std::shared_lock<std::shared_mutex> guard(mtx_);
 
     //READ and PROCESS
     if (smh->submessageLength < RTPSMESSAGE_DATA_MIN_LENGTH)
@@ -844,9 +853,9 @@ bool MessageReceiver::proc_Submsg_Data(
 
 bool MessageReceiver::proc_Submsg_DataFrag(
         CDRMessage_t* msg,
-        SubmessageHeader_t* smh)
+        SubmessageHeader_t* smh) const
 {
-    std::lock_guard<std::mutex> guard(mtx_);
+    std::shared_lock<std::shared_mutex> guard(mtx_);
 
     //READ and PROCESS
     if (smh->submessageLength < RTPSMESSAGE_DATA_MIN_LENGTH)
@@ -1019,8 +1028,10 @@ bool MessageReceiver::proc_Submsg_DataFrag(
 
 bool MessageReceiver::proc_Submsg_Heartbeat(
         CDRMessage_t* msg,
-        SubmessageHeader_t* smh)
+        SubmessageHeader_t* smh) const
 {
+    std::shared_lock<std::shared_mutex> guard(mtx_);
+
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     bool finalFlag = (smh->flags & BIT(1)) != 0;
     bool livelinessFlag = (smh->flags & BIT(2)) != 0;
@@ -1057,7 +1068,6 @@ bool MessageReceiver::proc_Submsg_Heartbeat(
         return false;
     }
 
-    std::lock_guard<std::mutex> guard(mtx_);
     //Look for the correct reader and writers:
     findAllReaders(readerGUID.entityId,
             [&writerGUID, &HBCount, &firstSN, &lastSN, finalFlag, livelinessFlag](RTPSReader* reader)
@@ -1070,8 +1080,10 @@ bool MessageReceiver::proc_Submsg_Heartbeat(
 
 bool MessageReceiver::proc_Submsg_Acknack(
         CDRMessage_t* msg,
-        SubmessageHeader_t* smh)
+        SubmessageHeader_t* smh) const
 {
+    std::shared_lock<std::shared_mutex> guard(mtx_);
+
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     bool finalFlag = (smh->flags & BIT(1)) != 0;
     //Assign message endianness
@@ -1090,7 +1102,6 @@ bool MessageReceiver::proc_Submsg_Acknack(
     writerGUID.guidPrefix = dest_guid_prefix_;
     CDRMessage::readEntityId(msg, &writerGUID.entityId);
 
-
     SequenceNumberSet_t SNSet = CDRMessage::readSequenceNumberSet(msg);
     uint32_t Ackcount;
     if (!CDRMessage::readUInt32(msg, &Ackcount))
@@ -1099,7 +1110,6 @@ bool MessageReceiver::proc_Submsg_Acknack(
         return false;
     }
 
-    std::lock_guard<std::mutex> guard(mtx_);
     //Look for the correct writer to use the acknack
     for (RTPSWriter* it : associated_writers_)
     {
@@ -1120,8 +1130,10 @@ bool MessageReceiver::proc_Submsg_Acknack(
 
 bool MessageReceiver::proc_Submsg_Gap(
         CDRMessage_t* msg,
-        SubmessageHeader_t* smh)
+        SubmessageHeader_t* smh) const
 {
+    std::shared_lock<std::shared_mutex> guard(mtx_);
+
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     //Assign message endianness
     if (endiannessFlag)
@@ -1147,7 +1159,6 @@ bool MessageReceiver::proc_Submsg_Gap(
         return false;
     }
 
-    std::lock_guard<std::mutex> guard(mtx_);
     findAllReaders(readerGUID.entityId,
             [&writerGUID, &gapStart, &gapList](RTPSReader* reader)
             {
@@ -1161,6 +1172,8 @@ bool MessageReceiver::proc_Submsg_InfoTS(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh)
 {
+    std::lock_guard<std::shared_mutex> guard(mtx_);
+
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     bool timeFlag = (smh->flags & BIT(1)) != 0;
     //Assign message endianness
@@ -1189,6 +1202,8 @@ bool MessageReceiver::proc_Submsg_InfoDST(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh)
 {
+    std::lock_guard<std::shared_mutex> guard(mtx_);
+
     bool endiannessFlag = (smh->flags & BIT(0)) != 0u;
     //bool timeFlag = smh->flags & BIT(1) ? true : false;
     //Assign message endianness
@@ -1214,6 +1229,8 @@ bool MessageReceiver::proc_Submsg_InfoSRC(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh)
 {
+    std::lock_guard<std::shared_mutex> guard(mtx_);
+
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     //bool timeFlag = smh->flags & BIT(1) ? true : false;
     //Assign message endianness
@@ -1241,8 +1258,10 @@ bool MessageReceiver::proc_Submsg_InfoSRC(
 
 bool MessageReceiver::proc_Submsg_NackFrag(
         CDRMessage_t* msg,
-        SubmessageHeader_t* smh)
+        SubmessageHeader_t* smh) const
 {
+    std::shared_lock<std::shared_mutex> guard(mtx_);
+
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     //Assign message endianness
     if (endiannessFlag)
@@ -1274,7 +1293,6 @@ bool MessageReceiver::proc_Submsg_NackFrag(
         return false;
     }
 
-    std::lock_guard<std::mutex> guard(mtx_);
     //Look for the correct writer to use the acknack
     for (RTPSWriter* it : associated_writers_)
     {
@@ -1295,8 +1313,10 @@ bool MessageReceiver::proc_Submsg_NackFrag(
 
 bool MessageReceiver::proc_Submsg_HeartbeatFrag(
         CDRMessage_t* msg,
-        SubmessageHeader_t* smh)
+        SubmessageHeader_t* smh) const
 {
+    std::shared_lock<std::shared_mutex> guard(mtx_);
+
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     //Assign message endianness
     if (endiannessFlag)
@@ -1344,7 +1364,7 @@ bool MessageReceiver::proc_Submsg_HeartbeatFrag(
 void MessageReceiver::notify_network_statistics(
         const Locator_t& source_locator,
         const Locator_t& reception_locator,
-        CDRMessage_t* msg)
+        CDRMessage_t* msg) const
 {
     static_cast<void>(source_locator);
     static_cast<void>(reception_locator);

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -316,6 +316,12 @@ void MessageReceiver::processCDRMsg(
         const Locator_t& reception_locator,
         CDRMessage_t* msg)
 {
+    if (msg->length < RTPSMESSAGE_HEADER_SIZE)
+    {
+        logWarning(RTPS_MSG_IN, IDSTRING "Received message too short, ignoring");
+        return;
+    }
+
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     GuidPrefix_t participantGuidPrefix;
 #else
@@ -330,12 +336,6 @@ void MessageReceiver::processCDRMsg(
 
     {
         std::lock_guard<eprosima::shared_mutex> guard(mtx_);
-
-        if (msg->length < RTPSMESSAGE_HEADER_SIZE)
-        {
-            logWarning(RTPS_MSG_IN, IDSTRING "Received message too short, ignoring");
-            return;
-        }
 
         reset();
 

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -24,9 +24,9 @@
 
 #include <fastdds/core/policy/ParameterList.hpp>
 #include <fastdds/dds/log/Log.hpp>
-
 #include <fastdds/rtps/reader/RTPSReader.h>
 #include <fastdds/rtps/writer/RTPSWriter.h>
+#include <fastrtps/utils/shared_mutex.hpp>
 
 #include <rtps/participant/RTPSParticipantImpl.h>
 #include <statistics/rtps/StatisticsBase.hpp>
@@ -316,7 +316,6 @@ void MessageReceiver::processCDRMsg(
         const Locator_t& reception_locator,
         CDRMessage_t* msg)
 {
-
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     GuidPrefix_t participantGuidPrefix;
 #else

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -221,7 +221,7 @@ void MessageReceiver::process_data_fragment_message_without_security(
 void MessageReceiver::associateEndpoint(
         Endpoint* to_add)
 {
-    std::lock_guard<std::shared_mutex> guard(mtx_);
+    std::lock_guard<eprosima::shared_mutex> guard(mtx_);
     if (to_add->getAttributes().endpointKind == WRITER)
     {
         const auto writer = dynamic_cast<RTPSWriter*>(to_add);
@@ -265,7 +265,7 @@ void MessageReceiver::associateEndpoint(
 void MessageReceiver::removeEndpoint(
         Endpoint* to_remove)
 {
-    std::lock_guard<std::shared_mutex> guard(mtx_);
+    std::lock_guard<eprosima::shared_mutex> guard(mtx_);
 
     if (to_remove->getAttributes().endpointKind == WRITER)
     {
@@ -330,7 +330,7 @@ void MessageReceiver::processCDRMsg(
 #endif // if HAVE_SECURITY
 
     {
-        std::lock_guard<std::shared_mutex> guard(mtx_);
+        std::lock_guard<eprosima::shared_mutex> guard(mtx_);
 
         if (msg->length < RTPSMESSAGE_HEADER_SIZE)
         {
@@ -685,7 +685,7 @@ bool MessageReceiver::proc_Submsg_Data(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh) const
 {
-    std::shared_lock<std::shared_mutex> guard(mtx_);
+    eprosima::shared_lock<eprosima::shared_mutex> guard(mtx_);
 
     //READ and PROCESS
     if (smh->submessageLength < RTPSMESSAGE_DATA_MIN_LENGTH)
@@ -855,7 +855,7 @@ bool MessageReceiver::proc_Submsg_DataFrag(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh) const
 {
-    std::shared_lock<std::shared_mutex> guard(mtx_);
+    eprosima::shared_lock<eprosima::shared_mutex> guard(mtx_);
 
     //READ and PROCESS
     if (smh->submessageLength < RTPSMESSAGE_DATA_MIN_LENGTH)
@@ -1030,7 +1030,7 @@ bool MessageReceiver::proc_Submsg_Heartbeat(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh) const
 {
-    std::shared_lock<std::shared_mutex> guard(mtx_);
+    eprosima::shared_lock<eprosima::shared_mutex> guard(mtx_);
 
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     bool finalFlag = (smh->flags & BIT(1)) != 0;
@@ -1082,7 +1082,7 @@ bool MessageReceiver::proc_Submsg_Acknack(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh) const
 {
-    std::shared_lock<std::shared_mutex> guard(mtx_);
+    eprosima::shared_lock<eprosima::shared_mutex> guard(mtx_);
 
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     bool finalFlag = (smh->flags & BIT(1)) != 0;
@@ -1132,7 +1132,7 @@ bool MessageReceiver::proc_Submsg_Gap(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh) const
 {
-    std::shared_lock<std::shared_mutex> guard(mtx_);
+    eprosima::shared_lock<eprosima::shared_mutex> guard(mtx_);
 
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     //Assign message endianness
@@ -1172,7 +1172,7 @@ bool MessageReceiver::proc_Submsg_InfoTS(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh)
 {
-    std::lock_guard<std::shared_mutex> guard(mtx_);
+    std::lock_guard<eprosima::shared_mutex> guard(mtx_);
 
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     bool timeFlag = (smh->flags & BIT(1)) != 0;
@@ -1202,7 +1202,7 @@ bool MessageReceiver::proc_Submsg_InfoDST(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh)
 {
-    std::lock_guard<std::shared_mutex> guard(mtx_);
+    std::lock_guard<eprosima::shared_mutex> guard(mtx_);
 
     bool endiannessFlag = (smh->flags & BIT(0)) != 0u;
     //bool timeFlag = smh->flags & BIT(1) ? true : false;
@@ -1229,7 +1229,7 @@ bool MessageReceiver::proc_Submsg_InfoSRC(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh)
 {
-    std::lock_guard<std::shared_mutex> guard(mtx_);
+    std::lock_guard<eprosima::shared_mutex> guard(mtx_);
 
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     //bool timeFlag = smh->flags & BIT(1) ? true : false;
@@ -1260,7 +1260,7 @@ bool MessageReceiver::proc_Submsg_NackFrag(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh) const
 {
-    std::shared_lock<std::shared_mutex> guard(mtx_);
+    eprosima::shared_lock<eprosima::shared_mutex> guard(mtx_);
 
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     //Assign message endianness
@@ -1315,7 +1315,7 @@ bool MessageReceiver::proc_Submsg_HeartbeatFrag(
         CDRMessage_t* msg,
         SubmessageHeader_t* smh) const
 {
-    std::shared_lock<std::shared_mutex> guard(mtx_);
+    eprosima::shared_lock<eprosima::shared_mutex> guard(mtx_);
 
     bool endiannessFlag = (smh->flags & BIT(0)) != 0;
     //Assign message endianness

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -325,7 +325,6 @@ RTPSParticipantImpl::RTPSParticipantImpl(
 
 #if HAVE_SECURITY
     // Start security
-    // TODO(Ricardo) Get returned value in future.
     if (!m_security_manager.init(
                 security_attributes_,
                 PParam.properties))

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -325,8 +325,10 @@ RTPSParticipantImpl::RTPSParticipantImpl(
 
 #if HAVE_SECURITY
     // Start security
-    if (!m_security_manager.init(security_attributes_, PParam.properties,
-            m_is_security_active))
+    // TODO(Ricardo) Get returned value in future.
+    if (!m_security_manager.init(
+                security_attributes_,
+                PParam.properties))
     {
         // Participant will be deleted, no need to allocate buffers or create builtin endpoints
         return;
@@ -390,12 +392,10 @@ RTPSParticipantImpl::RTPSParticipantImpl(
 
 
 #if HAVE_SECURITY
-    if (m_is_security_active)
+    if (m_security_manager.is_security_active())
     {
-        m_is_security_active = m_security_manager.create_entities();
-        if (!m_is_security_active)
+        if (!m_security_manager.create_entities())
         {
-            // Participant will be deleted, no need to create builtin endpoints
             return;
         }
     }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -370,9 +370,14 @@ public:
         return security_attributes_;
     }
 
-    bool is_secure() const
+    inline bool is_security_initialized() const
     {
-        return m_is_security_active;
+        return m_security_manager.is_security_initialized();
+    }
+
+    inline bool is_secure() const
+    {
+        return m_security_manager.is_security_active();
     }
 
     bool pairing_remote_reader_with_local_writer_after_security(
@@ -556,8 +561,6 @@ private:
 #if HAVE_SECURITY
     // Security manager
     security::SecurityManager m_security_manager;
-    // Security activation flag
-    bool m_is_security_active = false;
 #endif // if HAVE_SECURITY
 
     //! Encapsulates all associated resources on a Receiving element.

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -352,10 +352,8 @@ bool SecurityManager::init(
                     throw true;
                 }
             }
-            else
-            {
-                throw false;
-            }
+
+            throw false;
         }
         else
         {

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -374,7 +374,7 @@ bool SecurityManager::init(
             }
         }
     }
-    catch (SecurityException e)
+    catch (const SecurityException& e)
     {
         logError(SECURITY, "Logging plugin not configured. Security logging will be disabled. ("
                 << e.what() << ").");

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -470,7 +470,7 @@ void SecurityManager::destroy()
                 access_plugin_->return_permissions_handle(permissions_handle, exception);
             }
 
-            std::shared_ptr<SharedSecretHandle> shared_secret_handle = dp_it.second->get_shared_secret();
+            std::shared_ptr<SecretHandle> shared_secret_handle = dp_it.second->get_shared_secret();
             if (shared_secret_handle != nullptr)
             {
                 authentication_plugin_->return_sharedsecret_handle(shared_secret_handle, exception);
@@ -700,7 +700,7 @@ bool SecurityManager::discovered_participant(
         if (auth_status == AUTHENTICATION_OK)
         {
             //TODO(Ricardo) Shared secret on this case?
-            std::shared_ptr<SharedSecretHandle> ss;
+            std::shared_ptr<SecretHandle> ss;
             participant_authorized(participant_data, remote_participant_info, ss);
         }
     }
@@ -763,7 +763,7 @@ void SecurityManager::remove_participant(
                 access_plugin_->return_permissions_handle(permissions_handle, exception);
             }
 
-            std::shared_ptr<SharedSecretHandle> shared_secret_handle = dp_it->second->get_shared_secret();
+            std::shared_ptr<SecretHandle> shared_secret_handle = dp_it->second->get_shared_secret();
             if (shared_secret_handle != nullptr)
             {
                 authentication_plugin_->return_sharedsecret_handle(shared_secret_handle, exception);
@@ -996,7 +996,7 @@ bool SecurityManager::on_process_handshake(
                 // if authentication was finished, starts encryption.
                 if (remote_participant_info->auth_status_ == AUTHENTICATION_OK)
                 {
-                    std::shared_ptr<SharedSecretHandle> shared_secret_handle = authentication_plugin_->get_shared_secret(
+                    std::shared_ptr<SecretHandle> shared_secret_handle = authentication_plugin_->get_shared_secret(
                         *remote_participant_info->handshake_handle_, exception);
                     if (!participant_authorized(participant_data, remote_participant_info,
                             shared_secret_handle))
@@ -2223,7 +2223,7 @@ void SecurityManager::exchange_participant_crypto(
 // TODO (Ricardo) Change participant_data
 std::shared_ptr<ParticipantCryptoHandle> SecurityManager::register_and_match_crypto_endpoint(
         IdentityHandle& remote_participant_identity,
-        SharedSecretHandle& shared_secret)
+        SecretHandle& shared_secret)
 {
     if (crypto_plugin_ == nullptr)
     {
@@ -2864,7 +2864,7 @@ bool SecurityManager::discovered_reader(
 
     PermissionsHandle* remote_permissions = nullptr;
     std::shared_ptr<ParticipantCryptoHandle> remote_participant_crypto_handle;
-    std::shared_ptr<SharedSecretHandle> shared_secret_handle;
+    std::shared_ptr<SecretHandle> shared_secret_handle;
 
     if (!security_attributes.match(remote_reader_data.security_attributes_,
             remote_reader_data.plugin_security_attributes_))
@@ -3210,7 +3210,7 @@ bool SecurityManager::discovered_writer(
 
     PermissionsHandle* remote_permissions = nullptr;
     std::shared_ptr<ParticipantCryptoHandle> remote_participant_crypto_handle;
-    std::shared_ptr<SharedSecretHandle> shared_secret_handle;
+    std::shared_ptr<SecretHandle> shared_secret_handle;
 
     if (!security_attributes.match(remote_writer_data.security_attributes_,
             remote_writer_data.plugin_security_attributes_))
@@ -3871,7 +3871,7 @@ bool SecurityManager::decode_serialized_payload(
 bool SecurityManager::participant_authorized(
         const ParticipantProxyData& participant_data,
         const DiscoveredParticipantInfo::AuthUniquePtr& remote_participant_info,
-        std::shared_ptr<SharedSecretHandle>& shared_secret_handle)
+        std::shared_ptr<SecretHandle>& shared_secret_handle)
 {
     auto sentry = is_security_manager_initialized();
     if (!sentry)

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -134,8 +134,8 @@ bool SecurityManager::init(
         SecurityException exception;
         domain_id_ = participant_->get_domain_id();
         const PropertyPolicy log_properties = PropertyPolicyHelper::get_properties_with_prefix(
-                participant_->getRTPSParticipantAttributes().properties,
-                "dds.sec.log.builtin.DDS_LogTopic.");
+            participant_->getRTPSParticipantAttributes().properties,
+            "dds.sec.log.builtin.DDS_LogTopic.");
 
         // length(log_properties) == 0 considered as logging disable.
         if (PropertyPolicyHelper::length(log_properties) > 0)
@@ -162,11 +162,12 @@ bool SecurityManager::init(
                     }
                     else
                     {
-                        throw SecurityException("Unknown value '" + *distribute + "' for LogOptions::distribute."); ;
+                        throw SecurityException("Unknown value '" + *distribute + "' for LogOptions::distribute.");
                     }
                 }
 
-                const std::string* const log_level = PropertyPolicyHelper::find_property(log_properties, "logging_level");
+                const std::string* const log_level =
+                        PropertyPolicyHelper::find_property(log_properties, "logging_level");
                 if (log_level != nullptr)
                 {
                     if (!string_to_LogLevel(*log_level, log_options.log_level, exception))
@@ -182,13 +183,13 @@ bool SecurityManager::init(
                 }
 
                 if (!(logging_plugin_->set_guid(participant_->getGuid(), exception) &&
-                            logging_plugin_->set_domain_id(domain_id_, exception)))
+                        logging_plugin_->set_domain_id(domain_id_, exception)))
                 {
                     throw exception;
                 }
 
                 if (!( logging_plugin_->set_log_options(log_options, exception) &&
-                            logging_plugin_->enable_logging(exception)))
+                        logging_plugin_->enable_logging(exception)))
                 {
                     throw exception;
                 }
@@ -215,11 +216,11 @@ bool SecurityManager::init(
             do
             {
                 ret = authentication_plugin_->validate_local_identity(&local_identity_handle_,
-                        adjusted_participant_key,
-                        domain_id_,
-                        participant_->getRTPSParticipantAttributes(),
-                        participant_->getGuid(),
-                        exception);
+                                adjusted_participant_key,
+                                domain_id_,
+                                participant_->getRTPSParticipantAttributes(),
+                                participant_->getGuid(),
+                                exception);
             } while (ret == VALIDATION_PENDING_RETRY && usleep_bool());
 
             if (ret == VALIDATION_OK)
@@ -237,18 +238,18 @@ bool SecurityManager::init(
                     access_plugin_->set_logger(logging_plugin_, exception);
 
                     local_permissions_handle_ = access_plugin_->validate_local_permissions(
-                            *authentication_plugin_, *local_identity_handle_,
-                            domain_id_,
-                            participant_->getRTPSParticipantAttributes(),
-                            exception);
+                        *authentication_plugin_, *local_identity_handle_,
+                        domain_id_,
+                        participant_->getRTPSParticipantAttributes(),
+                        exception);
 
                     if (local_permissions_handle_ != nullptr)
                     {
                         if (!local_permissions_handle_->nil())
                         {
                             if (access_plugin_->check_create_participant(*local_permissions_handle_,
-                                        domain_id_,
-                                        participant_->getRTPSParticipantAttributes(), exception))
+                                    domain_id_,
+                                    participant_->getRTPSParticipantAttributes(), exception))
                             {
                                 // Set credentials.
                                 PermissionsCredentialToken* token = nullptr;
@@ -260,9 +261,10 @@ bool SecurityManager::init(
                                                 *local_identity_handle_, *token, exception))
                                     {
                                         if (!access_plugin_->get_participant_sec_attributes(*local_permissions_handle_,
-                                                    attributes, exception))
+                                                attributes, exception))
                                         {
-                                            access_plugin_->return_permissions_handle(local_permissions_handle_, exception);
+                                            access_plugin_->return_permissions_handle(local_permissions_handle_,
+                                                    exception);
                                             local_permissions_handle_ = nullptr;
                                         }
                                     }
@@ -298,13 +300,13 @@ bool SecurityManager::init(
                 {
                     // Read participant properties.
                     const std::string* property_value = PropertyPolicyHelper::find_property(participant_properties,
-                            "rtps.participant.rtps_protection_kind");
+                                    "rtps.participant.rtps_protection_kind");
                     if (property_value != nullptr && property_value->compare("ENCRYPT") == 0)
                     {
                         attributes.is_rtps_protected = true;
                         attributes.plugin_participant_attributes |=
-                            PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_VALID |
-                            PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ENCRYPTED;
+                                PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_VALID |
+                                PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ENCRYPTED;
                     }
                 }
 
@@ -316,12 +318,13 @@ bool SecurityManager::init(
                     {
                         crypto_plugin_->set_logger(logging_plugin_, exception);
 
-                        local_participant_crypto_handle_ = crypto_plugin_->cryptokeyfactory()->register_local_participant(
-                                *local_identity_handle_,
-                                *local_permissions_handle_,
-                                participant_properties.properties(),
-                                attributes,
-                                exception);
+                        local_participant_crypto_handle_ =
+                                crypto_plugin_->cryptokeyfactory()->register_local_participant(
+                            *local_identity_handle_,
+                            *local_permissions_handle_,
+                            participant_properties.properties(),
+                            attributes,
+                            exception);
 
                         if (local_participant_crypto_handle_ != nullptr)
                         {
@@ -371,7 +374,7 @@ bool SecurityManager::init(
             }
         }
     }
-    catch(SecurityException e)
+    catch (SecurityException e)
     {
         logError(SECURITY, "Logging plugin not configured. Security logging will be disabled. ("
                 << e.what() << ").");
@@ -379,9 +382,9 @@ bool SecurityManager::init(
         logging_plugin_ = nullptr;
         return false;
     }
-    catch(bool e)
+    catch (bool e)
     {
-        if(!e)
+        if (!e)
         {
             cancel_init();
             return false;
@@ -582,8 +585,10 @@ bool SecurityManager::discovered_participant(
         const ParticipantProxyData& participant_data)
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return false;
+    }
 
     // Early return when ParticipantSecurityInfo does not match
     auto& sec_attrs = participant_->security_attributes();
@@ -608,12 +613,12 @@ bool SecurityManager::discovered_participant(
         std::lock_guard<shared_mutex> _(mutex_);
 
         auto map_ret = discovered_participants_.insert(
-                std::make_pair(
-                    participant_data.m_guid,
-                    std::unique_ptr<DiscoveredParticipantInfo>(
-                        new DiscoveredParticipantInfo(
-                            auth_status,
-                            participant_data))));
+            std::make_pair(
+                participant_data.m_guid,
+                std::unique_ptr<DiscoveredParticipantInfo>(
+                    new DiscoveredParticipantInfo(
+                        auth_status,
+                        participant_data))));
 
         undiscovered = map_ret.second;
         remote_participant_info = map_ret.first->second->get_auth();
@@ -728,8 +733,10 @@ void SecurityManager::remove_participant(
         const ParticipantProxyData& participant_data)
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return;
+    }
 
     // Unmatch from builtin endpoints.
     unmatch_builtin_endpoints(participant_data);
@@ -744,7 +751,7 @@ void SecurityManager::remove_participant(
             SecurityException exception;
 
             ParticipantCryptoHandle* participant_crypto_handle =
-                dp_it->second->get_participant_crypto();
+                    dp_it->second->get_participant_crypto();
             if (participant_crypto_handle != nullptr)
             {
                 crypto_plugin_->cryptokeyfactory()->unregister_participant(participant_crypto_handle,
@@ -816,8 +823,10 @@ bool SecurityManager::on_process_handshake(
         HandshakeMessageToken&& message_in)
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return false;
+    }
 
     HandshakeMessageToken* handshake_message = nullptr;
     SecurityException exception;
@@ -1415,8 +1424,10 @@ void SecurityManager::process_participant_stateless_message(
     assert(change);
 
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return;
+    }
 
     // Deserialize message
     ParticipantGenericMessage message;
@@ -1637,8 +1648,10 @@ void SecurityManager::process_participant_volatile_message_secure(
     assert(change);
 
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return;
+    }
 
     // Deserialize message
     ParticipantGenericMessage message;
@@ -1713,7 +1726,8 @@ void SecurityManager::process_participant_volatile_message_secure(
             }
             else
             {
-                logInfo(SECURITY, "Received Participant Cryptography message but not found related remote_participant_key");
+                logInfo(SECURITY,
+                        "Received Participant Cryptography message but not found related remote_participant_key");
             }
         }
 
@@ -1795,7 +1809,7 @@ void SecurityManager::process_participant_volatile_message_secure(
                 else
                 {
                     remote_reader_pending_messages_.emplace(std::make_pair(message.source_endpoint_key(),
-                                message.destination_endpoint_key()),
+                            message.destination_endpoint_key()),
                             std::move(message.message_data()));
                 }
             }
@@ -1870,7 +1884,7 @@ void SecurityManager::process_participant_volatile_message_secure(
                 else
                 {
                     remote_writer_pending_messages_.emplace(std::make_pair(message.source_endpoint_key(),
-                                message.destination_endpoint_key()),
+                            message.destination_endpoint_key()),
                             std::move(message.message_data()));
                 }
             }
@@ -1921,8 +1935,10 @@ bool SecurityManager::get_identity_token(
     assert(identity_token);
 
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return false;
+    }
 
     if (authentication_plugin_)
     {
@@ -1943,8 +1959,10 @@ bool SecurityManager::return_identity_token(
     }
 
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return false;
+    }
 
     if (authentication_plugin_)
     {
@@ -1962,8 +1980,10 @@ bool SecurityManager::get_permissions_token(
     assert(permissions_token);
 
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return false;
+    }
 
     if (access_plugin_)
     {
@@ -1984,8 +2004,10 @@ bool SecurityManager::return_permissions_token(
     }
 
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return false;
+    }
 
     if (access_plugin_)
     {
@@ -2002,8 +2024,10 @@ uint32_t SecurityManager::builtin_endpoints() const
     uint32_t be = 0;
 
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return be;
+    }
 
     if (participant_stateless_message_reader_ != nullptr)
     {
@@ -2233,8 +2257,10 @@ bool SecurityManager::encode_rtps_message(
         const std::vector<GuidPrefix_t>& receiving_list) const
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return false;
+    }
 
     shared_lock<shared_mutex> _(mutex_);
 
@@ -2287,8 +2313,10 @@ int SecurityManager::decode_rtps_message(
     }
 
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return 0;
+    }
 
     if (crypto_plugin_ == nullptr)
     {
@@ -2353,8 +2381,10 @@ bool SecurityManager::register_local_writer(
         EndpointSecurityAttributes& security_attributes)
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return false;
+    }
 
     SecurityException exception;
     bool returned_value = get_datawriter_sec_attributes(writer_properties, security_attributes);
@@ -2385,8 +2415,10 @@ bool SecurityManager::get_datawriter_sec_attributes(
         EndpointSecurityAttributes& security_attributes)
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return false;
+    }
 
     bool returned_value = true;
     SecurityException exception;
@@ -2483,8 +2515,10 @@ bool SecurityManager::register_local_builtin_writer(
         EndpointSecurityAttributes& security_attributes)
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return false;
+    }
 
     bool returned_value = true;
     SecurityException exception;
@@ -2515,8 +2549,10 @@ bool SecurityManager::unregister_local_writer(
         const GUID_t& writer_guid)
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return false;
+    }
 
     if (crypto_plugin_ == nullptr)
     {
@@ -2553,8 +2589,10 @@ bool SecurityManager::register_local_reader(
         EndpointSecurityAttributes& security_attributes)
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return false;
+    }
 
     SecurityException exception;
     bool returned_value = get_datareader_sec_attributes(reader_properties, security_attributes);
@@ -2586,8 +2624,10 @@ bool SecurityManager::get_datareader_sec_attributes(
         EndpointSecurityAttributes& security_attributes)
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return false;
+    }
 
     bool returned_value = true;
     SecurityException exception;
@@ -2684,8 +2724,10 @@ bool SecurityManager::register_local_builtin_reader(
         EndpointSecurityAttributes& security_attributes)
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return false;
+    }
 
     bool returned_value = true;
     SecurityException exception;
@@ -2716,8 +2758,10 @@ bool SecurityManager::unregister_local_reader(
         const GUID_t& reader_guid)
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return false;
+    }
 
     if (crypto_plugin_ == nullptr)
     {
@@ -2763,8 +2807,10 @@ void SecurityManager::remove_reader(
         const GUID_t& remote_reader_guid)
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return;
+    }
 
     if (crypto_plugin_ == nullptr)
     {
@@ -2810,8 +2856,10 @@ bool SecurityManager::discovered_reader(
         bool is_builtin)
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return false;
+    }
 
     std::unique_lock<shared_mutex> lock(mutex_);
 
@@ -3105,8 +3153,10 @@ void SecurityManager::remove_writer(
         const GUID_t& remote_writer_guid)
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return;
+    }
 
     if (crypto_plugin_ == nullptr)
     {
@@ -3152,8 +3202,10 @@ bool SecurityManager::discovered_writer(
         bool is_builtin)
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return false;
+    }
 
     std::unique_lock<shared_mutex> lock(mutex_);
 
@@ -3440,8 +3492,10 @@ bool SecurityManager::encode_writer_submessage(
         const std::vector<GUID_t>& receiving_list) const
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return false;
+    }
 
     if (crypto_plugin_ == nullptr)
     {
@@ -3533,8 +3587,10 @@ bool SecurityManager::encode_reader_submessage(
         const std::vector<GUID_t>& receiving_list) const
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return false;
+    }
 
     if (crypto_plugin_ == nullptr)
     {
@@ -3626,8 +3682,10 @@ int SecurityManager::decode_rtps_submessage(
         const GuidPrefix_t& sending_participant) const
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return false;
+    }
 
     if (message.buffer[message.pos] != SEC_PREFIX)
     {
@@ -3717,8 +3775,10 @@ bool SecurityManager::encode_serialized_payload(
         const GUID_t& writer_guid) const
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return false;
+    }
 
     if (crypto_plugin_ == nullptr)
     {
@@ -3762,8 +3822,10 @@ bool SecurityManager::decode_serialized_payload(
         const GUID_t& writer_guid) const
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return false;
+    }
 
     if (crypto_plugin_ == nullptr)
     {
@@ -3813,8 +3875,10 @@ bool SecurityManager::participant_authorized(
         SharedSecretHandle* shared_secret_handle)
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return false;
+    }
 
     logInfo(SECURITY, "Authorized participant " << participant_data.m_guid);
 
@@ -4016,8 +4080,10 @@ bool SecurityManager::participant_authorized(
 uint32_t SecurityManager::calculate_extra_size_for_rtps_message() const
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return 0;
+    }
 
     if (crypto_plugin_ == nullptr)
     {
@@ -4034,8 +4100,10 @@ uint32_t SecurityManager::calculate_extra_size_for_rtps_submessage(
         const GUID_t& writer_guid) const
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return 0;
+    }
 
     if (crypto_plugin_ == nullptr)
     {
@@ -4063,8 +4131,10 @@ uint32_t SecurityManager::calculate_extra_size_for_encoded_payload(
         const GUID_t& writer_guid) const
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return 0;
+    }
 
     if (crypto_plugin_ == nullptr)
     {
@@ -4092,8 +4162,10 @@ void SecurityManager::resend_handshake_message_token(
         const GUID_t& remote_participant_key) const
 {
     auto sentry = is_security_manager_initialized();
-    if(!sentry)
+    if (!sentry)
+    {
         return;
+    }
 
     shared_lock<shared_mutex> _(mutex_);
 

--- a/src/cpp/rtps/security/SecurityManager.h
+++ b/src/cpp/rtps/security/SecurityManager.h
@@ -711,7 +711,7 @@ private:
 
     PermissionsHandle* local_permissions_handle_;
 
-    ParticipantCryptoHandle* local_participant_crypto_handle_;
+    std::shared_ptr<ParticipantCryptoHandle> local_participant_crypto_handle_;
 
     // collection members can be modified inside SecurityManager const calls because them take care of its own
     // synchronization

--- a/src/cpp/rtps/security/SecurityManager.h
+++ b/src/cpp/rtps/security/SecurityManager.h
@@ -193,7 +193,7 @@ public:
             EndpointSecurityAttributes& security_attributes);
 
     /**
-     * Returns a handle to the identity token used in handshake
+     * Retrieves a handle to the identity token used in handshake
      *
      * @param identity_token IdentityToken** handle reference to set
      * @return true on successful retrieval
@@ -211,7 +211,7 @@ public:
             IdentityToken* identity_token) const;
 
     /**
-     * Returns a handle to the permision token used in handshake
+     * Retrieves a handle to the permision token used in handshake
      *
      * @param permissions_token PermissionsToken** handle reference to set
      * @return true on successful retrieval

--- a/src/cpp/rtps/security/SecurityManager.h
+++ b/src/cpp/rtps/security/SecurityManager.h
@@ -379,7 +379,6 @@ private:
                 AuthenticationStatus auth_status,
                 const ParticipantProxyData& participant_data)
             : auth_(new AuthenticationInfo(auth_status))
-            , shared_secret_handle_(nullptr)
             , permissions_handle_(nullptr)
             , participant_crypto_(nullptr)
             , participant_data_(participant_data)
@@ -410,13 +409,13 @@ private:
         }
 
         void set_shared_secret(
-                SharedSecretHandle* shared_secret)
+                std::shared_ptr<SharedSecretHandle>& shared_secret)
         {
             std::lock_guard<std::mutex> g(mtx_);
             shared_secret_handle_ = shared_secret;
         }
 
-        SharedSecretHandle* get_shared_secret()
+        std::shared_ptr<SharedSecretHandle> get_shared_secret()
         {
             std::lock_guard<std::mutex> g(mtx_);
             return shared_secret_handle_;
@@ -442,13 +441,13 @@ private:
         }
 
         void set_participant_crypto(
-                ParticipantCryptoHandle* participant_crypto)
+                std::shared_ptr<ParticipantCryptoHandle> participant_crypto)
         {
             std::lock_guard<std::mutex> g(mtx_);
             participant_crypto_ = participant_crypto;
         }
 
-        ParticipantCryptoHandle* get_participant_crypto()
+        std::shared_ptr<ParticipantCryptoHandle> get_participant_crypto()
         {
             std::lock_guard<std::mutex> g(mtx_);
             return participant_crypto_;
@@ -469,11 +468,11 @@ private:
 
         AuthUniquePtr auth_;
 
-        SharedSecretHandle* shared_secret_handle_;
+        std::shared_ptr<SharedSecretHandle> shared_secret_handle_;
 
         PermissionsHandle* permissions_handle_;
 
-        ParticipantCryptoHandle* participant_crypto_;
+        std::shared_ptr<ParticipantCryptoHandle> participant_crypto_;
 
         ParticipantProxyData participant_data_;
 
@@ -619,7 +618,7 @@ private:
     void unmatch_builtin_endpoints(
             const ParticipantProxyData& participant_data);
 
-    ParticipantCryptoHandle* register_and_match_crypto_endpoint(
+    std::shared_ptr<ParticipantCryptoHandle> register_and_match_crypto_endpoint(
             IdentityHandle& remote_participant_identity,
             SharedSecretHandle& shared_secret);
 
@@ -631,7 +630,7 @@ private:
      * @param remote_participant_guid GUID_t& remote participant id
      */
     void exchange_participant_crypto(
-            ParticipantCryptoHandle* remote_participant_crypto,
+            std::shared_ptr<ParticipantCryptoHandle> remote_participant_crypto,
             const GUID_t& remote_participant_guid);
 
     void process_participant_stateless_message(
@@ -681,7 +680,7 @@ private:
     bool participant_authorized(
             const ParticipantProxyData& participant_data,
             const DiscoveredParticipantInfo::AuthUniquePtr& remote_participant_info,
-            SharedSecretHandle* shared_secret_handle);
+            std::shared_ptr<SharedSecretHandle>& shared_secret_handle);
 
     void resend_handshake_message_token(
             const GUID_t& remote_participant_key) const;

--- a/src/cpp/rtps/security/SecurityManager.h
+++ b/src/cpp/rtps/security/SecurityManager.h
@@ -20,16 +20,17 @@
 
 #include <rtps/security/SecurityPluginFactory.h>
 
-#include <fastdds/rtps/security/authentication/Handshake.h>
-#include <fastdds/rtps/security/common/ParticipantGenericMessage.h>
-#include <fastdds/rtps/reader/ReaderListener.h>
-#include <fastdds/rtps/common/SequenceNumber.h>
-#include <fastdds/rtps/common/SerializedPayload.h>
+#include <fastdds/rtps/attributes/HistoryAttributes.h>
+#include <fastdds/rtps/builtin/data/ParticipantProxyData.h>
 #include <fastdds/rtps/builtin/data/ReaderProxyData.h>
 #include <fastdds/rtps/builtin/data/WriterProxyData.h>
-#include <fastdds/rtps/builtin/data/ParticipantProxyData.h>
-#include <fastdds/rtps/attributes/HistoryAttributes.h>
+#include <fastdds/rtps/common/SequenceNumber.h>
+#include <fastdds/rtps/common/SerializedPayload.h>
+#include <fastdds/rtps/reader/ReaderListener.h>
 #include <fastdds/rtps/resources/TimedEvent.h>
+#include <fastdds/rtps/security/authentication/Handshake.h>
+#include <fastdds/rtps/security/common/ParticipantGenericMessage.h>
+#include <fastrtps/utils/shared_mutex.hpp>
 
 #include <map>
 #include <mutex>
@@ -58,27 +59,70 @@ class Cryptography;
 struct ParticipantSecurityAttributes;
 struct EndpointSecurityAttributes;
 
+/**
+ * Class SecurityManager used to implemente the security handshake protocol.
+ *
+ * @ingroup SECURITY_MODULE
+ */
 class SecurityManager
 {
 public:
 
+    /**
+     * SecurityManager constructor
+     *
+     * @param participant RTPSParticipantImpl* references the associated participant
+     */
     SecurityManager(
             RTPSParticipantImpl* participant);
 
+    // @brief Destructor
     ~SecurityManager();
 
+    /**
+     * SecurityManager initialization
+     *
+     * @param attributes ParticipantSecurityAttributes references the plugin configuration
+     * @param participant_properties PropertyPolicy& references configuration provided on participant creation
+     * @return true if the configuration is successfully applied (plugins creation and set up)
+     */
     bool init(
             ParticipantSecurityAttributes& attributes,
-            const PropertyPolicy& participant_properties,
-            bool& security_activated);
+            const PropertyPolicy& participant_properties);
 
+    /**
+     * Creates all the security builtin endpoints
+     *
+     * @pre SecurityManager mutex shouldn't have been taken.
+     *
+     * @return true on successful creation
+     */
     bool create_entities();
 
+    /**
+     * @brief resource clean up
+     *
+     * @pre SecurityManager mutex shouldn't have been taken.
+     */
     void destroy();
 
+    /**
+     * Called from the discovery listener. Begins the security handshake of the security protocol.
+     *
+     * @pre SecurityManager mutex shouldn't have been taken.
+     * @param participant_data ParticipantProxyData& references the participant proxy
+     * @return true on success
+     */
     bool discovered_participant(
             const ParticipantProxyData& participant_data);
 
+    /**
+     * Called from the discovery listener. Frees all the resources associated to a demise participant.
+     *
+     * @pre SecurityManager mutex shouldn't have been taken.
+     * @param participant_data ParticipantProxyData& references the participant proxy
+     * @return true on success
+     */
     void remove_participant(
             const ParticipantProxyData& participant_data);
 
@@ -148,21 +192,51 @@ public:
             const PropertyPolicy& reader_properties,
             EndpointSecurityAttributes& security_attributes);
 
+    /**
+     * Returns a handle to the identity token used in handshake
+     *
+     * @param identity_token IdentityToken** handle reference to set
+     * @return true on successful retrieval
+     */
     bool get_identity_token(
-            IdentityToken** identity_token);
+            IdentityToken** identity_token) const;
 
+    /**
+     * Releases a handle to the identity token used in handshake
+     *
+     * @param identity_token IdentityToken* handle reference to release
+     * @return true on successful disposal
+     */
     bool return_identity_token(
-            IdentityToken* identity_token);
+            IdentityToken* identity_token) const;
 
+    /**
+     * Returns a handle to the permision token used in handshake
+     *
+     * @param permissions_token PermissionsToken** handle reference to set
+     * @return true on successful retrieval
+     */
     bool get_permissions_token(
-            PermissionsToken** permissions_token);
+            PermissionsToken** permissions_token) const;
 
+    /**
+     * Releases a handle to the permissions token used in handshake
+     *
+     * @param permissions_token PermissionsToken* handle reference to release
+     * @return true on successful disposal
+     */
     bool return_permissions_token(
-            PermissionsToken* permissions_token);
+            PermissionsToken* permissions_token) const;
 
-    uint32_t builtin_endpoints();
+    /**
+     * Returns a mask of available security builtin endpoints
+     *
+     * @pre SecurityManager mutex shouldn't have been taken with exclusive ownership.
+     * @return mask
+     */
+    uint32_t builtin_endpoints() const;
 
-    RTPSParticipantImpl* participant()
+    RTPSParticipantImpl* participant() const
     {
         return participant_;
     }
@@ -170,48 +244,70 @@ public:
     bool encode_rtps_message(
             const CDRMessage_t& input_message,
             CDRMessage_t& output_message,
-            const std::vector<GuidPrefix_t>& receiving_list);
+            const std::vector<GuidPrefix_t>& receiving_list) const;
 
     int decode_rtps_message(
             const CDRMessage_t& message,
             CDRMessage_t& out_message,
-            const GuidPrefix_t& sending_participant);
+            const GuidPrefix_t& sending_participant) const;
 
     bool encode_writer_submessage(
             const CDRMessage_t& input_message,
             CDRMessage_t& output_message,
             const GUID_t& writer_guid,
-            const std::vector<GUID_t>& receiving_list);
+            const std::vector<GUID_t>& receiving_list) const;
 
     bool encode_reader_submessage(
             const CDRMessage_t& input_message,
             CDRMessage_t& output_message,
             const GUID_t& reader_guid,
-            const std::vector<GUID_t>& receiving_list);
+            const std::vector<GUID_t>& receiving_list) const;
 
     int decode_rtps_submessage(
             CDRMessage_t& message,
             CDRMessage_t& out_message,
-            const GuidPrefix_t& sending_participant);
+            const GuidPrefix_t& sending_participant) const;
 
     bool encode_serialized_payload(
             const SerializedPayload_t& payload,
             SerializedPayload_t& output_payload,
-            const GUID_t& writer_guid);
+            const GUID_t& writer_guid) const;
 
     bool decode_serialized_payload(
             const SerializedPayload_t& secure_payload,
             SerializedPayload_t& payload,
             const GUID_t& reader_guid,
-            const GUID_t& writer_guid);
+            const GUID_t& writer_guid) const;
 
-    uint32_t calculate_extra_size_for_rtps_message();
+    uint32_t calculate_extra_size_for_rtps_message() const;
 
     uint32_t calculate_extra_size_for_rtps_submessage(
-            const GUID_t& writer_guid);
+            const GUID_t& writer_guid) const;
 
     uint32_t calculate_extra_size_for_encoded_payload(
-            const GUID_t& writer_guid);
+            const GUID_t& writer_guid) const;
+
+    /**
+     * Queries the state
+     *
+     * @return true if enabled
+     */
+    bool is_security_active() const
+    {
+        if(ready_state_)
+            return *ready_state_;
+        return false;
+    }
+
+    /**
+     * Queries the initialization state
+     *
+     * @return false if not initialized or disabled
+     */
+    bool is_security_initialized() const
+    {
+        return (bool)ready_state_;
+    }
 
 private:
 
@@ -300,55 +396,65 @@ private:
 
         AuthUniquePtr get_auth()
         {
+            std::lock_guard<std::mutex> g(mtx_);
             return std::move(auth_);
         }
 
         void set_auth(
                 AuthUniquePtr& auth)
         {
+            std::lock_guard<std::mutex> g(mtx_);
             auth_ = std::move(auth);
         }
 
         void set_shared_secret(
                 SharedSecretHandle* shared_secret)
         {
+            std::lock_guard<std::mutex> g(mtx_);
             shared_secret_handle_ = shared_secret;
         }
 
         SharedSecretHandle* get_shared_secret()
         {
+            std::lock_guard<std::mutex> g(mtx_);
             return shared_secret_handle_;
         }
 
         void set_permissions_handle(
                 PermissionsHandle* handle)
         {
+            std::lock_guard<std::mutex> g(mtx_);
             permissions_handle_ = handle;
         }
 
         PermissionsHandle* get_permissions_handle()
         {
+            std::lock_guard<std::mutex> g(mtx_);
             return permissions_handle_;
         }
 
         const PermissionsHandle* get_permissions_handle() const
         {
+            std::lock_guard<std::mutex> g(mtx_);
             return permissions_handle_;
         }
 
         void set_participant_crypto(
                 ParticipantCryptoHandle* participant_crypto)
         {
+            std::lock_guard<std::mutex> g(mtx_);
             participant_crypto_ = participant_crypto;
         }
 
         ParticipantCryptoHandle* get_participant_crypto()
         {
+            std::lock_guard<std::mutex> g(mtx_);
             return participant_crypto_;
         }
 
         const ParticipantProxyData& participant_data() const
         {
+            std::lock_guard<std::mutex> g(mtx_);
             return participant_data_;
         }
 
@@ -356,6 +462,8 @@ private:
 
         DiscoveredParticipantInfo(
                 const DiscoveredParticipantInfo& info) = delete;
+
+        mutable std::mutex mtx_;
 
         AuthUniquePtr auth_;
 
@@ -425,13 +533,31 @@ private:
 
     void cancel_init();
 
+    /**
+     * Releases resources associated to another secured participant discovered.
+     *
+     * @param auth_ptr DiscoveredParticipantInfo::AuthUniquePtr& remote participant info to release.
+     */
     void remove_discovered_participant_info(
             const DiscoveredParticipantInfo::AuthUniquePtr& auth_ptr);
 
+    /**
+     * Sets the specified info for a remote participant
+     *
+     * @pre SecurityManager mutex should not have been taken yet.
+     *
+     * @param remote_participant_key GUID_t& reference to the participant to update
+     * @param auth_ptr DiscoveredParticipantInfo::AuthUniquePtr& remote participant info to set.
+     */
     bool restore_discovered_participant_info(
             const GUID_t& remote_participant_key,
             DiscoveredParticipantInfo::AuthUniquePtr& auth_ptr);
 
+    /**
+     * Deletes all the security builtin endpoints
+     *
+     * @pre SecurityManager mutex should have been taken as exclusive ownership.
+     */
     void delete_entities();
     bool create_participant_stateless_message_entities();
     void delete_participant_stateless_message_entities();
@@ -464,12 +590,30 @@ private:
             const EndpointSecurityAttributes& security_attributes,
             bool is_builtin);
 
+    /**
+     * Match builtin endpoints with those of a remote participant
+     *
+     * @pre SecurityManager mutex shouldn't have been taken with exclusive ownership.
+     * @param participant_data ParticipantProxyData& remote participant proxy
+     */
     void match_builtin_endpoints(
             const ParticipantProxyData& participant_data);
 
+    /**
+     * Match builtin endpoints devoted to key exchanges with those of a remote participant
+     *
+     * @pre SecurityManager mutex shouldn't have been taken with exclusive ownership.
+     * @param participant_data ParticipantProxyData& remote participant proxy
+     */
     void match_builtin_key_exchange_endpoints(
             const ParticipantProxyData& participant_data);
 
+    /**
+     * Unmatch builtin endpoints with those of a remote participant
+     *
+     * @pre SecurityManager mutex shouldn't have been taken with exclusive ownership.
+     * @param participant_data ParticipantProxyData& remote participant proxy
+     */
     void unmatch_builtin_endpoints(
             const ParticipantProxyData& participant_data);
 
@@ -477,6 +621,13 @@ private:
             IdentityHandle& remote_participant_identity,
             SharedSecretHandle& shared_secret);
 
+    /**
+     * Manage cryptographic exchange with a remote participant
+     *
+     * @pre SecurityManager mutex shouldn't have been taken with exclusive ownership.
+     * @param remote_participant_crypto ParticipantCryptoHandle* handle to cryptographic data
+     * @param remote_participant_guid GUID_t& remote participant id
+     */
     void exchange_participant_crypto(
             ParticipantCryptoHandle* remote_participant_crypto,
             const GUID_t& remote_participant_guid);
@@ -487,6 +638,17 @@ private:
     void process_participant_volatile_message_secure(
             const CacheChange_t* const change);
 
+    /**
+     * Called from the discovery listener and security builitin listeners.
+     * Implements security protocol handshake logic state machine.
+     *
+     * @pre SecurityManager mutex shouldn't have been taken.
+     * @param participant_data ParticipantProxyData& exchange partner
+     * @param remote_participant_info DiscoveredParticipantInfo::AuthUniquePtr& exchange partner authorization data
+     * @param message_identity MessageIdentity&& identifies the message to process
+     * @param message HandshakeMessageToken&& required by the protocol
+     * @return true on success
+     */
     bool on_process_handshake(
             const ParticipantProxyData& participant_data,
             DiscoveredParticipantInfo::AuthUniquePtr& remote_participant_info,
@@ -496,23 +658,23 @@ private:
     ParticipantGenericMessage generate_authentication_message(
             const MessageIdentity& related_message_identity,
             const GUID_t& destination_participant_key,
-            HandshakeMessageToken& handshake_message);
+            HandshakeMessageToken& handshake_message) const;
 
     ParticipantGenericMessage generate_participant_crypto_token_message(
             const GUID_t& destination_participant_key,
-            ParticipantCryptoTokenSeq& crypto_tokens);
+            ParticipantCryptoTokenSeq& crypto_tokens) const;
 
     ParticipantGenericMessage generate_writer_crypto_token_message(
             const GUID_t& destination_participant_key,
             const GUID_t& destination_endpoint_key,
             const GUID_t& source_endpoint_key,
-            ParticipantCryptoTokenSeq& crypto_tokens);
+            ParticipantCryptoTokenSeq& crypto_tokens) const;
 
     ParticipantGenericMessage generate_reader_crypto_token_message(
             const GUID_t& destination_participant_key,
             const GUID_t& destination_endpoint_key,
             const GUID_t& source_endpoint_key,
-            ParticipantCryptoTokenSeq& crypto_tokens);
+            ParticipantCryptoTokenSeq& crypto_tokens) const;
 
     bool participant_authorized(
             const ParticipantProxyData& participant_data,
@@ -520,7 +682,7 @@ private:
             SharedSecretHandle* shared_secret_handle);
 
     void resend_handshake_message_token(
-            const GUID_t& remote_participant_key);
+            const GUID_t& remote_participant_key) const;
 
     RTPSParticipantImpl* participant_;
     StatelessWriter* participant_stateless_message_writer_;
@@ -549,15 +711,74 @@ private:
 
     ParticipantCryptoHandle* local_participant_crypto_handle_;
 
-    std::map<GUID_t, DiscoveredParticipantInfo> discovered_participants_;
+    // collection members can be modified inside SecurityManager const calls because them take care of its own
+    // synchronization
+    std::map<GUID_t, std::unique_ptr<DiscoveredParticipantInfo>> discovered_participants_;
 
     GUID_t auth_source_guid;
 
-    std::mutex mutex_;
+    /**
+     * Enables the use of the plugins for the other methods
+     *
+     * @pre this method was never called before
+     * @return RAII object
+     */
+    void enable_security_manager()
+    {
+        assert(!ready_state_);
+        ready_state_.reset(new bool(nullptr != authentication_plugin_));
+    }
 
-    std::atomic<int64_t> auth_last_sequence_number_;
+    /**
+     * Returns an object that:
+     * @li its <tt>bool operator()</tt> allows to check plugins availability
+     * @li guarantees the plugings won't be destroyed while the object is alive
+     * Use as:
+     *  @code{.cpp}
+     *      auto sentry = is_security_manager_enabled();
+     *      if(!sentry)
+     *          return;
+     *      // henceforth plugins are available
+     *  @endcode
+     *
+     * @return RAII object
+     */
+    std::shared_ptr<bool> is_security_manager_initialized() const
+    {
+        return ready_state_;
+    }
 
-    std::atomic<int64_t> crypto_last_sequence_number_;
+    /**
+     * Disables the use of the plugins for the other methods.
+     * Waits until no other method uses the plugins
+     *
+     * @pre <tt>enable_security_manager()</tt> was called
+     * @post no method using the plugins will be ongoing or called
+     */
+    void disable_security_manager()
+    {
+        std::weak_ptr<bool> wp(ready_state_);
+        ready_state_.reset();
+
+        while(!wp.expired())
+        {
+            std::this_thread::yield();
+        };
+    }
+
+    /**
+     * Syncronization object for plugin initialization, <tt>mutex_</tt> protection is not necessary to guarantee plugin
+     * availability.
+     * @li (bool)ready_state_ -> SecurityManager initialized
+     * @li (bool)*ready_state_ -> security active
+     */
+    std::shared_ptr<bool> ready_state_;
+
+    mutable shared_mutex mutex_;
+
+    mutable std::atomic<int64_t> auth_last_sequence_number_;
+
+    mutable std::atomic<int64_t> crypto_last_sequence_number_;
 
     struct DatawriterAssociations
     {
@@ -595,10 +816,10 @@ private:
     std::list<std::tuple<ReaderProxyData, GUID_t, GUID_t>> remote_reader_pending_discovery_messages_;
     std::list<std::tuple<WriterProxyData, GUID_t, GUID_t>> remote_writer_pending_discovery_messages_;
 
-    std::mutex temp_stateless_data_lock_;
+    // The temporary proxies are required to prevent dynamic allocations and enforce real time on execution
+    // They are protected by the corresponding builtin reader endpoints mutexes to avoid data races
     ReaderProxyData temp_stateless_reader_proxy_data_;
     WriterProxyData temp_stateless_writer_proxy_data_;
-    std::mutex temp_volatile_data_lock_;
     ReaderProxyData temp_volatile_reader_proxy_data_;
     WriterProxyData temp_volatile_writer_proxy_data_;
 

--- a/src/cpp/rtps/security/SecurityManager.h
+++ b/src/cpp/rtps/security/SecurityManager.h
@@ -409,13 +409,13 @@ private:
         }
 
         void set_shared_secret(
-                std::shared_ptr<SharedSecretHandle>& shared_secret)
+                std::shared_ptr<SecretHandle>& shared_secret)
         {
             std::lock_guard<std::mutex> g(mtx_);
             shared_secret_handle_ = shared_secret;
         }
 
-        std::shared_ptr<SharedSecretHandle> get_shared_secret()
+        std::shared_ptr<SecretHandle> get_shared_secret()
         {
             std::lock_guard<std::mutex> g(mtx_);
             return shared_secret_handle_;
@@ -468,7 +468,7 @@ private:
 
         AuthUniquePtr auth_;
 
-        std::shared_ptr<SharedSecretHandle> shared_secret_handle_;
+        std::shared_ptr<SecretHandle> shared_secret_handle_;
 
         PermissionsHandle* permissions_handle_;
 
@@ -620,7 +620,7 @@ private:
 
     std::shared_ptr<ParticipantCryptoHandle> register_and_match_crypto_endpoint(
             IdentityHandle& remote_participant_identity,
-            SharedSecretHandle& shared_secret);
+            SecretHandle& shared_secret);
 
     /**
      * Manage cryptographic exchange with a remote participant
@@ -680,7 +680,7 @@ private:
     bool participant_authorized(
             const ParticipantProxyData& participant_data,
             const DiscoveredParticipantInfo::AuthUniquePtr& remote_participant_info,
-            std::shared_ptr<SharedSecretHandle>& shared_secret_handle);
+            std::shared_ptr<SecretHandle>& shared_secret_handle);
 
     void resend_handshake_message_token(
             const GUID_t& remote_participant_key) const;

--- a/src/cpp/rtps/security/SecurityManager.h
+++ b/src/cpp/rtps/security/SecurityManager.h
@@ -294,8 +294,10 @@ public:
      */
     bool is_security_active() const
     {
-        if(ready_state_)
+        if (ready_state_)
+        {
             return *ready_state_;
+        }
         return false;
     }
 
@@ -760,10 +762,10 @@ private:
         std::weak_ptr<bool> wp(ready_state_);
         ready_state_.reset();
 
-        while(!wp.expired())
+        while (!wp.expired())
         {
             std::this_thread::yield();
-        };
+        }
     }
 
     /**

--- a/src/cpp/rtps/security/common/SharedSecretHandle.cpp
+++ b/src/cpp/rtps/security/common/SharedSecretHandle.cpp
@@ -27,7 +27,15 @@ const std::vector<uint8_t>* SharedSecretHelper::find_data_value(
         const std::string& name)
 {
     const std::vector<uint8_t>* returnedValue = nullptr;
-    const SharedSecret& sharedsecret = **SharedSecretHandle::narrow(secret);
+    const SharedSecretHandle& sh = SharedSecretHandle::narrow(secret);
+
+    // Check the right class is underneath the handle
+    if (sh.nil())
+    {
+        return nullptr;
+    }
+
+    const SharedSecret& sharedsecret = **sh;
 
     for (auto property = sharedsecret.data_.begin(); property != sharedsecret.data_.end(); ++property)
     {

--- a/src/cpp/rtps/security/common/SharedSecretHandle.cpp
+++ b/src/cpp/rtps/security/common/SharedSecretHandle.cpp
@@ -22,14 +22,16 @@ using namespace eprosima::fastrtps::rtps::security;
 
 const char* const SharedSecret::class_id_ = "SharedSecret";
 
-const std::vector<uint8_t>* SharedSecretHelper::find_data_value(const SecretHandle& secret, const std::string& name)
+const std::vector<uint8_t>* SharedSecretHelper::find_data_value(
+        const SecretHandle& secret,
+        const std::string& name)
 {
     const std::vector<uint8_t>* returnedValue = nullptr;
     const SharedSecret& sharedsecret = **SharedSecretHandle::narrow(secret);
 
-    for(auto property = sharedsecret.data_.begin(); property != sharedsecret.data_.end(); ++property)
+    for (auto property = sharedsecret.data_.begin(); property != sharedsecret.data_.end(); ++property)
     {
-        if(property->name().compare(name) == 0)
+        if (property->name().compare(name) == 0)
         {
             returnedValue = &property->value();
             break;

--- a/src/cpp/rtps/security/common/SharedSecretHandle.cpp
+++ b/src/cpp/rtps/security/common/SharedSecretHandle.cpp
@@ -22,25 +22,10 @@ using namespace eprosima::fastrtps::rtps::security;
 
 const char* const SharedSecret::class_id_ = "SharedSecret";
 
-std::vector<uint8_t>* SharedSecretHelper::find_data_value(SharedSecret& sharedsecret, const std::string& name)
-{
-    std::vector<uint8_t>* returnedValue = nullptr;
-
-    for(auto property = sharedsecret.data_.begin(); property != sharedsecret.data_.end(); ++property)
-    {
-        if(property->name().compare(name) == 0)
-        {
-            returnedValue = &property->value();
-            break;
-        }
-    }
-
-    return returnedValue;
-}
-
-const std::vector<uint8_t>* SharedSecretHelper::find_data_value(const SharedSecret& sharedsecret, const std::string& name)
+const std::vector<uint8_t>* SharedSecretHelper::find_data_value(const SecretHandle& secret, const std::string& name)
 {
     const std::vector<uint8_t>* returnedValue = nullptr;
+    const SharedSecret& sharedsecret = **SharedSecretHandle::narrow(secret);
 
     for(auto property = sharedsecret.data_.begin(); property != sharedsecret.data_.end(); ++property)
     {

--- a/src/cpp/security/accesscontrol/AccessPermissionsHandle.h
+++ b/src/cpp/security/accesscontrol/AccessPermissionsHandle.h
@@ -64,7 +64,9 @@ public:
     Grant grant;
 };
 
-typedef HandleImpl<AccessPermissions> AccessPermissionsHandle;
+class Permissions;
+
+typedef HandleImpl<AccessPermissions, Permissions> AccessPermissionsHandle;
 
 } //namespace security
 } //namespace rtps

--- a/src/cpp/security/accesscontrol/Permissions.cpp
+++ b/src/cpp/security/accesscontrol/Permissions.cpp
@@ -803,7 +803,7 @@ PermissionsHandle* Permissions::validate_local_permissions(
         return nullptr;
     }
 
-    AccessPermissionsHandle* ah = new AccessPermissionsHandle();
+    AccessPermissionsHandle* ah = &AccessPermissionsHandle::narrow(*get_permissions_handle(exception));
 
     (*ah)->store_ = load_permissions_ca(*permissions_ca, (*ah)->there_are_crls_, (*ah)->sn, (*ah)->algo, exception);
 
@@ -891,6 +891,11 @@ bool Permissions::return_permissions_credential_token(
 {
     delete token;
     return true;
+}
+
+PermissionsHandle* Permissions::get_permissions_handle(SecurityException&)
+{
+    return new (std::nothrow) AccessPermissionsHandle();
 }
 
 bool Permissions::return_permissions_handle(
@@ -991,7 +996,7 @@ PermissionsHandle* Permissions::validate_remote_permissions(
         return nullptr;
     }
 
-    AccessPermissionsHandle* handle =  new AccessPermissionsHandle();
+    AccessPermissionsHandle* handle = &AccessPermissionsHandle::narrow(*get_permissions_handle(exception));
     (*handle)->grant = std::move(remote_grant);
     (*handle)->governance_rule_ = lph->governance_rule_;
     (*handle)->governance_topic_rules_ = lph->governance_topic_rules_;

--- a/src/cpp/security/accesscontrol/Permissions.cpp
+++ b/src/cpp/security/accesscontrol/Permissions.cpp
@@ -893,7 +893,8 @@ bool Permissions::return_permissions_credential_token(
     return true;
 }
 
-PermissionsHandle* Permissions::get_permissions_handle(SecurityException&)
+PermissionsHandle* Permissions::get_permissions_handle(
+        SecurityException&)
 {
     return new (std::nothrow) AccessPermissionsHandle();
 }

--- a/src/cpp/security/accesscontrol/Permissions.h
+++ b/src/cpp/security/accesscontrol/Permissions.h
@@ -50,6 +50,8 @@ class Permissions : public AccessControl
         bool return_permissions_credential_token(PermissionsCredentialToken* token,
                 SecurityException& exception) override;
 
+        PermissionsHandle* get_permissions_handle(SecurityException& exception) override;
+
         bool return_permissions_handle(PermissionsHandle* permissions_handle,
                 SecurityException& exception) override;
 

--- a/src/cpp/security/accesscontrol/Permissions.h
+++ b/src/cpp/security/accesscontrol/Permissions.h
@@ -29,72 +29,108 @@ namespace security {
 
 class Permissions : public AccessControl
 {
-    public:
+public:
 
-        virtual ~Permissions() = default;
+    virtual ~Permissions() = default;
 
-        PermissionsHandle* validate_local_permissions(Authentication& auth_plugin,
-                const IdentityHandle& identity,
-                const uint32_t domain_id,
-                const RTPSParticipantAttributes& participant_attr,
-                SecurityException& exception) override;
+    PermissionsHandle* validate_local_permissions(
+            Authentication& auth_plugin,
+            const IdentityHandle& identity,
+            const uint32_t domain_id,
+            const RTPSParticipantAttributes& participant_attr,
+            SecurityException& exception) override;
 
-        bool get_permissions_token(PermissionsToken** permissions_token, const PermissionsHandle& handle,
-                SecurityException& exception) override;
+    bool get_permissions_token(
+            PermissionsToken** permissions_token,
+            const PermissionsHandle& handle,
+            SecurityException& exception) override;
 
-        bool return_permissions_token(PermissionsToken* token, SecurityException& exception) override;
+    bool return_permissions_token(
+            PermissionsToken* token,
+            SecurityException& exception) override;
 
-        bool get_permissions_credential_token(PermissionsCredentialToken** permissions_credential_token,
-                const PermissionsHandle& handle, SecurityException& exception) override;
+    bool get_permissions_credential_token(
+            PermissionsCredentialToken** permissions_credential_token,
+            const PermissionsHandle& handle,
+            SecurityException& exception) override;
 
-        bool return_permissions_credential_token(PermissionsCredentialToken* token,
-                SecurityException& exception) override;
+    bool return_permissions_credential_token(
+            PermissionsCredentialToken* token,
+            SecurityException& exception) override;
 
-        PermissionsHandle* get_permissions_handle(SecurityException& exception) override;
+    PermissionsHandle* get_permissions_handle(
+            SecurityException& exception) override;
 
-        bool return_permissions_handle(PermissionsHandle* permissions_handle,
-                SecurityException& exception) override;
+    bool return_permissions_handle(
+            PermissionsHandle* permissions_handle,
+            SecurityException& exception) override;
 
-        PermissionsHandle* validate_remote_permissions(Authentication& auth_plugin,
-                const IdentityHandle& local_identity_handle,
-                const PermissionsHandle& local_permissions_handle,
-                const IdentityHandle& remote_identity_handle,
-                const PermissionsToken& remote_permissions_token,
-                const PermissionsCredentialToken& remote_credential_token,
-                SecurityException& exception) override;
+    PermissionsHandle* validate_remote_permissions(
+            Authentication& auth_plugin,
+            const IdentityHandle& local_identity_handle,
+            const PermissionsHandle& local_permissions_handle,
+            const IdentityHandle& remote_identity_handle,
+            const PermissionsToken& remote_permissions_token,
+            const PermissionsCredentialToken& remote_credential_token,
+            SecurityException& exception) override;
 
-        bool check_create_participant(const PermissionsHandle& local_handle, const uint32_t domain_id,
-                const RTPSParticipantAttributes& qos, SecurityException& exception) override;
+    bool check_create_participant(
+            const PermissionsHandle& local_handle,
+            const uint32_t domain_id,
+            const RTPSParticipantAttributes& qos,
+            SecurityException& exception) override;
 
-        bool check_remote_participant(const PermissionsHandle& remote_handle, const uint32_t domain_id,
-                const ParticipantProxyData&, SecurityException& exception) override;
+    bool check_remote_participant(
+            const PermissionsHandle& remote_handle,
+            const uint32_t domain_id,
+            const ParticipantProxyData&,
+            SecurityException& exception) override;
 
-        bool check_create_datawriter(const PermissionsHandle& local_handle,
-                const uint32_t domain_id, const std::string& topic_name,
-                const std::vector<std::string>& partitions, SecurityException& exception) override;
+    bool check_create_datawriter(
+            const PermissionsHandle& local_handle,
+            const uint32_t domain_id,
+            const std::string& topic_name,
+            const std::vector<std::string>& partitions,
+            SecurityException& exception) override;
 
-        bool check_create_datareader(const PermissionsHandle& local_handle,
-                const uint32_t domain_id, const std::string& topic_name,
-                const std::vector<std::string>& partitions, SecurityException& exception) override;
+    bool check_create_datareader(
+            const PermissionsHandle& local_handle,
+            const uint32_t domain_id,
+            const std::string& topic_name,
+            const std::vector<std::string>& partitions,
+            SecurityException& exception) override;
 
-        bool check_remote_datawriter(const PermissionsHandle& remote_handle,
-                const uint32_t domain_id, const WriterProxyData& publication_data,
-                SecurityException& exception) override;
+    bool check_remote_datawriter(
+            const PermissionsHandle& remote_handle,
+            const uint32_t domain_id,
+            const WriterProxyData& publication_data,
+            SecurityException& exception) override;
 
-        bool check_remote_datareader(const PermissionsHandle& remote_handle,
-                const uint32_t domain_id, const ReaderProxyData& subscription_data,
-                bool& relay_only, SecurityException& exception) override;
+    bool check_remote_datareader(
+            const PermissionsHandle& remote_handle,
+            const uint32_t domain_id,
+            const ReaderProxyData& subscription_data,
+            bool& relay_only,
+            SecurityException& exception) override;
 
-        bool get_participant_sec_attributes(const PermissionsHandle& local_handle,
-                ParticipantSecurityAttributes& attributes, SecurityException& exception) override;
+    bool get_participant_sec_attributes(
+            const PermissionsHandle& local_handle,
+            ParticipantSecurityAttributes& attributes,
+            SecurityException& exception) override;
 
-        bool get_datawriter_sec_attributes(const PermissionsHandle& permissions_handle,
-                const std::string& topic_name, const std::vector<std::string>& partitions,
-                EndpointSecurityAttributes& attributes, SecurityException& exception) override;
+    bool get_datawriter_sec_attributes(
+            const PermissionsHandle& permissions_handle,
+            const std::string& topic_name,
+            const std::vector<std::string>& partitions,
+            EndpointSecurityAttributes& attributes,
+            SecurityException& exception) override;
 
-        bool get_datareader_sec_attributes(const PermissionsHandle& permissions_handle,
-                const std::string& topic_name, const std::vector<std::string>& partitions,
-                EndpointSecurityAttributes& attributes, SecurityException& exception) override;
+    bool get_datareader_sec_attributes(
+            const PermissionsHandle& permissions_handle,
+            const std::string& topic_name,
+            const std::vector<std::string>& partitions,
+            EndpointSecurityAttributes& attributes,
+            SecurityException& exception) override;
 };
 
 } //namespace security

--- a/src/cpp/security/authentication/PKIDH.cpp
+++ b/src/cpp/security/authentication/PKIDH.cpp
@@ -921,7 +921,7 @@ std::shared_ptr<SecretHandle> PKIDH::generate_sharedsecret(
                         {
                             data.value().assign(md, md + 32);
                             handle = std::dynamic_pointer_cast<SharedSecretHandle>(
-                                    get_shared_secret(SharedSecretHandle::nil_handle, exception));
+                                get_shared_secret(SharedSecretHandle::nil_handle, exception));
                             (*handle)->data_.push_back(std::move(data));
                         }
                         else
@@ -2180,9 +2180,9 @@ ValidationResult_t PKIDH::process_handshake_request(
         final_message.binary_properties().push_back(std::move(bproperty));
 
         handshake_handle->sharedsecret_ =
-            std::dynamic_pointer_cast<SharedSecretHandle>(
-                    generate_sharedsecret(handshake_handle->dhkeys_, handshake_handle->peerkeys_,
-                        exception));
+                std::dynamic_pointer_cast<SharedSecretHandle>(
+            generate_sharedsecret(handshake_handle->dhkeys_, handshake_handle->peerkeys_,
+            exception));
 
         if (handshake_handle->sharedsecret_ != nullptr)
         {
@@ -2377,9 +2377,9 @@ ValidationResult_t PKIDH::process_handshake_reply(
     }
 
     handshake_handle->sharedsecret_ =
-        std::dynamic_pointer_cast<SharedSecretHandle>(
-                generate_sharedsecret(handshake_handle->dhkeys_, handshake_handle->peerkeys_,
-                    exception));
+            std::dynamic_pointer_cast<SharedSecretHandle>(
+        generate_sharedsecret(handshake_handle->dhkeys_, handshake_handle->peerkeys_,
+        exception));
 
     if (handshake_handle->sharedsecret_ != nullptr)
     {
@@ -2414,9 +2414,10 @@ std::shared_ptr<SecretHandle> PKIDH::get_shared_secret(
     // create ad hoc deleter because this object can only be created/release from the friend factory
     auto p = new (std::nothrow) SharedSecretHandle;
     return std::dynamic_pointer_cast<SecretHandle>(
-            std::shared_ptr<SharedSecretHandle>(p, [](SharedSecretHandle* p) {
-                delete p;
-                }));
+        std::shared_ptr<SharedSecretHandle>(p, [](SharedSecretHandle* p)
+        {
+            delete p;
+        }));
 }
 
 bool PKIDH::set_listener(
@@ -2465,7 +2466,8 @@ bool PKIDH::return_handshake_handle(
     return false;
 }
 
-IdentityHandle* PKIDH::get_identity_handle(SecurityException&)
+IdentityHandle* PKIDH::get_identity_handle(
+        SecurityException&)
 {
     return new (std::nothrow) PKIIdentityHandle();
 }

--- a/src/cpp/security/authentication/PKIDH.h
+++ b/src/cpp/security/authentication/PKIDH.h
@@ -71,9 +71,9 @@ public:
             HandshakeHandle& handshake_handle,
             SecurityException& exception) override;
 
-    SharedSecretHandle* get_shared_secret(
+    std::shared_ptr<SharedSecretHandle> get_shared_secret(
             const HandshakeHandle& handshake_handle,
-            SecurityException& exception) override;
+            SecurityException& exception) const override;
 
     bool set_listener(
             AuthenticationListener* listener,
@@ -97,8 +97,8 @@ public:
             SecurityException& exception) override;
 
     bool return_sharedsecret_handle(
-            SharedSecretHandle* sharedsecret_handle,
-            SecurityException& exception) override;
+            std::shared_ptr<SharedSecretHandle>& sharedsecret_handle,
+            SecurityException& exception) const override;
 
     bool set_permissions_credential_and_token(
             IdentityHandle& identity_handle,
@@ -130,6 +130,10 @@ private:
             PKIHandshakeHandle& handshake_handle,
             SecurityException& exception);
 
+    std::shared_ptr<SharedSecretHandle> generate_sharedsecret(
+            EVP_PKEY* private_key,
+            EVP_PKEY* public_key,
+            SecurityException& exception) const;
 };
 
 } //namespace security

--- a/src/cpp/security/authentication/PKIDH.h
+++ b/src/cpp/security/authentication/PKIDH.h
@@ -71,7 +71,7 @@ public:
             HandshakeHandle& handshake_handle,
             SecurityException& exception) override;
 
-    std::shared_ptr<SharedSecretHandle> get_shared_secret(
+    std::shared_ptr<SecretHandle> get_shared_secret(
             const HandshakeHandle& handshake_handle,
             SecurityException& exception) const override;
 
@@ -92,12 +92,15 @@ public:
             HandshakeHandle* handshake_handle,
             SecurityException& exception) override;
 
+    IdentityHandle* get_identity_handle(
+            SecurityException& exception) override;
+
     bool return_identity_handle(
             IdentityHandle* identity_handle,
             SecurityException& exception) override;
 
     bool return_sharedsecret_handle(
-            std::shared_ptr<SharedSecretHandle>& sharedsecret_handle,
+            std::shared_ptr<SecretHandle>& sharedsecret_handle,
             SecurityException& exception) const override;
 
     bool set_permissions_credential_and_token(
@@ -130,7 +133,7 @@ private:
             PKIHandshakeHandle& handshake_handle,
             SecurityException& exception);
 
-    std::shared_ptr<SharedSecretHandle> generate_sharedsecret(
+    std::shared_ptr<SecretHandle> generate_sharedsecret(
             EVP_PKEY* private_key,
             EVP_PKEY* public_key,
             SecurityException& exception) const;

--- a/src/cpp/security/authentication/PKIHandshakeHandle.h
+++ b/src/cpp/security/authentication/PKIHandshakeHandle.h
@@ -31,33 +31,32 @@ namespace security {
 
 class PKIHandshake
 {
-    public:
+public:
 
-        PKIHandshake() = default;
+    PKIHandshake() = default;
 
-        ~PKIHandshake()
+    ~PKIHandshake()
+    {
+        if (dhkeys_ != nullptr)
         {
-            if(dhkeys_ != nullptr)
-            {
-                EVP_PKEY_free(dhkeys_);
-            }
-
-            if(peerkeys_ != nullptr)
-            {
-                EVP_PKEY_free(peerkeys_);
-            }
+            EVP_PKEY_free(dhkeys_);
         }
 
+        if (peerkeys_ != nullptr)
+        {
+            EVP_PKEY_free(peerkeys_);
+        }
+    }
 
-        static const char* const class_id_;
+    static const char* const class_id_;
 
-        std::string kagree_alg_;
-        EVP_PKEY* dhkeys_ = { nullptr };
-        EVP_PKEY* peerkeys_ = { nullptr };
-        const PKIIdentityHandle* local_identity_handle_ = { nullptr };
-        PKIIdentityHandle* remote_identity_handle_ = { nullptr };
-        HandshakeMessageToken handshake_message_;
-        std::shared_ptr<SharedSecretHandle> sharedsecret_;
+    std::string kagree_alg_;
+    EVP_PKEY* dhkeys_ = { nullptr };
+    EVP_PKEY* peerkeys_ = { nullptr };
+    const PKIIdentityHandle* local_identity_handle_ = { nullptr };
+    PKIIdentityHandle* remote_identity_handle_ = { nullptr };
+    HandshakeMessageToken handshake_message_;
+    std::shared_ptr<SharedSecretHandle> sharedsecret_;
 };
 
 class PKIDH;

--- a/src/cpp/security/authentication/PKIHandshakeHandle.h
+++ b/src/cpp/security/authentication/PKIHandshakeHandle.h
@@ -33,9 +33,7 @@ class PKIHandshake
 {
     public:
 
-        PKIHandshake() : dhkeys_(nullptr), peerkeys_(nullptr),
-        local_identity_handle_(nullptr), remote_identity_handle_(nullptr),
-        sharedsecret_(nullptr) {}
+        PKIHandshake() = default;
 
         ~PKIHandshake()
         {
@@ -48,26 +46,23 @@ class PKIHandshake
             {
                 EVP_PKEY_free(peerkeys_);
             }
-
-            if(sharedsecret_ != nullptr)
-            {
-                delete sharedsecret_;
-            }
         }
 
 
         static const char* const class_id_;
 
         std::string kagree_alg_;
-        EVP_PKEY* dhkeys_;
-        EVP_PKEY* peerkeys_;
-        const PKIIdentityHandle* local_identity_handle_;
-        PKIIdentityHandle* remote_identity_handle_;
+        EVP_PKEY* dhkeys_ = { nullptr };
+        EVP_PKEY* peerkeys_ = { nullptr };
+        const PKIIdentityHandle* local_identity_handle_ = { nullptr };
+        PKIIdentityHandle* remote_identity_handle_ = { nullptr };
         HandshakeMessageToken handshake_message_;
-        SharedSecretHandle* sharedsecret_;
+        std::shared_ptr<SharedSecretHandle> sharedsecret_;
 };
 
-typedef HandleImpl<PKIHandshake> PKIHandshakeHandle;
+class PKIDH;
+
+typedef HandleImpl<PKIHandshake, PKIDH> PKIHandshakeHandle;
 
 } //namespace security
 } //namespace rtps

--- a/src/cpp/security/authentication/PKIIdentityHandle.h
+++ b/src/cpp/security/authentication/PKIIdentityHandle.h
@@ -89,7 +89,9 @@ class PKIIdentity
         PermissionsCredentialToken permissions_credential_token_;
 };
 
-typedef HandleImpl<PKIIdentity> PKIIdentityHandle;
+class PKIDH;
+
+typedef HandleImpl<PKIIdentity, PKIDH> PKIIdentityHandle;
 
 } //namespace security
 } //namespace rtps

--- a/src/cpp/security/authentication/PKIIdentityHandle.h
+++ b/src/cpp/security/authentication/PKIIdentityHandle.h
@@ -38,55 +38,57 @@ static const char* const ECDH_prime256v1 = "ECDH+prime256v1-CEUM";
 
 class PKIIdentity
 {
-    public:
+public:
 
-        PKIIdentity() : store_(nullptr),
-        cert_(nullptr), pkey_(nullptr),
-        cert_content_(nullptr),
-        kagree_alg_(DH_2048_256),
-        there_are_crls_(false)
-        {}
+    PKIIdentity()
+        : store_(nullptr)
+        , cert_(nullptr)
+        , pkey_(nullptr)
+        , cert_content_(nullptr)
+        , kagree_alg_(DH_2048_256)
+        , there_are_crls_(false)
+    {
+    }
 
-        ~PKIIdentity()
+    ~PKIIdentity()
+    {
+        if (store_ != nullptr)
         {
-            if(store_ != nullptr)
-            {
-                X509_STORE_free(store_);
-            }
-
-            if(cert_ != nullptr)
-            {
-                X509_free(cert_);
-            }
-
-            if(pkey_ != nullptr)
-            {
-                EVP_PKEY_free(pkey_);
-            }
-
-            if(cert_content_ != nullptr)
-            {
-                BUF_MEM_free(cert_content_);
-            }
+            X509_STORE_free(store_);
         }
 
+        if (cert_ != nullptr)
+        {
+            X509_free(cert_);
+        }
 
-        static const char* const class_id_;
+        if (pkey_ != nullptr)
+        {
+            EVP_PKEY_free(pkey_);
+        }
 
-        X509_STORE* store_;
-        X509* cert_;
-        EVP_PKEY* pkey_;
-        GUID_t participant_key_;
-        BUF_MEM* cert_content_;
-        std::string sn;
-        std::string algo;
-        std::string sign_alg_;
-        std::string kagree_alg_;
-        std::string cert_sn_;
-        std::string cert_sn_rfc2253_;
-        bool there_are_crls_;
-        IdentityToken identity_token_;
-        PermissionsCredentialToken permissions_credential_token_;
+        if (cert_content_ != nullptr)
+        {
+            BUF_MEM_free(cert_content_);
+        }
+    }
+
+    static const char* const class_id_;
+
+    X509_STORE* store_;
+    X509* cert_;
+    EVP_PKEY* pkey_;
+    GUID_t participant_key_;
+    BUF_MEM* cert_content_;
+    std::string sn;
+    std::string algo;
+    std::string sign_alg_;
+    std::string kagree_alg_;
+    std::string cert_sn_;
+    std::string cert_sn_rfc2253_;
+    bool there_are_crls_;
+    IdentityToken identity_token_;
+    PermissionsCredentialToken permissions_credential_token_;
 };
 
 class PKIDH;

--- a/src/cpp/security/cryptography/AESGCMGMAC.cpp
+++ b/src/cpp/security/cryptography/AESGCMGMAC.cpp
@@ -55,4 +55,3 @@ AESGCMGMAC::~AESGCMGMAC()
     delete m_cryptokeyexchange;
     delete m_cryptotransform;
 }
-

--- a/src/cpp/security/cryptography/AESGCMGMAC.cpp
+++ b/src/cpp/security/cryptography/AESGCMGMAC.cpp
@@ -28,33 +28,31 @@ using namespace eprosima::fastrtps::rtps::security;
 AESGCMGMAC::AESGCMGMAC()
 {
     m_cryptokeyexchange = new AESGCMGMAC_KeyExchange();
-    m_cryptokeyfactory = new AESGCMGMAC_KeyFactory();
+    m_cryptokeyfactory = std::make_shared<AESGCMGMAC_KeyFactory>();
     m_cryptotransform = new AESGCMGMAC_Transform();
 
     // Seed prng
     RAND_load_file("/dev/urandom", 32);
 }
 
-AESGCMGMAC_KeyExchange* AESGCMGMAC::keyexchange(){
-
+AESGCMGMAC_KeyExchange* AESGCMGMAC::keyexchange()
+{
     return (AESGCMGMAC_KeyExchange*) m_cryptokeyexchange;
 }
 
-AESGCMGMAC_KeyFactory* AESGCMGMAC::keyfactory(){
-
-    return (AESGCMGMAC_KeyFactory*) m_cryptokeyfactory;
+std::shared_ptr<AESGCMGMAC_KeyFactory> AESGCMGMAC::keyfactory()
+{
+    return m_cryptokeyfactory;
 }
 
-AESGCMGMAC_Transform* AESGCMGMAC::cryptotransform(){
-
+AESGCMGMAC_Transform* AESGCMGMAC::transform()
+{
     return (AESGCMGMAC_Transform*) m_cryptotransform;
 }
 
-AESGCMGMAC::~AESGCMGMAC(){
-
+AESGCMGMAC::~AESGCMGMAC()
+{
     delete m_cryptokeyexchange;
-    delete m_cryptokeyfactory;
     delete m_cryptotransform;
-
 }
 

--- a/src/cpp/security/cryptography/AESGCMGMAC.h
+++ b/src/cpp/security/cryptography/AESGCMGMAC.h
@@ -1,5 +1,5 @@
 // Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
-//G
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -26,6 +26,7 @@
 #include <security/cryptography/AESGCMGMAC_KeyFactory.h>
 #include <security/cryptography/AESGCMGMAC_Transform.h>
 
+#include <memory>
 
 namespace eprosima {
 namespace fastrtps {
@@ -34,15 +35,33 @@ namespace security {
 
 class AESGCMGMAC : public Cryptography
 {
+    CryptoKeyExchange *m_cryptokeyexchange;
+    std::shared_ptr<AESGCMGMAC_KeyFactory> m_cryptokeyfactory;
+    CryptoTransform *m_cryptotransform;
+
 public:
 
     AESGCMGMAC();
     ~AESGCMGMAC();
 
-    AESGCMGMAC_KeyExchange* keyexchange();
-    AESGCMGMAC_KeyFactory* keyfactory();
-    AESGCMGMAC_Transform* cryptotransform();
+    CryptoKeyExchange* cryptokeyexchange() override
+    {
+        return keyexchange();
+    }
 
+    CryptoKeyFactory* cryptokeyfactory() override
+    {
+        return keyfactory().get();
+    }
+
+    CryptoTransform* cryptotransform() override
+    {
+        return transform();
+    }
+
+    AESGCMGMAC_KeyExchange* keyexchange();
+    std::shared_ptr<AESGCMGMAC_KeyFactory> keyfactory();
+    AESGCMGMAC_Transform* transform();
 };
 
 } //namespace security

--- a/src/cpp/security/cryptography/AESGCMGMAC.h
+++ b/src/cpp/security/cryptography/AESGCMGMAC.h
@@ -35,9 +35,9 @@ namespace security {
 
 class AESGCMGMAC : public Cryptography
 {
-    CryptoKeyExchange *m_cryptokeyexchange;
+    CryptoKeyExchange* m_cryptokeyexchange;
     std::shared_ptr<AESGCMGMAC_KeyFactory> m_cryptokeyfactory;
-    CryptoTransform *m_cryptotransform;
+    CryptoTransform* m_cryptotransform;
 
 public:
 

--- a/src/cpp/security/cryptography/AESGCMGMAC_KeyFactory.cpp
+++ b/src/cpp/security/cryptography/AESGCMGMAC_KeyFactory.cpp
@@ -222,13 +222,13 @@ std::shared_ptr<ParticipantCryptoHandle> AESGCMGMAC_KeyFactory::register_matched
         const ParticipantCryptoHandle& local_participant_crypto_handle,
         const IdentityHandle& /*remote_participant_identity*/,
         const PermissionsHandle& /*remote_participant_permissions*/,
-        const SharedSecretHandle& shared_secret,
+        const SecretHandle& shared_secret,
         SecurityException& exception)
 {
     //Extract information from the handshake. It will be needed in order to compute KeyMaterials
-    const std::vector<uint8_t>* challenge_1 = SharedSecretHelper::find_data_value(**shared_secret, "Challenge1");
-    const std::vector<uint8_t>* shared_secret_ss = SharedSecretHelper::find_data_value(**shared_secret, "SharedSecret");
-    const std::vector<uint8_t>* challenge_2 = SharedSecretHelper::find_data_value(**shared_secret, "Challenge2");
+    const std::vector<uint8_t>* challenge_1 = SharedSecretHelper::find_data_value(shared_secret, "Challenge1");
+    const std::vector<uint8_t>* shared_secret_ss = SharedSecretHelper::find_data_value(shared_secret, "SharedSecret");
+    const std::vector<uint8_t>* challenge_2 = SharedSecretHelper::find_data_value(shared_secret, "Challenge2");
     if ((challenge_1 == nullptr) || (shared_secret_ss == nullptr) || (challenge_2 == nullptr))
     {
         logWarning(SECURITY_CRYPTO, "Malformed SharedSecretHandle");
@@ -455,7 +455,7 @@ DatawriterCryptoHandle* AESGCMGMAC_KeyFactory::register_local_datawriter(
 DatareaderCryptoHandle* AESGCMGMAC_KeyFactory::register_matched_remote_datareader(
         DatawriterCryptoHandle& local_datawriter_crypto_handle,
         ParticipantCryptoHandle& remote_participant_crypto,
-        const SharedSecretHandle& /*shared_secret*/,
+        const SecretHandle& /*shared_secret*/,
         const bool relay_only,
         SecurityException& /*exception*/)
 {
@@ -659,7 +659,7 @@ DatareaderCryptoHandle* AESGCMGMAC_KeyFactory::register_local_datareader(
 DatawriterCryptoHandle* AESGCMGMAC_KeyFactory::register_matched_remote_datawriter(
         DatareaderCryptoHandle& local_datareader_crypto_handle,
         ParticipantCryptoHandle& remote_participant_crypt,
-        const SharedSecretHandle& /*shared_secret*/,
+        const SecretHandle& /*shared_secret*/,
         SecurityException& /*exception*/)
 {
     //Create Participant2ParticipantKeyMaterial (Based on local ParticipantKeyMaterial) and

--- a/src/cpp/security/cryptography/AESGCMGMAC_KeyFactory.cpp
+++ b/src/cpp/security/cryptography/AESGCMGMAC_KeyFactory.cpp
@@ -43,7 +43,7 @@
 // discarding return value of function with 'nodiscard' attribute
 #if defined(_MSC_VER)
 #   pragma warning(disable : 4834)
-#endif
+#endif // if defined(_MSC_VER)
 
 static bool create_kx_key(
         std::array<uint8_t, 32>& out_data,
@@ -105,15 +105,17 @@ static bool create_kx_key(
 using namespace eprosima::fastrtps::rtps;
 using namespace eprosima::fastrtps::rtps::security;
 
-ParticipantCryptoHandleDeleter::ParticipantCryptoHandleDeleter(AESGCMGMAC_KeyFactory& factory)
+ParticipantCryptoHandleDeleter::ParticipantCryptoHandleDeleter(
+        AESGCMGMAC_KeyFactory& factory)
 {
     // TODO: promote to weak_from_this on C++17
     factory_ = std::weak_ptr<AESGCMGMAC_KeyFactory>(factory.shared_from_this());
 }
 
-void ParticipantCryptoHandleDeleter::operator()(AESGCMGMAC_ParticipantCryptoHandle* pk)
+void ParticipantCryptoHandleDeleter::operator ()(
+        AESGCMGMAC_ParticipantCryptoHandle* pk)
 {
-    if(nullptr == pk)
+    if (nullptr == pk)
     {
         return;
     }
@@ -123,7 +125,7 @@ void ParticipantCryptoHandleDeleter::operator()(AESGCMGMAC_ParticipantCryptoHand
 
     // Dummy exception if none provided
     SecurityException exception;
-    if(nullptr == (*pk)->exception_)
+    if (nullptr == (*pk)->exception_)
     {
         (*pk)->exception_ = &exception;
     }
@@ -567,7 +569,7 @@ DatareaderCryptoHandle* AESGCMGMAC_KeyFactory::register_matched_remote_datareade
     //     = remote_participant->Participant2ParticipantKxKeyMaterial.at(0);
 
     (*RRCrypto)->Parent_participant =
-        std::weak_ptr<ParticipantCryptoHandle>(remote_participant_crypto.shared_from_this());
+            std::weak_ptr<ParticipantCryptoHandle>(remote_participant_crypto.shared_from_this());
     //Save this CryptoHandle as part of the remote participant
 
     (*remote_participant)->Readers.push_back(RRCrypto);
@@ -745,7 +747,7 @@ DatawriterCryptoHandle* AESGCMGMAC_KeyFactory::register_matched_remote_datawrite
     //     remote_participant->Participant2ParticipantKxKeyMaterial.at(0);
 
     (*RWCrypto)->Parent_participant =
-        std::weak_ptr<ParticipantCryptoHandle>(remote_participant_crypt.shared_from_this());
+            std::weak_ptr<ParticipantCryptoHandle>(remote_participant_crypt.shared_from_this());
 
     //Save this CryptoHandle as part of the remote participant
     (*remote_participant)->Writers.push_back(RWCrypto);
@@ -771,18 +773,26 @@ void AESGCMGMAC_KeyFactory::release_participant(
         // This method should be called from the shared_ptr deleter. The endpoints
         // can no longer lock() on the participant handle using their weak pointers
         assert([&key]() -> bool
-                { // returns true if executed from the deleter
-                    try { key.shared_from_this(); }
-                    catch(std::bad_weak_ptr&) { return true; }
+                {
+                    // returns true if executed from the deleter
+                    try
+                    {
+                        key.shared_from_this();
+                    }
+                    catch (std::bad_weak_ptr&)
+                    {
+                        return true;
+                    }
                     return false;
-                }() );
+                }
+                    ());
 
-        for(auto& writer : key->Writers)
+        for (auto& writer : key->Writers)
         {
             unregister_datawriter(writer, exception);
         }
 
-        for(auto& reader : key->Readers)
+        for (auto& reader : key->Readers)
         {
             unregister_datareader(reader, exception);
         }
@@ -806,7 +816,7 @@ bool AESGCMGMAC_KeyFactory::unregister_participant(
 
     // Associate the exception object
     AESGCMGMAC_ParticipantCryptoHandle& handle =
-        AESGCMGMAC_ParticipantCryptoHandle::narrow(*participant_crypto_handle);
+            AESGCMGMAC_ParticipantCryptoHandle::narrow(*participant_crypto_handle);
 
     // must not be nil and deleter_ associated on construction
     assert(nullptr == handle->exception_);
@@ -816,12 +826,12 @@ bool AESGCMGMAC_KeyFactory::unregister_participant(
     // the exception argument will be populated here
     std::weak_ptr<ParticipantCryptoHandle> wp(participant_crypto_handle);
     participant_crypto_handle.reset();
-    if(!wp.expired())
+    if (!wp.expired())
     {
         exception = SecurityException("Outstanding works on the crypto handle");
         handle->exception_ = nullptr;
         return false;
-    };
+    }
 
     return true;
 }
@@ -830,26 +840,26 @@ std::shared_ptr<DatawriterCryptoHandle> AESGCMGMAC_KeyFactory::get_datawriter_ha
 {
     // Deleter should be enforced because AESGCMGMAC_WriterCryptoHandle can only be created/destroyed from this factory
     return std::dynamic_pointer_cast<DatawriterCryptoHandle>(
-            std::shared_ptr<AESGCMGMAC_WriterCryptoHandle>(
-                    new AESGCMGMAC_WriterCryptoHandle,
-                    [](AESGCMGMAC_WriterCryptoHandle* p)
-                    {
-                        delete p;
-                    }
-                ));
+        std::shared_ptr<AESGCMGMAC_WriterCryptoHandle>(
+            new AESGCMGMAC_WriterCryptoHandle,
+            [](AESGCMGMAC_WriterCryptoHandle* p)
+            {
+                delete p;
+            }
+            ));
 }
 
 std::shared_ptr<DatareaderCryptoHandle> AESGCMGMAC_KeyFactory::get_datareader_handle()
 {
     // Deleter should be enforced because AESGCMGMAC_ReaderCryptoHandle can only be created/destroyed from this factory
     return std::dynamic_pointer_cast<DatareaderCryptoHandle>(
-            std::shared_ptr<AESGCMGMAC_ReaderCryptoHandle>(
-                    new AESGCMGMAC_ReaderCryptoHandle,
-                    [](AESGCMGMAC_ReaderCryptoHandle* p)
-                    {
-                        delete p;
-                    }
-                ));
+        std::shared_ptr<AESGCMGMAC_ReaderCryptoHandle>(
+            new AESGCMGMAC_ReaderCryptoHandle,
+            [](AESGCMGMAC_ReaderCryptoHandle* p)
+            {
+                delete p;
+            }
+            ));
 }
 
 bool AESGCMGMAC_KeyFactory::unregister_datawriter(
@@ -867,7 +877,7 @@ bool AESGCMGMAC_KeyFactory::unregister_datawriter(
     // on participant handle destruction no lock can be taken
     // this code manages removal during participant lifetime
     auto parent_participant = std::dynamic_pointer_cast<AESGCMGMAC_ParticipantCryptoHandle>(
-            (*datawriter)->Parent_participant.lock());
+        (*datawriter)->Parent_participant.lock());
 
     if (parent_participant)
     {
@@ -906,7 +916,7 @@ bool AESGCMGMAC_KeyFactory::unregister_datareader(
     // on participant handle destruction no lock can be taken
     // this code manages removal during participant lifetime
     auto parent_participant = std::dynamic_pointer_cast<AESGCMGMAC_ParticipantCryptoHandle>(
-            (*datareader)->Parent_participant.lock());
+        (*datareader)->Parent_participant.lock());
 
     if (parent_participant)
     {

--- a/src/cpp/security/cryptography/AESGCMGMAC_KeyFactory.cpp
+++ b/src/cpp/security/cryptography/AESGCMGMAC_KeyFactory.cpp
@@ -254,7 +254,6 @@ std::shared_ptr<ParticipantCryptoHandle> AESGCMGMAC_KeyFactory::register_matched
     bool is_origin_auth =
             (plugin_attrs & PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ORIGIN_AUTHENTICATED) != 0;
 
-
     // Remote Participant CryptoHandle, to be returned at the end of the function
     std::shared_ptr<AESGCMGMAC_ParticipantCryptoHandle> RPCrypto;
 

--- a/src/cpp/security/cryptography/AESGCMGMAC_KeyFactory.h
+++ b/src/cpp/security/cryptography/AESGCMGMAC_KeyFactory.h
@@ -38,9 +38,11 @@ namespace {
 // Auxiliary class to delete the handles, privy to this compilation unit
 struct ParticipantCryptoHandleDeleter
 {
-    ParticipantCryptoHandleDeleter(AESGCMGMAC_KeyFactory& factory);
+    ParticipantCryptoHandleDeleter(
+            AESGCMGMAC_KeyFactory& factory);
 
-    void operator()(AESGCMGMAC_ParticipantCryptoHandle* pk);
+    void operator ()(
+            AESGCMGMAC_ParticipantCryptoHandle* pk);
 
     // Reference to the factory
     std::weak_ptr<AESGCMGMAC_KeyFactory> factory_;
@@ -53,7 +55,8 @@ class AESGCMGMAC_KeyFactory : public CryptoKeyFactory, public std::enable_shared
     friend ParticipantCryptoHandleDeleter;
 
     // Actual unregister_participant() implementation called from the handle destructor
-    void release_participant(AESGCMGMAC_ParticipantCryptoHandle& key);
+    void release_participant(
+            AESGCMGMAC_ParticipantCryptoHandle& key);
 
     // DatawriterCryptoHandle & DatareaderCryptoHandle creation methods.
     std::shared_ptr<DatawriterCryptoHandle> get_datawriter_handle();

--- a/src/cpp/security/cryptography/AESGCMGMAC_KeyFactory.h
+++ b/src/cpp/security/cryptography/AESGCMGMAC_KeyFactory.h
@@ -40,7 +40,7 @@ struct ParticipantCryptoHandleDeleter
 {
     ParticipantCryptoHandleDeleter(AESGCMGMAC_KeyFactory& factory);
 
-    void operator()(ParticipantKeyHandle* pk);
+    void operator()(AESGCMGMAC_ParticipantCryptoHandle* pk);
 
     // Reference to the factory
     std::weak_ptr<AESGCMGMAC_KeyFactory> factory_;
@@ -53,7 +53,7 @@ class AESGCMGMAC_KeyFactory : public CryptoKeyFactory, public std::enable_shared
     friend ParticipantCryptoHandleDeleter;
 
     // Actual unregister_participant() implementation called from the handle destructor
-    void release_participant(ParticipantKeyHandle* key);
+    void release_participant(AESGCMGMAC_ParticipantCryptoHandle& key);
 
 public:
 

--- a/src/cpp/security/cryptography/AESGCMGMAC_KeyFactory.h
+++ b/src/cpp/security/cryptography/AESGCMGMAC_KeyFactory.h
@@ -70,7 +70,7 @@ public:
             const ParticipantCryptoHandle& local_participant_crypto_handle,
             const IdentityHandle& remote_participant_identity,
             const PermissionsHandle& remote_participant_permissions,
-            const SharedSecretHandle& shared_secret,
+            const SecretHandle& shared_secret,
             SecurityException& exception) override;
 
     DatawriterCryptoHandle* register_local_datawriter(
@@ -82,7 +82,7 @@ public:
     DatareaderCryptoHandle* register_matched_remote_datareader(
             DatawriterCryptoHandle& local_datawriter_crypto_handle,
             ParticipantCryptoHandle& remote_participant_crypto,
-            const SharedSecretHandle& shared_secret,
+            const SecretHandle& shared_secret,
             const bool relay_only,
             SecurityException& exception) override;
 
@@ -95,7 +95,7 @@ public:
     DatawriterCryptoHandle* register_matched_remote_datawriter(
             DatareaderCryptoHandle& local_datareader_crypto_handle,
             ParticipantCryptoHandle& remote_participant_crypt,
-            const SharedSecretHandle& shared_secret,
+            const SecretHandle& shared_secret,
             SecurityException& exception) override;
 
     bool unregister_participant(

--- a/src/cpp/security/cryptography/AESGCMGMAC_KeyFactory.h
+++ b/src/cpp/security/cryptography/AESGCMGMAC_KeyFactory.h
@@ -55,6 +55,10 @@ class AESGCMGMAC_KeyFactory : public CryptoKeyFactory, public std::enable_shared
     // Actual unregister_participant() implementation called from the handle destructor
     void release_participant(AESGCMGMAC_ParticipantCryptoHandle& key);
 
+    // DatawriterCryptoHandle & DatareaderCryptoHandle creation methods.
+    std::shared_ptr<DatawriterCryptoHandle> get_datawriter_handle();
+    std::shared_ptr<DatareaderCryptoHandle> get_datareader_handle();
+
 public:
 
     AESGCMGMAC_KeyFactory();
@@ -103,12 +107,16 @@ public:
             SecurityException& exception) override;
 
     bool unregister_datawriter(
-            DatawriterCryptoHandle* datawriter_crypto_handle,
+            std::shared_ptr<DatawriterCryptoHandle>& datawriter_crypto_handle,
             SecurityException& exception) override;
 
     bool unregister_datareader(
-            DatareaderCryptoHandle* datareader_crypto_handle,
+            std::shared_ptr<DatareaderCryptoHandle>& datareader_crypto_handle,
             SecurityException& exception) override;
+
+    // introduce convenient overrides in this scope
+    using CryptoKeyFactory::unregister_datawriter;
+    using CryptoKeyFactory::unregister_datareader;
 
 private:
 

--- a/src/cpp/security/cryptography/AESGCMGMAC_Transform.cpp
+++ b/src/cpp/security/cryptography/AESGCMGMAC_Transform.cpp
@@ -460,7 +460,7 @@ bool AESGCMGMAC_Transform::encode_rtps_message(
         CDRMessage_t& encoded_rtps_message,
         const CDRMessage_t& plain_rtps_message,
         ParticipantCryptoHandle& sending_crypto,
-        std::vector<ParticipantCryptoHandle*>& receiving_crypto_list,
+        std::vector<std::shared_ptr<ParticipantCryptoHandle>>& receiving_crypto_list,
         SecurityException& /*exception*/)
 {
     AESGCMGMAC_ParticipantCryptoHandle& local_participant = AESGCMGMAC_ParticipantCryptoHandle::narrow(sending_crypto);
@@ -1819,7 +1819,7 @@ bool AESGCMGMAC_Transform::serialize_SecureDataTag(
         eprosima::fastcdr::Cdr& serializer,
         const AESGCMGMAC_ParticipantCryptoHandle& local_participant,
         const std::array<uint8_t, 12>& initialization_vector,
-        std::vector<ParticipantCryptoHandle*>& receiving_crypto_list,
+        std::vector<std::shared_ptr<ParticipantCryptoHandle>>& receiving_crypto_list,
         bool update_specific_keys,
         SecureDataTag& tag)
 {

--- a/src/cpp/security/cryptography/AESGCMGMAC_Transform.cpp
+++ b/src/cpp/security/cryptography/AESGCMGMAC_Transform.cpp
@@ -153,7 +153,7 @@ bool AESGCMGMAC_Transform::encode_serialized_payload(
 
     try
     {
-        std::vector<DatareaderCryptoHandle*> receiving_datareader_crypto_list;
+        std::vector<std::shared_ptr<DatareaderCryptoHandle>> receiving_datareader_crypto_list;
         if (!serialize_SecureDataTag(serializer, keyMat.transformation_kind, session->session_id,
                 initialization_vector, receiving_datareader_crypto_list, false, tag, nKeys - 1))
         {
@@ -176,7 +176,7 @@ bool AESGCMGMAC_Transform::encode_datawriter_submessage(
         CDRMessage_t& encoded_rtps_submessage,
         const CDRMessage_t& plain_rtps_submessage,
         DatawriterCryptoHandle& sending_datawriter_crypto,
-        std::vector<DatareaderCryptoHandle*>& receiving_datareader_crypto_list,
+        std::vector<std::shared_ptr<DatareaderCryptoHandle>>& receiving_datareader_crypto_list,
         SecurityException& /*exception*/)
 {
     AESGCMGMAC_WriterCryptoHandle& local_writer = AESGCMGMAC_WriterCryptoHandle::narrow(sending_datawriter_crypto);
@@ -318,7 +318,7 @@ bool AESGCMGMAC_Transform::encode_datareader_submessage(
         CDRMessage_t& encoded_rtps_submessage,
         const CDRMessage_t& plain_rtps_submessage,
         DatareaderCryptoHandle& sending_datareader_crypto,
-        std::vector<DatawriterCryptoHandle*>& receiving_datawriter_crypto_list,
+        std::vector<std::shared_ptr<DatawriterCryptoHandle>>& receiving_datawriter_crypto_list,
         SecurityException& /*exception*/)
 {
     AESGCMGMAC_ReaderCryptoHandle& local_reader = AESGCMGMAC_ReaderCryptoHandle::narrow(sending_datareader_crypto);
@@ -1701,7 +1701,7 @@ bool AESGCMGMAC_Transform::serialize_SecureDataTag(
         const std::array<uint8_t, 4>& transformation_kind,
         const uint32_t session_id,
         const std::array<uint8_t, 12>& initialization_vector,
-        std::vector<EntityCryptoHandle*>& receiving_crypto_list,
+        std::vector<std::shared_ptr<ParticipantCryptoHandle>>& receiving_crypto_list,
         bool update_specific_keys,
         SecureDataTag& tag,
         size_t sessionIndex)

--- a/src/cpp/security/cryptography/AESGCMGMAC_Transform.h
+++ b/src/cpp/security/cryptography/AESGCMGMAC_Transform.h
@@ -49,21 +49,21 @@ public:
             CDRMessage_t& encoded_rtps_submessage,
             const CDRMessage_t& plain_rtps_submessage,
             DatawriterCryptoHandle& sending_datawriter_crypto,
-            std::vector<DatareaderCryptoHandle*>& receiving_datareader_crypto_list,
+            std::vector<std::shared_ptr<DatareaderCryptoHandle>>& receiving_datareader_crypto_list,
             SecurityException& exception) override;
 
     bool encode_datareader_submessage(
             CDRMessage_t& encoded_rtps_submessage,
             const CDRMessage_t& plain_rtps_submessage,
             DatareaderCryptoHandle& sending_datareader_crypto,
-            std::vector<DatawriterCryptoHandle*>& receiving_datawriter_crypto_list,
+            std::vector<std::shared_ptr<DatawriterCryptoHandle>>& receiving_datawriter_crypto_list,
             SecurityException& exception) override;
 
     bool encode_rtps_message(
             CDRMessage_t& encoded_rtps_message,
             const CDRMessage_t& plain_rtps_message,
             ParticipantCryptoHandle& sending_crypto,
-            std::vector<ParticipantCryptoHandle*>& receiving_crypto_list,
+            std::vector<std::shared_ptr<ParticipantCryptoHandle>>& receiving_crypto_list,
             SecurityException& exception) override;
 
     bool decode_rtps_message(
@@ -142,7 +142,7 @@ public:
             const std::array<uint8_t, 4>& transformation_kind,
             const uint32_t session_id,
             const std::array<uint8_t, 12>& initialization_vector,
-            std::vector<EntityCryptoHandle*>& receiving_datareader_crypto_list,
+            std::vector<std::shared_ptr<EntityCryptoHandle>>& receiving_crypto_list,
             bool update_specific_keys,
             SecureDataTag& tag,
             size_t sessionIndex);
@@ -151,7 +151,7 @@ public:
             eprosima::fastcdr::Cdr& serializer,
             const AESGCMGMAC_ParticipantCryptoHandle& local_participant,
             const std::array<uint8_t, 12>& initialization_vector,
-            std::vector<ParticipantCryptoHandle*>& receiving_crypto_list,
+            std::vector<std::shared_ptr<EntityCryptoHandle>>& receiving_crypto_list,
             bool update_specific_keys,
             SecureDataTag& tag);
 

--- a/src/cpp/security/cryptography/AESGCMGMAC_Types.h
+++ b/src/cpp/security/cryptography/AESGCMGMAC_Types.h
@@ -26,6 +26,7 @@
 #include <fastdds/rtps/security/accesscontrol/ParticipantSecurityAttributes.h>
 #include <fastdds/rtps/security/accesscontrol/EndpointSecurityAttributes.h>
 
+#include <cassert>
 #include <functional>
 #include <limits>
 #include <mutex>
@@ -166,24 +167,16 @@ struct EntityKeyHandle
     std::mutex mutex_;
 };
 
-typedef HandleImpl<EntityKeyHandle> AESGCMGMAC_WriterCryptoHandle;
-typedef HandleImpl<EntityKeyHandle> AESGCMGMAC_ReaderCryptoHandle;
-typedef HandleImpl<EntityKeyHandle> AESGCMGMAC_EntityCryptoHandle;
+class AESGCMGMAC_KeyFactory;
+
+typedef HandleImpl<EntityKeyHandle, AESGCMGMAC_KeyFactory> AESGCMGMAC_WriterCryptoHandle;
+typedef HandleImpl<EntityKeyHandle, AESGCMGMAC_KeyFactory> AESGCMGMAC_ReaderCryptoHandle;
+typedef HandleImpl<EntityKeyHandle, AESGCMGMAC_KeyFactory> AESGCMGMAC_EntityCryptoHandle;
 
 struct ParticipantKeyHandle
 {
     static const char* const class_id_;
 
-    ~ParticipantKeyHandle()
-    {
-        if(deleter_)
-        {
-            deleter_(this);
-        }
-    }
-
-    // release resources functor
-    std::function<void(ParticipantKeyHandle*)> deleter_;
     // Reference to an auxiliary exception object on destruction
     SecurityException* exception_ = {nullptr};
 
@@ -208,7 +201,7 @@ struct ParticipantKeyHandle
     std::mutex mutex_;
 };
 
-typedef HandleImpl<ParticipantKeyHandle> AESGCMGMAC_ParticipantCryptoHandle;
+typedef HandleImpl<ParticipantKeyHandle, AESGCMGMAC_KeyFactory> AESGCMGMAC_ParticipantCryptoHandle;
 
 } //namespaces security
 } //namespace rtps

--- a/src/cpp/security/cryptography/AESGCMGMAC_Types.h
+++ b/src/cpp/security/cryptography/AESGCMGMAC_Types.h
@@ -146,13 +146,16 @@ struct EntityKeyHandle
 {
     static const char* const class_id_;
 
+    // Reference to an auxiliary exception object on destruction
+    SecurityException* exception_ = {nullptr};
+
     //Plugin security options
     PluginEndpointSecurityAttributesMask EndpointPluginAttributes = 0;
     //Storage for the LocalCryptoHandle master_key, not used in RemoteCryptoHandles
     KeyMaterial_AES_GCM_GMAC_Seq EntityKeyMaterial;
     //KeyId of the master_key of the parent Participant and pointer to the relevant CryptoHandle
     CryptoTransformKeyId Participant_master_key_id = c_transformKeyIdZero;
-    ParticipantCryptoHandle* Parent_participant = nullptr;
+    std::weak_ptr<ParticipantCryptoHandle> Parent_participant;
 
     //(Direct) ReceiverSpecific Keys - Inherently hold the master_key of the writer
     KeyMaterial_AES_GCM_GMAC_Seq Entity2RemoteKeyMaterial;
@@ -191,9 +194,9 @@ struct ParticipantKeyHandle
     //(Reverse) ReceiverSpecific Keys - Inherently hold the master_key of the remote readers
     std::vector<KeyMaterial_AES_GCM_GMAC> RemoteParticipant2ParticipantKeyMaterial;
     //List of Pointers to the CryptoHandles of all matched Writers
-    std::vector<DatawriterCryptoHandle*> Writers;
+    std::vector<std::shared_ptr<DatawriterCryptoHandle>> Writers;
     //List of Pointers to the CryptoHandles of all matched Readers
-    std::vector<DatareaderCryptoHandle*> Readers;
+    std::vector<std::shared_ptr<DatareaderCryptoHandle>> Readers;
 
     //Data used to store the current session keys and to determine when it has to be updated
     KeySessionData Session;

--- a/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
@@ -404,11 +404,13 @@ public:
     size_t block_for_at_least(
             size_t at_least)
     {
-        block([this, at_least]() -> bool
+        size_t read_count_locked; // solves TSan data race
+        block([this, &read_count_locked, at_least]() -> bool
                 {
+                    read_count_locked = current_processed_count_;
                     return current_processed_count_ >= at_least;
                 });
-        return current_processed_count_;
+        return read_count_locked;
     }
 
     void block(

--- a/test/mock/rtps/SecurityPluginFactory/rtps/security/MockAccessControlPlugin.h
+++ b/test/mock/rtps/SecurityPluginFactory/rtps/security/MockAccessControlPlugin.h
@@ -33,102 +33,103 @@ namespace security {
 
 class MockAccessControlPlugin : public AccessControl
 {
-    public:
+public:
 
     using AccessPermissionsHandle = HandleImpl<AccessPermissions, MockAccessControlPlugin>;
 
     MOCK_METHOD(PermissionsHandle*, validate_local_permissions, (
-            Authentication& auth_plugin,
-            const IdentityHandle& identity,
-            const uint32_t domain_id,
-            const RTPSParticipantAttributes& participant_attr,
-            SecurityException& exception), (override));
+                Authentication & auth_plugin,
+                const IdentityHandle& identity,
+                const uint32_t domain_id,
+                const RTPSParticipantAttributes& participant_attr,
+                SecurityException & exception), (override));
 
     MOCK_METHOD(bool, get_permissions_token, (
-            PermissionsToken** permissions_token,
-            const PermissionsHandle& handle,
-            SecurityException& exception), (override));
+                PermissionsToken * *permissions_token,
+                const PermissionsHandle& handle,
+                SecurityException & exception), (override));
 
-    MOCK_METHOD(bool, return_permissions_token,(
-            PermissionsToken* token,
-            SecurityException& exception), (override));
+    MOCK_METHOD(bool, return_permissions_token, (
+                PermissionsToken * token,
+                SecurityException & exception), (override));
 
     MOCK_METHOD(bool, get_permissions_credential_token, (
-            PermissionsCredentialToken** permissions_credential_token,
-            const PermissionsHandle& handle,
-            SecurityException& exception), (override));
+                PermissionsCredentialToken * *permissions_credential_token,
+                const PermissionsHandle& handle,
+                SecurityException & exception), (override));
 
     MOCK_METHOD(bool, return_permissions_credential_token, (
-            PermissionsCredentialToken* token,
-            SecurityException& exception), (override));
+                PermissionsCredentialToken * token,
+                SecurityException & exception), (override));
 
     MOCK_METHOD(PermissionsHandle*, validate_remote_permissions, (
-            Authentication& auth_plugin,
-            const IdentityHandle& local_identity_handle,
-            const PermissionsHandle& local_permissions_handle,
-            const IdentityHandle& remote_identity_handle,
-            const PermissionsToken& remote_permissions_token,
-            const PermissionsCredentialToken& remote_credential_token,
-            SecurityException& exception), (override));
+                Authentication & auth_plugin,
+                const IdentityHandle& local_identity_handle,
+                const PermissionsHandle& local_permissions_handle,
+                const IdentityHandle& remote_identity_handle,
+                const PermissionsToken& remote_permissions_token,
+                const PermissionsCredentialToken& remote_credential_token,
+                SecurityException & exception), (override));
 
     MOCK_METHOD(bool, check_create_participant, (
-            const PermissionsHandle& local_handle,
-            const uint32_t domain_id,
-            const RTPSParticipantAttributes& qos,
-            SecurityException& exception), (override));
+                const PermissionsHandle& local_handle,
+                const uint32_t domain_id,
+                const RTPSParticipantAttributes& qos,
+                SecurityException & exception), (override));
 
     MOCK_METHOD(bool, check_remote_participant, (
-            const PermissionsHandle& remote_handle,
-            const uint32_t domain_id,
-            const ParticipantProxyData&,
-            SecurityException& exception), (override));
+                const PermissionsHandle& remote_handle,
+                const uint32_t domain_id,
+                const ParticipantProxyData&,
+                SecurityException & exception), (override));
 
     MOCK_METHOD(bool, check_create_datawriter, (
-            const PermissionsHandle& local_handle,
-            const uint32_t domain_id,
-            const std::string& topic_name,
-            const std::vector<std::string>& partitions,
-            SecurityException& exception), (override));
+                const PermissionsHandle& local_handle,
+                const uint32_t domain_id,
+                const std::string& topic_name,
+                const std::vector<std::string>& partitions,
+                SecurityException & exception), (override));
 
     MOCK_METHOD(bool, check_create_datareader, (
-            const PermissionsHandle& local_handle,
-            const uint32_t domain_id,
-            const std::string& topic_name,
-            const std::vector<std::string>& partitions,
-            SecurityException& exception), (override));
+                const PermissionsHandle& local_handle,
+                const uint32_t domain_id,
+                const std::string& topic_name,
+                const std::vector<std::string>& partitions,
+                SecurityException & exception), (override));
 
     MOCK_METHOD(bool, check_remote_datawriter, (
-            const PermissionsHandle& remote_handle,
-            const uint32_t domain_id,
-            const WriterProxyData& publication_data,
-            SecurityException& exception), (override));
+                const PermissionsHandle& remote_handle,
+                const uint32_t domain_id,
+                const WriterProxyData& publication_data,
+                SecurityException & exception), (override));
 
     MOCK_METHOD(bool, check_remote_datareader, (
-            const PermissionsHandle& remote_handle,
-            const uint32_t domain_id,
-            const ReaderProxyData& subscription_data,
-            bool& relay_only,
-            SecurityException& exception), (override));
+                const PermissionsHandle& remote_handle,
+                const uint32_t domain_id,
+                const ReaderProxyData& subscription_data,
+                bool& relay_only,
+                SecurityException & exception), (override));
     MOCK_METHOD(bool, get_participant_sec_attributes, (
-            const PermissionsHandle& local_handle,
-            ParticipantSecurityAttributes& attributes,
-            SecurityException& exception), (override));
+                const PermissionsHandle& local_handle,
+                ParticipantSecurityAttributes & attributes,
+                SecurityException & exception), (override));
 
     MOCK_METHOD(bool, get_datawriter_sec_attributes, (
-            const PermissionsHandle& permissions_handle,
-            const std::string& topic_name,
-            const std::vector<std::string>& partitions,
-            EndpointSecurityAttributes& attributes,
-            SecurityException& exception), (override));
+                const PermissionsHandle& permissions_handle,
+                const std::string& topic_name,
+                const std::vector<std::string>& partitions,
+                EndpointSecurityAttributes & attributes,
+                SecurityException & exception), (override));
 
     MOCK_METHOD(bool, get_datareader_sec_attributes, (
-            const PermissionsHandle& permissions_handle,
-            const std::string& topic_name,
-            const std::vector<std::string>& partitions,
-            EndpointSecurityAttributes& attributes,
-            SecurityException& exception), (override));
+                const PermissionsHandle& permissions_handle,
+                const std::string& topic_name,
+                const std::vector<std::string>& partitions,
+                EndpointSecurityAttributes & attributes,
+                SecurityException & exception), (override));
 
-    PermissionsHandle* get_permissions_handle(SecurityException&)
+    PermissionsHandle* get_permissions_handle(
+            SecurityException&)
     {
         return new (std::nothrow) AccessPermissionsHandle();
     }

--- a/test/mock/rtps/SecurityPluginFactory/rtps/security/MockAccessControlPlugin.h
+++ b/test/mock/rtps/SecurityPluginFactory/rtps/security/MockAccessControlPlugin.h
@@ -1,0 +1,151 @@
+// Copyright 2022 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*!
+ * @file MockAccessControlPlugin.h
+ */
+
+#ifndef _SECURITY_MOCKACCESSCONTROLPLUGIN_H_
+#define _SECURITY_MOCKACCESSCONTROLPLUGIN_H_
+
+#include <fastdds/rtps/builtin/data/ReaderProxyData.h>
+#include <fastdds/rtps/builtin/data/WriterProxyData.h>
+#include <fastdds/rtps/builtin/data/ParticipantProxyData.h>
+
+#include <fastdds/rtps/security/accesscontrol/AccessControl.h>
+#include <gmock/gmock.h>
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+namespace security {
+
+class MockAccessControlPlugin : public AccessControl
+{
+    public:
+
+    using AccessPermissionsHandle = HandleImpl<AccessPermissions, MockAccessControlPlugin>;
+
+    MOCK_METHOD(PermissionsHandle*, validate_local_permissions, (
+            Authentication& auth_plugin,
+            const IdentityHandle& identity,
+            const uint32_t domain_id,
+            const RTPSParticipantAttributes& participant_attr,
+            SecurityException& exception), (override));
+
+    MOCK_METHOD(bool, get_permissions_token, (
+            PermissionsToken** permissions_token,
+            const PermissionsHandle& handle,
+            SecurityException& exception), (override));
+
+    MOCK_METHOD(bool, return_permissions_token,(
+            PermissionsToken* token,
+            SecurityException& exception), (override));
+
+    MOCK_METHOD(bool, get_permissions_credential_token, (
+            PermissionsCredentialToken** permissions_credential_token,
+            const PermissionsHandle& handle,
+            SecurityException& exception), (override));
+
+    MOCK_METHOD(bool, return_permissions_credential_token, (
+            PermissionsCredentialToken* token,
+            SecurityException& exception), (override));
+
+    MOCK_METHOD(PermissionsHandle*, validate_remote_permissions, (
+            Authentication& auth_plugin,
+            const IdentityHandle& local_identity_handle,
+            const PermissionsHandle& local_permissions_handle,
+            const IdentityHandle& remote_identity_handle,
+            const PermissionsToken& remote_permissions_token,
+            const PermissionsCredentialToken& remote_credential_token,
+            SecurityException& exception), (override));
+
+    MOCK_METHOD(bool, check_create_participant, (
+            const PermissionsHandle& local_handle,
+            const uint32_t domain_id,
+            const RTPSParticipantAttributes& qos,
+            SecurityException& exception), (override));
+
+    MOCK_METHOD(bool, check_remote_participant, (
+            const PermissionsHandle& remote_handle,
+            const uint32_t domain_id,
+            const ParticipantProxyData&,
+            SecurityException& exception), (override));
+
+    MOCK_METHOD(bool, check_create_datawriter, (
+            const PermissionsHandle& local_handle,
+            const uint32_t domain_id,
+            const std::string& topic_name,
+            const std::vector<std::string>& partitions,
+            SecurityException& exception), (override));
+
+    MOCK_METHOD(bool, check_create_datareader, (
+            const PermissionsHandle& local_handle,
+            const uint32_t domain_id,
+            const std::string& topic_name,
+            const std::vector<std::string>& partitions,
+            SecurityException& exception), (override));
+
+    MOCK_METHOD(bool, check_remote_datawriter, (
+            const PermissionsHandle& remote_handle,
+            const uint32_t domain_id,
+            const WriterProxyData& publication_data,
+            SecurityException& exception), (override));
+
+    MOCK_METHOD(bool, check_remote_datareader, (
+            const PermissionsHandle& remote_handle,
+            const uint32_t domain_id,
+            const ReaderProxyData& subscription_data,
+            bool& relay_only,
+            SecurityException& exception), (override));
+    MOCK_METHOD(bool, get_participant_sec_attributes, (
+            const PermissionsHandle& local_handle,
+            ParticipantSecurityAttributes& attributes,
+            SecurityException& exception), (override));
+
+    MOCK_METHOD(bool, get_datawriter_sec_attributes, (
+            const PermissionsHandle& permissions_handle,
+            const std::string& topic_name,
+            const std::vector<std::string>& partitions,
+            EndpointSecurityAttributes& attributes,
+            SecurityException& exception), (override));
+
+    MOCK_METHOD(bool, get_datareader_sec_attributes, (
+            const PermissionsHandle& permissions_handle,
+            const std::string& topic_name,
+            const std::vector<std::string>& partitions,
+            EndpointSecurityAttributes& attributes,
+            SecurityException& exception), (override));
+
+    PermissionsHandle* get_permissions_handle(SecurityException&)
+    {
+        return new (std::nothrow) AccessPermissionsHandle();
+    }
+
+    bool return_permissions_handle(
+            PermissionsHandle* permissions_handle,
+            SecurityException&)
+    {
+        delete dynamic_cast<AccessPermissionsHandle*>(permissions_handle);
+        return true;
+    }
+
+};
+
+} //namespace security
+} //namespace rtps
+} //namespace fastrtps
+} //namespace eprosima
+
+#endif // _SECURITY_MOCKACCESSCONTROLPLUGIN_H_

--- a/test/mock/rtps/SecurityPluginFactory/rtps/security/MockAccessControlPlugin.h
+++ b/test/mock/rtps/SecurityPluginFactory/rtps/security/MockAccessControlPlugin.h
@@ -129,14 +129,14 @@ public:
                 SecurityException & exception), (override));
 
     PermissionsHandle* get_permissions_handle(
-            SecurityException&)
+            SecurityException&) override
     {
         return new (std::nothrow) AccessPermissionsHandle();
     }
 
     bool return_permissions_handle(
             PermissionsHandle* permissions_handle,
-            SecurityException&)
+            SecurityException&) override
     {
         delete dynamic_cast<AccessPermissionsHandle*>(permissions_handle);
         return true;

--- a/test/mock/rtps/SecurityPluginFactory/rtps/security/MockAuthenticationPlugin.h
+++ b/test/mock/rtps/SecurityPluginFactory/rtps/security/MockAuthenticationPlugin.h
@@ -36,101 +36,129 @@ class MockAuthenticationPlugin : public Authentication
 {
     public:
 
-        MOCK_METHOD6(validate_local_identity, ValidationResult_t(IdentityHandle** local_identity_handle,
-                GUID_t& adjusted_participant_key,
-                const uint32_t domain_id,
-                const RTPSParticipantAttributes& participant_attr,
-                const GUID_t& candidate_participant_key,
-                SecurityException& exception));
+    using PKIIdentityHandle = HandleImpl<PKIIdentity, MockAuthenticationPlugin>;
+    using SharedSecretHandle = HandleImpl<SharedSecret, MockAuthenticationPlugin>;
 
-        MOCK_METHOD5(validate_remote_identity_rvr, ValidationResult_t(IdentityHandle** remote_identity_handle,
-                const IdentityHandle& local_identity_handle,
-                IdentityToken remote_identity_token,
-                const GUID_t& remote_participant_key,
-                SecurityException& exception));
+    MOCK_METHOD(ValidationResult_t, validate_local_identity, (IdentityHandle** local_identity_handle,
+            GUID_t& adjusted_participant_key,
+            const uint32_t domain_id,
+            const RTPSParticipantAttributes& participant_attr,
+            const GUID_t& candidate_participant_key,
+            SecurityException& exception), (override));
 
-        MOCK_METHOD6(begin_handshake_request, ValidationResult_t(HandshakeHandle** handshake_handle,
-                HandshakeMessageToken** handshake_message,
-                const IdentityHandle& initiator_identity_handle,
-                IdentityHandle& replier_identity_handle,
-                const CDRMessage_t& cdr_participant_data,
-                SecurityException& exception));
+    MOCK_METHOD5(validate_remote_identity_rvr, ValidationResult_t(IdentityHandle** remote_identity_handle,
+            const IdentityHandle& local_identity_handle,
+            IdentityToken remote_identity_token,
+            const GUID_t& remote_participant_key,
+            SecurityException& exception));
 
-        MOCK_METHOD7(begin_handshake_reply_rvr, ValidationResult_t(HandshakeHandle** handshake_handle,
-                HandshakeMessageToken** handshake_message_out,
-                HandshakeMessageToken handshake_message_in,
-                IdentityHandle& initiator_identity_handle,
-                const IdentityHandle& replier_identity_handle,
-                const CDRMessage_t& cdr_participant_data,
-                SecurityException& exception));
+    MOCK_METHOD(ValidationResult_t, begin_handshake_request, (HandshakeHandle** handshake_handle,
+            HandshakeMessageToken** handshake_message,
+            const IdentityHandle& initiator_identity_handle,
+            IdentityHandle& replier_identity_handle,
+            const CDRMessage_t& cdr_participant_data,
+            SecurityException& exception), (override));
 
-        MOCK_METHOD4(process_handshake_rvr, ValidationResult_t(HandshakeMessageToken** handshake_message_out,
-                HandshakeMessageToken handshake_message_in,
-                HandshakeHandle& handshake_handle,
-                SecurityException& exception));
+    MOCK_METHOD7(begin_handshake_reply_rvr, ValidationResult_t(HandshakeHandle** handshake_handle,
+            HandshakeMessageToken** handshake_message_out,
+            HandshakeMessageToken handshake_message_in,
+            IdentityHandle& initiator_identity_handle,
+            const IdentityHandle& replier_identity_handle,
+            const CDRMessage_t& cdr_participant_data,
+            SecurityException& exception));
 
-        MOCK_METHOD2(get_shared_secret, SharedSecretHandle*(const HandshakeHandle& handshake_handle,
-                SecurityException& exception));
+    MOCK_METHOD4(process_handshake_rvr, ValidationResult_t(HandshakeMessageToken** handshake_message_out,
+            HandshakeMessageToken handshake_message_in,
+            HandshakeHandle& handshake_handle,
+            SecurityException& exception));
 
-        MOCK_METHOD2(set_listener, bool(AuthenticationListener* listener,
-                SecurityException& exception));
+    MOCK_METHOD(bool, set_listener, (AuthenticationListener* listener,
+                SecurityException& exception), (override));
 
-        MOCK_METHOD3(get_identity_token, bool(IdentityToken** identity_token,
-                const IdentityHandle& handle,
-                SecurityException& exception));
+    MOCK_METHOD(bool, get_identity_token, (IdentityToken** identity_token,
+            const IdentityHandle& handle,
+            SecurityException& exception), (override));
 
-        MOCK_METHOD2(return_identity_token, bool(IdentityToken* token,
-                SecurityException& exception));
+    MOCK_METHOD(bool, return_identity_token, (IdentityToken* token,
+            SecurityException& exception), (override));
 
-        MOCK_METHOD2(return_handshake_handle, bool(HandshakeHandle* handshake_handle,
-                SecurityException& exception));
+    MOCK_METHOD(bool, return_handshake_handle, (HandshakeHandle* handshake_handle,
+            SecurityException& exception), (override));
 
-        MOCK_METHOD2(return_identity_handle, bool(IdentityHandle* identity_handle,
-                SecurityException& exception));
+    MOCK_METHOD(bool, set_permissions_credential_and_token, (IdentityHandle& identity_handle,
+            PermissionsCredentialToken& permissions_credential_token,
+            SecurityException& ex), (override));
 
-        MOCK_METHOD2(return_sharedsecret_handle, bool(SharedSecretHandle* sharedsecret_handle,
-                SecurityException& exception));
+    MOCK_METHOD(bool, get_authenticated_peer_credential_token, (PermissionsCredentialToken **token,
+            const IdentityHandle& identity_handle, SecurityException& exception), (override));
 
-        MOCK_METHOD3(set_permissions_credential_and_token, bool(IdentityHandle& identity_handle,
-                PermissionsCredentialToken& permissions_credential_token,
-                SecurityException& ex));
+    MOCK_METHOD(bool, return_authenticated_peer_credential_token, (PermissionsCredentialToken* token,
+            SecurityException& ex), (override));
 
-        MOCK_METHOD3(get_authenticated_peer_credential_token, bool(PermissionsCredentialToken **token,
-                const IdentityHandle& identity_handle, SecurityException& exception));
+    ValidationResult_t validate_remote_identity(IdentityHandle** remote_identity_handle,
+            const IdentityHandle& local_identity_handle,
+            const IdentityToken& remote_identity_token,
+            const GUID_t& remote_participant_key,
+            SecurityException& exception)
+    {
+        return validate_remote_identity_rvr(remote_identity_handle, local_identity_handle,
+                remote_identity_token, remote_participant_key, exception);
+    }
 
-        MOCK_METHOD2(return_authenticated_peer_credential_token, bool(PermissionsCredentialToken* token,
-                SecurityException& ex));
+    ValidationResult_t begin_handshake_reply(HandshakeHandle** handshake_handle,
+            HandshakeMessageToken** handshake_message_out,
+            HandshakeMessageToken&& handshake_message_in,
+            IdentityHandle& initiator_identity_handle,
+            const IdentityHandle& replier_identity_handle,
+            const CDRMessage_t& cdr_participant_data,
+            SecurityException& exception)
+    {
+        return begin_handshake_reply_rvr(handshake_handle, handshake_message_out, handshake_message_in,
+                initiator_identity_handle, replier_identity_handle, cdr_participant_data, exception);
+    }
 
-        ValidationResult_t validate_remote_identity(IdentityHandle** remote_identity_handle,
-                const IdentityHandle& local_identity_handle,
-                const IdentityToken& remote_identity_token,
-                const GUID_t& remote_participant_key,
-                SecurityException& exception)
-        {
-            return validate_remote_identity_rvr(remote_identity_handle, local_identity_handle,
-                    remote_identity_token, remote_participant_key, exception);
-        }
+    ValidationResult_t process_handshake(HandshakeMessageToken** handshake_message_out,
+            HandshakeMessageToken&& handshake_message_in,
+            HandshakeHandle& handshake_handle,
+            SecurityException& exception)
+    {
+        return process_handshake_rvr(handshake_message_out, handshake_message_in,
+                handshake_handle, exception);
+    }
 
-        ValidationResult_t begin_handshake_reply(HandshakeHandle** handshake_handle,
-                HandshakeMessageToken** handshake_message_out,
-                HandshakeMessageToken&& handshake_message_in,
-                IdentityHandle& initiator_identity_handle,
-                const IdentityHandle& replier_identity_handle,
-                const CDRMessage_t& cdr_participant_data,
-                SecurityException& exception)
-        {
-            return begin_handshake_reply_rvr(handshake_handle, handshake_message_out, handshake_message_in,
-                    initiator_identity_handle, replier_identity_handle, cdr_participant_data, exception);
-        }
+    IdentityHandle* get_identity_handle(SecurityException&)
+    {
+        return new (std::nothrow) PKIIdentityHandle();
+    }
 
-        ValidationResult_t process_handshake(HandshakeMessageToken** handshake_message_out,
-                HandshakeMessageToken&& handshake_message_in,
-                HandshakeHandle& handshake_handle,
-                SecurityException& exception)
-        {
-            return process_handshake_rvr(handshake_message_out, handshake_message_in,
-                    handshake_handle, exception);
-        }
+    bool return_identity_handle(
+            IdentityHandle* identity_handle,
+            SecurityException&)
+    {
+        delete dynamic_cast<PKIIdentityHandle*>(identity_handle);
+        return true;
+    }
+
+    std::shared_ptr<SecretHandle> get_shared_secret(
+            const HandshakeHandle&,
+            SecurityException&) const
+    {
+        // create ad hoc deleter because this object can only be created/release from the friend factory
+        auto p = new (std::nothrow) SharedSecretHandle;
+        return std::dynamic_pointer_cast<SecretHandle>(std::shared_ptr<SharedSecretHandle>(p,
+                    [](SharedSecretHandle* p)
+                    {
+                        delete p;
+                    }));
+    }
+
+    bool return_sharedsecret_handle(
+            std::shared_ptr<SecretHandle>& sharedsecret_handle,
+            SecurityException&) const
+    {
+        sharedsecret_handle.reset();
+        return true;
+    }
 };
 
 } // namespace security

--- a/test/mock/rtps/SecurityPluginFactory/rtps/security/MockAuthenticationPlugin.h
+++ b/test/mock/rtps/SecurityPluginFactory/rtps/security/MockAuthenticationPlugin.h
@@ -128,12 +128,19 @@ class MockAuthenticationPlugin : public Authentication
                 handshake_handle, exception);
     }
 
-    IdentityHandle* get_identity_handle(SecurityException&)
+    MOCK_METHOD(IdentityHandle*, get_identity_handle, (
+                SecurityException&), (override));
+
+    IdentityHandle* get_identity_handle_impl(SecurityException&)
     {
         return new (std::nothrow) PKIIdentityHandle();
     }
 
-    bool return_identity_handle(
+    MOCK_METHOD(bool, return_identity_handle, (
+            IdentityHandle* identity_handle,
+            SecurityException&), (override));
+
+    bool return_identity_handle_impl(
             IdentityHandle* identity_handle,
             SecurityException&)
     {

--- a/test/mock/rtps/SecurityPluginFactory/rtps/security/MockAuthenticationPlugin.h
+++ b/test/mock/rtps/SecurityPluginFactory/rtps/security/MockAuthenticationPlugin.h
@@ -22,6 +22,8 @@
 // TODO(Ricardo) Change when GMock supports r-values.
 
 #include <fastrtps/rtps/security/authentication/Authentication.h>
+#include <security/authentication/PKIIdentityHandle.h>
+
 #include <gmock/gmock.h>
 
 #pragma warning(push)
@@ -139,7 +141,11 @@ class MockAuthenticationPlugin : public Authentication
         return true;
     }
 
-    std::shared_ptr<SecretHandle> get_shared_secret(
+    MOCK_METHOD(std::shared_ptr<SecretHandle>, get_shared_secret, (
+            const HandshakeHandle&,
+            SecurityException&), (const, override));
+
+    std::shared_ptr<SecretHandle> get_shared_secret_impl(
             const HandshakeHandle&,
             SecurityException&) const
     {
@@ -152,7 +158,11 @@ class MockAuthenticationPlugin : public Authentication
                     }));
     }
 
-    bool return_sharedsecret_handle(
+    MOCK_METHOD(bool, return_sharedsecret_handle, (
+            std::shared_ptr<SecretHandle>& sharedsecret_handle,
+            SecurityException&), (const, override));
+
+    bool return_sharedsecret_handle_impl(
             std::shared_ptr<SecretHandle>& sharedsecret_handle,
             SecurityException&) const
     {

--- a/test/mock/rtps/SecurityPluginFactory/rtps/security/MockAuthenticationPlugin.h
+++ b/test/mock/rtps/SecurityPluginFactory/rtps/security/MockAuthenticationPlugin.h
@@ -131,7 +131,7 @@ class MockAuthenticationPlugin : public Authentication
     MOCK_METHOD(IdentityHandle*, get_identity_handle, (
                 SecurityException&), (override));
 
-    IdentityHandle* get_identity_handle_impl(SecurityException&)
+    IdentityHandle* get_dummy_identity_handle()
     {
         return new (std::nothrow) PKIIdentityHandle();
     }
@@ -140,9 +140,8 @@ class MockAuthenticationPlugin : public Authentication
             IdentityHandle* identity_handle,
             SecurityException&), (override));
 
-    bool return_identity_handle_impl(
-            IdentityHandle* identity_handle,
-            SecurityException&)
+    bool return_dummy_identity_handle(
+            IdentityHandle* identity_handle)
     {
         delete dynamic_cast<PKIIdentityHandle*>(identity_handle);
         return true;
@@ -152,9 +151,7 @@ class MockAuthenticationPlugin : public Authentication
             const HandshakeHandle&,
             SecurityException&), (const, override));
 
-    std::shared_ptr<SecretHandle> get_shared_secret_impl(
-            const HandshakeHandle&,
-            SecurityException&) const
+    std::shared_ptr<SecretHandle> get_dummy_shared_secret() const
     {
         // create ad hoc deleter because this object can only be created/release from the friend factory
         auto p = new (std::nothrow) SharedSecretHandle;
@@ -169,9 +166,8 @@ class MockAuthenticationPlugin : public Authentication
             std::shared_ptr<SecretHandle>& sharedsecret_handle,
             SecurityException&), (const, override));
 
-    bool return_sharedsecret_handle_impl(
-            std::shared_ptr<SecretHandle>& sharedsecret_handle,
-            SecurityException&) const
+    bool return_dummy_sharedsecret(
+            std::shared_ptr<SecretHandle>& sharedsecret_handle) const
     {
         sharedsecret_handle.reset();
         return true;

--- a/test/mock/rtps/SecurityPluginFactory/rtps/security/MockAuthenticationPlugin.h
+++ b/test/mock/rtps/SecurityPluginFactory/rtps/security/MockAuthenticationPlugin.h
@@ -102,7 +102,7 @@ public:
             const IdentityHandle& local_identity_handle,
             const IdentityToken& remote_identity_token,
             const GUID_t& remote_participant_key,
-            SecurityException& exception)
+            SecurityException& exception) override
     {
         return validate_remote_identity_rvr(remote_identity_handle, local_identity_handle,
                        remote_identity_token, remote_participant_key, exception);
@@ -115,7 +115,7 @@ public:
             IdentityHandle& initiator_identity_handle,
             const IdentityHandle& replier_identity_handle,
             const CDRMessage_t& cdr_participant_data,
-            SecurityException& exception)
+            SecurityException& exception) override
     {
         return begin_handshake_reply_rvr(handshake_handle, handshake_message_out, handshake_message_in,
                        initiator_identity_handle, replier_identity_handle, cdr_participant_data, exception);
@@ -125,7 +125,7 @@ public:
             HandshakeMessageToken** handshake_message_out,
             HandshakeMessageToken&& handshake_message_in,
             HandshakeHandle& handshake_handle,
-            SecurityException& exception)
+            SecurityException& exception) override
     {
         return process_handshake_rvr(handshake_message_out, handshake_message_in,
                        handshake_handle, exception);

--- a/test/mock/rtps/SecurityPluginFactory/rtps/security/MockAuthenticationPlugin.h
+++ b/test/mock/rtps/SecurityPluginFactory/rtps/security/MockAuthenticationPlugin.h
@@ -36,78 +36,80 @@ namespace security {
 
 class MockAuthenticationPlugin : public Authentication
 {
-    public:
+public:
 
     using PKIIdentityHandle = HandleImpl<PKIIdentity, MockAuthenticationPlugin>;
     using SharedSecretHandle = HandleImpl<SharedSecret, MockAuthenticationPlugin>;
 
-    MOCK_METHOD(ValidationResult_t, validate_local_identity, (IdentityHandle** local_identity_handle,
-            GUID_t& adjusted_participant_key,
+    MOCK_METHOD(ValidationResult_t, validate_local_identity, (IdentityHandle * *local_identity_handle,
+            GUID_t & adjusted_participant_key,
             const uint32_t domain_id,
             const RTPSParticipantAttributes& participant_attr,
             const GUID_t& candidate_participant_key,
-            SecurityException& exception), (override));
+            SecurityException & exception), (override));
 
-    MOCK_METHOD5(validate_remote_identity_rvr, ValidationResult_t(IdentityHandle** remote_identity_handle,
+    MOCK_METHOD5(validate_remote_identity_rvr, ValidationResult_t(IdentityHandle * *remote_identity_handle,
             const IdentityHandle& local_identity_handle,
             IdentityToken remote_identity_token,
             const GUID_t& remote_participant_key,
-            SecurityException& exception));
+            SecurityException & exception));
 
-    MOCK_METHOD(ValidationResult_t, begin_handshake_request, (HandshakeHandle** handshake_handle,
-            HandshakeMessageToken** handshake_message,
+    MOCK_METHOD(ValidationResult_t, begin_handshake_request, (HandshakeHandle * *handshake_handle,
+            HandshakeMessageToken * *handshake_message,
             const IdentityHandle& initiator_identity_handle,
-            IdentityHandle& replier_identity_handle,
+            IdentityHandle & replier_identity_handle,
             const CDRMessage_t& cdr_participant_data,
-            SecurityException& exception), (override));
+            SecurityException & exception), (override));
 
-    MOCK_METHOD7(begin_handshake_reply_rvr, ValidationResult_t(HandshakeHandle** handshake_handle,
-            HandshakeMessageToken** handshake_message_out,
+    MOCK_METHOD7(begin_handshake_reply_rvr, ValidationResult_t(HandshakeHandle * *handshake_handle,
+            HandshakeMessageToken * *handshake_message_out,
             HandshakeMessageToken handshake_message_in,
-            IdentityHandle& initiator_identity_handle,
+            IdentityHandle & initiator_identity_handle,
             const IdentityHandle& replier_identity_handle,
             const CDRMessage_t& cdr_participant_data,
-            SecurityException& exception));
+            SecurityException & exception));
 
-    MOCK_METHOD4(process_handshake_rvr, ValidationResult_t(HandshakeMessageToken** handshake_message_out,
+    MOCK_METHOD4(process_handshake_rvr, ValidationResult_t(HandshakeMessageToken * *handshake_message_out,
             HandshakeMessageToken handshake_message_in,
-            HandshakeHandle& handshake_handle,
-            SecurityException& exception));
+            HandshakeHandle & handshake_handle,
+            SecurityException & exception));
 
-    MOCK_METHOD(bool, set_listener, (AuthenticationListener* listener,
-                SecurityException& exception), (override));
+    MOCK_METHOD(bool, set_listener, (AuthenticationListener * listener,
+            SecurityException & exception), (override));
 
-    MOCK_METHOD(bool, get_identity_token, (IdentityToken** identity_token,
+    MOCK_METHOD(bool, get_identity_token, (IdentityToken * *identity_token,
             const IdentityHandle& handle,
-            SecurityException& exception), (override));
+            SecurityException & exception), (override));
 
-    MOCK_METHOD(bool, return_identity_token, (IdentityToken* token,
-            SecurityException& exception), (override));
+    MOCK_METHOD(bool, return_identity_token, (IdentityToken * token,
+            SecurityException & exception), (override));
 
-    MOCK_METHOD(bool, return_handshake_handle, (HandshakeHandle* handshake_handle,
-            SecurityException& exception), (override));
+    MOCK_METHOD(bool, return_handshake_handle, (HandshakeHandle * handshake_handle,
+            SecurityException & exception), (override));
 
-    MOCK_METHOD(bool, set_permissions_credential_and_token, (IdentityHandle& identity_handle,
-            PermissionsCredentialToken& permissions_credential_token,
-            SecurityException& ex), (override));
+    MOCK_METHOD(bool, set_permissions_credential_and_token, (IdentityHandle & identity_handle,
+            PermissionsCredentialToken & permissions_credential_token,
+            SecurityException & ex), (override));
 
-    MOCK_METHOD(bool, get_authenticated_peer_credential_token, (PermissionsCredentialToken **token,
-            const IdentityHandle& identity_handle, SecurityException& exception), (override));
+    MOCK_METHOD(bool, get_authenticated_peer_credential_token, (PermissionsCredentialToken * *token,
+            const IdentityHandle& identity_handle, SecurityException & exception), (override));
 
-    MOCK_METHOD(bool, return_authenticated_peer_credential_token, (PermissionsCredentialToken* token,
-            SecurityException& ex), (override));
+    MOCK_METHOD(bool, return_authenticated_peer_credential_token, (PermissionsCredentialToken * token,
+            SecurityException & ex), (override));
 
-    ValidationResult_t validate_remote_identity(IdentityHandle** remote_identity_handle,
+    ValidationResult_t validate_remote_identity(
+            IdentityHandle** remote_identity_handle,
             const IdentityHandle& local_identity_handle,
             const IdentityToken& remote_identity_token,
             const GUID_t& remote_participant_key,
             SecurityException& exception)
     {
         return validate_remote_identity_rvr(remote_identity_handle, local_identity_handle,
-                remote_identity_token, remote_participant_key, exception);
+                       remote_identity_token, remote_participant_key, exception);
     }
 
-    ValidationResult_t begin_handshake_reply(HandshakeHandle** handshake_handle,
+    ValidationResult_t begin_handshake_reply(
+            HandshakeHandle** handshake_handle,
             HandshakeMessageToken** handshake_message_out,
             HandshakeMessageToken&& handshake_message_in,
             IdentityHandle& initiator_identity_handle,
@@ -116,20 +118,21 @@ class MockAuthenticationPlugin : public Authentication
             SecurityException& exception)
     {
         return begin_handshake_reply_rvr(handshake_handle, handshake_message_out, handshake_message_in,
-                initiator_identity_handle, replier_identity_handle, cdr_participant_data, exception);
+                       initiator_identity_handle, replier_identity_handle, cdr_participant_data, exception);
     }
 
-    ValidationResult_t process_handshake(HandshakeMessageToken** handshake_message_out,
+    ValidationResult_t process_handshake(
+            HandshakeMessageToken** handshake_message_out,
             HandshakeMessageToken&& handshake_message_in,
             HandshakeHandle& handshake_handle,
             SecurityException& exception)
     {
         return process_handshake_rvr(handshake_message_out, handshake_message_in,
-                handshake_handle, exception);
+                       handshake_handle, exception);
     }
 
     MOCK_METHOD(IdentityHandle*, get_identity_handle, (
-                SecurityException&), (override));
+                SecurityException &), (override));
 
     IdentityHandle* get_dummy_identity_handle()
     {
@@ -137,8 +140,8 @@ class MockAuthenticationPlugin : public Authentication
     }
 
     MOCK_METHOD(bool, return_identity_handle, (
-            IdentityHandle* identity_handle,
-            SecurityException&), (override));
+                IdentityHandle * identity_handle,
+                SecurityException &), (override));
 
     bool return_dummy_identity_handle(
             IdentityHandle* identity_handle)
@@ -148,23 +151,23 @@ class MockAuthenticationPlugin : public Authentication
     }
 
     MOCK_METHOD(std::shared_ptr<SecretHandle>, get_shared_secret, (
-            const HandshakeHandle&,
-            SecurityException&), (const, override));
+                const HandshakeHandle&,
+                SecurityException &), (const, override));
 
     std::shared_ptr<SecretHandle> get_dummy_shared_secret() const
     {
         // create ad hoc deleter because this object can only be created/release from the friend factory
         auto p = new (std::nothrow) SharedSecretHandle;
         return std::dynamic_pointer_cast<SecretHandle>(std::shared_ptr<SharedSecretHandle>(p,
-                    [](SharedSecretHandle* p)
-                    {
-                        delete p;
-                    }));
+                       [](SharedSecretHandle* p)
+                       {
+                           delete p;
+                       }));
     }
 
     MOCK_METHOD(bool, return_sharedsecret_handle, (
-            std::shared_ptr<SecretHandle>& sharedsecret_handle,
-            SecurityException&), (const, override));
+                std::shared_ptr<SecretHandle>& sharedsecret_handle,
+                SecurityException &), (const, override));
 
     bool return_dummy_sharedsecret(
             std::shared_ptr<SecretHandle>& sharedsecret_handle) const
@@ -172,6 +175,7 @@ class MockAuthenticationPlugin : public Authentication
         sharedsecret_handle.reset();
         return true;
     }
+
 };
 
 } // namespace security

--- a/test/mock/rtps/SecurityPluginFactory/rtps/security/MockCryptoKeyFactory.h
+++ b/test/mock/rtps/SecurityPluginFactory/rtps/security/MockCryptoKeyFactory.h
@@ -20,6 +20,9 @@
 
 #include <fastrtps/rtps/security/cryptography/CryptoKeyFactory.h>
 #include <fastrtps/rtps/security/cryptography/CryptoTypes.h>
+
+#include <security/cryptography/AESGCMGMAC_Types.h>
+
 #include <gmock/gmock.h>
 
 #pragma warning(push)
@@ -33,6 +36,7 @@ namespace security {
 class MockCryptoKeyFactory : public CryptoKeyFactory
 {
     public:
+        using AESGCMGMAC_ParticipantCryptoHandle = HandleImpl<ParticipantKeyHandle, MockCryptoKeyFactory>;
 
         virtual ~MockCryptoKeyFactory(){}
 
@@ -87,7 +91,25 @@ class MockCryptoKeyFactory : public CryptoKeyFactory
                 DatareaderCryptoHandle*,
                 SecurityException&));
 
+        MOCK_METHOD2(unregister_datawriter, bool (
+                std::shared_ptr<DatawriterCryptoHandle>&,
+                SecurityException&));
 
+        MOCK_METHOD2(unregister_datareader, bool (
+                std::shared_ptr<DatareaderCryptoHandle>&,
+                SecurityException&));
+
+        std::shared_ptr<ParticipantCryptoHandle> get_dummy_participant_handle() const
+        {
+            // create ad hoc deleter because this object can only be created/release from the friend factory
+            auto p = new (std::nothrow) AESGCMGMAC_ParticipantCryptoHandle;
+            return std::dynamic_pointer_cast<ParticipantCryptoHandle>(
+                    std::shared_ptr<AESGCMGMAC_ParticipantCryptoHandle>(p,
+                        [](AESGCMGMAC_ParticipantCryptoHandle* p)
+                        {
+                            delete p;
+                        }));
+        }
 };
 
 } //namespace security

--- a/test/mock/rtps/SecurityPluginFactory/rtps/security/MockCryptoKeyFactory.h
+++ b/test/mock/rtps/SecurityPluginFactory/rtps/security/MockCryptoKeyFactory.h
@@ -36,18 +36,18 @@ class MockCryptoKeyFactory : public CryptoKeyFactory
 
         virtual ~MockCryptoKeyFactory(){}
 
-        MOCK_METHOD5(register_local_participant, ParticipantCryptoHandle* (
+        MOCK_METHOD5(register_local_participant, std::shared_ptr<ParticipantCryptoHandle> (
                 const IdentityHandle&,
                 const PermissionsHandle&,
                 const PropertySeq&,
                 const ParticipantSecurityAttributes&,
                 SecurityException&));
 
-        MOCK_METHOD5(register_matched_remote_participant, ParticipantCryptoHandle* (
+        MOCK_METHOD5(register_matched_remote_participant, std::shared_ptr<ParticipantCryptoHandle> (
                 const ParticipantCryptoHandle&,
                 const IdentityHandle&,
                 const PermissionsHandle&,
-                const SharedSecretHandle&,
+                const SecretHandle&,
                 SecurityException&));
 
         MOCK_METHOD4(register_local_datawriter, DatawriterCryptoHandle* (
@@ -59,7 +59,7 @@ class MockCryptoKeyFactory : public CryptoKeyFactory
         MOCK_METHOD5(register_matched_remote_datareader, DatareaderCryptoHandle* (
                 DatawriterCryptoHandle&,
                 ParticipantCryptoHandle&,
-                const SharedSecretHandle&,
+                const SecretHandle&,
                 const bool,
                 SecurityException&));
 
@@ -72,11 +72,11 @@ class MockCryptoKeyFactory : public CryptoKeyFactory
         MOCK_METHOD4(register_matched_remote_datawriter, DatawriterCryptoHandle* (
                 DatareaderCryptoHandle&,
                 ParticipantCryptoHandle&,
-                const SharedSecretHandle&,
+                const SecretHandle&,
                 SecurityException&));
 
         MOCK_METHOD2(unregister_participant, bool (
-                ParticipantCryptoHandle*,
+                std::shared_ptr<ParticipantCryptoHandle>&,
                 SecurityException&));
 
         MOCK_METHOD2(unregister_datawriter, bool (

--- a/test/mock/rtps/SecurityPluginFactory/rtps/security/MockCryptoKeyFactory.h
+++ b/test/mock/rtps/SecurityPluginFactory/rtps/security/MockCryptoKeyFactory.h
@@ -35,81 +35,85 @@ namespace security {
 
 class MockCryptoKeyFactory : public CryptoKeyFactory
 {
-    public:
-        using AESGCMGMAC_ParticipantCryptoHandle = HandleImpl<ParticipantKeyHandle, MockCryptoKeyFactory>;
+public:
 
-        virtual ~MockCryptoKeyFactory(){}
+    using AESGCMGMAC_ParticipantCryptoHandle = HandleImpl<ParticipantKeyHandle, MockCryptoKeyFactory>;
 
-        MOCK_METHOD5(register_local_participant, std::shared_ptr<ParticipantCryptoHandle> (
+    virtual ~MockCryptoKeyFactory()
+    {
+    }
+
+    MOCK_METHOD5(register_local_participant, std::shared_ptr<ParticipantCryptoHandle> (
                 const IdentityHandle&,
                 const PermissionsHandle&,
                 const PropertySeq&,
                 const ParticipantSecurityAttributes&,
                 SecurityException&));
 
-        MOCK_METHOD5(register_matched_remote_participant, std::shared_ptr<ParticipantCryptoHandle> (
+    MOCK_METHOD5(register_matched_remote_participant, std::shared_ptr<ParticipantCryptoHandle> (
                 const ParticipantCryptoHandle&,
                 const IdentityHandle&,
                 const PermissionsHandle&,
                 const SecretHandle&,
                 SecurityException&));
 
-        MOCK_METHOD4(register_local_datawriter, DatawriterCryptoHandle* (
+    MOCK_METHOD4(register_local_datawriter, DatawriterCryptoHandle * (
                 ParticipantCryptoHandle&,
                 const PropertySeq&,
                 const EndpointSecurityAttributes&,
-                SecurityException&));
+                SecurityException &));
 
-        MOCK_METHOD5(register_matched_remote_datareader, DatareaderCryptoHandle* (
+    MOCK_METHOD5(register_matched_remote_datareader, DatareaderCryptoHandle * (
                 DatawriterCryptoHandle&,
                 ParticipantCryptoHandle&,
                 const SecretHandle&,
                 const bool,
-                SecurityException&));
+                SecurityException &));
 
-        MOCK_METHOD4(register_local_datareader, DatareaderCryptoHandle* (
+    MOCK_METHOD4(register_local_datareader, DatareaderCryptoHandle * (
                 ParticipantCryptoHandle&,
                 const PropertySeq&,
                 const EndpointSecurityAttributes&,
-                SecurityException&));
+                SecurityException &));
 
-        MOCK_METHOD4(register_matched_remote_datawriter, DatawriterCryptoHandle* (
+    MOCK_METHOD4(register_matched_remote_datawriter, DatawriterCryptoHandle * (
                 DatareaderCryptoHandle&,
                 ParticipantCryptoHandle&,
                 const SecretHandle&,
-                SecurityException&));
+                SecurityException &));
 
-        MOCK_METHOD2(unregister_participant, bool (
+    MOCK_METHOD2(unregister_participant, bool (
                 std::shared_ptr<ParticipantCryptoHandle>&,
-                SecurityException&));
+                SecurityException &));
 
-        MOCK_METHOD2(unregister_datawriter, bool (
+    MOCK_METHOD2(unregister_datawriter, bool (
                 DatawriterCryptoHandle*,
-                SecurityException&));
+                SecurityException &));
 
-        MOCK_METHOD2(unregister_datareader, bool (
+    MOCK_METHOD2(unregister_datareader, bool (
                 DatareaderCryptoHandle*,
-                SecurityException&));
+                SecurityException &));
 
-        MOCK_METHOD2(unregister_datawriter, bool (
+    MOCK_METHOD2(unregister_datawriter, bool (
                 std::shared_ptr<DatawriterCryptoHandle>&,
-                SecurityException&));
+                SecurityException &));
 
-        MOCK_METHOD2(unregister_datareader, bool (
+    MOCK_METHOD2(unregister_datareader, bool (
                 std::shared_ptr<DatareaderCryptoHandle>&,
-                SecurityException&));
+                SecurityException &));
 
-        std::shared_ptr<ParticipantCryptoHandle> get_dummy_participant_handle() const
-        {
-            // create ad hoc deleter because this object can only be created/release from the friend factory
-            auto p = new (std::nothrow) AESGCMGMAC_ParticipantCryptoHandle;
-            return std::dynamic_pointer_cast<ParticipantCryptoHandle>(
-                    std::shared_ptr<AESGCMGMAC_ParticipantCryptoHandle>(p,
-                        [](AESGCMGMAC_ParticipantCryptoHandle* p)
-                        {
-                            delete p;
-                        }));
-        }
+    std::shared_ptr<ParticipantCryptoHandle> get_dummy_participant_handle() const
+    {
+        // create ad hoc deleter because this object can only be created/release from the friend factory
+        auto p = new (std::nothrow) AESGCMGMAC_ParticipantCryptoHandle;
+        return std::dynamic_pointer_cast<ParticipantCryptoHandle>(
+            std::shared_ptr<AESGCMGMAC_ParticipantCryptoHandle>(p,
+            [](AESGCMGMAC_ParticipantCryptoHandle* p)
+            {
+                delete p;
+            }));
+    }
+
 };
 
 } //namespace security

--- a/test/mock/rtps/SecurityPluginFactory/rtps/security/MockCryptoTransform.h
+++ b/test/mock/rtps/SecurityPluginFactory/rtps/security/MockCryptoTransform.h
@@ -44,21 +44,21 @@ class MockCryptoTransform : public CryptoTransform
                 CDRMessage_t&,
                 const CDRMessage_t&,
                 DatawriterCryptoHandle&,
-                std::vector<DatareaderCryptoHandle*>&,
+                std::vector<std::shared_ptr<DatareaderCryptoHandle>>&,
                 SecurityException&));
 
         MOCK_METHOD5(encode_datareader_submessage, bool (
                 CDRMessage_t&,
                 const CDRMessage_t&,
                 DatareaderCryptoHandle&,
-                std::vector<DatawriterCryptoHandle*>&,
+                std::vector<std::shared_ptr<DatawriterCryptoHandle>>&,
                 SecurityException &exception));
 
         MOCK_METHOD5(encode_rtps_message, bool (
                 CDRMessage_t&,
                 const CDRMessage_t&,
                 ParticipantCryptoHandle&,
-                std::vector<ParticipantCryptoHandle*>&,
+                std::vector<std::shared_ptr<ParticipantCryptoHandle>>&,
                 SecurityException&));
 
         MOCK_METHOD5(decode_rtps_message, bool (

--- a/test/mock/rtps/SecurityPluginFactory/rtps/security/MockCryptoTransform.h
+++ b/test/mock/rtps/SecurityPluginFactory/rtps/security/MockCryptoTransform.h
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /*!
- * @file MockCryptoTransform.h	
+ * @file MockCryptoTransform.h
  */
 #ifndef _RTPS_SECURITY_MOCKCRYPTOTRANSFORM_H_
 #define _RTPS_SECURITY_MOCKCRYPTOTRANSFORM_H_
@@ -29,81 +29,96 @@ namespace security {
 
 class MockCryptoTransform : public CryptoTransform
 {
-    public:
+public:
 
-        virtual ~MockCryptoTransform(){}
+    virtual ~MockCryptoTransform()
+    {
+    }
 
-        MOCK_METHOD5(encode_serialized_payload, bool (
+    MOCK_METHOD5(encode_serialized_payload, bool (
                 SerializedPayload_t&,
                 std::vector<uint8_t>&,
                 const SerializedPayload_t&,
                 DatawriterCryptoHandle&,
-                SecurityException&));
+                SecurityException &));
 
-        MOCK_METHOD5(encode_datawriter_submessage, bool (
+    MOCK_METHOD5(encode_datawriter_submessage, bool (
                 CDRMessage_t&,
                 const CDRMessage_t&,
                 DatawriterCryptoHandle&,
                 std::vector<std::shared_ptr<DatareaderCryptoHandle>>&,
-                SecurityException&));
+                SecurityException &));
 
-        MOCK_METHOD5(encode_datareader_submessage, bool (
+    MOCK_METHOD5(encode_datareader_submessage, bool (
                 CDRMessage_t&,
                 const CDRMessage_t&,
                 DatareaderCryptoHandle&,
                 std::vector<std::shared_ptr<DatawriterCryptoHandle>>&,
-                SecurityException &exception));
+                SecurityException & exception));
 
-        MOCK_METHOD5(encode_rtps_message, bool (
+    MOCK_METHOD5(encode_rtps_message, bool (
                 CDRMessage_t&,
                 const CDRMessage_t&,
                 ParticipantCryptoHandle&,
                 std::vector<std::shared_ptr<ParticipantCryptoHandle>>&,
-                SecurityException&));
+                SecurityException &));
 
-        MOCK_METHOD5(decode_rtps_message, bool (
+    MOCK_METHOD5(decode_rtps_message, bool (
                 CDRMessage_t&,
                 const CDRMessage_t&,
                 const ParticipantCryptoHandle&,
                 const ParticipantCryptoHandle&,
-                SecurityException&));
+                SecurityException &));
 
-        MOCK_METHOD7(preprocess_secure_submsg, bool (
-                DatawriterCryptoHandle**,
-                DatareaderCryptoHandle**,
+    MOCK_METHOD7(preprocess_secure_submsg, bool (
+                DatawriterCryptoHandle * *,
+                DatareaderCryptoHandle * *,
                 SecureSubmessageCategory_t&,
                 const CDRMessage_t&,
                 ParticipantCryptoHandle&,
                 ParticipantCryptoHandle&,
-                SecurityException&));
+                SecurityException &));
 
-        MOCK_METHOD5(decode_datawriter_submessage, bool (
+    MOCK_METHOD5(decode_datawriter_submessage, bool (
                 CDRMessage_t&,
                 CDRMessage_t&,
                 DatareaderCryptoHandle&,
                 DatawriterCryptoHandle&,
-                SecurityException&));
+                SecurityException &));
 
-        MOCK_METHOD5(decode_datareader_submessage, bool (
+    MOCK_METHOD5(decode_datareader_submessage, bool (
                 CDRMessage_t&,
                 CDRMessage_t&,
                 DatawriterCryptoHandle&,
                 DatareaderCryptoHandle&,
-                SecurityException&));
+                SecurityException &));
 
-        MOCK_METHOD6(decode_serialized_payload, bool (
+    MOCK_METHOD6(decode_serialized_payload, bool (
                 SerializedPayload_t&,
                 const SerializedPayload_t&,
                 const std::vector<uint8_t>&,
                 DatareaderCryptoHandle&,
                 DatawriterCryptoHandle&,
-                SecurityException&));
+                SecurityException &));
 
-        uint32_t calculate_extra_size_for_rtps_message(uint32_t /*number_discovered_participants*/) const { return 0; };
+    uint32_t calculate_extra_size_for_rtps_message(
+            uint32_t /*number_discovered_participants*/) const
+    {
+        return 0;
+    }
 
-        uint32_t calculate_extra_size_for_rtps_submessage(uint32_t /*number_discovered_readers*/) const { return 0; };
+    uint32_t calculate_extra_size_for_rtps_submessage(
+            uint32_t /*number_discovered_readers*/) const
+    {
+        return 0;
+    }
 
-        uint32_t calculate_extra_size_for_encoded_payload(uint32_t /*number_discovered_readers*/) const { return 0; };
+    uint32_t calculate_extra_size_for_encoded_payload(
+            uint32_t /*number_discovered_readers*/) const
+    {
+        return 0;
+    }
+
 };
 
 } //namespace security

--- a/test/mock/rtps/SecurityPluginFactory/rtps/security/MockCryptographyPlugin.h
+++ b/test/mock/rtps/SecurityPluginFactory/rtps/security/MockCryptographyPlugin.h
@@ -34,11 +34,19 @@ class MockCryptographyPlugin : public Cryptography
 {
 public:
 
-    MockCryptographyPlugin()
+    CryptoKeyExchange* cryptokeyexchange() override
     {
-        m_cryptokeyfactory = &cryptokeyfactory_;
-        m_cryptokeyexchange = &cryptokeyexchange_;
-        m_cryptotransform = &cryptotransform_;
+        return &cryptokeyexchange_;
+    }
+
+    CryptoKeyFactory* cryptokeyfactory() override
+    {
+        return &cryptokeyfactory_;
+    }
+
+    CryptoTransform* cryptotransform() override
+    {
+        return &cryptotransform_;
     }
 
     MockCryptoKeyFactory cryptokeyfactory_;

--- a/test/unittest/rtps/security/CMakeLists.txt
+++ b/test/unittest/rtps/security/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SOURCES_SECURITY_TEST_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/security/SecurityManager.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/security/exceptions/SecurityException.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/utils/TimedConditionVariable.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/security/cryptography/AESGCMGMAC_Types.cpp
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/SecurityPluginFactory/rtps/security/SecurityPluginFactory.cpp
     )
 

--- a/test/unittest/rtps/security/SecurityInitializationTests.cpp
+++ b/test/unittest/rtps/security/SecurityInitializationTests.cpp
@@ -27,7 +27,6 @@ TEST_F(SecurityTest, initialization_auth_nullptr)
     security_activated_ = manager_.init(security_attributes_, participant_properties_);
     ASSERT_TRUE(security_activated_);
     ASSERT_TRUE(manager_.is_security_initialized());
-    ASSERT_TRUE(!security_activated_ || manager_.create_entities());
 }
 
 TEST_F(SecurityTest, initialization_auth_failed)

--- a/test/unittest/rtps/security/SecurityInitializationTests.cpp
+++ b/test/unittest/rtps/security/SecurityInitializationTests.cpp
@@ -61,15 +61,15 @@ TEST_F(SecurityTest, initialization_fail_participant_stateless_message_writer)
 {
     DefaultValue<const GUID_t&>::Set(guid);
     DefaultValue<const ParticipantSecurityAttributes&>::Set(security_attributes_);
-    MockParticipantCryptoHandle local_participant_crypto_handle;
+    auto local_participant_crypto_handle = get_sh_ptr<MockParticipantCryptoHandle>();
 
     EXPECT_CALL(*auth_plugin_, validate_local_identity(_, _, _, _, _, _)).Times(1).
             WillOnce(DoAll(SetArgPointee<0>(&local_identity_handle_), Return(ValidationResult_t::VALIDATION_OK)));
     EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
             register_local_participant(Ref(local_identity_handle_), _, _, _, _)).Times(1).
-            WillOnce(Return(&local_participant_crypto_handle));
+            WillOnce(Return(local_participant_crypto_handle));
     EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
-            unregister_participant(&local_participant_crypto_handle, _)).Times(1).
+            unregister_participant(local_participant_crypto_handle, _)).Times(1).
             WillOnce(Return(true));
     EXPECT_CALL(participant_, createWriter_mock(_, _, _, _, _, _)).Times(1).
             WillOnce(Return(false));
@@ -84,16 +84,16 @@ TEST_F(SecurityTest, initialization_fail_participant_stateless_message_reader)
 {
     DefaultValue<const GUID_t&>::Set(guid);
     DefaultValue<const ParticipantSecurityAttributes&>::Set(security_attributes_);
-    MockParticipantCryptoHandle local_participant_crypto_handle;
+    auto local_participant_crypto_handle = get_sh_ptr<MockParticipantCryptoHandle>();
     NiceMock<StatelessWriter>* stateless_writer = new NiceMock<StatelessWriter>(&participant_);
 
     EXPECT_CALL(*auth_plugin_, validate_local_identity(_, _, _, _, _, _)).Times(1).
             WillOnce(DoAll(SetArgPointee<0>(&local_identity_handle_), Return(ValidationResult_t::VALIDATION_OK)));
     EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
             register_local_participant(Ref(local_identity_handle_), _, _, _, _)).Times(1).
-            WillOnce(Return(&local_participant_crypto_handle));
+            WillOnce(Return(local_participant_crypto_handle));
     EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
-            unregister_participant(&local_participant_crypto_handle, _)).Times(1).
+            unregister_participant(local_participant_crypto_handle, _)).Times(1).
             WillOnce(Return(true));
     EXPECT_CALL(participant_, createWriter_mock(_, _, _, _, _, _)).Times(1).
             WillOnce(DoAll(SetArgPointee<0>(stateless_writer), Return(true)));
@@ -110,7 +110,7 @@ TEST_F(SecurityTest, initialization_fail_participant_volatile_message_writer)
 {
     DefaultValue<const GUID_t&>::Set(guid);
     DefaultValue<const ParticipantSecurityAttributes&>::Set(security_attributes_);
-    MockParticipantCryptoHandle local_participant_crypto_handle;
+    auto local_participant_crypto_handle = get_sh_ptr<MockParticipantCryptoHandle>();
     NiceMock<StatelessWriter>* stateless_writer = new NiceMock<StatelessWriter>(&participant_);
     NiceMock<StatelessReader>* stateless_reader = new NiceMock<StatelessReader>();
 
@@ -118,9 +118,9 @@ TEST_F(SecurityTest, initialization_fail_participant_volatile_message_writer)
             WillOnce(DoAll(SetArgPointee<0>(&local_identity_handle_), Return(ValidationResult_t::VALIDATION_OK)));
     EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
             register_local_participant(Ref(local_identity_handle_), _, _, _, _)).Times(1).
-            WillOnce(Return(&local_participant_crypto_handle));
+            WillOnce(Return(local_participant_crypto_handle));
     EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
-            unregister_participant(&local_participant_crypto_handle, _)).Times(1).
+            unregister_participant(local_participant_crypto_handle, _)).Times(1).
             WillOnce(Return(true));
     EXPECT_CALL(participant_, createWriter_mock(_, _, _, _, _, _)).Times(2).
             WillOnce(DoAll(SetArgPointee<0>(stateless_writer), Return(true))).
@@ -138,7 +138,7 @@ TEST_F(SecurityTest, initialization_fail_participant_volatile_message_reader)
 {
     DefaultValue<const GUID_t&>::Set(guid);
     DefaultValue<const ParticipantSecurityAttributes&>::Set(security_attributes_);
-    MockParticipantCryptoHandle local_participant_crypto_handle;
+    auto local_participant_crypto_handle = get_sh_ptr<MockParticipantCryptoHandle>();
     NiceMock<StatelessWriter>* stateless_writer = new NiceMock<StatelessWriter>(&participant_);
     NiceMock<StatelessReader>* stateless_reader = new NiceMock<StatelessReader>();
     NiceMock<StatefulWriter>* volatile_writer = new NiceMock<StatefulWriter>(&participant_);
@@ -147,9 +147,9 @@ TEST_F(SecurityTest, initialization_fail_participant_volatile_message_reader)
             WillOnce(DoAll(SetArgPointee<0>(&local_identity_handle_), Return(ValidationResult_t::VALIDATION_OK)));
     EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
             register_local_participant(Ref(local_identity_handle_), _, _, _, _)).Times(1).
-            WillOnce(Return(&local_participant_crypto_handle));
+            WillOnce(Return(local_participant_crypto_handle));
     EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
-            unregister_participant(&local_participant_crypto_handle, _)).Times(1).
+            unregister_participant(local_participant_crypto_handle, _)).Times(1).
             WillOnce(Return(true));
     EXPECT_CALL(participant_, createWriter_mock(_, _, _, _, _, _)).Times(2).
             WillOnce(DoAll(SetArgPointee<0>(stateless_writer), Return(true))).
@@ -168,7 +168,7 @@ TEST_F(SecurityTest, initialization_auth_retry)
 {
     DefaultValue<const GUID_t&>::Set(guid);
     DefaultValue<const ParticipantSecurityAttributes&>::Set(security_attributes_);
-    MockParticipantCryptoHandle local_participant_crypto_handle;
+    auto local_participant_crypto_handle = get_sh_ptr<MockParticipantCryptoHandle>();
     NiceMock<StatelessWriter>* stateless_writer = new NiceMock<StatelessWriter>(&participant_);
     NiceMock<StatelessReader>* stateless_reader = new NiceMock<StatelessReader>();
     NiceMock<StatefulWriter>* volatile_writer = new NiceMock<StatefulWriter>(&participant_);
@@ -179,9 +179,9 @@ TEST_F(SecurityTest, initialization_auth_retry)
             WillOnce(DoAll(SetArgPointee<0>(&local_identity_handle_), Return(ValidationResult_t::VALIDATION_OK)));
     EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
             register_local_participant(Ref(local_identity_handle_), _, _, _, _)).Times(1).
-            WillOnce(Return(&local_participant_crypto_handle));
+            WillOnce(Return(local_participant_crypto_handle));
     EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
-            unregister_participant(&local_participant_crypto_handle, _)).Times(1).
+            unregister_participant(local_participant_crypto_handle, _)).Times(1).
             WillOnce(Return(true));
     EXPECT_CALL(participant_, createWriter_mock(_, _, _, _, _, _)).Times(2).
             WillOnce(DoAll(SetArgPointee<0>(stateless_writer), Return(true))).

--- a/test/unittest/rtps/security/SecurityInitializationTests.cpp
+++ b/test/unittest/rtps/security/SecurityInitializationTests.cpp
@@ -33,8 +33,8 @@ TEST_F(SecurityTest, initialization_auth_failed)
 {
     DefaultValue<const GUID_t&>::Set(guid);
 
-    EXPECT_CALL(*auth_plugin_, validate_local_identity(_,_,_,_,_,_)).Times(1).
-        WillOnce(Return(ValidationResult_t::VALIDATION_FAILED));
+    EXPECT_CALL(*auth_plugin_, validate_local_identity(_, _, _, _, _, _)).Times(1).
+            WillOnce(Return(ValidationResult_t::VALIDATION_FAILED));
 
     security_activated_ = manager_.init(security_attributes_, participant_properties_);
     ASSERT_FALSE(security_activated_);
@@ -46,10 +46,11 @@ TEST_F(SecurityTest, initialization_register_local_participant_error)
     DefaultValue<const GUID_t&>::Set(guid);
     DefaultValue<const ParticipantSecurityAttributes&>::Set(security_attributes_);
 
-    EXPECT_CALL(*auth_plugin_, validate_local_identity(_,_,_,_,_,_)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&local_identity_handle_), Return(ValidationResult_t::VALIDATION_OK)));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, register_local_participant(Ref(local_identity_handle_),_,_,_,_)).Times(1).
-        WillOnce(Return(nullptr));
+    EXPECT_CALL(*auth_plugin_, validate_local_identity(_, _, _, _, _, _)).Times(1).
+            WillOnce(DoAll(SetArgPointee<0>(&local_identity_handle_), Return(ValidationResult_t::VALIDATION_OK)));
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
+            register_local_participant(Ref(local_identity_handle_), _, _, _, _)).Times(1).
+            WillOnce(Return(nullptr));
 
     security_activated_ = manager_.init(security_attributes_, participant_properties_);
     ASSERT_FALSE(security_activated_);
@@ -62,14 +63,16 @@ TEST_F(SecurityTest, initialization_fail_participant_stateless_message_writer)
     DefaultValue<const ParticipantSecurityAttributes&>::Set(security_attributes_);
     MockParticipantCryptoHandle local_participant_crypto_handle;
 
-    EXPECT_CALL(*auth_plugin_, validate_local_identity(_,_,_,_,_,_)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&local_identity_handle_), Return(ValidationResult_t::VALIDATION_OK)));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, register_local_participant(Ref(local_identity_handle_),_,_,_,_)).Times(1).
-        WillOnce(Return(&local_participant_crypto_handle));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, unregister_participant(&local_participant_crypto_handle,_)).Times(1).
-        WillOnce(Return(true));
-    EXPECT_CALL(participant_, createWriter_mock(_,_,_,_,_,_)).Times(1).
-        WillOnce(Return(false));
+    EXPECT_CALL(*auth_plugin_, validate_local_identity(_, _, _, _, _, _)).Times(1).
+            WillOnce(DoAll(SetArgPointee<0>(&local_identity_handle_), Return(ValidationResult_t::VALIDATION_OK)));
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
+            register_local_participant(Ref(local_identity_handle_), _, _, _, _)).Times(1).
+            WillOnce(Return(&local_participant_crypto_handle));
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
+            unregister_participant(&local_participant_crypto_handle, _)).Times(1).
+            WillOnce(Return(true));
+    EXPECT_CALL(participant_, createWriter_mock(_, _, _, _, _, _)).Times(1).
+            WillOnce(Return(false));
 
     security_activated_ = manager_.init(security_attributes_, participant_properties_);
     ASSERT_TRUE(security_activated_);
@@ -84,16 +87,18 @@ TEST_F(SecurityTest, initialization_fail_participant_stateless_message_reader)
     MockParticipantCryptoHandle local_participant_crypto_handle;
     NiceMock<StatelessWriter>* stateless_writer = new NiceMock<StatelessWriter>(&participant_);
 
-    EXPECT_CALL(*auth_plugin_, validate_local_identity(_,_,_,_,_,_)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&local_identity_handle_), Return(ValidationResult_t::VALIDATION_OK)));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, register_local_participant(Ref(local_identity_handle_),_,_,_,_)).Times(1).
-        WillOnce(Return(&local_participant_crypto_handle));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, unregister_participant(&local_participant_crypto_handle,_)).Times(1).
-        WillOnce(Return(true));
-    EXPECT_CALL(participant_, createWriter_mock(_,_,_,_,_,_)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(stateless_writer), Return(true)));
-    EXPECT_CALL(participant_, createReader_mock(_,_,_,_,_,_,_)).Times(1).
-        WillOnce(Return(false));
+    EXPECT_CALL(*auth_plugin_, validate_local_identity(_, _, _, _, _, _)).Times(1).
+            WillOnce(DoAll(SetArgPointee<0>(&local_identity_handle_), Return(ValidationResult_t::VALIDATION_OK)));
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
+            register_local_participant(Ref(local_identity_handle_), _, _, _, _)).Times(1).
+            WillOnce(Return(&local_participant_crypto_handle));
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
+            unregister_participant(&local_participant_crypto_handle, _)).Times(1).
+            WillOnce(Return(true));
+    EXPECT_CALL(participant_, createWriter_mock(_, _, _, _, _, _)).Times(1).
+            WillOnce(DoAll(SetArgPointee<0>(stateless_writer), Return(true)));
+    EXPECT_CALL(participant_, createReader_mock(_, _, _, _, _, _, _)).Times(1).
+            WillOnce(Return(false));
 
     security_activated_ = manager_.init(security_attributes_, participant_properties_);
     ASSERT_TRUE(security_activated_);
@@ -109,17 +114,19 @@ TEST_F(SecurityTest, initialization_fail_participant_volatile_message_writer)
     NiceMock<StatelessWriter>* stateless_writer = new NiceMock<StatelessWriter>(&participant_);
     NiceMock<StatelessReader>* stateless_reader = new NiceMock<StatelessReader>();
 
-    EXPECT_CALL(*auth_plugin_, validate_local_identity(_,_,_,_,_,_)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&local_identity_handle_), Return(ValidationResult_t::VALIDATION_OK)));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, register_local_participant(Ref(local_identity_handle_),_,_,_,_)).Times(1).
-        WillOnce(Return(&local_participant_crypto_handle));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, unregister_participant(&local_participant_crypto_handle,_)).Times(1).
-        WillOnce(Return(true));
-    EXPECT_CALL(participant_, createWriter_mock(_,_,_,_,_,_)).Times(2).
-        WillOnce(DoAll(SetArgPointee<0>(stateless_writer), Return(true))).
-        WillOnce(Return(false));
-    EXPECT_CALL(participant_, createReader_mock(_,_,_,_,_,_,_)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(stateless_reader), Return(true)));
+    EXPECT_CALL(*auth_plugin_, validate_local_identity(_, _, _, _, _, _)).Times(1).
+            WillOnce(DoAll(SetArgPointee<0>(&local_identity_handle_), Return(ValidationResult_t::VALIDATION_OK)));
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
+            register_local_participant(Ref(local_identity_handle_), _, _, _, _)).Times(1).
+            WillOnce(Return(&local_participant_crypto_handle));
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
+            unregister_participant(&local_participant_crypto_handle, _)).Times(1).
+            WillOnce(Return(true));
+    EXPECT_CALL(participant_, createWriter_mock(_, _, _, _, _, _)).Times(2).
+            WillOnce(DoAll(SetArgPointee<0>(stateless_writer), Return(true))).
+            WillOnce(Return(false));
+    EXPECT_CALL(participant_, createReader_mock(_, _, _, _, _, _, _)).Times(1).
+            WillOnce(DoAll(SetArgPointee<0>(stateless_reader), Return(true)));
 
     security_activated_ = manager_.init(security_attributes_, participant_properties_);
     ASSERT_TRUE(security_activated_);
@@ -136,18 +143,20 @@ TEST_F(SecurityTest, initialization_fail_participant_volatile_message_reader)
     NiceMock<StatelessReader>* stateless_reader = new NiceMock<StatelessReader>();
     NiceMock<StatefulWriter>* volatile_writer = new NiceMock<StatefulWriter>(&participant_);
 
-    EXPECT_CALL(*auth_plugin_, validate_local_identity(_,_,_,_,_,_)).Times(1).
-        WillOnce(DoAll(SetArgPointee<0>(&local_identity_handle_), Return(ValidationResult_t::VALIDATION_OK)));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, register_local_participant(Ref(local_identity_handle_),_,_,_,_)).Times(1).
-        WillOnce(Return(&local_participant_crypto_handle));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, unregister_participant(&local_participant_crypto_handle,_)).Times(1).
-        WillOnce(Return(true));
-    EXPECT_CALL(participant_, createWriter_mock(_,_,_,_,_,_)).Times(2).
-        WillOnce(DoAll(SetArgPointee<0>(stateless_writer), Return(true))).
-        WillOnce(DoAll(SetArgPointee<0>(volatile_writer), Return(true)));
-    EXPECT_CALL(participant_, createReader_mock(_,_,_,_,_,_,_)).Times(2).
-        WillOnce(DoAll(SetArgPointee<0>(stateless_reader), Return(true))).
-        WillOnce(Return(false));
+    EXPECT_CALL(*auth_plugin_, validate_local_identity(_, _, _, _, _, _)).Times(1).
+            WillOnce(DoAll(SetArgPointee<0>(&local_identity_handle_), Return(ValidationResult_t::VALIDATION_OK)));
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
+            register_local_participant(Ref(local_identity_handle_), _, _, _, _)).Times(1).
+            WillOnce(Return(&local_participant_crypto_handle));
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
+            unregister_participant(&local_participant_crypto_handle, _)).Times(1).
+            WillOnce(Return(true));
+    EXPECT_CALL(participant_, createWriter_mock(_, _, _, _, _, _)).Times(2).
+            WillOnce(DoAll(SetArgPointee<0>(stateless_writer), Return(true))).
+            WillOnce(DoAll(SetArgPointee<0>(volatile_writer), Return(true)));
+    EXPECT_CALL(participant_, createReader_mock(_, _, _, _, _, _, _)).Times(2).
+            WillOnce(DoAll(SetArgPointee<0>(stateless_reader), Return(true))).
+            WillOnce(Return(false));
 
     security_activated_ = manager_.init(security_attributes_, participant_properties_);
     ASSERT_TRUE(security_activated_);
@@ -165,21 +174,23 @@ TEST_F(SecurityTest, initialization_auth_retry)
     NiceMock<StatefulWriter>* volatile_writer = new NiceMock<StatefulWriter>(&participant_);
     NiceMock<StatefulReader>* volatile_reader = new NiceMock<StatefulReader>();
 
-    EXPECT_CALL(*auth_plugin_, validate_local_identity(_,_,_,_,_,_)).Times(2).
-        WillOnce(Return(ValidationResult_t::VALIDATION_PENDING_RETRY)).
-        WillOnce(DoAll(SetArgPointee<0>(&local_identity_handle_), Return(ValidationResult_t::VALIDATION_OK)));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, register_local_participant(Ref(local_identity_handle_),_,_,_,_)).Times(1).
-        WillOnce(Return(&local_participant_crypto_handle));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, unregister_participant(&local_participant_crypto_handle,_)).Times(1).
-        WillOnce(Return(true));
-    EXPECT_CALL(participant_, createWriter_mock(_,_,_,_,_,_)).Times(2).
-        WillOnce(DoAll(SetArgPointee<0>(stateless_writer), Return(true))).
-        WillOnce(DoAll(SetArgPointee<0>(volatile_writer), Return(true)));
-    EXPECT_CALL(participant_, createReader_mock(_,_,_,_,_,_,_)).Times(2).
-        WillOnce(DoAll(SetArgPointee<0>(stateless_reader), Return(true))).
-        WillOnce(DoAll(SetArgPointee<0>(volatile_reader), Return(true)));
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
-        WillOnce(Return(true));
+    EXPECT_CALL(*auth_plugin_, validate_local_identity(_, _, _, _, _, _)).Times(2).
+            WillOnce(Return(ValidationResult_t::VALIDATION_PENDING_RETRY)).
+            WillOnce(DoAll(SetArgPointee<0>(&local_identity_handle_), Return(ValidationResult_t::VALIDATION_OK)));
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
+            register_local_participant(Ref(local_identity_handle_), _, _, _, _)).Times(1).
+            WillOnce(Return(&local_participant_crypto_handle));
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
+            unregister_participant(&local_participant_crypto_handle, _)).Times(1).
+            WillOnce(Return(true));
+    EXPECT_CALL(participant_, createWriter_mock(_, _, _, _, _, _)).Times(2).
+            WillOnce(DoAll(SetArgPointee<0>(stateless_writer), Return(true))).
+            WillOnce(DoAll(SetArgPointee<0>(volatile_writer), Return(true)));
+    EXPECT_CALL(participant_, createReader_mock(_, _, _, _, _, _, _)).Times(2).
+            WillOnce(DoAll(SetArgPointee<0>(stateless_reader), Return(true))).
+            WillOnce(DoAll(SetArgPointee<0>(volatile_reader), Return(true)));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_, _)).Times(1).
+            WillOnce(Return(true));
 
     security_activated_ = manager_.init(security_attributes_, participant_properties_);
     ASSERT_TRUE(security_activated_);
@@ -190,8 +201,8 @@ TEST_F(SecurityTest, initialization_auth_retry)
 
 TEST_F(SecurityTest, initialization_ok)
 {
-    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
-        WillOnce(Return(true));
+    EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_, _)).Times(1).
+            WillOnce(Return(true));
 
     initialization_ok();
 

--- a/test/unittest/rtps/security/SecurityInitializationTests.cpp
+++ b/test/unittest/rtps/security/SecurityInitializationTests.cpp
@@ -24,7 +24,9 @@ TEST_F(SecurityTest, initialization_auth_nullptr)
     SecurityPluginFactory::release_auth_plugin();
     DefaultValue<const GUID_t&>::Set(guid);
 
-    ASSERT_TRUE(manager_.init(security_attributes_, participant_properties_, security_activated_));
+    security_activated_ = manager_.init(security_attributes_, participant_properties_);
+    ASSERT_TRUE(security_activated_);
+    ASSERT_TRUE(manager_.is_security_initialized());
     ASSERT_TRUE(!security_activated_ || manager_.create_entities());
 }
 
@@ -35,7 +37,9 @@ TEST_F(SecurityTest, initialization_auth_failed)
     EXPECT_CALL(*auth_plugin_, validate_local_identity(_,_,_,_,_,_)).Times(1).
         WillOnce(Return(ValidationResult_t::VALIDATION_FAILED));
 
-    ASSERT_FALSE(manager_.init(security_attributes_, participant_properties_, security_activated_));
+    security_activated_ = manager_.init(security_attributes_, participant_properties_);
+    ASSERT_FALSE(security_activated_);
+    ASSERT_FALSE(manager_.is_security_initialized());
 }
 
 TEST_F(SecurityTest, initialization_register_local_participant_error)
@@ -48,7 +52,9 @@ TEST_F(SecurityTest, initialization_register_local_participant_error)
     EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, register_local_participant(Ref(local_identity_handle_),_,_,_,_)).Times(1).
         WillOnce(Return(nullptr));
 
-    ASSERT_FALSE(manager_.init(security_attributes_, participant_properties_, security_activated_));
+    security_activated_ = manager_.init(security_attributes_, participant_properties_);
+    ASSERT_FALSE(security_activated_);
+    ASSERT_FALSE(manager_.is_security_initialized());
 }
 
 TEST_F(SecurityTest, initialization_fail_participant_stateless_message_writer)
@@ -66,8 +72,9 @@ TEST_F(SecurityTest, initialization_fail_participant_stateless_message_writer)
     EXPECT_CALL(participant_, createWriter_mock(_,_,_,_,_,_)).Times(1).
         WillOnce(Return(false));
 
-    ASSERT_TRUE(manager_.init(security_attributes_, participant_properties_, security_activated_));
+    security_activated_ = manager_.init(security_attributes_, participant_properties_);
     ASSERT_TRUE(security_activated_);
+    ASSERT_TRUE(manager_.is_security_initialized());
     ASSERT_FALSE(manager_.create_entities());
 }
 
@@ -89,8 +96,9 @@ TEST_F(SecurityTest, initialization_fail_participant_stateless_message_reader)
     EXPECT_CALL(participant_, createReader_mock(_,_,_,_,_,_,_)).Times(1).
         WillOnce(Return(false));
 
-    ASSERT_TRUE(manager_.init(security_attributes_, participant_properties_, security_activated_));
+    security_activated_ = manager_.init(security_attributes_, participant_properties_);
     ASSERT_TRUE(security_activated_);
+    ASSERT_TRUE(manager_.is_security_initialized());
     ASSERT_FALSE(manager_.create_entities());
 }
 
@@ -114,8 +122,9 @@ TEST_F(SecurityTest, initialization_fail_participant_volatile_message_writer)
     EXPECT_CALL(participant_, createReader_mock(_,_,_,_,_,_,_)).Times(1).
         WillOnce(DoAll(SetArgPointee<0>(stateless_reader), Return(true)));
 
-    ASSERT_TRUE(manager_.init(security_attributes_, participant_properties_, security_activated_));
+    security_activated_ = manager_.init(security_attributes_, participant_properties_);
     ASSERT_TRUE(security_activated_);
+    ASSERT_TRUE(manager_.is_security_initialized());
     ASSERT_FALSE(manager_.create_entities());
 }
 
@@ -141,8 +150,9 @@ TEST_F(SecurityTest, initialization_fail_participant_volatile_message_reader)
         WillOnce(DoAll(SetArgPointee<0>(stateless_reader), Return(true))).
         WillOnce(Return(false));
 
-    ASSERT_TRUE(manager_.init(security_attributes_, participant_properties_, security_activated_));
+    security_activated_ = manager_.init(security_attributes_, participant_properties_);
     ASSERT_TRUE(security_activated_);
+    ASSERT_TRUE(manager_.is_security_initialized());
     ASSERT_FALSE(manager_.create_entities());
 }
 
@@ -172,8 +182,10 @@ TEST_F(SecurityTest, initialization_auth_retry)
     EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
         WillOnce(Return(true));
 
-    ASSERT_TRUE(manager_.init(security_attributes_, participant_properties_, security_activated_));
-    ASSERT_TRUE(!security_activated_ || manager_.create_entities());
+    security_activated_ = manager_.init(security_attributes_, participant_properties_);
+    ASSERT_TRUE(security_activated_);
+    ASSERT_TRUE(manager_.is_security_initialized());
+    ASSERT_TRUE(manager_.create_entities());
 }
 
 

--- a/test/unittest/rtps/security/SecurityTests.cpp
+++ b/test/unittest/rtps/security/SecurityTests.cpp
@@ -39,8 +39,10 @@ void SecurityTest::initialization_ok()
             WillOnce(DoAll(SetArgPointee<0>(stateless_reader_), Return(true))).
             WillOnce(DoAll(SetArgPointee<0>(volatile_reader_), Return(true)));
 
-    ASSERT_TRUE(manager_.init(security_attributes_, participant_properties_, security_activated_));
-    ASSERT_TRUE(!security_activated_ || manager_.create_entities());
+    security_activated_ = manager_.init(security_attributes_, participant_properties_);
+    ASSERT_TRUE(security_activated_);
+    ASSERT_TRUE(manager_.is_security_initialized());
+    ASSERT_TRUE(!manager_.is_security_initialized() || manager_.create_entities());
 }
 
 void SecurityTest::initialization_auth_ok()
@@ -60,8 +62,10 @@ void SecurityTest::initialization_auth_ok()
     EXPECT_CALL(participant_, createReader_mock(_, _, _, _, _, _, _)).Times(1).
             WillOnce(DoAll(SetArgPointee<0>(stateless_reader_), Return(true)));
 
-    ASSERT_TRUE(manager_.init(security_attributes_, participant_properties_, security_activated_));
-    ASSERT_TRUE(!security_activated_ || manager_.create_entities());
+    security_activated_ = manager_.init(security_attributes_, participant_properties_);
+    ASSERT_TRUE(security_activated_);
+    ASSERT_TRUE(manager_.is_security_initialized());
+    ASSERT_TRUE(!manager_.is_security_initialized() || manager_.create_entities());
 }
 
 void SecurityTest::request_process_ok(

--- a/test/unittest/rtps/security/SecurityTests.cpp
+++ b/test/unittest/rtps/security/SecurityTests.cpp
@@ -30,7 +30,7 @@ void SecurityTest::initialization_ok()
             register_local_participant(Ref(local_identity_handle_), _, _, _, _)).Times(1).
             WillOnce(Return(&local_participant_crypto_handle_));
     EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
-            unregister_participant(&local_participant_crypto_handle_, _)).Times(1).
+            unregister_participant(local_participant_crypto_handle_, _)).Times(1).
             WillOnce(Return(true));
     EXPECT_CALL(participant_, createWriter_mock(_, _, _, _, _, _)).Times(2).
             WillOnce(DoAll(SetArgPointee<0>(stateless_writer_), Return(true))).
@@ -205,8 +205,8 @@ void SecurityTest::final_message_process_ok(
 
     HandshakeMessageToken handshake_message;
     CacheChange_t* change2 = new CacheChange_t(200);
-    MockSharedSecretHandle shared_secret_handle;
-    MockParticipantCryptoHandle participant_crypto_handle;
+    std::shared_ptr<SecretHandle> shared_secret_handle;
+    std::shared_ptr<ParticipantCryptoHandle> participant_crypto_handle;
 
     EXPECT_CALL(*auth_plugin_, process_handshake_rvr(_, _, Ref(handshake_handle_), _)).Times(1).
             WillOnce(DoAll(SetArgPointee<0>(&handshake_message),
@@ -222,7 +222,7 @@ void SecurityTest::final_message_process_ok(
     EXPECT_CALL(pdpsimple_, notifyAboveRemoteEndpoints(_)).Times(1);
     EXPECT_CALL(*auth_plugin_, get_shared_secret(Ref(handshake_handle_), _)).Times(1).
             WillOnce(Return(&shared_secret_handle));
-    EXPECT_CALL(*auth_plugin_, return_sharedsecret_handle(&shared_secret_handle, _)).Times(1).
+    EXPECT_CALL(*auth_plugin_, return_sharedsecret_handle(shared_secret_handle, _)).Times(1).
             WillRepeatedly(Return(true));
     EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
             register_matched_remote_participant(Ref(local_participant_crypto_handle_),
@@ -231,7 +231,7 @@ void SecurityTest::final_message_process_ok(
     EXPECT_CALL(crypto_plugin_->cryptokeyexchange_, create_local_participant_crypto_tokens(_,
             Ref(local_participant_crypto_handle_), Ref(participant_crypto_handle), _)).Times(1).
             WillOnce(Return(true));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, unregister_participant(&participant_crypto_handle, _)).Times(1).
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, unregister_participant(participant_crypto_handle, _)).Times(1).
             WillOnce(Return(true));
 
     ParticipantAuthenticationInfo info;

--- a/test/unittest/rtps/security/SecurityTests.cpp
+++ b/test/unittest/rtps/security/SecurityTests.cpp
@@ -42,7 +42,7 @@ void SecurityTest::initialization_ok()
     security_activated_ = manager_.init(security_attributes_, participant_properties_);
     ASSERT_TRUE(security_activated_);
     ASSERT_TRUE(manager_.is_security_initialized());
-    ASSERT_TRUE(!manager_.is_security_initialized() || manager_.create_entities());
+    ASSERT_TRUE(manager_.create_entities());
 }
 
 void SecurityTest::initialization_auth_ok()
@@ -65,7 +65,7 @@ void SecurityTest::initialization_auth_ok()
     security_activated_ = manager_.init(security_attributes_, participant_properties_);
     ASSERT_TRUE(security_activated_);
     ASSERT_TRUE(manager_.is_security_initialized());
-    ASSERT_TRUE(!manager_.is_security_initialized() || manager_.create_entities());
+    ASSERT_TRUE(manager_.create_entities());
 }
 
 void SecurityTest::request_process_ok(

--- a/test/unittest/rtps/security/SecurityTests.cpp
+++ b/test/unittest/rtps/security/SecurityTests.cpp
@@ -205,8 +205,11 @@ void SecurityTest::final_message_process_ok(
 
     HandshakeMessageToken handshake_message;
     CacheChange_t* change2 = new CacheChange_t(200);
-    std::shared_ptr<SecretHandle> shared_secret_handle;
-    std::shared_ptr<ParticipantCryptoHandle> participant_crypto_handle;
+    auto shared_secret_handle = auth_plugin_->get_dummy_shared_secret();
+
+    auto mock_crypto_factory = dynamic_cast<MockCryptoKeyFactory*>(crypto_plugin_->cryptokeyfactory());
+    assert(mock_crypto_factory != nullptr);
+    auto participant_crypto_handle = mock_crypto_factory->get_dummy_participant_handle();
 
     EXPECT_CALL(*auth_plugin_, process_handshake_rvr(_, _, Ref(handshake_handle_), _)).Times(1).
             WillOnce(DoAll(SetArgPointee<0>(&handshake_message),

--- a/test/unittest/rtps/security/SecurityTests.cpp
+++ b/test/unittest/rtps/security/SecurityTests.cpp
@@ -28,7 +28,7 @@ void SecurityTest::initialization_ok()
             WillOnce(DoAll(SetArgPointee<0>(&local_identity_handle_), Return(ValidationResult_t::VALIDATION_OK)));
     EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
             register_local_participant(Ref(local_identity_handle_), _, _, _, _)).Times(1).
-            WillOnce(Return(&local_participant_crypto_handle_));
+            WillOnce(Return(local_participant_crypto_handle_));
     EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
             unregister_participant(local_participant_crypto_handle_, _)).Times(1).
             WillOnce(Return(true));
@@ -221,15 +221,15 @@ void SecurityTest::final_message_process_ok(
     EXPECT_CALL(participant_, pdpsimple()).Times(1).WillOnce(Return(&pdpsimple_));
     EXPECT_CALL(pdpsimple_, notifyAboveRemoteEndpoints(_)).Times(1);
     EXPECT_CALL(*auth_plugin_, get_shared_secret(Ref(handshake_handle_), _)).Times(1).
-            WillOnce(Return(&shared_secret_handle));
+            WillOnce(Return(shared_secret_handle));
     EXPECT_CALL(*auth_plugin_, return_sharedsecret_handle(shared_secret_handle, _)).Times(1).
             WillRepeatedly(Return(true));
     EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
-            register_matched_remote_participant(Ref(local_participant_crypto_handle_),
-            Ref(remote_identity_handle_), _, Ref(shared_secret_handle), _)).Times(1).
-            WillOnce(Return(&participant_crypto_handle));
+            register_matched_remote_participant(Ref(*local_participant_crypto_handle_),
+            Ref(remote_identity_handle_), _, Ref(*shared_secret_handle), _)).Times(1).
+            WillOnce(Return(participant_crypto_handle));
     EXPECT_CALL(crypto_plugin_->cryptokeyexchange_, create_local_participant_crypto_tokens(_,
-            Ref(local_participant_crypto_handle_), Ref(participant_crypto_handle), _)).Times(1).
+            Ref(*local_participant_crypto_handle_), Ref(*participant_crypto_handle), _)).Times(1).
             WillOnce(Return(true));
     EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, unregister_participant(participant_crypto_handle, _)).Times(1).
             WillOnce(Return(true));

--- a/test/unittest/rtps/security/SecurityTests.hpp
+++ b/test/unittest/rtps/security/SecurityTests.hpp
@@ -37,6 +37,8 @@ using namespace eprosima::fastrtps::rtps;
 using namespace eprosima::fastrtps::rtps::security;
 using namespace ::testing;
 
+class SecurityTest;
+
 class MockIdentity
 {
 public:
@@ -44,7 +46,7 @@ public:
     static const char* const class_id_;
 };
 
-typedef HandleImpl<MockIdentity> MockIdentityHandle;
+typedef HandleImpl<MockIdentity, SecurityTest> MockIdentityHandle;
 
 class MockHandshake
 {
@@ -53,9 +55,9 @@ public:
     static const char* const class_id_;
 };
 
-typedef HandleImpl<MockHandshake> MockHandshakeHandle;
+typedef HandleImpl<MockHandshake, SecurityTest> MockHandshakeHandle;
 
-typedef HandleImpl<SharedSecret> MockSharedSecretHandle;
+typedef HandleImpl<SharedSecret, SecurityTest> MockSharedSecretHandle;
 
 class MockParticipantCrypto
 {
@@ -64,7 +66,7 @@ public:
     static const char* const class_id_;
 };
 
-typedef HandleImpl<MockParticipantCrypto> MockParticipantCryptoHandle;
+typedef HandleImpl<MockParticipantCrypto, SecurityTest> MockParticipantCryptoHandle;
 
 class SecurityTest : public ::testing::Test
 {
@@ -139,6 +141,7 @@ public:
         , participant_data_(c_default_RTPSParticipantAllocationAttributes)
         , default_cdr_message(RTPSMESSAGE_DEFAULT_SIZE)
     {
+        local_participant_crypto_handle_ = std::make_shared<MockParticipantCrypto>();
     }
 
     ~SecurityTest()
@@ -158,7 +161,7 @@ public:
     MockIdentityHandle local_identity_handle_;
     MockIdentityHandle remote_identity_handle_;
     MockHandshakeHandle handshake_handle_;
-    MockParticipantCryptoHandle local_participant_crypto_handle_;
+    std::shared_ptr<ParticipantCryptoHandle> local_participant_crypto_handle_;
     ParticipantProxyData participant_data_;
     ParticipantSecurityAttributes security_attributes_;
     PropertyPolicy participant_properties_;

--- a/test/unittest/rtps/security/SecurityTests.hpp
+++ b/test/unittest/rtps/security/SecurityTests.hpp
@@ -143,8 +143,11 @@ public:
     {
         // enforce deleter due to handle destructor protected nature
         local_participant_crypto_handle_.reset(
-                new MockParticipantCryptoHandle,
-                [](MockParticipantCryptoHandle* p) { delete p; });
+            new MockParticipantCryptoHandle,
+            [](MockParticipantCryptoHandle* p)
+            {
+                delete p;
+            });
     }
 
     ~SecurityTest()
@@ -179,7 +182,7 @@ public:
 
     // handle factory for the tests
     template<class T>
-    typename std::enable_if<std::is_base_of<Handle,T>::value, T&>::type
+    typename std::enable_if<std::is_base_of<Handle, T>::value, T&>::type
     get_handle() const
     {
         return *new T;
@@ -187,18 +190,22 @@ public:
 
     // specialization for shared_ptrs doesn't need return method
     template<class T>
-    typename std::enable_if<std::is_base_of<Handle,T>::value, std::shared_ptr<Handle>>::type
+    typename std::enable_if<std::is_base_of<Handle, T>::value, std::shared_ptr<Handle>>::type
     get_sh_ptr() const
     {
         return std::dynamic_pointer_cast<Handle>(
-                std::shared_ptr<T>(
-                    new T,
-                    [](T * p){delete p;}));
+            std::shared_ptr<T>(
+                new T,
+                [](T* p)
+                {
+                    delete p;
+                }));
     }
 
     template<class T>
-    typename std::enable_if<std::is_base_of<Handle,T>::value, void>::type
-    return_handle(T& h) const
+    typename std::enable_if<std::is_base_of<Handle, T>::value, void>::type
+    return_handle(
+            T& h) const
     {
         delete &h;
     }

--- a/test/unittest/rtps/security/SecurityValidationRemoteTests.cpp
+++ b/test/unittest/rtps/security/SecurityValidationRemoteTests.cpp
@@ -56,6 +56,8 @@ TEST_F(SecurityTest, discovered_participant_validation_remote_identity_ok)
     EXPECT_CALL(*participant_.getListener(), onParticipantAuthentication(_, info)).Times(1);
 
     ASSERT_TRUE(manager_.discovered_participant(participant_data));
+
+    return_handle(remote_identity_handle);
 }
 
 TEST_F(SecurityTest, discovered_participant_validation_remote_identity_pending_handshake_message)
@@ -75,6 +77,8 @@ TEST_F(SecurityTest, discovered_participant_validation_remote_identity_pending_h
     ParticipantProxyData participant_data;
     fill_participant_key(participant_data.m_guid);
     ASSERT_TRUE(manager_.discovered_participant(participant_data));
+
+    return_handle(remote_identity_handle);
 }
 
 TEST_F(SecurityTest, discovered_participant_validation_remote_identity_pending_handshake_request_fail)
@@ -104,6 +108,8 @@ TEST_F(SecurityTest, discovered_participant_validation_remote_identity_pending_h
     EXPECT_CALL(*participant_.getListener(), onParticipantAuthentication(_, info)).Times(1);
 
     ASSERT_FALSE(manager_.discovered_participant(participant_data));
+
+    return_handle(remote_identity_handle);
 }
 
 TEST_F(SecurityTest, discovered_participant_validation_remote_identity_pending_handshake_request_ok)

--- a/test/unittest/rtps/security/SecurityValidationRemoteTests.cpp
+++ b/test/unittest/rtps/security/SecurityValidationRemoteTests.cpp
@@ -37,7 +37,7 @@ TEST_F(SecurityTest, discovered_participant_validation_remote_identity_ok)
 {
     initialization_auth_ok();
 
-    MockIdentityHandle remote_identity_handle;
+    auto& remote_identity_handle = get_handle<MockIdentityHandle>();
     ParticipantProxyData participant_data;
     fill_participant_key(participant_data.m_guid);
 
@@ -62,7 +62,7 @@ TEST_F(SecurityTest, discovered_participant_validation_remote_identity_pending_h
 {
     initialization_ok();
 
-    MockIdentityHandle remote_identity_handle;
+    auto& remote_identity_handle = get_handle<MockIdentityHandle>();
 
     EXPECT_CALL(*auth_plugin_, validate_remote_identity_rvr(_, Ref(local_identity_handle_), _, _, _)).Times(1).
             WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle),
@@ -81,7 +81,7 @@ TEST_F(SecurityTest, discovered_participant_validation_remote_identity_pending_h
 {
     initialization_ok();
 
-    MockIdentityHandle remote_identity_handle;
+    auto& remote_identity_handle = get_handle<MockIdentityHandle>();
 
     EXPECT_CALL(*auth_plugin_, validate_remote_identity_rvr(_, Ref(local_identity_handle_), _, _, _)).Times(1).
             WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle),
@@ -110,10 +110,10 @@ TEST_F(SecurityTest, discovered_participant_validation_remote_identity_pending_h
 {
     initialization_ok();
 
-    MockIdentityHandle remote_identity_handle;
-    MockHandshakeHandle handshake_handle;
-    MockSharedSecretHandle shared_secret_handle;
-    MockParticipantCryptoHandle participant_crypto_handle;
+    auto& remote_identity_handle = get_handle<MockIdentityHandle>();
+    auto& handshake_handle = get_handle<MockHandshakeHandle>();
+    auto shared_secret_handle = get_sh_ptr<MockSharedSecretHandle>();
+    auto participant_crypto_handle = get_sh_ptr<MockParticipantCryptoHandle>();
     ParticipantProxyData participant_data;
     fill_participant_key(participant_data.m_guid);
 
@@ -134,17 +134,17 @@ TEST_F(SecurityTest, discovered_participant_validation_remote_identity_pending_h
     EXPECT_CALL(pdpsimple_, notifyAboveRemoteEndpoints(_)).Times(1);
     EXPECT_CALL(pdpsimple_, get_participant_proxy_data_serialized(BIGEND)).Times(1);
     EXPECT_CALL(*auth_plugin_, get_shared_secret(Ref(handshake_handle), _)).Times(1).
-            WillOnce(Return(&shared_secret_handle));
-    EXPECT_CALL(*auth_plugin_, return_sharedsecret_handle(&shared_secret_handle, _)).Times(1).
+            WillOnce(Return(shared_secret_handle));
+    EXPECT_CALL(*auth_plugin_, return_sharedsecret_handle(shared_secret_handle, _)).Times(1).
             WillRepeatedly(Return(true));
     EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
-            register_matched_remote_participant(Ref(local_participant_crypto_handle_),
-            Ref(remote_identity_handle), _, Ref(shared_secret_handle), _)).Times(1).
-            WillOnce(Return(&participant_crypto_handle));
+            register_matched_remote_participant(Ref(*local_participant_crypto_handle_),
+            Ref(remote_identity_handle), _, Ref(*shared_secret_handle), _)).Times(1).
+            WillOnce(Return(participant_crypto_handle));
     EXPECT_CALL(crypto_plugin_->cryptokeyexchange_, create_local_participant_crypto_tokens(_,
-            Ref(local_participant_crypto_handle_), Ref(participant_crypto_handle), _)).Times(1).
+            Ref(*local_participant_crypto_handle_), Ref(*participant_crypto_handle), _)).Times(1).
             WillOnce(Return(true));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, unregister_participant(&participant_crypto_handle, _)).Times(1).
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, unregister_participant(participant_crypto_handle, _)).Times(1).
             WillOnce(Return(true));
 
     ParticipantAuthenticationInfo info;
@@ -153,14 +153,17 @@ TEST_F(SecurityTest, discovered_participant_validation_remote_identity_pending_h
     EXPECT_CALL(*participant_.getListener(), onParticipantAuthentication(_, info)).Times(1);
 
     ASSERT_TRUE(manager_.discovered_participant(participant_data));
+
+    return_handle(remote_identity_handle);
+    return_handle(handshake_handle);
 }
 
 TEST_F(SecurityTest, discovered_participant_validation_remote_identity_new_change_fail)
 {
     initialization_ok();
 
-    MockIdentityHandle remote_identity_handle;
-    MockHandshakeHandle handshake_handle;
+    auto& remote_identity_handle = get_handle<MockIdentityHandle>();
+    auto& handshake_handle = get_handle<MockHandshakeHandle>();
     HandshakeMessageToken handshake_message;
 
     EXPECT_CALL(*auth_plugin_, validate_remote_identity_rvr(_, Ref(local_identity_handle_), _, _, _)).Times(1).
@@ -184,14 +187,17 @@ TEST_F(SecurityTest, discovered_participant_validation_remote_identity_new_chang
     ParticipantProxyData participant_data;
     fill_participant_key(participant_data.m_guid);
     ASSERT_FALSE(manager_.discovered_participant(participant_data));
+
+    return_handle(remote_identity_handle);
+    return_handle(handshake_handle);
 }
 
 TEST_F(SecurityTest, discovered_participant_validation_remote_identity_add_change_fail)
 {
     initialization_ok();
 
-    MockIdentityHandle remote_identity_handle;
-    MockHandshakeHandle handshake_handle;
+    auto& remote_identity_handle = get_handle<MockIdentityHandle>();
+    auto& handshake_handle = get_handle<MockHandshakeHandle>();
     HandshakeMessageToken handshake_message;
     CacheChange_t* change = new CacheChange_t(200);
 
@@ -220,6 +226,9 @@ TEST_F(SecurityTest, discovered_participant_validation_remote_identity_add_chang
     ASSERT_FALSE(manager_.discovered_participant(participant_data));
 
     destroy_manager_and_change(change, false);
+
+    return_handle(remote_identity_handle);
+    return_handle(handshake_handle);
 }
 
 TEST_F(SecurityTest, discovered_participant_validation_remote_identity_pending_handshake_request_pending_message)
@@ -262,12 +271,12 @@ TEST_F(SecurityTest, discovered_participant_validation_remote_identity_pending_h
 {
     initialization_ok();
 
-    MockIdentityHandle remote_identity_handle;
-    MockHandshakeHandle handshake_handle;
+    auto& remote_identity_handle = get_handle<MockIdentityHandle>();
+    auto& handshake_handle = get_handle<MockHandshakeHandle>();
     HandshakeMessageToken handshake_message;
     CacheChange_t* change = new CacheChange_t(200);
-    MockSharedSecretHandle shared_secret_handle;
-    MockParticipantCryptoHandle participant_crypto_handle;
+    auto shared_secret_handle = get_sh_ptr<MockSharedSecretHandle>();
+    auto participant_crypto_handle = get_sh_ptr<MockParticipantCryptoHandle>();
     ParticipantProxyData participant_data;
     fill_participant_key(participant_data.m_guid);
 
@@ -292,17 +301,17 @@ TEST_F(SecurityTest, discovered_participant_validation_remote_identity_pending_h
     EXPECT_CALL(pdpsimple_, notifyAboveRemoteEndpoints(_)).Times(1);
     EXPECT_CALL(pdpsimple_, get_participant_proxy_data_serialized(BIGEND)).Times(1);
     EXPECT_CALL(*auth_plugin_, get_shared_secret(Ref(handshake_handle), _)).Times(1).
-            WillOnce(Return(&shared_secret_handle));
-    EXPECT_CALL(*auth_plugin_, return_sharedsecret_handle(&shared_secret_handle, _)).Times(1).
+            WillOnce(Return(shared_secret_handle));
+    EXPECT_CALL(*auth_plugin_, return_sharedsecret_handle(shared_secret_handle, _)).Times(1).
             WillRepeatedly(Return(true));
     EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
-            register_matched_remote_participant(Ref(local_participant_crypto_handle_),
-            Ref(remote_identity_handle), _, Ref(shared_secret_handle), _)).Times(1).
-            WillOnce(Return(&participant_crypto_handle));
+            register_matched_remote_participant(Ref(*local_participant_crypto_handle_),
+            Ref(remote_identity_handle), _, Ref(*shared_secret_handle), _)).Times(1).
+            WillOnce(Return(participant_crypto_handle));
     EXPECT_CALL(crypto_plugin_->cryptokeyexchange_, create_local_participant_crypto_tokens(_,
-            Ref(local_participant_crypto_handle_), Ref(participant_crypto_handle), _)).Times(1).
+            Ref(*local_participant_crypto_handle_), Ref(*participant_crypto_handle), _)).Times(1).
             WillOnce(Return(true));
-    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, unregister_participant(&participant_crypto_handle, _)).Times(1).
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, unregister_participant(participant_crypto_handle, _)).Times(1).
             WillOnce(Return(true));
 
     ParticipantAuthenticationInfo info;
@@ -313,14 +322,17 @@ TEST_F(SecurityTest, discovered_participant_validation_remote_identity_pending_h
     ASSERT_TRUE(manager_.discovered_participant(participant_data));
 
     destroy_manager_and_change(change);
+
+    return_handle(remote_identity_handle);
+    return_handle(handshake_handle);
 }
 
 TEST_F(SecurityTest, discovered_participant_ok)
 {
     initialization_ok();
 
-    MockIdentityHandle remote_identity_handle;
-    MockHandshakeHandle handshake_handle;
+    auto& remote_identity_handle = get_handle<MockIdentityHandle>();
+    auto& handshake_handle = get_handle<MockHandshakeHandle>();
     HandshakeMessageToken handshake_message;
     CacheChange_t* change = new CacheChange_t(200);
 
@@ -349,14 +361,17 @@ TEST_F(SecurityTest, discovered_participant_ok)
     ASSERT_TRUE(manager_.discovered_participant(participant_data));
 
     destroy_manager_and_change(change);
+
+    return_handle(remote_identity_handle);
+    return_handle(handshake_handle);
 }
 
 TEST_F(SecurityTest, discovered_participant_validate_remote_fail_and_then_ok)
 {
     initialization_ok();
 
-    MockIdentityHandle remote_identity_handle;
-    MockHandshakeHandle handshake_handle;
+    auto& remote_identity_handle = get_handle<MockIdentityHandle>();
+    auto& handshake_handle = get_handle<MockHandshakeHandle>();
     HandshakeMessageToken handshake_message;
     CacheChange_t* change = new CacheChange_t(200);
 
@@ -395,4 +410,7 @@ TEST_F(SecurityTest, discovered_participant_validate_remote_fail_and_then_ok)
     ASSERT_TRUE(manager_.discovered_participant(participant_data));
 
     destroy_manager_and_change(change);
+
+    return_handle(remote_identity_handle);
+    return_handle(handshake_handle);
 }

--- a/test/unittest/security/authentication/AuthenticationPluginTests.hpp
+++ b/test/unittest/security/authentication/AuthenticationPluginTests.hpp
@@ -64,8 +64,8 @@ public:
             const eprosima::fastrtps::rtps::security::HandshakeMessageToken& message,
             const eprosima::fastrtps::rtps::security::HandshakeMessageToken& reply_message);
     static void check_shared_secrets(
-            const eprosima::fastrtps::rtps::security::SharedSecretHandle& sharedsecret1,
-            const eprosima::fastrtps::rtps::security::SharedSecretHandle& sharedsecret2);
+            const eprosima::fastrtps::rtps::security::SecretHandle& sharedsecret1,
+            const eprosima::fastrtps::rtps::security::SecretHandle& sharedsecret2);
 
     eprosima::fastrtps::rtps::security::PKIDH plugin;
 };
@@ -148,16 +148,18 @@ TEST_F(AuthenticationPluginTest, validate_local_identity_wrong_validation)
 
 TEST_F(AuthenticationPluginTest, handshake_process_ok)
 {
-    eprosima::fastrtps::rtps::security::IdentityHandle* local_identity_handle1 = nullptr;
+    using namespace eprosima::fastrtps::rtps::security;
+
+    IdentityHandle* local_identity_handle1 = nullptr;
     eprosima::fastrtps::rtps::GUID_t adjusted_participant_key1;
     eprosima::fastrtps::rtps::GUID_t adjusted_participant_key2;
     uint32_t domain_id = 0;
     eprosima::fastrtps::rtps::RTPSParticipantAttributes participant_attr;
     eprosima::fastrtps::rtps::GUID_t candidate_participant_key1;
     eprosima::fastrtps::rtps::GUID_t candidate_participant_key2;
-    eprosima::fastrtps::rtps::security::SecurityException exception;
-    eprosima::fastrtps::rtps::security::ValidationResult_t result =
-            eprosima::fastrtps::rtps::security::ValidationResult_t::VALIDATION_FAILED;
+    SecurityException exception;
+    ValidationResult_t result =
+            ValidationResult_t::VALIDATION_FAILED;
 
     participant_attr.properties = get_valid_policy();
 
@@ -168,11 +170,11 @@ TEST_F(AuthenticationPluginTest, handshake_process_ok)
                     candidate_participant_key1,
                     exception);
 
-    ASSERT_TRUE(result == eprosima::fastrtps::rtps::security::ValidationResult_t::VALIDATION_OK);
+    ASSERT_TRUE(result == ValidationResult_t::VALIDATION_OK);
     ASSERT_TRUE(local_identity_handle1 != nullptr);
     AuthenticationPluginTest::check_local_identity_handle(*local_identity_handle1);
 
-    eprosima::fastrtps::rtps::security::IdentityHandle* local_identity_handle2 = nullptr;
+    IdentityHandle* local_identity_handle2 = nullptr;
     result = plugin.validate_local_identity(&local_identity_handle2,
                     adjusted_participant_key2,
                     domain_id,
@@ -180,11 +182,11 @@ TEST_F(AuthenticationPluginTest, handshake_process_ok)
                     candidate_participant_key2,
                     exception);
 
-    ASSERT_TRUE(result == eprosima::fastrtps::rtps::security::ValidationResult_t::VALIDATION_OK);
+    ASSERT_TRUE(result == ValidationResult_t::VALIDATION_OK);
     ASSERT_TRUE(local_identity_handle2 != nullptr);
     AuthenticationPluginTest::check_local_identity_handle(*local_identity_handle2);
 
-    eprosima::fastrtps::rtps::security::IdentityHandle* remote_identity_handle1 = nullptr;
+    IdentityHandle* remote_identity_handle1 = nullptr;
     eprosima::fastrtps::rtps::IdentityToken remote_identity_token1 = generate_remote_identity_token_ok(
         *local_identity_handle1);
     eprosima::fastrtps::rtps::GUID_t remote_participant_key;
@@ -198,7 +200,7 @@ TEST_F(AuthenticationPluginTest, handshake_process_ok)
     ASSERT_TRUE(remote_identity_handle1 != nullptr);
     AuthenticationPluginTest::check_remote_identity_handle(*remote_identity_handle1);
 
-    eprosima::fastrtps::rtps::security::IdentityHandle* remote_identity_handle2 = nullptr;
+    IdentityHandle* remote_identity_handle2 = nullptr;
     eprosima::fastrtps::rtps::IdentityToken remote_identity_token2 = generate_remote_identity_token_ok(
         *local_identity_handle2);
 
@@ -211,8 +213,8 @@ TEST_F(AuthenticationPluginTest, handshake_process_ok)
     ASSERT_TRUE(remote_identity_handle2 != nullptr);
     AuthenticationPluginTest::check_remote_identity_handle(*remote_identity_handle2);
 
-    eprosima::fastrtps::rtps::security::HandshakeHandle* handshake_handle = nullptr;
-    eprosima::fastrtps::rtps::security::HandshakeMessageToken* handshake_message = nullptr;
+    HandshakeHandle* handshake_handle = nullptr;
+    HandshakeMessageToken* handshake_message = nullptr;
     eprosima::fastrtps::rtps::ParticipantProxyData participant_data1(eprosima::fastrtps::rtps::
             c_default_RTPSParticipantAllocationAttributes);
     participant_data1.m_guid = adjusted_participant_key1;
@@ -227,13 +229,13 @@ TEST_F(AuthenticationPluginTest, handshake_process_ok)
                     auxMsg,
                     exception);
 
-    ASSERT_TRUE(result == eprosima::fastrtps::rtps::security::ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE);
+    ASSERT_TRUE(result == ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE);
     ASSERT_TRUE(handshake_handle != nullptr);
     ASSERT_TRUE(handshake_message != nullptr);
     check_handshake_request_message(*handshake_handle, *handshake_message);
 
-    eprosima::fastrtps::rtps::security::HandshakeHandle* handshake_handle_reply = nullptr;
-    eprosima::fastrtps::rtps::security::HandshakeMessageToken* handshake_message_reply = nullptr;
+    HandshakeHandle* handshake_handle_reply = nullptr;
+    HandshakeMessageToken* handshake_message_reply = nullptr;
     eprosima::fastrtps::rtps::ParticipantProxyData participant_data2(eprosima::fastrtps::rtps::
             c_default_RTPSParticipantAllocationAttributes);
     participant_data2.m_guid = adjusted_participant_key2;
@@ -245,48 +247,51 @@ TEST_F(AuthenticationPluginTest, handshake_process_ok)
 
     result = plugin.begin_handshake_reply(&handshake_handle_reply,
                     &handshake_message_reply,
-                    eprosima::fastrtps::rtps::security::HandshakeMessageToken(*handshake_message),
+                    HandshakeMessageToken(*handshake_message),
                     *remote_identity_handle2,
                     *local_identity_handle2,
                     auxMsg,
                     exception);
 
-    ASSERT_TRUE(result == eprosima::fastrtps::rtps::security::ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE);
+    ASSERT_TRUE(result == ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE);
     ASSERT_TRUE(handshake_handle_reply != nullptr);
     ASSERT_TRUE(handshake_message_reply != nullptr);
     check_handshake_reply_message(*handshake_handle_reply, *handshake_message_reply, *handshake_message);
 
-    eprosima::fastrtps::rtps::security::HandshakeMessageToken* handshake_message_final = nullptr;
+    HandshakeMessageToken* handshake_message_final = nullptr;
 
     result = plugin.process_handshake(&handshake_message_final,
-                    eprosima::fastrtps::rtps::security::HandshakeMessageToken(*handshake_message_reply),
+                    HandshakeMessageToken(*handshake_message_reply),
                     *handshake_handle,
                     exception);
 
-    ASSERT_TRUE(result == eprosima::fastrtps::rtps::security::ValidationResult_t::VALIDATION_OK_WITH_FINAL_MESSAGE);
+    ASSERT_TRUE(result == ValidationResult_t::VALIDATION_OK_WITH_FINAL_MESSAGE);
     ASSERT_TRUE(handshake_message_final != nullptr);
     check_handshake_final_message(*handshake_handle, *handshake_message_final, *handshake_message_reply);
 
-    eprosima::fastrtps::rtps::security::HandshakeMessageToken* handshake_message_aux = nullptr;
+    HandshakeMessageToken* handshake_message_aux = nullptr;
 
     result = plugin.process_handshake(&handshake_message_aux,
-                    eprosima::fastrtps::rtps::security::HandshakeMessageToken(*handshake_message_final),
+                    HandshakeMessageToken(*handshake_message_final),
                     *handshake_handle_reply,
                     exception);
 
-    ASSERT_TRUE(result == eprosima::fastrtps::rtps::security::ValidationResult_t::VALIDATION_OK);
+    ASSERT_TRUE(result == ValidationResult_t::VALIDATION_OK);
 
-    eprosima::fastrtps::rtps::security::SharedSecretHandle* sharedsecret1 = plugin.get_shared_secret(*handshake_handle,
-                    exception);
-    ASSERT_TRUE(sharedsecret1 != nullptr);
+    std::shared_ptr<SecretHandle> secret1 = plugin.get_shared_secret(*handshake_handle, exception);
+    ASSERT_TRUE(secret1);
+    auto sharedsecret1 = std::dynamic_pointer_cast<SharedSecretHandle>(secret1);
+    ASSERT_TRUE(sharedsecret1);
 
-    eprosima::fastrtps::rtps::security::SharedSecretHandle* sharedsecret2 = plugin.get_shared_secret(
-        *handshake_handle_reply, exception);
-    ASSERT_TRUE(sharedsecret2 != nullptr);
+    std::shared_ptr<SecretHandle> secret2 = plugin.get_shared_secret(*handshake_handle_reply, exception);
+    ASSERT_TRUE(secret2);
+    auto sharedsecret2 = std::dynamic_pointer_cast<SharedSecretHandle>(secret2);
+    ASSERT_TRUE(sharedsecret2);
+
     check_shared_secrets(*sharedsecret1, *sharedsecret2);
 
-    ASSERT_TRUE(plugin.return_sharedsecret_handle(sharedsecret2, exception));
-    ASSERT_TRUE(plugin.return_sharedsecret_handle(sharedsecret1, exception));
+    ASSERT_TRUE(plugin.return_sharedsecret_handle(secret2, exception));
+    ASSERT_TRUE(plugin.return_sharedsecret_handle(secret1, exception));
     ASSERT_TRUE(plugin.return_handshake_handle(handshake_handle_reply, exception));
     ASSERT_TRUE(plugin.return_handshake_handle(handshake_handle, exception));
     ASSERT_TRUE(plugin.return_identity_handle(remote_identity_handle2, exception));

--- a/test/unittest/security/authentication/AuthenticationPluginTests.hpp
+++ b/test/unittest/security/authentication/AuthenticationPluginTests.hpp
@@ -216,7 +216,7 @@ TEST_F(AuthenticationPluginTest, handshake_process_ok)
     HandshakeHandle* handshake_handle = nullptr;
     HandshakeMessageToken* handshake_message = nullptr;
     eprosima::fastrtps::rtps::ParticipantProxyData participant_data1(eprosima::fastrtps::rtps::
-            c_default_RTPSParticipantAllocationAttributes);
+                    c_default_RTPSParticipantAllocationAttributes);
     participant_data1.m_guid = adjusted_participant_key1;
     eprosima::fastrtps::rtps::CDRMessage_t auxMsg(RTPSMESSAGE_DEFAULT_SIZE);
     auxMsg.msg_endian = eprosima::fastrtps::rtps::BIGEND;
@@ -237,7 +237,7 @@ TEST_F(AuthenticationPluginTest, handshake_process_ok)
     HandshakeHandle* handshake_handle_reply = nullptr;
     HandshakeMessageToken* handshake_message_reply = nullptr;
     eprosima::fastrtps::rtps::ParticipantProxyData participant_data2(eprosima::fastrtps::rtps::
-            c_default_RTPSParticipantAllocationAttributes);
+                    c_default_RTPSParticipantAllocationAttributes);
     participant_data2.m_guid = adjusted_participant_key2;
 
     auxMsg.length = 0;

--- a/test/unittest/security/authentication/BuiltinPKIDHTests.cpp
+++ b/test/unittest/security/authentication/BuiltinPKIDHTests.cpp
@@ -379,22 +379,22 @@ void AuthenticationPluginTest::check_handshake_final_message(
 }
 
 void AuthenticationPluginTest::check_shared_secrets(
-        const SharedSecretHandle& sharedsecret1,
-        const SharedSecretHandle& sharedsecret2)
+        const SecretHandle& sharedsecret1,
+        const SecretHandle& sharedsecret2)
 {
-    const std::vector<uint8_t>* challenge1_1 = SharedSecretHelper::find_data_value(**sharedsecret1, "Challenge1");
+    const std::vector<uint8_t>* challenge1_1 = SharedSecretHelper::find_data_value(sharedsecret1, "Challenge1");
     ASSERT_TRUE(challenge1_1 != nullptr);
-    const std::vector<uint8_t>* challenge1_2 = SharedSecretHelper::find_data_value(**sharedsecret2, "Challenge1");
+    const std::vector<uint8_t>* challenge1_2 = SharedSecretHelper::find_data_value(sharedsecret2, "Challenge1");
     ASSERT_TRUE(challenge1_2 != nullptr);
     ASSERT_TRUE(*challenge1_1 == *challenge1_2);
-    const std::vector<uint8_t>* challenge2_1 = SharedSecretHelper::find_data_value(**sharedsecret1, "Challenge2");
+    const std::vector<uint8_t>* challenge2_1 = SharedSecretHelper::find_data_value(sharedsecret1, "Challenge2");
     ASSERT_TRUE(challenge2_1 != nullptr);
-    const std::vector<uint8_t>* challenge2_2 = SharedSecretHelper::find_data_value(**sharedsecret2, "Challenge2");
+    const std::vector<uint8_t>* challenge2_2 = SharedSecretHelper::find_data_value(sharedsecret2, "Challenge2");
     ASSERT_TRUE(challenge2_2 != nullptr);
     ASSERT_TRUE(*challenge2_1 == *challenge2_2);
-    const std::vector<uint8_t>* sharedsecret_1 = SharedSecretHelper::find_data_value(**sharedsecret1, "SharedSecret");
+    const std::vector<uint8_t>* sharedsecret_1 = SharedSecretHelper::find_data_value(sharedsecret1, "SharedSecret");
     ASSERT_TRUE(sharedsecret_1 != nullptr);
-    const std::vector<uint8_t>* sharedsecret_2 = SharedSecretHelper::find_data_value(**sharedsecret2, "SharedSecret");
+    const std::vector<uint8_t>* sharedsecret_2 = SharedSecretHelper::find_data_value(sharedsecret2, "SharedSecret");
     ASSERT_TRUE(sharedsecret_2 != nullptr);
     ASSERT_TRUE(*sharedsecret_1 == *sharedsecret_2);
 }

--- a/test/unittest/security/cryptography/CMakeLists.txt
+++ b/test/unittest/security/cryptography/CMakeLists.txt
@@ -27,14 +27,14 @@ set(COMMON_SOURCES_CRYPTO_PLUGIN_TEST_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/exceptions/Exception.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/security/exceptions/SecurityException.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/security/common/SharedSecretHandle.cpp
-    )
-
-add_executable(BuiltinAESGCMGMAC ${COMMON_SOURCES_CRYPTO_PLUGIN_TEST_SOURCE}
     ${PROJECT_SOURCE_DIR}/src/cpp/security/cryptography/AESGCMGMAC.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/security/cryptography/AESGCMGMAC_KeyExchange.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/security/cryptography/AESGCMGMAC_KeyFactory.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/security/cryptography/AESGCMGMAC_Transform.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/security/cryptography/AESGCMGMAC_Types.cpp
+    )
+
+add_executable(BuiltinAESGCMGMAC ${COMMON_SOURCES_CRYPTO_PLUGIN_TEST_SOURCE}
     ${PROJECT_SOURCE_DIR}/src/cpp/security/authentication/PKIIdentityHandle.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/security/accesscontrol/AccessPermissionsHandle.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/builtinAESGCMGMACTests.cpp)
@@ -43,18 +43,17 @@ target_compile_definitions(BuiltinAESGCMGMAC PRIVATE FASTRTPS_NO_LIB
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
+
 target_include_directories(BuiltinAESGCMGMAC PRIVATE
     ${OPENSSL_INCLUDE_DIR}
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/SecurityPluginFactory/rtps
     ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
     ${PROJECT_SOURCE_DIR}/src/cpp
     )
+
 target_link_libraries(BuiltinAESGCMGMAC fastcdr GTest::gmock ${OPENSSL_LIBRARIES})
+
 add_gtest(BuiltinAESGCMGMAC SOURCES ${COMMON_SOURCES_CRYPTO_PLUGIN_TEST_SOURCE}
-    ${PROJECT_SOURCE_DIR}/src/cpp/security/cryptography/AESGCMGMAC.cpp
-    ${PROJECT_SOURCE_DIR}/src/cpp/security/cryptography/AESGCMGMAC_KeyExchange.cpp
-    ${PROJECT_SOURCE_DIR}/src/cpp/security/cryptography/AESGCMGMAC_KeyFactory.cpp
-    ${PROJECT_SOURCE_DIR}/src/cpp/security/cryptography/AESGCMGMAC_Transform.cpp
-    ${PROJECT_SOURCE_DIR}/src/cpp/security/cryptography/AESGCMGMAC_Types.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/builtinAESGCMGMACTests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CryptographyPluginTests.hpp
     ENVIRONMENTS "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")

--- a/test/unittest/security/cryptography/CryptographyPluginTests.hpp
+++ b/test/unittest/security/cryptography/CryptographyPluginTests.hpp
@@ -47,35 +47,36 @@ protected:
 
         // Delegate SharedSecret creation to an actual implementation
         ON_CALL(auth_plugin, get_shared_secret)
-            .WillByDefault([this](const HandshakeHandle& h, SecurityException& e)
+            .WillByDefault([this](
+                    const HandshakeHandle&,
+                    SecurityException&)
                     {
-                        return auth_plugin.get_shared_secret_impl(h, e);
+                        return auth_plugin.get_dummy_shared_secret();
                     });
 
         // Delegate SharedSecret disposal to an actual implementation
         ON_CALL(auth_plugin, return_sharedsecret_handle)
             .WillByDefault([this](
                     std::shared_ptr<SecretHandle>& sh,
-                    SecurityException& e)
+                    SecurityException&)
                     {
-                        return auth_plugin.return_sharedsecret_handle_impl(sh, e);
+                        return auth_plugin.return_dummy_sharedsecret(sh);
                     });
 
         // Delegate identity handle creation to an actual implementation
         ON_CALL(auth_plugin, get_identity_handle)
-            .WillByDefault([this](
-                SecurityException& e)
+            .WillByDefault([this](SecurityException&)
                 {
-                    return auth_plugin.get_identity_handle_impl(e);
+                    return auth_plugin.get_dummy_identity_handle();
                 });
 
         // Delegate identity handle disposal to an actual implementation
         ON_CALL(auth_plugin, return_identity_handle)
             .WillByDefault([this](
                 IdentityHandle* ih,
-                SecurityException& e)
+                SecurityException&)
                 {
-                    return auth_plugin.return_identity_handle_impl(ih, e);
+                    return auth_plugin.return_dummy_identity_handle(ih);
                 });
     }
 
@@ -1766,7 +1767,7 @@ TEST_F(CryptographyPluginTest, transform_preprocess_secure_submessage)
     std::shared_ptr<SecretHandle> secret =
         auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
 
-    std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
+    auto shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
     part_sec_attr.is_rtps_protected = true;
     part_sec_attr.plugin_participant_attributes = PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ENCRYPTED |
@@ -1778,10 +1779,10 @@ TEST_F(CryptographyPluginTest, transform_preprocess_secure_submessage)
     sec_attrs.plugin_endpoint_attributes = PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ENCRYPTED |
             PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ORIGIN_AUTHENTICATED;
 
-    std::shared_ptr<ParticipantCryptoHandle> participant_A =
+    auto participant_A =
             CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle, part_sec_attr,
                     exception);
-    std::shared_ptr<ParticipantCryptoHandle> participant_B =
+    auto participant_B =
             CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle, part_sec_attr,
                     exception);
 
@@ -1885,7 +1886,7 @@ TEST_F(CryptographyPluginTest, transform_preprocess_secure_submessage)
     plain_payload.length = 18;
 
     std::vector<std::shared_ptr<DatawriterCryptoHandle>> receivers;
-    receivers.push_back(remote_writer->shared_from_this());
+    receivers.push_back(remote_writer->shared_from_this()); // hic sunt dracones
 
     EXPECT_TRUE(CryptoPlugin->cryptotransform()->encode_datareader_submessage(encoded_datareader_payload, plain_payload,
             *reader, receivers, exception));

--- a/test/unittest/security/cryptography/CryptographyPluginTests.hpp
+++ b/test/unittest/security/cryptography/CryptographyPluginTests.hpp
@@ -1888,7 +1888,7 @@ TEST_F(CryptographyPluginTest, transform_preprocess_secure_submessage)
     plain_payload.length = 18;
 
     std::vector<std::shared_ptr<DatawriterCryptoHandle>> receivers;
-    receivers.push_back(remote_writer->shared_from_this()); // hic sunt dracones
+    receivers.push_back(remote_writer->shared_from_this());
 
     EXPECT_TRUE(CryptoPlugin->cryptotransform()->encode_datareader_submessage(encoded_datareader_payload, plain_payload,
             *reader, receivers, exception));

--- a/test/unittest/security/cryptography/CryptographyPluginTests.hpp
+++ b/test/unittest/security/cryptography/CryptographyPluginTests.hpp
@@ -32,6 +32,11 @@ class CryptographyPluginTest : public ::testing::Test
 {
 protected:
 
+    // Mock the handles to avoid cast issues
+    using SharedSecretHandle = eprosima::fastrtps::rtps::security::MockAuthenticationPlugin::SharedSecretHandle;
+    using PKIIdentityHandle = eprosima::fastrtps::rtps::security::MockAuthenticationPlugin::PKIIdentityHandle;
+    using AccessPermissionsHandle = eprosima::fastrtps::rtps::security::MockAccessControlPlugin::AccessPermissionsHandle;
+
     virtual void SetUp()
     {
         using namespace eprosima::fastrtps::rtps::security;
@@ -87,8 +92,8 @@ public:
     }
 
     eprosima::fastrtps::rtps::security::AESGCMGMAC* CryptoPlugin;
-    eprosima::fastrtps::rtps::security::MockAuthenticationPlugin auth_plugin;
-    eprosima::fastrtps::rtps::security::MockAccessControlPlugin access_plugin;
+    ::testing::NiceMock<eprosima::fastrtps::rtps::security::MockAuthenticationPlugin> auth_plugin;
+    ::testing::NiceMock<eprosima::fastrtps::rtps::security::MockAccessControlPlugin> access_plugin;
 };
 
 TEST_F(CryptographyPluginTest, factory_CreateLocalParticipantHandle)

--- a/test/unittest/security/cryptography/CryptographyPluginTests.hpp
+++ b/test/unittest/security/cryptography/CryptographyPluginTests.hpp
@@ -165,7 +165,7 @@ TEST_F(CryptographyPluginTest, factory_RegisterRemoteParticipant)
     ParticipantSecurityAttributes part_sec_attr;
 
     std::shared_ptr<SecretHandle> secret =
-        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+        auth_plugin.get_shared_secret_impl(SharedSecretHandle::nil_handle, exception);
 
     std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
@@ -239,7 +239,7 @@ TEST_F(CryptographyPluginTest, factory_RegisterRemoteParticipant)
     CryptoPlugin->keyfactory()->unregister_participant(local, exception);
 
     auth_plugin.return_identity_handle(&i_handle, exception);
-    auth_plugin.return_sharedsecret_handle(secret, exception);
+    auth_plugin.return_sharedsecret_handle_impl(secret, exception);
     access_plugin.return_permissions_handle(&perm_handle,exception);
 }
 
@@ -305,7 +305,7 @@ TEST_F(CryptographyPluginTest, exchange_ParticipantCryptoTokens)
     ParticipantSecurityAttributes part_sec_attr;
 
     std::shared_ptr<SecretHandle> secret =
-        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+        auth_plugin.get_shared_secret_impl(SharedSecretHandle::nil_handle, exception);
 
     std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
@@ -396,7 +396,7 @@ TEST_F(CryptographyPluginTest, exchange_ParticipantCryptoTokens)
     CryptoPlugin->keyfactory()->unregister_participant(ParticipantB_remote, exception);
 
     auth_plugin.return_identity_handle(&i_handle, exception);
-    auth_plugin.return_sharedsecret_handle(secret, exception);
+    auth_plugin.return_sharedsecret_handle_impl(secret, exception);
     access_plugin.return_permissions_handle(&perm_handle,exception);
 }
 
@@ -416,7 +416,7 @@ TEST_F(CryptographyPluginTest, transform_RTPSMessage)
     ParticipantSecurityAttributes part_sec_attr;
 
     std::shared_ptr<SecretHandle> secret =
-        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+        auth_plugin.get_shared_secret_impl(SharedSecretHandle::nil_handle, exception);
 
     std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
@@ -594,7 +594,7 @@ TEST_F(CryptographyPluginTest, transform_RTPSMessage)
     CryptoPlugin->keyfactory()->unregister_participant(ParticipantB_remote, exception);
 
     auth_plugin.return_identity_handle(&i_handle, exception);
-    auth_plugin.return_sharedsecret_handle(secret, exception);
+    auth_plugin.return_sharedsecret_handle_impl(secret, exception);
     access_plugin.return_permissions_handle(&perm_handle,exception);
 }
 
@@ -616,7 +616,7 @@ TEST_F(CryptographyPluginTest, factory_CreateLocalWriterHandle)
     EndpointSecurityAttributes sec_attrs;
 
     std::shared_ptr<SecretHandle> secret =
-        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+        auth_plugin.get_shared_secret_impl(SharedSecretHandle::nil_handle, exception);
 
     std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
@@ -669,7 +669,7 @@ TEST_F(CryptographyPluginTest, factory_CreateLocalWriterHandle)
 
     //Release resources and check the handle is indeed empty
     auth_plugin.return_identity_handle(&i_handle, exception);
-    auth_plugin.return_sharedsecret_handle(secret, exception);
+    auth_plugin.return_sharedsecret_handle_impl(secret, exception);
     access_plugin.return_permissions_handle(&perm_handle,exception);
 
     CryptoPlugin->keyfactory()->unregister_datawriter(target, exception);
@@ -694,7 +694,7 @@ TEST_F(CryptographyPluginTest, factory_CreateLocalReaderHandle)
     EndpointSecurityAttributes sec_attrs;
 
     std::shared_ptr<SecretHandle> secret =
-        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+        auth_plugin.get_shared_secret_impl(SharedSecretHandle::nil_handle, exception);
 
     std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
@@ -747,7 +747,7 @@ TEST_F(CryptographyPluginTest, factory_CreateLocalReaderHandle)
 
     //Release resources and check the handle is indeed empty
     auth_plugin.return_identity_handle(&i_handle, exception);
-    auth_plugin.return_sharedsecret_handle(secret, exception);
+    auth_plugin.return_sharedsecret_handle_impl(secret, exception);
     access_plugin.return_permissions_handle(&perm_handle,exception);
 
     CryptoPlugin->keyfactory()->unregister_datareader(target, exception);
@@ -772,7 +772,7 @@ TEST_F(CryptographyPluginTest, factory_RegisterRemoteReaderWriter)
     EndpointSecurityAttributes sec_attrs;
 
     std::shared_ptr<SecretHandle> secret =
-        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+        auth_plugin.get_shared_secret_impl(SharedSecretHandle::nil_handle, exception);
 
     std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
@@ -842,7 +842,7 @@ TEST_F(CryptographyPluginTest, factory_RegisterRemoteReaderWriter)
     ASSERT_TRUE(remote_writer != nullptr);
 
     auth_plugin.return_identity_handle(&i_handle, exception);
-    auth_plugin.return_sharedsecret_handle(secret, exception);
+    auth_plugin.return_sharedsecret_handle_impl(secret, exception);
     access_plugin.return_permissions_handle(&perm_handle,exception);
 
     CryptoPlugin->keyfactory()->unregister_datawriter(writer, exception);
@@ -878,7 +878,7 @@ TEST_F(CryptographyPluginTest, exchange_ReaderWriterCryptoTokens)
     EndpointSecurityAttributes sec_attrs;
 
     std::shared_ptr<SecretHandle> secret =
-        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+        auth_plugin.get_shared_secret_impl(SharedSecretHandle::nil_handle, exception);
 
     std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
@@ -994,7 +994,7 @@ TEST_F(CryptographyPluginTest, exchange_ReaderWriterCryptoTokens)
 
     //Release resources and check the handle is indeed empty
     auth_plugin.return_identity_handle(&i_handle, exception);
-    auth_plugin.return_sharedsecret_handle(secret, exception);
+    auth_plugin.return_sharedsecret_handle_impl(secret, exception);
     access_plugin.return_permissions_handle(&perm_handle,exception);
 
     CryptoPlugin->keyfactory()->unregister_datawriter(writer, exception);
@@ -1029,7 +1029,7 @@ TEST_F(CryptographyPluginTest, transform_SerializedPayload)
     EndpointSecurityAttributes sec_attrs;
 
     std::shared_ptr<SecretHandle> secret =
-        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+        auth_plugin.get_shared_secret_impl(SharedSecretHandle::nil_handle, exception);
 
     std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
@@ -1236,7 +1236,7 @@ TEST_F(CryptographyPluginTest, transform_SerializedPayload)
     CryptoPlugin->keyfactory()->unregister_participant(ParticipantB_remote, exception);
 
     auth_plugin.return_identity_handle(&i_handle, exception);
-    auth_plugin.return_sharedsecret_handle(secret, exception);
+    auth_plugin.return_sharedsecret_handle_impl(secret, exception);
     access_plugin.return_permissions_handle(&perm_handle,exception);
 }
 
@@ -1258,7 +1258,7 @@ TEST_F(CryptographyPluginTest, transform_Writer_Submesage)
     EndpointSecurityAttributes sec_attrs;
 
     std::shared_ptr<SecretHandle> secret =
-        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+        auth_plugin.get_shared_secret_impl(SharedSecretHandle::nil_handle, exception);
 
     std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
@@ -1456,7 +1456,7 @@ TEST_F(CryptographyPluginTest, transform_Writer_Submesage)
        ASSERT_TRUE(plain_payload == decoded_payload);
      */
 
-    auth_plugin.return_sharedsecret_handle(secret, exception);
+    auth_plugin.return_sharedsecret_handle_impl(secret, exception);
     auth_plugin.return_identity_handle(&i_handle, exception);
     access_plugin.return_permissions_handle(&perm_handle,exception);
 
@@ -1491,7 +1491,7 @@ TEST_F(CryptographyPluginTest, transform_Reader_Submessage)
     EndpointSecurityAttributes sec_attrs;
 
     std::shared_ptr<SecretHandle> secret =
-        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+        auth_plugin.get_shared_secret_impl(SharedSecretHandle::nil_handle, exception);
 
     std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
@@ -1701,7 +1701,7 @@ TEST_F(CryptographyPluginTest, transform_Reader_Submessage)
     CryptoPlugin->keyfactory()->unregister_participant(participant_B, exception);
     CryptoPlugin->keyfactory()->unregister_participant(ParticipantB_remote, exception);
 
-    auth_plugin.return_sharedsecret_handle(secret, exception);
+    auth_plugin.return_sharedsecret_handle_impl(secret, exception);
     auth_plugin.return_identity_handle(&i_handle, exception);
     access_plugin.return_permissions_handle(&perm_handle,exception);
 }
@@ -1724,7 +1724,7 @@ TEST_F(CryptographyPluginTest, transform_preprocess_secure_submessage)
     EndpointSecurityAttributes sec_attrs;
 
     std::shared_ptr<SecretHandle> secret =
-        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+        auth_plugin.get_shared_secret_impl(SharedSecretHandle::nil_handle, exception);
 
     std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
@@ -1890,7 +1890,7 @@ TEST_F(CryptographyPluginTest, transform_preprocess_secure_submessage)
     EXPECT_TRUE(CryptoPlugin->keyfactory()->unregister_participant(participant_B, exception));
     EXPECT_TRUE(CryptoPlugin->keyfactory()->unregister_participant(ParticipantB_remote, exception));
 
-    auth_plugin.return_sharedsecret_handle(secret, exception);
+    auth_plugin.return_sharedsecret_handle_impl(secret, exception);
     auth_plugin.return_identity_handle(&i_handle, exception);
     access_plugin.return_permissions_handle(&perm_handle,exception);
 }

--- a/test/unittest/security/cryptography/CryptographyPluginTests.hpp
+++ b/test/unittest/security/cryptography/CryptographyPluginTests.hpp
@@ -35,7 +35,8 @@ protected:
     // Mock the handles to avoid cast issues
     using SharedSecretHandle = eprosima::fastrtps::rtps::security::MockAuthenticationPlugin::SharedSecretHandle;
     using PKIIdentityHandle = eprosima::fastrtps::rtps::security::MockAuthenticationPlugin::PKIIdentityHandle;
-    using AccessPermissionsHandle = eprosima::fastrtps::rtps::security::MockAccessControlPlugin::AccessPermissionsHandle;
+    using AccessPermissionsHandle =
+            eprosima::fastrtps::rtps::security::MockAccessControlPlugin::AccessPermissionsHandle;
 
     virtual void SetUp()
     {
@@ -47,34 +48,34 @@ protected:
 
         // Delegate SharedSecret creation to an actual implementation
         ON_CALL(auth_plugin, get_shared_secret)
-            .WillByDefault([this](
+                .WillByDefault([this](
                     const HandshakeHandle&,
                     SecurityException&)
-                    {
-                        return auth_plugin.get_dummy_shared_secret();
-                    });
+                {
+                    return auth_plugin.get_dummy_shared_secret();
+                });
 
         // Delegate SharedSecret disposal to an actual implementation
         ON_CALL(auth_plugin, return_sharedsecret_handle)
-            .WillByDefault([this](
+                .WillByDefault([this](
                     std::shared_ptr<SecretHandle>& sh,
                     SecurityException&)
-                    {
-                        return auth_plugin.return_dummy_sharedsecret(sh);
-                    });
+                {
+                    return auth_plugin.return_dummy_sharedsecret(sh);
+                });
 
         // Delegate identity handle creation to an actual implementation
         ON_CALL(auth_plugin, get_identity_handle)
-            .WillByDefault([this](SecurityException&)
+                .WillByDefault([this](SecurityException&)
                 {
                     return auth_plugin.get_dummy_identity_handle();
                 });
 
         // Delegate identity handle disposal to an actual implementation
         ON_CALL(auth_plugin, return_identity_handle)
-            .WillByDefault([this](
-                IdentityHandle* ih,
-                SecurityException&)
+                .WillByDefault([this](
+                    IdentityHandle* ih,
+                    SecurityException&)
                 {
                     return auth_plugin.return_dummy_identity_handle(ih);
                 });
@@ -104,10 +105,10 @@ TEST_F(CryptographyPluginTest, factory_CreateLocalParticipantHandle)
     SecurityException exception;
 
     PKIIdentityHandle& i_handle =
-        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+            PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
 
     AccessPermissionsHandle& perm_handle =
-        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+            AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
 
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
     ParticipantSecurityAttributes part_sec_attr;
@@ -126,65 +127,66 @@ TEST_F(CryptographyPluginTest, factory_CreateLocalParticipantHandle)
     ASSERT_GT(local_participant->Participant2ParticipantKeyMaterial.size(), 0ul);
     ASSERT_GT(local_participant->Participant2ParticipantKxKeyMaterial.size(), 0ul);
 
-    ASSERT_TRUE( (local_participant->ParticipantKeyMaterial.transformation_kind ==
-            c_transfrom_kind_aes256_gcm) );
-    ASSERT_TRUE( (local_participant->Participant2ParticipantKeyMaterial.at(0).transformation_kind ==
-            c_transfrom_kind_aes256_gcm) );
-    ASSERT_TRUE( (local_participant->Participant2ParticipantKxKeyMaterial.at(0).transformation_kind ==
-            c_transfrom_kind_aes256_gcm) );
+    ASSERT_TRUE((local_participant->ParticipantKeyMaterial.transformation_kind ==
+            c_transfrom_kind_aes256_gcm));
+    ASSERT_TRUE((local_participant->Participant2ParticipantKeyMaterial.at(0).transformation_kind ==
+            c_transfrom_kind_aes256_gcm));
+    ASSERT_TRUE((local_participant->Participant2ParticipantKxKeyMaterial.at(0).transformation_kind ==
+            c_transfrom_kind_aes256_gcm));
 
     ASSERT_FALSE( std::all_of(local_participant->ParticipantKeyMaterial.master_salt.begin(),
             local_participant->ParticipantKeyMaterial.master_salt.end(), [](uint8_t i)
             {
                 return i == 0;
-            }) );
+            }));
     ASSERT_FALSE( std::all_of(local_participant->Participant2ParticipantKeyMaterial.at(0).master_salt.begin(),
             local_participant->Participant2ParticipantKeyMaterial.at(0).master_salt.end(), [](uint8_t i)
             {
                 return i == 0;
-            }) );
+            }));
     ASSERT_FALSE( std::all_of(local_participant->Participant2ParticipantKxKeyMaterial.at(0).master_salt.begin(),
             local_participant->Participant2ParticipantKxKeyMaterial.at(0).master_salt.end(), [](uint8_t i)
             {
                 return i == 0;
-            }) );
+            }));
 
     ASSERT_FALSE( std::all_of(local_participant->ParticipantKeyMaterial.master_sender_key.begin(),
             local_participant->ParticipantKeyMaterial.master_sender_key.end(), [](uint8_t i)
             {
                 return i == 0;
-            }) );
+            }));
     ASSERT_FALSE( std::all_of(local_participant->Participant2ParticipantKeyMaterial.at(0).master_sender_key.begin(),
             local_participant->Participant2ParticipantKeyMaterial.at(0).master_sender_key.end(), [](uint8_t i)
             {
                 return i == 0;
-            }) );
+            }));
     ASSERT_FALSE( std::all_of(local_participant->Participant2ParticipantKxKeyMaterial.at(0).master_sender_key.begin(),
             local_participant->Participant2ParticipantKxKeyMaterial.at(0).master_sender_key.end(), [](uint8_t i)
             {
                 return i == 0;
-            }) );
+            }));
 
     ASSERT_FALSE( std::any_of(local_participant->ParticipantKeyMaterial.receiver_specific_key_id.begin(),
             local_participant->ParticipantKeyMaterial.receiver_specific_key_id.end(), [](uint8_t i)
             {
                 return i != 0;
-            }) );
+            }));
     ASSERT_FALSE( std::all_of(local_participant->Participant2ParticipantKeyMaterial.at(0).receiver_specific_key_id.begin(),
             local_participant->Participant2ParticipantKeyMaterial.at(0).receiver_specific_key_id.end(), [](uint8_t i)
             {
                 return i == 0;
-            }) );
+            }));
     ASSERT_FALSE( std::all_of(local_participant->Participant2ParticipantKxKeyMaterial.at(0).receiver_specific_key_id.
-            begin(), local_participant->Participant2ParticipantKxKeyMaterial.at(0).receiver_specific_key_id.end(),
+                    begin(),
+            local_participant->Participant2ParticipantKxKeyMaterial.at(0).receiver_specific_key_id.end(),
             [](uint8_t i)
             {
                 return i == 0;
-            }) );
+            }));
 
     //Release resources and check the handle is indeed empty
     auth_plugin.return_identity_handle(&i_handle, exception);
-    access_plugin.return_permissions_handle(&perm_handle,exception);
+    access_plugin.return_permissions_handle(&perm_handle, exception);
 
     CryptoPlugin->keyfactory()->unregister_participant(target, exception);
 }
@@ -197,16 +199,16 @@ TEST_F(CryptographyPluginTest, factory_RegisterRemoteParticipant)
     SecurityException exception;
 
     PKIIdentityHandle& i_handle =
-        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+            PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
 
     AccessPermissionsHandle& perm_handle =
-        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+            AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
 
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
     ParticipantSecurityAttributes part_sec_attr;
 
     std::shared_ptr<SecretHandle> secret =
-        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+            auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
 
     std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
@@ -281,7 +283,7 @@ TEST_F(CryptographyPluginTest, factory_RegisterRemoteParticipant)
 
     auth_plugin.return_identity_handle(&i_handle, exception);
     auth_plugin.return_sharedsecret_handle(secret, exception);
-    access_plugin.return_permissions_handle(&perm_handle,exception);
+    access_plugin.return_permissions_handle(&perm_handle, exception);
 }
 
 TEST_F(CryptographyPluginTest, exchange_CDRSerializenDeserialize){
@@ -291,10 +293,10 @@ TEST_F(CryptographyPluginTest, exchange_CDRSerializenDeserialize){
     SecurityException exception;
 
     PKIIdentityHandle& i_handle =
-        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+            PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
 
     AccessPermissionsHandle& perm_handle =
-        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+            AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
 
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
     ParticipantSecurityAttributes part_sec_attr;
@@ -327,7 +329,7 @@ TEST_F(CryptographyPluginTest, exchange_CDRSerializenDeserialize){
     CryptoPlugin->keyfactory()->unregister_participant(ParticipantA, exception);
 
     auth_plugin.return_identity_handle(&i_handle, exception);
-    access_plugin.return_permissions_handle(&perm_handle,exception);
+    access_plugin.return_permissions_handle(&perm_handle, exception);
 }
 
 TEST_F(CryptographyPluginTest, exchange_ParticipantCryptoTokens)
@@ -337,16 +339,16 @@ TEST_F(CryptographyPluginTest, exchange_ParticipantCryptoTokens)
     SecurityException exception;
 
     PKIIdentityHandle& i_handle =
-        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+            PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
 
     AccessPermissionsHandle& perm_handle =
-        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+            AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
 
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
     ParticipantSecurityAttributes part_sec_attr;
 
     std::shared_ptr<SecretHandle> secret =
-        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+            auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
 
     std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
@@ -438,7 +440,7 @@ TEST_F(CryptographyPluginTest, exchange_ParticipantCryptoTokens)
 
     auth_plugin.return_identity_handle(&i_handle, exception);
     auth_plugin.return_sharedsecret_handle(secret, exception);
-    access_plugin.return_permissions_handle(&perm_handle,exception);
+    access_plugin.return_permissions_handle(&perm_handle, exception);
 }
 
 TEST_F(CryptographyPluginTest, transform_RTPSMessage)
@@ -448,16 +450,16 @@ TEST_F(CryptographyPluginTest, transform_RTPSMessage)
     SecurityException exception;
 
     PKIIdentityHandle& i_handle =
-        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+            PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
 
     AccessPermissionsHandle& perm_handle =
-        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+            AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
 
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
     ParticipantSecurityAttributes part_sec_attr;
 
     std::shared_ptr<SecretHandle> secret =
-        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+            auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
 
     std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
@@ -636,7 +638,7 @@ TEST_F(CryptographyPluginTest, transform_RTPSMessage)
 
     auth_plugin.return_identity_handle(&i_handle, exception);
     auth_plugin.return_sharedsecret_handle(secret, exception);
-    access_plugin.return_permissions_handle(&perm_handle,exception);
+    access_plugin.return_permissions_handle(&perm_handle, exception);
 }
 
 TEST_F(CryptographyPluginTest, factory_CreateLocalWriterHandle)
@@ -646,10 +648,10 @@ TEST_F(CryptographyPluginTest, factory_CreateLocalWriterHandle)
     SecurityException exception;
 
     PKIIdentityHandle& i_handle =
-        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+            PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
 
     AccessPermissionsHandle& perm_handle =
-        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+            AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
 
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
     ParticipantSecurityAttributes part_sec_attr;
@@ -657,7 +659,7 @@ TEST_F(CryptographyPluginTest, factory_CreateLocalWriterHandle)
     EndpointSecurityAttributes sec_attrs;
 
     std::shared_ptr<SecretHandle> secret =
-        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+            auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
 
     std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
@@ -682,36 +684,36 @@ TEST_F(CryptographyPluginTest, factory_CreateLocalWriterHandle)
     ASSERT_TRUE(!local_writer.nil());
 
     ASSERT_TRUE(local_writer->Entity2RemoteKeyMaterial.empty());
-    ASSERT_TRUE( (local_writer->EntityKeyMaterial.at(0).transformation_kind == c_transfrom_kind_aes256_gcm) );
+    ASSERT_TRUE((local_writer->EntityKeyMaterial.at(0).transformation_kind == c_transfrom_kind_aes256_gcm));
 
     ASSERT_FALSE( std::all_of(local_writer->EntityKeyMaterial.at(0).master_salt.begin(),
             local_writer->EntityKeyMaterial.at(0).master_salt.end(), [](uint8_t i)
             {
                 return i == 0;
-            }) );
+            }));
 
     ASSERT_FALSE( std::all_of(local_writer->EntityKeyMaterial.at(0).master_sender_key.begin(),
             local_writer->EntityKeyMaterial.at(0).master_sender_key.end(), [](uint8_t i)
             {
                 return i == 0;
-            }) );
+            }));
 
     ASSERT_FALSE( std::any_of(local_writer->EntityKeyMaterial.at(0).receiver_specific_key_id.begin(),
             local_writer->EntityKeyMaterial.at(0).receiver_specific_key_id.end(), [](uint8_t i)
             {
                 return i != 0;
-            }) );
+            }));
 
     ASSERT_FALSE( std::any_of(local_writer->EntityKeyMaterial.at(0).master_receiver_specific_key.begin(),
             local_writer->EntityKeyMaterial.at(0).master_receiver_specific_key.end(), [](uint8_t i)
             {
                 return i != 0;
-            }) );
+            }));
 
     //Release resources and check the handle is indeed empty
     auth_plugin.return_identity_handle(&i_handle, exception);
     auth_plugin.return_sharedsecret_handle(secret, exception);
-    access_plugin.return_permissions_handle(&perm_handle,exception);
+    access_plugin.return_permissions_handle(&perm_handle, exception);
 
     CryptoPlugin->keyfactory()->unregister_datawriter(target, exception);
     CryptoPlugin->keyfactory()->unregister_participant(participant, exception);
@@ -724,10 +726,10 @@ TEST_F(CryptographyPluginTest, factory_CreateLocalReaderHandle)
     SecurityException exception;
 
     PKIIdentityHandle& i_handle =
-        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+            PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
 
     AccessPermissionsHandle& perm_handle =
-        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+            AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
 
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
     ParticipantSecurityAttributes part_sec_attr;
@@ -735,7 +737,7 @@ TEST_F(CryptographyPluginTest, factory_CreateLocalReaderHandle)
     EndpointSecurityAttributes sec_attrs;
 
     std::shared_ptr<SecretHandle> secret =
-        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+            auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
 
     std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
@@ -760,36 +762,36 @@ TEST_F(CryptographyPluginTest, factory_CreateLocalReaderHandle)
     ASSERT_TRUE(!local_reader.nil());
 
     ASSERT_TRUE(local_reader->Entity2RemoteKeyMaterial.empty());
-    ASSERT_TRUE( (local_reader->EntityKeyMaterial.at(0).transformation_kind == c_transfrom_kind_aes256_gcm) );
+    ASSERT_TRUE((local_reader->EntityKeyMaterial.at(0).transformation_kind == c_transfrom_kind_aes256_gcm));
 
     ASSERT_FALSE( std::all_of(local_reader->EntityKeyMaterial.at(0).master_salt.begin(),
             local_reader->EntityKeyMaterial.at(0).master_salt.end(), [](uint8_t i)
             {
                 return i == 0;
-            }) );
+            }));
 
     ASSERT_FALSE( std::all_of(local_reader->EntityKeyMaterial.at(0).master_sender_key.begin(),
             local_reader->EntityKeyMaterial.at(0).master_sender_key.end(), [](uint8_t i)
             {
                 return i == 0;
-            }) );
+            }));
 
     ASSERT_FALSE( std::any_of(local_reader->EntityKeyMaterial.at(0).receiver_specific_key_id.begin(),
             local_reader->EntityKeyMaterial.at(0).receiver_specific_key_id.end(), [](uint8_t i)
             {
                 return i != 0;
-            }) );
+            }));
 
     ASSERT_FALSE( std::any_of(local_reader->EntityKeyMaterial.at(0).master_receiver_specific_key.begin(),
             local_reader->EntityKeyMaterial.at(0).master_receiver_specific_key.end(), [](uint8_t i)
             {
                 return i != 0;
-            }) );
+            }));
 
     //Release resources and check the handle is indeed empty
     auth_plugin.return_identity_handle(&i_handle, exception);
     auth_plugin.return_sharedsecret_handle(secret, exception);
-    access_plugin.return_permissions_handle(&perm_handle,exception);
+    access_plugin.return_permissions_handle(&perm_handle, exception);
 
     CryptoPlugin->keyfactory()->unregister_datareader(target, exception);
     CryptoPlugin->keyfactory()->unregister_participant(participant, exception);
@@ -802,10 +804,10 @@ TEST_F(CryptographyPluginTest, factory_RegisterRemoteReaderWriter)
     SecurityException exception;
 
     PKIIdentityHandle& i_handle =
-        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+            PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
 
     AccessPermissionsHandle& perm_handle =
-        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+            AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
 
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
     ParticipantSecurityAttributes part_sec_attr;
@@ -813,7 +815,7 @@ TEST_F(CryptographyPluginTest, factory_RegisterRemoteReaderWriter)
     EndpointSecurityAttributes sec_attrs;
 
     std::shared_ptr<SecretHandle> secret =
-        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+            auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
 
     std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
@@ -884,7 +886,7 @@ TEST_F(CryptographyPluginTest, factory_RegisterRemoteReaderWriter)
 
     auth_plugin.return_identity_handle(&i_handle, exception);
     auth_plugin.return_sharedsecret_handle(secret, exception);
-    access_plugin.return_permissions_handle(&perm_handle,exception);
+    access_plugin.return_permissions_handle(&perm_handle, exception);
 
     CryptoPlugin->keyfactory()->unregister_datawriter(writer, exception);
     CryptoPlugin->keyfactory()->unregister_datareader(reader, exception);
@@ -908,10 +910,10 @@ TEST_F(CryptographyPluginTest, exchange_ReaderWriterCryptoTokens)
     SecurityException exception;
 
     PKIIdentityHandle& i_handle =
-        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+            PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
 
     AccessPermissionsHandle& perm_handle =
-        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+            AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
 
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
     ParticipantSecurityAttributes part_sec_attr;
@@ -919,7 +921,7 @@ TEST_F(CryptographyPluginTest, exchange_ReaderWriterCryptoTokens)
     EndpointSecurityAttributes sec_attrs;
 
     std::shared_ptr<SecretHandle> secret =
-        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+            auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
 
     std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
@@ -1036,7 +1038,7 @@ TEST_F(CryptographyPluginTest, exchange_ReaderWriterCryptoTokens)
     //Release resources and check the handle is indeed empty
     auth_plugin.return_identity_handle(&i_handle, exception);
     auth_plugin.return_sharedsecret_handle(secret, exception);
-    access_plugin.return_permissions_handle(&perm_handle,exception);
+    access_plugin.return_permissions_handle(&perm_handle, exception);
 
     CryptoPlugin->keyfactory()->unregister_datawriter(writer, exception);
     CryptoPlugin->keyfactory()->unregister_datawriter(remote_writer, exception);
@@ -1059,10 +1061,10 @@ TEST_F(CryptographyPluginTest, transform_SerializedPayload)
     SecurityException exception;
 
     PKIIdentityHandle& i_handle =
-        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+            PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
 
     AccessPermissionsHandle& perm_handle =
-        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+            AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
 
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
     ParticipantSecurityAttributes part_sec_attr;
@@ -1070,7 +1072,7 @@ TEST_F(CryptographyPluginTest, transform_SerializedPayload)
     EndpointSecurityAttributes sec_attrs;
 
     std::shared_ptr<SecretHandle> secret =
-        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+            auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
 
     std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
@@ -1278,7 +1280,7 @@ TEST_F(CryptographyPluginTest, transform_SerializedPayload)
 
     auth_plugin.return_identity_handle(&i_handle, exception);
     auth_plugin.return_sharedsecret_handle(secret, exception);
-    access_plugin.return_permissions_handle(&perm_handle,exception);
+    access_plugin.return_permissions_handle(&perm_handle, exception);
 }
 
 TEST_F(CryptographyPluginTest, transform_Writer_Submesage)
@@ -1288,10 +1290,10 @@ TEST_F(CryptographyPluginTest, transform_Writer_Submesage)
     SecurityException exception;
 
     PKIIdentityHandle& i_handle =
-        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+            PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
 
     AccessPermissionsHandle& perm_handle =
-        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+            AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
 
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
     ParticipantSecurityAttributes part_sec_attr;
@@ -1299,7 +1301,7 @@ TEST_F(CryptographyPluginTest, transform_Writer_Submesage)
     EndpointSecurityAttributes sec_attrs;
 
     std::shared_ptr<SecretHandle> secret =
-        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+            auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
 
     std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
@@ -1499,7 +1501,7 @@ TEST_F(CryptographyPluginTest, transform_Writer_Submesage)
 
     auth_plugin.return_sharedsecret_handle(secret, exception);
     auth_plugin.return_identity_handle(&i_handle, exception);
-    access_plugin.return_permissions_handle(&perm_handle,exception);
+    access_plugin.return_permissions_handle(&perm_handle, exception);
 
     CryptoPlugin->keyfactory()->unregister_datawriter(writer, exception);
     CryptoPlugin->keyfactory()->unregister_datawriter(remote_writer, exception);
@@ -1521,10 +1523,10 @@ TEST_F(CryptographyPluginTest, transform_Reader_Submessage)
     SecurityException exception;
 
     PKIIdentityHandle& i_handle =
-        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+            PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
 
     AccessPermissionsHandle& perm_handle =
-        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+            AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
 
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
     ParticipantSecurityAttributes part_sec_attr;
@@ -1532,7 +1534,7 @@ TEST_F(CryptographyPluginTest, transform_Reader_Submessage)
     EndpointSecurityAttributes sec_attrs;
 
     std::shared_ptr<SecretHandle> secret =
-        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+            auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
 
     std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
@@ -1744,7 +1746,7 @@ TEST_F(CryptographyPluginTest, transform_Reader_Submessage)
 
     auth_plugin.return_sharedsecret_handle(secret, exception);
     auth_plugin.return_identity_handle(&i_handle, exception);
-    access_plugin.return_permissions_handle(&perm_handle,exception);
+    access_plugin.return_permissions_handle(&perm_handle, exception);
 }
 
 TEST_F(CryptographyPluginTest, transform_preprocess_secure_submessage)
@@ -1754,10 +1756,10 @@ TEST_F(CryptographyPluginTest, transform_preprocess_secure_submessage)
     SecurityException exception;
 
     PKIIdentityHandle& i_handle =
-        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+            PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
 
     AccessPermissionsHandle& perm_handle =
-        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+            AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
 
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
     ParticipantSecurityAttributes part_sec_attr;
@@ -1765,7 +1767,7 @@ TEST_F(CryptographyPluginTest, transform_preprocess_secure_submessage)
     EndpointSecurityAttributes sec_attrs;
 
     std::shared_ptr<SecretHandle> secret =
-        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+            auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
 
     auto shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
@@ -1933,7 +1935,7 @@ TEST_F(CryptographyPluginTest, transform_preprocess_secure_submessage)
 
     auth_plugin.return_sharedsecret_handle(secret, exception);
     auth_plugin.return_identity_handle(&i_handle, exception);
-    access_plugin.return_permissions_handle(&perm_handle,exception);
+    access_plugin.return_permissions_handle(&perm_handle, exception);
 }
 
 #endif // ifndef _UNITTEST_SECURITY_CRYPTOGRAPHY_CRYPTOGRAPHYPLUGINTESTS_HPP_

--- a/test/unittest/security/cryptography/CryptographyPluginTests.hpp
+++ b/test/unittest/security/cryptography/CryptographyPluginTests.hpp
@@ -20,6 +20,9 @@
 #include <security/accesscontrol/AccessPermissionsHandle.h>
 #include <fastrtps/rtps/common/CDRMessage_t.h>
 
+#include <security/MockAccessControlPlugin.h>
+#include <security/MockAuthenticationPlugin.h>
+
 #include <gtest/gtest.h>
 #include <openssl/rand.h>
 #include <cstdlib>
@@ -49,43 +52,45 @@ public:
     }
 
     eprosima::fastrtps::rtps::security::AESGCMGMAC* CryptoPlugin;
-
+    eprosima::fastrtps::rtps::security::MockAuthenticationPlugin auth_plugin;
+    eprosima::fastrtps::rtps::security::MockAccessControlPlugin access_plugin;
 };
 
 TEST_F(CryptographyPluginTest, factory_CreateLocalParticipantHandle)
 {
+    using namespace eprosima::fastrtps::rtps::security;
 
-    eprosima::fastrtps::rtps::security::PKIIdentityHandle* i_handle =
-            new eprosima::fastrtps::rtps::security::PKIIdentityHandle();
-    eprosima::fastrtps::rtps::security::AccessPermissionsHandle* perm_handle =
-            new eprosima::fastrtps::rtps::security::AccessPermissionsHandle();
+    SecurityException exception;
+
+    PKIIdentityHandle& i_handle =
+        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+
+    AccessPermissionsHandle& perm_handle =
+        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
-    eprosima::fastrtps::rtps::security::ParticipantSecurityAttributes part_sec_attr;
-
-    eprosima::fastrtps::rtps::security::SecurityException exception;
+    ParticipantSecurityAttributes part_sec_attr;
 
     part_sec_attr.is_rtps_protected = true;
     part_sec_attr.plugin_participant_attributes = PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ENCRYPTED |
             PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ORIGIN_AUTHENTICATED;
 
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* target =
-            CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle, part_sec_attr,
+    std::shared_ptr<ParticipantCryptoHandle> target =
+            CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle, part_sec_attr,
                     exception);
-    ASSERT_TRUE(target != nullptr);
+    AESGCMGMAC_ParticipantCryptoHandle& local_participant = AESGCMGMAC_ParticipantCryptoHandle::narrow(*target);
 
-    eprosima::fastrtps::rtps::security::AESGCMGMAC_ParticipantCryptoHandle& local_participant =
-            eprosima::fastrtps::rtps::security::AESGCMGMAC_ParticipantCryptoHandle::narrow(*target);
-    ASSERT_TRUE(!local_participant.nil());
+    ASSERT_FALSE(local_participant.nil());
 
     ASSERT_GT(local_participant->Participant2ParticipantKeyMaterial.size(), 0ul);
     ASSERT_GT(local_participant->Participant2ParticipantKxKeyMaterial.size(), 0ul);
 
     ASSERT_TRUE( (local_participant->ParticipantKeyMaterial.transformation_kind ==
-            eprosima::fastrtps::rtps::security::c_transfrom_kind_aes256_gcm) );
+            c_transfrom_kind_aes256_gcm) );
     ASSERT_TRUE( (local_participant->Participant2ParticipantKeyMaterial.at(0).transformation_kind ==
-            eprosima::fastrtps::rtps::security::c_transfrom_kind_aes256_gcm) );
+            c_transfrom_kind_aes256_gcm) );
     ASSERT_TRUE( (local_participant->Participant2ParticipantKxKeyMaterial.at(0).transformation_kind ==
-            eprosima::fastrtps::rtps::security::c_transfrom_kind_aes256_gcm) );
+            c_transfrom_kind_aes256_gcm) );
 
     ASSERT_FALSE( std::all_of(local_participant->ParticipantKeyMaterial.master_salt.begin(),
             local_participant->ParticipantKeyMaterial.master_salt.end(), [](uint8_t i)
@@ -136,10 +141,9 @@ TEST_F(CryptographyPluginTest, factory_CreateLocalParticipantHandle)
                 return i == 0;
             }) );
 
-    delete i_handle;
-    delete perm_handle;
-
     //Release resources and check the handle is indeed empty
+    auth_plugin.return_identity_handle(&i_handle, exception);
+    access_plugin.return_permissions_handle(&perm_handle,exception);
 
     CryptoPlugin->keyfactory()->unregister_participant(target, exception);
 }
@@ -147,33 +151,39 @@ TEST_F(CryptographyPluginTest, factory_CreateLocalParticipantHandle)
 
 TEST_F(CryptographyPluginTest, factory_RegisterRemoteParticipant)
 {
+    using namespace eprosima::fastrtps::rtps::security;
 
-    eprosima::fastrtps::rtps::security::PKIIdentityHandle* i_handle =
-            new eprosima::fastrtps::rtps::security::PKIIdentityHandle();
-    eprosima::fastrtps::rtps::security::AccessPermissionsHandle* perm_handle =
-            new eprosima::fastrtps::rtps::security::AccessPermissionsHandle();
+    SecurityException exception;
+
+    PKIIdentityHandle& i_handle =
+        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+
+    AccessPermissionsHandle& perm_handle =
+        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
-    eprosima::fastrtps::rtps::security::ParticipantSecurityAttributes part_sec_attr;
-    eprosima::fastrtps::rtps::security::SharedSecretHandle* shared_secret =
-            new eprosima::fastrtps::rtps::security::SharedSecretHandle();
+    ParticipantSecurityAttributes part_sec_attr;
 
-    eprosima::fastrtps::rtps::security::SecurityException exception;
+    std::shared_ptr<SecretHandle> secret =
+        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+
+    std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
     part_sec_attr.is_rtps_protected = true;
     part_sec_attr.plugin_participant_attributes = PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ENCRYPTED |
             PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ORIGIN_AUTHENTICATED;
 
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* local =
-            CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle, part_sec_attr,
+    std::shared_ptr<ParticipantCryptoHandle> local =
+            CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle, part_sec_attr,
                     exception);
 
-    ASSERT_TRUE(local != nullptr);
+    ASSERT_TRUE(local);
 
     //Dissect results to check correct creation
 
     //Fill shared secret with dummy values
     std::vector<uint8_t> dummy_data, challenge_1, challenge_2;
-    eprosima::fastrtps::rtps::security::SharedSecret::BinaryData binary_data;
+    SharedSecret::BinaryData binary_data;
     challenge_1.resize(32);
     challenge_2.resize(32);
 
@@ -193,20 +203,20 @@ TEST_F(CryptographyPluginTest, factory_RegisterRemoteParticipant)
     binary_data.value(dummy_data);
     (*shared_secret)->data_.push_back(binary_data);
 
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* remote_A =
-            CryptoPlugin->keyfactory()->register_matched_remote_participant(*local, *i_handle, *perm_handle,
+    std::shared_ptr<ParticipantCryptoHandle> remote_A =
+            CryptoPlugin->keyfactory()->register_matched_remote_participant(*local, i_handle, perm_handle,
                     *shared_secret, exception);
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* remote_B =
-            CryptoPlugin->keyfactory()->register_matched_remote_participant(*local, *i_handle, *perm_handle,
+    std::shared_ptr<ParticipantCryptoHandle> remote_B =
+            CryptoPlugin->keyfactory()->register_matched_remote_participant(*local, i_handle, perm_handle,
                     *shared_secret, exception);
 
-    ASSERT_TRUE( (remote_A != nullptr) );
-    ASSERT_TRUE( (remote_B != nullptr) );
+    ASSERT_TRUE(remote_A);
+    ASSERT_TRUE(remote_B);
 
-    eprosima::fastrtps::rtps::security::AESGCMGMAC_ParticipantCryptoHandle& remote_participant_A =
-            eprosima::fastrtps::rtps::security::AESGCMGMAC_ParticipantCryptoHandle::narrow(*remote_A);
-    eprosima::fastrtps::rtps::security::AESGCMGMAC_ParticipantCryptoHandle& remote_participant_B =
-            eprosima::fastrtps::rtps::security::AESGCMGMAC_ParticipantCryptoHandle::narrow(*remote_B);
+    AESGCMGMAC_ParticipantCryptoHandle& remote_participant_A =
+            AESGCMGMAC_ParticipantCryptoHandle::narrow(*remote_A);
+    AESGCMGMAC_ParticipantCryptoHandle& remote_participant_B =
+            AESGCMGMAC_ParticipantCryptoHandle::narrow(*remote_B);
 
     //Check the presence of both remote P2PKeyMaterial and P2PKxKeyMaterial
     ASSERT_TRUE(remote_participant_A->Participant2ParticipantKeyMaterial.size() == 1);
@@ -228,36 +238,41 @@ TEST_F(CryptographyPluginTest, factory_RegisterRemoteParticipant)
     CryptoPlugin->keyfactory()->unregister_participant(remote_B, exception);
     CryptoPlugin->keyfactory()->unregister_participant(local, exception);
 
-    delete perm_handle;
-    delete i_handle;
-    delete shared_secret;
+    auth_plugin.return_identity_handle(&i_handle, exception);
+    auth_plugin.return_sharedsecret_handle(secret, exception);
+    access_plugin.return_permissions_handle(&perm_handle,exception);
 }
 
 TEST_F(CryptographyPluginTest, exchange_CDRSerializenDeserialize){
 
-    eprosima::fastrtps::rtps::security::PKIIdentityHandle* i_handle =
-            new eprosima::fastrtps::rtps::security::PKIIdentityHandle();
-    eprosima::fastrtps::rtps::security::AccessPermissionsHandle* perm_handle =
-            new eprosima::fastrtps::rtps::security::AccessPermissionsHandle();
+    using namespace eprosima::fastrtps::rtps::security;
+
+    SecurityException exception;
+
+    PKIIdentityHandle& i_handle =
+        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+
+    AccessPermissionsHandle& perm_handle =
+        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
-    eprosima::fastrtps::rtps::security::ParticipantSecurityAttributes part_sec_attr;
-    eprosima::fastrtps::rtps::security::SecurityException exception;
+    ParticipantSecurityAttributes part_sec_attr;
 
     part_sec_attr.is_rtps_protected = true;
     part_sec_attr.plugin_participant_attributes = PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ENCRYPTED |
             PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ORIGIN_AUTHENTICATED;
 
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* ParticipantA =
-            CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle, part_sec_attr,
+    std::shared_ptr<ParticipantCryptoHandle> ParticipantA =
+            CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle, part_sec_attr,
                     exception);
 
-    eprosima::fastrtps::rtps::security::AESGCMGMAC_ParticipantCryptoHandle& Participant_A =
-            eprosima::fastrtps::rtps::security::AESGCMGMAC_ParticipantCryptoHandle::narrow(*ParticipantA);
+    AESGCMGMAC_ParticipantCryptoHandle& Participant_A =
+            AESGCMGMAC_ParticipantCryptoHandle::narrow(*ParticipantA);
 
-    eprosima::fastrtps::rtps::security::KeyMaterial_AES_GCM_GMAC base = Participant_A->ParticipantKeyMaterial;
+    KeyMaterial_AES_GCM_GMAC base = Participant_A->ParticipantKeyMaterial;
 
     std::vector<uint8_t> serialized = CryptoPlugin->keyexchange()->KeyMaterialCDRSerialize(base);
-    eprosima::fastrtps::rtps::security::KeyMaterial_AES_GCM_GMAC result;
+    KeyMaterial_AES_GCM_GMAC result;
     CryptoPlugin->keyexchange()->KeyMaterialCDRDeserialize(result, &serialized);
     ASSERT_TRUE(
         (base.transformation_kind == result.transformation_kind) &
@@ -270,24 +285,29 @@ TEST_F(CryptographyPluginTest, exchange_CDRSerializenDeserialize){
 
     CryptoPlugin->keyfactory()->unregister_participant(ParticipantA, exception);
 
-    delete i_handle;
-    delete perm_handle;
-
+    auth_plugin.return_identity_handle(&i_handle, exception);
+    access_plugin.return_permissions_handle(&perm_handle,exception);
 }
 
 TEST_F(CryptographyPluginTest, exchange_ParticipantCryptoTokens)
 {
+    using namespace eprosima::fastrtps::rtps::security;
 
-    eprosima::fastrtps::rtps::security::PKIIdentityHandle* i_handle =
-            new eprosima::fastrtps::rtps::security::PKIIdentityHandle();
-    eprosima::fastrtps::rtps::security::AccessPermissionsHandle* perm_handle =
-            new eprosima::fastrtps::rtps::security::AccessPermissionsHandle();
+    SecurityException exception;
+
+    PKIIdentityHandle& i_handle =
+        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+
+    AccessPermissionsHandle& perm_handle =
+        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
-    eprosima::fastrtps::rtps::security::ParticipantSecurityAttributes part_sec_attr;
-    eprosima::fastrtps::rtps::security::SharedSecretHandle* shared_secret =
-            new eprosima::fastrtps::rtps::security::SharedSecretHandle();
+    ParticipantSecurityAttributes part_sec_attr;
 
-    eprosima::fastrtps::rtps::security::SecurityException exception;
+    std::shared_ptr<SecretHandle> secret =
+        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+
+    std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
     part_sec_attr.is_rtps_protected = true;
     part_sec_attr.plugin_participant_attributes = PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ENCRYPTED |
@@ -295,7 +315,7 @@ TEST_F(CryptographyPluginTest, exchange_ParticipantCryptoTokens)
 
     //Fill shared secret with dummy values
     std::vector<uint8_t> dummy_data, challenge_1, challenge_2;
-    eprosima::fastrtps::rtps::security::SharedSecret::BinaryData binary_data;
+    SharedSecret::BinaryData binary_data;
     challenge_1.resize(32);
     challenge_2.resize(32);
 
@@ -316,25 +336,25 @@ TEST_F(CryptographyPluginTest, exchange_ParticipantCryptoTokens)
     (*shared_secret)->data_.push_back(binary_data);
 
     //Create ParticipantA and ParticipantB
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* ParticipantA =
-            CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle, part_sec_attr,
+    std::shared_ptr<ParticipantCryptoHandle> ParticipantA =
+            CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle, part_sec_attr,
                     exception);
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* ParticipantB =
-            CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle, part_sec_attr,
+    std::shared_ptr<ParticipantCryptoHandle> ParticipantB =
+            CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle, part_sec_attr,
                     exception);
 
-    ASSERT_TRUE( (ParticipantA != nullptr) & (ParticipantB != nullptr) );
+    ASSERT_TRUE(ParticipantA && ParticipantB);
 
     //Register a remote for both Participants
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* ParticipantA_remote =
-            CryptoPlugin->keyfactory()->register_matched_remote_participant(*ParticipantA, *i_handle, *perm_handle,
+    std::shared_ptr<ParticipantCryptoHandle> ParticipantA_remote =
+            CryptoPlugin->keyfactory()->register_matched_remote_participant(*ParticipantA, i_handle, perm_handle,
                     *shared_secret, exception);
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* ParticipantB_remote =
-            CryptoPlugin->keyfactory()->register_matched_remote_participant(*ParticipantB, *i_handle, *perm_handle,
+    std::shared_ptr<ParticipantCryptoHandle> ParticipantB_remote =
+            CryptoPlugin->keyfactory()->register_matched_remote_participant(*ParticipantB, i_handle, perm_handle,
                     *shared_secret, exception);
 
     //Create CryptoTokens for both Participants
-    eprosima::fastrtps::rtps::security::ParticipantCryptoTokenSeq ParticipantA_CryptoTokens, ParticipantB_CryptoTokens;
+    ParticipantCryptoTokenSeq ParticipantA_CryptoTokens, ParticipantB_CryptoTokens;
 
     ASSERT_TRUE(
         CryptoPlugin->keyexchange()->create_local_participant_crypto_tokens(ParticipantA_CryptoTokens, *ParticipantA,
@@ -356,10 +376,10 @@ TEST_F(CryptographyPluginTest, exchange_ParticipantCryptoTokens)
         );
 
     //Check that ParticipantB's KeyMaterial is congruent with ParticipantA and viceversa
-    eprosima::fastrtps::rtps::security::AESGCMGMAC_ParticipantCryptoHandle& Participant_A_remote =
-            eprosima::fastrtps::rtps::security::AESGCMGMAC_ParticipantCryptoHandle::narrow(*ParticipantA_remote);
-    eprosima::fastrtps::rtps::security::AESGCMGMAC_ParticipantCryptoHandle& Participant_B_remote =
-            eprosima::fastrtps::rtps::security::AESGCMGMAC_ParticipantCryptoHandle::narrow(*ParticipantB_remote);
+    AESGCMGMAC_ParticipantCryptoHandle& Participant_A_remote =
+            AESGCMGMAC_ParticipantCryptoHandle::narrow(*ParticipantA_remote);
+    AESGCMGMAC_ParticipantCryptoHandle& Participant_B_remote =
+            AESGCMGMAC_ParticipantCryptoHandle::narrow(*ParticipantB_remote);
 
     ASSERT_TRUE(Participant_A_remote->RemoteParticipant2ParticipantKeyMaterial.size() == 1);
     ASSERT_TRUE(Participant_B_remote->RemoteParticipant2ParticipantKeyMaterial.size() == 1);
@@ -370,30 +390,35 @@ TEST_F(CryptographyPluginTest, exchange_ParticipantCryptoTokens)
                 0).master_sender_key == Participant_A_remote->RemoteParticipant2ParticipantKeyMaterial.at(
                 0).master_sender_key);
 
-
     CryptoPlugin->keyfactory()->unregister_participant(ParticipantA, exception);
     CryptoPlugin->keyfactory()->unregister_participant(ParticipantB, exception);
     CryptoPlugin->keyfactory()->unregister_participant(ParticipantA_remote, exception);
     CryptoPlugin->keyfactory()->unregister_participant(ParticipantB_remote, exception);
 
-    delete shared_secret;
-    delete perm_handle;
-    delete i_handle;
+    auth_plugin.return_identity_handle(&i_handle, exception);
+    auth_plugin.return_sharedsecret_handle(secret, exception);
+    access_plugin.return_permissions_handle(&perm_handle,exception);
 }
 
 TEST_F(CryptographyPluginTest, transform_RTPSMessage)
 {
+    using namespace eprosima::fastrtps::rtps::security;
 
-    eprosima::fastrtps::rtps::security::PKIIdentityHandle* i_handle =
-            new eprosima::fastrtps::rtps::security::PKIIdentityHandle();
-    eprosima::fastrtps::rtps::security::AccessPermissionsHandle* perm_handle =
-            new eprosima::fastrtps::rtps::security::AccessPermissionsHandle();
+    SecurityException exception;
+
+    PKIIdentityHandle& i_handle =
+        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+
+    AccessPermissionsHandle& perm_handle =
+        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
-    eprosima::fastrtps::rtps::security::ParticipantSecurityAttributes part_sec_attr;
-    eprosima::fastrtps::rtps::security::SharedSecretHandle* shared_secret =
-            new eprosima::fastrtps::rtps::security::SharedSecretHandle();
+    ParticipantSecurityAttributes part_sec_attr;
 
-    eprosima::fastrtps::rtps::security::SecurityException exception;
+    std::shared_ptr<SecretHandle> secret =
+        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+
+    std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
     part_sec_attr.is_rtps_protected = true;
     part_sec_attr.plugin_participant_attributes = PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ENCRYPTED |
@@ -401,7 +426,7 @@ TEST_F(CryptographyPluginTest, transform_RTPSMessage)
 
     //Fill shared secret with dummy values
     std::vector<uint8_t> dummy_data, challenge_1, challenge_2;
-    eprosima::fastrtps::rtps::security::SharedSecret::BinaryData binary_data;
+    SharedSecret::BinaryData binary_data;
     challenge_1.resize(32);
     challenge_2.resize(32);
 
@@ -422,25 +447,25 @@ TEST_F(CryptographyPluginTest, transform_RTPSMessage)
     (*shared_secret)->data_.push_back(binary_data);
 
     //Create ParticipantA and ParticipantB
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* ParticipantA =
-            CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle, part_sec_attr,
+    std::shared_ptr<ParticipantCryptoHandle> ParticipantA =
+            CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle, part_sec_attr,
                     exception);
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* ParticipantB =
-            CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle, part_sec_attr,
+    std::shared_ptr<ParticipantCryptoHandle> ParticipantB =
+            CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle, part_sec_attr,
                     exception);
 
-    ASSERT_TRUE( (ParticipantA != nullptr) & (ParticipantB != nullptr) );
+    ASSERT_TRUE(ParticipantA && ParticipantB);
 
     //Register a remote for both Participants
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* ParticipantA_remote =
-            CryptoPlugin->keyfactory()->register_matched_remote_participant(*ParticipantA, *i_handle, *perm_handle,
+    std::shared_ptr<ParticipantCryptoHandle> ParticipantA_remote =
+            CryptoPlugin->keyfactory()->register_matched_remote_participant(*ParticipantA, i_handle, perm_handle,
                     *shared_secret, exception);
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* ParticipantB_remote =
-            CryptoPlugin->keyfactory()->register_matched_remote_participant(*ParticipantB, *i_handle, *perm_handle,
+    std::shared_ptr<ParticipantCryptoHandle> ParticipantB_remote =
+            CryptoPlugin->keyfactory()->register_matched_remote_participant(*ParticipantB, i_handle, perm_handle,
                     *shared_secret, exception);
 
     //Create CryptoTokens for both Participants
-    eprosima::fastrtps::rtps::security::ParticipantCryptoTokenSeq ParticipantA_CryptoTokens, ParticipantB_CryptoTokens;
+    ParticipantCryptoTokenSeq ParticipantA_CryptoTokens, ParticipantB_CryptoTokens;
 
     CryptoPlugin->keyexchange()->create_local_participant_crypto_tokens(ParticipantA_CryptoTokens, *ParticipantA,
             *ParticipantA_remote, exception);
@@ -462,10 +487,10 @@ TEST_F(CryptographyPluginTest, transform_RTPSMessage)
     memcpy(plain_rtps_message.buffer, message, 11);
     plain_rtps_message.length = 11;
 
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* unintended_remote =
-            CryptoPlugin->keyfactory()->register_matched_remote_participant(*ParticipantA, *i_handle, *perm_handle,
+    std::shared_ptr<ParticipantCryptoHandle> unintended_remote =
+            CryptoPlugin->keyfactory()->register_matched_remote_participant(*ParticipantA, i_handle, perm_handle,
                     *shared_secret, exception);
-    std::vector<eprosima::fastrtps::rtps::security::ParticipantCryptoHandle*> receivers;
+    std::vector<std::shared_ptr<ParticipantCryptoHandle>> receivers;
 
     //Send message to intended participant
     receivers.push_back(ParticipantA_remote);
@@ -518,17 +543,17 @@ TEST_F(CryptographyPluginTest, transform_RTPSMessage)
     prop2.value("16");
     prop_handle.push_back(prop2);
     //Create ParticipantA and ParticipantB
-    ParticipantA = CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle,
+    ParticipantA = CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle,
                     part_sec_attr, exception);
-    ParticipantB = CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle,
+    ParticipantB = CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle,
                     part_sec_attr, exception);
 
     //Register a remote for both Participants
-    ParticipantA_remote = CryptoPlugin->keyfactory()->register_matched_remote_participant(*ParticipantA, *i_handle,
-                    *perm_handle, *shared_secret,
+    ParticipantA_remote = CryptoPlugin->keyfactory()->register_matched_remote_participant(*ParticipantA, i_handle,
+                    perm_handle, *shared_secret,
                     exception);
-    ParticipantB_remote = CryptoPlugin->keyfactory()->register_matched_remote_participant(*ParticipantB, *i_handle,
-                    *perm_handle, *shared_secret,
+    ParticipantB_remote = CryptoPlugin->keyfactory()->register_matched_remote_participant(*ParticipantB, i_handle,
+                    perm_handle, *shared_secret,
                     exception);
 
     //Create CryptoTokens for both Participants
@@ -543,8 +568,8 @@ TEST_F(CryptographyPluginTest, transform_RTPSMessage)
     CryptoPlugin->keyexchange()->set_remote_participant_crypto_tokens(*ParticipantB, *ParticipantB_remote,
             ParticipantA_CryptoTokens, exception);
 
-    unintended_remote = CryptoPlugin->keyfactory()->register_matched_remote_participant(*ParticipantA, *i_handle,
-                    *perm_handle, *shared_secret,
+    unintended_remote = CryptoPlugin->keyfactory()->register_matched_remote_participant(*ParticipantA, i_handle,
+                    perm_handle, *shared_secret,
                     exception);
 
     //Perform sample message exchange
@@ -568,25 +593,32 @@ TEST_F(CryptographyPluginTest, transform_RTPSMessage)
     CryptoPlugin->keyfactory()->unregister_participant(ParticipantA_remote, exception);
     CryptoPlugin->keyfactory()->unregister_participant(ParticipantB_remote, exception);
 
-    delete shared_secret;
-    delete i_handle;
-    delete perm_handle;
+    auth_plugin.return_identity_handle(&i_handle, exception);
+    auth_plugin.return_sharedsecret_handle(secret, exception);
+    access_plugin.return_permissions_handle(&perm_handle,exception);
 }
 
 TEST_F(CryptographyPluginTest, factory_CreateLocalWriterHandle)
 {
+    using namespace eprosima::fastrtps::rtps::security;
 
-    eprosima::fastrtps::rtps::security::PKIIdentityHandle* i_handle =
-            new eprosima::fastrtps::rtps::security::PKIIdentityHandle();
-    eprosima::fastrtps::rtps::security::AccessPermissionsHandle* perm_handle =
-            new eprosima::fastrtps::rtps::security::AccessPermissionsHandle();
+    SecurityException exception;
+
+    PKIIdentityHandle& i_handle =
+        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+
+    AccessPermissionsHandle& perm_handle =
+        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
-    eprosima::fastrtps::rtps::security::ParticipantSecurityAttributes part_sec_attr;
-    eprosima::fastrtps::rtps::security::EndpointSecurityAttributes sec_attrs;
-    eprosima::fastrtps::rtps::security::SharedSecretHandle* shared_secret =
-            new eprosima::fastrtps::rtps::security::SharedSecretHandle();
+    ParticipantSecurityAttributes part_sec_attr;
 
-    eprosima::fastrtps::rtps::security::SecurityException exception;
+    EndpointSecurityAttributes sec_attrs;
+
+    std::shared_ptr<SecretHandle> secret =
+        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+
+    std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
     part_sec_attr.is_rtps_protected = true;
     part_sec_attr.plugin_participant_attributes = PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ENCRYPTED |
@@ -598,20 +630,18 @@ TEST_F(CryptographyPluginTest, factory_CreateLocalWriterHandle)
     sec_attrs.plugin_endpoint_attributes = PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ENCRYPTED |
             PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ORIGIN_AUTHENTICATED;
 
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* participant =
-            CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle, part_sec_attr,
+    std::shared_ptr<ParticipantCryptoHandle> participant =
+            CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle, part_sec_attr,
                     exception);
-    eprosima::fastrtps::rtps::security::DatawriterCryptoHandle* target =
+    DatawriterCryptoHandle* target =
             CryptoPlugin->keyfactory()->register_local_datawriter(*participant, prop_handle, sec_attrs, exception);
     ASSERT_TRUE(target != nullptr);
 
-    eprosima::fastrtps::rtps::security::AESGCMGMAC_WriterCryptoHandle& local_writer =
-            eprosima::fastrtps::rtps::security::AESGCMGMAC_WriterCryptoHandle::narrow(*target);
+    AESGCMGMAC_WriterCryptoHandle& local_writer = AESGCMGMAC_WriterCryptoHandle::narrow(*target);
     ASSERT_TRUE(!local_writer.nil());
 
     ASSERT_TRUE(local_writer->Entity2RemoteKeyMaterial.empty());
-    ASSERT_TRUE( (local_writer->EntityKeyMaterial.at(0).transformation_kind ==
-            eprosima::fastrtps::rtps::security::c_transfrom_kind_aes256_gcm) );
+    ASSERT_TRUE( (local_writer->EntityKeyMaterial.at(0).transformation_kind == c_transfrom_kind_aes256_gcm) );
 
     ASSERT_FALSE( std::all_of(local_writer->EntityKeyMaterial.at(0).master_salt.begin(),
             local_writer->EntityKeyMaterial.at(0).master_salt.end(), [](uint8_t i)
@@ -637,10 +667,10 @@ TEST_F(CryptographyPluginTest, factory_CreateLocalWriterHandle)
                 return i != 0;
             }) );
 
-    delete i_handle;
-    delete perm_handle;
-    delete shared_secret;
     //Release resources and check the handle is indeed empty
+    auth_plugin.return_identity_handle(&i_handle, exception);
+    auth_plugin.return_sharedsecret_handle(secret, exception);
+    access_plugin.return_permissions_handle(&perm_handle,exception);
 
     CryptoPlugin->keyfactory()->unregister_datawriter(target, exception);
     CryptoPlugin->keyfactory()->unregister_participant(participant, exception);
@@ -648,18 +678,25 @@ TEST_F(CryptographyPluginTest, factory_CreateLocalWriterHandle)
 
 TEST_F(CryptographyPluginTest, factory_CreateLocalReaderHandle)
 {
+    using namespace eprosima::fastrtps::rtps::security;
 
-    eprosima::fastrtps::rtps::security::PKIIdentityHandle* i_handle =
-            new eprosima::fastrtps::rtps::security::PKIIdentityHandle();
-    eprosima::fastrtps::rtps::security::AccessPermissionsHandle* perm_handle =
-            new eprosima::fastrtps::rtps::security::AccessPermissionsHandle();
+    SecurityException exception;
+
+    PKIIdentityHandle& i_handle =
+        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+
+    AccessPermissionsHandle& perm_handle =
+        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
-    eprosima::fastrtps::rtps::security::ParticipantSecurityAttributes part_sec_attr;
-    eprosima::fastrtps::rtps::security::EndpointSecurityAttributes sec_attrs;
-    eprosima::fastrtps::rtps::security::SharedSecretHandle* shared_secret =
-            new eprosima::fastrtps::rtps::security::SharedSecretHandle();
+    ParticipantSecurityAttributes part_sec_attr;
 
-    eprosima::fastrtps::rtps::security::SecurityException exception;
+    EndpointSecurityAttributes sec_attrs;
+
+    std::shared_ptr<SecretHandle> secret =
+        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+
+    std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
     part_sec_attr.is_rtps_protected = true;
     part_sec_attr.plugin_participant_attributes = PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ENCRYPTED |
@@ -671,20 +708,18 @@ TEST_F(CryptographyPluginTest, factory_CreateLocalReaderHandle)
     sec_attrs.plugin_endpoint_attributes = PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ENCRYPTED |
             PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ORIGIN_AUTHENTICATED;
 
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* participant =
-            CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle, part_sec_attr,
+    std::shared_ptr<ParticipantCryptoHandle> participant =
+            CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle, part_sec_attr,
                     exception);
-    eprosima::fastrtps::rtps::security::DatareaderCryptoHandle* target =
+    DatareaderCryptoHandle* target =
             CryptoPlugin->keyfactory()->register_local_datareader(*participant, prop_handle, sec_attrs, exception);
     ASSERT_TRUE(target != nullptr);
 
-    eprosima::fastrtps::rtps::security::AESGCMGMAC_ReaderCryptoHandle& local_reader =
-            eprosima::fastrtps::rtps::security::AESGCMGMAC_ReaderCryptoHandle::narrow(*target);
+    AESGCMGMAC_ReaderCryptoHandle& local_reader = AESGCMGMAC_ReaderCryptoHandle::narrow(*target);
     ASSERT_TRUE(!local_reader.nil());
 
     ASSERT_TRUE(local_reader->Entity2RemoteKeyMaterial.empty());
-    ASSERT_TRUE( (local_reader->EntityKeyMaterial.at(0).transformation_kind ==
-            eprosima::fastrtps::rtps::security::c_transfrom_kind_aes256_gcm) );
+    ASSERT_TRUE( (local_reader->EntityKeyMaterial.at(0).transformation_kind == c_transfrom_kind_aes256_gcm) );
 
     ASSERT_FALSE( std::all_of(local_reader->EntityKeyMaterial.at(0).master_salt.begin(),
             local_reader->EntityKeyMaterial.at(0).master_salt.end(), [](uint8_t i)
@@ -710,10 +745,10 @@ TEST_F(CryptographyPluginTest, factory_CreateLocalReaderHandle)
                 return i != 0;
             }) );
 
-    delete i_handle;
-    delete perm_handle;
-    delete shared_secret;
     //Release resources and check the handle is indeed empty
+    auth_plugin.return_identity_handle(&i_handle, exception);
+    auth_plugin.return_sharedsecret_handle(secret, exception);
+    access_plugin.return_permissions_handle(&perm_handle,exception);
 
     CryptoPlugin->keyfactory()->unregister_datareader(target, exception);
     CryptoPlugin->keyfactory()->unregister_participant(participant, exception);
@@ -721,18 +756,25 @@ TEST_F(CryptographyPluginTest, factory_CreateLocalReaderHandle)
 
 TEST_F(CryptographyPluginTest, factory_RegisterRemoteReaderWriter)
 {
+    using namespace eprosima::fastrtps::rtps::security;
 
-    eprosima::fastrtps::rtps::security::PKIIdentityHandle* i_handle =
-            new eprosima::fastrtps::rtps::security::PKIIdentityHandle();
-    eprosima::fastrtps::rtps::security::AccessPermissionsHandle* perm_handle =
-            new eprosima::fastrtps::rtps::security::AccessPermissionsHandle();
+    SecurityException exception;
+
+    PKIIdentityHandle& i_handle =
+        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+
+    AccessPermissionsHandle& perm_handle =
+        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
-    eprosima::fastrtps::rtps::security::ParticipantSecurityAttributes part_sec_attr;
-    eprosima::fastrtps::rtps::security::EndpointSecurityAttributes sec_attrs;
-    eprosima::fastrtps::rtps::security::SharedSecretHandle* shared_secret =
-            new eprosima::fastrtps::rtps::security::SharedSecretHandle();
+    ParticipantSecurityAttributes part_sec_attr;
 
-    eprosima::fastrtps::rtps::security::SecurityException exception;
+    EndpointSecurityAttributes sec_attrs;
+
+    std::shared_ptr<SecretHandle> secret =
+        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+
+    std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
     part_sec_attr.is_rtps_protected = true;
     part_sec_attr.plugin_participant_attributes = PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ENCRYPTED |
@@ -744,21 +786,21 @@ TEST_F(CryptographyPluginTest, factory_RegisterRemoteReaderWriter)
     sec_attrs.plugin_endpoint_attributes = PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ENCRYPTED |
             PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ORIGIN_AUTHENTICATED;
 
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* participant_A =
-            CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle, part_sec_attr,
+    std::shared_ptr<ParticipantCryptoHandle> participant_A =
+            CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle, part_sec_attr,
                     exception);
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* participant_B =
-            CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle, part_sec_attr,
+    std::shared_ptr<ParticipantCryptoHandle> participant_B =
+            CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle, part_sec_attr,
                     exception);
 
-    eprosima::fastrtps::rtps::security::DatareaderCryptoHandle* reader =
+    DatareaderCryptoHandle* reader =
             CryptoPlugin->keyfactory()->register_local_datareader(*participant_A, prop_handle, sec_attrs, exception);
-    eprosima::fastrtps::rtps::security::DatareaderCryptoHandle* writer =
+    DatareaderCryptoHandle* writer =
             CryptoPlugin->keyfactory()->register_local_datawriter(*participant_B, prop_handle, sec_attrs, exception);
 
     //Fill shared secret with dummy values
     std::vector<uint8_t> dummy_data, challenge_1, challenge_2;
-    eprosima::fastrtps::rtps::security::SharedSecret::BinaryData binary_data;
+    SharedSecret::BinaryData binary_data;
     challenge_1.resize(32);
     challenge_2.resize(32);
 
@@ -779,30 +821,29 @@ TEST_F(CryptographyPluginTest, factory_RegisterRemoteReaderWriter)
     (*shared_secret)->data_.push_back(binary_data);
 
     //Register a remote for both Participants
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* ParticipantA_remote =
-            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_A, *i_handle, *perm_handle,
+    std::shared_ptr<ParticipantCryptoHandle> ParticipantA_remote =
+            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_A, i_handle, perm_handle,
                     *shared_secret, exception);
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* ParticipantB_remote =
-            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_B, *i_handle, *perm_handle,
+    std::shared_ptr<ParticipantCryptoHandle> ParticipantB_remote =
+            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_B, i_handle, perm_handle,
                     *shared_secret, exception);
 
     //Register DataReader with DataWriter
-    eprosima::fastrtps::rtps::security::DatareaderCryptoHandle* remote_reader =
+    DatareaderCryptoHandle* remote_reader =
             CryptoPlugin->keyfactory()->register_matched_remote_datareader(*writer, *ParticipantB_remote,
                     *shared_secret, false, exception);
     ASSERT_TRUE(remote_reader != nullptr);
 
 
     //Register DataWriter with DataReader
-
-    eprosima::fastrtps::rtps::security::DatawriterCryptoHandle* remote_writer =
+    DatawriterCryptoHandle* remote_writer =
             CryptoPlugin->keyfactory()->register_matched_remote_datawriter(*reader, *ParticipantA_remote,
                     *shared_secret, exception);
     ASSERT_TRUE(remote_writer != nullptr);
 
-    delete i_handle;
-    delete perm_handle;
-    delete shared_secret;
+    auth_plugin.return_identity_handle(&i_handle, exception);
+    auth_plugin.return_sharedsecret_handle(secret, exception);
+    access_plugin.return_permissions_handle(&perm_handle,exception);
 
     CryptoPlugin->keyfactory()->unregister_datawriter(writer, exception);
     CryptoPlugin->keyfactory()->unregister_datareader(reader, exception);
@@ -810,32 +851,36 @@ TEST_F(CryptographyPluginTest, factory_RegisterRemoteReaderWriter)
     CryptoPlugin->keyfactory()->unregister_datareader(remote_reader, exception);
     CryptoPlugin->keyfactory()->unregister_datawriter(remote_writer, exception);
 
-
     CryptoPlugin->keyfactory()->unregister_participant(participant_A, exception);
     CryptoPlugin->keyfactory()->unregister_participant(participant_B, exception);
     CryptoPlugin->keyfactory()->unregister_participant(ParticipantA_remote, exception);
     CryptoPlugin->keyfactory()->unregister_participant(ParticipantB_remote, exception);
-
-
 }
 
 TEST_F(CryptographyPluginTest, exchange_ReaderWriterCryptoTokens)
 {
+    using namespace eprosima::fastrtps::rtps::security;
 
     // Participant A owns Writer
     // Participant B owns Reader
 
-    eprosima::fastrtps::rtps::security::PKIIdentityHandle* i_handle =
-            new eprosima::fastrtps::rtps::security::PKIIdentityHandle();
-    eprosima::fastrtps::rtps::security::AccessPermissionsHandle* perm_handle =
-            new eprosima::fastrtps::rtps::security::AccessPermissionsHandle();
-    eprosima::fastrtps::rtps::PropertySeq prop_handle;
-    eprosima::fastrtps::rtps::security::ParticipantSecurityAttributes part_sec_attr;
-    eprosima::fastrtps::rtps::security::EndpointSecurityAttributes sec_attrs;
-    eprosima::fastrtps::rtps::security::SharedSecretHandle* shared_secret =
-            new eprosima::fastrtps::rtps::security::SharedSecretHandle();
+    SecurityException exception;
 
-    eprosima::fastrtps::rtps::security::SecurityException exception;
+    PKIIdentityHandle& i_handle =
+        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+
+    AccessPermissionsHandle& perm_handle =
+        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+
+    eprosima::fastrtps::rtps::PropertySeq prop_handle;
+    ParticipantSecurityAttributes part_sec_attr;
+
+    EndpointSecurityAttributes sec_attrs;
+
+    std::shared_ptr<SecretHandle> secret =
+        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+
+    std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
     part_sec_attr.is_rtps_protected = true;
     part_sec_attr.plugin_participant_attributes = PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ENCRYPTED |
@@ -847,21 +892,21 @@ TEST_F(CryptographyPluginTest, exchange_ReaderWriterCryptoTokens)
     sec_attrs.plugin_endpoint_attributes = PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ENCRYPTED |
             PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ORIGIN_AUTHENTICATED;
 
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* participant_A =
-            CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle, part_sec_attr,
+    std::shared_ptr<ParticipantCryptoHandle> participant_A =
+            CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle, part_sec_attr,
                     exception);
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* participant_B =
-            CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle, part_sec_attr,
+    std::shared_ptr<ParticipantCryptoHandle> participant_B =
+            CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle, part_sec_attr,
                     exception);
 
-    eprosima::fastrtps::rtps::security::DatareaderCryptoHandle* reader =
+    DatareaderCryptoHandle* reader =
             CryptoPlugin->keyfactory()->register_local_datareader(*participant_A, prop_handle, sec_attrs, exception);
-    eprosima::fastrtps::rtps::security::DatareaderCryptoHandle* writer =
+    DatareaderCryptoHandle* writer =
             CryptoPlugin->keyfactory()->register_local_datawriter(*participant_B, prop_handle, sec_attrs, exception);
 
     //Fill shared secret with dummy values
     std::vector<uint8_t> dummy_data, challenge_1, challenge_2;
-    eprosima::fastrtps::rtps::security::SharedSecret::BinaryData binary_data;
+    SharedSecret::BinaryData binary_data;
     challenge_1.resize(32);
     challenge_2.resize(32);
 
@@ -882,25 +927,25 @@ TEST_F(CryptographyPluginTest, exchange_ReaderWriterCryptoTokens)
     (*shared_secret)->data_.push_back(binary_data);
 
     //Register a remote for both Participants
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* ParticipantA_remote =
-            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_A, *i_handle, *perm_handle,
+    std::shared_ptr<ParticipantCryptoHandle> ParticipantA_remote =
+            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_A, i_handle, perm_handle,
                     *shared_secret, exception);
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* ParticipantB_remote =
-            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_B, *i_handle, *perm_handle,
+    std::shared_ptr<ParticipantCryptoHandle> ParticipantB_remote =
+            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_B, i_handle, perm_handle,
                     *shared_secret, exception);
 
     //Register DataReader with DataWriter
-    eprosima::fastrtps::rtps::security::DatareaderCryptoHandle* remote_reader =
+    DatareaderCryptoHandle* remote_reader =
             CryptoPlugin->keyfactory()->register_matched_remote_datareader(*writer, *ParticipantB_remote,
                     *shared_secret, false, exception);
 
     //Register DataWriter with DataReader
-    eprosima::fastrtps::rtps::security::DatawriterCryptoHandle* remote_writer =
+    DatawriterCryptoHandle* remote_writer =
             CryptoPlugin->keyfactory()->register_matched_remote_datawriter(*reader, *ParticipantA_remote,
                     *shared_secret, exception);
 
     //Create CryptoTokens for both Participants
-    eprosima::fastrtps::rtps::security::ParticipantCryptoTokenSeq ParticipantA_CryptoTokens, ParticipantB_CryptoTokens;
+    ParticipantCryptoTokenSeq ParticipantA_CryptoTokens, ParticipantB_CryptoTokens;
 
     CryptoPlugin->keyexchange()->create_local_participant_crypto_tokens(ParticipantA_CryptoTokens, *participant_A,
             *ParticipantA_remote, exception);
@@ -914,7 +959,7 @@ TEST_F(CryptographyPluginTest, exchange_ReaderWriterCryptoTokens)
             ParticipantA_CryptoTokens, exception);
 
     //Create CryptoTokens for the DataWriter and DataReader
-    eprosima::fastrtps::rtps::security::DatawriterCryptoTokenSeq Writer_CryptoTokens, Reader_CryptoTokens;
+    DatawriterCryptoTokenSeq Writer_CryptoTokens, Reader_CryptoTokens;
 
     ASSERT_TRUE(
         CryptoPlugin->keyexchange()->create_local_datawriter_crypto_tokens(Writer_CryptoTokens, *writer, *remote_reader,
@@ -937,10 +982,8 @@ TEST_F(CryptographyPluginTest, exchange_ReaderWriterCryptoTokens)
         );
 
     //Check contents
-    eprosima::fastrtps::rtps::security::AESGCMGMAC_WriterCryptoHandle& WriterH =
-            eprosima::fastrtps::rtps::security::AESGCMGMAC_WriterCryptoHandle::narrow(*writer);
-    eprosima::fastrtps::rtps::security::AESGCMGMAC_ReaderCryptoHandle& ReaderH =
-            eprosima::fastrtps::rtps::security::AESGCMGMAC_ReaderCryptoHandle::narrow(*reader);
+    AESGCMGMAC_WriterCryptoHandle& WriterH = AESGCMGMAC_WriterCryptoHandle::narrow(*writer);
+    AESGCMGMAC_ReaderCryptoHandle& ReaderH = AESGCMGMAC_ReaderCryptoHandle::narrow(*reader);
 
     ASSERT_TRUE(WriterH->Remote2EntityKeyMaterial.size() == 1);
     ASSERT_TRUE(ReaderH->Remote2EntityKeyMaterial.size() == 1);
@@ -949,9 +992,10 @@ TEST_F(CryptographyPluginTest, exchange_ReaderWriterCryptoTokens)
     ASSERT_TRUE(ReaderH->Entity2RemoteKeyMaterial.at(0).master_sender_key ==
             WriterH->Remote2EntityKeyMaterial.at(0).master_sender_key);
 
-    delete i_handle;
-    delete perm_handle;
-    delete shared_secret;
+    //Release resources and check the handle is indeed empty
+    auth_plugin.return_identity_handle(&i_handle, exception);
+    auth_plugin.return_sharedsecret_handle(secret, exception);
+    access_plugin.return_permissions_handle(&perm_handle,exception);
 
     CryptoPlugin->keyfactory()->unregister_datawriter(writer, exception);
     CryptoPlugin->keyfactory()->unregister_datawriter(remote_writer, exception);
@@ -962,25 +1006,32 @@ TEST_F(CryptographyPluginTest, exchange_ReaderWriterCryptoTokens)
     CryptoPlugin->keyfactory()->unregister_participant(participant_B, exception);
     CryptoPlugin->keyfactory()->unregister_participant(ParticipantA_remote, exception);
     CryptoPlugin->keyfactory()->unregister_participant(ParticipantB_remote, exception);
-
 }
 
 TEST_F(CryptographyPluginTest, transform_SerializedPayload)
 {
+    using namespace eprosima::fastrtps::rtps::security;
 
     // Participant A owns Writer
     // Participant B owns Reader
-    eprosima::fastrtps::rtps::security::PKIIdentityHandle* i_handle =
-            new eprosima::fastrtps::rtps::security::PKIIdentityHandle();
-    eprosima::fastrtps::rtps::security::AccessPermissionsHandle* perm_handle =
-            new eprosima::fastrtps::rtps::security::AccessPermissionsHandle();
-    eprosima::fastrtps::rtps::PropertySeq prop_handle;
-    eprosima::fastrtps::rtps::security::ParticipantSecurityAttributes part_sec_attr;
-    eprosima::fastrtps::rtps::security::EndpointSecurityAttributes sec_attrs;
-    eprosima::fastrtps::rtps::security::SharedSecretHandle* shared_secret =
-            new eprosima::fastrtps::rtps::security::SharedSecretHandle();
 
-    eprosima::fastrtps::rtps::security::SecurityException exception;
+    SecurityException exception;
+
+    PKIIdentityHandle& i_handle =
+        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+
+    AccessPermissionsHandle& perm_handle =
+        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+
+    eprosima::fastrtps::rtps::PropertySeq prop_handle;
+    ParticipantSecurityAttributes part_sec_attr;
+
+    EndpointSecurityAttributes sec_attrs;
+
+    std::shared_ptr<SecretHandle> secret =
+        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+
+    std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
     part_sec_attr.is_rtps_protected = true;
     part_sec_attr.plugin_participant_attributes = PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ENCRYPTED |
@@ -993,21 +1044,21 @@ TEST_F(CryptographyPluginTest, transform_SerializedPayload)
             PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ORIGIN_AUTHENTICATED |
             PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_PAYLOAD_ENCRYPTED;
 
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* participant_A =
-            CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle, part_sec_attr,
+    std::shared_ptr<ParticipantCryptoHandle> participant_A =
+            CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle, part_sec_attr,
                     exception);
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* participant_B =
-            CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle, part_sec_attr,
+    std::shared_ptr<ParticipantCryptoHandle> participant_B =
+            CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle, part_sec_attr,
                     exception);
 
-    eprosima::fastrtps::rtps::security::DatareaderCryptoHandle* reader =
+    DatareaderCryptoHandle* reader =
             CryptoPlugin->keyfactory()->register_local_datareader(*participant_A, prop_handle, sec_attrs, exception);
-    eprosima::fastrtps::rtps::security::DatareaderCryptoHandle* writer =
+    DatareaderCryptoHandle* writer =
             CryptoPlugin->keyfactory()->register_local_datawriter(*participant_B, prop_handle, sec_attrs, exception);
 
     //Fill shared secret with dummy values
     std::vector<uint8_t> dummy_data, challenge_1, challenge_2;
-    eprosima::fastrtps::rtps::security::SharedSecret::BinaryData binary_data;
+    SharedSecret::BinaryData binary_data;
     challenge_1.resize(32);
     challenge_2.resize(32);
 
@@ -1028,25 +1079,25 @@ TEST_F(CryptographyPluginTest, transform_SerializedPayload)
     (*shared_secret)->data_.push_back(binary_data);
 
     //Register a remote for both Participants
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* ParticipantA_remote =
-            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_A, *i_handle, *perm_handle,
+    std::shared_ptr<ParticipantCryptoHandle> ParticipantA_remote =
+            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_A, i_handle, perm_handle,
                     *shared_secret, exception);
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* ParticipantB_remote =
-            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_B, *i_handle, *perm_handle,
+    std::shared_ptr<ParticipantCryptoHandle> ParticipantB_remote =
+            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_B, i_handle, perm_handle,
                     *shared_secret, exception);
 
     //Register DataReader with DataWriter
-    eprosima::fastrtps::rtps::security::DatareaderCryptoHandle* remote_reader =
+    DatareaderCryptoHandle* remote_reader =
             CryptoPlugin->keyfactory()->register_matched_remote_datareader(*writer, *ParticipantB_remote,
                     *shared_secret, false, exception);
 
     //Register DataWriter with DataReader
-    eprosima::fastrtps::rtps::security::DatawriterCryptoHandle* remote_writer =
+    DatawriterCryptoHandle* remote_writer =
             CryptoPlugin->keyfactory()->register_matched_remote_datawriter(*reader, *ParticipantA_remote,
                     *shared_secret, exception);
 
     //Create CryptoTokens for both Participants
-    eprosima::fastrtps::rtps::security::ParticipantCryptoTokenSeq ParticipantA_CryptoTokens, ParticipantB_CryptoTokens;
+    ParticipantCryptoTokenSeq ParticipantA_CryptoTokens, ParticipantB_CryptoTokens;
 
     CryptoPlugin->keyexchange()->create_local_participant_crypto_tokens(ParticipantA_CryptoTokens, *participant_A,
             *ParticipantA_remote, exception);
@@ -1060,7 +1111,7 @@ TEST_F(CryptographyPluginTest, transform_SerializedPayload)
             ParticipantA_CryptoTokens, exception);
 
     //Create CryptoTokens for the DataWriter and DataReader
-    eprosima::fastrtps::rtps::security::DatawriterCryptoTokenSeq Writer_CryptoTokens, Reader_CryptoTokens;
+    DatawriterCryptoTokenSeq Writer_CryptoTokens, Reader_CryptoTokens;
 
     CryptoPlugin->keyexchange()->create_local_datawriter_crypto_tokens(Writer_CryptoTokens, *writer, *remote_reader,
             exception);
@@ -1119,20 +1170,20 @@ TEST_F(CryptographyPluginTest, transform_SerializedPayload)
     prop2.value("16");
     prop_handle.push_back(prop2);
 
-    participant_A = CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle,
+    participant_A = CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle,
                     part_sec_attr, exception);
-    participant_B = CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle,
+    participant_B = CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle,
                     part_sec_attr, exception);
 
     reader = CryptoPlugin->keyfactory()->register_local_datareader(*participant_A, prop_handle, sec_attrs, exception);
     writer = CryptoPlugin->keyfactory()->register_local_datawriter(*participant_B, prop_handle, sec_attrs, exception);
 
     //Register a remote for both Participants
-    ParticipantA_remote = CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_A, *i_handle,
-                    *perm_handle, *shared_secret,
+    ParticipantA_remote = CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_A, i_handle,
+                    perm_handle, *shared_secret,
                     exception);
-    ParticipantB_remote = CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_B, *i_handle,
-                    *perm_handle, *shared_secret,
+    ParticipantB_remote = CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_B, i_handle,
+                    perm_handle, *shared_secret,
                     exception);
     //Register DataReader with DataWriter
     remote_reader = CryptoPlugin->keyfactory()->register_matched_remote_datareader(*writer, *ParticipantB_remote,
@@ -1184,28 +1235,32 @@ TEST_F(CryptographyPluginTest, transform_SerializedPayload)
     CryptoPlugin->keyfactory()->unregister_participant(participant_B, exception);
     CryptoPlugin->keyfactory()->unregister_participant(ParticipantB_remote, exception);
 
-    delete i_handle;
-    delete perm_handle;
-    delete shared_secret;
+    auth_plugin.return_identity_handle(&i_handle, exception);
+    auth_plugin.return_sharedsecret_handle(secret, exception);
+    access_plugin.return_permissions_handle(&perm_handle,exception);
 }
 
 TEST_F(CryptographyPluginTest, transform_Writer_Submesage)
 {
+    using namespace eprosima::fastrtps::rtps::security;
 
-    // Participant A owns Writer
-    // Participant B owns Reader
+    SecurityException exception;
 
-    eprosima::fastrtps::rtps::security::PKIIdentityHandle* i_handle =
-            new eprosima::fastrtps::rtps::security::PKIIdentityHandle();
-    eprosima::fastrtps::rtps::security::AccessPermissionsHandle* perm_handle =
-            new eprosima::fastrtps::rtps::security::AccessPermissionsHandle();
+    PKIIdentityHandle& i_handle =
+        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+
+    AccessPermissionsHandle& perm_handle =
+        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
-    eprosima::fastrtps::rtps::security::ParticipantSecurityAttributes part_sec_attr;
-    eprosima::fastrtps::rtps::security::EndpointSecurityAttributes sec_attrs;
-    eprosima::fastrtps::rtps::security::SharedSecretHandle* shared_secret =
-            new eprosima::fastrtps::rtps::security::SharedSecretHandle();
+    ParticipantSecurityAttributes part_sec_attr;
 
-    eprosima::fastrtps::rtps::security::SecurityException exception;
+    EndpointSecurityAttributes sec_attrs;
+
+    std::shared_ptr<SecretHandle> secret =
+        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+
+    std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
     part_sec_attr.is_rtps_protected = true;
     part_sec_attr.plugin_participant_attributes = PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ENCRYPTED |
@@ -1217,21 +1272,21 @@ TEST_F(CryptographyPluginTest, transform_Writer_Submesage)
     sec_attrs.plugin_endpoint_attributes = PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ENCRYPTED |
             PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ORIGIN_AUTHENTICATED;
 
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* participant_A =
-            CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle, part_sec_attr,
+    std::shared_ptr<ParticipantCryptoHandle> participant_A =
+            CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle, part_sec_attr,
                     exception);
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* participant_B =
-            CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle, part_sec_attr,
+    std::shared_ptr<ParticipantCryptoHandle> participant_B =
+            CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle, part_sec_attr,
                     exception);
 
-    eprosima::fastrtps::rtps::security::DatareaderCryptoHandle* reader =
+    DatareaderCryptoHandle* reader =
             CryptoPlugin->keyfactory()->register_local_datareader(*participant_A, prop_handle, sec_attrs, exception);
-    eprosima::fastrtps::rtps::security::DatareaderCryptoHandle* writer =
+    DatareaderCryptoHandle* writer =
             CryptoPlugin->keyfactory()->register_local_datawriter(*participant_B, prop_handle, sec_attrs, exception);
 
     //Fill shared secret with dummy values
     std::vector<uint8_t> dummy_data, challenge_1, challenge_2;
-    eprosima::fastrtps::rtps::security::SharedSecret::BinaryData binary_data;
+    SharedSecret::BinaryData binary_data;
     challenge_1.resize(32);
     challenge_2.resize(32);
 
@@ -1252,25 +1307,25 @@ TEST_F(CryptographyPluginTest, transform_Writer_Submesage)
     (*shared_secret)->data_.push_back(binary_data);
 
     //Register a remote for both Participants
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* ParticipantA_remote =
-            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_A, *i_handle, *perm_handle,
+    std::shared_ptr<ParticipantCryptoHandle> ParticipantA_remote =
+            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_A, i_handle, perm_handle,
                     *shared_secret, exception);
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* ParticipantB_remote =
-            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_B, *i_handle, *perm_handle,
+    std::shared_ptr<ParticipantCryptoHandle> ParticipantB_remote =
+            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_B, i_handle, perm_handle,
                     *shared_secret, exception);
 
     //Register DataReader with DataWriter
-    eprosima::fastrtps::rtps::security::DatareaderCryptoHandle* remote_reader =
+    DatareaderCryptoHandle* remote_reader =
             CryptoPlugin->keyfactory()->register_matched_remote_datareader(*writer, *ParticipantB_remote,
                     *shared_secret, false, exception);
 
     //Register DataWriter with DataReader
-    eprosima::fastrtps::rtps::security::DatawriterCryptoHandle* remote_writer =
+    DatawriterCryptoHandle* remote_writer =
             CryptoPlugin->keyfactory()->register_matched_remote_datawriter(*reader, *ParticipantA_remote,
                     *shared_secret, exception);
 
     //Create CryptoTokens for both Participants
-    eprosima::fastrtps::rtps::security::ParticipantCryptoTokenSeq ParticipantA_CryptoTokens, ParticipantB_CryptoTokens;
+    ParticipantCryptoTokenSeq ParticipantA_CryptoTokens, ParticipantB_CryptoTokens;
 
     CryptoPlugin->keyexchange()->create_local_participant_crypto_tokens(ParticipantA_CryptoTokens, *participant_A,
             *ParticipantA_remote, exception);
@@ -1284,7 +1339,7 @@ TEST_F(CryptographyPluginTest, transform_Writer_Submesage)
             ParticipantA_CryptoTokens, exception);
 
     //Create CryptoTokens for the DataWriter and DataReader
-    eprosima::fastrtps::rtps::security::DatawriterCryptoTokenSeq Writer_CryptoTokens, Reader_CryptoTokens;
+    DatawriterCryptoTokenSeq Writer_CryptoTokens, Reader_CryptoTokens;
 
     CryptoPlugin->keyexchange()->create_local_datawriter_crypto_tokens(Writer_CryptoTokens, *writer, *remote_reader,
             exception);
@@ -1307,7 +1362,7 @@ TEST_F(CryptographyPluginTest, transform_Writer_Submesage)
     memcpy(plain_payload.data(), message, 18);
 
     std::vector<uint8_t> inline_qos;
-    std::vector<eprosima::fastrtps::rtps::security::DatareaderCryptoHandle*> receivers;
+    std::vector<DatareaderCryptoHandle*> receivers;
     receivers.push_back(remote_reader);
 
     //TODO(Ricardo) Fix
@@ -1341,20 +1396,20 @@ TEST_F(CryptographyPluginTest, transform_Writer_Submesage)
     prop2.value("16");
     prop_handle.push_back(prop2);
 
-    participant_A = CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle,
+    participant_A = CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle,
                     part_sec_attr, exception);
-    participant_B = CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle,
+    participant_B = CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle,
                     part_sec_attr, exception);
 
     reader = CryptoPlugin->keyfactory()->register_local_datareader(*participant_A, prop_handle, sec_attrs, exception);
     writer = CryptoPlugin->keyfactory()->register_local_datawriter(*participant_B, prop_handle, sec_attrs, exception);
 
     //Register a remote for both Participants
-    ParticipantA_remote = CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_A, *i_handle,
-                    *perm_handle, *shared_secret,
+    ParticipantA_remote = CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_A, i_handle,
+                    perm_handle, *shared_secret,
                     exception);
-    ParticipantB_remote = CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_B, *i_handle,
-                    *perm_handle, *shared_secret,
+    ParticipantB_remote = CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_B, i_handle,
+                    perm_handle, *shared_secret,
                     exception);
 
     //Register DataReader with DataWriter
@@ -1401,9 +1456,9 @@ TEST_F(CryptographyPluginTest, transform_Writer_Submesage)
        ASSERT_TRUE(plain_payload == decoded_payload);
      */
 
-    delete i_handle;
-    delete perm_handle;
-    delete shared_secret;
+    auth_plugin.return_sharedsecret_handle(secret, exception);
+    auth_plugin.return_identity_handle(&i_handle, exception);
+    access_plugin.return_permissions_handle(&perm_handle,exception);
 
     CryptoPlugin->keyfactory()->unregister_datawriter(writer, exception);
     CryptoPlugin->keyfactory()->unregister_datawriter(remote_writer, exception);
@@ -1420,21 +1475,25 @@ TEST_F(CryptographyPluginTest, transform_Writer_Submesage)
 
 TEST_F(CryptographyPluginTest, transform_Reader_Submessage)
 {
+    using namespace eprosima::fastrtps::rtps::security;
 
-    // Participant A owns Writer
-    // Participant B owns Reader
+    SecurityException exception;
 
-    eprosima::fastrtps::rtps::security::PKIIdentityHandle* i_handle =
-            new eprosima::fastrtps::rtps::security::PKIIdentityHandle();
-    eprosima::fastrtps::rtps::security::AccessPermissionsHandle* perm_handle =
-            new eprosima::fastrtps::rtps::security::AccessPermissionsHandle();
+    PKIIdentityHandle& i_handle =
+        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+
+    AccessPermissionsHandle& perm_handle =
+        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
-    eprosima::fastrtps::rtps::security::ParticipantSecurityAttributes part_sec_attr;
-    eprosima::fastrtps::rtps::security::EndpointSecurityAttributes sec_attrs;
-    eprosima::fastrtps::rtps::security::SharedSecretHandle* shared_secret =
-            new eprosima::fastrtps::rtps::security::SharedSecretHandle();
+    ParticipantSecurityAttributes part_sec_attr;
 
-    eprosima::fastrtps::rtps::security::SecurityException exception;
+    EndpointSecurityAttributes sec_attrs;
+
+    std::shared_ptr<SecretHandle> secret =
+        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+
+    std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
     part_sec_attr.is_rtps_protected = true;
     part_sec_attr.plugin_participant_attributes = PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ENCRYPTED |
@@ -1446,21 +1505,21 @@ TEST_F(CryptographyPluginTest, transform_Reader_Submessage)
     sec_attrs.plugin_endpoint_attributes = PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ENCRYPTED |
             PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ORIGIN_AUTHENTICATED;
 
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* participant_A =
-            CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle, part_sec_attr,
+    std::shared_ptr<ParticipantCryptoHandle> participant_A =
+            CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle, part_sec_attr,
                     exception);
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* participant_B =
-            CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle, part_sec_attr,
+    std::shared_ptr<ParticipantCryptoHandle> participant_B =
+            CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle, part_sec_attr,
                     exception);
 
-    eprosima::fastrtps::rtps::security::DatareaderCryptoHandle* reader =
+    DatareaderCryptoHandle* reader =
             CryptoPlugin->keyfactory()->register_local_datareader(*participant_A, prop_handle, sec_attrs, exception);
-    eprosima::fastrtps::rtps::security::DatareaderCryptoHandle* writer =
+    DatareaderCryptoHandle* writer =
             CryptoPlugin->keyfactory()->register_local_datawriter(*participant_B, prop_handle, sec_attrs, exception);
 
     //Fill shared secret with dummy values
     std::vector<uint8_t> dummy_data, challenge_1, challenge_2;
-    eprosima::fastrtps::rtps::security::SharedSecret::BinaryData binary_data;
+    SharedSecret::BinaryData binary_data;
     challenge_1.resize(32);
     challenge_2.resize(32);
 
@@ -1481,25 +1540,25 @@ TEST_F(CryptographyPluginTest, transform_Reader_Submessage)
     (*shared_secret)->data_.push_back(binary_data);
 
     //Register a remote for both Participants
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* ParticipantA_remote =
-            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_A, *i_handle, *perm_handle,
+    std::shared_ptr<ParticipantCryptoHandle> ParticipantA_remote =
+            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_A, i_handle, perm_handle,
                     *shared_secret, exception);
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* ParticipantB_remote =
-            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_B, *i_handle, *perm_handle,
+    std::shared_ptr<ParticipantCryptoHandle> ParticipantB_remote =
+            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_B, i_handle, perm_handle,
                     *shared_secret, exception);
 
     //Register DataReader with DataWriter
-    eprosima::fastrtps::rtps::security::DatareaderCryptoHandle* remote_reader =
+    DatareaderCryptoHandle* remote_reader =
             CryptoPlugin->keyfactory()->register_matched_remote_datareader(*writer, *ParticipantB_remote,
                     *shared_secret, false, exception);
 
     //Register DataWriter with DataReader
-    eprosima::fastrtps::rtps::security::DatawriterCryptoHandle* remote_writer =
+    DatawriterCryptoHandle* remote_writer =
             CryptoPlugin->keyfactory()->register_matched_remote_datawriter(*reader, *ParticipantA_remote,
                     *shared_secret, exception);
 
     //Create CryptoTokens for both Participants
-    eprosima::fastrtps::rtps::security::ParticipantCryptoTokenSeq ParticipantA_CryptoTokens, ParticipantB_CryptoTokens;
+    ParticipantCryptoTokenSeq ParticipantA_CryptoTokens, ParticipantB_CryptoTokens;
 
     CryptoPlugin->keyexchange()->create_local_participant_crypto_tokens(ParticipantA_CryptoTokens, *participant_A,
             *ParticipantA_remote, exception);
@@ -1513,7 +1572,7 @@ TEST_F(CryptographyPluginTest, transform_Reader_Submessage)
             ParticipantA_CryptoTokens, exception);
 
     //Create CryptoTokens for the DataWriter and DataReader
-    eprosima::fastrtps::rtps::security::DatawriterCryptoTokenSeq Writer_CryptoTokens, Reader_CryptoTokens;
+    DatawriterCryptoTokenSeq Writer_CryptoTokens, Reader_CryptoTokens;
 
     CryptoPlugin->keyexchange()->create_local_datawriter_crypto_tokens(Writer_CryptoTokens, *writer, *remote_reader,
             exception);
@@ -1535,7 +1594,7 @@ TEST_F(CryptographyPluginTest, transform_Reader_Submessage)
     plain_payload.resize(18);
     memcpy(plain_payload.data(), message, 18);
 
-    std::vector<eprosima::fastrtps::rtps::security::DatawriterCryptoHandle*> receivers;
+    std::vector<DatawriterCryptoHandle*> receivers;
     receivers.push_back(remote_writer);
 
     //TODO(Ricardo) Fix
@@ -1569,20 +1628,20 @@ TEST_F(CryptographyPluginTest, transform_Reader_Submessage)
     prop2.value("16");
     prop_handle.push_back(prop2);
 
-    participant_A = CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle,
+    participant_A = CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle,
                     part_sec_attr, exception);
-    participant_B = CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle,
+    participant_B = CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle,
                     part_sec_attr, exception);
 
     reader = CryptoPlugin->keyfactory()->register_local_datareader(*participant_A, prop_handle, sec_attrs, exception);
     writer = CryptoPlugin->keyfactory()->register_local_datawriter(*participant_B, prop_handle, sec_attrs, exception);
 
     //Register a remote for both Participants
-    ParticipantA_remote = CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_A, *i_handle,
-                    *perm_handle, *shared_secret,
+    ParticipantA_remote = CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_A, i_handle,
+                    perm_handle, *shared_secret,
                     exception);
-    ParticipantB_remote = CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_B, *i_handle,
-                    *perm_handle, *shared_secret,
+    ParticipantB_remote = CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_B, i_handle,
+                    perm_handle, *shared_secret,
                     exception);
 
     //Register DataReader with DataWriter
@@ -1642,27 +1701,32 @@ TEST_F(CryptographyPluginTest, transform_Reader_Submessage)
     CryptoPlugin->keyfactory()->unregister_participant(participant_B, exception);
     CryptoPlugin->keyfactory()->unregister_participant(ParticipantB_remote, exception);
 
-    delete i_handle;
-    delete perm_handle;
-    delete shared_secret;
+    auth_plugin.return_sharedsecret_handle(secret, exception);
+    auth_plugin.return_identity_handle(&i_handle, exception);
+    access_plugin.return_permissions_handle(&perm_handle,exception);
 }
 
 TEST_F(CryptographyPluginTest, transform_preprocess_secure_submessage)
 {
-    // Participant A owns Writer
-    // Participant B owns Reader
+    using namespace eprosima::fastrtps::rtps::security;
 
-    eprosima::fastrtps::rtps::security::PKIIdentityHandle* i_handle =
-            new eprosima::fastrtps::rtps::security::PKIIdentityHandle();
-    eprosima::fastrtps::rtps::security::AccessPermissionsHandle* perm_handle =
-            new eprosima::fastrtps::rtps::security::AccessPermissionsHandle();
+    SecurityException exception;
+
+    PKIIdentityHandle& i_handle =
+        PKIIdentityHandle::narrow(*auth_plugin.get_identity_handle(exception));
+
+    AccessPermissionsHandle& perm_handle =
+        AccessPermissionsHandle::narrow(*access_plugin.get_permissions_handle(exception));
+
     eprosima::fastrtps::rtps::PropertySeq prop_handle;
-    eprosima::fastrtps::rtps::security::ParticipantSecurityAttributes part_sec_attr;
-    eprosima::fastrtps::rtps::security::EndpointSecurityAttributes sec_attrs;
-    eprosima::fastrtps::rtps::security::SharedSecretHandle* shared_secret =
-            new eprosima::fastrtps::rtps::security::SharedSecretHandle();
+    ParticipantSecurityAttributes part_sec_attr;
 
-    eprosima::fastrtps::rtps::security::SecurityException exception;
+    EndpointSecurityAttributes sec_attrs;
+
+    std::shared_ptr<SecretHandle> secret =
+        auth_plugin.get_shared_secret(SharedSecretHandle::nil_handle, exception);
+
+    std::shared_ptr<SharedSecretHandle> shared_secret = std::dynamic_pointer_cast<SharedSecretHandle>(secret);
 
     part_sec_attr.is_rtps_protected = true;
     part_sec_attr.plugin_participant_attributes = PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ENCRYPTED |
@@ -1674,23 +1738,23 @@ TEST_F(CryptographyPluginTest, transform_preprocess_secure_submessage)
     sec_attrs.plugin_endpoint_attributes = PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ENCRYPTED |
             PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ORIGIN_AUTHENTICATED;
 
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* participant_A =
-            CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle, part_sec_attr,
+    std::shared_ptr<ParticipantCryptoHandle> participant_A =
+            CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle, part_sec_attr,
                     exception);
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* participant_B =
-            CryptoPlugin->keyfactory()->register_local_participant(*i_handle, *perm_handle, prop_handle, part_sec_attr,
+    std::shared_ptr<ParticipantCryptoHandle> participant_B =
+            CryptoPlugin->keyfactory()->register_local_participant(i_handle, perm_handle, prop_handle, part_sec_attr,
                     exception);
 
-    eprosima::fastrtps::rtps::security::DatareaderCryptoHandle* reader =
+    DatareaderCryptoHandle* reader =
             CryptoPlugin->keyfactory()->register_local_datareader(*participant_B, prop_handle, sec_attrs, exception);
     EXPECT_TRUE(reader != nullptr);
-    eprosima::fastrtps::rtps::security::DatareaderCryptoHandle* writer =
+    DatareaderCryptoHandle* writer =
             CryptoPlugin->keyfactory()->register_local_datawriter(*participant_A, prop_handle, sec_attrs, exception);
     EXPECT_TRUE(writer != nullptr);
 
     //Fill shared secret with dummy values
     std::vector<uint8_t> dummy_data, challenge_1, challenge_2;
-    eprosima::fastrtps::rtps::security::SharedSecret::BinaryData binary_data;
+    SharedSecret::BinaryData binary_data;
     challenge_1.resize(32);
     challenge_2.resize(32);
 
@@ -1711,29 +1775,29 @@ TEST_F(CryptographyPluginTest, transform_preprocess_secure_submessage)
     (*shared_secret)->data_.push_back(binary_data);
 
     //Register a remote for both Participants
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* ParticipantA_remote =
-            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_A, *i_handle, *perm_handle,
+    std::shared_ptr<ParticipantCryptoHandle> ParticipantA_remote =
+            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_A, i_handle, perm_handle,
                     *shared_secret, exception);
     EXPECT_TRUE(ParticipantA_remote != nullptr);
-    eprosima::fastrtps::rtps::security::ParticipantCryptoHandle* ParticipantB_remote =
-            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_B, *i_handle, *perm_handle,
+    std::shared_ptr<ParticipantCryptoHandle> ParticipantB_remote =
+            CryptoPlugin->keyfactory()->register_matched_remote_participant(*participant_B, i_handle, perm_handle,
                     *shared_secret, exception);
     EXPECT_TRUE(ParticipantB_remote != nullptr);
 
     //Register DataReader with DataWriter
-    eprosima::fastrtps::rtps::security::DatareaderCryptoHandle* remote_reader =
+    DatareaderCryptoHandle* remote_reader =
             CryptoPlugin->keyfactory()->register_matched_remote_datareader(*writer, *ParticipantA_remote,
                     *shared_secret, false, exception);
     EXPECT_TRUE(remote_reader != nullptr);
 
     //Register DataWriter with DataReader
-    eprosima::fastrtps::rtps::security::DatawriterCryptoHandle* remote_writer =
+    DatawriterCryptoHandle* remote_writer =
             CryptoPlugin->keyfactory()->register_matched_remote_datawriter(*reader, *ParticipantB_remote,
                     *shared_secret, exception);
     EXPECT_TRUE(remote_writer != nullptr);
 
     //Create CryptoTokens for both Participants
-    eprosima::fastrtps::rtps::security::ParticipantCryptoTokenSeq ParticipantA_CryptoTokens, ParticipantB_CryptoTokens;
+    ParticipantCryptoTokenSeq ParticipantA_CryptoTokens, ParticipantB_CryptoTokens;
 
     EXPECT_TRUE(CryptoPlugin->keyexchange()->create_local_participant_crypto_tokens(ParticipantA_CryptoTokens,
             *participant_A, *ParticipantA_remote, exception));
@@ -1747,7 +1811,7 @@ TEST_F(CryptographyPluginTest, transform_preprocess_secure_submessage)
             ParticipantA_CryptoTokens, exception));
 
     //Create CryptoTokens for the DataWriter and DataReader
-    eprosima::fastrtps::rtps::security::DatawriterCryptoTokenSeq Writer_CryptoTokens, Reader_CryptoTokens;
+    DatawriterCryptoTokenSeq Writer_CryptoTokens, Reader_CryptoTokens;
 
     EXPECT_TRUE(CryptoPlugin->keyexchange()->create_local_datawriter_crypto_tokens(Writer_CryptoTokens, *writer,
             *remote_reader, exception));
@@ -1761,10 +1825,10 @@ TEST_F(CryptographyPluginTest, transform_preprocess_secure_submessage)
             Writer_CryptoTokens, exception));
 
     //Verify each remote participant has data about the remote readers and writer
-    eprosima::fastrtps::rtps::security::AESGCMGMAC_ParticipantCryptoHandle& P_B =
-            eprosima::fastrtps::rtps::security::AESGCMGMAC_ParticipantCryptoHandle::narrow(*ParticipantB_remote);                                                                       //Owner of a Reader
-    eprosima::fastrtps::rtps::security::AESGCMGMAC_ParticipantCryptoHandle& P_A =
-            eprosima::fastrtps::rtps::security::AESGCMGMAC_ParticipantCryptoHandle::narrow(*ParticipantA_remote);                                                                       //Owner of a Writer
+    AESGCMGMAC_ParticipantCryptoHandle& P_B =
+            AESGCMGMAC_ParticipantCryptoHandle::narrow(*ParticipantB_remote);                                                                       //Owner of a Reader
+    AESGCMGMAC_ParticipantCryptoHandle& P_A =
+            AESGCMGMAC_ParticipantCryptoHandle::narrow(*ParticipantA_remote);                                                                       //Owner of a Writer
 
     ASSERT_TRUE( P_A->Readers.size() == 2);
     ASSERT_TRUE( P_A->Writers.size() == 1);
@@ -1780,35 +1844,35 @@ TEST_F(CryptographyPluginTest, transform_preprocess_secure_submessage)
     memcpy(plain_payload.buffer, message, 18);
     plain_payload.length = 18;
 
-    std::vector<eprosima::fastrtps::rtps::security::DatawriterCryptoHandle*> receivers;
-    receivers.push_back(remote_writer);
+    std::vector<std::shared_ptr<DatawriterCryptoHandle>> receivers;
+    receivers.push_back(remote_writer->shared_from_this());
 
     EXPECT_TRUE(CryptoPlugin->cryptotransform()->encode_datareader_submessage(encoded_datareader_payload, plain_payload,
             *reader, receivers, exception));
 
     receivers.clear();
-    receivers.push_back(remote_reader);
+    receivers.push_back(remote_reader->shared_from_this());
     plain_payload.pos = 0;
     EXPECT_TRUE(CryptoPlugin->cryptotransform()->encode_datawriter_submessage(encoded_datawriter_payload, plain_payload,
             *writer, receivers, exception));
 
-    eprosima::fastrtps::rtps::security::SecureSubmessageCategory_t message_category;
-    eprosima::fastrtps::rtps::security::DatareaderCryptoHandle** target_reader =
-            new eprosima::fastrtps::rtps::security::DatareaderCryptoHandle*;
-    eprosima::fastrtps::rtps::security::DatawriterCryptoHandle** target_writer =
-            new eprosima::fastrtps::rtps::security::DatawriterCryptoHandle*;
+    SecureSubmessageCategory_t message_category;
+    DatareaderCryptoHandle** target_reader =
+            new DatareaderCryptoHandle*;
+    DatawriterCryptoHandle** target_writer =
+            new DatawriterCryptoHandle*;
     encoded_datareader_payload.pos = 0;
     ASSERT_TRUE(CryptoPlugin->cryptotransform()->preprocess_secure_submsg(target_writer, target_reader,
             message_category, encoded_datareader_payload, *participant_A, *ParticipantA_remote, exception));
 
-    ASSERT_TRUE(message_category == eprosima::fastrtps::rtps::security::DATAREADER_SUBMESSAGE);
+    ASSERT_TRUE(message_category == DATAREADER_SUBMESSAGE);
     ASSERT_TRUE(*target_reader == remote_reader);
     ASSERT_TRUE(*target_writer == writer);
 
     encoded_datawriter_payload.pos = 0;
     ASSERT_TRUE(CryptoPlugin->cryptotransform()->preprocess_secure_submsg(target_writer, target_reader,
             message_category, encoded_datawriter_payload, *participant_B, *ParticipantB_remote, exception));
-    ASSERT_TRUE(message_category == eprosima::fastrtps::rtps::security::DATAWRITER_SUBMESSAGE);
+    ASSERT_TRUE(message_category == DATAWRITER_SUBMESSAGE);
     ASSERT_TRUE(*target_writer == remote_writer);
     ASSERT_TRUE(*target_reader == reader);
 
@@ -1826,9 +1890,9 @@ TEST_F(CryptographyPluginTest, transform_preprocess_secure_submessage)
     EXPECT_TRUE(CryptoPlugin->keyfactory()->unregister_participant(participant_B, exception));
     EXPECT_TRUE(CryptoPlugin->keyfactory()->unregister_participant(ParticipantB_remote, exception));
 
-    delete shared_secret;
-    delete perm_handle;
-    delete i_handle;
+    auth_plugin.return_sharedsecret_handle(secret, exception);
+    auth_plugin.return_identity_handle(&i_handle, exception);
+    access_plugin.return_permissions_handle(&perm_handle,exception);
 }
 
 #endif // ifndef _UNITTEST_SECURITY_CRYPTOGRAPHY_CRYPTOGRAPHYPLUGINTESTS_HPP_


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

For sanitizer CI see https://github.com/eProsima/Fast-DDS/pull/2628

<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Refactor Guidelines:
+ What to do with const-use of members and references to the plugins?
  - the pointer members are initialized on `init()` which is called from participant constructor.
  - the pointer members are removed on `destroy()` which is called from ~SecurityManager() from the participant destructor. 
  - meanwhile `discovered_participant` and `on_process_handshake` are called from transport threads and leads to a myriad of member calls. The issue here is that destroy is called concurrently with those transport calls and leads to a race.
 
  The initial approach was to promote them to smart pointers able to guarantee unique getters and setters [see](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4058.pdf)
      but this 2014 proposal of an atomic<unique_ptr<T>> had no success. Though on 2017 the standard admitted
        `__cpp_lib_atomic_shared_ptr (c++20) -> atomic<shared_ptr<T>>`
   
   Finally a sentry based approach was favoured. The sentry requirements are:
  + It protects the plugins and other pointer based ancillary that doesn't require sync per-se but only `nullptr` checking.
  + It uses RAII strategy, thus it must be a method that returns a temporary object. While this object is *alive* the pointers cannot be modified.
  + The `SecurityManager::destroy()` method should wait till all the transport driven calls are done.
  Note that all methods call from `destroy()` must be sentry free to allow their execution.
  Note also that the `destroy()` must always called from a sentry free stack.

+ Collections must follow C++ const conventions. For example:
   ```c++
          std::map<GUID_t, DiscoveredParticipantInfo> discovered_participants_;
   ```
  in C++ philosophy this implies that the collection elements are like members and cannot be modified from `SecurityManager` const methods. This obviously doesn't fit in the actual use of them. Enconding/decoding operations should be const for the SecurityManager because it doesn't change its state but these members state. I'm going to promote them to:
   ```c++
          std::map<GUID_t, unique_ptr<DiscoveredParticipantInfo>> discovered_participants_;
   ```
+ Promote current mutex to `shared_mutex`. The write lock to protect changes on members (like collections update) and references (`new`/`delete`).
+ Collection members update must resort to their own sync methods. This was the premise before seeing how  
      `DiscoveredParticipantInfo` guarantees atomical update of its `AuthenticationInfo` members by using `unique_ptr<>` in
      the getters and setters (though the getters and setters must use another sync mechanism).  
+ Note that the previous mutex was recursive. Now care must be taken to avoid reentrancy.

After testing these changes it was detected that the sentry approach cannot prevent data removal due to discovery callbacks.
That is when a participant or endpoint was removed nothing prevent its encoding keys from being removed while other threads were using them to encode/decode a message.
In order to prevent this a new handle strategy was enforced:
+ Reference counting was added to the keys and other info required for encoding/decoding. This way even if the participant or endpoint info is removed only when the encode/decode operations are finished the actual removal would take place.
+ The handles cannot be created arbitrarily as before but class factories are assigned. This way the heap allocations and deallocations are prevented outside of the controlled factory code. Using this strategy the reference counting block uniqueness is assured.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] NA Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] NA New feature has been added to the `versions.md` file (if applicable).
- [ ] NA New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
