### PR TITLE
Fix build failure with GCC 12 [14891]

### DIFF
--- a/src/cpp/security/cryptography/AESGCMGMAC_KeyExchange.cpp
+++ b/src/cpp/security/cryptography/AESGCMGMAC_KeyExchange.cpp
@@ -16,21 +16,23 @@
  * @file AESGCMGMAC_KeyExchange.cpp
  */
 
+#include "AESGCMGMAC_KeyExchange.h"
+
 #include <cstring>
 #include <sstream>
-#include <fastdds/rtps/common/Token.h>
-#include <fastdds/rtps/common/BinaryProperty.h>
-#include <security/cryptography/AESGCMGMAC_KeyExchange.h>
-#include <fastdds/dds/log/Log.hpp>
 
 #include <openssl/aes.h>
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 
+#include <fastdds/dds/log/Log.hpp>
+#include <fastdds/rtps/common/BinaryProperty.h>
+#include <fastdds/rtps/common/Token.h>
+
 // Solve error with Win32 macro
 #ifdef WIN32
 #undef max
-#endif
+#endif // ifdef WIN32
 
 using namespace eprosima::fastrtps::rtps::security;
 
@@ -54,7 +56,7 @@ bool AESGCMGMAC_KeyExchange::create_local_participant_crypto_tokens(
     AESGCMGMAC_ParticipantCryptoHandle& remote_participant = AESGCMGMAC_ParticipantCryptoHandle::narrow(
         remote_participant_crypto);
 
-    if ( local_participant.nil() || remote_participant.nil() )
+    if (local_participant.nil() || remote_participant.nil())
     {
         logWarning(SECURITY_CRYPTO, "Not a valid ParticipantCryptoHandle received");
         return false;
@@ -99,7 +101,7 @@ bool AESGCMGMAC_KeyExchange::set_remote_participant_crypto_tokens(
     AESGCMGMAC_ParticipantCryptoHandle& remote_participant = AESGCMGMAC_ParticipantCryptoHandle::narrow(
         remote_participant_crypto);
 
-    if ( local_participant.nil() || remote_participant.nil() )
+    if (local_participant.nil() || remote_participant.nil())
     {
         logWarning(SECURITY_CRYPTO, "Not a valid ParticipantCryptoHandle received");
         return false;
@@ -152,7 +154,7 @@ bool AESGCMGMAC_KeyExchange::create_local_datawriter_crypto_tokens(
     AESGCMGMAC_WriterCryptoHandle& local_writer = AESGCMGMAC_WriterCryptoHandle::narrow(local_datawriter_crypto);
     AESGCMGMAC_ReaderCryptoHandle& remote_reader = AESGCMGMAC_ReaderCryptoHandle::narrow(remote_datareader_crypto);
 
-    if ( local_writer.nil() || remote_reader.nil() )
+    if (local_writer.nil() || remote_reader.nil())
     {
         logWarning(SECURITY_CRYPTO, "Invalid CryptoHandle received");
         return false;
@@ -195,7 +197,7 @@ bool AESGCMGMAC_KeyExchange::create_local_datareader_crypto_tokens(
     AESGCMGMAC_ReaderCryptoHandle& local_reader = AESGCMGMAC_ReaderCryptoHandle::narrow(local_datareader_crypto);
     AESGCMGMAC_WriterCryptoHandle& remote_writer = AESGCMGMAC_WriterCryptoHandle::narrow(remote_datawriter_crypto);
 
-    if ( local_reader.nil() || remote_writer.nil() )
+    if (local_reader.nil() || remote_writer.nil())
     {
         logWarning(SECURITY_CRYPTO, "Invalid CryptoHandle received");
         return false;
@@ -237,7 +239,7 @@ bool AESGCMGMAC_KeyExchange::set_remote_datareader_crypto_tokens(
     AESGCMGMAC_WriterCryptoHandle& local_writer = AESGCMGMAC_WriterCryptoHandle::narrow(local_datawriter_crypto);
     AESGCMGMAC_ReaderCryptoHandle& remote_reader = AESGCMGMAC_ReaderCryptoHandle::narrow(remote_datareader_crypto);
 
-    if ( local_writer.nil() || remote_reader.nil() )
+    if (local_writer.nil() || remote_reader.nil())
     {
         logWarning(SECURITY_CRYPTO, "Invalid CryptoHandle received");
         return false;
@@ -304,7 +306,7 @@ bool AESGCMGMAC_KeyExchange::set_remote_datawriter_crypto_tokens(
     AESGCMGMAC_ReaderCryptoHandle& local_reader = AESGCMGMAC_ReaderCryptoHandle::narrow(local_datareader_crypto);
     AESGCMGMAC_WriterCryptoHandle& remote_writer = AESGCMGMAC_WriterCryptoHandle::narrow(remote_datawriter_crypto);
 
-    if ( local_reader.nil() || remote_writer.nil() )
+    if (local_reader.nil() || remote_writer.nil())
     {
         logWarning(SECURITY_CRYPTO, "Invalid CryptoHandle");
         return false;

--- a/src/cpp/security/cryptography/AESGCMGMAC_KeyExchange.cpp
+++ b/src/cpp/security/cryptography/AESGCMGMAC_KeyExchange.cpp
@@ -16,6 +16,7 @@
  * @file AESGCMGMAC_KeyExchange.cpp
  */
 
+#include <cstring>
 #include <sstream>
 #include <fastdds/rtps/common/Token.h>
 #include <fastdds/rtps/common/BinaryProperty.h>


### PR DESCRIPTION
This PR adds a missing header include for the `memcpy` function. Without that include, the build fails with GCC 12.

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->

Unchecked items above are not applicable.

## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
