### PR TITLE
[14749] Solving sanitizer issue 4139 <master>

### DIFF
--- a/include/fastdds/rtps/writer/LivelinessManager.h
+++ b/include/fastdds/rtps/writer/LivelinessManager.h
@@ -29,12 +29,12 @@ namespace eprosima {
 namespace fastrtps {
 namespace rtps {
 
-using LivelinessCallback = std::function<void(
-        const GUID_t&,
-        const LivelinessQosPolicyKind&,
-        const Duration_t&,
-        int32_t alive_change,
-        int32_t not_alive_change)>;
+using LivelinessCallback = std::function<void (
+                    const GUID_t&,
+                    const LivelinessQosPolicyKind&,
+                    const Duration_t&,
+                    int32_t alive_change,
+                    int32_t not_alive_change)>;
 
 /**
  * @brief A class managing the liveliness of a set of writers. Writers are represented by their LivelinessData
@@ -65,7 +65,8 @@ public:
      * @brief LivelinessManager
      * @param other
      */
-    LivelinessManager(const LivelinessManager& other) = delete;
+    LivelinessManager(
+            const LivelinessManager& other) = delete;
 
     /**
      * @brief Adds a writer to the set
@@ -108,21 +109,23 @@ public:
      * @param kind Liveliness kind
      * @return True if liveliness was successfully asserted
      */
-    bool assert_liveliness(LivelinessQosPolicyKind kind);
+    bool assert_liveliness(
+            LivelinessQosPolicyKind kind);
 
     /**
      * @brief A method to check any writer of the given kind is alive
      * @param kind The liveliness kind to check for
      * @return True if at least one writer of this kind is alive. False otherwise
      */
-    bool is_any_alive(LivelinessQosPolicyKind kind);
+    bool is_any_alive(
+            LivelinessQosPolicyKind kind);
 
     /**
      * @brief A method to return liveliness data
      * @details Should only be used for testing purposes
      * @return Vector of liveliness data
      */
-    const ResourceLimitedVector<LivelinessData> &get_liveliness_data() const;
+    const ResourceLimitedVector<LivelinessData>& get_liveliness_data() const;
 
 private:
 
@@ -131,7 +134,8 @@ private:
      * @param writer The liveliness data of the writer asserting liveliness
      * @pre The collection shared_mutex must be taken for reading
      */
-    void assert_writer_liveliness(LivelinessData& writer);
+    void assert_writer_liveliness(
+            LivelinessData& writer);
 
     /**
      * @brief A method to calculate the time when the next writer is going to lose liveliness

--- a/include/fastdds/rtps/writer/LivelinessManager.h
+++ b/include/fastdds/rtps/writer/LivelinessManager.h
@@ -18,9 +18,10 @@
 #ifndef _FASTDDS_RTPS_LIVELINESS_MANAGER_H_
 #define _FASTDDS_RTPS_LIVELINESS_MANAGER_H_
 
+#include <fastdds/rtps/resources/TimedEvent.h>
 #include <fastdds/rtps/writer/LivelinessData.h>
 #include <fastrtps/utils/collections/ResourceLimitedVector.hpp>
-#include <fastdds/rtps/resources/TimedEvent.h>
+#include <fastrtps/utils/shared_mutex.hpp>
 
 #include <mutex>
 
@@ -125,46 +126,39 @@ public:
 
 private:
 
-    //! @brief A method responsible for invoking the callback when liveliness is asserted
-    //! @param writer The liveliness data of the writer asserting liveliness
-    //!
+    /**
+     * @brief A method responsible for invoking the callback when liveliness is asserted
+     * @param writer The liveliness data of the writer asserting liveliness
+     * @pre The collection shared_mutex must be taken for reading
+     */
     void assert_writer_liveliness(LivelinessData& writer);
 
     /**
      * @brief A method to calculate the time when the next writer is going to lose liveliness
      * @details This method is public for testing purposes but it should not be used from outside this class
+     * @pre std::mutex_ should not be taken on calling this method to avoid deadlock.
      * @return True if at least one writer is alive
      */
     bool calculate_next();
-
-    //! @brief A method to find a writer from a guid, liveliness kind and lease duration
-    //! @param guid The guid of the writer
-    //! @param kind The liveliness kind
-    //! @param lease_duration The lease duration
-    //! @param wit_out Returns an iterator to the writer liveliness data
-    //! @return Returns true if writer was found, false otherwise
-    bool find_writer(
-            const GUID_t &guid,
-            const LivelinessQosPolicyKind &kind,
-            const Duration_t &lease_duration,
-            ResourceLimitedVector<LivelinessData>::iterator* wit_out);
-
 
     //! @brief A method called if the timer expires
     //! @return True if the timer should be restarted
     bool timer_expired();
 
     //! A callback to inform outside classes that a writer changed its liveliness status
-    LivelinessCallback callback_;
+    const LivelinessCallback callback_;
 
     //! A boolean indicating whether we are managing writers with automatic liveliness
-    bool manage_automatic_;
+    const bool manage_automatic_;
 
     //! A vector of liveliness data
     ResourceLimitedVector<LivelinessData> writers_;
 
-    //! A mutex to protect the liveliness data
+    //! A mutex to protect the liveliness data included LivelinessData objects
     std::mutex mutex_;
+
+    //! A mutex devoted to protect the writers_ collection
+    eprosima::shared_mutex col_mutex_;
 
     //! The timer owner, i.e. the writer which is next due to lose its liveliness
     LivelinessData* timer_owner_;

--- a/include/fastrtps/utils/collections/ResourceLimitedVector.hpp
+++ b/include/fastrtps/utils/collections/ResourceLimitedVector.hpp
@@ -558,7 +558,7 @@ protected:
      * Remove element.
      *
      * Removes the element pointed to by it.
-     * All iterators may become invalidated if this method returns true.
+     * All iterators may become invalidated.
      * This version doesn't keep the order of insertion, optimizing the number of copies performed.
      *
      * @param it   Iterator pointing to the item to be removed.
@@ -581,7 +581,7 @@ protected:
      * Remove element.
      *
      * Removes the element pointed to by it.
-     * All iterators may become invalidated if this method returns true.
+     * All iterators may become invalidated.
      * This version keeps the order of insertion, so when removing an item different from the last one,
      * part of the collection will be copied.
      *

--- a/src/cpp/rtps/writer/LivelinessManager.cpp
+++ b/src/cpp/rtps/writer/LivelinessManager.cpp
@@ -102,15 +102,16 @@ bool LivelinessManager::remove_writer(
         // collection guard
         std::lock_guard<shared_mutex> _(col_mutex_);
 
-        removed = writers_.remove_if([guid, kind, lease_duration, &status, this](LivelinessData& writer){
-                // writers_ elements guard
-                std::lock_guard<std::mutex> _(mutex_);
-                status = writer.status;
-                return writer.guid == guid &&
-                    writer.kind == kind &&
-                    writer.lease_duration == lease_duration &&
-                    --writer.count == 0;
-                });
+        removed = writers_.remove_if([guid, kind, lease_duration, &status, this](LivelinessData& writer)
+                        {
+                            // writers_ elements guard
+                            std::lock_guard<std::mutex> _(mutex_);
+                            status = writer.status;
+                            return writer.guid == guid &&
+                            writer.kind == kind &&
+                            writer.lease_duration == lease_duration &&
+                            --writer.count == 0;
+                        });
     }
 
     if (!removed)
@@ -203,7 +204,7 @@ bool LivelinessManager::assert_liveliness(
         }
     }
 
-    if(!found)
+    if (!found)
     {
         return false;
     }
@@ -342,7 +343,7 @@ bool LivelinessManager::timer_expired()
     {
         lock.lock();
 
-        if( timer_owner_ != nullptr)
+        if ( timer_owner_ != nullptr)
         {
             // Some times the interval could be negative if a writer expired during the call to this function
             // Once in this situation there is not much we can do but let asio timers expire inmediately

--- a/src/cpp/rtps/writer/LivelinessManager.cpp
+++ b/src/cpp/rtps/writer/LivelinessManager.cpp
@@ -51,7 +51,7 @@ bool LivelinessManager::add_writer(
 
     {
         // collection guard
-        shared_lock<shared_mutex> _(col_mutex_);
+        std::lock_guard<shared_mutex> _(col_mutex_);
 
         for (LivelinessData& writer : writers_)
         {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->
For sanitizer CI see https://github.com/eProsima/Fast-DDS/pull/2679

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
LivelinessManager should be refactored in order to solve lock inversion issues reported in several issues like 4139.
The class has now a
```
    std::mutex mutex_;
```
devoted to safeguarding the class data (including member collection contents). And a
```
   shared_mutex col_mutex_;
```
devoted to protecting member collections and allowing their safe traversal without taking any *writer lock* that will lead to lock inversion.
The code was reordered in order to prevent any callbacks (potencial deadlock sources) with any `lock` taken (only `shared_lock` or none is allowed.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] NA Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] NA New feature has been added to the `versions.md` file (if applicable).
- [ ] NA New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
