### PR TITLE
Behaviour change: historical data is not considered lost

### DIFF
--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -282,14 +282,7 @@ bool StatefulReader::matched_writer_add(
             {
                 SequenceNumberSet_t sns(last_seq + 1);
                 send_acknack(wp, sns, wp, false);
-                int32_t current_sample_lost = 0;
-                if (0 < (current_sample_lost = wp->lost_changes_update(last_seq + 1)))
-                {
-                    if (getListener() != nullptr)
-                    {
-                        getListener()->on_sample_lost((RTPSReader*)this, current_sample_lost);
-                    }
-                }
+                wp->lost_changes_update(last_seq + 1);
             }
         }
         else if (!is_same_process)

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -266,13 +266,16 @@ bool StatelessReader::change_received(
 
             if (getListener() != nullptr)
             {
-                assert(previous_seq < change->sequenceNumber);
-                uint64_t tmp = (change->sequenceNumber - previous_seq).to64long() - 1;
-                int32_t lost_samples = tmp > static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) ?
-                        std::numeric_limits<int32_t>::max() : static_cast<int32_t>(tmp);
-                if (0 < lost_samples)     // There are lost samples.
+                if (SequenceNumber_t{0, 0} != previous_seq)
                 {
-                    getListener()->on_sample_lost(this, lost_samples);
+                    assert(previous_seq < change->sequenceNumber);
+                    uint64_t tmp = (change->sequenceNumber - previous_seq).to64long() - 1;
+                    int32_t lost_samples = tmp > static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) ?
+                            std::numeric_limits<int32_t>::max() : static_cast<int32_t>(tmp);
+                    if (0 < lost_samples) // There are lost samples.
+                    {
+                        getListener()->on_sample_lost(this, lost_samples);
+                    }
                 }
 
                 // WARNING! This method could destroy the change

--- a/src/cpp/rtps/reader/WriterProxy.cpp
+++ b/src/cpp/rtps/reader/WriterProxy.cpp
@@ -88,6 +88,7 @@ WriterProxy::WriterProxy(
     , liveliness_kind_(AUTOMATIC_LIVELINESS_QOS)
     , locators_entry_(loc_alloc.max_unicast_locators, loc_alloc.max_multicast_locators)
     , is_datasharing_writer_(false)
+    , received_at_least_one_heartbeat_(false)
 {
     //Create Events
     ResourceEvent& event_manager = reader_->getRTPSParticipant()->getEventResource();
@@ -141,6 +142,7 @@ void WriterProxy::start(
     is_datasharing_writer_ = is_datasharing;
     initial_acknack_->restart_timer();
     loaded_from_storage(initial_sequence);
+    received_at_least_one_heartbeat_ = false;
 }
 
 void WriterProxy::update(
@@ -581,6 +583,12 @@ bool WriterProxy::process_heartbeat(
         else
         {
             assert_liveliness = liveliness_flag;
+        }
+
+        if (!received_at_least_one_heartbeat_)
+        {
+            current_sample_lost = 0;
+            received_at_least_one_heartbeat_ = true;
         }
 
         return true;

--- a/src/cpp/rtps/reader/WriterProxy.h
+++ b/src/cpp/rtps/reader/WriterProxy.h
@@ -413,6 +413,8 @@ private:
     LocatorSelectorEntry locators_entry_;
     //! Is the writer datasharing
     bool is_datasharing_writer_;
+    //! Wether at least one heartbeat was recevied.
+    bool received_at_least_one_heartbeat_;
 
     using ChangeIterator = decltype(changes_received_)::iterator;
 

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -826,19 +826,15 @@ TEST(DDSStatus, sample_lost_be_dw_lj_be_dr)
             {
                 {
                     std::unique_lock<std::mutex> lock(test_step_mtx);
-                    if (0 == test_step && 4 == status.total_count && 4 == status.total_count_change)
+                    if (0 == test_step && 1 == status.total_count && 1 == status.total_count_change)
                     {
                         ++test_step;
                     }
-                    else if (1 == test_step && 5 == status.total_count && 1 == status.total_count_change)
+                    else if (1 == test_step && 2 == status.total_count && 1 == status.total_count_change)
                     {
                         ++test_step;
                     }
-                    else if (2 == test_step && 6 == status.total_count && 1 == status.total_count_change)
-                    {
-                        ++test_step;
-                    }
-                    else if (3 == test_step && 8 == status.total_count && 2 == status.total_count_change)
+                    else if (2 == test_step && 4 == status.total_count && 2 == status.total_count_change)
                     {
                         ++test_step;
                     }
@@ -863,7 +859,7 @@ TEST(DDSStatus, sample_lost_be_dw_lj_be_dr)
     std::unique_lock<std::mutex> lock(test_step_mtx);
     test_step_cv.wait(lock, [&test_step]()
             {
-                return 4 == test_step;
+                return 3 == test_step;
             });
 }
 
@@ -953,7 +949,7 @@ TEST(DDSStatus, sample_lost_re_dw_lj_re_dr)
     std::unique_lock<std::mutex> lock(test_step_mtx);
     test_step_cv.wait(lock, [&test_count, &test_count_change_accum]()
             {
-                return 7 == test_count && 7 == test_count_change_accum;
+                return 4 == test_count && 4 == test_count_change_accum;
             });
 }
 
@@ -1040,19 +1036,15 @@ TEST(DDSStatus, sample_lost_re_dw_lj_be_dr)
             {
                 {
                     std::unique_lock<std::mutex> lock(test_step_mtx);
-                    if (0 == test_step && 4 == status.total_count && 4 == status.total_count_change)
+                    if (0 == test_step && 1 == status.total_count && 1 == status.total_count_change)
                     {
                         ++test_step;
                     }
-                    else if (1 == test_step && 5 == status.total_count && 1 == status.total_count_change)
+                    else if (1 == test_step && 2 == status.total_count && 1 == status.total_count_change)
                     {
                         ++test_step;
                     }
-                    else if (2 == test_step && 6 == status.total_count && 1 == status.total_count_change)
-                    {
-                        ++test_step;
-                    }
-                    else if (3 == test_step && 8 == status.total_count && 2 == status.total_count_change)
+                    else if (2 == test_step && 4 == status.total_count && 2 == status.total_count_change)
                     {
                         ++test_step;
                     }
@@ -1077,7 +1069,7 @@ TEST(DDSStatus, sample_lost_re_dw_lj_be_dr)
     std::unique_lock<std::mutex> lock(test_step_mtx);
     test_step_cv.wait(lock, [&test_step]()
             {
-                return 4 == test_step;
+                return 3 == test_step;
             });
 }
 
@@ -1240,19 +1232,15 @@ TEST(DDSStatus, sample_lost_waitset_be_dw_lj_be_dr)
             {
                 {
                     std::unique_lock<std::mutex> lock(test_step_mtx);
-                    if (0 == test_step && 4 == status.total_count && 4 == status.total_count_change)
+                    if (0 == test_step && 1 == status.total_count && 1 == status.total_count_change)
                     {
                         ++test_step;
                     }
-                    else if (1 == test_step && 5 == status.total_count && 1 == status.total_count_change)
+                    else if (1 == test_step && 2 == status.total_count && 1 == status.total_count_change)
                     {
                         ++test_step;
                     }
-                    else if (2 == test_step && 6 == status.total_count && 1 == status.total_count_change)
-                    {
-                        ++test_step;
-                    }
-                    else if (3 == test_step && 8 == status.total_count && 2 == status.total_count_change)
+                    else if (2 == test_step && 4 == status.total_count && 2 == status.total_count_change)
                     {
                         ++test_step;
                     }
@@ -1277,7 +1265,7 @@ TEST(DDSStatus, sample_lost_waitset_be_dw_lj_be_dr)
     std::unique_lock<std::mutex> lock(test_step_mtx);
     test_step_cv.wait(lock, [&test_step]()
             {
-                return 4 == test_step;
+                return 3 == test_step;
             });
 }
 
@@ -1367,7 +1355,7 @@ TEST(DDSStatus, sample_lost_waitset_re_dw_lj_re_dr)
     std::unique_lock<std::mutex> lock(test_step_mtx);
     test_step_cv.wait(lock, [&test_count, &test_count_change_accum]()
             {
-                return 7 == test_count && 7 == test_count_change_accum;
+                return 4 == test_count && 4 == test_count_change_accum;
             });
 }
 
@@ -1453,19 +1441,15 @@ TEST(DDSStatus, sample_lost_waitset_re_dw_lj_be_dr)
             {
                 {
                     std::unique_lock<std::mutex> lock(test_step_mtx);
-                    if (0 == test_step && 4 == status.total_count && 4 == status.total_count_change)
+                    if (0 == test_step && 1 == status.total_count && 1 == status.total_count_change)
                     {
                         ++test_step;
                     }
-                    else if (1 == test_step && 5 == status.total_count && 1 == status.total_count_change)
+                    else if (1 == test_step && 2 == status.total_count && 1 == status.total_count_change)
                     {
                         ++test_step;
                     }
-                    else if (2 == test_step && 6 == status.total_count && 1 == status.total_count_change)
-                    {
-                        ++test_step;
-                    }
-                    else if (3 == test_step && 8 == status.total_count && 2 == status.total_count_change)
+                    else if (2 == test_step && 4 == status.total_count && 2 == status.total_count_change)
                     {
                         ++test_step;
                     }
@@ -1490,7 +1474,7 @@ TEST(DDSStatus, sample_lost_waitset_re_dw_lj_be_dr)
     std::unique_lock<std::mutex> lock(test_step_mtx);
     test_step_cv.wait(lock, [&test_step]()
             {
-                return 4 == test_step;
+                return 3 == test_step;
             });
 }
 

--- a/test/unittest/rtps/reader/WriterProxyTests.cpp
+++ b/test/unittest/rtps/reader/WriterProxyTests.cpp
@@ -330,7 +330,7 @@ TEST(WriterProxyTests, LostChangesUpdate)
     ASSERT_EQ(SequenceNumber_t(0, 2), wproxy.available_changes_max());
     ASSERT_EQ(1u, wproxy.number_of_changes_from_writer());
     ASSERT_EQ(1u, wproxy.unknown_missing_changes_up_to(SequenceNumber_t(0, 4)));
-    ASSERT_EQ(2, current_sample_lost);
+    ASSERT_EQ(0, current_sample_lost);
 
     // 2. Simulate reception of a DATA(5) follow by a HEARTBEAT(5,5)
     EXPECT_CALL(*wproxy.heartbeat_response_, restart_timer()).Times(1u);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Because of #2282, several test started to fail in ROS2 CI. This is caused by a design decision: historical data is considered lost and therefore the user is warning. We decided to change this decision and start not considering historical data as lost. This PR performs the changes for that.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
