### PR TITLE
[14681] Fixing thread sanitizer issue 4169 <feature/tsan/fixes>

### DIFF
--- a/include/fastdds/rtps/builtin/discovery/endpoint/EDP.h
+++ b/include/fastdds/rtps/builtin/discovery/endpoint/EDP.h
@@ -30,6 +30,8 @@
 #include <fastdds/dds/core/status/SubscriptionMatchedStatus.hpp>
 #include <fastdds/dds/core/status/IncompatibleQosStatus.hpp>
 
+#include <fastrtps/utils/ProxyPool.hpp>
+
 #include <foonathan/memory/container.hpp>
 #include <foonathan/memory/memory_pool.hpp>
 
@@ -349,9 +351,11 @@ public:
 
 protected:
 
-    std::mutex temp_data_lock_;
-    ReaderProxyData temp_reader_proxy_data_;
-    WriterProxyData temp_writer_proxy_data_;
+    //! ProxyPool for temporary reader proxies
+    ProxyPool<ReaderProxyData> temp_reader_proxies_;
+
+    //! ProxyPool for temporary writer proxies
+    ProxyPool<WriterProxyData> temp_writer_proxies_;
 
 private:
 

--- a/include/fastdds/rtps/builtin/discovery/endpoint/EDP.h
+++ b/include/fastdds/rtps/builtin/discovery/endpoint/EDP.h
@@ -347,6 +347,12 @@ public:
     //! Pointer to the RTPSParticipant.
     RTPSParticipantImpl* mp_RTPSParticipant;
 
+protected:
+
+    std::mutex temp_data_lock_;
+    ReaderProxyData temp_reader_proxy_data_;
+    WriterProxyData temp_writer_proxy_data_;
+
 private:
 
     /**
@@ -395,9 +401,6 @@ private:
     bool hasTypeObject(
             const WriterProxyData* wdata,
             const ReaderProxyData* rdata) const;
-
-    ReaderProxyData temp_reader_proxy_data_;
-    WriterProxyData temp_writer_proxy_data_;
 
     using pool_allocator_t =
             foonathan::memory::memory_pool<foonathan::memory::node_pool, foonathan::memory::heap_allocator>;

--- a/include/fastdds/rtps/builtin/discovery/endpoint/EDP.h
+++ b/include/fastdds/rtps/builtin/discovery/endpoint/EDP.h
@@ -21,15 +21,14 @@
 #define _FASTDDS_RTPS_EDP_H_
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
+#include <fastdds/dds/core/status/IncompatibleQosStatus.hpp>
+#include <fastdds/dds/core/status/PublicationMatchedStatus.hpp>
+#include <fastdds/dds/core/status/SubscriptionMatchedStatus.hpp>
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
 #include <fastdds/rtps/builtin/data/ContentFilterProperty.hpp>
 #include <fastdds/rtps/builtin/data/ReaderProxyData.h>
 #include <fastdds/rtps/builtin/data/WriterProxyData.h>
 #include <fastdds/rtps/common/Guid.h>
-#include <fastdds/dds/core/status/PublicationMatchedStatus.hpp>
-#include <fastdds/dds/core/status/SubscriptionMatchedStatus.hpp>
-#include <fastdds/dds/core/status/IncompatibleQosStatus.hpp>
-
 #include <fastrtps/utils/ProxyPool.hpp>
 
 #include <foonathan/memory/container.hpp>
@@ -349,13 +348,17 @@ public:
     //! Pointer to the RTPSParticipant.
     RTPSParticipantImpl* mp_RTPSParticipant;
 
-protected:
+    /**
+     * Access the temporary proxy pool for reader proxies
+     * @return pool reference
+     */
+    ProxyPool<ReaderProxyData>& get_temporary_reader_proxies_pool();
 
-    //! ProxyPool for temporary reader proxies
-    ProxyPool<ReaderProxyData> temp_reader_proxies_;
-
-    //! ProxyPool for temporary writer proxies
-    ProxyPool<WriterProxyData> temp_writer_proxies_;
+    /**
+     * Access the temporary proxy pool for writer proxies
+     * @return pool reference
+     */
+    ProxyPool<WriterProxyData>& get_temporary_writer_proxies_pool();
 
 private:
 

--- a/include/fastdds/rtps/builtin/discovery/endpoint/EDPSimple.h
+++ b/include/fastdds/rtps/builtin/discovery/endpoint/EDPSimple.h
@@ -263,12 +263,6 @@ private:
             const GUID_t& local_writer,
             const ReaderProxyData& remote_reader_data) override;
 #endif // if HAVE_SECURITY
-
-protected:
-
-    std::mutex temp_data_lock_;
-    ReaderProxyData temp_reader_proxy_data_;
-    WriterProxyData temp_writer_proxy_data_;
 };
 
 } /* namespace rtps */

--- a/include/fastdds/rtps/builtin/discovery/participant/PDP.h
+++ b/include/fastdds/rtps/builtin/discovery/participant/PDP.h
@@ -25,13 +25,14 @@
 #include <mutex>
 #include <functional>
 
-#include <fastdds/rtps/common/Guid.h>
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
 #include <fastdds/rtps/builtin/data/ReaderProxyData.h>
 #include <fastdds/rtps/builtin/data/WriterProxyData.h>
-#include <fastrtps/qos/QosPolicies.h>
-#include <fastrtps/utils/collections/ResourceLimitedVector.hpp>
+#include <fastdds/rtps/common/Guid.h>
 #include <fastdds/rtps/participant/ParticipantDiscoveryInfo.h>
+#include <fastrtps/qos/QosPolicies.h>
+#include <fastrtps/utils/ProxyPool.hpp>
+#include <fastrtps/utils/collections/ResourceLimitedVector.hpp>
 
 namespace eprosima {
 
@@ -357,6 +358,24 @@ public:
      */
     std::list<eprosima::fastdds::rtps::RemoteServerAttributes>& remote_server_attributes();
 
+    /**
+     * Access the temporary proxy pool for reader proxies
+     * @return pool reference
+     */
+    ProxyPool<ReaderProxyData>& get_temporary_reader_proxies_pool()
+    {
+        return temp_reader_proxies_;
+    }
+
+    /**
+     * Access the temporary proxy pool for writer proxies
+     * @return pool reference
+     */
+    ProxyPool<WriterProxyData>& get_temporary_writer_proxies_pool()
+    {
+        return temp_writer_proxies_;
+    }
+
 protected:
 
     //!Pointer to the builtin protocols object.
@@ -397,12 +416,10 @@ protected:
     ReaderHistory* mp_PDPReaderHistory;
     //!Reader payload pool
     std::shared_ptr<ITopicPayloadPool> reader_payload_pool_;
-    //!ReaderProxyData to allow preallocation of remote locators
-    ReaderProxyData temp_reader_data_;
-    //!WriterProxyData to allow preallocation of remote locators
-    WriterProxyData temp_writer_data_;
-    //!To protect temp_writer_data_ and temp_reader_data_
-    std::mutex temp_data_lock_;
+    //! ProxyPool for temporary reader proxies
+    ProxyPool<ReaderProxyData> temp_reader_proxies_;
+    //! ProxyPool for temporary writer proxies
+    ProxyPool<WriterProxyData> temp_writer_proxies_;
     //!Participant data atomic access assurance
     std::recursive_mutex* mp_mutex;
     //!To protect callbacks (ParticipantProxyData&)

--- a/include/fastdds/rtps/common/EntityId_t.hpp
+++ b/include/fastdds/rtps/common/EntityId_t.hpp
@@ -177,6 +177,17 @@ struct RTPS_DllAPI EntityId_t
         return EntityId_t();
     }
 
+    bool is_reader()
+    {
+        // RTPS Standard table 9.1
+        return 0x4u & to_uint32();
+    }
+
+    bool is_writer()
+    {
+        // RTPS Standard table 9.1
+        return 0x2u & to_uint32() && !is_reader();
+    }
 };
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC

--- a/include/fastdds/rtps/common/EntityId_t.hpp
+++ b/include/fastdds/rtps/common/EntityId_t.hpp
@@ -177,13 +177,13 @@ struct RTPS_DllAPI EntityId_t
         return EntityId_t();
     }
 
-    bool is_reader()
+    bool is_reader() const
     {
         // RTPS Standard table 9.1
         return 0x4u & to_uint32();
     }
 
-    bool is_writer()
+    bool is_writer() const
     {
         // RTPS Standard table 9.1
         return 0x2u & to_uint32() && !is_reader();

--- a/include/fastdds/rtps/common/EntityId_t.hpp
+++ b/include/fastdds/rtps/common/EntityId_t.hpp
@@ -188,6 +188,7 @@ struct RTPS_DllAPI EntityId_t
         // RTPS Standard table 9.1
         return 0x2u & to_uint32() && !is_reader();
     }
+
 };
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC

--- a/include/fastrtps/utils/ProxyPool.hpp
+++ b/include/fastrtps/utils/ProxyPool.hpp
@@ -1,0 +1,211 @@
+// Copyright 2022 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*!
+ * @file ProxyPool.hpp
+ */
+
+#ifndef FASTRTPS_UTILS_PROXY_POOL_HPP_
+#define FASTRTPS_UTILS_PROXY_POOL_HPP_
+
+#include <array>
+#include <bitset>
+#include <cassert>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+
+#if defined(__has_include) && __has_include(<version>)
+#   include <version>
+#endif // if defined(__has_include) && __has_include(<version>)
+
+namespace eprosima
+{
+
+// unnamed namespace for isolation
+namespace {
+
+// Detect if integer_sequence is availalbe
+#if defined(__cpp_lib_integer_sequence) \
+    && ((__cpp_lib_integer_sequence <= _MSVC_LANG) \
+    || (__cpp_lib_integer_sequence <= __cplusplus))
+
+    // Array initialization usin C++14
+    template<class P, size_t... Ints>
+    std::array<P,sizeof...(Ints)> make_array(P&& i, std::index_sequence<Ints...> is)
+    {
+        return { (Ints == is.size() - 1 ? std::move(i) : i)...};
+    }
+
+    template<size_t N, class P>
+    std::array<P,N> make_array(P&& i)
+    {
+        return make_array<P>(std::move(i), std::make_index_sequence<N>{});
+    }
+
+#else // C++11 fallback
+
+    template<size_t N, class P, class... Ts>
+    std::array<P, N> make_array(P&& i, Ts&&... args);
+
+    template<bool, size_t N, class... Ts>
+    struct make_array_choice
+    {
+        template<class P>
+        static std::array<P,N> res(P&& i, Ts&&... args)
+        {
+            P tmp(i);
+            return make_array<N>(std::move(i), std::move(tmp), std::move(args)...);
+        }
+    };
+
+    template<size_t N, class... Ts>
+    struct make_array_choice<true, N, Ts...>
+    {
+        template<class P>
+        static std::array<P,N> res(P&& i, Ts&&... args)
+        {
+            return {std::move(i), std::move(args)...};
+        }
+    };
+
+    template<size_t N, class P, class... Ts>
+    std::array<P, N> make_array(P&& i, Ts&&... args)
+    {
+        return make_array_choice<N == (sizeof...(Ts) + 1), N, Ts...>::res(std::move(i), std::move(args)...);
+    }
+
+#endif // defined(__cpp_lib_integer_sequence)
+
+}
+
+template< class Proxy, std::size_t N = 4>
+class ProxyPool
+{
+    std::mutex mtx_;
+    std::condition_variable cv_;
+    std::array<Proxy,N> heap_;
+    std::bitset<N> mask_;
+
+    // unique_ptr<Proxy> deleters
+    class D {
+        // Because ProxyPool will be destroy after all the proxies are returned
+        // this reference is always valid
+        ProxyPool& pool_;
+
+        friend class ProxyPool;
+
+        D(ProxyPool * pool) : pool_(*pool) {}
+
+        public:
+
+        void operator()(Proxy* p) const
+        {
+            pool_.set_back(p);
+        }
+
+    } deleter_;
+
+    friend class D;
+
+    /*
+     * Return an available proxy to the pool.
+     * @param p pointer to the proxy.
+     */
+    void set_back(Proxy * p) noexcept
+    {
+        std::size_t idx = p - heap_.data();
+
+        std::lock_guard<std::mutex> _(mtx_);
+
+        // check is not there
+        assert(!mask_.test(idx));
+
+        // return the resource
+        mask_.set(idx);
+    }
+
+public:
+
+    using smart_ptr = std::unique_ptr<Proxy,D&>;
+
+    /*
+     * Constructor of the pool object.
+     * @param init Initialization value for all the proxies.
+     */
+    ProxyPool(Proxy&& init)
+        : heap_(make_array<N>(std::move(init)))
+        , deleter_(this)
+    {
+        // make all resources available
+        mask_.set();
+    }
+
+    /*
+     * Destructor for the pool object.
+     * It waits till all the proxies are back in the pool to prevent data races.
+     */
+    ~ProxyPool()
+    {
+        std::unique_lock<std::mutex> lock(mtx_);
+        cv_.wait(lock, [&](){return mask_.all();});
+    }
+
+    /*
+     * Returns the number of proxies in the pool.
+     * @return pool size
+     */
+    static constexpr std::size_t size()
+    {
+        return N;
+    }
+
+    /*
+     * Returns the number of proxies available in the pool.
+     * @return available proxies
+     */
+    std::size_t available() const noexcept
+    {
+        std::lock_guard<std::mutex> _(mtx_);
+        return mask_.count();
+    }
+
+    /*
+     * Retrieve an available proxy from the pool.
+     * If not available a wait ensues.
+     * Note deleter is referenced not copied to avoid heap allocations on smart pointer construction
+     * @return unique_ptr referencing the proxy. On destruction the resource is returned.
+     */
+    std::unique_ptr<Proxy,D&> get()
+    {
+        std::unique_lock<std::mutex> lock(mtx_);
+
+        // wait for available resources
+        cv_.wait(lock, [&](){return mask_.any();});
+
+        // find the first available
+        std::size_t idx = 0;
+        while (idx < mask_.size() && !mask_.test(idx)) {
+          ++idx;
+        }
+
+        // retrieve it
+        mask_.reset(idx);
+        return std::unique_ptr<Proxy, D&>(&heap_[idx], deleter_);
+    }
+};
+
+} // eprosima namespace
+
+#endif /* FASTRTPS_UTILS_PROXY_POOL_HPP_ */

--- a/include/fastrtps/utils/ProxyPool.hpp
+++ b/include/fastrtps/utils/ProxyPool.hpp
@@ -105,7 +105,7 @@ std::array<P, N> make_array(
 template< class Proxy, std::size_t N = 4>
 class ProxyPool
 {
-    std::mutex mtx_;
+    mutable std::mutex mtx_;
     std::condition_variable cv_;
     std::array<Proxy, N> heap_;
     std::bitset<N> mask_;

--- a/include/fastrtps/utils/ProxyPool.hpp
+++ b/include/fastrtps/utils/ProxyPool.hpp
@@ -30,8 +30,7 @@
 #   include <version>
 #endif // if defined(__has_include) && __has_include(<version>)
 
-namespace eprosima
-{
+namespace eprosima {
 
 // unnamed namespace for isolation
 namespace {
@@ -41,81 +40,101 @@ namespace {
     && ((__cpp_lib_integer_sequence <= _MSVC_LANG) \
     || (__cpp_lib_integer_sequence <= __cplusplus))
 
-    // Array initialization usin C++14
-    template<class P, size_t... Ints>
-    std::array<P,sizeof...(Ints)> make_array(P&& i, std::index_sequence<Ints...> is)
-    {
-        return { (Ints == is.size() - 1 ? std::move(i) : i)...};
-    }
+// Array initialization usin C++14
+template<class P, size_t... Ints>
+std::array<P, sizeof...(Ints)> make_array(
+        P&& i,
+        std::index_sequence<Ints...> is)
+{
+    return { (Ints == is.size() - 1 ? std::move(i) : i)...};
+}
 
-    template<size_t N, class P>
-    std::array<P,N> make_array(P&& i)
-    {
-        return make_array<P>(std::move(i), std::make_index_sequence<N>{});
-    }
+template<size_t N, class P>
+std::array<P, N> make_array(
+        P&& i)
+{
+    return make_array<P>(std::move(i), std::make_index_sequence<N>{});
+}
 
 #else // C++11 fallback
 
-    template<size_t N, class P, class... Ts>
-    std::array<P, N> make_array(P&& i, Ts&&... args);
+template<size_t N, class P, class ... Ts>
+std::array<P, N> make_array(
+        P&& i,
+        Ts&&... args);
 
-    template<bool, size_t N, class... Ts>
-    struct make_array_choice
+template<bool, size_t N, class ... Ts>
+struct make_array_choice
+{
+    template<class P>
+    static std::array<P, N> res(
+            P&& i,
+            Ts&&... args)
     {
-        template<class P>
-        static std::array<P,N> res(P&& i, Ts&&... args)
-        {
-            P tmp(i);
-            return make_array<N>(std::move(i), std::move(tmp), std::move(args)...);
-        }
-    };
-
-    template<size_t N, class... Ts>
-    struct make_array_choice<true, N, Ts...>
-    {
-        template<class P>
-        static std::array<P,N> res(P&& i, Ts&&... args)
-        {
-            return {std::move(i), std::move(args)...};
-        }
-    };
-
-    template<size_t N, class P, class... Ts>
-    std::array<P, N> make_array(P&& i, Ts&&... args)
-    {
-        return make_array_choice<N == (sizeof...(Ts) + 1), N, Ts...>::res(std::move(i), std::move(args)...);
+        P tmp(i);
+        return make_array<N>(std::move(i), std::move(tmp), std::move(args)...);
     }
+
+};
+
+template<size_t N, class ... Ts>
+struct make_array_choice<true, N, Ts...>
+{
+    template<class P>
+    static std::array<P, N> res(
+            P&& i,
+            Ts&&... args)
+    {
+        return {std::move(i), std::move(args)...};
+    }
+
+};
+
+template<size_t N, class P, class ... Ts>
+std::array<P, N> make_array(
+        P&& i,
+        Ts&&... args)
+{
+    return make_array_choice < N == (sizeof...(Ts) + 1), N, Ts ... > ::res(std::move(i), std::move(args)...);
+}
 
 #endif // defined(__cpp_lib_integer_sequence)
 
-}
+} // namespace
 
 template< class Proxy, std::size_t N = 4>
 class ProxyPool
 {
     std::mutex mtx_;
     std::condition_variable cv_;
-    std::array<Proxy,N> heap_;
+    std::array<Proxy, N> heap_;
     std::bitset<N> mask_;
 
     // unique_ptr<Proxy> deleters
-    class D {
+    class D
+    {
         // Because ProxyPool will be destroy after all the proxies are returned
         // this reference is always valid
         ProxyPool& pool_;
 
         friend class ProxyPool;
 
-        D(ProxyPool * pool) : pool_(*pool) {}
+        D(
+                ProxyPool* pool)
+            : pool_(*pool)
+        {
+        }
 
-        public:
+    public:
 
-        void operator()(Proxy* p) const
+        void operator ()(
+                Proxy* p) const
         {
             pool_.set_back(p);
         }
 
-    } deleter_;
+    }
+    deleter_;
 
     friend class D;
 
@@ -123,7 +142,8 @@ class ProxyPool
      * Return an available proxy to the pool.
      * @param p pointer to the proxy.
      */
-    void set_back(Proxy * p) noexcept
+    void set_back(
+            Proxy* p) noexcept
     {
         std::size_t idx = p - heap_.data();
 
@@ -138,13 +158,14 @@ class ProxyPool
 
 public:
 
-    using smart_ptr = std::unique_ptr<Proxy,D&>;
+    using smart_ptr = std::unique_ptr<Proxy, D&>;
 
     /*
      * Constructor of the pool object.
      * @param init Initialization value for all the proxies.
      */
-    ProxyPool(Proxy&& init)
+    ProxyPool(
+            Proxy&& init)
         : heap_(make_array<N>(std::move(init)))
         , deleter_(this)
     {
@@ -159,7 +180,10 @@ public:
     ~ProxyPool()
     {
         std::unique_lock<std::mutex> lock(mtx_);
-        cv_.wait(lock, [&](){return mask_.all();});
+        cv_.wait(lock, [&]()
+                {
+                    return mask_.all();
+                });
     }
 
     /*
@@ -187,23 +211,28 @@ public:
      * Note deleter is referenced not copied to avoid heap allocations on smart pointer construction
      * @return unique_ptr referencing the proxy. On destruction the resource is returned.
      */
-    std::unique_ptr<Proxy,D&> get()
+    std::unique_ptr<Proxy, D&> get()
     {
         std::unique_lock<std::mutex> lock(mtx_);
 
         // wait for available resources
-        cv_.wait(lock, [&](){return mask_.any();});
+        cv_.wait(lock, [&]()
+                {
+                    return mask_.any();
+                });
 
         // find the first available
         std::size_t idx = 0;
-        while (idx < mask_.size() && !mask_.test(idx)) {
-          ++idx;
+        while (idx < mask_.size() && !mask_.test(idx))
+        {
+            ++idx;
         }
 
         // retrieve it
         mask_.reset(idx);
         return std::unique_ptr<Proxy, D&>(&heap_[idx], deleter_);
     }
+
 };
 
 } // eprosima namespace

--- a/src/cpp/fastdds/builtin/typelookup/TypeLookupManager.cpp
+++ b/src/cpp/fastdds/builtin/typelookup/TypeLookupManager.cpp
@@ -105,19 +105,19 @@ TypeLookupManager::~TypeLookupManager()
      */
     if (nullptr != builtin_reply_reader_)
     {
-        participant_->deleteUserEndpoint(builtin_reply_reader_);
+        participant_->deleteUserEndpoint(builtin_reply_reader_->getGuid());
     }
     if (nullptr != builtin_reply_writer_)
     {
-        participant_->deleteUserEndpoint(builtin_reply_writer_);
+        participant_->deleteUserEndpoint(builtin_reply_writer_->getGuid());
     }
     if (nullptr != builtin_request_reader_)
     {
-        participant_->deleteUserEndpoint(builtin_request_reader_);
+        participant_->deleteUserEndpoint(builtin_request_reader_->getGuid());
     }
     if (nullptr != builtin_request_writer_)
     {
-        participant_->deleteUserEndpoint(builtin_request_writer_);
+        participant_->deleteUserEndpoint(builtin_request_writer_->getGuid());
     }
     delete builtin_request_writer_history_;
     delete builtin_reply_writer_history_;

--- a/src/cpp/fastdds/publisher/qos/WriterQos.cpp
+++ b/src/cpp/fastdds/publisher/qos/WriterQos.cpp
@@ -78,7 +78,7 @@ void WriterQos::setQos(
         m_destinationOrder = qos.m_destinationOrder;
         m_destinationOrder.hasChanged = true;
     }
-    if (m_userData.data_vec() != qos.m_userData.data_vec())
+    if (first_time || m_userData.data_vec() != qos.m_userData.data_vec())
     {
         m_userData = qos.m_userData;
         m_userData.hasChanged = true;
@@ -95,18 +95,18 @@ void WriterQos::setQos(
         m_presentation = qos.m_presentation;
         m_presentation.hasChanged = true;
     }
-    if (qos.m_partition.names().size() > 0)
+    if (first_time || qos.m_partition.names().size() > 0)
     {
         m_partition = qos.m_partition;
         m_partition.hasChanged = true;
     }
 
-    if (m_topicData.getValue() != qos.m_topicData.getValue())
+    if (first_time || m_topicData.getValue() != qos.m_topicData.getValue())
     {
         m_topicData = qos.m_topicData;
         m_topicData.hasChanged = true;
     }
-    if (m_groupData.getValue() != qos.m_groupData.getValue())
+    if (first_time || m_groupData.getValue() != qos.m_groupData.getValue())
     {
         m_groupData = qos.m_groupData;
         m_groupData.hasChanged = true;

--- a/src/cpp/fastdds/subscriber/qos/ReaderQos.cpp
+++ b/src/cpp/fastdds/subscriber/qos/ReaderQos.cpp
@@ -65,7 +65,7 @@ void ReaderQos::setQos(
         m_destinationOrder = qos.m_destinationOrder;
         m_destinationOrder.hasChanged = true;
     }
-    if (m_userData.data_vec() != qos.m_userData.data_vec())
+    if (first_time || m_userData.data_vec() != qos.m_userData.data_vec())
     {
         m_userData = qos.m_userData;
         m_userData.hasChanged = true;
@@ -82,17 +82,17 @@ void ReaderQos::setQos(
         m_presentation = qos.m_presentation;
         m_presentation.hasChanged = true;
     }
-    if (qos.m_partition.names() != m_partition.names())
+    if (first_time || qos.m_partition.names() != m_partition.names())
     {
         m_partition = qos.m_partition;
         m_partition.hasChanged = true;
     }
-    if (m_topicData.getValue() != qos.m_topicData.getValue())
+    if (first_time || m_topicData.getValue() != qos.m_topicData.getValue())
     {
         m_topicData = qos.m_topicData;
         m_topicData.hasChanged = true;
     }
-    if (m_groupData.getValue() != qos.m_groupData.getValue())
+    if (first_time || m_groupData.getValue() != qos.m_groupData.getValue())
     {
         m_groupData = qos.m_groupData;
         m_groupData.hasChanged = true;

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -362,7 +362,7 @@ bool RTPSDomain::removeRTPSWriter(
             {
                 t_p_RTPSParticipant participant = *it;
                 lock.unlock();
-                return participant.second->deleteUserEndpoint((Endpoint*)writer);
+                return participant.second->deleteUserEndpoint((Endpoint*)writer->getGuid());
             }
         }
     }
@@ -438,7 +438,7 @@ bool RTPSDomain::removeRTPSReader(
             {
                 t_p_RTPSParticipant participant = *it;
                 lock.unlock();
-                return participant.second->deleteUserEndpoint((Endpoint*)reader);
+                return participant.second->deleteUserEndpoint(reader->getGuid());
             }
         }
     }

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -362,7 +362,7 @@ bool RTPSDomain::removeRTPSWriter(
             {
                 t_p_RTPSParticipant participant = *it;
                 lock.unlock();
-                return participant.second->deleteUserEndpoint((Endpoint*)writer->getGuid());
+                return participant.second->deleteUserEndpoint(writer->getGuid());
             }
         }
     }

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
@@ -570,32 +570,32 @@ bool EDP::unpairWriterProxy(
     logInfo(RTPS_EDP, writer_guid);
 
     mp_RTPSParticipant->forEachUserReader([&, removed_by_lease](RTPSReader& r) -> bool
-    {
-        if (r.matched_writer_remove(writer_guid, removed_by_lease))
-        {
-            const GUID_t& reader_guid = r.getGuid();
+            {
+                if (r.matched_writer_remove(writer_guid, removed_by_lease))
+                {
+                    const GUID_t& reader_guid = r.getGuid();
 #if HAVE_SECURITY
-            mp_RTPSParticipant->security_manager().remove_writer(reader_guid,
+                    mp_RTPSParticipant->security_manager().remove_writer(reader_guid,
                     participant_guid, writer_guid);
 #endif // if HAVE_SECURITY
 
-            //MATCHED AND ADDED CORRECTLY:
-            if (r.getListener() != nullptr)
-            {
-                MatchingInfo info;
-                info.status = REMOVED_MATCHING;
-                info.remoteEndpointGuid = writer_guid;
-                r.getListener()->onReaderMatched(&r, info);
+                    //MATCHED AND ADDED CORRECTLY:
+                    if (r.getListener() != nullptr)
+                    {
+                        MatchingInfo info;
+                        info.status = REMOVED_MATCHING;
+                        info.remoteEndpointGuid = writer_guid;
+                        r.getListener()->onReaderMatched(&r, info);
 
-                const SubscriptionMatchedStatus& sub_info =
+                        const SubscriptionMatchedStatus& sub_info =
                         update_subscription_matched_status(reader_guid, writer_guid, -1);
-                r.getListener()->onReaderMatched(&r, sub_info);
-            }
-        }
+                        r.getListener()->onReaderMatched(&r, sub_info);
+                    }
+                }
 
-        // traverse all
-        return true;
-    });
+                // traverse all
+                return true;
+            });
 
     return true;
 }
@@ -609,31 +609,31 @@ bool EDP::unpairReaderProxy(
     logInfo(RTPS_EDP, reader_guid);
 
     mp_RTPSParticipant->forEachUserWriter([&](RTPSWriter& w) -> bool
-    {
-        if (w.matched_reader_remove(reader_guid))
-        {
-            const GUID_t& writer_guid = w.getGuid();
+            {
+                if (w.matched_reader_remove(reader_guid))
+                {
+                    const GUID_t& writer_guid = w.getGuid();
 #if HAVE_SECURITY
-            mp_RTPSParticipant->security_manager().remove_reader(writer_guid,
+                    mp_RTPSParticipant->security_manager().remove_reader(writer_guid,
                     participant_guid, reader_guid);
 #endif // if HAVE_SECURITY
-            //MATCHED AND ADDED CORRECTLY:
-            if (w.getListener() != nullptr)
-            {
-                MatchingInfo info;
-                info.status = REMOVED_MATCHING;
-                info.remoteEndpointGuid = reader_guid;
-                w.getListener()->onWriterMatched(&w, info);
+                    //MATCHED AND ADDED CORRECTLY:
+                    if (w.getListener() != nullptr)
+                    {
+                        MatchingInfo info;
+                        info.status = REMOVED_MATCHING;
+                        info.remoteEndpointGuid = reader_guid;
+                        w.getListener()->onWriterMatched(&w, info);
 
-                const PublicationMatchedStatus& pub_info =
+                        const PublicationMatchedStatus& pub_info =
                         update_publication_matched_status(reader_guid, writer_guid, -1);
-                w.getListener()->onWriterMatched(&w, pub_info);
-            }
-        }
+                        w.getListener()->onWriterMatched(&w, pub_info);
+                    }
+                }
 
-        // traverse all
-        return true;
-    });
+                // traverse all
+                return true;
+            });
 
     return true;
 }
@@ -1226,81 +1226,81 @@ bool EDP::pairing_reader_proxy_with_any_local_writer(
     logInfo(RTPS_EDP, rdata->guid() << " in topic: \"" << rdata->topicName() << "\"");
 
     mp_RTPSParticipant->forEachUserWriter([&, rdata](RTPSWriter& w) -> bool
-    {
-        std::unique_lock<std::mutex> lock(temp_data_lock_);
-
-        GUID_t writerGUID = w.getGuid();
-
-        if (mp_PDP->lookupWriterProxyData(writerGUID, temp_writer_proxy_data_))
-        {
-            MatchingFailureMask no_match_reason;
-            fastdds::dds::PolicyMask incompatible_qos;
-            bool valid = valid_matching(&temp_writer_proxy_data_, rdata, no_match_reason, incompatible_qos);
-            const GUID_t& reader_guid = rdata->guid();
-
-            lock.unlock();
-
-            if (valid)
             {
+                std::unique_lock<std::mutex> lock(temp_data_lock_);
+
+                GUID_t writerGUID = w.getGuid();
+
+                if (mp_PDP->lookupWriterProxyData(writerGUID, temp_writer_proxy_data_))
+                {
+                    MatchingFailureMask no_match_reason;
+                    fastdds::dds::PolicyMask incompatible_qos;
+                    bool valid = valid_matching(&temp_writer_proxy_data_, rdata, no_match_reason, incompatible_qos);
+                    const GUID_t& reader_guid = rdata->guid();
+
+                    lock.unlock();
+
+                    if (valid)
+                    {
 #if HAVE_SECURITY
-                if (!mp_RTPSParticipant->security_manager().discovered_reader(writerGUID, participant_guid,
+                        if (!mp_RTPSParticipant->security_manager().discovered_reader(writerGUID, participant_guid,
                         *rdata, w.getAttributes().security_attributes()))
-                {
-                    logError(RTPS_EDP, "Security manager returns an error for writer " << writerGUID);
-                }
+                        {
+                            logError(RTPS_EDP, "Security manager returns an error for writer " << writerGUID);
+                        }
 #else
-                if (w.matched_reader_add(*rdata))
-                {
-                    logInfo(RTPS_EDP_MATCH,
+                        if (w.matched_reader_add(*rdata))
+                        {
+                            logInfo(RTPS_EDP_MATCH,
                             "RP:" << rdata->guid() << " match W:" << w.getGuid() << ". RLoc:" <<
-                            rdata->remote_locators());
-                    //MATCHED AND ADDED CORRECTLY:
-                    if (w.getListener() != nullptr)
-                    {
-                        MatchingInfo info;
-                        info.status = MATCHED_MATCHING;
-                        info.remoteEndpointGuid = reader_guid;
-                        w.getListener()->onWriterMatched(&w, info);
+                                rdata->remote_locators());
+                            //MATCHED AND ADDED CORRECTLY:
+                            if (w.getListener() != nullptr)
+                            {
+                                MatchingInfo info;
+                                info.status = MATCHED_MATCHING;
+                                info.remoteEndpointGuid = reader_guid;
+                                w.getListener()->onWriterMatched(&w, info);
 
-                        const PublicationMatchedStatus& pub_info =
+                                const PublicationMatchedStatus& pub_info =
                                 update_publication_matched_status(reader_guid, writerGUID, 1);
-                        w.getListener()->onWriterMatched(&w, pub_info);
+                                w.getListener()->onWriterMatched(&w, pub_info);
+                            }
+                        }
+#endif // if HAVE_SECURITY
                     }
-                }
-#endif // if HAVE_SECURITY
-            }
-            else
-            {
-                if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && w.getListener() != nullptr)
-                {
-                    w.getListener()->on_offered_incompatible_qos(&w, incompatible_qos);
-                }
-
-                if (w.matched_reader_is_matched(reader_guid)
-                        && w.matched_reader_remove(reader_guid))
-                {
-#if HAVE_SECURITY
-                    mp_RTPSParticipant->security_manager().remove_reader(
-                        w.getGuid(), participant_guid, reader_guid);
-#endif // if HAVE_SECURITY
-                    //MATCHED AND ADDED CORRECTLY:
-                    if (w.getListener() != nullptr)
+                    else
                     {
-                        MatchingInfo info;
-                        info.status = REMOVED_MATCHING;
-                        info.remoteEndpointGuid = reader_guid;
-                        w.getListener()->onWriterMatched(&w, info);
+                        if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && w.getListener() != nullptr)
+                        {
+                            w.getListener()->on_offered_incompatible_qos(&w, incompatible_qos);
+                        }
 
-                        const PublicationMatchedStatus& pub_info =
+                        if (w.matched_reader_is_matched(reader_guid)
+                        && w.matched_reader_remove(reader_guid))
+                        {
+#if HAVE_SECURITY
+                            mp_RTPSParticipant->security_manager().remove_reader(
+                                w.getGuid(), participant_guid, reader_guid);
+#endif // if HAVE_SECURITY
+                            //MATCHED AND ADDED CORRECTLY:
+                            if (w.getListener() != nullptr)
+                            {
+                                MatchingInfo info;
+                                info.status = REMOVED_MATCHING;
+                                info.remoteEndpointGuid = reader_guid;
+                                w.getListener()->onWriterMatched(&w, info);
+
+                                const PublicationMatchedStatus& pub_info =
                                 update_publication_matched_status(reader_guid, writerGUID, -1);
-                        w.getListener()->onWriterMatched(&w, pub_info);
+                                w.getListener()->onWriterMatched(&w, pub_info);
+                            }
+                        }
                     }
                 }
-            }
-        }
-        // next iteration
-        return true;
-    });
+                // next iteration
+                return true;
+            });
 
     return true;
 }
@@ -1314,61 +1314,63 @@ bool EDP::pairing_reader_proxy_with_local_writer(
     logInfo(RTPS_EDP, rdata.guid() << " in topic: \"" << rdata.topicName() << "\"");
 
     mp_RTPSParticipant->forEachUserWriter([&](RTPSWriter& w) -> bool
-    {
-        GUID_t writerGUID = w.getGuid();
-        const GUID_t& reader_guid = rdata.guid();
-
-        if (local_writer == writerGUID)
-        {
-            std::unique_lock<std::mutex> lock(temp_data_lock_);
-
-            if (mp_PDP->lookupWriterProxyData(writerGUID, temp_writer_proxy_data_))
             {
-                MatchingFailureMask no_match_reason;
-                fastdds::dds::PolicyMask incompatible_qos;
-                bool valid = valid_matching(&temp_writer_proxy_data_, &rdata, no_match_reason, incompatible_qos);
+                GUID_t writerGUID = w.getGuid();
+                const GUID_t& reader_guid = rdata.guid();
 
-                lock.unlock();
-
-                if (valid)
+                if (local_writer == writerGUID)
                 {
-                    if (!mp_RTPSParticipant->security_manager().discovered_reader(writerGUID,
-                            remote_participant_guid, rdata, w.getAttributes().security_attributes()))
-                    {
-                        logError(RTPS_EDP, "Security manager returns an error for writer " << writerGUID);
-                    }
-                }
-                else
-                {
-                    if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && w.getListener() != nullptr)
-                    {
-                        w.getListener()->on_offered_incompatible_qos(&w, incompatible_qos);
-                    }
+                    std::unique_lock<std::mutex> lock(temp_data_lock_);
 
-                    if (w.matched_reader_is_matched(reader_guid)
-                            && w.matched_reader_remove(reader_guid))
+                    if (mp_PDP->lookupWriterProxyData(writerGUID, temp_writer_proxy_data_))
                     {
-                        mp_RTPSParticipant->security_manager().remove_reader(w.getGuid(),
-                                remote_participant_guid, reader_guid);
-                        //MATCHED AND ADDED CORRECTLY:
-                        if (w.getListener() != nullptr)
+                        MatchingFailureMask no_match_reason;
+                        fastdds::dds::PolicyMask incompatible_qos;
+                        bool valid = valid_matching(&temp_writer_proxy_data_, &rdata, no_match_reason,
+                        incompatible_qos);
+
+                        lock.unlock();
+
+                        if (valid)
                         {
-                            MatchingInfo info;
-                            info.status = REMOVED_MATCHING;
-                            info.remoteEndpointGuid = reader_guid;
-                            w.getListener()->onWriterMatched(&w, info);
+                            if (!mp_RTPSParticipant->security_manager().discovered_reader(writerGUID,
+                            remote_participant_guid, rdata, w.getAttributes().security_attributes()))
+                            {
+                                logError(RTPS_EDP, "Security manager returns an error for writer " << writerGUID);
+                            }
+                        }
+                        else
+                        {
+                            if (no_match_reason.test(MatchingFailureMask::incompatible_qos) &&
+                            w.getListener() != nullptr)
+                            {
+                                w.getListener()->on_offered_incompatible_qos(&w, incompatible_qos);
+                            }
 
-                            const PublicationMatchedStatus& pub_info =
+                            if (w.matched_reader_is_matched(reader_guid)
+                            && w.matched_reader_remove(reader_guid))
+                            {
+                                mp_RTPSParticipant->security_manager().remove_reader(w.getGuid(),
+                                remote_participant_guid, reader_guid);
+                                //MATCHED AND ADDED CORRECTLY:
+                                if (w.getListener() != nullptr)
+                                {
+                                    MatchingInfo info;
+                                    info.status = REMOVED_MATCHING;
+                                    info.remoteEndpointGuid = reader_guid;
+                                    w.getListener()->onWriterMatched(&w, info);
+
+                                    const PublicationMatchedStatus& pub_info =
                                     update_publication_matched_status(reader_guid, writerGUID, -1);
-                            w.getListener()->onWriterMatched(&w, pub_info);
+                                    w.getListener()->onWriterMatched(&w, pub_info);
+                                }
+                            }
                         }
                     }
                 }
-            }
-        }
-        // next iteration
-        return true;
-    });
+                // next iteration
+                return true;
+            });
 
     return true;
 }
@@ -1381,42 +1383,43 @@ bool EDP::pairing_remote_reader_with_local_writer_after_security(
     bool found = false;
 
     mp_RTPSParticipant->forEachUserWriter([&](RTPSWriter& w) -> bool
-    {
-        GUID_t writerGUID = w.getGuid();
-
-        const GUID_t& reader_guid = remote_reader_data.guid();
-
-        if (local_writer == writerGUID)
-        {
-            found = true;
-
-            if (w.matched_reader_add(remote_reader_data))
             {
-                logInfo(RTPS_EDP, "Valid Matching to local writer: " << writerGUID.entityId);
+                GUID_t writerGUID = w.getGuid();
 
-                matched = true;
+                const GUID_t& reader_guid = remote_reader_data.guid();
 
-                //MATCHED AND ADDED CORRECTLY:
-                if (w.getListener() != nullptr)
+                if (local_writer == writerGUID)
                 {
-                    MatchingInfo info;
-                    info.status = MATCHED_MATCHING;
-                    info.remoteEndpointGuid = reader_guid;
-                    w.getListener()->onWriterMatched(&w, info);
+                    found = true;
 
-                    const PublicationMatchedStatus& pub_info =
+                    if (w.matched_reader_add(remote_reader_data))
+                    {
+                        logInfo(RTPS_EDP, "Valid Matching to local writer: " << writerGUID.entityId);
+
+                        matched = true;
+
+                        //MATCHED AND ADDED CORRECTLY:
+                        if (w.getListener() != nullptr)
+                        {
+                            MatchingInfo info;
+                            info.status = MATCHED_MATCHING;
+                            info.remoteEndpointGuid = reader_guid;
+                            w.getListener()->onWriterMatched(&w, info);
+
+                            const PublicationMatchedStatus& pub_info =
                             update_publication_matched_status(reader_guid, writerGUID, 1);
-                    w.getListener()->onWriterMatched(&w, pub_info);
+                            w.getListener()->onWriterMatched(&w, pub_info);
+                        }
+                    }
+                    // don't look anymore
+                    return false;
                 }
-            }
-            // don't look anymore
-            return false;
-        }
-        // keep looking
-        return true;
-    });
+                // keep looking
+                return true;
+            });
 
-    return found ? matched : pairing_remote_reader_with_local_builtin_writer_after_security(local_writer, remote_reader_data);
+    return found ? matched : pairing_remote_reader_with_local_builtin_writer_after_security(local_writer,
+                   remote_reader_data);
 }
 
 #endif // if HAVE_SECURITY
@@ -1430,81 +1433,82 @@ bool EDP::pairing_writer_proxy_with_any_local_reader(
     logInfo(RTPS_EDP, wdata->guid() << " in topic: \"" << wdata->topicName() << "\"");
 
     mp_RTPSParticipant->forEachUserReader([&, wdata](RTPSReader& r) -> bool
-    {
-        std::unique_lock<std::mutex> lock(temp_data_lock_);
-
-        GUID_t readerGUID = r.getGuid();
-
-        if (mp_PDP->lookupReaderProxyData(readerGUID, temp_reader_proxy_data_))
-        {
-            MatchingFailureMask no_match_reason;
-            fastdds::dds::PolicyMask incompatible_qos;
-            bool valid = valid_matching(&temp_reader_proxy_data_, wdata, no_match_reason, incompatible_qos);
-            const GUID_t& writer_guid = wdata->guid();
-
-            lock.unlock();
-
-            if (valid)
             {
+                std::unique_lock<std::mutex> lock(temp_data_lock_);
+
+                GUID_t readerGUID = r.getGuid();
+
+                if (mp_PDP->lookupReaderProxyData(readerGUID, temp_reader_proxy_data_))
+                {
+                    MatchingFailureMask no_match_reason;
+                    fastdds::dds::PolicyMask incompatible_qos;
+                    bool valid = valid_matching(&temp_reader_proxy_data_, wdata, no_match_reason, incompatible_qos);
+                    const GUID_t& writer_guid = wdata->guid();
+
+                    lock.unlock();
+
+                    if (valid)
+                    {
 #if HAVE_SECURITY
-                if (!mp_RTPSParticipant->security_manager().discovered_writer(readerGUID, participant_guid,
+                        if (!mp_RTPSParticipant->security_manager().discovered_writer(readerGUID, participant_guid,
                         *wdata, r.getAttributes().security_attributes()))
-                {
-                    logError(RTPS_EDP, "Security manager returns an error for reader " << readerGUID);
-                }
+                        {
+                            logError(RTPS_EDP, "Security manager returns an error for reader " << readerGUID);
+                        }
 #else
-                if (r.matched_writer_add(*wdata))
-                {
-                    logInfo(RTPS_EDP_MATCH,
+                        if (r.matched_writer_add(*wdata))
+                        {
+                            logInfo(RTPS_EDP_MATCH,
                             "WP:" << wdata->guid() << " match R:" << r.getGuid() << ". WLoc:" <<
-                            wdata->remote_locators());
-                    //MATCHED AND ADDED CORRECTLY:
-                    if (r.getListener() != nullptr)
-                    {
-                        MatchingInfo info;
-                        info.status = MATCHED_MATCHING;
-                        info.remoteEndpointGuid = writer_guid;
-                        r.getListener()->onReaderMatched(&r, info);
+                                wdata->remote_locators());
+                            //MATCHED AND ADDED CORRECTLY:
+                            if (r.getListener() != nullptr)
+                            {
+                                MatchingInfo info;
+                                info.status = MATCHED_MATCHING;
+                                info.remoteEndpointGuid = writer_guid;
+                                r.getListener()->onReaderMatched(&r, info);
 
 
-                        const SubscriptionMatchedStatus& sub_info =
+                                const SubscriptionMatchedStatus& sub_info =
                                 update_subscription_matched_status(readerGUID, writer_guid, 1);
-                        r.getListener()->onReaderMatched(&r, sub_info);
+                                r.getListener()->onReaderMatched(&r, sub_info);
+                            }
+                        }
+#endif // if HAVE_SECURITY
                     }
-                }
-#endif // if HAVE_SECURITY
-            }
-            else
-            {
-                if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && r.getListener() != nullptr)
-                {
-                    r.getListener()->on_requested_incompatible_qos(&r, incompatible_qos);
-                }
-
-                if (r.matched_writer_is_matched(writer_guid)
-                        && r.matched_writer_remove(writer_guid))
-                {
-#if HAVE_SECURITY
-                    mp_RTPSParticipant->security_manager().remove_writer(readerGUID, participant_guid, writer_guid);
-#endif // if HAVE_SECURITY
-                    //MATCHED AND ADDED CORRECTLY:
-                    if (r.getListener() != nullptr)
+                    else
                     {
-                        MatchingInfo info;
-                        info.status = REMOVED_MATCHING;
-                        info.remoteEndpointGuid = writer_guid;
-                        r.getListener()->onReaderMatched(&r, info);
+                        if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && r.getListener() != nullptr)
+                        {
+                            r.getListener()->on_requested_incompatible_qos(&r, incompatible_qos);
+                        }
 
-                        const SubscriptionMatchedStatus& sub_info =
+                        if (r.matched_writer_is_matched(writer_guid)
+                        && r.matched_writer_remove(writer_guid))
+                        {
+#if HAVE_SECURITY
+                            mp_RTPSParticipant->security_manager().remove_writer(readerGUID, participant_guid,
+                            writer_guid);
+#endif // if HAVE_SECURITY
+                            //MATCHED AND ADDED CORRECTLY:
+                            if (r.getListener() != nullptr)
+                            {
+                                MatchingInfo info;
+                                info.status = REMOVED_MATCHING;
+                                info.remoteEndpointGuid = writer_guid;
+                                r.getListener()->onReaderMatched(&r, info);
+
+                                const SubscriptionMatchedStatus& sub_info =
                                 update_subscription_matched_status(readerGUID, writer_guid, -1);
-                        r.getListener()->onReaderMatched(&r, sub_info);
+                                r.getListener()->onReaderMatched(&r, sub_info);
+                            }
+                        }
                     }
                 }
-            }
-        }
-        // keep looking
-        return true;
-    });
+                // keep looking
+                return true;
+            });
 
     return true;
 }
@@ -1518,63 +1522,65 @@ bool EDP::pairing_writer_proxy_with_local_reader(
     logInfo(RTPS_EDP, wdata.guid() << " in topic: \"" << wdata.topicName() << "\"");
 
     mp_RTPSParticipant->forEachUserReader([&](RTPSReader& r) -> bool
-    {
-        GUID_t readerGUID = r.getGuid();
-
-        if (local_reader == readerGUID)
-        {
-            std::unique_lock<std::mutex> lock(temp_data_lock_);
-
-            if (mp_PDP->lookupReaderProxyData(readerGUID, temp_reader_proxy_data_))
             {
-                MatchingFailureMask no_match_reason;
-                fastdds::dds::PolicyMask incompatible_qos;
-                bool valid = valid_matching(&temp_reader_proxy_data_, &wdata, no_match_reason, incompatible_qos);
-                const GUID_t& writer_guid = wdata.guid();
+                GUID_t readerGUID = r.getGuid();
 
-                lock.unlock();
-
-                if (valid)
+                if (local_reader == readerGUID)
                 {
-                    if (!mp_RTPSParticipant->security_manager().discovered_writer(readerGUID,
-                            remote_participant_guid, wdata, r.getAttributes().security_attributes()))
-                    {
-                        logError(RTPS_EDP, "Security manager returns an error for reader " << readerGUID);
-                    }
-                }
-                else
-                {
-                    if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && r.getListener() != nullptr)
-                    {
-                        r.getListener()->on_requested_incompatible_qos(&r, incompatible_qos);
-                    }
+                    std::unique_lock<std::mutex> lock(temp_data_lock_);
 
-                    if (r.matched_writer_is_matched(writer_guid)
-                            && r.matched_writer_remove(writer_guid))
+                    if (mp_PDP->lookupReaderProxyData(readerGUID, temp_reader_proxy_data_))
                     {
-                        mp_RTPSParticipant->security_manager().remove_writer(readerGUID,
-                                remote_participant_guid, writer_guid);
-                        //MATCHED AND ADDED CORRECTLY:
-                        if (r.getListener() != nullptr)
+                        MatchingFailureMask no_match_reason;
+                        fastdds::dds::PolicyMask incompatible_qos;
+                        bool valid = valid_matching(&temp_reader_proxy_data_, &wdata, no_match_reason,
+                        incompatible_qos);
+                        const GUID_t& writer_guid = wdata.guid();
+
+                        lock.unlock();
+
+                        if (valid)
                         {
-                            MatchingInfo info;
-                            info.status = REMOVED_MATCHING;
-                            info.remoteEndpointGuid = writer_guid;
-                            r.getListener()->onReaderMatched(&r, info);
+                            if (!mp_RTPSParticipant->security_manager().discovered_writer(readerGUID,
+                            remote_participant_guid, wdata, r.getAttributes().security_attributes()))
+                            {
+                                logError(RTPS_EDP, "Security manager returns an error for reader " << readerGUID);
+                            }
+                        }
+                        else
+                        {
+                            if (no_match_reason.test(MatchingFailureMask::incompatible_qos) &&
+                            r.getListener() != nullptr)
+                            {
+                                r.getListener()->on_requested_incompatible_qos(&r, incompatible_qos);
+                            }
 
-                            const SubscriptionMatchedStatus& sub_info =
+                            if (r.matched_writer_is_matched(writer_guid)
+                            && r.matched_writer_remove(writer_guid))
+                            {
+                                mp_RTPSParticipant->security_manager().remove_writer(readerGUID,
+                                remote_participant_guid, writer_guid);
+                                //MATCHED AND ADDED CORRECTLY:
+                                if (r.getListener() != nullptr)
+                                {
+                                    MatchingInfo info;
+                                    info.status = REMOVED_MATCHING;
+                                    info.remoteEndpointGuid = writer_guid;
+                                    r.getListener()->onReaderMatched(&r, info);
+
+                                    const SubscriptionMatchedStatus& sub_info =
                                     update_subscription_matched_status(readerGUID, writer_guid, -1);
-                            r.getListener()->onReaderMatched(&r, sub_info);
+                                    r.getListener()->onReaderMatched(&r, sub_info);
+                                }
+                            }
                         }
                     }
+                    // don't keep searching
+                    return false;
                 }
-            }
-            // don't keep searching
-            return false;
-        }
-        // keep searching
-        return true;
-    });
+                // keep searching
+                return true;
+            });
 
     return true;
 }
@@ -1587,44 +1593,45 @@ bool EDP::pairing_remote_writer_with_local_reader_after_security(
     bool found = false;
 
     mp_RTPSParticipant->forEachUserReader([&](RTPSReader& r) -> bool
-    {
-        GUID_t readerGUID = r.getGuid();
-
-        const GUID_t& writer_guid = remote_writer_data.guid();
-
-        if (local_reader == readerGUID)
-        {
-            found = true;
-
-            // TODO(richiware) Implement and use move with attributes
-            if (r.matched_writer_add(remote_writer_data))
             {
-                logInfo(RTPS_EDP, "Valid Matching to local reader: " << readerGUID.entityId);
+                GUID_t readerGUID = r.getGuid();
 
-                matched = true;
+                const GUID_t& writer_guid = remote_writer_data.guid();
 
-                //MATCHED AND ADDED CORRECTLY:
-                if (r.getListener() != nullptr)
+                if (local_reader == readerGUID)
                 {
-                    MatchingInfo info;
-                    info.status = MATCHED_MATCHING;
-                    info.remoteEndpointGuid = writer_guid;
-                    r.getListener()->onReaderMatched(&r, info);
+                    found = true;
 
-                    const SubscriptionMatchedStatus& sub_info =
+                    // TODO(richiware) Implement and use move with attributes
+                    if (r.matched_writer_add(remote_writer_data))
+                    {
+                        logInfo(RTPS_EDP, "Valid Matching to local reader: " << readerGUID.entityId);
+
+                        matched = true;
+
+                        //MATCHED AND ADDED CORRECTLY:
+                        if (r.getListener() != nullptr)
+                        {
+                            MatchingInfo info;
+                            info.status = MATCHED_MATCHING;
+                            info.remoteEndpointGuid = writer_guid;
+                            r.getListener()->onReaderMatched(&r, info);
+
+                            const SubscriptionMatchedStatus& sub_info =
                             update_subscription_matched_status(readerGUID, writer_guid, 1);
-                    r.getListener()->onReaderMatched(&r, sub_info);
+                            r.getListener()->onReaderMatched(&r, sub_info);
 
+                        }
+                    }
+                    // dont' look anymore
+                    return false;
                 }
-            }
-            // dont' look anymore
-            return false;
-        }
-        // keep looking
-        return true;
-    });
+                // keep looking
+                return true;
+            });
 
-    return found ? matched : pairing_remote_writer_with_local_builtin_reader_after_security(local_reader, remote_writer_data);
+    return found ? matched : pairing_remote_writer_with_local_builtin_reader_after_security(local_reader,
+                   remote_writer_data);
 }
 
 #endif // if HAVE_SECURITY

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
@@ -75,14 +75,14 @@ EDP::EDP(
     : mp_PDP(p)
     , mp_RTPSParticipant(part)
     , temp_reader_proxies_({
-        part->getRTPSParticipantAttributes().allocation.locators.max_unicast_locators,
-        part->getRTPSParticipantAttributes().allocation.locators.max_multicast_locators,
-        part->getRTPSParticipantAttributes().allocation.data_limits,
-        part->getRTPSParticipantAttributes().allocation.content_filter})
+                part->getRTPSParticipantAttributes().allocation.locators.max_unicast_locators,
+                part->getRTPSParticipantAttributes().allocation.locators.max_multicast_locators,
+                part->getRTPSParticipantAttributes().allocation.data_limits,
+                part->getRTPSParticipantAttributes().allocation.content_filter})
     , temp_writer_proxies_({
-        part->getRTPSParticipantAttributes().allocation.locators.max_unicast_locators,
-        part->getRTPSParticipantAttributes().allocation.locators.max_multicast_locators,
-        part->getRTPSParticipantAttributes().allocation.data_limits})
+                part->getRTPSParticipantAttributes().allocation.locators.max_unicast_locators,
+                part->getRTPSParticipantAttributes().allocation.locators.max_multicast_locators,
+                part->getRTPSParticipantAttributes().allocation.data_limits})
     , reader_status_allocator_(
         reader_map_helper::node_size,
         reader_map_helper::min_pool_size<pool_allocator_t>(

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
@@ -1771,6 +1771,8 @@ const SubscriptionMatchedStatus& EDP::update_subscription_matched_status(
         const GUID_t& writer_guid,
         int change)
 {
+    std::lock_guard<std::recursive_mutex> _(*mp_PDP->getMutex());
+
     SubscriptionMatchedStatus* status;
     auto it = reader_status_.find(reader_guid);
     if (it == reader_status_.end())
@@ -1797,6 +1799,8 @@ const fastdds::dds::PublicationMatchedStatus& EDP::update_publication_matched_st
         const GUID_t& writer_guid,
         int change)
 {
+    std::lock_guard<std::recursive_mutex> _(*mp_PDP->getMutex());
+
     PublicationMatchedStatus* status;
     auto it = writer_status_.find(writer_guid);
     if (it == writer_status_.end())

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
@@ -228,7 +228,7 @@ bool EDPServer::removeLocalReader(
     // Recover reader information
     std::string topic_name;
     {
-        auto temp_reader_proxy_data = temp_reader_proxies_.get();
+        auto temp_reader_proxy_data = get_temporary_reader_proxies_pool().get();
         mp_PDP->lookupReaderProxyData(guid, *temp_reader_proxy_data);
         topic_name = temp_reader_proxy_data->topicName().to_string();
     }
@@ -288,7 +288,7 @@ bool EDPServer::removeLocalWriter(
     std::string topic_name;
 
     {
-        auto temp_writer_proxy_data = temp_writer_proxies_.get();
+        auto temp_writer_proxy_data = get_temporary_writer_proxies_pool().get();
         mp_PDP->lookupWriterProxyData(guid, *temp_writer_proxy_data);
         topic_name = temp_writer_proxy_data->topicName().to_string();
     }

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
@@ -228,9 +228,9 @@ bool EDPServer::removeLocalReader(
     // Recover reader information
     std::string topic_name;
     {
-        std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-        mp_PDP->lookupReaderProxyData(guid, temp_reader_proxy_data_);
-        topic_name = temp_reader_proxy_data_.topicName().to_string();
+        auto temp_reader_proxy_data = temp_reader_proxies_.get();
+        mp_PDP->lookupReaderProxyData(guid, *temp_reader_proxy_data);
+        topic_name = temp_reader_proxy_data->topicName().to_string();
     }
 
     // Remove proxy data associated with the reader
@@ -288,9 +288,9 @@ bool EDPServer::removeLocalWriter(
     std::string topic_name;
 
     {
-        std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-        mp_PDP->lookupWriterProxyData(guid, temp_writer_proxy_data_);
-        topic_name = temp_writer_proxy_data_.topicName().to_string();
+        auto temp_writer_proxy_data = temp_writer_proxies_.get();
+        mp_PDP->lookupWriterProxyData(guid, *temp_writer_proxy_data);
+        topic_name = temp_writer_proxy_data->topicName().to_string();
     }
 
     // Remove proxy data associated with the writer

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners.cpp
@@ -43,9 +43,7 @@ PDPServer* EDPServerPUBListener::get_pdp()
 
 EDPServerPUBListener::EDPServerPUBListener(
         EDPServer* sedp)
-    : EDPBasePUBListener(sedp->mp_RTPSParticipant->getAttributes().allocation.locators,
-            sedp->mp_RTPSParticipant->getAttributes().allocation.data_limits)
-    , sedp_(sedp)
+    : sedp_(sedp)
 {
 }
 
@@ -96,9 +94,10 @@ void EDPServerPUBListener::onNewCacheChangeAdded(
 
         // Retrieve the topic after creating the WriterProxyData (in add_writer_from_change()). This way, not matter
         // whether the DATA(w) is a new one or an update, the WriterProxyData exists, and so the topic can be retrieved
-        if (get_pdp()->lookupWriterProxyData(auxGUID, temp_writer_data_))
+        auto temp_writer_data = get_pdp()->get_temporary_writer_proxies_pool().get();
+        if (get_pdp()->lookupWriterProxyData(auxGUID, *temp_writer_data))
         {
-            topic_name = temp_writer_data_.topicName().to_string();
+            topic_name = temp_writer_data->topicName().to_string();
         }
     }
     // DATA(Uw) case
@@ -107,9 +106,10 @@ void EDPServerPUBListener::onNewCacheChangeAdded(
         logInfo(RTPS_EDP_LISTENER, "Disposed Remote Writer, removing...");
 
         // Retrieve the topic before removing the WriterProxyData. We need it to add the DATA(Uw) to the database
-        if (get_pdp()->lookupWriterProxyData(auxGUID, temp_writer_data_))
+        auto temp_writer_data = get_pdp()->get_temporary_writer_proxies_pool().get();
+        if (get_pdp()->lookupWriterProxyData(auxGUID, *temp_writer_data))
         {
-            topic_name = temp_writer_data_.topicName().to_string();
+            topic_name = temp_writer_data->topicName().to_string();
         }
         else
         {
@@ -157,10 +157,7 @@ PDPServer* EDPServerSUBListener::get_pdp()
 
 EDPServerSUBListener::EDPServerSUBListener(
         EDPServer* sedp)
-    : EDPBaseSUBListener(sedp->mp_RTPSParticipant->getAttributes().allocation.locators,
-            sedp->mp_RTPSParticipant->getAttributes().allocation.data_limits,
-            sedp->mp_RTPSParticipant->getAttributes().allocation.content_filter)
-    , sedp_(sedp)
+    : sedp_(sedp)
 {
 }
 
@@ -211,9 +208,10 @@ void EDPServerSUBListener::onNewCacheChangeAdded(
 
         // Retrieve the topic after creating the ReaderProxyData (in add_reader_from_change()). This way, not matter
         // whether the DATA(r) is a new one or an update, the ReaderProxyData exists, and so the topic can be retrieved
-        if (get_pdp()->lookupReaderProxyData(auxGUID, temp_reader_data_))
+        auto temp_reader_data = get_pdp()->get_temporary_reader_proxies_pool().get();
+        if (get_pdp()->lookupReaderProxyData(auxGUID, *temp_reader_data))
         {
-            topic_name = temp_reader_data_.topicName().to_string();
+            topic_name = temp_reader_data->topicName().to_string();
         }
         else
         {
@@ -227,9 +225,10 @@ void EDPServerSUBListener::onNewCacheChangeAdded(
         logInfo(RTPS_EDP_LISTENER, "Disposed Remote Reader, removing...");
 
         // Retrieve the topic before removing the ReaderProxyData. We need it to add the DATA(Ur) to the database
-        if (get_pdp()->lookupReaderProxyData(auxGUID, temp_reader_data_))
+        auto temp_reader_data = get_pdp()->get_temporary_reader_proxies_pool().get();
+        if (get_pdp()->lookupReaderProxyData(auxGUID, *temp_reader_data))
         {
-            topic_name = temp_reader_data_.topicName().to_string();
+            topic_name = temp_reader_data->topicName().to_string();
         }
 
         // Remove ReaderProxy data information

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -66,7 +66,7 @@ static void delete_reader(
 {
     if (nullptr != reader_pair.first)
     {
-        participant->deleteUserEndpoint(reader_pair.first);
+        participant->deleteUserEndpoint(reader_pair.first->getGuid());
         EDPUtils::release_payload_pool(pool, reader_pair.second->m_att, true);
         delete(reader_pair.second);
     }
@@ -79,7 +79,7 @@ static void delete_writer(
 {
     if (nullptr != writer_pair.first)
     {
-        participant->deleteUserEndpoint(writer_pair.first);
+        participant->deleteUserEndpoint(writer_pair.first->getGuid());
         EDPUtils::release_payload_pool(pool, writer_pair.second->m_att, false);
         delete(writer_pair.second);
     }
@@ -91,15 +91,6 @@ EDPSimple::EDPSimple(
     : EDP(p, part)
     , publications_listener_(nullptr)
     , subscriptions_listener_(nullptr)
-    , temp_reader_proxy_data_(
-        part->getRTPSParticipantAttributes().allocation.locators.max_unicast_locators,
-        part->getRTPSParticipantAttributes().allocation.locators.max_multicast_locators,
-        part->getRTPSParticipantAttributes().allocation.data_limits,
-        part->getRTPSParticipantAttributes().allocation.content_filter)
-    , temp_writer_proxy_data_(
-        part->getRTPSParticipantAttributes().allocation.locators.max_unicast_locators,
-        part->getRTPSParticipantAttributes().allocation.locators.max_multicast_locators,
-        part->getRTPSParticipantAttributes().allocation.data_limits)
 {
 }
 

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -764,7 +764,7 @@ void EDPSimple::assignRemoteEndpoints(
             pdata.metatraffic_locators.unicast.empty();
     auxendp &= DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER;
 
-    auto temp_reader_proxy_data = temp_reader_proxies_.get();
+    auto temp_reader_proxy_data = get_temporary_reader_proxies_pool().get();
 
     temp_reader_proxy_data->clear();
     temp_reader_proxy_data->m_expectsInlineQos = false;
@@ -773,7 +773,7 @@ void EDPSimple::assignRemoteEndpoints(
     temp_reader_proxy_data->m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
     temp_reader_proxy_data->m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
 
-    auto temp_writer_proxy_data = temp_writer_proxies_.get();
+    auto temp_writer_proxy_data = get_temporary_writer_proxies_pool().get();
 
     temp_writer_proxy_data->clear();
     temp_writer_proxy_data->guid().guidPrefix = pdata.m_guid.guidPrefix;

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.cpp
@@ -84,7 +84,7 @@ void EDPBasePUBListener::add_writer_from_change(
         }
 
         //LOAD INFORMATION IN DESTINATION WRITER PROXY DATA
-        auto copy_data_fun = [this, &temp_writer_data, &network](
+        auto copy_data_fun = [&temp_writer_data, &network](
             WriterProxyData* data,
             bool updating,
             const ParticipantProxyData& participant_data)
@@ -194,7 +194,7 @@ void EDPBaseSUBListener::add_reader_from_change(
             return;
         }
 
-        auto copy_data_fun = [this, &temp_reader_data, &network](
+        auto copy_data_fun = [&temp_reader_data, &network](
             ReaderProxyData* data,
             bool updating,
             const ParticipantProxyData& participant_data)

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.cpp
@@ -84,7 +84,7 @@ void EDPBasePUBListener::add_writer_from_change(
         }
 
         //LOAD INFORMATION IN DESTINATION WRITER PROXY DATA
-        auto copy_data_fun = [this,&temp_writer_data, &network](
+        auto copy_data_fun = [this, &temp_writer_data, &network](
             WriterProxyData* data,
             bool updating,
             const ParticipantProxyData& participant_data)

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.h
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.h
@@ -68,15 +68,7 @@ class EDPBasePUBListener : public EDPListener
 {
 public:
 
-    EDPBasePUBListener(
-            const RemoteLocatorsAllocationAttributes& locators_allocation,
-            const VariableLengthDataLimits& data_limits)
-        : temp_writer_data_(
-            locators_allocation.max_unicast_locators,
-            locators_allocation.max_multicast_locators,
-            data_limits)
-    {
-    }
+    EDPBasePUBListener() = default;
 
     virtual ~EDPBasePUBListener() = default;
 
@@ -88,9 +80,6 @@ protected:
             CacheChange_t* change,
             EDP* edp,
             bool release_change = true);
-
-    //!Temporary structure to avoid allocations
-    WriterProxyData temp_writer_data_;
 };
 
 /**
@@ -101,17 +90,7 @@ class EDPBaseSUBListener : public EDPListener
 {
 public:
 
-    EDPBaseSUBListener(
-            const RemoteLocatorsAllocationAttributes& locators_allocation,
-            const VariableLengthDataLimits& data_limits,
-            const fastdds::rtps::ContentFilterProperty::AllocationConfiguration& filter_allocation)
-        : temp_reader_data_(
-            locators_allocation.max_unicast_locators,
-            locators_allocation.max_multicast_locators,
-            data_limits,
-            filter_allocation)
-    {
-    }
+    EDPBaseSUBListener() = default;
 
     virtual ~EDPBaseSUBListener() = default;
 
@@ -123,9 +102,6 @@ protected:
             CacheChange_t* change,
             EDP* edp,
             bool release_change = true);
-
-    //!Temporary structure to avoid allocations
-    ReaderProxyData temp_reader_data_;
 };
 
 /*!
@@ -142,9 +118,7 @@ public:
      */
     EDPSimplePUBListener(
             EDPSimple* sedp)
-        : EDPBasePUBListener(sedp->mp_RTPSParticipant->getAttributes().allocation.locators,
-                sedp->mp_RTPSParticipant->getAttributes().allocation.data_limits)
-        , sedp_(sedp)
+        : sedp_(sedp)
     {
     }
 
@@ -190,10 +164,7 @@ public:
      */
     EDPSimpleSUBListener(
             EDPSimple* sedp)
-        : EDPBaseSUBListener(sedp->mp_RTPSParticipant->getAttributes().allocation.locators,
-                sedp->mp_RTPSParticipant->getAttributes().allocation.data_limits,
-                sedp->mp_RTPSParticipant->getAttributes().allocation.content_filter)
-        , sedp_(sedp)
+        : sedp_(sedp)
     {
     }
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -128,8 +128,8 @@ PDP::~PDP()
     delete resend_participant_info_event_;
     mp_RTPSParticipant->disableReader(mp_PDPReader);
     delete mp_EDP;
-    mp_RTPSParticipant->deleteUserEndpoint(mp_PDPWriter);
-    mp_RTPSParticipant->deleteUserEndpoint(mp_PDPReader);
+    mp_RTPSParticipant->deleteUserEndpoint(mp_PDPWriter->getGuid());
+    mp_RTPSParticipant->deleteUserEndpoint(mp_PDPReader->getGuid());
 
     if (mp_PDPWriterHistory)
     {

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -95,10 +95,15 @@ PDP::PDP (
     , mp_listener(nullptr)
     , mp_PDPWriterHistory(nullptr)
     , mp_PDPReaderHistory(nullptr)
-    , temp_reader_data_(allocation.locators.max_unicast_locators, allocation.locators.max_multicast_locators,
-            allocation.data_limits, allocation.content_filter)
-    , temp_writer_data_(allocation.locators.max_unicast_locators, allocation.locators.max_multicast_locators,
-            allocation.data_limits)
+    , temp_reader_proxies_({
+                allocation.locators.max_unicast_locators,
+                allocation.locators.max_multicast_locators,
+                allocation.data_limits,
+                allocation.content_filter})
+    , temp_writer_proxies_({
+                allocation.locators.max_unicast_locators,
+                allocation.locators.max_multicast_locators,
+                allocation.data_limits})
     , mp_mutex(new std::recursive_mutex())
     , resend_participant_info_event_(nullptr)
 {

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -344,15 +344,16 @@ void PDPClient::removeRemoteEndpoints(
 
             // rematch but discarding any previous state of the server
             // because we know the server shutdown intencionally
-            std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-            temp_writer_data_.clear();
-            temp_writer_data_.guid(wguid);
-            temp_writer_data_.persistence_guid(pdata->get_persistence_guid());
-            temp_writer_data_.set_persistence_entity_id(c_EntityId_SPDPWriter);
-            temp_writer_data_.set_remote_locators(pdata->metatraffic_locators, network, true);
-            temp_writer_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
-            temp_writer_data_.m_qos.m_durability.kind = TRANSIENT_DURABILITY_QOS;
-            mp_PDPReader->matched_writer_add(temp_writer_data_);
+            auto temp_writer_data = get_temporary_writer_proxies_pool().get();
+
+            temp_writer_data->clear();
+            temp_writer_data->guid(wguid);
+            temp_writer_data->persistence_guid(pdata->get_persistence_guid());
+            temp_writer_data->set_persistence_entity_id(c_EntityId_SPDPWriter);
+            temp_writer_data->set_remote_locators(pdata->metatraffic_locators, network, true);
+            temp_writer_data->m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+            temp_writer_data->m_qos.m_durability.kind = TRANSIENT_DURABILITY_QOS;
+            mp_PDPReader->matched_writer_add(*temp_writer_data);
         }
 
         auxendp = endp;
@@ -365,14 +366,15 @@ void PDPClient::removeRemoteEndpoints(
             rguid.entityId = c_EntityId_SPDPReader;
             mp_PDPWriter->matched_reader_remove(rguid);
 
-            std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-            temp_reader_data_.clear();
-            temp_reader_data_.m_expectsInlineQos = false;
-            temp_reader_data_.guid(rguid);
-            temp_reader_data_.set_remote_locators(pdata->metatraffic_locators, network, true);
-            temp_reader_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
-            temp_reader_data_.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
-            mp_PDPWriter->matched_reader_add(temp_reader_data_);
+            auto temp_reader_data = get_temporary_reader_proxies_pool().get();
+
+            temp_reader_data->clear();
+            temp_reader_data->m_expectsInlineQos = false;
+            temp_reader_data->guid(rguid);
+            temp_reader_data->set_remote_locators(pdata->metatraffic_locators, network, true);
+            temp_reader_data->m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+            temp_reader_data->m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
+            mp_PDPWriter->matched_reader_add(*temp_reader_data);
         }
     }
 }
@@ -593,29 +595,31 @@ void PDPClient::update_remote_servers_list()
 void PDPClient::match_pdp_writer_nts_(
         const eprosima::fastdds::rtps::RemoteServerAttributes& server_att)
 {
-    std::lock_guard<std::mutex> data_guard(temp_data_lock_);
     const NetworkFactory& network = mp_RTPSParticipant->network_factory();
-    temp_writer_data_.clear();
-    temp_writer_data_.guid(server_att.GetPDPWriter());
-    temp_writer_data_.set_multicast_locators(server_att.metatrafficMulticastLocatorList, network);
-    temp_writer_data_.set_remote_unicast_locators(server_att.metatrafficUnicastLocatorList, network);
-    temp_writer_data_.m_qos.m_durability.kind = TRANSIENT_DURABILITY_QOS;
-    temp_writer_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
-    mp_PDPReader->matched_writer_add(temp_writer_data_);
+    auto temp_writer_data = get_temporary_writer_proxies_pool().get();
+
+    temp_writer_data->clear();
+    temp_writer_data->guid(server_att.GetPDPWriter());
+    temp_writer_data->set_multicast_locators(server_att.metatrafficMulticastLocatorList, network);
+    temp_writer_data->set_remote_unicast_locators(server_att.metatrafficUnicastLocatorList, network);
+    temp_writer_data->m_qos.m_durability.kind = TRANSIENT_DURABILITY_QOS;
+    temp_writer_data->m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+    mp_PDPReader->matched_writer_add(*temp_writer_data);
 }
 
 void PDPClient::match_pdp_reader_nts_(
         const eprosima::fastdds::rtps::RemoteServerAttributes& server_att)
 {
-    std::lock_guard<std::mutex> data_guard(temp_data_lock_);
     const NetworkFactory& network = mp_RTPSParticipant->network_factory();
-    temp_reader_data_.clear();
-    temp_reader_data_.guid(server_att.GetPDPReader());
-    temp_reader_data_.set_multicast_locators(server_att.metatrafficMulticastLocatorList, network);
-    temp_reader_data_.set_remote_unicast_locators(server_att.metatrafficUnicastLocatorList, network);
-    temp_reader_data_.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
-    temp_reader_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
-    mp_PDPWriter->matched_reader_add(temp_reader_data_);
+    auto temp_reader_data = get_temporary_reader_proxies_pool().get();
+
+    temp_reader_data->clear();
+    temp_reader_data->guid(server_att.GetPDPReader());
+    temp_reader_data->set_multicast_locators(server_att.metatrafficMulticastLocatorList, network);
+    temp_reader_data->set_remote_unicast_locators(server_att.metatrafficUnicastLocatorList, network);
+    temp_reader_data->m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
+    temp_reader_data->m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+    mp_PDPWriter->matched_reader_add(*temp_reader_data);
 }
 
 const std::string& ros_discovery_server_env()

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -398,16 +398,17 @@ void PDPServer::assignRemoteEndpoints(
     uint32_t auxendp = endp & DISC_BUILTIN_ENDPOINT_PARTICIPANT_ANNOUNCER;
     if (0 != auxendp)
     {
-        std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-        temp_writer_data_.clear();
-        temp_writer_data_.guid().guidPrefix = pdata->m_guid.guidPrefix;
-        temp_writer_data_.guid().entityId = c_EntityId_SPDPWriter;
-        temp_writer_data_.persistence_guid(pdata->get_persistence_guid());
-        temp_writer_data_.set_persistence_entity_id(c_EntityId_SPDPWriter);
-        temp_writer_data_.set_remote_locators(pdata->metatraffic_locators, network, use_multicast_locators);
-        temp_writer_data_.m_qos.m_reliability.kind = dds::RELIABLE_RELIABILITY_QOS;
-        temp_writer_data_.m_qos.m_durability.kind = dds::TRANSIENT_LOCAL_DURABILITY_QOS;
-        mp_PDPReader->matched_writer_add(temp_writer_data_);
+        auto temp_writer_data = get_temporary_writer_proxies_pool().get();
+
+        temp_writer_data->clear();
+        temp_writer_data->guid().guidPrefix = pdata->m_guid.guidPrefix;
+        temp_writer_data->guid().entityId = c_EntityId_SPDPWriter;
+        temp_writer_data->persistence_guid(pdata->get_persistence_guid());
+        temp_writer_data->set_persistence_entity_id(c_EntityId_SPDPWriter);
+        temp_writer_data->set_remote_locators(pdata->metatraffic_locators, network, use_multicast_locators);
+        temp_writer_data->m_qos.m_reliability.kind = dds::RELIABLE_RELIABILITY_QOS;
+        temp_writer_data->m_qos.m_durability.kind = dds::TRANSIENT_LOCAL_DURABILITY_QOS;
+        mp_PDPReader->matched_writer_add(*temp_writer_data);
     }
     else
     {
@@ -420,16 +421,16 @@ void PDPServer::assignRemoteEndpoints(
     auxendp = endp & DISC_BUILTIN_ENDPOINT_PARTICIPANT_DETECTOR;
     if (0 != auxendp)
     {
-        std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-        temp_reader_data_.clear();
-        temp_reader_data_.m_expectsInlineQos = false;
-        temp_reader_data_.guid().guidPrefix = pdata->m_guid.guidPrefix;
-        temp_reader_data_.guid().entityId = c_EntityId_SPDPReader;
-        temp_writer_data_.persistence_guid(pdata->get_persistence_guid());
-        temp_reader_data_.set_remote_locators(pdata->metatraffic_locators, network, use_multicast_locators);
-        temp_reader_data_.m_qos.m_reliability.kind = dds::RELIABLE_RELIABILITY_QOS;
-        temp_reader_data_.m_qos.m_durability.kind = dds::TRANSIENT_LOCAL_DURABILITY_QOS;
-        mp_PDPWriter->matched_reader_add(temp_reader_data_);
+        auto temp_reader_data = get_temporary_reader_proxies_pool().get();
+
+        temp_reader_data->clear();
+        temp_reader_data->m_expectsInlineQos = false;
+        temp_reader_data->guid().guidPrefix = pdata->m_guid.guidPrefix;
+        temp_reader_data->guid().entityId = c_EntityId_SPDPReader;
+        temp_reader_data->set_remote_locators(pdata->metatraffic_locators, network, use_multicast_locators);
+        temp_reader_data->m_qos.m_reliability.kind = dds::RELIABLE_RELIABILITY_QOS;
+        temp_reader_data->m_qos.m_durability.kind = dds::TRANSIENT_LOCAL_DURABILITY_QOS;
+        mp_PDPWriter->matched_reader_add(*temp_reader_data);
     }
     else
     {
@@ -1778,29 +1779,31 @@ void PDPServer::process_backup_store()
 void PDPServer::match_pdp_writer_nts_(
         const eprosima::fastdds::rtps::RemoteServerAttributes& server_att)
 {
-    std::lock_guard<std::mutex> data_guard(temp_data_lock_);
     const NetworkFactory& network = mp_RTPSParticipant->network_factory();
-    temp_writer_data_.clear();
-    temp_writer_data_.guid(server_att.GetPDPWriter());
-    temp_writer_data_.set_multicast_locators(server_att.metatrafficMulticastLocatorList, network);
-    temp_writer_data_.set_remote_unicast_locators(server_att.metatrafficUnicastLocatorList, network);
-    temp_writer_data_.m_qos.m_durability.durabilityKind(durability_);
-    temp_writer_data_.m_qos.m_reliability.kind = dds::RELIABLE_RELIABILITY_QOS;
-    mp_PDPReader->matched_writer_add(temp_writer_data_);
+    auto temp_writer_data = get_temporary_writer_proxies_pool().get();
+
+    temp_writer_data->clear();
+    temp_writer_data->guid(server_att.GetPDPWriter());
+    temp_writer_data->set_multicast_locators(server_att.metatrafficMulticastLocatorList, network);
+    temp_writer_data->set_remote_unicast_locators(server_att.metatrafficUnicastLocatorList, network);
+    temp_writer_data->m_qos.m_durability.durabilityKind(durability_);
+    temp_writer_data->m_qos.m_reliability.kind = dds::RELIABLE_RELIABILITY_QOS;
+    mp_PDPReader->matched_writer_add(*temp_writer_data);
 }
 
 void PDPServer::match_pdp_reader_nts_(
         const eprosima::fastdds::rtps::RemoteServerAttributes& server_att)
 {
-    std::lock_guard<std::mutex> data_guard(temp_data_lock_);
     const NetworkFactory& network = mp_RTPSParticipant->network_factory();
-    temp_reader_data_.clear();
-    temp_reader_data_.guid(server_att.GetPDPReader());
-    temp_reader_data_.set_multicast_locators(server_att.metatrafficMulticastLocatorList, network);
-    temp_reader_data_.set_remote_unicast_locators(server_att.metatrafficUnicastLocatorList, network);
-    temp_reader_data_.m_qos.m_durability.kind = dds::TRANSIENT_LOCAL_DURABILITY_QOS;
-    temp_reader_data_.m_qos.m_reliability.kind = dds::RELIABLE_RELIABILITY_QOS;
-    mp_PDPWriter->matched_reader_add(temp_reader_data_);
+    auto temp_reader_data = get_temporary_reader_proxies_pool().get();
+
+    temp_reader_data->clear();
+    temp_reader_data->guid(server_att.GetPDPReader());
+    temp_reader_data->set_multicast_locators(server_att.metatrafficMulticastLocatorList, network);
+    temp_reader_data->set_remote_unicast_locators(server_att.metatrafficUnicastLocatorList, network);
+    temp_reader_data->m_qos.m_durability.kind = dds::TRANSIENT_LOCAL_DURABILITY_QOS;
+    temp_reader_data->m_qos.m_reliability.kind = dds::RELIABLE_RELIABILITY_QOS;
+    mp_PDPWriter->matched_reader_add(*temp_reader_data);
 }
 
 } // namespace rtps

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -361,30 +361,32 @@ void PDPSimple::assignRemoteEndpoints(
     auxendp &= DISC_BUILTIN_ENDPOINT_PARTICIPANT_ANNOUNCER;
     if (auxendp != 0)
     {
-        std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-        temp_writer_data_.clear();
-        temp_writer_data_.guid().guidPrefix = pdata->m_guid.guidPrefix;
-        temp_writer_data_.guid().entityId = c_EntityId_SPDPWriter;
-        temp_writer_data_.persistence_guid(pdata->get_persistence_guid());
-        temp_writer_data_.set_persistence_entity_id(c_EntityId_SPDPWriter);
-        temp_writer_data_.set_remote_locators(pdata->metatraffic_locators, network, use_multicast_locators);
-        temp_writer_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
-        temp_writer_data_.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
-        mp_PDPReader->matched_writer_add(temp_writer_data_);
+        auto temp_writer_data = get_temporary_writer_proxies_pool().get();
+
+        temp_writer_data->clear();
+        temp_writer_data->guid().guidPrefix = pdata->m_guid.guidPrefix;
+        temp_writer_data->guid().entityId = c_EntityId_SPDPWriter;
+        temp_writer_data->persistence_guid(pdata->get_persistence_guid());
+        temp_writer_data->set_persistence_entity_id(c_EntityId_SPDPWriter);
+        temp_writer_data->set_remote_locators(pdata->metatraffic_locators, network, use_multicast_locators);
+        temp_writer_data->m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+        temp_writer_data->m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
+        mp_PDPReader->matched_writer_add(*temp_writer_data);
     }
     auxendp = endp;
     auxendp &= DISC_BUILTIN_ENDPOINT_PARTICIPANT_DETECTOR;
     if (auxendp != 0)
     {
-        std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-        temp_reader_data_.clear();
-        temp_reader_data_.m_expectsInlineQos = false;
-        temp_reader_data_.guid().guidPrefix = pdata->m_guid.guidPrefix;
-        temp_reader_data_.guid().entityId = c_EntityId_SPDPReader;
-        temp_reader_data_.set_remote_locators(pdata->metatraffic_locators, network, use_multicast_locators);
-        temp_reader_data_.m_qos.m_reliability.kind = BEST_EFFORT_RELIABILITY_QOS;
-        temp_reader_data_.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
-        mp_PDPWriter->matched_reader_add(temp_reader_data_);
+        auto temp_reader_data = get_temporary_reader_proxies_pool().get();
+
+        temp_reader_data->clear();
+        temp_reader_data->m_expectsInlineQos = false;
+        temp_reader_data->guid().guidPrefix = pdata->m_guid.guidPrefix;
+        temp_reader_data->guid().entityId = c_EntityId_SPDPReader;
+        temp_reader_data->set_remote_locators(pdata->metatraffic_locators, network, use_multicast_locators);
+        temp_reader_data->m_qos.m_reliability.kind = BEST_EFFORT_RELIABILITY_QOS;
+        temp_reader_data->m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
+        mp_PDPWriter->matched_reader_add(*temp_reader_data);
 
         StatelessWriter* pW = dynamic_cast<StatelessWriter*>(mp_PDPWriter);
 

--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -139,8 +139,8 @@ WLP::~WLP()
 #if HAVE_SECURITY
     if (mp_participant->is_secure())
     {
-        mp_participant->deleteUserEndpoint(mp_builtinReaderSecure);
-        mp_participant->deleteUserEndpoint(mp_builtinWriterSecure);
+        mp_participant->deleteUserEndpoint(mp_builtinReaderSecure->getGuid());
+        mp_participant->deleteUserEndpoint(mp_builtinWriterSecure->getGuid());
 
         if (mp_builtinReaderSecureHistory)
         {
@@ -158,8 +158,8 @@ WLP::~WLP()
     }
 #endif // if HAVE_SECURITY
 
-    mp_participant->deleteUserEndpoint(mp_builtinReader);
-    mp_participant->deleteUserEndpoint(mp_builtinWriter);
+    mp_participant->deleteUserEndpoint(mp_builtinReader->getGuid());
+    mp_participant->deleteUserEndpoint(mp_builtinWriter->getGuid());
 
     if (mp_builtinReaderHistory)
     {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1440,7 +1440,10 @@ bool RTPSParticipantImpl::existsEntityId(
         EndpointKind_t kind) const
 {
 
-    auto check = [&ent](Endpoint* e) { return ent == e->getGuid().entityId; };
+    auto check = [&ent](Endpoint* e)
+            {
+                return ent == e->getGuid().entityId;
+            };
 
     shared_lock<shared_mutex> _(endpoints_list_mutex);
 
@@ -1683,7 +1686,7 @@ bool RTPSParticipantImpl::deleteUserEndpoint(
     }
 
     bool found = false, found_in_users = false;
-    Endpoint * p_endpoint = nullptr;
+    Endpoint* p_endpoint = nullptr;
 
     if (endpoint.entityId.is_writer())
     {
@@ -1744,7 +1747,7 @@ bool RTPSParticipantImpl::deleteUserEndpoint(
     {
         std::lock_guard<std::mutex> _(m_receiverResourcelistMutex);
 
-        for(auto& rb : m_receiverResourcelist)
+        for (auto& rb : m_receiverResourcelist)
         {
             auto receiver = rb.mp_receiver;
             if (receiver)
@@ -1815,14 +1818,14 @@ void RTPSParticipantImpl::deleteAllUserEndpoints()
 
         vector<RTPSWriter*> writers;
         set_difference(m_allWriterList.begin(), m_allWriterList.end(),
-                       m_userWriterList.begin(), m_userWriterList.end(),
-                       back_inserter(writers));
+                m_userWriterList.begin(), m_userWriterList.end(),
+                back_inserter(writers));
         swap(writers, m_allWriterList);
 
         vector<RTPSReader*> readers;
         set_difference(m_allReaderList.begin(), m_allReaderList.end(),
-                       m_userReaderList.begin(), m_userReaderList.end(),
-                       back_inserter(readers));
+                m_userReaderList.begin(), m_userReaderList.end(),
+                back_inserter(readers));
         swap(readers, m_allReaderList);
 
         // remove dangling references
@@ -1831,11 +1834,11 @@ void RTPSParticipantImpl::deleteAllUserEndpoints()
     }
 
     // unlink the transport receiver blocks from the endpoints
-    for( auto endpoint : tmp)
+    for ( auto endpoint : tmp)
     {
         std::lock_guard<std::mutex> _(m_receiverResourcelistMutex);
 
-        for(auto& rb : m_receiverResourcelist)
+        for (auto& rb : m_receiverResourcelist)
         {
             auto receiver = rb.mp_receiver;
             if (receiver)
@@ -1846,20 +1849,21 @@ void RTPSParticipantImpl::deleteAllUserEndpoints()
     }
 
     // Remove from builtin protocols
-    auto removeEndpoint = [this](EndpointKind_t kind, Endpoint  * p)
-    {
-        return kind == WRITER
+    auto removeEndpoint = [this](EndpointKind_t kind, Endpoint* p)
+            {
+                return kind == WRITER
                ? mp_builtinProtocols->removeLocalWriter((RTPSWriter*)p)
                : mp_builtinProtocols->removeLocalReader((RTPSReader*)p);
-    };
+            };
 
 #if HAVE_SECURITY
-    bool (eprosima::fastrtps::rtps::security::SecurityManager::* unregister_endpoint[2])(const GUID_t& writer_guid);
+    bool (eprosima::fastrtps::rtps::security::SecurityManager::* unregister_endpoint[2])(
+            const GUID_t& writer_guid);
     unregister_endpoint[WRITER] = &security::SecurityManager::unregister_local_writer;
     unregister_endpoint[READER] = &security::SecurityManager::unregister_local_reader;
 #endif // if HAVE_SECURITY
 
-    for( auto endpoint : tmp)
+    for ( auto endpoint : tmp)
     {
         auto kind = endpoint->getAttributes().endpointKind;
         removeEndpoint(kind, endpoint);

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -67,6 +67,8 @@ using UDPv4TransportDescriptor = fastdds::rtps::UDPv4TransportDescriptor;
 using TCPTransportDescriptor = fastdds::rtps::TCPTransportDescriptor;
 using SharedMemTransportDescriptor = fastdds::rtps::SharedMemTransportDescriptor;
 
+thread_local RTPSParticipantImpl* RTPSParticipantImpl::collections_mutex_owner_ = nullptr;
+
 static EntityId_t TrustedWriter(
         const EntityId_t& reader)
 {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -19,14 +19,17 @@
 #ifndef _RTPS_PARTICIPANT_RTPSPARTICIPANTIMPL_H_
 #define _RTPS_PARTICIPANT_RTPSPARTICIPANTIMPL_H_
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+
+#include <atomic>
+#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <list>
-#include <sys/types.h>
 #include <mutex>
-#include <atomic>
-#include <chrono>
+#include <sys/types.h>
+
 #include <fastrtps/utils/Semaphore.h>
+#include <fastrtps/utils/shared_mutex.hpp>
 
 #if defined(_WIN32)
 #include <process.h>
@@ -530,7 +533,7 @@ private:
     //!Id counter to correctly assign the ids to writers and readers.
     uint32_t IdCounter;
     //! Mutex to safely access endpoints collections
-    std::mutex endpoints_list_mutex;
+    shared_mutex endpoints_list_mutex;
     //!Writer List.
     std::vector<RTPSWriter*> m_allWriterList;
     //!Reader List
@@ -912,42 +915,49 @@ public:
      * @return True on success
      */
     bool deleteUserEndpoint(
-            Endpoint*);
+            const GUID_t &);
 
-    /**
-     * Get the begin of the user reader list
-     * @return Iterator pointing to the begin of the user reader list
+    //! Delete all user and builtin endpoints
+    void deleteAllEndpoints();
+
+    /** Traverses the user writers collection transforming its elements with a provided functor
+     * @param f - Functor applied to each element. Must accept a reference as parameter. Should return true to keep iterating.
+     * @return Functor provided in order to allow aggregates retrieval
      */
-    std::vector<RTPSReader*>::iterator userReadersListBegin()
+    template<class Functor>
+    Functor& forEachUserWriter(Functor& f)
     {
-        return m_userReaderList.begin();
+        shared_lock<shared_mutex> _(endpoints_list_mutex);
+
+        for( RTPSWriter* pw : m_userWriterList)
+        {
+            if(!f(*pw))
+            {
+                break;
+            }
+        }
+
+        return f;
     }
 
-    /**
-     * Get the end of the user reader list
-     * @return Iterator pointing to the end of the user reader list
+    /** Traverses the user readers collection transforming its elements with a provided functor
+     * @param f - Functor applied to each element. Must accept a reference as parameter. Should return true to keep iterating.
+     * @return Functor provided in order to allow aggregates retrieval
      */
-    std::vector<RTPSReader*>::iterator userReadersListEnd()
+    template<EndpointKind_t e, class Functor>
+    Functor& forEachUserReader(Functor& f)
     {
-        return m_userReaderList.end();
-    }
+        shared_lock<shared_mutex> _(endpoints_list_mutex);
 
-    /**
-     * Get the begin of the user writer list
-     * @return Iterator pointing to the begin of the user writer list
-     */
-    std::vector<RTPSWriter*>::iterator userWritersListBegin()
-    {
-        return m_userWriterList.begin();
-    }
+        for( RTPSReader* pr : m_userReaderList)
+        {
+            if(!f(*pr))
+            {
+                break;
+            }
+        }
 
-    /**
-     * Get the end of the user writer list
-     * @return Iterator pointing to the end of the user writer list
-     */
-    std::vector<RTPSWriter*>::iterator userWritersListEnd()
-    {
-        return m_userWriterList.end();
+        return f;
     }
 
     /** Helper function that creates ReceiverResources based on a Locator_t List, possibly mutating

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -934,7 +934,7 @@ public:
         shared_lock<shared_mutex> may_lock;
         RTPSParticipantImpl* previous_onwer = collections_mutex_owner_;
 
-        if(collections_mutex_owner_ != this)
+        if (collections_mutex_owner_ != this)
         {
             shared_lock<shared_mutex> lock(endpoints_list_mutex);
             may_lock = std::move(lock);
@@ -968,7 +968,7 @@ public:
         shared_lock<shared_mutex> may_lock;
         RTPSParticipantImpl* previous_onwer = collections_mutex_owner_;
 
-        if(collections_mutex_owner_ != this)
+        if (collections_mutex_owner_ != this)
         {
             shared_lock<shared_mutex> lock(endpoints_list_mutex);
             may_lock = std::move(lock);

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -932,7 +932,7 @@ public:
     {
         // check if we are reentrying
         shared_lock<shared_mutex> may_lock;
-        RTPSParticipantImpl* previous_onwer = collections_mutex_owner_;
+        RTPSParticipantImpl* previous_owner = collections_mutex_owner_;
 
         if (collections_mutex_owner_ != this)
         {
@@ -951,7 +951,7 @@ public:
         }
 
         // restore tls former value
-        std::swap(collections_mutex_owner_, previous_onwer);
+        std::swap(collections_mutex_owner_, previous_owner);
 
         return f;
     }
@@ -966,7 +966,7 @@ public:
     {
         // check if we are reentrying
         shared_lock<shared_mutex> may_lock;
-        RTPSParticipantImpl* previous_onwer = collections_mutex_owner_;
+        RTPSParticipantImpl* previous_owner = collections_mutex_owner_;
 
         if (collections_mutex_owner_ != this)
         {
@@ -984,7 +984,7 @@ public:
         }
 
         // restore tls former value
-        std::swap(collections_mutex_owner_, previous_onwer);
+        std::swap(collections_mutex_owner_, previous_owner);
 
         return f;
     }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -533,7 +533,7 @@ private:
     //!Id counter to correctly assign the ids to writers and readers.
     uint32_t IdCounter;
     //! Mutex to safely access endpoints collections
-    shared_mutex endpoints_list_mutex;
+    mutable shared_mutex endpoints_list_mutex;
     //!Writer List.
     std::vector<RTPSWriter*> m_allWriterList;
     //!Reader List
@@ -925,7 +925,7 @@ public:
      * @return Functor provided in order to allow aggregates retrieval
      */
     template<class Functor>
-    Functor& forEachUserWriter(Functor& f)
+    Functor forEachUserWriter(Functor f)
     {
         shared_lock<shared_mutex> _(endpoints_list_mutex);
 
@@ -944,8 +944,8 @@ public:
      * @param f - Functor applied to each element. Must accept a reference as parameter. Should return true to keep iterating.
      * @return Functor provided in order to allow aggregates retrieval
      */
-    template<EndpointKind_t e, class Functor>
-    Functor& forEachUserReader(Functor& f)
+    template<class Functor>
+    Functor forEachUserReader(Functor f)
     {
         shared_lock<shared_mutex> _(endpoints_list_mutex);
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -917,8 +917,8 @@ public:
     bool deleteUserEndpoint(
             const GUID_t &);
 
-    //! Delete all user and builtin endpoints
-    void deleteAllEndpoints();
+    //! Delete all user endpoints, builtin are disposed in its related classes
+    void deleteAllUserEndpoints();
 
     /** Traverses the user writers collection transforming its elements with a provided functor
      * @param f - Functor applied to each element. Must accept a reference as parameter. Should return true to keep iterating.

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -915,7 +915,7 @@ public:
      * @return True on success
      */
     bool deleteUserEndpoint(
-            const GUID_t &);
+            const GUID_t&);
 
     //! Delete all user endpoints, builtin are disposed in its related classes
     void deleteAllUserEndpoints();
@@ -925,13 +925,14 @@ public:
      * @return Functor provided in order to allow aggregates retrieval
      */
     template<class Functor>
-    Functor forEachUserWriter(Functor f)
+    Functor forEachUserWriter(
+            Functor f)
     {
         shared_lock<shared_mutex> _(endpoints_list_mutex);
 
-        for( RTPSWriter* pw : m_userWriterList)
+        for ( RTPSWriter* pw : m_userWriterList)
         {
-            if(!f(*pw))
+            if (!f(*pw))
             {
                 break;
             }
@@ -945,13 +946,14 @@ public:
      * @return Functor provided in order to allow aggregates retrieval
      */
     template<class Functor>
-    Functor forEachUserReader(Functor f)
+    Functor forEachUserReader(
+            Functor f)
     {
         shared_lock<shared_mutex> _(endpoints_list_mutex);
 
-        for( RTPSReader* pr : m_userReaderList)
+        for ( RTPSReader* pr : m_userReaderList)
         {
-            if(!f(*pr))
+            if (!f(*pr))
             {
                 break;
             }

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -1120,7 +1120,7 @@ void SecurityManager::delete_participant_stateless_message_writer()
 {
     if (participant_stateless_message_writer_ != nullptr)
     {
-        participant_->deleteUserEndpoint(participant_stateless_message_writer_);
+        participant_->deleteUserEndpoint(participant_stateless_message_writer_->getGuid());
         participant_stateless_message_writer_ = nullptr;
     }
 
@@ -1169,7 +1169,7 @@ void SecurityManager::delete_participant_stateless_message_reader()
 {
     if (participant_stateless_message_reader_ != nullptr)
     {
-        participant_->deleteUserEndpoint(participant_stateless_message_reader_);
+        participant_->deleteUserEndpoint(participant_stateless_message_reader_->getGuid());
         participant_stateless_message_reader_ = nullptr;
     }
 
@@ -1268,7 +1268,7 @@ void SecurityManager::delete_participant_volatile_message_secure_writer()
 {
     if (participant_volatile_message_secure_writer_ != nullptr)
     {
-        participant_->deleteUserEndpoint(participant_volatile_message_secure_writer_);
+        participant_->deleteUserEndpoint(participant_volatile_message_secure_writer_->getGuid());
         participant_volatile_message_secure_writer_ = nullptr;
     }
 
@@ -1317,7 +1317,7 @@ void SecurityManager::delete_participant_volatile_message_secure_reader()
 {
     if (participant_volatile_message_secure_reader_ != nullptr)
     {
-        participant_->deleteUserEndpoint(participant_volatile_message_secure_reader_);
+        participant_->deleteUserEndpoint(participant_volatile_message_secure_reader_->getGuid());
         participant_volatile_message_secure_reader_ = nullptr;
     }
 

--- a/test/mock/rtps/PDP/fastdds/rtps/builtin/discovery/participant/PDP.h
+++ b/test/mock/rtps/PDP/fastdds/rtps/builtin/discovery/participant/PDP.h
@@ -95,8 +95,8 @@ public:
     std::recursive_mutex* mutex_;
 
     // temporary proxies pools
-    ProxyPool<ReaderProxyData> temp_proxy_readers = {{4,1}};
-    ProxyPool<WriterProxyData> temp_proxy_writers = {{4,1}};
+    ProxyPool<ReaderProxyData> temp_proxy_readers = {{4, 1}};
+    ProxyPool<WriterProxyData> temp_proxy_writers = {{4, 1}};
 };
 
 

--- a/test/mock/rtps/PDP/fastdds/rtps/builtin/discovery/participant/PDP.h
+++ b/test/mock/rtps/PDP/fastdds/rtps/builtin/discovery/participant/PDP.h
@@ -79,9 +79,24 @@ public:
     MOCK_METHOD0(ParticipantProxiesBegin, ResourceLimitedVector<ParticipantProxyData*>::const_iterator());
 
     MOCK_METHOD0(ParticipantProxiesEnd, ResourceLimitedVector<ParticipantProxyData*>::const_iterator());
+
+    ProxyPool<ReaderProxyData>& get_temporary_reader_proxies_pool()
+    {
+        return temp_proxy_readers;
+    }
+
+    ProxyPool<WriterProxyData>& get_temporary_writer_proxies_pool()
+    {
+        return temp_proxy_writers;
+    }
+
     // *INDENT-ON*
 
     std::recursive_mutex* mutex_;
+
+    // temporary proxies pools
+    ProxyPool<ReaderProxyData> temp_proxy_readers = {{4,1}};
+    ProxyPool<WriterProxyData> temp_proxy_writers = {{4,1}};
 };
 
 

--- a/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
+++ b/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
@@ -198,7 +198,7 @@ public:
     }
 
     bool deleteUserEndpoint(
-        const GUID_t& )
+            const GUID_t& )
     {
         return true;
     }
@@ -265,13 +265,15 @@ public:
     }
 
     template<class Functor>
-    Functor forEachUserWriter(Functor f)
+    Functor forEachUserWriter(
+            Functor f)
     {
         return f;
     }
 
     template<class Functor>
-    Functor forEachUserReader(Functor f)
+    Functor forEachUserReader(
+            Functor f)
     {
         return f;
     }

--- a/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
+++ b/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
@@ -318,7 +318,7 @@ private:
     GUID_t generate_endpoint_guid() const
     {
         static uint32_t counter = 0;
-        constexpr char* prefix = "49.20.48.61.74.65.20.47.4D.6F.63.6B";
+        const char* prefix = "49.20.48.61.74.65.20.47.4D.6F.63.6B";
 
         GUID_t res;
         std::istringstream is(prefix);

--- a/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
+++ b/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
@@ -197,10 +197,10 @@ public:
         return ret;
     }
 
-    void deleteUserEndpoint(
-            Endpoint* endpoint)
+    bool deleteUserEndpoint(
+        const GUID_t& )
     {
-        delete endpoint;
+        return true;
     }
 
     MOCK_METHOD0(pdpsimple, PDPSimple * ());
@@ -262,6 +262,18 @@ public:
             EntityId_t&)
     {
         return true;
+    }
+
+    template<class Functor>
+    Functor forEachUserWriter(Functor f)
+    {
+        return f;
+    }
+
+    template<class Functor>
+    Functor forEachUserReader(Functor f)
+    {
+        return f;
     }
 
 private:

--- a/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
+++ b/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
@@ -125,12 +125,6 @@ public:
             const EntityId_t& entityId, bool isBuiltin, bool enable));
     // *INDENT-ON*
 
-    MOCK_METHOD0(userWritersListBegin, std::vector<RTPSWriter*>::iterator ());
-    MOCK_METHOD0(userWritersListEnd, std::vector<RTPSWriter*>::iterator ());
-
-    MOCK_METHOD0(userReadersListBegin, std::vector<RTPSReader*>::iterator ());
-    MOCK_METHOD0(userReadersListEnd, std::vector<RTPSReader*>::iterator ());
-
     MOCK_CONST_METHOD0(getParticipantMutex, std::recursive_mutex* ());
 
     bool createWriter(

--- a/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
+++ b/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
@@ -221,7 +221,7 @@ public:
     {
         // Check the map
         auto it = endpoints_.find(e);
-        if( it != endpoints_.end())
+        if ( it != endpoints_.end())
         {
             delete it->second;
             endpoints_.erase(it);
@@ -313,12 +313,12 @@ private:
 
     RTPSParticipantAttributes attr_;
 
-    std::map<GUID_t, Endpoint *> endpoints_;
+    std::map<GUID_t, Endpoint*> endpoints_;
 
     GUID_t generate_endpoint_guid() const
     {
         static uint32_t counter = 0;
-        constexpr char * prefix = "49.20.48.61.74.65.20.47.4D.6F.63.6B";
+        constexpr char* prefix = "49.20.48.61.74.65.20.47.4D.6F.63.6B";
 
         GUID_t res;
         std::istringstream is(prefix);
@@ -326,6 +326,7 @@ private:
         res.entityId = ++counter;
         return res;
     }
+
 };
 
 } // namespace rtps

--- a/test/mock/rtps/RTPSReader/fastdds/rtps/reader/RTPSReader.h
+++ b/test/mock/rtps/RTPSReader/fastdds/rtps/reader/RTPSReader.h
@@ -221,7 +221,7 @@ public:
 
     ReaderListener* listener_;
 
-    const GUID_t m_guid;
+    GUID_t m_guid;
 };
 
 } // namespace rtps

--- a/test/mock/rtps/StatefulWriter/fastdds/rtps/writer/StatefulWriter.h
+++ b/test/mock/rtps/StatefulWriter/fastdds/rtps/writer/StatefulWriter.h
@@ -58,8 +58,6 @@ public:
 
     MOCK_METHOD1 (matched_reader_is_matched, bool(const GUID_t& reader_guid));
 
-    MOCK_METHOD0(getGuid, const GUID_t& ());
-
     MOCK_METHOD1(unsent_change_added_to_history_mock, void(CacheChange_t*));
 
     MOCK_METHOD1(perform_nack_supression, void(const GUID_t&));

--- a/test/mock/rtps/StatelessWriter/fastdds/rtps/writer/StatelessWriter.h
+++ b/test/mock/rtps/StatelessWriter/fastdds/rtps/writer/StatelessWriter.h
@@ -45,8 +45,6 @@ public:
 
     MOCK_METHOD1 (matched_reader_is_matched, bool(const GUID_t& reader_guid));
 
-    MOCK_METHOD0(getGuid, const GUID_t& ());
-
     MOCK_METHOD1(unsent_change_added_to_history_mock, void(CacheChange_t*));
 
     RTPSParticipantImpl* getRTPSParticipant()

--- a/test/unittest/rtps/security/SecurityHandshakeProcessTests.cpp
+++ b/test/unittest/rtps/security/SecurityHandshakeProcessTests.cpp
@@ -612,7 +612,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_fail_process_handsha
 
     ParticipantGenericMessage message;
     message.message_identity().source_guid(remote_participant_key);
-    message.related_message_identity().source_guid(remote_participant_key);
+    message.related_message_identity().source_guid(stateless_writer_->getGuid());
     message.related_message_identity().sequence_number(1);
     message.destination_participant_key(remote_participant_key);
     message.message_class_id("dds.sec.auth");
@@ -665,7 +665,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_process_handshake
 
     ParticipantGenericMessage message;
     message.message_identity().source_guid(remote_participant_key);
-    message.related_message_identity().source_guid(remote_participant_key);
+    message.related_message_identity().source_guid(stateless_writer_->getGuid());
     message.related_message_identity().sequence_number(1);
     message.destination_participant_key(remote_participant_key);
     message.message_class_id("dds.sec.auth");
@@ -737,7 +737,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_re
 
     ParticipantGenericMessage message;
     message.message_identity().source_guid(remote_participant_key);
-    message.related_message_identity().source_guid(remote_participant_key);
+    message.related_message_identity().source_guid(stateless_writer_->getGuid());
     message.related_message_identity().sequence_number(1);
     message.destination_participant_key(remote_participant_key);
     message.message_class_id("dds.sec.auth");
@@ -791,7 +791,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_re
 
     ParticipantGenericMessage message;
     message.message_identity().source_guid(remote_participant_key);
-    message.related_message_identity().source_guid(remote_participant_key);
+    message.related_message_identity().source_guid(stateless_writer_->getGuid());
     message.related_message_identity().sequence_number(1);
     message.destination_participant_key(remote_participant_key);
     message.message_class_id("dds.sec.auth");
@@ -870,7 +870,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_re
 
     ParticipantGenericMessage message;
     message.message_identity().source_guid(remote_participant_key);
-    message.related_message_identity().source_guid(remote_participant_key);
+    message.related_message_identity().source_guid(stateless_writer_->getGuid());
     message.related_message_identity().sequence_number(1);
     message.destination_participant_key(remote_participant_key);
     message.message_class_id("dds.sec.auth");
@@ -1006,7 +1006,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_fail_process_handsha
 
     ParticipantGenericMessage message;
     message.message_identity().source_guid(remote_participant_key);
-    message.related_message_identity().source_guid(remote_participant_key);
+    message.related_message_identity().source_guid(stateless_writer_->getGuid());
     message.related_message_identity().sequence_number(1);
     message.destination_participant_key(remote_participant_key);
     message.message_class_id("dds.sec.auth");
@@ -1059,7 +1059,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_process_handshake
 
     ParticipantGenericMessage message;
     message.message_identity().source_guid(remote_participant_key);
-    message.related_message_identity().source_guid(remote_participant_key);
+    message.related_message_identity().source_guid(stateless_writer_->getGuid());
     message.related_message_identity().sequence_number(1);
     message.destination_participant_key(remote_participant_key);
     message.message_class_id("dds.sec.auth");

--- a/test/unittest/rtps/security/SecurityTests.cpp
+++ b/test/unittest/rtps/security/SecurityTests.cpp
@@ -179,7 +179,7 @@ void SecurityTest::final_message_process_ok(
 
     ParticipantGenericMessage message;
     message.message_identity().source_guid(remote_participant_key);
-    message.related_message_identity().source_guid(remote_participant_key);
+    message.related_message_identity().source_guid(stateless_writer_->getGuid());
     message.related_message_identity().sequence_number(1);
     message.destination_participant_key(remote_participant_key);
     message.message_class_id("dds.sec.auth");

--- a/test/unittest/rtps/writer/CMakeLists.txt
+++ b/test/unittest/rtps/writer/CMakeLists.txt
@@ -101,7 +101,7 @@ target_compile_definitions(RTPSWriterTests PRIVATE
     )
 target_include_directories(RTPSWriterTests PRIVATE
     ${Asio_INCLUDE_DIR})
-target_link_libraries(RTPSWriterTests fastrtps foonathan_memory
+target_link_libraries(RTPSWriterTests fastcdr fastrtps foonathan_memory
     GTest::gmock
     ${CMAKE_DL_LIBS})
 add_gtest(RTPSWriterTests SOURCES ${RTPSWRITERTESTS_SOURCE})

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -836,6 +836,8 @@ TEST_F(RTPSStatisticsTests, statistics_rpts_listener_gap_callback)
     // add a second sample and remove it to generate the gap
     write_small_sample(length);
     ASSERT_TRUE(writer_history_->remove_change(SequenceNumber_t{0, 2}));
+    // add a third sample in order to force the gap
+    write_small_sample(length);
 
     // create the late joiner as VOLATILE
     create_reader(length, RELIABLE, VOLATILE);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This pull request addresses the following family of deadlocks `A => B => C => A` where:

+ A  `RecursiveTimedMutex& Endpoint::getMutex()` Endpoint is EDP DataWriter in Participant 2.
+ B  Participant 1. `std::recursive_mutex RTPSParticipantImpl::getParticipantMutex()`
+ C  Participant 2. `std::recursive_mutex RTPSParticipantImpl::getParticipantMutex()`

It involves a test case where two participants are destroyed from the Main Thread.
The execution sequence that leads to deadlocks:

+ `A=>B` Flow controller thread for EDP DataWriter in Participant 2.
     EDP DataWriter sending messages through its flow controller, that is, flow controller's asynchronous thread
     (`FlowControllerImpl::run()`). The asynchronous thread takes the DataWriter mutex (A).  
     Later it delivers the sample via intraprocess to EDPDataReader in participant 2 which takes the participant
     mutex (B) to traverse endpoint collections and do matching.

+ `B=>C` Main Thread.
     On test destruction comes participant 1 removal.
     Participant 1 calls `RTPSParticipantImpl::disable()` which takes mutex B to traverse it's endpoint list for
     removal. Here the EDP demise notifications go via intraprocess  and ends up in `EDP::unpairWriterProxy()`
     call that requires C (participant 2 mutex) for unmatching.

+ `C=>A` Main Thread
     On test destruction comes participant 2 removal.
     Participant 2 calls `RTPSParticipantImpl::disable()` which takes mutex C to traverse it's endpoint list for
     removal. In order to send `DATA[U]R` message it requires mutex (A) to allocate a new CacheChange (single mutex for
     history and endpoint).

In order to solve the deadlock, the participant's endpoint collections will no longer be protected by the general
participant mutex but by a devoted one (this was partially done before but the refactor extends it to all collections).

```
    mutable shared_mutex endpoints_list_mutex;

    std::vector<RTPSWriter*> m_allWriterList;
    std::vector<RTPSReader*> m_allReaderList;
    std::vector<RTPSWriter*> m_userWriterList;
    std::vector<RTPSReader*> m_userReaderList;
```
Other changes added in this pull request:
+ In order to prevent deadlocks with the `temp_data_lock` mutex (devoted to protect EDP temporary proxies access) a new proxy pool is created in EDP. The proxies are then synchronized via *ownership* instead of *mutual exclusion*.
+ A *thread local storage* variable is added to the `RTPSParticipantImpl` class in order to prevent reentrancy in the `endpoints_list_mutex` (this situation takes place very often in *intraprocess* calls).

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] NA Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] NA Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] NA New feature has been added to the `versions.md` file (if applicable).
- [ ] NA New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
