### PR TITLE
[14833] DiscoveryServer list access deadlock fix <feature/tsan/fixes>

### DIFF
--- a/include/fastdds/rtps/attributes/ServerAttributes.h
+++ b/include/fastdds/rtps/attributes/ServerAttributes.h
@@ -109,20 +109,22 @@ typedef std::list<RemoteServerAttributes> RemoteServerList_t;
 template<class charT>
 struct server_ostream_separators
 {
-    static const charT * list_separator;
-    static const charT * locator_separator;
+    static const charT* list_separator;
+    static const charT* locator_separator;
 };
 
 template<class charT>
-std::basic_ostream<charT>& operator <<( std::basic_ostream<charT>& output, const RemoteServerAttributes& sa)
+std::basic_ostream<charT>& operator <<(
+        std::basic_ostream<charT>& output,
+        const RemoteServerAttributes& sa)
 {
     typename std::basic_ostream<charT>::sentry s(output);
     output << sa.guidPrefix;
-    if(!sa.metatrafficUnicastLocatorList.empty())
+    if (!sa.metatrafficUnicastLocatorList.empty())
     {
         output << server_ostream_separators<charT>::locator_separator << sa.metatrafficUnicastLocatorList;
     }
-    if(!sa.metatrafficMulticastLocatorList.empty())
+    if (!sa.metatrafficMulticastLocatorList.empty())
     {
         output << server_ostream_separators<charT>::locator_separator << sa.metatrafficUnicastLocatorList;
     }
@@ -130,7 +132,9 @@ std::basic_ostream<charT>& operator <<( std::basic_ostream<charT>& output, const
 }
 
 template<class charT>
-std::basic_ostream<charT>& operator <<( std::basic_ostream<charT>& output, const RemoteServerList_t& list)
+std::basic_ostream<charT>& operator <<(
+        std::basic_ostream<charT>& output,
+        const RemoteServerList_t& list)
 {
     typename std::basic_ostream<charT>::sentry s(output);
     std::ostream_iterator<RemoteServerAttributes> os_iterator(output, server_ostream_separators<charT>::list_separator);

--- a/include/fastdds/rtps/attributes/ServerAttributes.h
+++ b/include/fastdds/rtps/attributes/ServerAttributes.h
@@ -114,11 +114,11 @@ struct server_ostream_separators
 };
 
 #ifndef _MSC_VER
-    template<> const char* server_ostream_separators<char>::list_separator;
-    template<> const wchar_t* server_ostream_separators<wchar_t>::list_separator;
+template<> const char* server_ostream_separators<char>::list_separator;
+template<> const wchar_t* server_ostream_separators<wchar_t>::list_separator;
 
-    template<> const char* server_ostream_separators<char>::locator_separator;
-    template<> const wchar_t* server_ostream_separators<wchar_t>::locator_separator;
+template<> const char* server_ostream_separators<char>::locator_separator;
+template<> const wchar_t* server_ostream_separators<wchar_t>::locator_separator;
 #endif
 
 template<class charT>

--- a/include/fastdds/rtps/attributes/ServerAttributes.h
+++ b/include/fastdds/rtps/attributes/ServerAttributes.h
@@ -119,7 +119,7 @@ template<> const wchar_t* server_ostream_separators<wchar_t>::list_separator;
 
 template<> const char* server_ostream_separators<char>::locator_separator;
 template<> const wchar_t* server_ostream_separators<wchar_t>::locator_separator;
-#endif
+#endif // _MSC_VER
 
 template<class charT>
 std::basic_ostream<charT>& operator <<(

--- a/include/fastdds/rtps/attributes/ServerAttributes.h
+++ b/include/fastdds/rtps/attributes/ServerAttributes.h
@@ -113,6 +113,14 @@ struct server_ostream_separators
     static const charT* locator_separator;
 };
 
+#ifndef _MSC_VER
+    template<> const char* server_ostream_separators<char>::list_separator;
+    template<> const wchar_t* server_ostream_separators<wchar_t>::list_separator;
+
+    template<> const char* server_ostream_separators<char>::locator_separator;
+    template<> const wchar_t* server_ostream_separators<wchar_t>::locator_separator;
+#endif
+
 template<class charT>
 std::basic_ostream<charT>& operator <<(
         std::basic_ostream<charT>& output,

--- a/include/fastdds/rtps/attributes/ServerAttributes.h
+++ b/include/fastdds/rtps/attributes/ServerAttributes.h
@@ -24,6 +24,8 @@
 #include <fastdds/rtps/common/Guid.h>
 #include <fastdds/rtps/common/Locator.h>
 
+#include <algorithm>
+#include <iterator>
 #include <list>
 
 namespace eprosima {
@@ -104,6 +106,38 @@ public:
 
 typedef std::list<RemoteServerAttributes> RemoteServerList_t;
 
+template<class charT>
+struct server_ostream_separators
+{
+    static const charT * list_separator;
+    static const charT * locator_separator;
+};
+
+template<class charT>
+std::basic_ostream<charT>& operator <<( std::basic_ostream<charT>& output, const RemoteServerAttributes& sa)
+{
+    typename std::basic_ostream<charT>::sentry s(output);
+    output << sa.guidPrefix;
+    if(!sa.metatrafficUnicastLocatorList.empty())
+    {
+        output << server_ostream_separators<charT>::locator_separator << sa.metatrafficUnicastLocatorList;
+    }
+    if(!sa.metatrafficMulticastLocatorList.empty())
+    {
+        output << server_ostream_separators<charT>::locator_separator << sa.metatrafficUnicastLocatorList;
+    }
+    return output;
+}
+
+template<class charT>
+std::basic_ostream<charT>& operator <<( std::basic_ostream<charT>& output, const RemoteServerList_t& list)
+{
+    typename std::basic_ostream<charT>::sentry s(output);
+    std::ostream_iterator<RemoteServerAttributes> os_iterator(output, server_ostream_separators<charT>::list_separator);
+    std::copy(list.begin(), list.end(), os_iterator);
+    return output;
+}
+
 // port use if the ros environment variable doesn't specified one
 constexpr uint16_t DEFAULT_ROS2_SERVER_PORT = 11811;
 // default server base guidPrefix
@@ -131,7 +165,7 @@ const char* const DEFAULT_ROS2_MASTER_URI = "ROS_DISCOVERY_SERVER";
  * @return true if parsing succeeds, false otherwise (or if the list is empty)
  */
 RTPS_DllAPI bool load_environment_server_info(
-        std::string list,
+        const std::string& list,
         RemoteServerList_t& attributes);
 
 /**

--- a/include/fastdds/rtps/builtin/BuiltinProtocols.h
+++ b/include/fastdds/rtps/builtin/BuiltinProtocols.h
@@ -27,6 +27,8 @@
 #include <fastdds/rtps/builtin/data/ContentFilterProperty.hpp>
 #include <fastdds/rtps/network/NetworkFactory.h>
 
+#include <fastrtps/utils/shared_mutex.hpp>
+
 namespace eprosima {
 
 namespace fastdds {
@@ -66,6 +68,8 @@ private:
 
     BuiltinProtocols();
     virtual ~BuiltinProtocols();
+
+    eprosima::shared_mutex m_DiscoveryMutex;
 
 public:
 
@@ -190,6 +194,15 @@ public:
     void stopRTPSParticipantAnnouncement();
     //!Reset to timer to make periodic RTPSParticipant Announcements.
     void resetRTPSParticipantAnnouncement();
+
+    /**
+     * Get Discovery mutex
+     * @return Associated Mutex
+     */
+    inline eprosima::shared_mutex& getDiscoveryMutex()
+    {
+        return m_DiscoveryMutex;
+    }
 
 };
 

--- a/include/fastdds/rtps/builtin/BuiltinProtocols.h
+++ b/include/fastdds/rtps/builtin/BuiltinProtocols.h
@@ -69,7 +69,11 @@ private:
     BuiltinProtocols();
     virtual ~BuiltinProtocols();
 
-    eprosima::shared_mutex m_DiscoveryMutex;
+    /*
+    * Mutex to protect the m_DiscoveryServers collection. Element access is not protected by this mutex, the PDP mutex 
+    * needs to be used when querying or modifying mutable members of the collection. 
+    */
+    mutable eprosima::shared_mutex discovery_mutex_;
 
 public:
 
@@ -199,9 +203,9 @@ public:
      * Get Discovery mutex
      * @return Associated Mutex
      */
-    inline eprosima::shared_mutex& getDiscoveryMutex()
+    inline eprosima::shared_mutex& getDiscoveryMutex() const
     {
-        return m_DiscoveryMutex;
+        return discovery_mutex_;
     }
 
 };

--- a/include/fastdds/rtps/builtin/BuiltinProtocols.h
+++ b/include/fastdds/rtps/builtin/BuiltinProtocols.h
@@ -70,9 +70,9 @@ private:
     virtual ~BuiltinProtocols();
 
     /*
-    * Mutex to protect the m_DiscoveryServers collection. Element access is not protected by this mutex, the PDP mutex 
-    * needs to be used when querying or modifying mutable members of the collection. 
-    */
+     * Mutex to protect the m_DiscoveryServers collection. Element access is not protected by this mutex, the PDP mutex
+     * needs to be used when querying or modifying mutable members of the collection.
+     */
     mutable eprosima::shared_mutex discovery_mutex_;
 
 public:

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -178,6 +178,7 @@ set(${PROJECT_NAME}_source_files
     rtps/builtin/BuiltinProtocols.cpp
     rtps/builtin/discovery/participant/DirectMessageSender.cpp
     rtps/builtin/discovery/participant/PDP.cpp
+    rtps/builtin/discovery/participant/ServerAttributes.cpp
     rtps/builtin/discovery/participant/PDPSimple.cpp
     rtps/builtin/discovery/participant/PDPListener.cpp
     rtps/builtin/discovery/endpoint/EDP.cpp

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -25,11 +25,6 @@
 #include <string>
 #include <thread>
 
-#ifdef __unix__
-#   include <sys/file.h>
-#   include <unistd.h>
-#endif // ifdef __unix__
-
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/rtps/history/WriterHistory.h>
 #include <fastdds/rtps/participant/RTPSParticipant.h>
@@ -51,7 +46,6 @@
 #include <rtps/common/GuidUtils.hpp>
 #include <utils/Host.hpp>
 #include <utils/SystemInfo.hpp>
-
 
 namespace eprosima {
 namespace fastrtps {
@@ -613,52 +607,10 @@ bool RTPSDomainImpl::should_intraprocess_between(
 
 void RTPSDomainImpl::file_watch_callback()
 {
+    using namespace std::chrono_literals;
+
     // Ensure that all changes have been saved by the OS
-    auto fn = SystemInfo::get_environment_file();
-    auto max_wait = std::chrono::seconds(1);
-    auto start = std::chrono::system_clock::now();
-
-#ifdef _MSC_VER
-    {
-        std::ofstream os;
-        do
-        {
-            // MSVC specific
-            os.open(fn, std::ios::out | std::ios::app, _SH_DENYWR);
-            if (!os.is_open()
-                    // If the file is lock-opened in an external editor do not hang
-                    && (std::chrono::system_clock::now() - start) < max_wait )
-            {
-                std::this_thread::yield();
-            }
-            else
-            {
-                break;
-            }
-        }
-        while (true);
-    }
-#elif __unix__
-    {
-        int fd = open(fn.c_str(), O_WRONLY);
-
-        while (flock(fd, LOCK_EX | LOCK_NB)
-                // If the file is lock-opened in an external editor do not hang
-                && (std::chrono::system_clock::now() - start) < max_wait )
-        {
-            std::this_thread::yield();
-        }
-
-        flock(fd, LOCK_UN | LOCK_NB);
-        close(fd);
-    }
-#else
-    // plain wait
-    std::this_thread::sleep_for(max_wait);
-    // avoid unused warning
-    (void)start;
-    (void)fn;
-#endif // ifdef _MSC_VER
+    SystemInfo::wait_for_file_closure(SystemInfo::get_environment_file(), 1s);
 
     // For all RTPSParticipantImpl registered in the RTPSDomain, call RTPSParticipantImpl::environment_file_has_changed
     std::lock_guard<std::mutex> guard(RTPSDomain::m_mutex);

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -607,10 +607,10 @@ bool RTPSDomainImpl::should_intraprocess_between(
 
 void RTPSDomainImpl::file_watch_callback()
 {
-    using namespace std::chrono_literals;
+    auto _1s = std::chrono::seconds(1);
 
     // Ensure that all changes have been saved by the OS
-    SystemInfo::wait_for_file_closure(SystemInfo::get_environment_file(), 1s);
+    SystemInfo::wait_for_file_closure(SystemInfo::get_environment_file(), _1s);
 
     // For all RTPSParticipantImpl registered in the RTPSDomain, call RTPSParticipantImpl::environment_file_has_changed
     std::lock_guard<std::mutex> guard(RTPSDomain::m_mutex);

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -227,7 +227,7 @@ RTPSParticipant* RTPSDomain::createParticipant(
     }
 
     // Check the environment file in case it was modified during participant creation leading to a missed callback.
-    if (RTPSDomainImpl::file_watch_handle_)
+    if ((PParam.builtin.discovery_config.discoveryProtocol != DiscoveryProtocol_t::CLIENT) && RTPSDomainImpl::file_watch_handle_)
     {
         pimpl->environment_file_has_changed();
     }

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -479,7 +479,8 @@ RTPSParticipant* RTPSDomain::clientServerEnvironmentCreationOverride(
     }
 
     logInfo(DOMAIN, "Detected auto client-server environment variable."
-            "Trying to create client with the default server setup.");
+            << "Trying to create client with the default server setup: "
+            << client_att.builtin.discovery_config.m_DiscoveryServers);
 
     client_att.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::CLIENT;
     // RemoteServerAttributes already fill in above

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -656,6 +656,9 @@ void RTPSDomainImpl::file_watch_callback()
 #else
     // plain wait
     std::this_thread::sleep_for(max_wait);
+    // avoid unused warning
+    (void)start;
+    (void)fn;
 #endif // ifdef _MSC_VER
 
     // For all RTPSParticipantImpl registered in the RTPSDomain, call RTPSParticipantImpl::environment_file_has_changed

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -226,6 +226,12 @@ RTPSParticipant* RTPSDomain::createParticipant(
         m_RTPSParticipants.push_back(t_p_RTPSParticipant(p, pimpl));
     }
 
+    // Check the environment file in case it was modified during participant creation leading to a missed callback.
+    if (RTPSDomainImpl::file_watch_handle_)
+    {
+        pimpl->environment_file_has_changed();
+    }
+
     if (enabled)
     {
         // Start protocols

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -227,7 +227,8 @@ RTPSParticipant* RTPSDomain::createParticipant(
     }
 
     // Check the environment file in case it was modified during participant creation leading to a missed callback.
-    if ((PParam.builtin.discovery_config.discoveryProtocol != DiscoveryProtocol_t::CLIENT) && RTPSDomainImpl::file_watch_handle_)
+    if ((PParam.builtin.discovery_config.discoveryProtocol != DiscoveryProtocol_t::CLIENT) &&
+            RTPSDomainImpl::file_watch_handle_)
     {
         pimpl->environment_file_has_changed();
     }

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -27,7 +27,6 @@
 
 #ifdef __unix__
 #   include <sys/file.h>
-#   include <fcntl.h>
 #   include <unistd.h>
 #endif // ifdef __unix__
 
@@ -643,14 +642,14 @@ void RTPSDomainImpl::file_watch_callback()
     {
         int fd = open(fn.c_str(), O_WRONLY);
 
-        while (flock(fd, LOCK_EX)
+        while (flock(fd, LOCK_EX | LOCK_NB)
                 // If the file is lock-opened in an external editor do not hang
                 && (std::chrono::system_clock::now() - start) < max_wait )
         {
             std::this_thread::yield();
         }
 
-        flock(fd, LOCK_UN);
+        flock(fd, LOCK_UN | LOCK_NB);
         close(fd);
     }
 #else

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -82,7 +82,10 @@ bool BuiltinProtocols::initBuiltinProtocols(
 
     // TODO(jlbueno) The access to the list should be protected with the PDP mutex but requires a refactor on PDPClient
     // and PDPServer: read the remote servers list after the initialization of PDP.
-    m_DiscoveryServers = m_att.discovery_config.m_DiscoveryServers;
+    {
+        std::unique_lock<eprosima::shared_mutex> disc_lock(getDiscoveryMutex());
+        m_DiscoveryServers = m_att.discovery_config.m_DiscoveryServers;
+    }
 
     transform_server_remote_locators(p_part->network_factory());
 
@@ -173,6 +176,8 @@ void BuiltinProtocols::transform_server_remote_locators(
 {
     // TODO(jlbueno) The access to the list should be protected with the PDP mutex but requires a refactor on PDPClient
     // and PDPServer: read the remote servers list after the initialization of PDP.
+    eprosima::shared_lock<eprosima::shared_mutex> disc_lock(getDiscoveryMutex());
+
     for (eprosima::fastdds::rtps::RemoteServerAttributes& rs : m_DiscoveryServers)
     {
         for (Locator_t& loc : rs.metatrafficUnicastLocatorList)

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -1622,6 +1622,12 @@ bool DiscoveryDataBase::server_acked_by_my_servers()
 
     // Find the server's participant and check whether all its servers have ACKed the server's DATA(p)
     auto this_server = participants_.find(server_guid_prefix_);
+
+    if(this_server == participants_.end())
+    {
+        return false;
+    }
+
     for (auto prefix : servers_)
     {
         if (!this_server->second.is_matched(prefix))

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -1623,7 +1623,7 @@ bool DiscoveryDataBase::server_acked_by_my_servers()
     // Find the server's participant and check whether all its servers have ACKed the server's DATA(p)
     auto this_server = participants_.find(server_guid_prefix_);
 
-    if(this_server == participants_.end())
+    if (this_server == participants_.end())
     {
         return false;
     }

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -1623,10 +1623,8 @@ bool DiscoveryDataBase::server_acked_by_my_servers()
     // Find the server's participant and check whether all its servers have ACKed the server's DATA(p)
     auto this_server = participants_.find(server_guid_prefix_);
 
-    if (this_server == participants_.end())
-    {
-        return false;
-    }
+    // check is always there
+    assert(this_server != participants_.end());
 
     for (auto prefix : servers_)
     {

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -46,6 +46,7 @@
 
 #include <fastrtps/utils/TimeConversion.h>
 #include <fastrtps/utils/IPLocator.h>
+#include "fastrtps/utils/shared_mutex.hpp"
 
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
@@ -1128,7 +1129,7 @@ ParticipantProxyData* PDP::get_participant_proxy_data(
 
 std::list<eprosima::fastdds::rtps::RemoteServerAttributes>& PDP::remote_server_attributes()
 {
-    std::unique_lock<std::recursive_mutex> lock(*getMutex());
+    std::unique_lock<eprosima::shared_mutex> lock(mp_builtin->getDiscoveryMutex());
     return mp_builtin->m_DiscoveryServers;
 }
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1129,7 +1129,6 @@ ParticipantProxyData* PDP::get_participant_proxy_data(
 
 std::list<eprosima::fastdds::rtps::RemoteServerAttributes>& PDP::remote_server_attributes()
 {
-    std::unique_lock<eprosima::shared_mutex> lock(mp_builtin->getDiscoveryMutex());
     return mp_builtin->m_DiscoveryServers;
 }
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -289,9 +289,12 @@ void PDPClient::assignRemoteEndpoints(
         // Verify if this participant is a server
         for (auto& svr : mp_builtin->m_DiscoveryServers)
         {
-            if (svr.guidPrefix == pdata->m_guid.guidPrefix)
             {
-                svr.proxy = pdata;
+                std::unique_lock<std::recursive_mutex> lock(*getMutex());
+                if (svr.guidPrefix == pdata->m_guid.guidPrefix)
+                {
+                    svr.proxy = pdata;
+                }
             }
         }
     }
@@ -322,11 +325,14 @@ void PDPClient::removeRemoteEndpoints(
         // Verify if this participant is a server
         for (auto& svr : mp_builtin->m_DiscoveryServers)
         {
-            if (svr.guidPrefix == pdata->m_guid.guidPrefix)
             {
-                svr.proxy = nullptr; // reasign when we receive again server DATA(p)
-                is_server = true;
-                mp_sync->restart_timer(); // enable announcement and sync mechanism till this server reappears
+                std::unique_lock<std::recursive_mutex> lock(*getMutex());
+                if (svr.guidPrefix == pdata->m_guid.guidPrefix)
+                {
+                    svr.proxy = nullptr; // reasign when we receive again server DATA(p)
+                    is_server = true;
+                    mp_sync->restart_timer(); // enable announcement and sync mechanism till this server reappears
+                }
             }
         }
     }

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -555,7 +555,6 @@ bool PDPClient::match_servers_EDP_endpoints()
     // PDP must have been initialize
     assert(mp_EDP);
 
-    //std::lock_guard<std::recursive_mutex> lock(*getMutex());
     bool all = true; // have all servers been discovered?
 
     eprosima::shared_lock<eprosima::shared_mutex> disc_lock(mp_builtin->getDiscoveryMutex());

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -842,12 +842,6 @@ bool PDPClient::remove_remote_participant(
     return false;
 }
 
-template<> const char* server_ostream_separators<char>::list_separator = "; ";
-template<> const wchar_t* server_ostream_separators<wchar_t>::list_separator = L"; ";
-
-template<> const char* server_ostream_separators<char>::locator_separator = "|";
-template<> const wchar_t* server_ostream_separators<wchar_t>::locator_separator = L"|";
-
 } /* namespace rtps */
 } /* namespace fastdds */
 } /* namespace eprosima */

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -289,12 +289,10 @@ void PDPClient::assignRemoteEndpoints(
         // Verify if this participant is a server
         for (auto& svr : mp_builtin->m_DiscoveryServers)
         {
+            if (svr.guidPrefix == pdata->m_guid.guidPrefix)
             {
-                if (svr.guidPrefix == pdata->m_guid.guidPrefix)
-                {
-                    std::unique_lock<std::recursive_mutex> lock(*getMutex());
-                    svr.proxy = pdata;
-                }
+                std::unique_lock<std::recursive_mutex> lock(*getMutex());
+                svr.proxy = pdata;
             }
         }
     }
@@ -325,14 +323,12 @@ void PDPClient::removeRemoteEndpoints(
         // Verify if this participant is a server
         for (auto& svr : mp_builtin->m_DiscoveryServers)
         {
+            if (svr.guidPrefix == pdata->m_guid.guidPrefix)
             {
-                if (svr.guidPrefix == pdata->m_guid.guidPrefix)
-                {
-                    std::unique_lock<std::recursive_mutex> lock(*getMutex());
-                    svr.proxy = nullptr; // reasign when we receive again server DATA(p)
-                    is_server = true;
-                    mp_sync->restart_timer(); // enable announcement and sync mechanism till this server reappears
-                }
+                std::unique_lock<std::recursive_mutex> lock(*getMutex());
+                svr.proxy = nullptr; // reasign when we receive again server DATA(p)
+                is_server = true;
+                mp_sync->restart_timer(); // enable announcement and sync mechanism till this server reappears
             }
         }
     }

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -513,10 +513,10 @@ void PDPClient::announceParticipantState(
                 CacheChange_t* pPD;
                 if (mp_PDPWriterHistory->get_min_change(&pPD))
                 {
-                    std::lock_guard<std::recursive_mutex> lock(*getMutex());
-
                     std::vector<GUID_t> remote_readers;
                     LocatorList locators;
+
+                    eprosima::shared_lock<eprosima::shared_mutex> disc_lock(mp_builtin->getDiscoveryMutex());
 
                     for (auto& svr : mp_builtin->m_DiscoveryServers)
                     {

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -290,9 +290,9 @@ void PDPClient::assignRemoteEndpoints(
         for (auto& svr : mp_builtin->m_DiscoveryServers)
         {
             {
-                std::unique_lock<std::recursive_mutex> lock(*getMutex());
                 if (svr.guidPrefix == pdata->m_guid.guidPrefix)
                 {
+                    std::unique_lock<std::recursive_mutex> lock(*getMutex());
                     svr.proxy = pdata;
                 }
             }
@@ -326,9 +326,9 @@ void PDPClient::removeRemoteEndpoints(
         for (auto& svr : mp_builtin->m_DiscoveryServers)
         {
             {
-                std::unique_lock<std::recursive_mutex> lock(*getMutex());
                 if (svr.guidPrefix == pdata->m_guid.guidPrefix)
                 {
+                    std::unique_lock<std::recursive_mutex> lock(*getMutex());
                     svr.proxy = nullptr; // reasign when we receive again server DATA(p)
                     is_server = true;
                     mp_sync->restart_timer(); // enable announcement and sync mechanism till this server reappears

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -647,7 +647,7 @@ bool load_environment_server_info(
 }
 
 bool load_environment_server_info(
-        std::string list,
+        const std::string& list,
         RemoteServerList_t& attributes)
 {
     attributes.clear();
@@ -659,8 +659,8 @@ bool load_environment_server_info(
     /* Parsing ancillary regex */
     // Address should be <letter,numbers,dots>:<number>. We do not need to verify that the first part
     // is an IPv4 address, as it is done latter.
-    const std::regex ROS2_ADDRESS_PATTERN(R"(^([A-Za-z0-9-.]+)?:?(?:(\d+))?$)");
-    const std::regex ROS2_SERVER_LIST_PATTERN(R"(([^;]*);?)");
+    const static std::regex ROS2_ADDRESS_PATTERN(R"(^([A-Za-z0-9-.]+)?:?(?:(\d+))?$)");
+    const static std::regex ROS2_SERVER_LIST_PATTERN(R"(([^;]*);?)");
 
     try
     {
@@ -841,6 +841,12 @@ bool PDPClient::remove_remote_participant(
 
     return false;
 }
+
+template<> const char* server_ostream_separators<char>::list_separator = "; ";
+template<> const wchar_t* server_ostream_separators<wchar_t>::list_separator = L"; ";
+
+template<> const char* server_ostream_separators<char>::locator_separator = "|";
+template<> const wchar_t* server_ostream_separators<wchar_t>::locator_separator = L"|";
 
 } /* namespace rtps */
 } /* namespace fastdds */

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -750,18 +750,16 @@ void PDPServer::announceParticipantState(
         std::vector<GUID_t> remote_readers;
         LocatorList locators;
 
+        std::vector<GuidPrefix_t> direct_clients_and_servers = discovery_db_.direct_clients_and_servers();
+        for (GuidPrefix_t participant_prefix: direct_clients_and_servers)
         {
-            std::vector<GuidPrefix_t> direct_clients_and_servers = discovery_db_.direct_clients_and_servers();
-            for (GuidPrefix_t participant_prefix: direct_clients_and_servers)
-            {
-                // Add remote reader
-                GUID_t remote_guid(participant_prefix, c_EntityId_SPDPReader);
-                remote_readers.push_back(remote_guid);
+            // Add remote reader
+            GUID_t remote_guid(participant_prefix, c_EntityId_SPDPReader);
+            remote_readers.push_back(remote_guid);
 
-                locators.push_back(discovery_db_.participant_metatraffic_locators(participant_prefix));
-            }
-            send_announcement(change, remote_readers, locators, dispose);
+            locators.push_back(discovery_db_.participant_metatraffic_locators(participant_prefix));
         }
+        send_announcement(change, remote_readers, locators, dispose);
     }
 }
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -563,15 +563,15 @@ void PDPServer::announceParticipantState(
             - ResendParticipantProxyDataPeriod (participant event thread)
          */
 
+        getMutex()->lock();
+
+        std::lock_guard<fastrtps::RecursiveTimedMutex> wlock(pW->getMutex());
+
         if (!dispose)
         {
             // Create the CacheChange_t if necessary
             if (m_hasChangedLocalPDP.exchange(false) || new_change)
             {
-                getMutex()->lock();
-
-                std::lock_guard<fastrtps::RecursiveTimedMutex> wlock(pW->getMutex());
-
                 // Copy the participant data
                 ParticipantProxyData proxy_data_copy(*getLocalParticipantProxyData());
 
@@ -586,6 +586,7 @@ void PDPServer::announceParticipantState(
                     wp.related_sample_identity(local);
                 }
 
+                // Unlock PDP mutex since it's no longer needed.
                 getMutex()->unlock();
 
                 uint32_t cdr_size = proxy_data_copy.get_serialized_size(true);
@@ -663,7 +664,9 @@ void PDPServer::announceParticipantState(
             }
             else
             {
-                std::lock_guard<fastrtps::RecursiveTimedMutex> wlock(pW->getMutex());
+                // Unlock PDP mutex since it's no longer needed.
+                getMutex()->unlock();
+
                 // Retrieve the CacheChange_t from the database
                 change = discovery_db().cache_change_own_participant();
                 if (nullptr == change)
@@ -677,12 +680,11 @@ void PDPServer::announceParticipantState(
                     return;
                 }
             }
+
+
         }
         else
         {
-            getMutex()->lock();
-
-            std::lock_guard<fastrtps::RecursiveTimedMutex> wlock(pW->getMutex());
             // Copy the participant data
             ParticipantProxyData* local_participant = getLocalParticipantProxyData();
             InstanceHandle_t key = local_participant->m_key;
@@ -700,6 +702,7 @@ void PDPServer::announceParticipantState(
                 wp.related_sample_identity(local);
             }
 
+            // Unlock PDP mutex since it's no longer needed.
             getMutex()->unlock();
 
             change = pW->new_change(
@@ -748,8 +751,6 @@ void PDPServer::announceParticipantState(
         LocatorList locators;
 
         {
-            std::lock_guard<fastrtps::RecursiveTimedMutex> wlock(pW->getMutex());
-
             std::vector<GuidPrefix_t> direct_clients_and_servers = discovery_db_.direct_clients_and_servers();
             for (GuidPrefix_t participant_prefix: direct_clients_and_servers)
             {

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -562,7 +562,7 @@ void PDPServer::announceParticipantState(
             - DSClientEvent (own thread)
             - ResendParticipantProxyDataPeriod (participant event thread)
          */
-        
+
         if (!dispose)
         {
             // Create the CacheChange_t if necessary
@@ -756,7 +756,7 @@ void PDPServer::announceParticipantState(
                 // Add remote reader
                 GUID_t remote_guid(participant_prefix, c_EntityId_SPDPReader);
                 remote_readers.push_back(remote_guid);
-    
+
                 locators.push_back(discovery_db_.participant_metatraffic_locators(participant_prefix));
             }
             send_announcement(change, remote_readers, locators, dispose);

--- a/src/cpp/rtps/builtin/discovery/participant/ServerAttributes.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/ServerAttributes.cpp
@@ -1,0 +1,34 @@
+// Copyright 2022 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file ServerAttributes.cpp
+ *
+ */
+
+#include <fastdds/rtps/attributes/ServerAttributes.h>
+
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+
+template<> const char* server_ostream_separators<char>::list_separator = "; ";
+template<> const wchar_t* server_ostream_separators<wchar_t>::list_separator = L"; ";
+
+template<> const char* server_ostream_separators<char>::locator_separator = "|";
+template<> const wchar_t* server_ostream_separators<wchar_t>::locator_separator = L"|";
+
+} /* namespace rtps */
+} /* namespace fastdds */
+} /* namespace eprosima */

--- a/src/cpp/rtps/builtin/discovery/participant/timedevent/DSClientEvent.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/timedevent/DSClientEvent.cpp
@@ -63,7 +63,7 @@ bool DSClientEvent::event()
     eprosima::shared_lock<eprosima::shared_mutex> lock(mp_PDP->mp_builtin->getDiscoveryMutex());
     for (auto server: mp_PDP->remote_server_attributes())
     {
-        std::unique_lock<std::recursive_mutex> lock(*mp_PDP->getMutex());
+        std::unique_lock<std::recursive_mutex> pdp_lock(*mp_PDP->getMutex());
         // Get the participant proxy data of the server
         part_proxy_data = mp_PDP->get_participant_proxy_data(server.guidPrefix);
 

--- a/src/cpp/rtps/builtin/discovery/participant/timedevent/DSClientEvent.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/timedevent/DSClientEvent.cpp
@@ -24,6 +24,8 @@
 #include <rtps/participant/RTPSParticipantImpl.h>
 
 #include <fastdds/dds/log/Log.hpp>
+#include <fastdds/rtps/builtin/BuiltinProtocols.h>
+#include <fastrtps/utils/shared_mutex.hpp>
 
 #include <rtps/builtin/discovery/participant/timedevent/DSClientEvent.h>
 #include <rtps/builtin/discovery/participant/PDPClient.h>
@@ -58,9 +60,10 @@ bool DSClientEvent::event()
 
     // Iterate over remote servers to check for new unmatched servers
     ParticipantProxyData* part_proxy_data;
-    std::unique_lock<std::recursive_mutex> lock(*mp_PDP->getMutex());
+    eprosima::shared_lock<eprosima::shared_mutex> lock(mp_PDP->mp_builtin->getDiscoveryMutex());
     for (auto server: mp_PDP->remote_server_attributes())
     {
+        std::unique_lock<std::recursive_mutex> lock(*mp_PDP->getMutex());
         // Get the participant proxy data of the server
         part_proxy_data = mp_PDP->get_participant_proxy_data(server.guidPrefix);
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1252,6 +1252,7 @@ void RTPSParticipantImpl::update_attributes(
     }
 
     auto pdp = mp_builtinProtocols->mp_PDP;
+
     // Check if there are changes
     if (patt.builtin.discovery_config.m_DiscoveryServers != m_att.builtin.discovery_config.m_DiscoveryServers
             || patt.userData != m_att.userData
@@ -1357,13 +1358,11 @@ void RTPSParticipantImpl::update_attributes(
                     {
                         if (server_it->guidPrefix == incoming_server.guidPrefix)
                         {
-                            bool modified_locator = false;
                             // Check if the listening locators have been modified
                             for (auto guid : modified_servers)
                             {
                                 if (guid == incoming_server.GetParticipant())
                                 {
-                                    modified_locator = true;
                                     server_it->metatrafficUnicastLocatorList =
                                             incoming_server.metatrafficUnicastLocatorList;
                                     break;

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1260,6 +1260,16 @@ void RTPSParticipantImpl::update_attributes(
         update_pdp = true;
         std::vector<GUID_t> modified_servers;
         LocatorList_t modified_locators;
+
+        // Update RTPSParticipantAttributes member
+        m_att.userData = patt.userData;
+
+        // If there's no PDP don't process Discovery-related attributes.
+        if (!pdp)
+        {
+            return;
+        }
+
         // Check that the remote servers list is consistent: all the already known remote servers must be included in
         // the list and either new remote servers are added or remote server listening locator is modified.
         for (auto existing_server : m_att.builtin.discovery_config.m_DiscoveryServers)
@@ -1300,9 +1310,6 @@ void RTPSParticipantImpl::update_attributes(
                 return;
             }
         }
-
-        // Update RTPSParticipantAttributes member
-        m_att.userData = patt.userData;
 
         {
             std::lock_guard<std::recursive_mutex> lock(*pdp->getMutex());

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1375,7 +1375,10 @@ void RTPSParticipantImpl::update_attributes(
                 }
 
                 // Update the servers list in builtin protocols
-                mp_builtinProtocols->m_DiscoveryServers = m_att.builtin.discovery_config.m_DiscoveryServers;
+                {
+                    std::unique_lock<eprosima::shared_mutex> disc_lock(mp_builtinProtocols->getDiscoveryMutex());
+                    mp_builtinProtocols->m_DiscoveryServers = m_att.builtin.discovery_config.m_DiscoveryServers;
+                }
 
                 // Notify PDPServer
                 if (m_att.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::SERVER ||

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1369,10 +1369,7 @@ void RTPSParticipantImpl::update_attributes(
                                     break;
                                 }
                             }
-                            if (false == modified_locator)
-                            {
-                                break;
-                            }
+                            break;
                         }
                     }
                     if (server_it == m_att.builtin.discovery_config.m_DiscoveryServers.end())

--- a/src/cpp/utils/SystemInfo.cpp
+++ b/src/cpp/utils/SystemInfo.cpp
@@ -16,7 +16,6 @@
 
 #ifdef __unix__
 #   include <sys/file.h>
-#   include <sys/stat.h>
 #   include <unistd.h>
 #endif // ifdef __unix__
 
@@ -24,6 +23,7 @@
 #include <windows.h>
 #else
 #include <pwd.h>
+#include <sys/stat.h>
 #endif // _WIN32
 
 #include <fstream>

--- a/src/cpp/utils/SystemInfo.cpp
+++ b/src/cpp/utils/SystemInfo.cpp
@@ -138,8 +138,8 @@ bool SystemInfo::file_exists(
 }
 
 bool SystemInfo::wait_for_file_closure(
-         const std::string& filename,
-         const std::chrono::seconds timeout)
+        const std::string& filename,
+        const std::chrono::seconds timeout)
 {
     auto start = std::chrono::system_clock::now();
 

--- a/src/cpp/utils/SystemInfo.hpp
+++ b/src/cpp/utils/SystemInfo.hpp
@@ -143,7 +143,7 @@ public:
             std::string& username);
 
     /**
-     * Check if the file wiht name \c filename exists.
+     * Check if the file with name \c filename exists.
      * \c filename can also include the path to the file.
      *
      * \param [in] filename path/name of the file to check.
@@ -151,6 +151,18 @@ public:
      */
     static bool file_exists(
             const std::string& filename);
+
+    /**
+     * Wait for file with name \c filename 
+     * until exclusive lock can be taken on it
+     *
+     * \param [in] filename path/name of the file to check.
+     * \param [in] lock wait timeout
+     * @return True if the file could be locked. False otherwise (timeout).
+     */
+    static bool wait_for_file_closure(
+            const std::string& filename,
+            const std::chrono::seconds timeout);
 
     /**
      * Read FASTDDS_ENVIRONMENT_FILE_ENV_VAR environment value and save its value.

--- a/src/cpp/utils/SystemInfo.hpp
+++ b/src/cpp/utils/SystemInfo.hpp
@@ -153,7 +153,7 @@ public:
             const std::string& filename);
 
     /**
-     * Wait for file with name \c filename 
+     * Wait for file with name \c filename
      * until exclusive lock can be taken on it
      *
      * \param [in] filename path/name of the file to check.

--- a/test/blackbox/CMakeLists.txt
+++ b/test/blackbox/CMakeLists.txt
@@ -254,8 +254,6 @@ set(RTPS_BLACKBOXTESTS_SOURCE ${RTPS_BLACKBOXTESTS_TEST_SOURCE}
     utils/data_generators.cpp
     utils/lambda_functions.cpp
     utils/print_functions.cpp
-
-    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/ServerAttributes.cpp
     )
 add_executable(BlackboxTests_RTPS ${RTPS_BLACKBOXTESTS_SOURCE})
 target_compile_definitions(BlackboxTests_RTPS PRIVATE

--- a/test/blackbox/CMakeLists.txt
+++ b/test/blackbox/CMakeLists.txt
@@ -335,6 +335,7 @@ if(FASTRTPS_API_TESTS)
         ${BLACKBOXTESTS_SOURCE}
         api/fastrtps_deprecated/ReqRepHelloWorldRequester.cpp
         api/fastrtps_deprecated/ReqRepHelloWorldReplier.cpp
+        ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/ServerAttributes.cpp
         )
 
     add_executable(BlackboxTests_FastRTPS ${BLACKBOXTESTS_FASTRTPS_SOURCE})

--- a/test/blackbox/CMakeLists.txt
+++ b/test/blackbox/CMakeLists.txt
@@ -254,6 +254,8 @@ set(RTPS_BLACKBOXTESTS_SOURCE ${RTPS_BLACKBOXTESTS_TEST_SOURCE}
     utils/data_generators.cpp
     utils/lambda_functions.cpp
     utils/print_functions.cpp
+
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/ServerAttributes.cpp
     )
 add_executable(BlackboxTests_RTPS ${RTPS_BLACKBOXTESTS_SOURCE})
 target_compile_definitions(BlackboxTests_RTPS PRIVATE
@@ -299,6 +301,7 @@ set(DDS_BLACKBOXTESTS_SOURCE
     ${DDS_BLACKBOXTESTS_TEST_SOURCE}
     ${BLACKBOXTESTS_SOURCE}
     ${PROJECT_SOURCE_DIR}/src/cpp/utils/SystemInfo.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/ServerAttributes.cpp
     )
 
 # Prepare static discovery xml file for blackbox tests.

--- a/test/dds/discovery/CMakeLists.txt
+++ b/test/dds/discovery/CMakeLists.txt
@@ -21,6 +21,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
     set(DDS_PARTICIPANT_SOURCE
         ParticipantModule.cpp
         ParticipantMain.cpp
+        ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/ServerAttributes.cpp
         )
 
     add_executable(DDSParticipantDiscovery ${DDS_PARTICIPANT_SOURCE})

--- a/test/dds/discovery/CMakeLists.txt
+++ b/test/dds/discovery/CMakeLists.txt
@@ -21,7 +21,6 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
     set(DDS_PARTICIPANT_SOURCE
         ParticipantModule.cpp
         ParticipantMain.cpp
-        ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/ServerAttributes.cpp
         )
 
     add_executable(DDSParticipantDiscovery ${DDS_PARTICIPANT_SOURCE})

--- a/test/unittest/dds/participant/CMakeLists.txt
+++ b/test/unittest/dds/participant/CMakeLists.txt
@@ -17,6 +17,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../profiles/test_xml_profiles.xml
     COPYONLY)
 
 set(PARTICIPANTTESTS_SOURCE ParticipantTests.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/ServerAttributes.cpp
     )
 
 if(WIN32)

--- a/test/unittest/dds/participant/CMakeLists.txt
+++ b/test/unittest/dds/participant/CMakeLists.txt
@@ -16,7 +16,8 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../profiles/test_xml_profiles.xml
     ${CMAKE_CURRENT_BINARY_DIR}/test_xml_profiles.xml
     COPYONLY)
 
-set(PARTICIPANTTESTS_SOURCE ParticipantTests.cpp
+set(PARTICIPANTTESTS_SOURCE
+    ParticipantTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/ServerAttributes.cpp
     )
 

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -746,9 +746,7 @@ void set_and_check_with_environment_file(
         assert(res);
 
         std::smatch::iterator it = mr.cbegin();
-        // Check whether the address is IPv4
         auto address = (++it)->str();
-        assert(fastrtps::rtps::IPLocator::isIPv4(address));
         fastrtps::rtps::IPLocator::setIPv4(locator, address);
 
         assert(it != mr.cend());

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -769,7 +769,7 @@ void set_and_check_with_environment_file(
     file.close();
 
     // Wait for the file watch callback
-    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
     fastrtps::rtps::RTPSParticipantAttributes attributes;
     get_rtps_attributes(participant, attributes);
@@ -1057,9 +1057,6 @@ TEST(ParticipantTests, RepeatEnvironmentFileConfiguration)
     DomainParticipant* participant = DomainParticipantFactory::get_instance()->create_participant(0, qos);
     ASSERT_NE(nullptr, participant);
 #ifndef __APPLE__
-    // Give some room for OS file watch timer initialization
-    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-
     set_and_check_with_environment_file(participant, {"172.17.0.5:4321", "192.168.1.133:64863"}, filename);
     set_and_check_with_environment_file(participant, {"172.17.0.5:64863", "192.168.1.133:4321"}, filename);
     set_and_check_with_environment_file(participant, {"172.17.0.5:64863", "192.168.1.133:4321"}, filename);

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -834,15 +834,12 @@ TEST(ParticipantTests, SimpleParticipantDynamicAdditionRemoteServers)
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, output);
     // Modify environment file
 #ifndef __APPLE__
-    // Wait long enought for file watch callback rigging
-    std::this_thread::sleep_for(std::chrono::seconds(1));
-
     std::ofstream file(filename);
     file << "{\"ROS_DISCOVERY_SERVER\": \"84.22.253.128:8888;192.168.1.133:64863;localhost:1234\"}";
     file.close();
 
     // Wait long enought for the file watch callback
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
     get_rtps_attributes(participant, attributes);
 
     rtps::RemoteServerAttributes server;
@@ -977,11 +974,11 @@ TEST(ParticipantTests, ServerParticipantInconsistentRemoteServerListConfiguratio
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, qos_output);
 
     // Modify environment file: fails cause the initial guid prefix did not comply with the schema
-    std::this_thread::sleep_for(std::chrono::milliseconds(1100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
     file.open(filename);
     file << "{\"ROS_DISCOVERY_SERVER\": \"84.22.253.128:8888;192.168.1.133:64863;localhost:1234\"}";
     file.close();
-    std::this_thread::sleep_for(std::chrono::milliseconds(1100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
     get_rtps_attributes(participant, attributes);
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, qos_output);
     // Capture log warning
@@ -1028,11 +1025,11 @@ TEST(ParticipantTests, ServerParticipantInconsistentLocatorsRemoteServerListConf
     ASSERT_NE(nullptr, participant);
     // Try adding a new remote server
 #ifndef __APPLE__
-    std::this_thread::sleep_for(std::chrono::milliseconds(1100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
     std::ofstream file(filename);
     file << "{\"ROS_DISCOVERY_SERVER\": \"172.17.0.5:4321;192.168.1.133:64863\"}";
     file.close();
-    std::this_thread::sleep_for(std::chrono::milliseconds(1100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
     fastrtps::rtps::RTPSParticipantAttributes attributes;
     get_rtps_attributes(participant, attributes);
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, output);
@@ -1102,11 +1099,11 @@ TEST(ParticipantTests, ServerParticipantCorrectRemoteServerListConfiguration)
     // checked because it is not included in the attributes.
     DomainParticipantQos result_qos;
 #ifndef __APPLE__
-    std::this_thread::sleep_for(std::chrono::milliseconds(1100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
     file.open(filename);
     file << "{\"ROS_DISCOVERY_SERVER\": \"172.17.0.5:4321;;192.168.1.133:64863\"}";
     file.close();
-    std::this_thread::sleep_for(std::chrono::milliseconds(1100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
     server.clear();
     fastrtps::rtps::IPLocator::setIPv4(locator, "192.168.1.133");
     locator.port = 64863;
@@ -1116,11 +1113,11 @@ TEST(ParticipantTests, ServerParticipantCorrectRemoteServerListConfiguration)
     get_rtps_attributes(participant, attributes);
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, output);
     // Try to be consistent: add already known server
-    std::this_thread::sleep_for(std::chrono::milliseconds(1100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
     file.open(filename);
     file << "{\"ROS_DISCOVERY_SERVER\": \"172.17.0.5:4321;localhost:1234;192.168.1.133:64863\"}";
     file.close();
-    std::this_thread::sleep_for(std::chrono::milliseconds(1100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
     server.clear();
     fastrtps::rtps::IPLocator::setIPv4(locator, "127.0.0.1");
     locator.port = 1234;

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -742,6 +742,7 @@ void set_and_check_with_environment_file(
 
         std::smatch mr;
         auto res = std::regex_match(l, mr, ROS2_IPV4_PATTERN, std::regex_constants::match_not_null);
+        (void)res;
         assert(res);
 
         std::smatch::iterator it = mr.cbegin();

--- a/test/unittest/dds/publisher/CMakeLists.txt
+++ b/test/unittest/dds/publisher/CMakeLists.txt
@@ -112,6 +112,7 @@ set(DATAWRITERTESTS_SOURCE DataWriterTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/endpoint/EDPStatic.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/DirectMessageSender.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/ServerAttributes.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp

--- a/test/unittest/statistics/dds/CMakeLists.txt
+++ b/test/unittest/statistics/dds/CMakeLists.txt
@@ -167,6 +167,7 @@ if (SQLITE3_SUPPORT AND FASTDDS_STATISTICS)
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+        ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/ServerAttributes.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/timedevent/DSClientEvent.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/timedevent/DServerEvent.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/liveliness/WLP.cpp

--- a/test/unittest/statistics/rtps/CMakeLists.txt
+++ b/test/unittest/statistics/rtps/CMakeLists.txt
@@ -19,6 +19,7 @@ endif()
 set(STATISTICS_RTPS_TESTS_SOURCE
     RTPSStatisticsTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/statistics/types/types.cxx
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/ServerAttributes.cpp
     )
 
 add_executable(RTPSStatisticsTests ${STATISTICS_RTPS_TESTS_SOURCE})

--- a/test/unittest/statistics/rtps/CMakeLists.txt
+++ b/test/unittest/statistics/rtps/CMakeLists.txt
@@ -19,7 +19,6 @@ endif()
 set(STATISTICS_RTPS_TESTS_SOURCE
     RTPSStatisticsTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/statistics/types/types.cxx
-    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/ServerAttributes.cpp
     )
 
 add_executable(RTPSStatisticsTests ${STATISTICS_RTPS_TESTS_SOURCE})

--- a/test/unittest/utils/SystemInfoTests.cpp
+++ b/test/unittest/utils/SystemInfoTests.cpp
@@ -227,7 +227,6 @@ TEST_F(SystemInfoTests, EnvironmentFileTest)
 TEST_F(SystemInfoTests, FileWatchTest)
 {
     auto _1s = std::chrono::seconds(1);
-    auto _100ms = std::chrono::milliseconds(100);
 
     std::string filename = "environment_test_file.json";
     nlohmann::json file_content;
@@ -263,16 +262,6 @@ TEST_F(SystemInfoTests, FileWatchTest)
 
     file_content["EMPTY_ENV_VAR"] = "another_value";
 
-    // Avoid:
-    // 1. Filetime granularity issues.
-    //    Note that file changes within the same:
-    //     - 100 ns in windows
-    //     - 1 ns in linux
-    //    will not trigger a callback
-    // 2. OS time to update the results of Filetime info calls as:
-    //     - GetFileAttributesEx() < 1 ms
-    //     - stat() < 100 ms
-    std::this_thread::sleep_for(_100ms);
     {
         std::ofstream file(filename);
         file << file_content;
@@ -290,8 +279,6 @@ TEST_F(SystemInfoTests, FileWatchTest)
     // Restore content of file
     file_content["EMPTY_ENV_VAR"] = "";
 
-    // Avoid filetime granularity issues
-    std::this_thread::sleep_for(_100ms);
     {
         std::ofstream file(filename);
         file << file_content;

--- a/test/unittest/utils/SystemInfoTests.cpp
+++ b/test/unittest/utils/SystemInfoTests.cpp
@@ -256,9 +256,10 @@ TEST_F(SystemInfoTests, FileWatchTest)
     }
 
     // Check modifications.
-    block_for_at_least_N_callbacks(1);
-    uint32_t times_called = times_called_;
-    EXPECT_EQ(1u, times_called);
+    uint32_t times_called = 0;
+    block_for_at_least_N_callbacks(times_called + 1);
+    EXPECT_LT(times_called, times_called_);
+    times_called = times_called_;
 
     file_content["EMPTY_ENV_VAR"] = "another_value";
 
@@ -278,12 +279,13 @@ TEST_F(SystemInfoTests, FileWatchTest)
     }
 
     // Check modifications.
-    block_for_at_least_N_callbacks(2);
+    block_for_at_least_N_callbacks(times_called + 1);
+    EXPECT_LT(times_called, times_called_);
     times_called = times_called_;
-    EXPECT_EQ(2u, times_called);
 
     // Remove the watcher
     eprosima::SystemInfo::stop_watching_file(watch);
+    times_called = times_called_;
 
     // Restore content of file
     file_content["EMPTY_ENV_VAR"] = "";

--- a/test/unittest/utils/SystemInfoTests.cpp
+++ b/test/unittest/utils/SystemInfoTests.cpp
@@ -226,7 +226,8 @@ TEST_F(SystemInfoTests, EnvironmentFileTest)
  */
 TEST_F(SystemInfoTests, FileWatchTest)
 {
-    using namespace std::chrono_literals;
+    auto _1s = std::chrono::seconds(1);
+    auto _1ms = std::chrono::milliseconds(1);
 
     std::string filename = "environment_test_file.json";
     nlohmann::json file_content;
@@ -235,7 +236,7 @@ TEST_F(SystemInfoTests, FileWatchTest)
     eprosima::FileWatchHandle watch =
             eprosima::SystemInfo::watch_file(filename, [&]()
                     {
-                        eprosima::SystemInfo::wait_for_file_closure(filename, 1s);
+                        eprosima::SystemInfo::wait_for_file_closure(filename, _1s);
                         ++times_called_;
                         cv_.notify_all();
                     });
@@ -266,7 +267,7 @@ TEST_F(SystemInfoTests, FileWatchTest)
     //  - 100ns in windows
     //  - 1ns in linux
     // will not trigger a callback
-    std::this_thread::sleep_for(1ms);
+    std::this_thread::sleep_for(_1ms);
     {
         std::ofstream file(filename);
         file << file_content;
@@ -284,14 +285,14 @@ TEST_F(SystemInfoTests, FileWatchTest)
     file_content["EMPTY_ENV_VAR"] = "";
 
     // Avoid filetime granularity issues
-    std::this_thread::sleep_for(1ms);
+    std::this_thread::sleep_for(_1ms);
     {
         std::ofstream file(filename);
         file << file_content;
     }
 
     // Check no modifications were notified
-    std::this_thread::sleep_for(std::chrono::seconds(1));
+    std::this_thread::sleep_for(_1s);
     EXPECT_EQ(times_called, times_called_);
 }
 

--- a/test/unittest/utils/SystemInfoTests.cpp
+++ b/test/unittest/utils/SystemInfoTests.cpp
@@ -227,7 +227,7 @@ TEST_F(SystemInfoTests, EnvironmentFileTest)
 TEST_F(SystemInfoTests, FileWatchTest)
 {
     auto _1s = std::chrono::seconds(1);
-    auto _1ms = std::chrono::milliseconds(1);
+    auto _100ms = std::chrono::milliseconds(100);
 
     std::string filename = "environment_test_file.json";
     nlohmann::json file_content;
@@ -262,12 +262,16 @@ TEST_F(SystemInfoTests, FileWatchTest)
 
     file_content["EMPTY_ENV_VAR"] = "another_value";
 
-    // Avoid filetime granularity issues
-    // Note that file changes within the same:
-    //  - 100ns in windows
-    //  - 1ns in linux
-    // will not trigger a callback
-    std::this_thread::sleep_for(_1ms);
+    // Avoid:
+    // 1. Filetime granularity issues.
+    //    Note that file changes within the same:
+    //     - 100 ns in windows
+    //     - 1 ns in linux
+    //    will not trigger a callback
+    // 2. OS time to update the results of Filetime info calls as:
+    //     - GetFileAttributesEx() < 1 ms
+    //     - stat() < 100 ms
+    std::this_thread::sleep_for(_100ms);
     {
         std::ofstream file(filename);
         file << file_content;
@@ -285,7 +289,7 @@ TEST_F(SystemInfoTests, FileWatchTest)
     file_content["EMPTY_ENV_VAR"] = "";
 
     // Avoid filetime granularity issues
-    std::this_thread::sleep_for(_1ms);
+    std::this_thread::sleep_for(_100ms);
     {
         std::ofstream file(filename);
         file << file_content;

--- a/thirdparty/filewatch/FileWatch.hpp
+++ b/thirdparty/filewatch/FileWatch.hpp
@@ -1,24 +1,24 @@
-//	MIT License
-//	
-//	Copyright(c) 2017 Thomas Monkman
-//	
-//	Permission is hereby granted, free of charge, to any person obtaining a copy
-//	of this software and associated documentation files(the "Software"), to deal
-//	in the Software without restriction, including without limitation the rights
-//	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//	copies of the Software, and to permit persons to whom the Software is
-//	furnished to do so, subject to the following conditions :
-//	
-//	The above copyright notice and this permission notice shall be included in all
-//	copies or substantial portions of the Software.
-//	
-//	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
-//	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//	SOFTWARE.
+//  MIT License
+//
+//  Copyright(c) 2017 Thomas Monkman
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 #ifndef FILEWATCHER_H
 #define FILEWATCHER_H
@@ -66,325 +66,325 @@
 #include <vector>
 
 namespace filewatch {
-	enum class Event {
-		added,
-		removed,
-		modified,
-		renamed_old,
-		renamed_new
-	};
+    enum class Event {
+        added,
+        removed,
+        modified,
+        renamed_old,
+        renamed_new
+    };
 
-	/**
-	* \class FileWatch
-	*
-	* \brief Watches a folder or file, and will notify of changes via function callback.
-	*
-	* \author Thomas Monkman
-	*
-	*/
-	template<class T>
-	class FileWatch
-	{
-		typedef typename T::value_type C;
-		typedef std::basic_string<C, std::char_traits<C>> UnderpinningString;
-		typedef std::basic_regex<C, std::regex_traits<C>> UnderpinningRegex;
+    /**
+    * \class FileWatch
+    *
+    * \brief Watches a folder or file, and will notify of changes via function callback.
+    *
+    * \author Thomas Monkman
+    *
+    */
+    template<class T>
+    class FileWatch
+    {
+        typedef typename T::value_type C;
+        typedef std::basic_string<C, std::char_traits<C>> UnderpinningString;
+        typedef std::basic_regex<C, std::regex_traits<C>> UnderpinningRegex;
 
-	public:
+    public:
 
-		FileWatch(T path, UnderpinningRegex pattern, std::function<void(const T& file, const Event event_type)> callback) :
-			_path(path),
-			_pattern(pattern),
-			_callback(callback),
-			_directory(get_directory(path))
-		{
-			init();
-		}
+        FileWatch(T path, UnderpinningRegex pattern, std::function<void(const T& file, const Event event_type)> callback) :
+            _path(path),
+            _pattern(pattern),
+            _callback(callback),
+            _directory(get_directory(path))
+        {
+            init();
+        }
 
-		FileWatch(T path, std::function<void(const T& file, const Event event_type)> callback) :
-			FileWatch<T>(path, UnderpinningRegex(_regex_all), callback) {}
+        FileWatch(T path, std::function<void(const T& file, const Event event_type)> callback) :
+            FileWatch<T>(path, UnderpinningRegex(_regex_all), callback) {}
 
-		~FileWatch() {
-			destroy();
-		}
+        ~FileWatch() {
+            destroy();
+        }
 
-		FileWatch(const FileWatch<T>& other) : FileWatch<T>(other._path, other._callback) {}
+        FileWatch(const FileWatch<T>& other) : FileWatch<T>(other._path, other._callback) {}
 
-		FileWatch<T>& operator=(const FileWatch<T>& other) 
-		{
-			if (this == &other) { return *this; }
+        FileWatch<T>& operator=(const FileWatch<T>& other)
+        {
+            if (this == &other) { return *this; }
 
-			destroy();
-			_path = other._path;
-			_callback = other._callback;
-			_directory = get_directory(other._path);
-			init();
-			return *this;
-		}
+            destroy();
+            _path = other._path;
+            _callback = other._callback;
+            _directory = get_directory(other._path);
+            init();
+            return *this;
+        }
 
-		// Const memeber varibles don't let me implent moves nicely, if moves are really wanted std::unique_ptr should be used and move that.
-		FileWatch<T>(FileWatch<T>&&) = delete;
-		FileWatch<T>& operator=(FileWatch<T>&&) & = delete;
+        // Const memeber varibles don't let me implent moves nicely, if moves are really wanted std::unique_ptr should be used and move that.
+        FileWatch<T>(FileWatch<T>&&) = delete;
+        FileWatch<T>& operator=(FileWatch<T>&&) & = delete;
 
-	private:
-		static constexpr C _regex_all[] = { '.', '*', '\0' };
-		static constexpr C _this_directory[] = { '.', '/', '\0' };
+    private:
+        static constexpr C _regex_all[] = { '.', '*', '\0' };
+        static constexpr C _this_directory[] = { '.', '/', '\0' };
 
-		struct PathParts
-		{
-			PathParts(T directory, T filename) : directory(directory), filename(filename) {}
-			T directory;
-			T filename;
-		};
-		const T _path;
+        struct PathParts
+        {
+            PathParts(T directory, T filename) : directory(directory), filename(filename) {}
+            T directory;
+            T filename;
+        };
+        const T _path;
 
-		UnderpinningRegex _pattern;
+        UnderpinningRegex _pattern;
 
-		static constexpr std::size_t _buffer_size = { 1024 * 256 };
+        static constexpr std::size_t _buffer_size = { 1024 * 256 };
 
-		// only used if watch a single file
-		bool _watching_single_file = { false };
-		T _filename;
+        // only used if watch a single file
+        bool _watching_single_file = { false };
+        T _filename;
 
-		std::atomic<bool> _destory = { false };
-		std::function<void(const T& file, const Event event_type)> _callback;
+        std::atomic<bool> _destory = { false };
+        std::function<void(const T& file, const Event event_type)> _callback;
 
-		std::thread _watch_thread;
+        std::thread _watch_thread;
 
-		std::condition_variable _cv;
-		std::mutex _callback_mutex;
-		std::vector<std::pair<T, Event>> _callback_information;
-		std::thread _callback_thread;
+        std::condition_variable _cv;
+        std::mutex _callback_mutex;
+        std::vector<std::pair<T, Event>> _callback_information;
+        std::thread _callback_thread;
 
-		std::promise<void> _running;
+        std::promise<void> _running;
 
         std::chrono::time_point<std::chrono::system_clock> last_write_time_;
 
 #ifdef _WIN32
-		HANDLE _directory = { nullptr };
-		HANDLE _close_event = { nullptr };
+        HANDLE _directory = { nullptr };
+        HANDLE _close_event = { nullptr };
 
-		const DWORD _listen_filters =
-			FILE_NOTIFY_CHANGE_SECURITY |
-			FILE_NOTIFY_CHANGE_CREATION |
-			FILE_NOTIFY_CHANGE_LAST_ACCESS |
-			FILE_NOTIFY_CHANGE_LAST_WRITE |
-			FILE_NOTIFY_CHANGE_SIZE |
-			FILE_NOTIFY_CHANGE_ATTRIBUTES |
-			FILE_NOTIFY_CHANGE_DIR_NAME |
-			FILE_NOTIFY_CHANGE_FILE_NAME;
+        const DWORD _listen_filters =
+            FILE_NOTIFY_CHANGE_SECURITY |
+            FILE_NOTIFY_CHANGE_CREATION |
+            FILE_NOTIFY_CHANGE_LAST_ACCESS |
+            FILE_NOTIFY_CHANGE_LAST_WRITE |
+            FILE_NOTIFY_CHANGE_SIZE |
+            FILE_NOTIFY_CHANGE_ATTRIBUTES |
+            FILE_NOTIFY_CHANGE_DIR_NAME |
+            FILE_NOTIFY_CHANGE_FILE_NAME;
 
-		const std::map<DWORD, Event> _event_type_mapping = {
-			{ FILE_ACTION_ADDED, Event::added },
-			{ FILE_ACTION_REMOVED, Event::removed },
-			{ FILE_ACTION_MODIFIED, Event::modified },
-			{ FILE_ACTION_RENAMED_OLD_NAME, Event::renamed_old },
-			{ FILE_ACTION_RENAMED_NEW_NAME, Event::renamed_new }
-		};
+        const std::map<DWORD, Event> _event_type_mapping = {
+            { FILE_ACTION_ADDED, Event::added },
+            { FILE_ACTION_REMOVED, Event::removed },
+            { FILE_ACTION_MODIFIED, Event::modified },
+            { FILE_ACTION_RENAMED_OLD_NAME, Event::renamed_old },
+            { FILE_ACTION_RENAMED_NEW_NAME, Event::renamed_new }
+        };
 
         // time epoch translation
         std::pair<ULARGE_INTEGER, std::chrono::time_point<std::chrono::system_clock>> base_;
 #endif // WIN32
 
 #if __unix__
-		struct FolderInfo {
-			int folder;
-			int watch;
-		};
+        struct FolderInfo {
+            int folder;
+            int watch;
+        };
 
-		FolderInfo  _directory;
+        FolderInfo  _directory;
 
-		const std::uint32_t _listen_filters = IN_MODIFY | IN_CREATE | IN_DELETE;
+        const std::uint32_t _listen_filters = IN_MODIFY | IN_CREATE | IN_DELETE;
 
-		const static std::size_t event_size = (sizeof(struct inotify_event));
+        const static std::size_t event_size = (sizeof(struct inotify_event));
 #endif // __unix__
 
-		void init() 
-		{
+        void init()
+        {
 #ifdef _WIN32
-			_close_event = CreateEvent(NULL, TRUE, FALSE, NULL);
-			if (!_close_event) {
-				throw std::system_error(GetLastError(), std::system_category());
-			}
+            _close_event = CreateEvent(NULL, TRUE, FALSE, NULL);
+            if (!_close_event) {
+                throw std::system_error(GetLastError(), std::system_category());
+            }
 #endif // WIN32
-			_callback_thread = std::move(std::thread([this]() {
-				try {
-					callback_thread();
-				} catch (...) {
-					try {
-						_running.set_exception(std::current_exception());
-					}
-					catch (...) {} // set_exception() may throw too
-				}
-			}));
-			_watch_thread = std::move(std::thread([this]() { 
-				try {
-					monitor_directory();
-				} catch (...) {
-					try {
-						_running.set_exception(std::current_exception());
-					}
-					catch (...) {} // set_exception() may throw too
-				}
-			}));
+            _callback_thread = std::move(std::thread([this]() {
+                try {
+                    callback_thread();
+                } catch (...) {
+                    try {
+                        _running.set_exception(std::current_exception());
+                    }
+                    catch (...) {} // set_exception() may throw too
+                }
+            }));
+            _watch_thread = std::move(std::thread([this]() {
+                try {
+                    monitor_directory();
+                } catch (...) {
+                    try {
+                        _running.set_exception(std::current_exception());
+                    }
+                    catch (...) {} // set_exception() may throw too
+                }
+            }));
 
-			std::future<void> future = _running.get_future();
-			future.get(); //block until the monitor_directory is up and running
-		}
+            std::future<void> future = _running.get_future();
+            future.get(); //block until the monitor_directory is up and running
+        }
 
-		void destroy()
-		{
-			_destory = true;
-			_running = std::promise<void>();
+        void destroy()
+        {
+            _destory = true;
+            _running = std::promise<void>();
 #ifdef _WIN32
-			SetEvent(_close_event);
+            SetEvent(_close_event);
 #elif __unix__
-			inotify_rm_watch(_directory.folder, _directory.watch);
+            inotify_rm_watch(_directory.folder, _directory.watch);
 #endif // __unix__
-			_cv.notify_all();
-			_watch_thread.join();
-			_callback_thread.join();
+            _cv.notify_all();
+            _watch_thread.join();
+            _callback_thread.join();
 #ifdef _WIN32
-			CloseHandle(_directory);
+            CloseHandle(_directory);
 #elif __unix__
-			close(_directory.folder);
+            close(_directory.folder);
 #endif // __unix__
-		}
+        }
 
-		const PathParts split_directory_and_file(const T& path) const 
-		{
-			const auto predict = [](C character) {
+        const PathParts split_directory_and_file(const T& path) const
+        {
+            const auto predict = [](C character) {
 #ifdef _WIN32
-				return character == C('\\') || character == C('/');
+                return character == C('\\') || character == C('/');
 #elif __unix__
-				return character == C('/');
+                return character == C('/');
 #endif // __unix__
-			};
+            };
 
-			UnderpinningString path_string = path;
-			const auto pivot = std::find_if(path_string.rbegin(), path_string.rend(), predict).base();
-			//if the path is something like "test.txt" there will be no directory part, however we still need one, so insert './'
-			const T directory = [&]() {
-				const auto extracted_directory = UnderpinningString(path_string.begin(), pivot);
-				return (extracted_directory.size() > 0) ? extracted_directory : UnderpinningString(_this_directory);
-			}();
-			const T filename = UnderpinningString(pivot, path_string.end());
-			return PathParts(directory, filename);
-		}
+            UnderpinningString path_string = path;
+            const auto pivot = std::find_if(path_string.rbegin(), path_string.rend(), predict).base();
+            //if the path is something like "test.txt" there will be no directory part, however we still need one, so insert './'
+            const T directory = [&]() {
+                const auto extracted_directory = UnderpinningString(path_string.begin(), pivot);
+                return (extracted_directory.size() > 0) ? extracted_directory : UnderpinningString(_this_directory);
+            }();
+            const T filename = UnderpinningString(pivot, path_string.end());
+            return PathParts(directory, filename);
+        }
 
-		bool pass_filter(const UnderpinningString& file_path)
-		{ 
-			if (_watching_single_file) {
-				const UnderpinningString extracted_filename = { split_directory_and_file(file_path).filename };
-				//if we are watching a single file, only that file should trigger action
-				return extracted_filename == _filename;
-			}
-			return std::regex_match(file_path, _pattern);
-		}
+        bool pass_filter(const UnderpinningString& file_path)
+        {
+            if (_watching_single_file) {
+                const UnderpinningString extracted_filename = { split_directory_and_file(file_path).filename };
+                //if we are watching a single file, only that file should trigger action
+                return extracted_filename == _filename;
+            }
+            return std::regex_match(file_path, _pattern);
+        }
 
 #ifdef _WIN32
-		template<typename... Args> DWORD GetFileAttributesX(const char* lpFileName, Args... args) {
-			return GetFileAttributesA(lpFileName, args...);
-		}
-		template<typename... Args> DWORD GetFileAttributesX(const wchar_t* lpFileName, Args... args) {
-			return GetFileAttributesW(lpFileName, args...);
-		}
+        template<typename... Args> DWORD GetFileAttributesX(const char* lpFileName, Args... args) {
+            return GetFileAttributesA(lpFileName, args...);
+        }
+        template<typename... Args> DWORD GetFileAttributesX(const wchar_t* lpFileName, Args... args) {
+            return GetFileAttributesW(lpFileName, args...);
+        }
 
-		template<typename... Args> HANDLE CreateFileX(const char* lpFileName, Args... args) {
-			return CreateFileA(lpFileName, args...);
-		}
-		template<typename... Args> HANDLE CreateFileX(const wchar_t* lpFileName, Args... args) {
-			return CreateFileW(lpFileName, args...);
-		}
+        template<typename... Args> HANDLE CreateFileX(const char* lpFileName, Args... args) {
+            return CreateFileA(lpFileName, args...);
+        }
+        template<typename... Args> HANDLE CreateFileX(const wchar_t* lpFileName, Args... args) {
+            return CreateFileW(lpFileName, args...);
+        }
 
-		HANDLE get_directory(const T& path) 
-		{
-			auto file_info = GetFileAttributesX(path.c_str());
+        HANDLE get_directory(const T& path)
+        {
+            auto file_info = GetFileAttributesX(path.c_str());
 
-			if (file_info == INVALID_FILE_ATTRIBUTES)
-			{
-				throw std::system_error(GetLastError(), std::system_category());
-			}
-			_watching_single_file = (file_info & FILE_ATTRIBUTE_DIRECTORY) == false;
+            if (file_info == INVALID_FILE_ATTRIBUTES)
+            {
+                throw std::system_error(GetLastError(), std::system_category());
+            }
+            _watching_single_file = (file_info & FILE_ATTRIBUTE_DIRECTORY) == false;
 
-			const T watch_path = [this, &path]() {
-				if (_watching_single_file)
-				{
-					const auto parsed_path = split_directory_and_file(path);
-					_filename = parsed_path.filename;
-					return parsed_path.directory;
-				}
-				else 
-				{
-					return path;
-				}
-			}();
+            const T watch_path = [this, &path]() {
+                if (_watching_single_file)
+                {
+                    const auto parsed_path = split_directory_and_file(path);
+                    _filename = parsed_path.filename;
+                    return parsed_path.directory;
+                }
+                else
+                {
+                    return path;
+                }
+            }();
 
-			HANDLE directory = CreateFileX(
-				watch_path.c_str(),           // pointer to the file name
-				FILE_LIST_DIRECTORY,    // access (read/write) mode
-				FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, // share mode
-				nullptr, // security descriptor
-				OPEN_EXISTING,         // how to create
-				FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED, // file attributes
-				HANDLE(0));                 // file with attributes to copy
+            HANDLE directory = CreateFileX(
+                watch_path.c_str(),           // pointer to the file name
+                FILE_LIST_DIRECTORY,    // access (read/write) mode
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, // share mode
+                nullptr, // security descriptor
+                OPEN_EXISTING,         // how to create
+                FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED, // file attributes
+                HANDLE(0));                 // file with attributes to copy
 
-			if (directory == INVALID_HANDLE_VALUE)
-			{
-				throw std::system_error(GetLastError(), std::system_category());
-			}
+            if (directory == INVALID_HANDLE_VALUE)
+            {
+                throw std::system_error(GetLastError(), std::system_category());
+            }
 
-			init_last_write_time();
+            init_last_write_time();
 
-			return directory;
-		}
+            return directory;
+        }
 
-		void convert_wstring(const std::wstring& wstr, std::string& out)
-		{
-			int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), NULL, 0, NULL, NULL);
-			out.resize(size_needed, '\0');
-			WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &out[0], size_needed, NULL, NULL);
-		}
+        void convert_wstring(const std::wstring& wstr, std::string& out)
+        {
+            int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), NULL, 0, NULL, NULL);
+            out.resize(size_needed, '\0');
+            WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &out[0], size_needed, NULL, NULL);
+        }
 
-		void convert_wstring(const std::wstring& wstr, std::wstring& out)
-		{
-			out = wstr;
-		}
+        void convert_wstring(const std::wstring& wstr, std::wstring& out)
+        {
+            out = wstr;
+        }
 
-		void monitor_directory() 
-		{
-			std::vector<BYTE> buffer(_buffer_size);
-			DWORD bytes_returned = 0;
-			OVERLAPPED overlapped_buffer{ 0 };
+        void monitor_directory()
+        {
+            std::vector<BYTE> buffer(_buffer_size);
+            DWORD bytes_returned = 0;
+            OVERLAPPED overlapped_buffer{ 0 };
 
-			overlapped_buffer.hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
-			if (!overlapped_buffer.hEvent) {
-				std::cerr << "Error creating monitor event" << std::endl;
-			}
+            overlapped_buffer.hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
+            if (!overlapped_buffer.hEvent) {
+                std::cerr << "Error creating monitor event" << std::endl;
+            }
 
-			std::array<HANDLE, 2> handles{ overlapped_buffer.hEvent, _close_event };
+            std::array<HANDLE, 2> handles{ overlapped_buffer.hEvent, _close_event };
 
-			auto async_pending = false;
-			_running.set_value();
-			do {
-				std::vector<std::pair<T, Event>> parsed_information;
-				ReadDirectoryChangesW(
-					_directory,
-					buffer.data(), static_cast<DWORD>(buffer.size()),
-					TRUE,
-					_listen_filters,
-					&bytes_returned,
-					&overlapped_buffer, NULL);
-			
-				async_pending = true;
-			
-				switch (WaitForMultipleObjects(2, handles.data(), FALSE, INFINITE))
-				{
-				case WAIT_OBJECT_0:
-				{
-					if (!GetOverlappedResult(_directory, &overlapped_buffer, &bytes_returned, TRUE)) {
-						throw std::system_error(GetLastError(), std::system_category());
-					}
-					async_pending = false;
+            auto async_pending = false;
+            _running.set_value();
+            do {
+                std::vector<std::pair<T, Event>> parsed_information;
+                ReadDirectoryChangesW(
+                    _directory,
+                    buffer.data(), static_cast<DWORD>(buffer.size()),
+                    TRUE,
+                    _listen_filters,
+                    &bytes_returned,
+                    &overlapped_buffer, NULL);
+
+                async_pending = true;
+
+                switch (WaitForMultipleObjects(2, handles.data(), FALSE, INFINITE))
+                {
+                case WAIT_OBJECT_0:
+                {
+                    if (!GetOverlappedResult(_directory, &overlapped_buffer, &bytes_returned, TRUE)) {
+                        throw std::system_error(GetLastError(), std::system_category());
+                    }
+                    async_pending = false;
 
                     // Get current time
                     _WIN32_FILE_ATTRIBUTE_DATA att;
@@ -396,109 +396,109 @@ namespace filewatch {
                                 std::ratio_multiply<std::hecto, typename std::chrono::nanoseconds::period>>(
                                     reinterpret_cast<ULARGE_INTEGER*>(&att.ftLastWriteTime)->QuadPart - base_.first.QuadPart);
 
-					if (bytes_returned == 0 || current_time == last_write_time_) {
-						break;
-					}
+                    if (bytes_returned == 0 || current_time == last_write_time_) {
+                        break;
+                    }
 
-					FILE_NOTIFY_INFORMATION *file_information = reinterpret_cast<FILE_NOTIFY_INFORMATION*>(&buffer[0]);
-					do
-					{
-						std::wstring changed_file_w{ file_information->FileName, file_information->FileNameLength / sizeof(file_information->FileName[0]) };
-						UnderpinningString changed_file;
-						convert_wstring(changed_file_w, changed_file);
-						if (pass_filter(changed_file))
-						{
-							parsed_information.emplace_back(T{ changed_file }, _event_type_mapping.at(file_information->Action));
-						}
+                    FILE_NOTIFY_INFORMATION *file_information = reinterpret_cast<FILE_NOTIFY_INFORMATION*>(&buffer[0]);
+                    do
+                    {
+                        std::wstring changed_file_w{ file_information->FileName, file_information->FileNameLength / sizeof(file_information->FileName[0]) };
+                        UnderpinningString changed_file;
+                        convert_wstring(changed_file_w, changed_file);
+                        if (pass_filter(changed_file))
+                        {
+                            parsed_information.emplace_back(T{ changed_file }, _event_type_mapping.at(file_information->Action));
+                        }
 
-						last_write_time_ = current_time;
+                        last_write_time_ = current_time;
 
-						if (file_information->NextEntryOffset == 0) {
-							break;
-						}
+                        if (file_information->NextEntryOffset == 0) {
+                            break;
+                        }
 
-						file_information = reinterpret_cast<FILE_NOTIFY_INFORMATION*>(reinterpret_cast<BYTE*>(file_information) + file_information->NextEntryOffset);
-					} while (true);
-					break;
-				}
-				case WAIT_OBJECT_0 + 1:
-					// quit
-					break;
-				case WAIT_FAILED:
-					break;
-				}
-				//dispatch callbacks
-				{
-					std::lock_guard<std::mutex> lock(_callback_mutex);
-					_callback_information.insert(_callback_information.end(), parsed_information.begin(), parsed_information.end());
-				}
-				_cv.notify_all();
-			} while (_destory == false);
+                        file_information = reinterpret_cast<FILE_NOTIFY_INFORMATION*>(reinterpret_cast<BYTE*>(file_information) + file_information->NextEntryOffset);
+                    } while (true);
+                    break;
+                }
+                case WAIT_OBJECT_0 + 1:
+                    // quit
+                    break;
+                case WAIT_FAILED:
+                    break;
+                }
+                //dispatch callbacks
+                {
+                    std::lock_guard<std::mutex> lock(_callback_mutex);
+                    _callback_information.insert(_callback_information.end(), parsed_information.begin(), parsed_information.end());
+                }
+                _cv.notify_all();
+            } while (_destory == false);
 
-			if (async_pending)
-			{
-				//clean up running async io
-				CancelIo(_directory);
-				GetOverlappedResult(_directory, &overlapped_buffer, &bytes_returned, TRUE);
-			}
-		}
+            if (async_pending)
+            {
+                //clean up running async io
+                CancelIo(_directory);
+                GetOverlappedResult(_directory, &overlapped_buffer, &bytes_returned, TRUE);
+            }
+        }
 #endif // WIN32
 
 #if __unix__
 
-		bool is_file(const T& path) const
-		{
-			struct stat statbuf = {};
-			if (stat(path.c_str(), &statbuf) != 0)
-			{
-				throw std::system_error(errno, std::system_category());
-			}
-			return S_ISREG(statbuf.st_mode);
-		}
+        bool is_file(const T& path) const
+        {
+            struct stat statbuf = {};
+            if (stat(path.c_str(), &statbuf) != 0)
+            {
+                throw std::system_error(errno, std::system_category());
+            }
+            return S_ISREG(statbuf.st_mode);
+        }
 
-		FolderInfo get_directory(const T& path) 
-		{
-			const auto folder = inotify_init();
-			if (folder < 0) 
-			{
-				throw std::system_error(errno, std::system_category());
-			}
-			//const auto listen_filters = _listen_filters;
+        FolderInfo get_directory(const T& path)
+        {
+            const auto folder = inotify_init();
+            if (folder < 0)
+            {
+                throw std::system_error(errno, std::system_category());
+            }
+            //const auto listen_filters = _listen_filters;
 
-			_watching_single_file = is_file(path);
+            _watching_single_file = is_file(path);
 
-			const T watch_path = [this, &path]() {
-				if (_watching_single_file)
-				{
-					const auto parsed_path = split_directory_and_file(path);
-					_filename = parsed_path.filename;
-					return parsed_path.directory;
-				}
-				else
-				{
-					return path;
-				}
-			}();
+            const T watch_path = [this, &path]() {
+                if (_watching_single_file)
+                {
+                    const auto parsed_path = split_directory_and_file(path);
+                    _filename = parsed_path.filename;
+                    return parsed_path.directory;
+                }
+                else
+                {
+                    return path;
+                }
+            }();
 
-			const auto watch = inotify_add_watch(folder, watch_path.c_str(), IN_MODIFY | IN_CREATE | IN_DELETE );
-			if (watch < 0) 
-			{
-				throw std::system_error(errno, std::system_category());
-			}
+            const auto watch = inotify_add_watch(folder, watch_path.c_str(), IN_MODIFY | IN_CREATE | IN_DELETE );
+            if (watch < 0)
+            {
+                throw std::system_error(errno, std::system_category());
+            }
 
-			init_last_write_time();
+            init_last_write_time();
 
-			return { folder, watch };
-		}
+            return { folder, watch };
+        }
 
-		void monitor_directory() 
-		{
-			std::vector<char> buffer(_buffer_size);
+        void monitor_directory()
+        {
+            std::vector<char> buffer(_buffer_size);
 
-			_running.set_value();
-			while (_destory == false) 
-			{
-				const auto length = read(_directory.folder, static_cast<void*>(buffer.data()), buffer.size());
+            _running.set_value();
+            while (_destory == false)
+            {
+                const auto length = read(_directory.folder, static_cast<void*>(buffer.data()), buffer.size());
 
                 struct stat result;
                 stat(_path.c_str(), &result);
@@ -507,81 +507,81 @@ namespace filewatch {
                 current_time += std::chrono::seconds(result.st_mtim.tv_sec);
                 current_time += std::chrono::nanoseconds(result.st_mtim.tv_nsec);
 
-				if (length > 0 && current_time != last_write_time_)
-				{
-					int i = 0;
-					last_write_time_ = current_time;
-					std::vector<std::pair<T, Event>> parsed_information;
-					bool already_modified = false;
-					while (i < length) 
-					{
-						struct inotify_event *event = reinterpret_cast<struct inotify_event *>(&buffer[i]); // NOLINT
-						if (event->len) 
-						{
-							const UnderpinningString changed_file{ event->name };
-							if (pass_filter(changed_file))
-							{
-								if (event->mask & IN_CREATE) 
-								{
-									parsed_information.emplace_back(T{ changed_file }, Event::added);
-								}
-								else if (event->mask & IN_DELETE) 
-								{
-									parsed_information.emplace_back(T{ changed_file }, Event::removed);
-								}
-								else if (event->mask & IN_MODIFY && !already_modified)
-								{
-									already_modified = true;
-									parsed_information.emplace_back(T{ changed_file }, Event::modified);
-								}
-							}
-						}
-						i += event_size + event->len;
-					}
-					//dispatch callbacks
-					{
-						std::lock_guard<std::mutex> lock(_callback_mutex);
-						_callback_information.insert(_callback_information.end(), parsed_information.begin(), parsed_information.end());
-					}
-					_cv.notify_all();
-				}
-			}
-		}
+                if (length > 0 && current_time != last_write_time_)
+                {
+                    int i = 0;
+                    last_write_time_ = current_time;
+                    std::vector<std::pair<T, Event>> parsed_information;
+                    bool already_modified = false;
+                    while (i < length)
+                    {
+                        struct inotify_event *event = reinterpret_cast<struct inotify_event *>(&buffer[i]); // NOLINT
+                        if (event->len)
+                        {
+                            const UnderpinningString changed_file{ event->name };
+                            if (pass_filter(changed_file))
+                            {
+                                if (event->mask & IN_CREATE)
+                                {
+                                    parsed_information.emplace_back(T{ changed_file }, Event::added);
+                                }
+                                else if (event->mask & IN_DELETE)
+                                {
+                                    parsed_information.emplace_back(T{ changed_file }, Event::removed);
+                                }
+                                else if (event->mask & IN_MODIFY && !already_modified)
+                                {
+                                    already_modified = true;
+                                    parsed_information.emplace_back(T{ changed_file }, Event::modified);
+                                }
+                            }
+                        }
+                        i += event_size + event->len;
+                    }
+                    //dispatch callbacks
+                    {
+                        std::lock_guard<std::mutex> lock(_callback_mutex);
+                        _callback_information.insert(_callback_information.end(), parsed_information.begin(), parsed_information.end());
+                    }
+                    _cv.notify_all();
+                }
+            }
+        }
 #endif // __unix__
 
-		void callback_thread()
-		{
-			while (_destory == false) {
-				std::unique_lock<std::mutex> lock(_callback_mutex);
-				if (_callback_information.empty() && _destory == false) {
-					_cv.wait(lock, [this] { return _callback_information.size() > 0 || _destory; });
-				}
-				decltype(_callback_information) callback_information = {};
-				std::swap(callback_information, _callback_information);
-				lock.unlock();
+        void callback_thread()
+        {
+            while (_destory == false) {
+                std::unique_lock<std::mutex> lock(_callback_mutex);
+                if (_callback_information.empty() && _destory == false) {
+                    _cv.wait(lock, [this] { return _callback_information.size() > 0 || _destory; });
+                }
+                decltype(_callback_information) callback_information = {};
+                std::swap(callback_information, _callback_information);
+                lock.unlock();
 
-				for (const auto& file : callback_information) {
-					if (_callback) {
-						try
-						{
-							_callback(file.first, file.second);
-						}
-						catch (const std::exception&)
-						{
-						}
-					}
-				}
-			}
-		}
+                for (const auto& file : callback_information) {
+                    if (_callback) {
+                        try
+                        {
+                            _callback(file.first, file.second);
+                        }
+                        catch (const std::exception&)
+                        {
+                        }
+                    }
+                }
+            }
+        }
 
-		void init_last_write_time()
-		{
+        void init_last_write_time()
+        {
 #ifdef _WIN32
             // Define epoch reference
             GetSystemTimeAsFileTime((LPFILETIME)&base_.first);
             base_.second = std::chrono::system_clock::now();
 
-			// Initialize last_write_time_
+            // Initialize last_write_time_
             _WIN32_FILE_ATTRIBUTE_DATA att;
             GetFileAttributesExA(_path.c_str(), GetFileExInfoStandard, &att);
 
@@ -591,18 +591,18 @@ namespace filewatch {
                         std::ratio_multiply<std::hecto, typename std::chrono::nanoseconds::period>>(
                             reinterpret_cast<ULARGE_INTEGER*>(&att.ftLastWriteTime)->QuadPart - base_.first.QuadPart);
 #else
-			// Initialize last_write_time_
+            // Initialize last_write_time_
             struct stat result;
             stat(_path.c_str(), &result);
 
             last_write_time_ += std::chrono::seconds(result.st_mtim.tv_sec);
             last_write_time_ += std::chrono::nanoseconds(result.st_mtim.tv_nsec);
 #endif
-		}
+        }
 
-	};
+    };
 
-	template<class T> constexpr typename FileWatch<T>::C FileWatch<T>::_regex_all[];
-	template<class T> constexpr typename FileWatch<T>::C FileWatch<T>::_this_directory[];
+    template<class T> constexpr typename FileWatch<T>::C FileWatch<T>::_regex_all[];
+    template<class T> constexpr typename FileWatch<T>::C FileWatch<T>::_this_directory[];
 }
 #endif


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR must be merged after #2730.

This PR fixes Thread Sanitizer issues 4135 and its equivalents.

This deadlock is caused by having the PDP lock taken when iterating over the DiscoveryServer list calling `match_pdp_reader_nts_`, which in turn calls `matched_reader_add_`, locking the Writer lock.
As seen in previous Sanitizer issues, these two locks should be taken in reverse order: Writer first then PDP. When a participant is enabled, it takes the mutexes in the proper order, leading to a deadlock.

The deadlock occurs as follows:

`PDPServer::createPDPEndpoints` (A) -> `StatefulWriter::matched_reader_add` (B)
`PDPServer::announceParticipantState` (B) -> `PDPServer::announceParticipantState` (A)

Since the second pair of locks cannot be reversed due to the previous rule. to prevent this issue the use of the PDP mutex is phased out in favor of a new shared_mutex inside the BuildinProtocols header to control access to DIscoveryServer list. This allows the replacement of some PDP locks by new shared_lock calls.

### Collateral extra works

As a piggyback the `FileWatch` mechanism to load the *Discovery Server List* from a file was revamped.
This was unavoidable because some `FileWatch` related tests failed as a consequence of the synchronization changes.
To summarize the changes:
+ `FileWatch` detection granularity now matches the `chrono::system_clock` one in each OS.
+ `FileWatch` filtering of redundant callbacks has been improved using file size besides last write time.
+ An new test has been added to test a hotfix in the *Discovery Server List* update mechanism.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->



## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
