### PR TITLE
[14663] Use Mersenne Twister as random generator

### DIFF
--- a/src/cpp/rtps/common/GuidUtils.hpp
+++ b/src/cpp/rtps/common/GuidUtils.hpp
@@ -102,7 +102,8 @@ private:
         prefix_.value[4] = static_cast<octet>(pid & 0xFF);
         prefix_.value[5] = static_cast<octet>((pid >> 8) & 0xFF);
 
-        std::random_device generator;
+        std::random_device device;
+        std::mt19937 generator(device());
         std::uniform_int_distribution<uint16_t> distribution(0, std::numeric_limits<uint16_t>::max());
         uint16_t rand_value = distribution(generator);
         prefix_.value[6] = static_cast<octet>(rand_value & 0xFF);

--- a/src/cpp/rtps/common/GuidUtils.hpp
+++ b/src/cpp/rtps/common/GuidUtils.hpp
@@ -102,6 +102,9 @@ private:
         prefix_.value[4] = static_cast<octet>(pid & 0xFF);
         prefix_.value[5] = static_cast<octet>((pid >> 8) & 0xFF);
 
+        // Using std::random_device as the generator made program hang forever on some CPUs (issue #2694), so we
+        // changed this into a std::mt19937 seeded by a std::random_device. Since we are just adding some randomness
+        // to the PID part of the GUID, it will still provide enough uniqueness on the cases stated above.
         std::random_device device;
         std::mt19937 generator(device());
         std::uniform_int_distribution<uint16_t> distribution(0, std::numeric_limits<uint16_t>::max());


### PR DESCRIPTION
Signed-off-by: Miguel Company <MiguelCompany@eprosima.com>

<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This should fix #2694 by using a Mersenne Twister RNG seeded by the random device. Since the GUID of the participant also includes the process identifier, the uniqueness of the GUID will still be enough on most use-cases.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
@mergifyio backport 2.5.x 2.3.x 2.1.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
