### PR TITLE
Fix SharedMemWatchdog datarace (issue 1049) [14916] <master>

### DIFF
--- a/src/cpp/utils/shared_memory/SharedMemWatchdog.hpp
+++ b/src/cpp/utils/shared_memory/SharedMemWatchdog.hpp
@@ -15,11 +15,12 @@
 #ifndef _FASTDDS_SHAREDMEM_WATCHDOG_H_
 #define _FASTDDS_SHAREDMEM_WATCHDOG_H_
 
-#include <thread>
+#include <atomic>
 #include <condition_variable>
-#include <mutex>
-#include <unordered_set>
 #include <memory>
+#include <mutex>
+#include <thread>
+#include <unordered_set>
 
 namespace eprosima {
 namespace fastdds {
@@ -96,7 +97,7 @@ private:
     std::mutex wake_run_mutex_;
     bool wake_run_;
 
-    bool exit_thread_;
+    std::atomic_bool exit_thread_;
 
     SharedMemWatchdog()
         : wake_run_(false)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

`SharedMemWatchdog::exit_thread_` has a data race on destruction because it's accessed from the main thread. as easy as
promote it to atomic_bool.

Review and testing on: https://github.com/eProsima/Fast-DDS/pull/2761

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
