### PR TITLE
Fix WLP deadlock and EDP discovery performance improvement [14450][14457] <feature/tsan/fixes>

### DIFF
--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -185,118 +185,127 @@ bool StatefulReader::matched_writer_add(
 {
     assert(wdata.guid() != c_Guid_Unknown);
 
-    std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
-
-    if (!is_alive_)
     {
-        return false;
-    }
+        std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
 
-    bool is_same_process = RTPSDomainImpl::should_intraprocess_between(m_guid, wdata.guid());
-    bool is_datasharing = !is_same_process && is_datasharing_compatible_with(wdata);
 
-    for (WriterProxy* it : matched_writers_)
-    {
-        if (it->guid() == wdata.guid())
+        if (!is_alive_)
         {
-            logInfo(RTPS_READER, "Attempting to add existing writer, updating information");
-            it->update(wdata);
-            if (!is_same_process)
+            return false;
+        }
+
+        bool is_same_process = RTPSDomainImpl::should_intraprocess_between(m_guid, wdata.guid());
+        bool is_datasharing = !is_same_process && is_datasharing_compatible_with(wdata);
+
+        for (WriterProxy* it : matched_writers_)
+        {
+            if (it->guid() == wdata.guid())
             {
-                for (const Locator_t& locator : it->remote_locators_shrinked())
+                logInfo(RTPS_READER, "Attempting to add existing writer, updating information");
+                it->update(wdata);
+                if (!is_same_process)
                 {
-                    getRTPSParticipant()->createSenderResources(locator);
+                    for (const Locator_t& locator : it->remote_locators_shrinked())
+                    {
+                        getRTPSParticipant()->createSenderResources(locator);
+                    }
+                }
+                if (nullptr != mp_listener)
+                {
+                    mp_listener->on_writer_discovery(this, WriterDiscoveryInfo::CHANGED_QOS_WRITER, wdata.guid(),
+                            &wdata);
+                }
+                return false;
+            }
+        }
+
+        // Get a writer proxy from the inactive pool (or create a new one if necessary and allowed)
+        WriterProxy* wp = nullptr;
+        if (matched_writers_pool_.empty())
+        {
+            size_t max_readers = matched_writers_pool_.max_size();
+            if (getMatchedWritersSize() + matched_writers_pool_.size() < max_readers)
+            {
+                const RTPSParticipantAttributes& part_att = mp_RTPSParticipant->getRTPSParticipantAttributes();
+                wp = new WriterProxy(this, part_att.allocation.locators, proxy_changes_config_);
+            }
+            else
+            {
+                logWarning(RTPS_READER, "Maximum number of reader proxies (" << max_readers << \
+                        ") reached for writer " << m_guid);
+                return false;
+            }
+        }
+        else
+        {
+            wp = matched_writers_pool_.back();
+            matched_writers_pool_.pop_back();
+        }
+
+        SequenceNumber_t initial_sequence;
+        add_persistence_guid(wdata.guid(), wdata.persistence_guid());
+        initial_sequence = get_last_notified(wdata.guid());
+
+        wp->start(wdata, initial_sequence, is_datasharing);
+
+        if (!is_same_process)
+        {
+            for (const Locator_t& locator : wp->remote_locators_shrinked())
+            {
+                getRTPSParticipant()->createSenderResources(locator);
+            }
+        }
+
+        if (is_datasharing)
+        {
+            if (datasharing_listener_->add_datasharing_writer(wdata.guid(),
+                    m_att.durabilityKind == VOLATILE,
+                    mp_history->m_att.maximumReservedCaches))
+            {
+                matched_writers_.push_back(wp);
+                logInfo(RTPS_READER, "Writer Proxy " << wdata.guid() << " added to " << this->m_guid.entityId
+                                                     << " with data sharing");
+            }
+            else
+            {
+                logError(RTPS_READER, "Failed to add Writer Proxy " << wdata.guid()
+                                                                    << " to " << this->m_guid.entityId
+                                                                    << " with data sharing.");
+                wp->stop();
+                matched_writers_pool_.push_back(wp);
+                return false;
+            }
+
+            // Intraprocess manages durability itself
+            if (VOLATILE == m_att.durabilityKind)
+            {
+                std::shared_ptr<ReaderPool> pool = datasharing_listener_->get_pool_for_writer(wp->guid());
+                SequenceNumber_t last_seq = pool->get_last_read_sequence_number();
+                if (SequenceNumber_t::unknown() != last_seq)
+                {
+                    SequenceNumberSet_t sns(last_seq + 1);
+                    send_acknack(wp, sns, wp, false);
+                    wp->lost_changes_update(last_seq + 1);
                 }
             }
-            if (nullptr != mp_listener)
+            else if (!is_same_process)
             {
-                mp_listener->on_writer_discovery(this, WriterDiscoveryInfo::CHANGED_QOS_WRITER, wdata.guid(), &wdata);
+                // simulate a notification to force reading of transient changes
+                datasharing_listener_->notify(false);
             }
-            return false;
-        }
-    }
-
-    // Get a writer proxy from the inactive pool (or create a new one if necessary and allowed)
-    WriterProxy* wp = nullptr;
-    if (matched_writers_pool_.empty())
-    {
-        size_t max_readers = matched_writers_pool_.max_size();
-        if (getMatchedWritersSize() + matched_writers_pool_.size() < max_readers)
-        {
-            const RTPSParticipantAttributes& part_att = mp_RTPSParticipant->getRTPSParticipantAttributes();
-            wp = new WriterProxy(this, part_att.allocation.locators, proxy_changes_config_);
         }
         else
-        {
-            logWarning(RTPS_READER, "Maximum number of reader proxies (" << max_readers << \
-                    ") reached for writer " << m_guid);
-            return false;
-        }
-    }
-    else
-    {
-        wp = matched_writers_pool_.back();
-        matched_writers_pool_.pop_back();
-    }
-
-    SequenceNumber_t initial_sequence;
-    add_persistence_guid(wdata.guid(), wdata.persistence_guid());
-    initial_sequence = get_last_notified(wdata.guid());
-
-    wp->start(wdata, initial_sequence, is_datasharing);
-
-    if (!is_same_process)
-    {
-        for (const Locator_t& locator : wp->remote_locators_shrinked())
-        {
-            getRTPSParticipant()->createSenderResources(locator);
-        }
-    }
-
-    if (is_datasharing)
-    {
-        if (datasharing_listener_->add_datasharing_writer(wdata.guid(),
-                m_att.durabilityKind == VOLATILE,
-                mp_history->m_att.maximumReservedCaches))
         {
             matched_writers_.push_back(wp);
-            logInfo(RTPS_READER, "Writer Proxy " << wdata.guid() << " added to " << this->m_guid.entityId
-                                                 << " with data sharing");
-        }
-        else
-        {
-            logError(RTPS_READER, "Failed to add Writer Proxy " << wdata.guid()
-                                                                << " to " << this->m_guid.entityId
-                                                                << " with data sharing.");
-            wp->stop();
-            matched_writers_pool_.push_back(wp);
-            return false;
+            logInfo(RTPS_READER, "Writer Proxy " << wp->guid() << " added to " << m_guid.entityId);
         }
 
-        // Intraprocess manages durability itself
-        if (VOLATILE == m_att.durabilityKind)
+        if (nullptr != mp_listener)
         {
-            std::shared_ptr<ReaderPool> pool = datasharing_listener_->get_pool_for_writer(wp->guid());
-            SequenceNumber_t last_seq = pool->get_last_read_sequence_number();
-            if (SequenceNumber_t::unknown() != last_seq)
-            {
-                SequenceNumberSet_t sns(last_seq + 1);
-                send_acknack(wp, sns, wp, false);
-                wp->lost_changes_update(last_seq + 1);
-            }
+            mp_listener->on_writer_discovery(this, WriterDiscoveryInfo::DISCOVERED_WRITER, wdata.guid(), &wdata);
         }
-        else if (!is_same_process)
-        {
-            // simulate a notification to force reading of transient changes
-            datasharing_listener_->notify(false);
-        }
-    }
-    else
-    {
-        matched_writers_.push_back(wp);
-        logInfo(RTPS_READER, "Writer Proxy " << wp->guid() << " added to " << m_guid.entityId);
-    }
 
+    }
     if (liveliness_lease_duration_ < c_TimeInfinite)
     {
         auto wlp = this->mp_RTPSParticipant->wlp();
@@ -313,10 +322,6 @@ bool StatefulReader::matched_writer_add(
         }
     }
 
-    if (nullptr != mp_listener)
-    {
-        mp_listener->on_writer_discovery(this, WriterDiscoveryInfo::DISCOVERED_WRITER, wdata.guid(), &wdata);
-    }
     return true;
 }
 
@@ -324,6 +329,24 @@ bool StatefulReader::matched_writer_remove(
         const GUID_t& writer_guid,
         bool removed_by_lease)
 {
+
+    if (is_alive_ && liveliness_lease_duration_ < c_TimeInfinite)
+    {
+        auto wlp = this->mp_RTPSParticipant->wlp();
+        if ( wlp != nullptr)
+        {
+            wlp->sub_liveliness_manager_->remove_writer(
+                writer_guid,
+                liveliness_kind_,
+                liveliness_lease_duration_);
+        }
+        else
+        {
+            logError(RTPS_LIVELINESS,
+                    "Finite liveliness lease duration but WLP not enabled, cannot remove writer");
+        }
+    }
+
     std::unique_lock<RecursiveTimedMutex> lock(mp_mutex);
     WriterProxy* wproxy = nullptr;
     if (is_alive_)
@@ -331,22 +354,6 @@ bool StatefulReader::matched_writer_remove(
         //Remove cachechanges belonging to the unmatched writer
         mp_history->writer_unmatched(writer_guid, get_last_notified(writer_guid));
 
-        if (liveliness_lease_duration_ < c_TimeInfinite)
-        {
-            auto wlp = this->mp_RTPSParticipant->wlp();
-            if ( wlp != nullptr)
-            {
-                wlp->sub_liveliness_manager_->remove_writer(
-                    writer_guid,
-                    liveliness_kind_,
-                    liveliness_lease_duration_);
-            }
-            else
-            {
-                logError(RTPS_LIVELINESS,
-                        "Finite liveliness lease duration but WLP not enabled, cannot remove writer");
-            }
-        }
 
         for (ResourceLimitedVector<WriterProxy*>::iterator it = matched_writers_.begin();
                 it != matched_writers_.end();

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -186,6 +186,22 @@ bool StatelessReader::matched_writer_remove(
         const GUID_t& writer_guid,
         bool removed_by_lease)
 {
+    if (liveliness_lease_duration_ < c_TimeInfinite)
+    {
+        auto wlp = mp_RTPSParticipant->wlp();
+        if ( wlp != nullptr)
+        {
+            wlp->sub_liveliness_manager_->remove_writer(
+                writer_guid,
+                liveliness_kind_,
+                liveliness_lease_duration_);
+        }
+        else
+        {
+            logError(RTPS_LIVELINESS,
+                    "Finite liveliness lease duration but WLP not enabled, cannot remove writer");
+        }
+    }
     {
         std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
 
@@ -213,22 +229,6 @@ bool StatelessReader::matched_writer_remove(
                 }
                 return true;
             }
-        }
-    }
-    if (liveliness_lease_duration_ < c_TimeInfinite)
-    {
-        auto wlp = mp_RTPSParticipant->wlp();
-        if ( wlp != nullptr)
-        {
-            wlp->sub_liveliness_manager_->remove_writer(
-                writer_guid,
-                liveliness_kind_,
-                liveliness_lease_duration_);
-        }
-        else
-        {
-            logError(RTPS_LIVELINESS,
-                    "Finite liveliness lease duration but WLP not enabled, cannot remove writer");
         }
     }
     return false;

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -91,63 +91,79 @@ StatelessReader::StatelessReader(
 bool StatelessReader::matched_writer_add(
         const WriterProxyData& wdata)
 {
-    std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
-    for (const RemoteWriterInfo_t& writer : matched_writers_)
     {
-        if (writer.guid == wdata.guid())
+        std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
+        for (const RemoteWriterInfo_t& writer : matched_writers_)
         {
-            logWarning(RTPS_READER, "Attempting to add existing writer");
-            if (nullptr != mp_listener)
+            if (writer.guid == wdata.guid())
             {
-                mp_listener->on_writer_discovery(this, WriterDiscoveryInfo::CHANGED_QOS_WRITER, wdata.guid(), &wdata);
+                logWarning(RTPS_READER, "Attempting to add existing writer");
+                if (nullptr != mp_listener)
+                {
+                    mp_listener->on_writer_discovery(this, WriterDiscoveryInfo::CHANGED_QOS_WRITER, wdata.guid(),
+                            &wdata);
+                }
+                return false;
+            }
+        }
+
+        bool is_same_process = RTPSDomainImpl::should_intraprocess_between(m_guid, wdata.guid());
+        bool is_datasharing = !is_same_process && is_datasharing_compatible_with(wdata);
+
+        RemoteWriterInfo_t info;
+        info.guid = wdata.guid();
+        info.persistence_guid = wdata.persistence_guid();
+        info.has_manual_topic_liveliness = (MANUAL_BY_TOPIC_LIVELINESS_QOS == wdata.m_qos.m_liveliness.kind);
+        info.is_datasharing = is_datasharing;
+
+        if (is_datasharing)
+        {
+            if (datasharing_listener_->add_datasharing_writer(wdata.guid(),
+                    m_att.durabilityKind == VOLATILE,
+                    mp_history->m_att.maximumReservedCaches))
+            {
+                logInfo(RTPS_READER, "Writer Proxy " << wdata.guid() << " added to " << this->m_guid.entityId
+                                                     << " with data sharing");
+            }
+            else
+            {
+                logError(RTPS_READER, "Failed to add Writer Proxy " << wdata.guid()
+                                                                    << " to " << this->m_guid.entityId
+                                                                    << " with data sharing.");
+                return false;
+            }
+
+        }
+
+        if (matched_writers_.emplace_back(info) == nullptr)
+        {
+            logWarning(RTPS_READER, "No space to add writer " << wdata.guid() << " to reader " << m_guid);
+            if (is_datasharing)
+            {
+                datasharing_listener_->remove_datasharing_writer(wdata.guid());
             }
             return false;
         }
-    }
+        logInfo(RTPS_READER, "Writer " << wdata.guid() << " added to reader " << m_guid);
 
-    bool is_same_process = RTPSDomainImpl::should_intraprocess_between(m_guid, wdata.guid());
-    bool is_datasharing = !is_same_process && is_datasharing_compatible_with(wdata);
+        add_persistence_guid(info.guid, info.persistence_guid);
 
-    RemoteWriterInfo_t info;
-    info.guid = wdata.guid();
-    info.persistence_guid = wdata.persistence_guid();
-    info.has_manual_topic_liveliness = (MANUAL_BY_TOPIC_LIVELINESS_QOS == wdata.m_qos.m_liveliness.kind);
-    info.is_datasharing = is_datasharing;
+        m_acceptMessagesFromUnkownWriters = false;
 
-    if (is_datasharing)
-    {
-        if (datasharing_listener_->add_datasharing_writer(wdata.guid(),
-                m_att.durabilityKind == VOLATILE,
-                mp_history->m_att.maximumReservedCaches))
+        // Intraprocess manages durability itself
+        if (is_datasharing && !is_same_process && m_att.durabilityKind != VOLATILE)
         {
-            logInfo(RTPS_READER, "Writer Proxy " << wdata.guid() << " added to " << this->m_guid.entityId
-                                                 << " with data sharing");
+            // simulate a notification to force reading of transient changes
+            // this has to be done after the writer is added to the matched_writers or the processing may fail
+            datasharing_listener_->notify(false);
         }
-        else
+
+        if (nullptr != mp_listener)
         {
-            logError(RTPS_READER, "Failed to add Writer Proxy " << wdata.guid()
-                                                                << " to " << this->m_guid.entityId
-                                                                << " with data sharing.");
-            return false;
+            mp_listener->on_writer_discovery(this, WriterDiscoveryInfo::DISCOVERED_WRITER, wdata.guid(), &wdata);
         }
 
     }
-
-    if (matched_writers_.emplace_back(info) == nullptr)
-    {
-        logWarning(RTPS_READER, "No space to add writer " << wdata.guid() << " to reader " << m_guid);
-        if (is_datasharing)
-        {
-            datasharing_listener_->remove_datasharing_writer(wdata.guid());
-        }
-        return false;
-    }
-    logInfo(RTPS_READER, "Writer " << wdata.guid() << " added to reader " << m_guid);
-
-    add_persistence_guid(info.guid, info.persistence_guid);
-
-    m_acceptMessagesFromUnkownWriters = false;
-
     if (liveliness_lease_duration_ < c_TimeInfinite)
     {
         auto wlp = mp_RTPSParticipant->wlp();
@@ -163,19 +179,6 @@ bool StatelessReader::matched_writer_add(
             logError(RTPS_LIVELINESS, "Finite liveliness lease duration but WLP not enabled");
         }
     }
-
-    // Intraprocess manages durability itself
-    if (is_datasharing && !is_same_process && m_att.durabilityKind != VOLATILE)
-    {
-        // simulate a notification to force reading of transient changes
-        // this has to be done after the writer is added to the matched_writers or the processing may fail
-        datasharing_listener_->notify(false);
-    }
-
-    if (nullptr != mp_listener)
-    {
-        mp_listener->on_writer_discovery(this, WriterDiscoveryInfo::DISCOVERED_WRITER, wdata.guid(), &wdata);
-    }
     return true;
 }
 
@@ -183,11 +186,35 @@ bool StatelessReader::matched_writer_remove(
         const GUID_t& writer_guid,
         bool removed_by_lease)
 {
-    std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
+    {
+        std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
 
-    //Remove cachechanges belonging to the unmatched writer
-    mp_history->writer_unmatched(writer_guid, get_last_notified(writer_guid));
+        //Remove cachechanges belonging to the unmatched writer
+        mp_history->writer_unmatched(writer_guid, get_last_notified(writer_guid));
 
+        ResourceLimitedVector<RemoteWriterInfo_t>::iterator it;
+        for (it = matched_writers_.begin(); it != matched_writers_.end(); ++it)
+        {
+            if (it->guid == writer_guid)
+            {
+                logInfo(RTPS_READER, "Writer " << writer_guid << " removed from " << m_guid);
+
+                if (it->is_datasharing && datasharing_listener_->remove_datasharing_writer(writer_guid))
+                {
+                    logInfo(RTPS_READER, "Data sharing writer " << writer_guid << " removed from " << m_guid.entityId);
+                    remove_changes_from(writer_guid, true);
+                }
+
+                remove_persistence_guid(it->guid, it->persistence_guid, removed_by_lease);
+                matched_writers_.erase(it);
+                if (nullptr != mp_listener)
+                {
+                    mp_listener->on_writer_discovery(this, WriterDiscoveryInfo::REMOVED_WRITER, writer_guid, nullptr);
+                }
+                return true;
+            }
+        }
+    }
     if (liveliness_lease_duration_ < c_TimeInfinite)
     {
         auto wlp = mp_RTPSParticipant->wlp();
@@ -204,30 +231,6 @@ bool StatelessReader::matched_writer_remove(
                     "Finite liveliness lease duration but WLP not enabled, cannot remove writer");
         }
     }
-
-    ResourceLimitedVector<RemoteWriterInfo_t>::iterator it;
-    for (it = matched_writers_.begin(); it != matched_writers_.end(); ++it)
-    {
-        if (it->guid == writer_guid)
-        {
-            logInfo(RTPS_READER, "Writer " << writer_guid << " removed from " << m_guid);
-
-            if (it->is_datasharing && datasharing_listener_->remove_datasharing_writer(writer_guid))
-            {
-                logInfo(RTPS_READER, "Data sharing writer " << writer_guid << " removed from " << m_guid.entityId);
-                remove_changes_from(writer_guid, true);
-            }
-
-            remove_persistence_guid(it->guid, it->persistence_guid, removed_by_lease);
-            matched_writers_.erase(it);
-            if (nullptr != mp_listener)
-            {
-                mp_listener->on_writer_discovery(this, WriterDiscoveryInfo::REMOVED_WRITER, writer_guid, nullptr);
-            }
-            return true;
-        }
-    }
-
     return false;
 }
 

--- a/src/cpp/rtps/transport/UDPTransportInterface.h
+++ b/src/cpp/rtps/transport/UDPTransportInterface.h
@@ -162,6 +162,8 @@ public:
         return configuration()->maxMessageSize;
     }
 
+    void update_network_interfaces() override;
+
 protected:
 
     friend class UDPChannelResource;
@@ -278,6 +280,8 @@ protected:
             const SendResourceList& sender_resource_list,
             std::vector<fastrtps::rtps::IPFinder::info_IP>& locNames,
             bool return_loopback = false);
+
+    std::atomic_bool rescan_interfaces_ = {true};
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/transport/UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/UDPv4Transport.cpp
@@ -556,6 +556,7 @@ void UDPv4Transport::SetSocketOutboundInterface(
 
 void UDPv4Transport::update_network_interfaces()
 {
+    UDPTransportInterface::update_network_interfaces();
     for (auto& channelResources : mInputSockets)
     {
         for (UDPChannelResource* channelResource : channelResources.second)

--- a/src/cpp/rtps/transport/UDPv6Transport.cpp
+++ b/src/cpp/rtps/transport/UDPv6Transport.cpp
@@ -587,6 +587,7 @@ bool UDPv6Transport::compare_ips(
 
 void UDPv6Transport::update_network_interfaces()
 {
+    UDPTransportInterface::update_network_interfaces();
     // TODO(jlbueno)
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Deadlock fix already directed to master (https://github.com/eProsima/Fast-DDS/pull/2712).
The basic idea is modifying the RTPSReader subclasses matching code to avoid taking simultaneously the reader endpoint mutex and the participant & PDP mutexes required for WLP calls.
This PR aim is to simplify integration with tsan deadlock fixes by creating a commit in the intermediate branch.
Note both PR use the same branch, thus if one can merge so does the other.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.