### PR TITLE
[14630] Adding configuration data for external locators feature

### DIFF
--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -24,6 +24,7 @@
 
 #include <fastdds/dds/core/policy/ParameterTypes.hpp>
 
+#include <fastdds/rtps/attributes/ExternalLocators.hpp>
 #include <fastdds/rtps/attributes/PropertyPolicy.h>
 #include <fastdds/rtps/attributes/RTPSParticipantAllocationAttributes.hpp>
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
@@ -2675,6 +2676,7 @@ public:
                (this->throughput_controller == b.throughput_controller) &&
                (this->default_unicast_locator_list == b.default_unicast_locator_list) &&
                (this->default_multicast_locator_list == b.default_multicast_locator_list) &&
+               (this->default_external_unicast_locators == b.default_external_unicast_locators) &&
                QosPolicy::operator ==(b);
     }
 
@@ -2710,6 +2712,11 @@ public:
      * case that it was defined with NO UnicastLocators. This is usually left empty.
      */
     rtps::LocatorList default_multicast_locator_list;
+
+    /**
+     * The collection of external locators to use for communication on user created topics.
+     */
+    rtps::ExternalLocators default_external_unicast_locators;
 };
 
 //! Qos Policy to configure the transport layer

--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -2690,16 +2690,16 @@ public:
     //! Optionally allows user to define the GuidPrefix_t
     fastrtps::rtps::GuidPrefix_t prefix;
 
-    //!Participant ID <br> By default, -1.
+    //! Participant ID <br> By default, -1.
     int32_t participant_id;
 
     //! Builtin parameters.
     fastrtps::rtps::BuiltinAttributes builtin;
 
-    //!Port Parameters
+    //! Port Parameters
     fastrtps::rtps::PortParameters port;
 
-    //!Throughput controller parameters. Leave default for uncontrolled flow.
+    //! Throughput controller parameters. Leave default for uncontrolled flow.
     fastrtps::rtps::ThroughputControllerDescriptor throughput_controller;
 
     /**
@@ -2710,7 +2710,7 @@ public:
 
     /**
      * Default list of Multicast Locators to be used for any Endpoint defined inside this RTPSParticipant in the
-     * case that it was defined with NO UnicastLocators. This is usually left empty.
+     * case that it was defined with NO MulticastLocators. This is usually left empty.
      */
     rtps::LocatorList default_multicast_locator_list;
 

--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -2811,10 +2811,10 @@ public:
     //!Remote locator list
     rtps::LocatorList remote_locator_list;
 
-    //!The collection of external locators to use for communication.
+    //! The collection of external locators to use for communication.
     fastdds::rtps::ExternalLocators external_unicast_locators;
 
-    //!Whether locators that don't match with the announced locators should be kept.
+    //! Whether locators that don't match with the announced locators should be kept.
     bool ignore_non_matching_locators = false;
 
     //!User Defined ID, used for StaticEndpointDiscovery. <br> By default, -1.

--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -2780,7 +2780,7 @@ public:
     uint32_t listen_socket_buffer_size;
 };
 
-//!Qos Policy to configure the endpoint
+//! Qos Policy to configure the endpoint
 class RTPSEndpointQos
 {
 public:
@@ -2802,13 +2802,13 @@ public:
                (this->history_memory_policy == b.history_memory_policy);
     }
 
-    //!Unicast locator list
+    //! Unicast locator list
     rtps::LocatorList unicast_locator_list;
 
-    //!Multicast locator list
+    //! Multicast locator list
     rtps::LocatorList multicast_locator_list;
 
-    //!Remote locator list
+    //! Remote locator list
     rtps::LocatorList remote_locator_list;
 
     //! The collection of external locators to use for communication.
@@ -2817,13 +2817,13 @@ public:
     //! Whether locators that don't match with the announced locators should be kept.
     bool ignore_non_matching_locators = false;
 
-    //!User Defined ID, used for StaticEndpointDiscovery. <br> By default, -1.
+    //! User Defined ID, used for StaticEndpointDiscovery. <br> By default, -1.
     int16_t user_defined_id = -1;
 
-    //!Entity ID, if the user wants to specify the EntityID of the endpoint. <br> By default, -1.
+    //! Entity ID, if the user wants to specify the EntityID of the endpoint. <br> By default, -1.
     int16_t entity_id = -1;
 
-    //!Underlying History memory policy. <br> By default, PREALLOCATED_MEMORY_MODE.
+    //! Underlying History memory policy. <br> By default, PREALLOCATED_MEMORY_MODE.
     fastrtps::rtps::MemoryManagementPolicy_t history_memory_policy = fastrtps::rtps::PREALLOCATED_MEMORY_MODE;
 };
 

--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -2785,12 +2785,7 @@ class RTPSEndpointQos
 {
 public:
 
-    RTPS_DllAPI RTPSEndpointQos()
-        : user_defined_id(-1)
-        , entity_id(-1)
-        , history_memory_policy(fastrtps::rtps::PREALLOCATED_MEMORY_MODE)
-    {
-    }
+    RTPS_DllAPI RTPSEndpointQos() = default;
 
     virtual RTPS_DllAPI ~RTPSEndpointQos() = default;
 
@@ -2800,6 +2795,8 @@ public:
         return (this->unicast_locator_list == b.unicast_locator_list) &&
                (this->multicast_locator_list == b.multicast_locator_list) &&
                (this->remote_locator_list == b.remote_locator_list) &&
+               (this->external_unicast_locators == b.external_unicast_locators) &&
+               (this->ignore_non_matching_locators == b.ignore_non_matching_locators) &&
                (this->user_defined_id == b.user_defined_id) &&
                (this->entity_id == b.entity_id) &&
                (this->history_memory_policy == b.history_memory_policy);
@@ -2814,14 +2811,20 @@ public:
     //!Remote locator list
     rtps::LocatorList remote_locator_list;
 
+    //!The collection of external locators to use for communication.
+    fastdds::rtps::ExternalLocators external_unicast_locators;
+
+    //!Whether locators that don't match with the announced locators should be kept.
+    bool ignore_non_matching_locators = false;
+
     //!User Defined ID, used for StaticEndpointDiscovery. <br> By default, -1.
-    int16_t user_defined_id;
+    int16_t user_defined_id = -1;
 
     //!Entity ID, if the user wants to specify the EntityID of the endpoint. <br> By default, -1.
-    int16_t entity_id;
+    int16_t entity_id = -1;
 
     //!Underlying History memory policy. <br> By default, PREALLOCATED_MEMORY_MODE.
-    fastrtps::rtps::MemoryManagementPolicy_t history_memory_policy;
+    fastrtps::rtps::MemoryManagementPolicy_t history_memory_policy = fastrtps::rtps::PREALLOCATED_MEMORY_MODE;
 };
 
 //!Qos Policy to configure the limit of the writer resources

--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -2677,6 +2677,7 @@ public:
                (this->default_unicast_locator_list == b.default_unicast_locator_list) &&
                (this->default_multicast_locator_list == b.default_multicast_locator_list) &&
                (this->default_external_unicast_locators == b.default_external_unicast_locators) &&
+               (this->ignore_non_matching_locators == b.ignore_non_matching_locators) &&
                QosPolicy::operator ==(b);
     }
 
@@ -2717,6 +2718,11 @@ public:
      * The collection of external locators to use for communication on user created topics.
      */
     rtps::ExternalLocators default_external_unicast_locators;
+
+    /**
+     * Whether locators that don't match with the announced locators should be kept.
+     */
+    bool ignore_non_matching_locators = false;
 };
 
 //! Qos Policy to configure the transport layer

--- a/include/fastdds/rtps/attributes/EndpointAttributes.h
+++ b/include/fastdds/rtps/attributes/EndpointAttributes.h
@@ -19,6 +19,7 @@
 #ifndef _FASTDDS_ENDPOINTATTRIBUTES_H_
 #define _FASTDDS_ENDPOINTATTRIBUTES_H_
 
+#include <fastdds/rtps/attributes/ExternalLocators.hpp>
 #include <fastdds/rtps/attributes/PropertyPolicy.h>
 #include <fastrtps/qos/QosPolicies.h>
 
@@ -56,6 +57,12 @@ public:
 
     //!GUID used for persistence
     GUID_t persistence_guid;
+
+    //!The collection of external locators to use for communication.
+    fastdds::rtps::ExternalLocators external_unicast_locators;
+
+    //!Whether locators that don't match with the announced locators should be kept.
+    bool ignore_non_matching_locators = false;
 
     //!Unicast locator list
     LocatorList_t unicastLocatorList;

--- a/include/fastdds/rtps/attributes/EndpointAttributes.h
+++ b/include/fastdds/rtps/attributes/EndpointAttributes.h
@@ -43,54 +43,45 @@ class EndpointAttributes
 {
 public:
 
-    //!Endpoint kind, default value WRITER
-    EndpointKind_t endpointKind;
+    //! Endpoint kind, default value WRITER
+    EndpointKind_t endpointKind = EndpointKind_t::WRITER;
 
-    //!Topic kind, default value NO_KEY
-    TopicKind_t topicKind;
+    //! Topic kind, default value NO_KEY
+    TopicKind_t topicKind = TopicKind_t::NO_KEY;
 
-    //!Reliability kind, default value BEST_EFFORT
-    ReliabilityKind_t reliabilityKind;
+    //! Reliability kind, default value BEST_EFFORT
+    ReliabilityKind_t reliabilityKind = ReliabilityKind_t::BEST_EFFORT;
 
-    //!Durability kind, default value VOLATILE
-    DurabilityKind_t durabilityKind;
+    //! Durability kind, default value VOLATILE
+    DurabilityKind_t durabilityKind = DurabilityKind_t::VOLATILE;
 
-    //!GUID used for persistence
+    //! GUID used for persistence
     GUID_t persistence_guid;
 
-    //!The collection of external locators to use for communication.
+    //! The collection of external locators to use for communication.
     fastdds::rtps::ExternalLocators external_unicast_locators;
 
     //! Whether locators that don't match with the announced locators should be kept.
     bool ignore_non_matching_locators = false;
 
-    //!Unicast locator list
+    //! Unicast locator list
     LocatorList_t unicastLocatorList;
 
-    //!Multicast locator list
+    //! Multicast locator list
     LocatorList_t multicastLocatorList;
 
     //! Remote locator list.
     LocatorList_t remoteLocatorList;
 
-    //!Properties
+    //! Properties
     PropertyPolicy properties;
 
     EndpointAttributes()
-        : endpointKind(WRITER)
-        , topicKind(NO_KEY)
-        , reliabilityKind(BEST_EFFORT)
-        , durabilityKind(VOLATILE)
-        , persistence_guid()
-        , m_userDefinedID(-1)
-        , m_entityID(-1)
     {
         datasharing_.off();
     }
 
-    virtual ~EndpointAttributes()
-    {
-    }
+    virtual ~EndpointAttributes() = default;
 
     /**
      * Get the user defined ID
@@ -164,16 +155,18 @@ public:
 
 private:
 
-    //!User Defined ID, used for StaticEndpointDiscovery, default value -1.
-    int16_t m_userDefinedID;
+    //! User Defined ID, used for StaticEndpointDiscovery, default value -1.
+    int16_t m_userDefinedID = -1;
 
-    //!Entity ID, if the user want to specify the EntityID of the enpoint, default value -1.
-    int16_t m_entityID;
+    //! Entity ID, if the user want to specify the EntityID of the enpoint, default value -1.
+    int16_t m_entityID = -1;
 
 #if HAVE_SECURITY
+    //! Security attributes
     security::EndpointSecurityAttributes security_attributes_;
 #endif // HAVE_SECURITY
 
+    //! Settings for datasharing
     DataSharingQosPolicy datasharing_;
 };
 

--- a/include/fastdds/rtps/attributes/EndpointAttributes.h
+++ b/include/fastdds/rtps/attributes/EndpointAttributes.h
@@ -61,7 +61,7 @@ public:
     //!The collection of external locators to use for communication.
     fastdds::rtps::ExternalLocators external_unicast_locators;
 
-    //!Whether locators that don't match with the announced locators should be kept.
+    //! Whether locators that don't match with the announced locators should be kept.
     bool ignore_non_matching_locators = false;
 
     //!Unicast locator list

--- a/include/fastdds/rtps/attributes/ExternalLocators.hpp
+++ b/include/fastdds/rtps/attributes/ExternalLocators.hpp
@@ -1,0 +1,48 @@
+// Copyright 2022 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file ExternalLocators.hpp
+ */
+
+#ifndef _FASTDDS_RTPS_ATTRIBUTES_EXTERNALLOCATORS_HPP_
+#define _FASTDDS_RTPS_ATTRIBUTES_EXTERNALLOCATORS_HPP_
+
+#include <map>
+#include <vector>
+
+#include <fastdds/rtps/common/LocatorWithMask.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+
+/**
+ * A collection of LocatorWithMask grouped by externality and cost.
+ */
+using ExternalLocators = std::map<
+    uint8_t, // externality_index
+    std::map<
+        uint8_t, // cost
+        std::vector<LocatorWithMask> // locators with their mask
+        >,
+    std::greater<uint8_t> // Ordered by greater externality_index
+    >;
+
+
+} // namespace rtps
+} // namespace fastdds
+} // namespace eprosima
+
+#endif /* _FASTDDS_RTPS_ATTRIBUTES_EXTERNALLOCATORS_HPP_ */

--- a/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h
+++ b/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h
@@ -490,7 +490,7 @@ public:
 
     /**
      * Default list of Multicast Locators to be used for any Endpoint defined inside this RTPSParticipant in the
-     * case that it was defined with NO UnicastLocators. This is usually left empty.
+     * case that it was defined with NO MulticastLocators. This is usually left empty.
      */
     LocatorList_t defaultMulticastLocatorList;
 
@@ -527,37 +527,38 @@ public:
     //! Builtin parameters.
     BuiltinAttributes builtin;
 
-    //!Port Parameters
+    //! Port Parameters
     PortParameters port;
 
-    //!User Data of the participant
+    //! User Data of the participant
     std::vector<octet> userData;
 
-    //!Participant ID
+    //! Participant ID
     int32_t participantID;
 
-    //!Throughput controller parameters. Leave default for uncontrolled flow.
+    //! Throughput controller parameters. Leave default for uncontrolled flow.
     ThroughputControllerDescriptor throughputController;
 
-    //!User defined transports to use alongside or in place of builtins.
+    //! User defined transports to use alongside or in place of builtins.
     std::vector<std::shared_ptr<fastdds::rtps::TransportDescriptorInterface>> userTransports;
 
-    //!Set as false to disable the default UDPv4 implementation.
+    //! Set as false to disable the default UDPv4 implementation.
     bool useBuiltinTransports;
-    //!Holds allocation limits affecting collections managed by a participant.
+
+    //! Holds allocation limits affecting collections managed by a participant.
     RTPSParticipantAllocationAttributes allocation;
 
     //! Property policies
     PropertyPolicy properties;
 
-    //!Set the name of the participant.
+    //! Set the name of the participant.
     inline void setName(
             const char* nam)
     {
         name = nam;
     }
 
-    //!Get the name of the participant.
+    //! Get the name of the participant.
     inline const char* getName() const
     {
         return name.c_str();
@@ -568,7 +569,7 @@ public:
 
 private:
 
-    //!Name of the participant.
+    //! Name of the participant.
     string_255 name;
 };
 

--- a/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h
+++ b/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h
@@ -467,6 +467,7 @@ public:
         return (this->name == b.name) &&
                (this->defaultUnicastLocatorList == b.defaultUnicastLocatorList) &&
                (this->defaultMulticastLocatorList == b.defaultMulticastLocatorList) &&
+               (this->default_external_unicast_locators == b.default_external_unicast_locators) &&
                (this->sendSocketBufferSize == b.sendSocketBufferSize) &&
                (this->listenSocketBufferSize == b.listenSocketBufferSize) &&
                (this->builtin == b.builtin) &&
@@ -491,6 +492,11 @@ public:
      * case that it was defined with NO UnicastLocators. This is usually left empty.
      */
     LocatorList_t defaultMulticastLocatorList;
+
+    /**
+     * The collection of external locators to use for communication on user created topics.
+     */
+    fastdds::rtps::ExternalLocators default_external_unicast_locators;
 
     /*!
      * @brief Send socket buffer size for the send resource. Zero value indicates to use default system buffer size.

--- a/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h
+++ b/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h
@@ -375,16 +375,16 @@ public:
     //! Discovery protocol related attributes
     DiscoverySettings discovery_config;
 
-    //!Indicates to use the WriterLiveliness protocol.
+    //! Indicates to use the WriterLiveliness protocol.
     bool use_WriterLivelinessProtocol = true;
 
-    //!TypeLookup Service settings
+    //! TypeLookup Service settings
     TypeLookupSettings typelookup_config;
 
-    //!Metatraffic Unicast Locator List
+    //! Metatraffic Unicast Locator List
     LocatorList_t metatrafficUnicastLocatorList;
 
-    //!Metatraffic Multicast Locator List.
+    //! Metatraffic Multicast Locator List.
     LocatorList_t metatrafficMulticastLocatorList;
 
     //! The collection of external locators to use for communication on metatraffic topics.
@@ -410,7 +410,7 @@ public:
     //! Mutation tries if the port is being used.
     uint32_t mutation_tries = 100u;
 
-    //!Set to true to avoid multicast traffic on builtin endpoints
+    //! Set to true to avoid multicast traffic on builtin endpoints
     bool avoid_builtin_multicast = true;
 
     BuiltinAttributes() = default;

--- a/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h
+++ b/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h
@@ -468,6 +468,7 @@ public:
                (this->defaultUnicastLocatorList == b.defaultUnicastLocatorList) &&
                (this->defaultMulticastLocatorList == b.defaultMulticastLocatorList) &&
                (this->default_external_unicast_locators == b.default_external_unicast_locators) &&
+               (this->ignore_non_matching_locators == b.ignore_non_matching_locators) &&
                (this->sendSocketBufferSize == b.sendSocketBufferSize) &&
                (this->listenSocketBufferSize == b.listenSocketBufferSize) &&
                (this->builtin == b.builtin) &&
@@ -497,6 +498,11 @@ public:
      * The collection of external locators to use for communication on user created topics.
      */
     fastdds::rtps::ExternalLocators default_external_unicast_locators;
+
+    /**
+     * Whether locators that don't match with the announced locators should be kept.
+     */
+    bool ignore_non_matching_locators = false;
 
     /*!
      * @brief Send socket buffer size for the send resource. Zero value indicates to use default system buffer size.

--- a/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h
+++ b/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h
@@ -19,17 +19,18 @@
 #ifndef _FASTDDS_RTPSPARTICIPANTPARAMETERS_H_
 #define _FASTDDS_RTPSPARTICIPANTPARAMETERS_H_
 
-#include <fastdds/rtps/common/Time_t.h>
-#include <fastdds/rtps/common/Locator.h>
-#include <fastdds/rtps/common/PortParameters.h>
+#include <fastdds/rtps/attributes/ExternalLocators.hpp>
 #include <fastdds/rtps/attributes/PropertyPolicy.h>
-#include <fastdds/rtps/flowcontrol/ThroughputControllerDescriptor.h>
-#include <fastdds/rtps/transport/TransportInterface.h>
-#include <fastdds/rtps/resources/ResourceManagement.h>
-#include <fastrtps/utils/fixed_size_string.hpp>
 #include <fastdds/rtps/attributes/RTPSParticipantAllocationAttributes.hpp>
 #include <fastdds/rtps/attributes/ServerAttributes.h>
+#include <fastdds/rtps/common/Locator.h>
+#include <fastdds/rtps/common/PortParameters.h>
+#include <fastdds/rtps/common/Time_t.h>
 #include <fastdds/rtps/flowcontrol/FlowControllerDescriptor.hpp>
+#include <fastdds/rtps/flowcontrol/ThroughputControllerDescriptor.h>
+#include <fastdds/rtps/resources/ResourceManagement.h>
+#include <fastdds/rtps/transport/TransportInterface.h>
+#include <fastrtps/utils/fixed_size_string.hpp>
 
 #include <memory>
 #include <sstream>
@@ -386,6 +387,9 @@ public:
     //!Metatraffic Multicast Locator List.
     LocatorList_t metatrafficMulticastLocatorList;
 
+    //! The collection of external locators to use for communication on metatraffic topics.
+    fastdds::rtps::ExternalLocators metatraffic_external_unicast_locators;
+
     //! Initial peers.
     LocatorList_t initialPeersList;
 
@@ -422,6 +426,7 @@ public:
                (typelookup_config.use_server == b.typelookup_config.use_server) &&
                (this->metatrafficUnicastLocatorList == b.metatrafficUnicastLocatorList) &&
                (this->metatrafficMulticastLocatorList == b.metatrafficMulticastLocatorList) &&
+               (this->metatraffic_external_unicast_locators == b.metatraffic_external_unicast_locators) &&
                (this->initialPeersList == b.initialPeersList) &&
                (this->readerHistoryMemoryPolicy == b.readerHistoryMemoryPolicy) &&
                (this->readerPayloadSize == b.readerPayloadSize) &&

--- a/include/fastdds/rtps/common/LocatorWithMask.hpp
+++ b/include/fastdds/rtps/common/LocatorWithMask.hpp
@@ -1,0 +1,67 @@
+// Copyright 2022 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file LocatorWithMask.hpp
+ */
+
+#ifndef _FASTDDS_RTPS_COMMON_LOCATORWITHMASK_HPP_
+#define _FASTDDS_RTPS_COMMON_LOCATORWITHMASK_HPP_
+
+#include <fastrtps/fastrtps_dll.h>
+
+#include <fastdds/rtps/common/Locator.h>
+
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+
+/**
+ * A Locator with a mask that defines the number of significant bits of its address.
+ */
+class RTPS_DllAPI LocatorWithMask : public Locator
+{
+public:
+
+    /**
+     * Get the number of significant bits on the address of this locator.
+     *
+     * @return number of significant bits on the address of this locator.
+     */
+    uint8_t mask() const
+    {
+        return mask_;
+    }
+
+    /**
+     * Set the number of significant bits on the address of this locator.
+     *
+     * @param mask number of significant bits on the address of this locator.
+     */
+    void mask(
+            uint8_t mask)
+    {
+        mask_ = mask;
+    }
+
+private:
+
+    uint8_t mask_ = 24;
+};
+
+} // namespace rtps
+} // namespace fastdds
+} // namespace eprosima
+
+#endif /* _FASTDDS_RTPS_COMMON_LOCATORWITHMASK_HPP_ */

--- a/include/fastrtps/attributes/PublisherAttributes.h
+++ b/include/fastrtps/attributes/PublisherAttributes.h
@@ -41,16 +41,9 @@ class PublisherAttributes
 {
 public:
 
-    PublisherAttributes()
-        : historyMemoryPolicy(rtps::PREALLOCATED_MEMORY_MODE)
-        , m_userDefinedID(-1)
-        , m_entityID(-1)
-    {
-    }
+    PublisherAttributes() = default;
 
-    virtual ~PublisherAttributes()
-    {
-    }
+    virtual ~PublisherAttributes() = default;
 
     bool operator ==(
             const PublisherAttributes& b) const
@@ -67,22 +60,22 @@ public:
                (this->properties == b.properties);
     }
 
-    //!Topic Attributes for the Publisher
+    //! Topic Attributes for the Publisher
     TopicAttributes topic;
 
-    //!QOS for the Publisher
+    //! QOS for the Publisher
     WriterQos qos;
 
-    //!Writer Attributes
+    //! Writer Attributes
     rtps::WriterTimes times;
 
-    //!Unicast locator list
+    //! Unicast locator list
     rtps::LocatorList_t unicastLocatorList;
 
-    //!Multicast locator list
+    //! Multicast locator list
     rtps::LocatorList_t multicastLocatorList;
 
-    //!Remote locator list
+    //! Remote locator list
     rtps::LocatorList_t remoteLocatorList;
 
     //! The collection of external locators to use for communication.
@@ -91,14 +84,16 @@ public:
     //! Whether locators that don't match with the announced locators should be kept.
     bool ignore_non_matching_locators = false;
 
-    //!Throughput controller
+    //! Throughput controller
     rtps::ThroughputControllerDescriptor throughputController;
 
-    //!Underlying History memory policy
-    rtps::MemoryManagementPolicy_t historyMemoryPolicy;
+    //! Underlying History memory policy
+    rtps::MemoryManagementPolicy_t historyMemoryPolicy = rtps::MemoryManagementPolicy_t::PREALLOCATED_MEMORY_MODE;
 
-    //!Properties
+    //! Properties
     rtps::PropertyPolicy properties;
+
+    //! Allocation limits on the matched subscribers collections
     ResourceLimitedContainerConfig matched_subscriber_allocation;
 
     /**
@@ -141,13 +136,13 @@ public:
 
 private:
 
-    //!User Defined ID, used for StaticEndpointDiscovery, default value -1.
-    int16_t m_userDefinedID;
-    //!Entity ID, if the user want to specify the EntityID of the enpoint, default value -1.
-    int16_t m_entityID;
+    //! User Defined ID, used for StaticEndpointDiscovery, default value -1.
+    int16_t m_userDefinedID = -1;
+    //! Entity ID, if the user want to specify the EntityID of the enpoint, default value -1.
+    int16_t m_entityID = -1;
 };
 
 } // namespace fastrtps
-} /* namespace eprosima */
+} // namespace eprosima
 
 #endif /* PUBLISHERATTRIBUTES_H_ */

--- a/include/fastrtps/attributes/PublisherAttributes.h
+++ b/include/fastrtps/attributes/PublisherAttributes.h
@@ -21,13 +21,14 @@
 
 #include <fastdds/rtps/resources/ResourceManagement.h>
 
+#include <fastdds/rtps/attributes/ExternalLocators.hpp>
+#include <fastdds/rtps/attributes/PropertyPolicy.h>
+#include <fastdds/rtps/attributes/WriterAttributes.h>
 #include <fastdds/rtps/common/Locator.h>
 #include <fastdds/rtps/common/Time_t.h>
-#include <fastdds/rtps/attributes/WriterAttributes.h>
 #include <fastdds/rtps/flowcontrol/ThroughputControllerDescriptor.h>
 #include <fastrtps/attributes/TopicAttributes.h>
 #include <fastrtps/qos/WriterQos.h>
-#include <fastdds/rtps/attributes/PropertyPolicy.h>
 
 namespace eprosima {
 namespace fastrtps {
@@ -83,6 +84,12 @@ public:
 
     //!Remote locator list
     rtps::LocatorList_t remoteLocatorList;
+
+    //!The collection of external locators to use for communication.
+    fastdds::rtps::ExternalLocators external_unicast_locators;
+
+    //!Whether locators that don't match with the announced locators should be kept.
+    bool ignore_non_matching_locators = false;
 
     //!Throughput controller
     rtps::ThroughputControllerDescriptor throughputController;

--- a/include/fastrtps/attributes/PublisherAttributes.h
+++ b/include/fastrtps/attributes/PublisherAttributes.h
@@ -85,10 +85,10 @@ public:
     //!Remote locator list
     rtps::LocatorList_t remoteLocatorList;
 
-    //!The collection of external locators to use for communication.
+    //! The collection of external locators to use for communication.
     fastdds::rtps::ExternalLocators external_unicast_locators;
 
-    //!Whether locators that don't match with the announced locators should be kept.
+    //! Whether locators that don't match with the announced locators should be kept.
     bool ignore_non_matching_locators = false;
 
     //!Throughput controller

--- a/include/fastrtps/attributes/SubscriberAttributes.h
+++ b/include/fastrtps/attributes/SubscriberAttributes.h
@@ -19,16 +19,14 @@
 #ifndef SUBSCRIBERATTRIBUTES_H_
 #define SUBSCRIBERATTRIBUTES_H_
 
-#include <fastdds/rtps/resources/ResourceManagement.h>
-
+#include <fastdds/rtps/attributes/ExternalLocators.hpp>
+#include <fastdds/rtps/attributes/PropertyPolicy.h>
+#include <fastdds/rtps/attributes/ReaderAttributes.h>
 #include <fastdds/rtps/common/Time_t.h>
 #include <fastdds/rtps/common/Locator.h>
-#include <fastdds/rtps/attributes/ReaderAttributes.h>
+#include <fastdds/rtps/resources/ResourceManagement.h>
 #include <fastrtps/attributes/TopicAttributes.h>
 #include <fastrtps/qos/ReaderQos.h>
-#include <fastdds/rtps/attributes/PropertyPolicy.h>
-
-
 
 namespace eprosima {
 namespace fastrtps {
@@ -58,6 +56,12 @@ public:
 
     //!Remote locator list
     rtps::LocatorList_t remoteLocatorList;
+
+    //!The collection of external locators to use for communication.
+    fastdds::rtps::ExternalLocators external_unicast_locators;
+
+    //!Whether locators that don't match with the announced locators should be kept.
+    bool ignore_non_matching_locators = false;
 
     //!Expects Inline QOS
     bool expectsInlineQos;

--- a/include/fastrtps/attributes/SubscriberAttributes.h
+++ b/include/fastrtps/attributes/SubscriberAttributes.h
@@ -39,7 +39,7 @@ class SubscriberAttributes
 {
 public:
 
-    //!Topic Attributes
+    //! Topic Attributes
     TopicAttributes topic;
 
     //!Reader QOs.

--- a/include/fastrtps/attributes/SubscriberAttributes.h
+++ b/include/fastrtps/attributes/SubscriberAttributes.h
@@ -42,50 +42,42 @@ public:
     //! Topic Attributes
     TopicAttributes topic;
 
-    //!Reader QOs.
+    //! Reader QOs.
     ReaderQos qos;
 
-    //!Times for a RELIABLE Reader
+    //! Times for a RELIABLE Reader
     rtps::ReaderTimes times;
 
-    //!Unicast locator list
+    //! Unicast locator list
     rtps::LocatorList_t unicastLocatorList;
 
-    //!Multicast locator list
+    //! Multicast locator list
     rtps::LocatorList_t multicastLocatorList;
 
-    //!Remote locator list
+    //! Remote locator list
     rtps::LocatorList_t remoteLocatorList;
 
-    //!The collection of external locators to use for communication.
+    //! The collection of external locators to use for communication.
     fastdds::rtps::ExternalLocators external_unicast_locators;
 
-    //!Whether locators that don't match with the announced locators should be kept.
+    //! Whether locators that don't match with the announced locators should be kept.
     bool ignore_non_matching_locators = false;
 
-    //!Expects Inline QOS
-    bool expectsInlineQos;
+    //! Expects Inline QOS
+    bool expectsInlineQos = false;
 
-    //!Underlying History memory policy
+    //! Underlying History memory policy
     rtps::MemoryManagementPolicy_t historyMemoryPolicy;
 
-    //!Properties
+    //! Properties
     rtps::PropertyPolicy properties;
 
-    //!Matched publishers allocation limits
+    //! Matched publishers allocation limits
     ResourceLimitedContainerConfig matched_publisher_allocation;
 
-    SubscriberAttributes()
-        : expectsInlineQos(false)
-        , historyMemoryPolicy(rtps::PREALLOCATED_MEMORY_MODE)
-        , m_userDefinedID(-1)
-        , m_entityID(-1)
-    {
-    }
+    SubscriberAttributes() = default;
 
-    virtual ~SubscriberAttributes()
-    {
-    }
+    virtual ~SubscriberAttributes() = default;
 
     bool operator ==(
             const SubscriberAttributes& b) const
@@ -146,11 +138,11 @@ public:
 
 private:
 
-    //!User Defined ID, used for StaticEndpointDiscovery, default value -1.
-    int16_t m_userDefinedID;
+    //! User Defined ID, used for StaticEndpointDiscovery, default value -1.
+    int16_t m_userDefinedID = -1;
 
-    //!Entity ID, if the user want to specify the EntityID of the enpoint, default value -1.
-    int16_t m_entityID;
+    //! Entity ID, if the user want to specify the EntityID of the enpoint, default value -1.
+    int16_t m_entityID = -1;
 };
 
 } /* namespace fastrtps */

--- a/include/fastrtps/attributes/SubscriberAttributes.h
+++ b/include/fastrtps/attributes/SubscriberAttributes.h
@@ -39,93 +39,114 @@ namespace fastrtps {
  */
 class SubscriberAttributes
 {
-    public:
-        //!Topic Attributes
-        TopicAttributes topic;
+public:
 
-        //!Reader QOs.
-        ReaderQos qos;
+    //!Topic Attributes
+    TopicAttributes topic;
 
-        //!Times for a RELIABLE Reader
-        rtps::ReaderTimes times;
+    //!Reader QOs.
+    ReaderQos qos;
 
-        //!Unicast locator list
-        rtps::LocatorList_t unicastLocatorList;
+    //!Times for a RELIABLE Reader
+    rtps::ReaderTimes times;
 
-        //!Multicast locator list
-        rtps::LocatorList_t multicastLocatorList;
+    //!Unicast locator list
+    rtps::LocatorList_t unicastLocatorList;
 
-        //!Remote locator list
-        rtps::LocatorList_t remoteLocatorList;
+    //!Multicast locator list
+    rtps::LocatorList_t multicastLocatorList;
 
-        //!Expects Inline QOS
-        bool expectsInlineQos;
+    //!Remote locator list
+    rtps::LocatorList_t remoteLocatorList;
 
-        //!Underlying History memory policy
-        rtps::MemoryManagementPolicy_t historyMemoryPolicy;
+    //!Expects Inline QOS
+    bool expectsInlineQos;
 
-        //!Properties
-        rtps::PropertyPolicy properties;
+    //!Underlying History memory policy
+    rtps::MemoryManagementPolicy_t historyMemoryPolicy;
 
-        //!Matched publishers allocation limits
-        ResourceLimitedContainerConfig matched_publisher_allocation;
+    //!Properties
+    rtps::PropertyPolicy properties;
 
-        SubscriberAttributes()
-            : expectsInlineQos(false)
-            , historyMemoryPolicy(rtps::PREALLOCATED_MEMORY_MODE)
-            , m_userDefinedID(-1)
-            , m_entityID(-1)
-        {}
+    //!Matched publishers allocation limits
+    ResourceLimitedContainerConfig matched_publisher_allocation;
 
-        virtual ~SubscriberAttributes(){}
+    SubscriberAttributes()
+        : expectsInlineQos(false)
+        , historyMemoryPolicy(rtps::PREALLOCATED_MEMORY_MODE)
+        , m_userDefinedID(-1)
+        , m_entityID(-1)
+    {
+    }
 
-        bool operator==(const SubscriberAttributes& b) const
-        {
-            return (this->topic == b.topic) &&
-                (this->qos == b.qos) &&
-                (this->times == b.times) &&
-                (this->unicastLocatorList == b.unicastLocatorList) &&
-                (this->multicastLocatorList == b.multicastLocatorList) &&
-                (this->remoteLocatorList == b.remoteLocatorList) &&
-                (this->historyMemoryPolicy == b.historyMemoryPolicy) &&
-                (this->properties == b.properties);
-        }
+    virtual ~SubscriberAttributes()
+    {
+    }
 
-        bool operator!=(const SubscriberAttributes& b) const
-        {
-            return !(*this == b);
-        }
+    bool operator ==(
+            const SubscriberAttributes& b) const
+    {
+        return (this->topic == b.topic) &&
+               (this->qos == b.qos) &&
+               (this->times == b.times) &&
+               (this->unicastLocatorList == b.unicastLocatorList) &&
+               (this->multicastLocatorList == b.multicastLocatorList) &&
+               (this->remoteLocatorList == b.remoteLocatorList) &&
+               (this->historyMemoryPolicy == b.historyMemoryPolicy) &&
+               (this->properties == b.properties);
+    }
 
-        /**
-         * Get the user defined ID
-         * @return User defined ID
-         */
-        inline int16_t getUserDefinedID() const { return m_userDefinedID; }
+    bool operator !=(
+            const SubscriberAttributes& b) const
+    {
+        return !(*this == b);
+    }
 
-        /**
-         * Get the entity defined ID
-         * @return Entity ID
-         */
-        inline int16_t getEntityID() const { return m_entityID; }
+    /**
+     * Get the user defined ID
+     * @return User defined ID
+     */
+    inline int16_t getUserDefinedID() const
+    {
+        return m_userDefinedID;
+    }
 
-        /**
-         * Set the user defined ID
-         * @param id User defined ID to be set
-         */
-        inline void setUserDefinedID(uint8_t id) { m_userDefinedID = id; }
+    /**
+     * Get the entity defined ID
+     * @return Entity ID
+     */
+    inline int16_t getEntityID() const
+    {
+        return m_entityID;
+    }
 
-        /**
-         * Set the entity ID
-         * @param id Entity ID to be set
-         */
-        inline void setEntityID(uint8_t id) { m_entityID = id; }
+    /**
+     * Set the user defined ID
+     * @param id User defined ID to be set
+     */
+    inline void setUserDefinedID(
+            uint8_t id)
+    {
+        m_userDefinedID = id;
+    }
 
-    private:
-        //!User Defined ID, used for StaticEndpointDiscovery, default value -1.
-        int16_t m_userDefinedID;
+    /**
+     * Set the entity ID
+     * @param id Entity ID to be set
+     */
+    inline void setEntityID(
+            uint8_t id)
+    {
+        m_entityID = id;
+    }
 
-        //!Entity ID, if the user want to specify the EntityID of the enpoint, default value -1.
-        int16_t m_entityID;
+private:
+
+    //!User Defined ID, used for StaticEndpointDiscovery, default value -1.
+    int16_t m_userDefinedID;
+
+    //!Entity ID, if the user want to specify the EntityID of the enpoint, default value -1.
+    int16_t m_entityID;
 };
 
 } /* namespace fastrtps */


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds `metatraffic_external_unicast_locators`, `default_external_unicast_locators`, and `ignore_non_matching_locators` to the participant configuration structures.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [ ] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
