### PR TITLE
[14813] WaitSet deadlock fix <master>

### DIFF
--- a/include/fastdds/rtps/builtin/discovery/endpoint/EDP.h
+++ b/include/fastdds/rtps/builtin/discovery/endpoint/EDP.h
@@ -21,14 +21,15 @@
 #define _FASTDDS_RTPS_EDP_H_
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
+#include <fastdds/dds/core/status/IncompatibleQosStatus.hpp>
+#include <fastdds/dds/core/status/PublicationMatchedStatus.hpp>
+#include <fastdds/dds/core/status/SubscriptionMatchedStatus.hpp>
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
 #include <fastdds/rtps/builtin/data/ContentFilterProperty.hpp>
 #include <fastdds/rtps/builtin/data/ReaderProxyData.h>
 #include <fastdds/rtps/builtin/data/WriterProxyData.h>
 #include <fastdds/rtps/common/Guid.h>
-#include <fastdds/dds/core/status/PublicationMatchedStatus.hpp>
-#include <fastdds/dds/core/status/SubscriptionMatchedStatus.hpp>
-#include <fastdds/dds/core/status/IncompatibleQosStatus.hpp>
+#include <fastrtps/utils/ProxyPool.hpp>
 
 #include <foonathan/memory/container.hpp>
 #include <foonathan/memory/memory_pool.hpp>
@@ -347,6 +348,18 @@ public:
     //! Pointer to the RTPSParticipant.
     RTPSParticipantImpl* mp_RTPSParticipant;
 
+    /**
+     * Access the temporary proxy pool for reader proxies
+     * @return pool reference
+     */
+    ProxyPool<ReaderProxyData>& get_temporary_reader_proxies_pool();
+
+    /**
+     * Access the temporary proxy pool for writer proxies
+     * @return pool reference
+     */
+    ProxyPool<WriterProxyData>& get_temporary_writer_proxies_pool();
+
 private:
 
     /**
@@ -395,9 +408,6 @@ private:
     bool hasTypeObject(
             const WriterProxyData* wdata,
             const ReaderProxyData* rdata) const;
-
-    ReaderProxyData temp_reader_proxy_data_;
-    WriterProxyData temp_writer_proxy_data_;
 
     using pool_allocator_t =
             foonathan::memory::memory_pool<foonathan::memory::node_pool, foonathan::memory::heap_allocator>;

--- a/include/fastdds/rtps/builtin/discovery/endpoint/EDPSimple.h
+++ b/include/fastdds/rtps/builtin/discovery/endpoint/EDPSimple.h
@@ -263,12 +263,6 @@ private:
             const GUID_t& local_writer,
             const ReaderProxyData& remote_reader_data) override;
 #endif // if HAVE_SECURITY
-
-protected:
-
-    std::mutex temp_data_lock_;
-    ReaderProxyData temp_reader_proxy_data_;
-    WriterProxyData temp_writer_proxy_data_;
 };
 
 } /* namespace rtps */

--- a/include/fastdds/rtps/builtin/discovery/participant/PDP.h
+++ b/include/fastdds/rtps/builtin/discovery/participant/PDP.h
@@ -25,13 +25,14 @@
 #include <mutex>
 #include <functional>
 
-#include <fastdds/rtps/common/Guid.h>
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
 #include <fastdds/rtps/builtin/data/ReaderProxyData.h>
 #include <fastdds/rtps/builtin/data/WriterProxyData.h>
-#include <fastrtps/qos/QosPolicies.h>
-#include <fastrtps/utils/collections/ResourceLimitedVector.hpp>
+#include <fastdds/rtps/common/Guid.h>
 #include <fastdds/rtps/participant/ParticipantDiscoveryInfo.h>
+#include <fastrtps/qos/QosPolicies.h>
+#include <fastrtps/utils/ProxyPool.hpp>
+#include <fastrtps/utils/collections/ResourceLimitedVector.hpp>
 
 namespace eprosima {
 
@@ -357,6 +358,24 @@ public:
      */
     std::list<eprosima::fastdds::rtps::RemoteServerAttributes>& remote_server_attributes();
 
+    /**
+     * Access the temporary proxy pool for reader proxies
+     * @return pool reference
+     */
+    ProxyPool<ReaderProxyData>& get_temporary_reader_proxies_pool()
+    {
+        return temp_reader_proxies_;
+    }
+
+    /**
+     * Access the temporary proxy pool for writer proxies
+     * @return pool reference
+     */
+    ProxyPool<WriterProxyData>& get_temporary_writer_proxies_pool()
+    {
+        return temp_writer_proxies_;
+    }
+
 protected:
 
     //!Pointer to the builtin protocols object.
@@ -397,12 +416,10 @@ protected:
     ReaderHistory* mp_PDPReaderHistory;
     //!Reader payload pool
     std::shared_ptr<ITopicPayloadPool> reader_payload_pool_;
-    //!ReaderProxyData to allow preallocation of remote locators
-    ReaderProxyData temp_reader_data_;
-    //!WriterProxyData to allow preallocation of remote locators
-    WriterProxyData temp_writer_data_;
-    //!To protect temp_writer_data_ and temp_reader_data_
-    std::mutex temp_data_lock_;
+    //! ProxyPool for temporary reader proxies
+    ProxyPool<ReaderProxyData> temp_reader_proxies_;
+    //! ProxyPool for temporary writer proxies
+    ProxyPool<WriterProxyData> temp_writer_proxies_;
     //!Participant data atomic access assurance
     std::recursive_mutex* mp_mutex;
     //!To protect callbacks (ParticipantProxyData&)

--- a/include/fastdds/rtps/common/EntityId_t.hpp
+++ b/include/fastdds/rtps/common/EntityId_t.hpp
@@ -177,6 +177,18 @@ struct RTPS_DllAPI EntityId_t
         return EntityId_t();
     }
 
+    bool is_reader() const
+    {
+        // RTPS Standard table 9.1
+        return 0x4u & to_uint32();
+    }
+
+    bool is_writer() const
+    {
+        // RTPS Standard table 9.1
+        return 0x2u & to_uint32() && !is_reader();
+    }
+
 };
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC

--- a/include/fastrtps/utils/ProxyPool.hpp
+++ b/include/fastrtps/utils/ProxyPool.hpp
@@ -1,0 +1,240 @@
+// Copyright 2022 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*!
+ * @file ProxyPool.hpp
+ */
+
+#ifndef FASTRTPS_UTILS_PROXY_POOL_HPP_
+#define FASTRTPS_UTILS_PROXY_POOL_HPP_
+
+#include <array>
+#include <bitset>
+#include <cassert>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+
+#if defined(__has_include) && __has_include(<version>)
+#   include <version>
+#endif // if defined(__has_include) && __has_include(<version>)
+
+namespace eprosima {
+
+// unnamed namespace for isolation
+namespace {
+
+// Detect if integer_sequence is availalbe
+#if defined(__cpp_lib_integer_sequence) \
+    && ((__cpp_lib_integer_sequence <= _MSVC_LANG) \
+    || (__cpp_lib_integer_sequence <= __cplusplus))
+
+// Array initialization usin C++14
+template<class P, size_t... Ints>
+std::array<P, sizeof...(Ints)> make_array(
+        P&& i,
+        std::index_sequence<Ints...> is)
+{
+    return { (Ints == is.size() - 1 ? std::move(i) : i)...};
+}
+
+template<size_t N, class P>
+std::array<P, N> make_array(
+        P&& i)
+{
+    return make_array<P>(std::move(i), std::make_index_sequence<N>{});
+}
+
+#else // C++11 fallback
+
+template<size_t N, class P, class ... Ts>
+std::array<P, N> make_array(
+        P&& i,
+        Ts&&... args);
+
+template<bool, size_t N, class ... Ts>
+struct make_array_choice
+{
+    template<class P>
+    static std::array<P, N> res(
+            P&& i,
+            Ts&&... args)
+    {
+        P tmp(i);
+        return make_array<N>(std::move(i), std::move(tmp), std::move(args)...);
+    }
+
+};
+
+template<size_t N, class ... Ts>
+struct make_array_choice<true, N, Ts...>
+{
+    template<class P>
+    static std::array<P, N> res(
+            P&& i,
+            Ts&&... args)
+    {
+        return {std::move(i), std::move(args)...};
+    }
+
+};
+
+template<size_t N, class P, class ... Ts>
+std::array<P, N> make_array(
+        P&& i,
+        Ts&&... args)
+{
+    return make_array_choice < N == (sizeof...(Ts) + 1), N, Ts ... > ::res(std::move(i), std::move(args)...);
+}
+
+#endif // defined(__cpp_lib_integer_sequence)
+
+} // namespace
+
+template< class Proxy, std::size_t N = 4>
+class ProxyPool
+{
+    mutable std::mutex mtx_;
+    std::condition_variable cv_;
+    std::array<Proxy, N> heap_;
+    std::bitset<N> mask_;
+
+    // unique_ptr<Proxy> deleters
+    class D
+    {
+        // Because ProxyPool will be destroy after all the proxies are returned
+        // this reference is always valid
+        ProxyPool& pool_;
+
+        friend class ProxyPool;
+
+        D(
+                ProxyPool* pool)
+            : pool_(*pool)
+        {
+        }
+
+    public:
+
+        void operator ()(
+                Proxy* p) const
+        {
+            pool_.set_back(p);
+        }
+
+    }
+    deleter_;
+
+    friend class D;
+
+    /*
+     * Return an available proxy to the pool.
+     * @param p pointer to the proxy.
+     */
+    void set_back(
+            Proxy* p) noexcept
+    {
+        std::size_t idx = p - heap_.data();
+
+        std::lock_guard<std::mutex> _(mtx_);
+
+        // check is not there
+        assert(!mask_.test(idx));
+
+        // return the resource
+        mask_.set(idx);
+    }
+
+public:
+
+    using smart_ptr = std::unique_ptr<Proxy, D&>;
+
+    /*
+     * Constructor of the pool object.
+     * @param init Initialization value for all the proxies.
+     */
+    ProxyPool(
+            Proxy&& init)
+        : heap_(make_array<N>(std::move(init)))
+        , deleter_(this)
+    {
+        // make all resources available
+        mask_.set();
+    }
+
+    /*
+     * Destructor for the pool object.
+     * It waits till all the proxies are back in the pool to prevent data races.
+     */
+    ~ProxyPool()
+    {
+        std::unique_lock<std::mutex> lock(mtx_);
+        cv_.wait(lock, [&]()
+                {
+                    return mask_.all();
+                });
+    }
+
+    /*
+     * Returns the number of proxies in the pool.
+     * @return pool size
+     */
+    static constexpr std::size_t size()
+    {
+        return N;
+    }
+
+    /*
+     * Returns the number of proxies available in the pool.
+     * @return available proxies
+     */
+    std::size_t available() const noexcept
+    {
+        std::lock_guard<std::mutex> _(mtx_);
+        return mask_.count();
+    }
+
+    /*
+     * Retrieve an available proxy from the pool.
+     * If not available a wait ensues.
+     * Note deleter is referenced not copied to avoid heap allocations on smart pointer construction
+     * @return unique_ptr referencing the proxy. On destruction the resource is returned.
+     */
+    std::unique_ptr<Proxy, D&> get()
+    {
+        std::unique_lock<std::mutex> lock(mtx_);
+
+        // wait for available resources
+        cv_.wait(lock, [&]()
+                {
+                    return mask_.any();
+                });
+
+        // find the first available
+        std::size_t idx = 0;
+        while (idx < mask_.size() && !mask_.test(idx))
+        {
+            ++idx;
+        }
+
+        // retrieve it
+        mask_.reset(idx);
+        return std::unique_ptr<Proxy, D&>(&heap_[idx], deleter_);
+    }
+
+};
+
+} // eprosima namespace
+
+#endif /* FASTRTPS_UTILS_PROXY_POOL_HPP_ */

--- a/src/cpp/fastdds/builtin/typelookup/TypeLookupManager.cpp
+++ b/src/cpp/fastdds/builtin/typelookup/TypeLookupManager.cpp
@@ -105,19 +105,19 @@ TypeLookupManager::~TypeLookupManager()
      */
     if (nullptr != builtin_reply_reader_)
     {
-        participant_->deleteUserEndpoint(builtin_reply_reader_);
+        participant_->deleteUserEndpoint(builtin_reply_reader_->getGuid());
     }
     if (nullptr != builtin_reply_writer_)
     {
-        participant_->deleteUserEndpoint(builtin_reply_writer_);
+        participant_->deleteUserEndpoint(builtin_reply_writer_->getGuid());
     }
     if (nullptr != builtin_request_reader_)
     {
-        participant_->deleteUserEndpoint(builtin_request_reader_);
+        participant_->deleteUserEndpoint(builtin_request_reader_->getGuid());
     }
     if (nullptr != builtin_request_writer_)
     {
-        participant_->deleteUserEndpoint(builtin_request_writer_);
+        participant_->deleteUserEndpoint(builtin_request_writer_->getGuid());
     }
     delete builtin_request_writer_history_;
     delete builtin_reply_writer_history_;

--- a/src/cpp/fastdds/core/condition/WaitSetImpl.cpp
+++ b/src/cpp/fastdds/core/condition/WaitSetImpl.cpp
@@ -61,10 +61,15 @@ ReturnCode_t WaitSetImpl::attach_condition(
         // This is a new condition. Inform the notifier of our interest.
         condition.get_notifier()->attach_to(this);
 
-        // Should wake_up when adding a new triggered condition
-        if (is_waiting_ && condition.get_trigger_value())
         {
-            wake_up();
+            // Might happen that a wait changes is_waiting_'s status. Protect it.
+            std::lock_guard<std::mutex> guard(mutex_);
+
+            // Should wake_up when adding a new triggered condition
+            if (is_waiting_ && condition.get_trigger_value())
+            {
+                wake_up();
+            }
         }
     }
 

--- a/src/cpp/fastdds/core/condition/WaitSetImpl.cpp
+++ b/src/cpp/fastdds/core/condition/WaitSetImpl.cpp
@@ -46,9 +46,15 @@ WaitSetImpl::~WaitSetImpl()
 ReturnCode_t WaitSetImpl::attach_condition(
         const Condition& condition)
 {
-    std::lock_guard<std::mutex> guard(mutex_);
-    bool was_there = entries_.remove(&condition);
-    entries_.emplace_back(&condition);
+    bool was_there = false;
+
+    {
+        // We only need to protect access to the collection.
+        std::lock_guard<std::mutex> guard(mutex_);
+
+        was_there = entries_.remove(&condition);
+        entries_.emplace_back(&condition);
+    }
 
     if (!was_there)
     {
@@ -68,8 +74,13 @@ ReturnCode_t WaitSetImpl::attach_condition(
 ReturnCode_t WaitSetImpl::detach_condition(
         const Condition& condition)
 {
-    std::lock_guard<std::mutex> guard(mutex_);
-    bool was_there = entries_.remove(&condition);
+    bool was_there = false;
+
+    {
+        // We only need to protect access to the collection.
+        std::lock_guard<std::mutex> guard(mutex_);
+        was_there = entries_.remove(&condition);
+    }
 
     if (was_there)
     {

--- a/src/cpp/fastdds/publisher/qos/WriterQos.cpp
+++ b/src/cpp/fastdds/publisher/qos/WriterQos.cpp
@@ -78,7 +78,7 @@ void WriterQos::setQos(
         m_destinationOrder = qos.m_destinationOrder;
         m_destinationOrder.hasChanged = true;
     }
-    if (m_userData.data_vec() != qos.m_userData.data_vec())
+    if (first_time || m_userData.data_vec() != qos.m_userData.data_vec())
     {
         m_userData = qos.m_userData;
         m_userData.hasChanged = true;
@@ -95,18 +95,18 @@ void WriterQos::setQos(
         m_presentation = qos.m_presentation;
         m_presentation.hasChanged = true;
     }
-    if (qos.m_partition.names().size() > 0)
+    if (first_time || qos.m_partition.names().size() > 0)
     {
         m_partition = qos.m_partition;
         m_partition.hasChanged = true;
     }
 
-    if (m_topicData.getValue() != qos.m_topicData.getValue())
+    if (first_time || m_topicData.getValue() != qos.m_topicData.getValue())
     {
         m_topicData = qos.m_topicData;
         m_topicData.hasChanged = true;
     }
-    if (m_groupData.getValue() != qos.m_groupData.getValue())
+    if (first_time || m_groupData.getValue() != qos.m_groupData.getValue())
     {
         m_groupData = qos.m_groupData;
         m_groupData.hasChanged = true;

--- a/src/cpp/fastdds/subscriber/qos/ReaderQos.cpp
+++ b/src/cpp/fastdds/subscriber/qos/ReaderQos.cpp
@@ -65,7 +65,7 @@ void ReaderQos::setQos(
         m_destinationOrder = qos.m_destinationOrder;
         m_destinationOrder.hasChanged = true;
     }
-    if (m_userData.data_vec() != qos.m_userData.data_vec())
+    if (first_time || m_userData.data_vec() != qos.m_userData.data_vec())
     {
         m_userData = qos.m_userData;
         m_userData.hasChanged = true;
@@ -82,17 +82,17 @@ void ReaderQos::setQos(
         m_presentation = qos.m_presentation;
         m_presentation.hasChanged = true;
     }
-    if (qos.m_partition.names() != m_partition.names())
+    if (first_time || qos.m_partition.names() != m_partition.names())
     {
         m_partition = qos.m_partition;
         m_partition.hasChanged = true;
     }
-    if (m_topicData.getValue() != qos.m_topicData.getValue())
+    if (first_time || m_topicData.getValue() != qos.m_topicData.getValue())
     {
         m_topicData = qos.m_topicData;
         m_topicData.hasChanged = true;
     }
-    if (m_groupData.getValue() != qos.m_groupData.getValue())
+    if (first_time || m_groupData.getValue() != qos.m_groupData.getValue())
     {
         m_groupData = qos.m_groupData;
         m_groupData.hasChanged = true;

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -362,7 +362,7 @@ bool RTPSDomain::removeRTPSWriter(
             {
                 t_p_RTPSParticipant participant = *it;
                 lock.unlock();
-                return participant.second->deleteUserEndpoint((Endpoint*)writer);
+                return participant.second->deleteUserEndpoint(writer->getGuid());
             }
         }
     }
@@ -438,7 +438,7 @@ bool RTPSDomain::removeRTPSReader(
             {
                 t_p_RTPSParticipant participant = *it;
                 lock.unlock();
-                return participant.second->deleteUserEndpoint((Endpoint*)reader);
+                return participant.second->deleteUserEndpoint(reader->getGuid());
             }
         }
     }

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
@@ -74,15 +74,6 @@ EDP::EDP(
         RTPSParticipantImpl* part)
     : mp_PDP(p)
     , mp_RTPSParticipant(part)
-    , temp_reader_proxy_data_(
-        part->getRTPSParticipantAttributes().allocation.locators.max_unicast_locators,
-        part->getRTPSParticipantAttributes().allocation.locators.max_multicast_locators,
-        part->getRTPSParticipantAttributes().allocation.data_limits,
-        part->getRTPSParticipantAttributes().allocation.content_filter)
-    , temp_writer_proxy_data_(
-        part->getRTPSParticipantAttributes().allocation.locators.max_unicast_locators,
-        part->getRTPSParticipantAttributes().allocation.locators.max_multicast_locators,
-        part->getRTPSParticipantAttributes().allocation.data_limits)
     , reader_status_allocator_(
         reader_map_helper::node_size,
         reader_map_helper::min_pool_size<pool_allocator_t>(
@@ -569,32 +560,34 @@ bool EDP::unpairWriterProxy(
 
     logInfo(RTPS_EDP, writer_guid);
 
-    std::lock_guard<std::recursive_mutex> guard(*mp_RTPSParticipant->getParticipantMutex());
-    for (std::vector<RTPSReader*>::iterator rit = mp_RTPSParticipant->userReadersListBegin();
-            rit != mp_RTPSParticipant->userReadersListEnd(); ++rit)
-    {
-        if ((*rit)->matched_writer_remove(writer_guid, removed_by_lease))
-        {
-            const GUID_t& reader_guid = (*rit)->getGuid();
+    mp_RTPSParticipant->forEachUserReader([&, removed_by_lease](RTPSReader& r) -> bool
+            {
+                if (r.matched_writer_remove(writer_guid, removed_by_lease))
+                {
+                    const GUID_t& reader_guid = r.getGuid();
 #if HAVE_SECURITY
-            mp_RTPSParticipant->security_manager().remove_writer(reader_guid,
+                    mp_RTPSParticipant->security_manager().remove_writer(reader_guid,
                     participant_guid, writer_guid);
 #endif // if HAVE_SECURITY
 
-            //MATCHED AND ADDED CORRECTLY:
-            if ((*rit)->getListener() != nullptr)
-            {
-                MatchingInfo info;
-                info.status = REMOVED_MATCHING;
-                info.remoteEndpointGuid = writer_guid;
-                (*rit)->getListener()->onReaderMatched((*rit), info);
+                    //MATCHED AND ADDED CORRECTLY:
+                    if (r.getListener() != nullptr)
+                    {
+                        MatchingInfo info;
+                        info.status = REMOVED_MATCHING;
+                        info.remoteEndpointGuid = writer_guid;
+                        r.getListener()->onReaderMatched(&r, info);
 
-                const SubscriptionMatchedStatus& sub_info =
+                        const SubscriptionMatchedStatus& sub_info =
                         update_subscription_matched_status(reader_guid, writer_guid, -1);
-                (*rit)->getListener()->onReaderMatched((*rit), sub_info);
-            }
-        }
-    }
+                        r.getListener()->onReaderMatched(&r, sub_info);
+                    }
+                }
+
+                // traverse all
+                return true;
+            });
+
     return true;
 }
 
@@ -606,31 +599,33 @@ bool EDP::unpairReaderProxy(
 
     logInfo(RTPS_EDP, reader_guid);
 
-    std::lock_guard<std::recursive_mutex> guard(*mp_RTPSParticipant->getParticipantMutex());
-    for (std::vector<RTPSWriter*>::iterator wit = mp_RTPSParticipant->userWritersListBegin();
-            wit != mp_RTPSParticipant->userWritersListEnd(); ++wit)
-    {
-        if ((*wit)->matched_reader_remove(reader_guid))
-        {
-            const GUID_t& writer_guid = (*wit)->getGuid();
+    mp_RTPSParticipant->forEachUserWriter([&](RTPSWriter& w) -> bool
+            {
+                if (w.matched_reader_remove(reader_guid))
+                {
+                    const GUID_t& writer_guid = w.getGuid();
 #if HAVE_SECURITY
-            mp_RTPSParticipant->security_manager().remove_reader(writer_guid,
+                    mp_RTPSParticipant->security_manager().remove_reader(writer_guid,
                     participant_guid, reader_guid);
 #endif // if HAVE_SECURITY
-            //MATCHED AND ADDED CORRECTLY:
-            if ((*wit)->getListener() != nullptr)
-            {
-                MatchingInfo info;
-                info.status = REMOVED_MATCHING;
-                info.remoteEndpointGuid = reader_guid;
-                (*wit)->getListener()->onWriterMatched((*wit), info);
+                    //MATCHED AND ADDED CORRECTLY:
+                    if (w.getListener() != nullptr)
+                    {
+                        MatchingInfo info;
+                        info.status = REMOVED_MATCHING;
+                        info.remoteEndpointGuid = reader_guid;
+                        w.getListener()->onWriterMatched(&w, info);
 
-                const PublicationMatchedStatus& pub_info =
+                        const PublicationMatchedStatus& pub_info =
                         update_publication_matched_status(reader_guid, writer_guid, -1);
-                (*wit)->getListener()->onWriterMatched((*wit), pub_info);
-            }
-        }
-    }
+                        w.getListener()->onWriterMatched(&w, pub_info);
+                    }
+                }
+
+                // traverse all
+                return true;
+            });
+
     return true;
 }
 
@@ -1033,7 +1028,19 @@ bool EDP::valid_matching(
 
 }
 
-//TODO Estas cuatro funciones comparten codigo comun (2 a 2) y se podrían seguramente combinar.
+ProxyPool<ReaderProxyData>& EDP::get_temporary_reader_proxies_pool()
+{
+    assert(mp_PDP != nullptr);
+    return mp_PDP->get_temporary_reader_proxies_pool();
+}
+
+ProxyPool<WriterProxyData>& EDP::get_temporary_writer_proxies_pool()
+{
+    assert(mp_PDP != nullptr);
+    return mp_PDP->get_temporary_writer_proxies_pool();
+}
+
+//TODO This four functions share common code (2 to 2) and surely can be templatized.
 
 bool EDP::pairingReader(
         RTPSReader* R,
@@ -1220,80 +1227,82 @@ bool EDP::pairing_reader_proxy_with_any_local_writer(
     (void)participant_guid;
 
     logInfo(RTPS_EDP, rdata->guid() << " in topic: \"" << rdata->topicName() << "\"");
-    std::lock_guard<std::recursive_mutex> pguard(*mp_PDP->getMutex());
-    std::lock_guard<std::recursive_mutex> guard(*mp_RTPSParticipant->getParticipantMutex());
-    for (std::vector<RTPSWriter*>::iterator wit = mp_RTPSParticipant->userWritersListBegin();
-            wit != mp_RTPSParticipant->userWritersListEnd(); ++wit)
-    {
-        (*wit)->getMutex().lock();
-        GUID_t writerGUID = (*wit)->getGuid();
-        (*wit)->getMutex().unlock();
-        if (mp_PDP->lookupWriterProxyData(writerGUID, temp_writer_proxy_data_))
-        {
-            MatchingFailureMask no_match_reason;
-            fastdds::dds::PolicyMask incompatible_qos;
-            bool valid = valid_matching(&temp_writer_proxy_data_, rdata, no_match_reason, incompatible_qos);
-            const GUID_t& reader_guid = rdata->guid();
 
-            if (valid)
+    mp_RTPSParticipant->forEachUserWriter([&, rdata](RTPSWriter& w) -> bool
             {
-#if HAVE_SECURITY
-                if (!mp_RTPSParticipant->security_manager().discovered_reader(writerGUID, participant_guid,
-                        *rdata, (*wit)->getAttributes().security_attributes()))
+                auto temp_writer_proxy_data = get_temporary_writer_proxies_pool().get();
+                GUID_t writerGUID = w.getGuid();
+
+                if (mp_PDP->lookupWriterProxyData(writerGUID, *temp_writer_proxy_data))
                 {
-                    logError(RTPS_EDP, "Security manager returns an error for writer " << writerGUID);
-                }
+                    MatchingFailureMask no_match_reason;
+                    fastdds::dds::PolicyMask incompatible_qos;
+                    bool valid = valid_matching(temp_writer_proxy_data.get(), rdata, no_match_reason, incompatible_qos);
+                    const GUID_t& reader_guid = rdata->guid();
+
+                    temp_writer_proxy_data.reset();
+
+                    if (valid)
+                    {
+#if HAVE_SECURITY
+                        if (!mp_RTPSParticipant->security_manager().discovered_reader(writerGUID, participant_guid,
+                        *rdata, w.getAttributes().security_attributes()))
+                        {
+                            logError(RTPS_EDP, "Security manager returns an error for writer " << writerGUID);
+                        }
 #else
-                if ((*wit)->matched_reader_add(*rdata))
-                {
-                    logInfo(RTPS_EDP_MATCH,
-                            "RP:" << rdata->guid() << " match W:" << (*wit)->getGuid() << ". RLoc:" <<
-                            rdata->remote_locators());
-                    //MATCHED AND ADDED CORRECTLY:
-                    if ((*wit)->getListener() != nullptr)
-                    {
-                        MatchingInfo info;
-                        info.status = MATCHED_MATCHING;
-                        info.remoteEndpointGuid = reader_guid;
-                        (*wit)->getListener()->onWriterMatched((*wit), info);
+                        if (w.matched_reader_add(*rdata))
+                        {
+                            logInfo(RTPS_EDP_MATCH,
+                            "RP:" << rdata->guid() << " match W:" << w.getGuid() << ". RLoc:" <<
+                                rdata->remote_locators());
+                            //MATCHED AND ADDED CORRECTLY:
+                            if (w.getListener() != nullptr)
+                            {
+                                MatchingInfo info;
+                                info.status = MATCHED_MATCHING;
+                                info.remoteEndpointGuid = reader_guid;
+                                w.getListener()->onWriterMatched(&w, info);
 
-                        const PublicationMatchedStatus& pub_info =
+                                const PublicationMatchedStatus& pub_info =
                                 update_publication_matched_status(reader_guid, writerGUID, 1);
-                        (*wit)->getListener()->onWriterMatched((*wit), pub_info);
+                                w.getListener()->onWriterMatched(&w, pub_info);
+                            }
+                        }
+#endif // if HAVE_SECURITY
                     }
-                }
-#endif // if HAVE_SECURITY
-            }
-            else
-            {
-                if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && (*wit)->getListener() != nullptr)
-                {
-                    (*wit)->getListener()->on_offered_incompatible_qos((*wit), incompatible_qos);
-                }
-
-                if ((*wit)->matched_reader_is_matched(reader_guid)
-                        && (*wit)->matched_reader_remove(reader_guid))
-                {
-#if HAVE_SECURITY
-                    mp_RTPSParticipant->security_manager().remove_reader(
-                        (*wit)->getGuid(), participant_guid, reader_guid);
-#endif // if HAVE_SECURITY
-                    //MATCHED AND ADDED CORRECTLY:
-                    if ((*wit)->getListener() != nullptr)
+                    else
                     {
-                        MatchingInfo info;
-                        info.status = REMOVED_MATCHING;
-                        info.remoteEndpointGuid = reader_guid;
-                        (*wit)->getListener()->onWriterMatched((*wit), info);
+                        if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && w.getListener() != nullptr)
+                        {
+                            w.getListener()->on_offered_incompatible_qos(&w, incompatible_qos);
+                        }
 
-                        const PublicationMatchedStatus& pub_info =
+                        if (w.matched_reader_is_matched(reader_guid)
+                        && w.matched_reader_remove(reader_guid))
+                        {
+#if HAVE_SECURITY
+                            mp_RTPSParticipant->security_manager().remove_reader(
+                                w.getGuid(), participant_guid, reader_guid);
+#endif // if HAVE_SECURITY
+                            //MATCHED AND ADDED CORRECTLY:
+                            if (w.getListener() != nullptr)
+                            {
+                                MatchingInfo info;
+                                info.status = REMOVED_MATCHING;
+                                info.remoteEndpointGuid = reader_guid;
+                                w.getListener()->onWriterMatched(&w, info);
+
+                                const PublicationMatchedStatus& pub_info =
                                 update_publication_matched_status(reader_guid, writerGUID, -1);
-                        (*wit)->getListener()->onWriterMatched((*wit), pub_info);
+                                w.getListener()->onWriterMatched(&w, pub_info);
+                            }
+                        }
                     }
                 }
-            }
-        }
-    }
+                // next iteration
+                return true;
+            });
 
     return true;
 }
@@ -1305,61 +1314,65 @@ bool EDP::pairing_reader_proxy_with_local_writer(
         ReaderProxyData& rdata)
 {
     logInfo(RTPS_EDP, rdata.guid() << " in topic: \"" << rdata.topicName() << "\"");
-    std::lock_guard<std::recursive_mutex> pguard(*mp_PDP->getMutex());
-    std::lock_guard<std::recursive_mutex> guard(*mp_RTPSParticipant->getParticipantMutex());
-    for (std::vector<RTPSWriter*>::iterator wit = mp_RTPSParticipant->userWritersListBegin();
-            wit != mp_RTPSParticipant->userWritersListEnd(); ++wit)
-    {
-        (*wit)->getMutex().lock();
-        GUID_t writerGUID = (*wit)->getGuid();
-        (*wit)->getMutex().unlock();
-        const GUID_t& reader_guid = rdata.guid();
 
-        if (local_writer == writerGUID)
-        {
-            if (mp_PDP->lookupWriterProxyData(writerGUID, temp_writer_proxy_data_))
+    mp_RTPSParticipant->forEachUserWriter([&](RTPSWriter& w) -> bool
             {
-                MatchingFailureMask no_match_reason;
-                fastdds::dds::PolicyMask incompatible_qos;
-                bool valid = valid_matching(&temp_writer_proxy_data_, &rdata, no_match_reason, incompatible_qos);
+                GUID_t writerGUID = w.getGuid();
+                const GUID_t& reader_guid = rdata.guid();
 
-                if (valid)
+                if (local_writer == writerGUID)
                 {
-                    if (!mp_RTPSParticipant->security_manager().discovered_reader(writerGUID,
-                            remote_participant_guid, rdata, (*wit)->getAttributes().security_attributes()))
-                    {
-                        logError(RTPS_EDP, "Security manager returns an error for writer " << writerGUID);
-                    }
-                }
-                else
-                {
-                    if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && (*wit)->getListener() != nullptr)
-                    {
-                        (*wit)->getListener()->on_offered_incompatible_qos((*wit), incompatible_qos);
-                    }
+                    auto temp_writer_proxy_data = get_temporary_writer_proxies_pool().get();
 
-                    if ((*wit)->matched_reader_is_matched(reader_guid)
-                            && (*wit)->matched_reader_remove(reader_guid))
+                    if (mp_PDP->lookupWriterProxyData(writerGUID, *temp_writer_proxy_data))
                     {
-                        mp_RTPSParticipant->security_manager().remove_reader((*wit)->getGuid(),
-                                remote_participant_guid, reader_guid);
-                        //MATCHED AND ADDED CORRECTLY:
-                        if ((*wit)->getListener() != nullptr)
+                        MatchingFailureMask no_match_reason;
+                        fastdds::dds::PolicyMask incompatible_qos;
+                        bool valid = valid_matching(temp_writer_proxy_data.get(), &rdata, no_match_reason,
+                        incompatible_qos);
+
+                        temp_writer_proxy_data.reset();
+
+                        if (valid)
                         {
-                            MatchingInfo info;
-                            info.status = REMOVED_MATCHING;
-                            info.remoteEndpointGuid = reader_guid;
-                            (*wit)->getListener()->onWriterMatched((*wit), info);
+                            if (!mp_RTPSParticipant->security_manager().discovered_reader(writerGUID,
+                            remote_participant_guid, rdata, w.getAttributes().security_attributes()))
+                            {
+                                logError(RTPS_EDP, "Security manager returns an error for writer " << writerGUID);
+                            }
+                        }
+                        else
+                        {
+                            if (no_match_reason.test(MatchingFailureMask::incompatible_qos) &&
+                            w.getListener() != nullptr)
+                            {
+                                w.getListener()->on_offered_incompatible_qos(&w, incompatible_qos);
+                            }
 
-                            const PublicationMatchedStatus& pub_info =
+                            if (w.matched_reader_is_matched(reader_guid)
+                            && w.matched_reader_remove(reader_guid))
+                            {
+                                mp_RTPSParticipant->security_manager().remove_reader(w.getGuid(),
+                                remote_participant_guid, reader_guid);
+                                //MATCHED AND ADDED CORRECTLY:
+                                if (w.getListener() != nullptr)
+                                {
+                                    MatchingInfo info;
+                                    info.status = REMOVED_MATCHING;
+                                    info.remoteEndpointGuid = reader_guid;
+                                    w.getListener()->onWriterMatched(&w, info);
+
+                                    const PublicationMatchedStatus& pub_info =
                                     update_publication_matched_status(reader_guid, writerGUID, -1);
-                            (*wit)->getListener()->onWriterMatched((*wit), pub_info);
+                                    w.getListener()->onWriterMatched(&w, pub_info);
+                                }
+                            }
                         }
                     }
                 }
-            }
-        }
-    }
+                // next iteration
+                return true;
+            });
 
     return true;
 }
@@ -1368,42 +1381,47 @@ bool EDP::pairing_remote_reader_with_local_writer_after_security(
         const GUID_t& local_writer,
         const ReaderProxyData& remote_reader_data)
 {
-    std::lock_guard<std::recursive_mutex> guard(*mp_RTPSParticipant->getParticipantMutex());
-    for (std::vector<RTPSWriter*>::iterator wit = mp_RTPSParticipant->userWritersListBegin();
-            wit != mp_RTPSParticipant->userWritersListEnd(); ++wit)
-    {
-        (*wit)->getMutex().lock();
-        GUID_t writerGUID = (*wit)->getGuid();
-        (*wit)->getMutex().unlock();
-        const GUID_t& reader_guid = remote_reader_data.guid();
+    bool matched = false;
+    bool found = false;
 
-        if (local_writer == writerGUID)
-        {
-            if ((*wit)->matched_reader_add(remote_reader_data))
+    mp_RTPSParticipant->forEachUserWriter([&](RTPSWriter& w) -> bool
             {
-                logInfo(RTPS_EDP, "Valid Matching to local writer: " << writerGUID.entityId);
-                //MATCHED AND ADDED CORRECTLY:
-                if ((*wit)->getListener() != nullptr)
+                GUID_t writerGUID = w.getGuid();
+
+                const GUID_t& reader_guid = remote_reader_data.guid();
+
+                if (local_writer == writerGUID)
                 {
-                    MatchingInfo info;
-                    info.status = MATCHED_MATCHING;
-                    info.remoteEndpointGuid = reader_guid;
-                    (*wit)->getListener()->onWriterMatched((*wit), info);
+                    found = true;
 
+                    if (w.matched_reader_add(remote_reader_data))
+                    {
+                        logInfo(RTPS_EDP, "Valid Matching to local writer: " << writerGUID.entityId);
 
-                    const PublicationMatchedStatus& pub_info =
+                        matched = true;
+
+                        //MATCHED AND ADDED CORRECTLY:
+                        if (w.getListener() != nullptr)
+                        {
+                            MatchingInfo info;
+                            info.status = MATCHED_MATCHING;
+                            info.remoteEndpointGuid = reader_guid;
+                            w.getListener()->onWriterMatched(&w, info);
+
+                            const PublicationMatchedStatus& pub_info =
                             update_publication_matched_status(reader_guid, writerGUID, 1);
-                    (*wit)->getListener()->onWriterMatched((*wit), pub_info);
+                            w.getListener()->onWriterMatched(&w, pub_info);
+                        }
+                    }
+                    // don't look anymore
+                    return false;
                 }
-
+                // keep looking
                 return true;
-            }
+            });
 
-            return false;
-        }
-    }
-
-    return pairing_remote_reader_with_local_builtin_writer_after_security(local_writer, remote_reader_data);
+    return found ? matched : pairing_remote_reader_with_local_builtin_writer_after_security(local_writer,
+                   remote_reader_data);
 }
 
 #endif // if HAVE_SECURITY
@@ -1415,81 +1433,84 @@ bool EDP::pairing_writer_proxy_with_any_local_reader(
     (void)participant_guid;
 
     logInfo(RTPS_EDP, wdata->guid() << " in topic: \"" << wdata->topicName() << "\"");
-    std::lock_guard<std::recursive_mutex> pguard(*mp_PDP->getMutex());
-    std::lock_guard<std::recursive_mutex> guard(*mp_RTPSParticipant->getParticipantMutex());
-    for (std::vector<RTPSReader*>::iterator rit = mp_RTPSParticipant->userReadersListBegin();
-            rit != mp_RTPSParticipant->userReadersListEnd(); ++rit)
-    {
-        GUID_t readerGUID;
-        (*rit)->getMutex().lock();
-        readerGUID = (*rit)->getGuid();
-        (*rit)->getMutex().unlock();
-        if (mp_PDP->lookupReaderProxyData(readerGUID, temp_reader_proxy_data_))
-        {
-            MatchingFailureMask no_match_reason;
-            fastdds::dds::PolicyMask incompatible_qos;
-            bool valid = valid_matching(&temp_reader_proxy_data_, wdata, no_match_reason, incompatible_qos);
-            const GUID_t& writer_guid = wdata->guid();
 
-            if (valid)
+    mp_RTPSParticipant->forEachUserReader([&, wdata](RTPSReader& r) -> bool
             {
-#if HAVE_SECURITY
-                if (!mp_RTPSParticipant->security_manager().discovered_writer(readerGUID, participant_guid,
-                        *wdata, (*rit)->getAttributes().security_attributes()))
+                auto temp_reader_proxy_data = get_temporary_reader_proxies_pool().get();
+                GUID_t readerGUID = r.getGuid();
+
+                if (mp_PDP->lookupReaderProxyData(readerGUID, *temp_reader_proxy_data))
                 {
-                    logError(RTPS_EDP, "Security manager returns an error for reader " << readerGUID);
-                }
+                    MatchingFailureMask no_match_reason;
+                    fastdds::dds::PolicyMask incompatible_qos;
+                    bool valid = valid_matching(temp_reader_proxy_data.get(), wdata, no_match_reason, incompatible_qos);
+                    const GUID_t& writer_guid = wdata->guid();
+
+                    temp_reader_proxy_data.reset();
+
+                    if (valid)
+                    {
+#if HAVE_SECURITY
+                        if (!mp_RTPSParticipant->security_manager().discovered_writer(readerGUID, participant_guid,
+                        *wdata, r.getAttributes().security_attributes()))
+                        {
+                            logError(RTPS_EDP, "Security manager returns an error for reader " << readerGUID);
+                        }
 #else
-                if ((*rit)->matched_writer_add(*wdata))
-                {
-                    logInfo(RTPS_EDP_MATCH,
-                            "WP:" << wdata->guid() << " match R:" << (*rit)->getGuid() << ". WLoc:" <<
-                            wdata->remote_locators());
-                    //MATCHED AND ADDED CORRECTLY:
-                    if ((*rit)->getListener() != nullptr)
-                    {
-                        MatchingInfo info;
-                        info.status = MATCHED_MATCHING;
-                        info.remoteEndpointGuid = writer_guid;
-                        (*rit)->getListener()->onReaderMatched((*rit), info);
+                        if (r.matched_writer_add(*wdata))
+                        {
+                            logInfo(RTPS_EDP_MATCH,
+                            "WP:" << wdata->guid() << " match R:" << r.getGuid() << ". WLoc:" <<
+                                wdata->remote_locators());
+                            //MATCHED AND ADDED CORRECTLY:
+                            if (r.getListener() != nullptr)
+                            {
+                                MatchingInfo info;
+                                info.status = MATCHED_MATCHING;
+                                info.remoteEndpointGuid = writer_guid;
+                                r.getListener()->onReaderMatched(&r, info);
 
 
-                        const SubscriptionMatchedStatus& sub_info =
+                                const SubscriptionMatchedStatus& sub_info =
                                 update_subscription_matched_status(readerGUID, writer_guid, 1);
-                        (*rit)->getListener()->onReaderMatched((*rit), sub_info);
+                                r.getListener()->onReaderMatched(&r, sub_info);
+                            }
+                        }
+#endif // if HAVE_SECURITY
                     }
-                }
-#endif // if HAVE_SECURITY
-            }
-            else
-            {
-                if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && (*rit)->getListener() != nullptr)
-                {
-                    (*rit)->getListener()->on_requested_incompatible_qos((*rit), incompatible_qos);
-                }
-
-                if ((*rit)->matched_writer_is_matched(writer_guid)
-                        && (*rit)->matched_writer_remove(writer_guid))
-                {
-#if HAVE_SECURITY
-                    mp_RTPSParticipant->security_manager().remove_writer(readerGUID, participant_guid, writer_guid);
-#endif // if HAVE_SECURITY
-                    //MATCHED AND ADDED CORRECTLY:
-                    if ((*rit)->getListener() != nullptr)
+                    else
                     {
-                        MatchingInfo info;
-                        info.status = REMOVED_MATCHING;
-                        info.remoteEndpointGuid = writer_guid;
-                        (*rit)->getListener()->onReaderMatched((*rit), info);
+                        if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && r.getListener() != nullptr)
+                        {
+                            r.getListener()->on_requested_incompatible_qos(&r, incompatible_qos);
+                        }
 
-                        const SubscriptionMatchedStatus& sub_info =
+                        if (r.matched_writer_is_matched(writer_guid)
+                        && r.matched_writer_remove(writer_guid))
+                        {
+#if HAVE_SECURITY
+                            mp_RTPSParticipant->security_manager().remove_writer(readerGUID, participant_guid,
+                            writer_guid);
+#endif // if HAVE_SECURITY
+                            //MATCHED AND ADDED CORRECTLY:
+                            if (r.getListener() != nullptr)
+                            {
+                                MatchingInfo info;
+                                info.status = REMOVED_MATCHING;
+                                info.remoteEndpointGuid = writer_guid;
+                                r.getListener()->onReaderMatched(&r, info);
+
+                                const SubscriptionMatchedStatus& sub_info =
                                 update_subscription_matched_status(readerGUID, writer_guid, -1);
-                        (*rit)->getListener()->onReaderMatched((*rit), sub_info);
+                                r.getListener()->onReaderMatched(&r, sub_info);
+                            }
+                        }
                     }
                 }
-            }
-        }
-    }
+                // keep looking
+                return true;
+            });
+
     return true;
 }
 
@@ -1500,62 +1521,68 @@ bool EDP::pairing_writer_proxy_with_local_reader(
         WriterProxyData& wdata)
 {
     logInfo(RTPS_EDP, wdata.guid() << " in topic: \"" << wdata.topicName() << "\"");
-    std::lock_guard<std::recursive_mutex> pguard(*mp_PDP->getMutex());
-    std::lock_guard<std::recursive_mutex> guard(*mp_RTPSParticipant->getParticipantMutex());
-    for (std::vector<RTPSReader*>::iterator rit = mp_RTPSParticipant->userReadersListBegin();
-            rit != mp_RTPSParticipant->userReadersListEnd(); ++rit)
-    {
-        GUID_t readerGUID;
-        (*rit)->getMutex().lock();
-        readerGUID = (*rit)->getGuid();
-        (*rit)->getMutex().unlock();
 
-        if (local_reader == readerGUID)
-        {
-            if (mp_PDP->lookupReaderProxyData(readerGUID, temp_reader_proxy_data_))
+    mp_RTPSParticipant->forEachUserReader([&](RTPSReader& r) -> bool
             {
-                MatchingFailureMask no_match_reason;
-                fastdds::dds::PolicyMask incompatible_qos;
-                bool valid = valid_matching(&temp_reader_proxy_data_, &wdata, no_match_reason, incompatible_qos);
-                const GUID_t& writer_guid = wdata.guid();
+                GUID_t readerGUID = r.getGuid();
 
-                if (valid)
+                if (local_reader == readerGUID)
                 {
-                    if (!mp_RTPSParticipant->security_manager().discovered_writer(readerGUID,
-                            remote_participant_guid, wdata, (*rit)->getAttributes().security_attributes()))
-                    {
-                        logError(RTPS_EDP, "Security manager returns an error for reader " << readerGUID);
-                    }
-                }
-                else
-                {
-                    if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && (*rit)->getListener() != nullptr)
-                    {
-                        (*rit)->getListener()->on_requested_incompatible_qos((*rit), incompatible_qos);
-                    }
+                    auto temp_reader_proxy_data = get_temporary_reader_proxies_pool().get();
 
-                    if ((*rit)->matched_writer_is_matched(writer_guid)
-                            && (*rit)->matched_writer_remove(writer_guid))
+                    if (mp_PDP->lookupReaderProxyData(readerGUID, *temp_reader_proxy_data))
                     {
-                        mp_RTPSParticipant->security_manager().remove_writer(readerGUID,
-                                remote_participant_guid, writer_guid);
-                        //MATCHED AND ADDED CORRECTLY:
-                        if ((*rit)->getListener() != nullptr)
+                        MatchingFailureMask no_match_reason;
+                        fastdds::dds::PolicyMask incompatible_qos;
+                        bool valid = valid_matching(temp_reader_proxy_data.get(), &wdata, no_match_reason,
+                        incompatible_qos);
+                        const GUID_t& writer_guid = wdata.guid();
+
+                        temp_reader_proxy_data.reset();
+
+                        if (valid)
                         {
-                            MatchingInfo info;
-                            info.status = REMOVED_MATCHING;
-                            info.remoteEndpointGuid = writer_guid;
-                            (*rit)->getListener()->onReaderMatched((*rit), info);
+                            if (!mp_RTPSParticipant->security_manager().discovered_writer(readerGUID,
+                            remote_participant_guid, wdata, r.getAttributes().security_attributes()))
+                            {
+                                logError(RTPS_EDP, "Security manager returns an error for reader " << readerGUID);
+                            }
+                        }
+                        else
+                        {
+                            if (no_match_reason.test(MatchingFailureMask::incompatible_qos) &&
+                            r.getListener() != nullptr)
+                            {
+                                r.getListener()->on_requested_incompatible_qos(&r, incompatible_qos);
+                            }
 
-                            const SubscriptionMatchedStatus& sub_info =
+                            if (r.matched_writer_is_matched(writer_guid)
+                            && r.matched_writer_remove(writer_guid))
+                            {
+                                mp_RTPSParticipant->security_manager().remove_writer(readerGUID,
+                                remote_participant_guid, writer_guid);
+                                //MATCHED AND ADDED CORRECTLY:
+                                if (r.getListener() != nullptr)
+                                {
+                                    MatchingInfo info;
+                                    info.status = REMOVED_MATCHING;
+                                    info.remoteEndpointGuid = writer_guid;
+                                    r.getListener()->onReaderMatched(&r, info);
+
+                                    const SubscriptionMatchedStatus& sub_info =
                                     update_subscription_matched_status(readerGUID, writer_guid, -1);
-                            (*rit)->getListener()->onReaderMatched((*rit), sub_info);
+                                    r.getListener()->onReaderMatched(&r, sub_info);
+                                }
+                            }
                         }
                     }
+                    // don't keep searching
+                    return false;
                 }
-            }
-        }
-    }
+                // keep searching
+                return true;
+            });
+
     return true;
 }
 
@@ -1563,44 +1590,49 @@ bool EDP::pairing_remote_writer_with_local_reader_after_security(
         const GUID_t& local_reader,
         const WriterProxyData& remote_writer_data)
 {
-    std::lock_guard<std::recursive_mutex> guard(*mp_RTPSParticipant->getParticipantMutex());
-    for (std::vector<RTPSReader*>::iterator rit = mp_RTPSParticipant->userReadersListBegin();
-            rit != mp_RTPSParticipant->userReadersListEnd(); ++rit)
-    {
-        GUID_t readerGUID;
-        (*rit)->getMutex().lock();
-        readerGUID = (*rit)->getGuid();
-        (*rit)->getMutex().unlock();
-        const GUID_t& writer_guid = remote_writer_data.guid();
+    bool matched = false;
+    bool found = false;
 
-        if (local_reader == readerGUID)
-        {
-            // TODO(richiware) Implement and use move with attributes
-            if ((*rit)->matched_writer_add(remote_writer_data))
+    mp_RTPSParticipant->forEachUserReader([&](RTPSReader& r) -> bool
             {
-                logInfo(RTPS_EDP, "Valid Matching to local reader: " << readerGUID.entityId);
-                //MATCHED AND ADDED CORRECTLY:
-                if ((*rit)->getListener() != nullptr)
+                GUID_t readerGUID = r.getGuid();
+
+                const GUID_t& writer_guid = remote_writer_data.guid();
+
+                if (local_reader == readerGUID)
                 {
-                    MatchingInfo info;
-                    info.status = MATCHED_MATCHING;
-                    info.remoteEndpointGuid = writer_guid;
-                    (*rit)->getListener()->onReaderMatched((*rit), info);
+                    found = true;
 
-                    const SubscriptionMatchedStatus& sub_info =
+                    // TODO(richiware) Implement and use move with attributes
+                    if (r.matched_writer_add(remote_writer_data))
+                    {
+                        logInfo(RTPS_EDP, "Valid Matching to local reader: " << readerGUID.entityId);
+
+                        matched = true;
+
+                        //MATCHED AND ADDED CORRECTLY:
+                        if (r.getListener() != nullptr)
+                        {
+                            MatchingInfo info;
+                            info.status = MATCHED_MATCHING;
+                            info.remoteEndpointGuid = writer_guid;
+                            r.getListener()->onReaderMatched(&r, info);
+
+                            const SubscriptionMatchedStatus& sub_info =
                             update_subscription_matched_status(readerGUID, writer_guid, 1);
-                    (*rit)->getListener()->onReaderMatched((*rit), sub_info);
+                            r.getListener()->onReaderMatched(&r, sub_info);
 
+                        }
+                    }
+                    // dont' look anymore
+                    return false;
                 }
-
+                // keep looking
                 return true;
-            }
+            });
 
-            return false;
-        }
-    }
-
-    return pairing_remote_writer_with_local_builtin_reader_after_security(local_reader, remote_writer_data);
+    return found ? matched : pairing_remote_writer_with_local_builtin_reader_after_security(local_reader,
+                   remote_writer_data);
 }
 
 #endif // if HAVE_SECURITY
@@ -1747,6 +1779,8 @@ const SubscriptionMatchedStatus& EDP::update_subscription_matched_status(
         const GUID_t& writer_guid,
         int change)
 {
+    std::lock_guard<std::recursive_mutex> _(*mp_PDP->getMutex());
+
     SubscriptionMatchedStatus* status;
     auto it = reader_status_.find(reader_guid);
     if (it == reader_status_.end())
@@ -1773,6 +1807,8 @@ const fastdds::dds::PublicationMatchedStatus& EDP::update_publication_matched_st
         const GUID_t& writer_guid,
         int change)
 {
+    std::lock_guard<std::recursive_mutex> _(*mp_PDP->getMutex());
+
     PublicationMatchedStatus* status;
     auto it = writer_status_.find(writer_guid);
     if (it == writer_status_.end())

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
@@ -228,9 +228,9 @@ bool EDPServer::removeLocalReader(
     // Recover reader information
     std::string topic_name;
     {
-        std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-        mp_PDP->lookupReaderProxyData(guid, temp_reader_proxy_data_);
-        topic_name = temp_reader_proxy_data_.topicName().to_string();
+        auto temp_reader_proxy_data = get_temporary_reader_proxies_pool().get();
+        mp_PDP->lookupReaderProxyData(guid, *temp_reader_proxy_data);
+        topic_name = temp_reader_proxy_data->topicName().to_string();
     }
 
     // Remove proxy data associated with the reader
@@ -288,9 +288,9 @@ bool EDPServer::removeLocalWriter(
     std::string topic_name;
 
     {
-        std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-        mp_PDP->lookupWriterProxyData(guid, temp_writer_proxy_data_);
-        topic_name = temp_writer_proxy_data_.topicName().to_string();
+        auto temp_writer_proxy_data = get_temporary_writer_proxies_pool().get();
+        mp_PDP->lookupWriterProxyData(guid, *temp_writer_proxy_data);
+        topic_name = temp_writer_proxy_data->topicName().to_string();
     }
 
     // Remove proxy data associated with the writer

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners.cpp
@@ -43,9 +43,7 @@ PDPServer* EDPServerPUBListener::get_pdp()
 
 EDPServerPUBListener::EDPServerPUBListener(
         EDPServer* sedp)
-    : EDPBasePUBListener(sedp->mp_RTPSParticipant->getAttributes().allocation.locators,
-            sedp->mp_RTPSParticipant->getAttributes().allocation.data_limits)
-    , sedp_(sedp)
+    : sedp_(sedp)
 {
 }
 
@@ -96,9 +94,10 @@ void EDPServerPUBListener::onNewCacheChangeAdded(
 
         // Retrieve the topic after creating the WriterProxyData (in add_writer_from_change()). This way, not matter
         // whether the DATA(w) is a new one or an update, the WriterProxyData exists, and so the topic can be retrieved
-        if (get_pdp()->lookupWriterProxyData(auxGUID, temp_writer_data_))
+        auto temp_writer_data = get_pdp()->get_temporary_writer_proxies_pool().get();
+        if (get_pdp()->lookupWriterProxyData(auxGUID, *temp_writer_data))
         {
-            topic_name = temp_writer_data_.topicName().to_string();
+            topic_name = temp_writer_data->topicName().to_string();
         }
     }
     // DATA(Uw) case
@@ -107,9 +106,10 @@ void EDPServerPUBListener::onNewCacheChangeAdded(
         logInfo(RTPS_EDP_LISTENER, "Disposed Remote Writer, removing...");
 
         // Retrieve the topic before removing the WriterProxyData. We need it to add the DATA(Uw) to the database
-        if (get_pdp()->lookupWriterProxyData(auxGUID, temp_writer_data_))
+        auto temp_writer_data = get_pdp()->get_temporary_writer_proxies_pool().get();
+        if (get_pdp()->lookupWriterProxyData(auxGUID, *temp_writer_data))
         {
-            topic_name = temp_writer_data_.topicName().to_string();
+            topic_name = temp_writer_data->topicName().to_string();
         }
         else
         {
@@ -157,10 +157,7 @@ PDPServer* EDPServerSUBListener::get_pdp()
 
 EDPServerSUBListener::EDPServerSUBListener(
         EDPServer* sedp)
-    : EDPBaseSUBListener(sedp->mp_RTPSParticipant->getAttributes().allocation.locators,
-            sedp->mp_RTPSParticipant->getAttributes().allocation.data_limits,
-            sedp->mp_RTPSParticipant->getAttributes().allocation.content_filter)
-    , sedp_(sedp)
+    : sedp_(sedp)
 {
 }
 
@@ -211,9 +208,10 @@ void EDPServerSUBListener::onNewCacheChangeAdded(
 
         // Retrieve the topic after creating the ReaderProxyData (in add_reader_from_change()). This way, not matter
         // whether the DATA(r) is a new one or an update, the ReaderProxyData exists, and so the topic can be retrieved
-        if (get_pdp()->lookupReaderProxyData(auxGUID, temp_reader_data_))
+        auto temp_reader_data = get_pdp()->get_temporary_reader_proxies_pool().get();
+        if (get_pdp()->lookupReaderProxyData(auxGUID, *temp_reader_data))
         {
-            topic_name = temp_reader_data_.topicName().to_string();
+            topic_name = temp_reader_data->topicName().to_string();
         }
         else
         {
@@ -227,9 +225,10 @@ void EDPServerSUBListener::onNewCacheChangeAdded(
         logInfo(RTPS_EDP_LISTENER, "Disposed Remote Reader, removing...");
 
         // Retrieve the topic before removing the ReaderProxyData. We need it to add the DATA(Ur) to the database
-        if (get_pdp()->lookupReaderProxyData(auxGUID, temp_reader_data_))
+        auto temp_reader_data = get_pdp()->get_temporary_reader_proxies_pool().get();
+        if (get_pdp()->lookupReaderProxyData(auxGUID, *temp_reader_data))
         {
-            topic_name = temp_reader_data_.topicName().to_string();
+            topic_name = temp_reader_data->topicName().to_string();
         }
 
         // Remove ReaderProxy data information

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -66,7 +66,7 @@ static void delete_reader(
 {
     if (nullptr != reader_pair.first)
     {
-        participant->deleteUserEndpoint(reader_pair.first);
+        participant->deleteUserEndpoint(reader_pair.first->getGuid());
         EDPUtils::release_payload_pool(pool, reader_pair.second->m_att, true);
         delete(reader_pair.second);
     }
@@ -79,7 +79,7 @@ static void delete_writer(
 {
     if (nullptr != writer_pair.first)
     {
-        participant->deleteUserEndpoint(writer_pair.first);
+        participant->deleteUserEndpoint(writer_pair.first->getGuid());
         EDPUtils::release_payload_pool(pool, writer_pair.second->m_att, false);
         delete(writer_pair.second);
     }
@@ -91,15 +91,6 @@ EDPSimple::EDPSimple(
     : EDP(p, part)
     , publications_listener_(nullptr)
     , subscriptions_listener_(nullptr)
-    , temp_reader_proxy_data_(
-        part->getRTPSParticipantAttributes().allocation.locators.max_unicast_locators,
-        part->getRTPSParticipantAttributes().allocation.locators.max_multicast_locators,
-        part->getRTPSParticipantAttributes().allocation.data_limits,
-        part->getRTPSParticipantAttributes().allocation.content_filter)
-    , temp_writer_proxy_data_(
-        part->getRTPSParticipantAttributes().allocation.locators.max_unicast_locators,
-        part->getRTPSParticipantAttributes().allocation.locators.max_multicast_locators,
-        part->getRTPSParticipantAttributes().allocation.data_limits)
 {
 }
 
@@ -773,30 +764,32 @@ void EDPSimple::assignRemoteEndpoints(
             pdata.metatraffic_locators.unicast.empty();
     auxendp &= DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER;
 
-    std::lock_guard<std::mutex> data_guard(temp_data_lock_);
+    auto temp_reader_proxy_data = get_temporary_reader_proxies_pool().get();
 
-    temp_reader_proxy_data_.clear();
-    temp_reader_proxy_data_.m_expectsInlineQos = false;
-    temp_reader_proxy_data_.guid().guidPrefix = pdata.m_guid.guidPrefix;
-    temp_reader_proxy_data_.set_remote_locators(pdata.metatraffic_locators, network, use_multicast_locators);
-    temp_reader_proxy_data_.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
-    temp_reader_proxy_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+    temp_reader_proxy_data->clear();
+    temp_reader_proxy_data->m_expectsInlineQos = false;
+    temp_reader_proxy_data->guid().guidPrefix = pdata.m_guid.guidPrefix;
+    temp_reader_proxy_data->set_remote_locators(pdata.metatraffic_locators, network, use_multicast_locators);
+    temp_reader_proxy_data->m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
+    temp_reader_proxy_data->m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
 
-    temp_writer_proxy_data_.clear();
-    temp_writer_proxy_data_.guid().guidPrefix = pdata.m_guid.guidPrefix;
-    temp_writer_proxy_data_.persistence_guid(pdata.get_persistence_guid());
-    temp_writer_proxy_data_.set_remote_locators(pdata.metatraffic_locators, network, use_multicast_locators);
-    temp_writer_proxy_data_.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
-    temp_writer_proxy_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+    auto temp_writer_proxy_data = get_temporary_writer_proxies_pool().get();
+
+    temp_writer_proxy_data->clear();
+    temp_writer_proxy_data->guid().guidPrefix = pdata.m_guid.guidPrefix;
+    temp_writer_proxy_data->persistence_guid(pdata.get_persistence_guid());
+    temp_writer_proxy_data->set_remote_locators(pdata.metatraffic_locators, network, use_multicast_locators);
+    temp_writer_proxy_data->m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
+    temp_writer_proxy_data->m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
 
     //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
     //auxendp = 1;
     if (auxendp != 0 && publications_reader_.first != nullptr) //Exist Pub Writer and i have pub reader
     {
         logInfo(RTPS_EDP, "Adding SEDP Pub Writer to my Pub Reader");
-        temp_writer_proxy_data_.guid().entityId = c_EntityId_SEDPPubWriter;
-        temp_writer_proxy_data_.set_persistence_entity_id(c_EntityId_SEDPPubWriter);
-        publications_reader_.first->matched_writer_add(temp_writer_proxy_data_);
+        temp_writer_proxy_data->guid().entityId = c_EntityId_SEDPPubWriter;
+        temp_writer_proxy_data->set_persistence_entity_id(c_EntityId_SEDPPubWriter);
+        publications_reader_.first->matched_writer_add(*temp_writer_proxy_data);
     }
     auxendp = endp;
     auxendp &= DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR;
@@ -805,8 +798,8 @@ void EDPSimple::assignRemoteEndpoints(
     if (auxendp != 0 && publications_writer_.first != nullptr) //Exist Pub Detector
     {
         logInfo(RTPS_EDP, "Adding SEDP Pub Reader to my Pub Writer");
-        temp_reader_proxy_data_.guid().entityId = c_EntityId_SEDPPubReader;
-        publications_writer_.first->matched_reader_add(temp_reader_proxy_data_);
+        temp_reader_proxy_data->guid().entityId = c_EntityId_SEDPPubReader;
+        publications_writer_.first->matched_reader_add(*temp_reader_proxy_data);
     }
     auxendp = endp;
     auxendp &= DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER;
@@ -815,9 +808,9 @@ void EDPSimple::assignRemoteEndpoints(
     if (auxendp != 0 && subscriptions_reader_.first != nullptr) //Exist Pub Announcer
     {
         logInfo(RTPS_EDP, "Adding SEDP Sub Writer to my Sub Reader");
-        temp_writer_proxy_data_.guid().entityId = c_EntityId_SEDPSubWriter;
-        temp_writer_proxy_data_.set_persistence_entity_id(c_EntityId_SEDPSubWriter);
-        subscriptions_reader_.first->matched_writer_add(temp_writer_proxy_data_);
+        temp_writer_proxy_data->guid().entityId = c_EntityId_SEDPSubWriter;
+        temp_writer_proxy_data->set_persistence_entity_id(c_EntityId_SEDPSubWriter);
+        subscriptions_reader_.first->matched_writer_add(*temp_writer_proxy_data);
     }
     auxendp = endp;
     auxendp &= DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_DETECTOR;
@@ -826,8 +819,8 @@ void EDPSimple::assignRemoteEndpoints(
     if (auxendp != 0 && subscriptions_writer_.first != nullptr) //Exist Pub Announcer
     {
         logInfo(RTPS_EDP, "Adding SEDP Sub Reader to my Sub Writer");
-        temp_reader_proxy_data_.guid().entityId = c_EntityId_SEDPSubReader;
-        subscriptions_writer_.first->matched_reader_add(temp_reader_proxy_data_);
+        temp_reader_proxy_data->guid().entityId = c_EntityId_SEDPSubReader;
+        subscriptions_writer_.first->matched_reader_add(*temp_reader_proxy_data);
     }
 
 #if HAVE_SECURITY
@@ -837,11 +830,11 @@ void EDPSimple::assignRemoteEndpoints(
     //auxendp = 1;
     if (auxendp != 0 && publications_secure_reader_.first != nullptr)
     {
-        temp_writer_proxy_data_.guid().entityId = sedp_builtin_publications_secure_writer;
-        temp_writer_proxy_data_.set_persistence_entity_id(sedp_builtin_publications_secure_writer);
+        temp_writer_proxy_data->guid().entityId = sedp_builtin_publications_secure_writer;
+        temp_writer_proxy_data->set_persistence_entity_id(sedp_builtin_publications_secure_writer);
 
         if (!mp_RTPSParticipant->security_manager().discovered_builtin_writer(
-                    publications_secure_reader_.first->getGuid(), pdata.m_guid, temp_writer_proxy_data_,
+                    publications_secure_reader_.first->getGuid(), pdata.m_guid, *temp_writer_proxy_data,
                     publications_secure_reader_.first->getAttributes().security_attributes()))
         {
             logError(RTPS_EDP, "Security manager returns an error for writer " <<
@@ -855,9 +848,9 @@ void EDPSimple::assignRemoteEndpoints(
     //auxendp = 1;
     if (auxendp != 0 && publications_secure_writer_.first != nullptr)
     {
-        temp_reader_proxy_data_.guid().entityId = sedp_builtin_publications_secure_reader;
+        temp_reader_proxy_data->guid().entityId = sedp_builtin_publications_secure_reader;
         if (!mp_RTPSParticipant->security_manager().discovered_builtin_reader(
-                    publications_secure_writer_.first->getGuid(), pdata.m_guid, temp_reader_proxy_data_,
+                    publications_secure_writer_.first->getGuid(), pdata.m_guid, *temp_reader_proxy_data,
                     publications_secure_writer_.first->getAttributes().security_attributes()))
         {
             logError(RTPS_EDP, "Security manager returns an error for writer " <<
@@ -871,11 +864,11 @@ void EDPSimple::assignRemoteEndpoints(
     //auxendp = 1;
     if (auxendp != 0 && subscriptions_secure_reader_.first != nullptr)
     {
-        temp_writer_proxy_data_.guid().entityId = sedp_builtin_subscriptions_secure_writer;
-        temp_writer_proxy_data_.set_persistence_entity_id(sedp_builtin_subscriptions_secure_writer);
+        temp_writer_proxy_data->guid().entityId = sedp_builtin_subscriptions_secure_writer;
+        temp_writer_proxy_data->set_persistence_entity_id(sedp_builtin_subscriptions_secure_writer);
 
         if (!mp_RTPSParticipant->security_manager().discovered_builtin_writer(
-                    subscriptions_secure_reader_.first->getGuid(), pdata.m_guid, temp_writer_proxy_data_,
+                    subscriptions_secure_reader_.first->getGuid(), pdata.m_guid, *temp_writer_proxy_data,
                     subscriptions_secure_reader_.first->getAttributes().security_attributes()))
         {
             logError(RTPS_EDP, "Security manager returns an error for writer " <<
@@ -890,9 +883,9 @@ void EDPSimple::assignRemoteEndpoints(
     if (auxendp != 0 && subscriptions_secure_writer_.first != nullptr)
     {
         logInfo(RTPS_EDP, "Adding SEDP Sub Reader to my Sub Writer");
-        temp_reader_proxy_data_.guid().entityId = sedp_builtin_subscriptions_secure_reader;
+        temp_reader_proxy_data->guid().entityId = sedp_builtin_subscriptions_secure_reader;
         if (!mp_RTPSParticipant->security_manager().discovered_builtin_reader(
-                    subscriptions_secure_writer_.first->getGuid(), pdata.m_guid, temp_reader_proxy_data_,
+                    subscriptions_secure_writer_.first->getGuid(), pdata.m_guid, *temp_reader_proxy_data,
                     subscriptions_secure_writer_.first->getAttributes().security_attributes()))
         {
             logError(RTPS_EDP, "Security manager returns an error for writer " <<

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.cpp
@@ -72,38 +72,43 @@ void EDPBasePUBListener::add_writer_from_change(
     //LOAD INFORMATION IN DESTINATION WRITER PROXY DATA
     const NetworkFactory& network = edp->mp_RTPSParticipant->network_factory();
     CDRMessage_t tempMsg(change->serializedPayload);
-    if (temp_writer_data_.readFromCDRMessage(&tempMsg, network,
+    auto temp_writer_data = edp->get_temporary_writer_proxies_pool().get();
+
+    if (temp_writer_data->readFromCDRMessage(&tempMsg, network,
             edp->mp_RTPSParticipant->has_shm_transport()))
     {
-        if (temp_writer_data_.guid().guidPrefix == edp->mp_RTPSParticipant->getGuid().guidPrefix)
+        if (temp_writer_data->guid().guidPrefix == edp->mp_RTPSParticipant->getGuid().guidPrefix)
         {
             logInfo(RTPS_EDP, "Message from own RTPSParticipant, ignoring");
             return;
         }
 
         //LOAD INFORMATION IN DESTINATION WRITER PROXY DATA
-        auto copy_data_fun = [this, &network](
+        auto copy_data_fun = [&temp_writer_data, &network](
             WriterProxyData* data,
             bool updating,
             const ParticipantProxyData& participant_data)
                 {
-                    if (!temp_writer_data_.has_locators())
+                    if (!temp_writer_data->has_locators())
                     {
-                        temp_writer_data_.set_remote_locators(participant_data.default_locators, network, true);
+                        temp_writer_data->set_remote_locators(participant_data.default_locators, network, true);
                     }
 
-                    if (updating && !data->is_update_allowed(temp_writer_data_))
+                    if (updating && !data->is_update_allowed(*temp_writer_data))
                     {
                         logWarning(RTPS_EDP,
                                 "Received incompatible update for WriterQos. writer_guid = " << data->guid());
                     }
-                    *data = temp_writer_data_;
+                    *data = *temp_writer_data;
                     return true;
                 };
 
         GUID_t participant_guid;
         WriterProxyData* writer_data =
-                edp->mp_PDP->addWriterProxyData(temp_writer_data_.guid(), participant_guid, copy_data_fun);
+                edp->mp_PDP->addWriterProxyData(temp_writer_data->guid(), participant_guid, copy_data_fun);
+
+        // release temporary proxy
+        temp_writer_data.reset();
 
         //Removing change from history
         reader_history->remove_change(reader_history->find_change(change), release_change);
@@ -178,38 +183,43 @@ void EDPBaseSUBListener::add_reader_from_change(
     //LOAD INFORMATION IN TEMPORAL WRITER PROXY DATA
     const NetworkFactory& network = edp->mp_RTPSParticipant->network_factory();
     CDRMessage_t tempMsg(change->serializedPayload);
-    if (temp_reader_data_.readFromCDRMessage(&tempMsg, network,
+    auto temp_reader_data = edp->get_temporary_reader_proxies_pool().get();
+
+    if (temp_reader_data->readFromCDRMessage(&tempMsg, network,
             edp->mp_RTPSParticipant->has_shm_transport()))
     {
-        if (temp_reader_data_.guid().guidPrefix == edp->mp_RTPSParticipant->getGuid().guidPrefix)
+        if (temp_reader_data->guid().guidPrefix == edp->mp_RTPSParticipant->getGuid().guidPrefix)
         {
             logInfo(RTPS_EDP, "From own RTPSParticipant, ignoring");
             return;
         }
 
-        auto copy_data_fun = [this, &network](
+        auto copy_data_fun = [&temp_reader_data, &network](
             ReaderProxyData* data,
             bool updating,
             const ParticipantProxyData& participant_data)
                 {
-                    if (!temp_reader_data_.has_locators())
+                    if (!temp_reader_data->has_locators())
                     {
-                        temp_reader_data_.set_remote_locators(participant_data.default_locators, network, true);
+                        temp_reader_data->set_remote_locators(participant_data.default_locators, network, true);
                     }
 
-                    if (updating && !data->is_update_allowed(temp_reader_data_))
+                    if (updating && !data->is_update_allowed(*temp_reader_data))
                     {
                         logWarning(RTPS_EDP,
                                 "Received incompatible update for ReaderQos. reader_guid = " << data->guid());
                     }
-                    *data = temp_reader_data_;
+                    *data = *temp_reader_data;
                     return true;
                 };
 
         //LOOK IF IS AN UPDATED INFORMATION
         GUID_t participant_guid;
         ReaderProxyData* reader_data =
-                edp->mp_PDP->addReaderProxyData(temp_reader_data_.guid(), participant_guid, copy_data_fun);
+                edp->mp_PDP->addReaderProxyData(temp_reader_data->guid(), participant_guid, copy_data_fun);
+
+        // Release the temporary proxy
+        temp_reader_data.reset();
 
         // Remove change from history.
         reader_history->remove_change(reader_history->find_change(change), release_change);

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.h
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.h
@@ -68,15 +68,7 @@ class EDPBasePUBListener : public EDPListener
 {
 public:
 
-    EDPBasePUBListener(
-            const RemoteLocatorsAllocationAttributes& locators_allocation,
-            const VariableLengthDataLimits& data_limits)
-        : temp_writer_data_(
-            locators_allocation.max_unicast_locators,
-            locators_allocation.max_multicast_locators,
-            data_limits)
-    {
-    }
+    EDPBasePUBListener() = default;
 
     virtual ~EDPBasePUBListener() = default;
 
@@ -88,9 +80,6 @@ protected:
             CacheChange_t* change,
             EDP* edp,
             bool release_change = true);
-
-    //!Temporary structure to avoid allocations
-    WriterProxyData temp_writer_data_;
 };
 
 /**
@@ -101,17 +90,7 @@ class EDPBaseSUBListener : public EDPListener
 {
 public:
 
-    EDPBaseSUBListener(
-            const RemoteLocatorsAllocationAttributes& locators_allocation,
-            const VariableLengthDataLimits& data_limits,
-            const fastdds::rtps::ContentFilterProperty::AllocationConfiguration& filter_allocation)
-        : temp_reader_data_(
-            locators_allocation.max_unicast_locators,
-            locators_allocation.max_multicast_locators,
-            data_limits,
-            filter_allocation)
-    {
-    }
+    EDPBaseSUBListener() = default;
 
     virtual ~EDPBaseSUBListener() = default;
 
@@ -123,9 +102,6 @@ protected:
             CacheChange_t* change,
             EDP* edp,
             bool release_change = true);
-
-    //!Temporary structure to avoid allocations
-    ReaderProxyData temp_reader_data_;
 };
 
 /*!
@@ -142,9 +118,7 @@ public:
      */
     EDPSimplePUBListener(
             EDPSimple* sedp)
-        : EDPBasePUBListener(sedp->mp_RTPSParticipant->getAttributes().allocation.locators,
-                sedp->mp_RTPSParticipant->getAttributes().allocation.data_limits)
-        , sedp_(sedp)
+        : sedp_(sedp)
     {
     }
 
@@ -190,10 +164,7 @@ public:
      */
     EDPSimpleSUBListener(
             EDPSimple* sedp)
-        : EDPBaseSUBListener(sedp->mp_RTPSParticipant->getAttributes().allocation.locators,
-                sedp->mp_RTPSParticipant->getAttributes().allocation.data_limits,
-                sedp->mp_RTPSParticipant->getAttributes().allocation.content_filter)
-        , sedp_(sedp)
+        : sedp_(sedp)
     {
     }
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -95,10 +95,15 @@ PDP::PDP (
     , mp_listener(nullptr)
     , mp_PDPWriterHistory(nullptr)
     , mp_PDPReaderHistory(nullptr)
-    , temp_reader_data_(allocation.locators.max_unicast_locators, allocation.locators.max_multicast_locators,
-            allocation.data_limits, allocation.content_filter)
-    , temp_writer_data_(allocation.locators.max_unicast_locators, allocation.locators.max_multicast_locators,
-            allocation.data_limits)
+    , temp_reader_proxies_({
+                allocation.locators.max_unicast_locators,
+                allocation.locators.max_multicast_locators,
+                allocation.data_limits,
+                allocation.content_filter})
+    , temp_writer_proxies_({
+                allocation.locators.max_unicast_locators,
+                allocation.locators.max_multicast_locators,
+                allocation.data_limits})
     , mp_mutex(new std::recursive_mutex())
     , resend_participant_info_event_(nullptr)
 {
@@ -128,8 +133,8 @@ PDP::~PDP()
     delete resend_participant_info_event_;
     mp_RTPSParticipant->disableReader(mp_PDPReader);
     delete mp_EDP;
-    mp_RTPSParticipant->deleteUserEndpoint(mp_PDPWriter);
-    mp_RTPSParticipant->deleteUserEndpoint(mp_PDPReader);
+    mp_RTPSParticipant->deleteUserEndpoint(mp_PDPWriter->getGuid());
+    mp_RTPSParticipant->deleteUserEndpoint(mp_PDPReader->getGuid());
 
     if (mp_PDPWriterHistory)
     {

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -344,15 +344,16 @@ void PDPClient::removeRemoteEndpoints(
 
             // rematch but discarding any previous state of the server
             // because we know the server shutdown intencionally
-            std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-            temp_writer_data_.clear();
-            temp_writer_data_.guid(wguid);
-            temp_writer_data_.persistence_guid(pdata->get_persistence_guid());
-            temp_writer_data_.set_persistence_entity_id(c_EntityId_SPDPWriter);
-            temp_writer_data_.set_remote_locators(pdata->metatraffic_locators, network, true);
-            temp_writer_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
-            temp_writer_data_.m_qos.m_durability.kind = TRANSIENT_DURABILITY_QOS;
-            mp_PDPReader->matched_writer_add(temp_writer_data_);
+            auto temp_writer_data = get_temporary_writer_proxies_pool().get();
+
+            temp_writer_data->clear();
+            temp_writer_data->guid(wguid);
+            temp_writer_data->persistence_guid(pdata->get_persistence_guid());
+            temp_writer_data->set_persistence_entity_id(c_EntityId_SPDPWriter);
+            temp_writer_data->set_remote_locators(pdata->metatraffic_locators, network, true);
+            temp_writer_data->m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+            temp_writer_data->m_qos.m_durability.kind = TRANSIENT_DURABILITY_QOS;
+            mp_PDPReader->matched_writer_add(*temp_writer_data);
         }
 
         auxendp = endp;
@@ -365,14 +366,15 @@ void PDPClient::removeRemoteEndpoints(
             rguid.entityId = c_EntityId_SPDPReader;
             mp_PDPWriter->matched_reader_remove(rguid);
 
-            std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-            temp_reader_data_.clear();
-            temp_reader_data_.m_expectsInlineQos = false;
-            temp_reader_data_.guid(rguid);
-            temp_reader_data_.set_remote_locators(pdata->metatraffic_locators, network, true);
-            temp_reader_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
-            temp_reader_data_.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
-            mp_PDPWriter->matched_reader_add(temp_reader_data_);
+            auto temp_reader_data = get_temporary_reader_proxies_pool().get();
+
+            temp_reader_data->clear();
+            temp_reader_data->m_expectsInlineQos = false;
+            temp_reader_data->guid(rguid);
+            temp_reader_data->set_remote_locators(pdata->metatraffic_locators, network, true);
+            temp_reader_data->m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+            temp_reader_data->m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
+            mp_PDPWriter->matched_reader_add(*temp_reader_data);
         }
     }
 }
@@ -593,29 +595,31 @@ void PDPClient::update_remote_servers_list()
 void PDPClient::match_pdp_writer_nts_(
         const eprosima::fastdds::rtps::RemoteServerAttributes& server_att)
 {
-    std::lock_guard<std::mutex> data_guard(temp_data_lock_);
     const NetworkFactory& network = mp_RTPSParticipant->network_factory();
-    temp_writer_data_.clear();
-    temp_writer_data_.guid(server_att.GetPDPWriter());
-    temp_writer_data_.set_multicast_locators(server_att.metatrafficMulticastLocatorList, network);
-    temp_writer_data_.set_remote_unicast_locators(server_att.metatrafficUnicastLocatorList, network);
-    temp_writer_data_.m_qos.m_durability.kind = TRANSIENT_DURABILITY_QOS;
-    temp_writer_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
-    mp_PDPReader->matched_writer_add(temp_writer_data_);
+    auto temp_writer_data = get_temporary_writer_proxies_pool().get();
+
+    temp_writer_data->clear();
+    temp_writer_data->guid(server_att.GetPDPWriter());
+    temp_writer_data->set_multicast_locators(server_att.metatrafficMulticastLocatorList, network);
+    temp_writer_data->set_remote_unicast_locators(server_att.metatrafficUnicastLocatorList, network);
+    temp_writer_data->m_qos.m_durability.kind = TRANSIENT_DURABILITY_QOS;
+    temp_writer_data->m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+    mp_PDPReader->matched_writer_add(*temp_writer_data);
 }
 
 void PDPClient::match_pdp_reader_nts_(
         const eprosima::fastdds::rtps::RemoteServerAttributes& server_att)
 {
-    std::lock_guard<std::mutex> data_guard(temp_data_lock_);
     const NetworkFactory& network = mp_RTPSParticipant->network_factory();
-    temp_reader_data_.clear();
-    temp_reader_data_.guid(server_att.GetPDPReader());
-    temp_reader_data_.set_multicast_locators(server_att.metatrafficMulticastLocatorList, network);
-    temp_reader_data_.set_remote_unicast_locators(server_att.metatrafficUnicastLocatorList, network);
-    temp_reader_data_.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
-    temp_reader_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
-    mp_PDPWriter->matched_reader_add(temp_reader_data_);
+    auto temp_reader_data = get_temporary_reader_proxies_pool().get();
+
+    temp_reader_data->clear();
+    temp_reader_data->guid(server_att.GetPDPReader());
+    temp_reader_data->set_multicast_locators(server_att.metatrafficMulticastLocatorList, network);
+    temp_reader_data->set_remote_unicast_locators(server_att.metatrafficUnicastLocatorList, network);
+    temp_reader_data->m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
+    temp_reader_data->m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+    mp_PDPWriter->matched_reader_add(*temp_reader_data);
 }
 
 const std::string& ros_discovery_server_env()

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -398,16 +398,17 @@ void PDPServer::assignRemoteEndpoints(
     uint32_t auxendp = endp & DISC_BUILTIN_ENDPOINT_PARTICIPANT_ANNOUNCER;
     if (0 != auxendp)
     {
-        std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-        temp_writer_data_.clear();
-        temp_writer_data_.guid().guidPrefix = pdata->m_guid.guidPrefix;
-        temp_writer_data_.guid().entityId = c_EntityId_SPDPWriter;
-        temp_writer_data_.persistence_guid(pdata->get_persistence_guid());
-        temp_writer_data_.set_persistence_entity_id(c_EntityId_SPDPWriter);
-        temp_writer_data_.set_remote_locators(pdata->metatraffic_locators, network, use_multicast_locators);
-        temp_writer_data_.m_qos.m_reliability.kind = dds::RELIABLE_RELIABILITY_QOS;
-        temp_writer_data_.m_qos.m_durability.kind = dds::TRANSIENT_LOCAL_DURABILITY_QOS;
-        mp_PDPReader->matched_writer_add(temp_writer_data_);
+        auto temp_writer_data = get_temporary_writer_proxies_pool().get();
+
+        temp_writer_data->clear();
+        temp_writer_data->guid().guidPrefix = pdata->m_guid.guidPrefix;
+        temp_writer_data->guid().entityId = c_EntityId_SPDPWriter;
+        temp_writer_data->persistence_guid(pdata->get_persistence_guid());
+        temp_writer_data->set_persistence_entity_id(c_EntityId_SPDPWriter);
+        temp_writer_data->set_remote_locators(pdata->metatraffic_locators, network, use_multicast_locators);
+        temp_writer_data->m_qos.m_reliability.kind = dds::RELIABLE_RELIABILITY_QOS;
+        temp_writer_data->m_qos.m_durability.kind = dds::TRANSIENT_LOCAL_DURABILITY_QOS;
+        mp_PDPReader->matched_writer_add(*temp_writer_data);
     }
     else
     {
@@ -420,16 +421,16 @@ void PDPServer::assignRemoteEndpoints(
     auxendp = endp & DISC_BUILTIN_ENDPOINT_PARTICIPANT_DETECTOR;
     if (0 != auxendp)
     {
-        std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-        temp_reader_data_.clear();
-        temp_reader_data_.m_expectsInlineQos = false;
-        temp_reader_data_.guid().guidPrefix = pdata->m_guid.guidPrefix;
-        temp_reader_data_.guid().entityId = c_EntityId_SPDPReader;
-        temp_writer_data_.persistence_guid(pdata->get_persistence_guid());
-        temp_reader_data_.set_remote_locators(pdata->metatraffic_locators, network, use_multicast_locators);
-        temp_reader_data_.m_qos.m_reliability.kind = dds::RELIABLE_RELIABILITY_QOS;
-        temp_reader_data_.m_qos.m_durability.kind = dds::TRANSIENT_LOCAL_DURABILITY_QOS;
-        mp_PDPWriter->matched_reader_add(temp_reader_data_);
+        auto temp_reader_data = get_temporary_reader_proxies_pool().get();
+
+        temp_reader_data->clear();
+        temp_reader_data->m_expectsInlineQos = false;
+        temp_reader_data->guid().guidPrefix = pdata->m_guid.guidPrefix;
+        temp_reader_data->guid().entityId = c_EntityId_SPDPReader;
+        temp_reader_data->set_remote_locators(pdata->metatraffic_locators, network, use_multicast_locators);
+        temp_reader_data->m_qos.m_reliability.kind = dds::RELIABLE_RELIABILITY_QOS;
+        temp_reader_data->m_qos.m_durability.kind = dds::TRANSIENT_LOCAL_DURABILITY_QOS;
+        mp_PDPWriter->matched_reader_add(*temp_reader_data);
     }
     else
     {
@@ -1778,29 +1779,31 @@ void PDPServer::process_backup_store()
 void PDPServer::match_pdp_writer_nts_(
         const eprosima::fastdds::rtps::RemoteServerAttributes& server_att)
 {
-    std::lock_guard<std::mutex> data_guard(temp_data_lock_);
     const NetworkFactory& network = mp_RTPSParticipant->network_factory();
-    temp_writer_data_.clear();
-    temp_writer_data_.guid(server_att.GetPDPWriter());
-    temp_writer_data_.set_multicast_locators(server_att.metatrafficMulticastLocatorList, network);
-    temp_writer_data_.set_remote_unicast_locators(server_att.metatrafficUnicastLocatorList, network);
-    temp_writer_data_.m_qos.m_durability.durabilityKind(durability_);
-    temp_writer_data_.m_qos.m_reliability.kind = dds::RELIABLE_RELIABILITY_QOS;
-    mp_PDPReader->matched_writer_add(temp_writer_data_);
+    auto temp_writer_data = get_temporary_writer_proxies_pool().get();
+
+    temp_writer_data->clear();
+    temp_writer_data->guid(server_att.GetPDPWriter());
+    temp_writer_data->set_multicast_locators(server_att.metatrafficMulticastLocatorList, network);
+    temp_writer_data->set_remote_unicast_locators(server_att.metatrafficUnicastLocatorList, network);
+    temp_writer_data->m_qos.m_durability.durabilityKind(durability_);
+    temp_writer_data->m_qos.m_reliability.kind = dds::RELIABLE_RELIABILITY_QOS;
+    mp_PDPReader->matched_writer_add(*temp_writer_data);
 }
 
 void PDPServer::match_pdp_reader_nts_(
         const eprosima::fastdds::rtps::RemoteServerAttributes& server_att)
 {
-    std::lock_guard<std::mutex> data_guard(temp_data_lock_);
     const NetworkFactory& network = mp_RTPSParticipant->network_factory();
-    temp_reader_data_.clear();
-    temp_reader_data_.guid(server_att.GetPDPReader());
-    temp_reader_data_.set_multicast_locators(server_att.metatrafficMulticastLocatorList, network);
-    temp_reader_data_.set_remote_unicast_locators(server_att.metatrafficUnicastLocatorList, network);
-    temp_reader_data_.m_qos.m_durability.kind = dds::TRANSIENT_LOCAL_DURABILITY_QOS;
-    temp_reader_data_.m_qos.m_reliability.kind = dds::RELIABLE_RELIABILITY_QOS;
-    mp_PDPWriter->matched_reader_add(temp_reader_data_);
+    auto temp_reader_data = get_temporary_reader_proxies_pool().get();
+
+    temp_reader_data->clear();
+    temp_reader_data->guid(server_att.GetPDPReader());
+    temp_reader_data->set_multicast_locators(server_att.metatrafficMulticastLocatorList, network);
+    temp_reader_data->set_remote_unicast_locators(server_att.metatrafficUnicastLocatorList, network);
+    temp_reader_data->m_qos.m_durability.kind = dds::TRANSIENT_LOCAL_DURABILITY_QOS;
+    temp_reader_data->m_qos.m_reliability.kind = dds::RELIABLE_RELIABILITY_QOS;
+    mp_PDPWriter->matched_reader_add(*temp_reader_data);
 }
 
 } // namespace rtps

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -361,30 +361,32 @@ void PDPSimple::assignRemoteEndpoints(
     auxendp &= DISC_BUILTIN_ENDPOINT_PARTICIPANT_ANNOUNCER;
     if (auxendp != 0)
     {
-        std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-        temp_writer_data_.clear();
-        temp_writer_data_.guid().guidPrefix = pdata->m_guid.guidPrefix;
-        temp_writer_data_.guid().entityId = c_EntityId_SPDPWriter;
-        temp_writer_data_.persistence_guid(pdata->get_persistence_guid());
-        temp_writer_data_.set_persistence_entity_id(c_EntityId_SPDPWriter);
-        temp_writer_data_.set_remote_locators(pdata->metatraffic_locators, network, use_multicast_locators);
-        temp_writer_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
-        temp_writer_data_.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
-        mp_PDPReader->matched_writer_add(temp_writer_data_);
+        auto temp_writer_data = get_temporary_writer_proxies_pool().get();
+
+        temp_writer_data->clear();
+        temp_writer_data->guid().guidPrefix = pdata->m_guid.guidPrefix;
+        temp_writer_data->guid().entityId = c_EntityId_SPDPWriter;
+        temp_writer_data->persistence_guid(pdata->get_persistence_guid());
+        temp_writer_data->set_persistence_entity_id(c_EntityId_SPDPWriter);
+        temp_writer_data->set_remote_locators(pdata->metatraffic_locators, network, use_multicast_locators);
+        temp_writer_data->m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+        temp_writer_data->m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
+        mp_PDPReader->matched_writer_add(*temp_writer_data);
     }
     auxendp = endp;
     auxendp &= DISC_BUILTIN_ENDPOINT_PARTICIPANT_DETECTOR;
     if (auxendp != 0)
     {
-        std::lock_guard<std::mutex> data_guard(temp_data_lock_);
-        temp_reader_data_.clear();
-        temp_reader_data_.m_expectsInlineQos = false;
-        temp_reader_data_.guid().guidPrefix = pdata->m_guid.guidPrefix;
-        temp_reader_data_.guid().entityId = c_EntityId_SPDPReader;
-        temp_reader_data_.set_remote_locators(pdata->metatraffic_locators, network, use_multicast_locators);
-        temp_reader_data_.m_qos.m_reliability.kind = BEST_EFFORT_RELIABILITY_QOS;
-        temp_reader_data_.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
-        mp_PDPWriter->matched_reader_add(temp_reader_data_);
+        auto temp_reader_data = get_temporary_reader_proxies_pool().get();
+
+        temp_reader_data->clear();
+        temp_reader_data->m_expectsInlineQos = false;
+        temp_reader_data->guid().guidPrefix = pdata->m_guid.guidPrefix;
+        temp_reader_data->guid().entityId = c_EntityId_SPDPReader;
+        temp_reader_data->set_remote_locators(pdata->metatraffic_locators, network, use_multicast_locators);
+        temp_reader_data->m_qos.m_reliability.kind = BEST_EFFORT_RELIABILITY_QOS;
+        temp_reader_data->m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
+        mp_PDPWriter->matched_reader_add(*temp_reader_data);
 
         StatelessWriter* pW = dynamic_cast<StatelessWriter*>(mp_PDPWriter);
 

--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -139,8 +139,8 @@ WLP::~WLP()
 #if HAVE_SECURITY
     if (mp_participant->is_secure())
     {
-        mp_participant->deleteUserEndpoint(mp_builtinReaderSecure);
-        mp_participant->deleteUserEndpoint(mp_builtinWriterSecure);
+        mp_participant->deleteUserEndpoint(mp_builtinReaderSecure->getGuid());
+        mp_participant->deleteUserEndpoint(mp_builtinWriterSecure->getGuid());
 
         if (mp_builtinReaderSecureHistory)
         {
@@ -158,8 +158,8 @@ WLP::~WLP()
     }
 #endif // if HAVE_SECURITY
 
-    mp_participant->deleteUserEndpoint(mp_builtinReader);
-    mp_participant->deleteUserEndpoint(mp_builtinWriter);
+    mp_participant->deleteUserEndpoint(mp_builtinReader->getGuid());
+    mp_participant->deleteUserEndpoint(mp_builtinWriter->getGuid());
 
     if (mp_builtinReaderHistory)
     {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -67,6 +67,8 @@ using UDPv4TransportDescriptor = fastdds::rtps::UDPv4TransportDescriptor;
 using TCPTransportDescriptor = fastdds::rtps::TCPTransportDescriptor;
 using SharedMemTransportDescriptor = fastdds::rtps::SharedMemTransportDescriptor;
 
+thread_local RTPSParticipantImpl* RTPSParticipantImpl::collections_mutex_owner_ = nullptr;
+
 static EntityId_t TrustedWriter(
         const EntityId_t& reader)
 {
@@ -464,27 +466,7 @@ void RTPSParticipantImpl::disable()
         block.disable();
     }
 
-    {
-        // take PDP mutex to avoid ABBA deadlock, make not be avaiable on DiscoveryProtocol::NONE
-        std::unique_ptr<std::lock_guard<std::recursive_mutex>> _;
-        if (mp_builtinProtocols->mp_PDP)
-        {
-            // TODO: promote to make_unike in C++14 upgrade
-            _.reset(new std::lock_guard<std::recursive_mutex>(*mp_builtinProtocols->mp_PDP->getMutex()));
-        }
-
-        std::lock_guard<std::recursive_mutex> __(*mp_mutex);
-
-        while (m_userReaderList.size() > 0)
-        {
-            deleteUserEndpoint(static_cast<Endpoint*>(*m_userReaderList.begin()));
-        }
-
-        while (m_userWriterList.size() > 0)
-        {
-            deleteUserEndpoint(static_cast<Endpoint*>(*m_userWriterList.begin()));
-        }
-    }
+    deleteAllUserEndpoints();
 
     mp_event_thr.stop_thread();
 
@@ -770,13 +752,13 @@ bool RTPSParticipantImpl::create_writer(
     }
 
     {
-        std::lock_guard<std::mutex> lock(endpoints_list_mutex);
+        std::lock_guard<shared_mutex> _(endpoints_list_mutex);
         m_allWriterList.push_back(SWriter);
-    }
-    if (!is_builtin)
-    {
-        std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
-        m_userWriterList.push_back(SWriter);
+
+        if (!is_builtin)
+        {
+            m_userWriterList.push_back(SWriter);
+        }
     }
     *writer_out = SWriter;
 
@@ -908,13 +890,14 @@ bool RTPSParticipantImpl::create_reader(
     }
 
     {
-        std::lock_guard<std::mutex> lock(endpoints_list_mutex);
+        std::lock_guard<shared_mutex> _(endpoints_list_mutex);
+
         m_allReaderList.push_back(SReader);
-    }
-    if (!is_builtin)
-    {
-        std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
-        m_userReaderList.push_back(SReader);
+
+        if (!is_builtin)
+        {
+            m_userReaderList.push_back(SReader);
+        }
     }
     *reader_out = SReader;
 
@@ -1172,7 +1155,7 @@ bool RTPSParticipantImpl::createReader(
 RTPSReader* RTPSParticipantImpl::find_local_reader(
         const GUID_t& reader_guid)
 {
-    std::lock_guard<std::mutex> guard(endpoints_list_mutex);
+    shared_lock<shared_mutex> _(endpoints_list_mutex);
 
     for (auto reader : m_allReaderList)
     {
@@ -1188,7 +1171,7 @@ RTPSReader* RTPSParticipantImpl::find_local_reader(
 RTPSWriter* RTPSParticipantImpl::find_local_writer(
         const GUID_t& writer_guid)
 {
-    std::lock_guard<std::mutex> guard(endpoints_list_mutex);
+    shared_lock<shared_mutex> _(endpoints_list_mutex);
 
     for (auto writer : m_allWriterList)
     {
@@ -1458,27 +1441,23 @@ bool RTPSParticipantImpl::existsEntityId(
         const EntityId_t& ent,
         EndpointKind_t kind) const
 {
-    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
+
+    auto check = [&ent](Endpoint* e)
+            {
+                return ent == e->getGuid().entityId;
+            };
+
+    shared_lock<shared_mutex> _(endpoints_list_mutex);
+
     if (kind == WRITER)
     {
-        for (std::vector<RTPSWriter*>::const_iterator it = m_userWriterList.begin(); it != m_userWriterList.end(); ++it)
-        {
-            if (ent == (*it)->getGuid().entityId)
-            {
-                return true;
-            }
-        }
+        return std::any_of(m_userWriterList.begin(), m_userWriterList.end(), check);
     }
     else
     {
-        for (std::vector<RTPSReader*>::const_iterator it = m_userReaderList.begin(); it != m_userReaderList.end(); ++it)
-        {
-            if (ent == (*it)->getGuid().entityId)
-            {
-                return true;
-            }
-        }
+        return std::any_of(m_userReaderList.begin(), m_userReaderList.end(), check);
     }
+
     return false;
 }
 
@@ -1701,111 +1680,207 @@ void RTPSParticipantImpl::createSenderResources(
 }
 
 bool RTPSParticipantImpl::deleteUserEndpoint(
-        Endpoint* p_endpoint)
+        const GUID_t& endpoint)
 {
-    m_receiverResourcelistMutex.lock();
-    for (auto it = m_receiverResourcelist.begin(); it != m_receiverResourcelist.end(); ++it)
+    if ( getGuid().guidPrefix != endpoint.guidPrefix)
     {
-        it->mp_receiver->removeEndpoint(p_endpoint);
+        return false;
     }
-    m_receiverResourcelistMutex.unlock();
 
     bool found = false, found_in_users = false;
+    Endpoint* p_endpoint = nullptr;
+
+    if (endpoint.entityId.is_writer())
     {
-        if (p_endpoint->getAttributes().endpointKind == WRITER)
+        std::lock_guard<shared_mutex> _(endpoints_list_mutex);
+
+        for (auto wit = m_userWriterList.begin(); wit != m_userWriterList.end(); ++wit)
         {
+            if ((*wit)->getGuid().entityId == endpoint.entityId) //Found it
             {
-                std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
-                for (auto wit = m_userWriterList.begin(); wit != m_userWriterList.end(); ++wit)
-                {
-                    if ((*wit)->getGuid().entityId == p_endpoint->getGuid().entityId) //Found it
-                    {
-                        m_userWriterList.erase(wit);
-                        found_in_users = true;
-                        break;
-                    }
-                }
+                m_userWriterList.erase(wit);
+                found_in_users = true;
+                break;
             }
-            {
-                std::lock_guard<std::mutex> lock(endpoints_list_mutex);
-                for (auto wit = m_allWriterList.begin(); wit != m_allWriterList.end(); ++wit)
-                {
-                    if ((*wit)->getGuid().entityId == p_endpoint->getGuid().entityId) //Found it
-                    {
-                        m_allWriterList.erase(wit);
-                        found = true;
-                        break;
-                    }
-                }
-            }
-        }
-        else
-        {
-            {
-                std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
-                for (auto rit = m_userReaderList.begin(); rit != m_userReaderList.end(); ++rit)
-                {
-                    if ((*rit)->getGuid().entityId == p_endpoint->getGuid().entityId) //Found it
-                    {
-                        m_userReaderList.erase(rit);
-                        found_in_users = true;
-                        break;
-                    }
-                }
-            }
-            {
-                std::lock_guard<std::mutex> lock(endpoints_list_mutex);
-                for (auto rit = m_allReaderList.begin(); rit != m_allReaderList.end(); ++rit)
-                {
-                    if ((*rit)->getGuid().entityId == p_endpoint->getGuid().entityId) //Found it
-                    {
-                        m_allReaderList.erase(rit);
-                        found = true;
-                        break;
-                    }
-                }
-            }
-        }
-        if (!found)
-        {
-            return false;
         }
 
-        //REMOVE FOR BUILTINPROTOCOLS
-        if (p_endpoint->getAttributes().endpointKind == WRITER)
+        for (auto wit = m_allWriterList.begin(); wit != m_allWriterList.end(); ++wit)
         {
-            if (found_in_users)
+            if ((*wit)->getGuid().entityId == endpoint.entityId) //Found it
             {
-                mp_builtinProtocols->removeLocalWriter(static_cast<RTPSWriter*>(p_endpoint));
+                p_endpoint = *wit;
+                m_allWriterList.erase(wit);
+                found = true;
+                break;
             }
-
-#if HAVE_SECURITY
-            if (p_endpoint->getAttributes().security_attributes().is_submessage_protected ||
-                    p_endpoint->getAttributes().security_attributes().is_payload_protected)
-            {
-                m_security_manager.unregister_local_writer(p_endpoint->getGuid());
-            }
-#endif // if HAVE_SECURITY
-        }
-        else
-        {
-            if (found_in_users)
-            {
-                mp_builtinProtocols->removeLocalReader(static_cast<RTPSReader*>(p_endpoint));
-            }
-
-#if HAVE_SECURITY
-            if (p_endpoint->getAttributes().security_attributes().is_submessage_protected ||
-                    p_endpoint->getAttributes().security_attributes().is_payload_protected)
-            {
-                m_security_manager.unregister_local_reader(p_endpoint->getGuid());
-            }
-#endif // if HAVE_SECURITY
         }
     }
-    //	std::lock_guard<std::recursive_mutex> guardEndpoint(*p_endpoint->getMutex());
+    else
+    {
+        std::lock_guard<shared_mutex> _(endpoints_list_mutex);
+
+        for (auto rit = m_userReaderList.begin(); rit != m_userReaderList.end(); ++rit)
+        {
+            if ((*rit)->getGuid().entityId == endpoint.entityId) //Found it
+            {
+                m_userReaderList.erase(rit);
+                found_in_users = true;
+                break;
+            }
+        }
+
+        for (auto rit = m_allReaderList.begin(); rit != m_allReaderList.end(); ++rit)
+        {
+            if ((*rit)->getGuid().entityId == endpoint.entityId) //Found it
+            {
+                p_endpoint = *rit;
+                m_allReaderList.erase(rit);
+                found = true;
+                break;
+            }
+        }
+    }
+
+    if (!found)
+    {
+        return false;
+    }
+
+    {
+        std::lock_guard<std::mutex> _(m_receiverResourcelistMutex);
+
+        for (auto& rb : m_receiverResourcelist)
+        {
+            auto receiver = rb.mp_receiver;
+            if (receiver)
+            {
+                receiver->removeEndpoint(p_endpoint);
+            }
+        }
+    }
+
+    //REMOVE FROM BUILTIN PROTOCOLS
+    if (p_endpoint->getAttributes().endpointKind == WRITER)
+    {
+        if (found_in_users)
+        {
+            mp_builtinProtocols->removeLocalWriter(static_cast<RTPSWriter*>(p_endpoint));
+        }
+
+#if HAVE_SECURITY
+        if (p_endpoint->getAttributes().security_attributes().is_submessage_protected ||
+                p_endpoint->getAttributes().security_attributes().is_payload_protected)
+        {
+            m_security_manager.unregister_local_writer(p_endpoint->getGuid());
+        }
+#endif // if HAVE_SECURITY
+    }
+    else
+    {
+        if (found_in_users)
+        {
+            mp_builtinProtocols->removeLocalReader(static_cast<RTPSReader*>(p_endpoint));
+        }
+
+#if HAVE_SECURITY
+        if (p_endpoint->getAttributes().security_attributes().is_submessage_protected ||
+                p_endpoint->getAttributes().security_attributes().is_payload_protected)
+        {
+            m_security_manager.unregister_local_reader(p_endpoint->getGuid());
+        }
+#endif // if HAVE_SECURITY
+    }
+
     delete(p_endpoint);
     return true;
+}
+
+void RTPSParticipantImpl::deleteAllUserEndpoints()
+{
+    std::vector<Endpoint*> tmp(0);
+
+    {
+        using namespace std;
+
+        lock_guard<shared_mutex> _(endpoints_list_mutex);
+
+        // move the collections to a local
+        tmp.resize(m_userWriterList.size() + m_userReaderList.size());
+        auto it = move(m_userWriterList.begin(), m_userWriterList.end(), tmp.begin());
+        it = move(m_userReaderList.begin(), m_userReaderList.end(), it);
+
+        // check we have copied all elements
+        assert(tmp.end() == it);
+
+        // now update the all collections by removing the user elements
+        sort(m_userWriterList.begin(), m_userWriterList.end());
+        sort(m_userReaderList.begin(), m_userReaderList.end());
+        sort(m_allWriterList.begin(), m_allWriterList.end());
+        sort(m_allReaderList.begin(), m_allReaderList.end());
+
+        vector<RTPSWriter*> writers;
+        set_difference(m_allWriterList.begin(), m_allWriterList.end(),
+                m_userWriterList.begin(), m_userWriterList.end(),
+                back_inserter(writers));
+        swap(writers, m_allWriterList);
+
+        vector<RTPSReader*> readers;
+        set_difference(m_allReaderList.begin(), m_allReaderList.end(),
+                m_userReaderList.begin(), m_userReaderList.end(),
+                back_inserter(readers));
+        swap(readers, m_allReaderList);
+
+        // remove dangling references
+        m_userWriterList.clear();
+        m_userReaderList.clear();
+    }
+
+    // unlink the transport receiver blocks from the endpoints
+    for ( auto endpoint : tmp)
+    {
+        std::lock_guard<std::mutex> _(m_receiverResourcelistMutex);
+
+        for (auto& rb : m_receiverResourcelist)
+        {
+            auto receiver = rb.mp_receiver;
+            if (receiver)
+            {
+                receiver->removeEndpoint(endpoint);
+            }
+        }
+    }
+
+    // Remove from builtin protocols
+    auto removeEndpoint = [this](EndpointKind_t kind, Endpoint* p)
+            {
+                return kind == WRITER
+               ? mp_builtinProtocols->removeLocalWriter((RTPSWriter*)p)
+               : mp_builtinProtocols->removeLocalReader((RTPSReader*)p);
+            };
+
+#if HAVE_SECURITY
+    bool (eprosima::fastrtps::rtps::security::SecurityManager::* unregister_endpoint[2])(
+            const GUID_t& writer_guid);
+    unregister_endpoint[WRITER] = &security::SecurityManager::unregister_local_writer;
+    unregister_endpoint[READER] = &security::SecurityManager::unregister_local_reader;
+#endif // if HAVE_SECURITY
+
+    for ( auto endpoint : tmp)
+    {
+        auto kind = endpoint->getAttributes().endpointKind;
+        removeEndpoint(kind, endpoint);
+
+#if HAVE_SECURITY
+        if (endpoint->getAttributes().security_attributes().is_submessage_protected ||
+                endpoint->getAttributes().security_attributes().is_payload_protected)
+        {
+            (m_security_manager.*unregister_endpoint[kind])(endpoint->getGuid());
+        }
+#endif // if HAVE_SECURITY
+
+        // remove the endpoints
+        delete(endpoint);
+    }
 }
 
 void RTPSParticipantImpl::normalize_endpoint_locators(
@@ -2384,11 +2459,11 @@ bool RTPSParticipantImpl::register_in_writer(
         std::shared_ptr<fastdds::statistics::IListener> listener,
         GUID_t writer_guid)
 {
-    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
     bool res = false;
 
     if ( GUID_t::unknown() == writer_guid )
     {
+        shared_lock<shared_mutex> _(endpoints_list_mutex);
         res = true;
         for ( auto writer : m_userWriterList)
         {
@@ -2411,11 +2486,11 @@ bool RTPSParticipantImpl::register_in_reader(
         std::shared_ptr<fastdds::statistics::IListener> listener,
         GUID_t reader_guid)
 {
-    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
     bool res = false;
 
     if ( GUID_t::unknown() == reader_guid )
     {
+        shared_lock<shared_mutex> _(endpoints_list_mutex);
         res = true;
         for ( auto reader : m_userReaderList)
         {
@@ -2437,7 +2512,7 @@ bool RTPSParticipantImpl::register_in_reader(
 bool RTPSParticipantImpl::unregister_in_writer(
         std::shared_ptr<fastdds::statistics::IListener> listener)
 {
-    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
+    shared_lock<shared_mutex> _(endpoints_list_mutex);
     bool res = true;
 
     for ( auto writer : m_userWriterList)
@@ -2454,7 +2529,7 @@ bool RTPSParticipantImpl::unregister_in_writer(
 bool RTPSParticipantImpl::unregister_in_reader(
         std::shared_ptr<fastdds::statistics::IListener> listener)
 {
-    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
+    shared_lock<shared_mutex> _(endpoints_list_mutex);
     bool res = true;
 
     for ( auto reader : m_userReaderList)

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -19,14 +19,17 @@
 #ifndef _RTPS_PARTICIPANT_RTPSPARTICIPANTIMPL_H_
 #define _RTPS_PARTICIPANT_RTPSPARTICIPANTIMPL_H_
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+
+#include <atomic>
+#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <list>
-#include <sys/types.h>
 #include <mutex>
-#include <atomic>
-#include <chrono>
+#include <sys/types.h>
+
 #include <fastrtps/utils/Semaphore.h>
+#include <fastrtps/utils/shared_mutex.hpp>
 
 #if defined(_WIN32)
 #include <process.h>
@@ -530,7 +533,9 @@ private:
     //!Id counter to correctly assign the ids to writers and readers.
     uint32_t IdCounter;
     //! Mutex to safely access endpoints collections
-    std::mutex endpoints_list_mutex;
+    mutable shared_mutex endpoints_list_mutex;
+    //! This member avoids shared_mutex reentrancy by tracking last participant into traversing the endpoints collections
+    static thread_local RTPSParticipantImpl* collections_mutex_owner_;
     //!Writer List.
     std::vector<RTPSWriter*> m_allWriterList;
     //!Reader List
@@ -912,42 +917,76 @@ public:
      * @return True on success
      */
     bool deleteUserEndpoint(
-            Endpoint*);
+            const GUID_t&);
 
-    /**
-     * Get the begin of the user reader list
-     * @return Iterator pointing to the begin of the user reader list
+    //! Delete all user endpoints, builtin are disposed in its related classes
+    void deleteAllUserEndpoints();
+
+    /** Traverses the user writers collection transforming its elements with a provided functor
+     * @param f - Functor applied to each element. Must accept a reference as parameter. Should return true to keep iterating.
+     * @return Functor provided in order to allow aggregates retrieval
      */
-    std::vector<RTPSReader*>::iterator userReadersListBegin()
+    template<class Functor>
+    Functor forEachUserWriter(
+            Functor f)
     {
-        return m_userReaderList.begin();
+        // check if we are reentrying
+        shared_lock<shared_mutex> may_lock;
+        RTPSParticipantImpl* previous_owner = collections_mutex_owner_;
+
+        if (collections_mutex_owner_ != this)
+        {
+            shared_lock<shared_mutex> lock(endpoints_list_mutex);
+            may_lock = std::move(lock);
+            collections_mutex_owner_ = this;
+        }
+
+        // traverse the list
+        for ( RTPSWriter* pw : m_userWriterList)
+        {
+            if (!f(*pw))
+            {
+                break;
+            }
+        }
+
+        // restore tls former value
+        std::swap(collections_mutex_owner_, previous_owner);
+
+        return f;
     }
 
-    /**
-     * Get the end of the user reader list
-     * @return Iterator pointing to the end of the user reader list
+    /** Traverses the user readers collection transforming its elements with a provided functor
+     * @param f - Functor applied to each element. Must accept a reference as parameter. Should return true to keep iterating.
+     * @return Functor provided in order to allow aggregates retrieval
      */
-    std::vector<RTPSReader*>::iterator userReadersListEnd()
+    template<class Functor>
+    Functor forEachUserReader(
+            Functor f)
     {
-        return m_userReaderList.end();
-    }
+        // check if we are reentrying
+        shared_lock<shared_mutex> may_lock;
+        RTPSParticipantImpl* previous_owner = collections_mutex_owner_;
 
-    /**
-     * Get the begin of the user writer list
-     * @return Iterator pointing to the begin of the user writer list
-     */
-    std::vector<RTPSWriter*>::iterator userWritersListBegin()
-    {
-        return m_userWriterList.begin();
-    }
+        if (collections_mutex_owner_ != this)
+        {
+            shared_lock<shared_mutex> lock(endpoints_list_mutex);
+            may_lock = std::move(lock);
+            collections_mutex_owner_ = this;
+        }
 
-    /**
-     * Get the end of the user writer list
-     * @return Iterator pointing to the end of the user writer list
-     */
-    std::vector<RTPSWriter*>::iterator userWritersListEnd()
-    {
-        return m_userWriterList.end();
+        for ( RTPSReader* pr : m_userReaderList)
+        {
+            if (!f(*pr))
+            {
+                break;
+            }
+        }
+
+        // restore tls former value
+        std::swap(collections_mutex_owner_, previous_owner);
+
+        return f;
     }
 
     /** Helper function that creates ReceiverResources based on a Locator_t List, possibly mutating

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -1120,7 +1120,7 @@ void SecurityManager::delete_participant_stateless_message_writer()
 {
     if (participant_stateless_message_writer_ != nullptr)
     {
-        participant_->deleteUserEndpoint(participant_stateless_message_writer_);
+        participant_->deleteUserEndpoint(participant_stateless_message_writer_->getGuid());
         participant_stateless_message_writer_ = nullptr;
     }
 
@@ -1169,7 +1169,7 @@ void SecurityManager::delete_participant_stateless_message_reader()
 {
     if (participant_stateless_message_reader_ != nullptr)
     {
-        participant_->deleteUserEndpoint(participant_stateless_message_reader_);
+        participant_->deleteUserEndpoint(participant_stateless_message_reader_->getGuid());
         participant_stateless_message_reader_ = nullptr;
     }
 
@@ -1268,7 +1268,7 @@ void SecurityManager::delete_participant_volatile_message_secure_writer()
 {
     if (participant_volatile_message_secure_writer_ != nullptr)
     {
-        participant_->deleteUserEndpoint(participant_volatile_message_secure_writer_);
+        participant_->deleteUserEndpoint(participant_volatile_message_secure_writer_->getGuid());
         participant_volatile_message_secure_writer_ = nullptr;
     }
 
@@ -1317,7 +1317,7 @@ void SecurityManager::delete_participant_volatile_message_secure_reader()
 {
     if (participant_volatile_message_secure_reader_ != nullptr)
     {
-        participant_->deleteUserEndpoint(participant_volatile_message_secure_reader_);
+        participant_->deleteUserEndpoint(participant_volatile_message_secure_reader_->getGuid());
         participant_volatile_message_secure_reader_ = nullptr;
     }
 

--- a/test/mock/rtps/PDP/fastdds/rtps/builtin/discovery/participant/PDP.h
+++ b/test/mock/rtps/PDP/fastdds/rtps/builtin/discovery/participant/PDP.h
@@ -79,9 +79,24 @@ public:
     MOCK_METHOD0(ParticipantProxiesBegin, ResourceLimitedVector<ParticipantProxyData*>::const_iterator());
 
     MOCK_METHOD0(ParticipantProxiesEnd, ResourceLimitedVector<ParticipantProxyData*>::const_iterator());
+
+    ProxyPool<ReaderProxyData>& get_temporary_reader_proxies_pool()
+    {
+        return temp_proxy_readers;
+    }
+
+    ProxyPool<WriterProxyData>& get_temporary_writer_proxies_pool()
+    {
+        return temp_proxy_writers;
+    }
+
     // *INDENT-ON*
 
     std::recursive_mutex* mutex_;
+
+    // temporary proxies pools
+    ProxyPool<ReaderProxyData> temp_proxy_readers = {{4, 1}};
+    ProxyPool<WriterProxyData> temp_proxy_writers = {{4, 1}};
 };
 
 

--- a/test/mock/rtps/RTPSReader/fastdds/rtps/reader/RTPSReader.h
+++ b/test/mock/rtps/RTPSReader/fastdds/rtps/reader/RTPSReader.h
@@ -221,7 +221,7 @@ public:
 
     ReaderListener* listener_;
 
-    const GUID_t m_guid;
+    GUID_t m_guid;
 };
 
 } // namespace rtps

--- a/test/mock/rtps/StatefulWriter/fastdds/rtps/writer/StatefulWriter.h
+++ b/test/mock/rtps/StatefulWriter/fastdds/rtps/writer/StatefulWriter.h
@@ -58,8 +58,6 @@ public:
 
     MOCK_METHOD1 (matched_reader_is_matched, bool(const GUID_t& reader_guid));
 
-    MOCK_METHOD0(getGuid, const GUID_t& ());
-
     MOCK_METHOD1(unsent_change_added_to_history_mock, void(CacheChange_t*));
 
     MOCK_METHOD1(perform_nack_supression, void(const GUID_t&));

--- a/test/mock/rtps/StatelessWriter/fastdds/rtps/writer/StatelessWriter.h
+++ b/test/mock/rtps/StatelessWriter/fastdds/rtps/writer/StatelessWriter.h
@@ -45,8 +45,6 @@ public:
 
     MOCK_METHOD1 (matched_reader_is_matched, bool(const GUID_t& reader_guid));
 
-    MOCK_METHOD0(getGuid, const GUID_t& ());
-
     MOCK_METHOD1(unsent_change_added_to_history_mock, void(CacheChange_t*));
 
     RTPSParticipantImpl* getRTPSParticipant()

--- a/test/unittest/rtps/security/SecurityHandshakeProcessTests.cpp
+++ b/test/unittest/rtps/security/SecurityHandshakeProcessTests.cpp
@@ -612,7 +612,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_fail_process_handsha
 
     ParticipantGenericMessage message;
     message.message_identity().source_guid(remote_participant_key);
-    message.related_message_identity().source_guid(remote_participant_key);
+    message.related_message_identity().source_guid(stateless_writer_->getGuid());
     message.related_message_identity().sequence_number(1);
     message.destination_participant_key(remote_participant_key);
     message.message_class_id("dds.sec.auth");
@@ -665,7 +665,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_process_handshake
 
     ParticipantGenericMessage message;
     message.message_identity().source_guid(remote_participant_key);
-    message.related_message_identity().source_guid(remote_participant_key);
+    message.related_message_identity().source_guid(stateless_writer_->getGuid());
     message.related_message_identity().sequence_number(1);
     message.destination_participant_key(remote_participant_key);
     message.message_class_id("dds.sec.auth");
@@ -737,7 +737,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_re
 
     ParticipantGenericMessage message;
     message.message_identity().source_guid(remote_participant_key);
-    message.related_message_identity().source_guid(remote_participant_key);
+    message.related_message_identity().source_guid(stateless_writer_->getGuid());
     message.related_message_identity().sequence_number(1);
     message.destination_participant_key(remote_participant_key);
     message.message_class_id("dds.sec.auth");
@@ -791,7 +791,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_re
 
     ParticipantGenericMessage message;
     message.message_identity().source_guid(remote_participant_key);
-    message.related_message_identity().source_guid(remote_participant_key);
+    message.related_message_identity().source_guid(stateless_writer_->getGuid());
     message.related_message_identity().sequence_number(1);
     message.destination_participant_key(remote_participant_key);
     message.message_class_id("dds.sec.auth");
@@ -870,7 +870,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_re
 
     ParticipantGenericMessage message;
     message.message_identity().source_guid(remote_participant_key);
-    message.related_message_identity().source_guid(remote_participant_key);
+    message.related_message_identity().source_guid(stateless_writer_->getGuid());
     message.related_message_identity().sequence_number(1);
     message.destination_participant_key(remote_participant_key);
     message.message_class_id("dds.sec.auth");
@@ -1006,7 +1006,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_fail_process_handsha
 
     ParticipantGenericMessage message;
     message.message_identity().source_guid(remote_participant_key);
-    message.related_message_identity().source_guid(remote_participant_key);
+    message.related_message_identity().source_guid(stateless_writer_->getGuid());
     message.related_message_identity().sequence_number(1);
     message.destination_participant_key(remote_participant_key);
     message.message_class_id("dds.sec.auth");
@@ -1059,7 +1059,7 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_process_handshake
 
     ParticipantGenericMessage message;
     message.message_identity().source_guid(remote_participant_key);
-    message.related_message_identity().source_guid(remote_participant_key);
+    message.related_message_identity().source_guid(stateless_writer_->getGuid());
     message.related_message_identity().sequence_number(1);
     message.destination_participant_key(remote_participant_key);
     message.message_class_id("dds.sec.auth");

--- a/test/unittest/rtps/security/SecurityTests.cpp
+++ b/test/unittest/rtps/security/SecurityTests.cpp
@@ -179,7 +179,7 @@ void SecurityTest::final_message_process_ok(
 
     ParticipantGenericMessage message;
     message.message_identity().source_guid(remote_participant_key);
-    message.related_message_identity().source_guid(remote_participant_key);
+    message.related_message_identity().source_guid(stateless_writer_->getGuid());
     message.related_message_identity().sequence_number(1);
     message.destination_participant_key(remote_participant_key);
     message.message_class_id("dds.sec.auth");

--- a/test/unittest/rtps/writer/CMakeLists.txt
+++ b/test/unittest/rtps/writer/CMakeLists.txt
@@ -101,7 +101,7 @@ target_compile_definitions(RTPSWriterTests PRIVATE
     )
 target_include_directories(RTPSWriterTests PRIVATE
     ${Asio_INCLUDE_DIR})
-target_link_libraries(RTPSWriterTests fastrtps foonathan_memory
+target_link_libraries(RTPSWriterTests fastcdr fastrtps foonathan_memory
     GTest::gmock
     ${CMAKE_DL_LIBS})
 add_gtest(RTPSWriterTests SOURCES ${RTPSWRITERTESTS_SOURCE})

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -836,6 +836,8 @@ TEST_F(RTPSStatisticsTests, statistics_rpts_listener_gap_callback)
     // add a second sample and remove it to generate the gap
     write_small_sample(length);
     ASSERT_TRUE(writer_history_->remove_change(SequenceNumber_t{0, 2}));
+    // add a third sample in order to force the gap
+    write_small_sample(length);
 
     // create the late joiner as VOLATILE
     create_reader(length, RELIABLE, VOLATILE);


### PR DESCRIPTION
Signed-off-by: Javier Santiago <javiersantiago@eprosima.com>

<!-- Provide a general summary of your changes in the Title above -->

The sanitizer ci runs & review on https://github.com/eProsima/Fast-DDS/pull/2730
It must be merged after https://github.com/eProsima/Fast-DDS/pull/2717

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This applies to Thread Sanitizer issues 4121, 4122, 4123.

All these issues follow the same pattern. A new Condition is registered while an old one is being destroyed. This causes a deadlock since the locks are taken as follows:

`WaitSetImpl::attach_condition` (A) -> `ConditionNotifier::attach_to` (B)
`ConditionNotifier::will_be_deleted` (B) -> `WaitSetImpl::will_be_deleted` (A)

We prevent the issue by reducing the scope of lock A's protection inside `attach_condition` and `detach_condition`.


<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.

