### PR TITLE
Changes for iOS build possible.

### DIFF
--- a/src/cpp/utils/IPFinder.cpp
+++ b/src/cpp/utils/IPFinder.cpp
@@ -40,9 +40,14 @@
 #include <string.h>
 #include <net/if.h>
 #include <sys/ioctl.h>
+#if !defined(__APPLE__)
 #include <net/if_arp.h>
+#endif // if defined(__APPLE__)
 #include <errno.h>
 #if defined(__APPLE__)
+#if !__is_target_os(ios)
+#include <net/if_arp.h>
+#endif
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #include <net/if_dl.h>
@@ -272,6 +277,15 @@ bool IPFinder::getAllMACAddress(
 
 #elif defined(__APPLE__)
 
+#if __is_target_os(ios)
+bool IPFinder::getAllMACAddress(
+        std::vector<info_MAC>* macs)
+{
+    return false;
+}
+
+#else
+
 bool IPFinder::getAllMACAddress(
         std::vector<info_MAC>* macs)
 {
@@ -325,6 +339,7 @@ bool IPFinder::getAllMACAddress(
     }
     return true;
 }
+#endif
 
 #elif defined(__linux__)
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
Changes for iOS build possible.

## Description
Since iOS 11 Apple doesn't allow apps to access the MAC addresses in the ARP table. So in iOS IPFinder::getAllMACAddress function always return false and code fallback to make id from ip address.
## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
