### PR TITLE
Fix resetting of `LivelinessLostStatus::total_changes` [14984]

### DIFF
--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1221,7 +1221,7 @@ void DataWriterImpl::InnerDataWriterListener::on_liveliness_lost(
         LivelinessLostStatus callback_status;
         if (ReturnCode_t::RETCODE_OK == data_writer_->get_liveliness_lost_status(callback_status))
         {
-            listener->on_liveliness_lost( data_writer_->user_datawriter_, status);
+            listener->on_liveliness_lost(data_writer_->user_datawriter_, callback_status);
         }
     }
     data_writer_->user_datawriter_->get_statuscondition().get_impl()->set_status(notify_status, true);
@@ -1572,7 +1572,7 @@ LivelinessLostStatus& DataWriterImpl::update_liveliness_lost_status(
         const fastrtps::LivelinessLostStatus& liveliness_lost_status)
 {
     liveliness_lost_status_.total_count = liveliness_lost_status.total_count;
-    liveliness_lost_status_.total_count_change += liveliness_lost_status.total_count;
+    liveliness_lost_status_.total_count_change += liveliness_lost_status.total_count_change;
     return liveliness_lost_status_;
 }
 

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1213,12 +1213,16 @@ void DataWriterImpl::InnerDataWriterListener::on_liveliness_lost(
         fastrtps::rtps::RTPSWriter* /*writer*/,
         const fastrtps::LivelinessLostStatus& status)
 {
+    data_writer_->update_liveliness_lost_status(status);
     StatusMask notify_status = StatusMask::liveliness_lost();
     DataWriterListener* listener = data_writer_->get_listener_for(notify_status);
     if (listener != nullptr)
     {
-        listener->on_liveliness_lost(
-            data_writer_->user_datawriter_, status);
+        LivelinessLostStatus callback_status;
+        if (ReturnCode_t::RETCODE_OK == data_writer_->get_liveliness_lost_status(callback_status))
+        {
+            listener->on_liveliness_lost( data_writer_->user_datawriter_, status);
+        }
     }
     data_writer_->user_datawriter_->get_statuscondition().get_impl()->set_status(notify_status, true);
 }
@@ -1481,10 +1485,8 @@ ReturnCode_t DataWriterImpl::get_liveliness_lost_status(
     {
         std::unique_lock<RecursiveTimedMutex> lock(writer_->getMutex());
 
-        status.total_count = writer_->liveliness_lost_status_.total_count;
-        status.total_count_change = writer_->liveliness_lost_status_.total_count_change;
-
-        writer_->liveliness_lost_status_.total_count_change = 0u;
+        status = liveliness_lost_status_;
+        liveliness_lost_status_.total_count_change = 0u;
     }
 
     user_datawriter_->get_statuscondition().get_impl()->set_status(StatusMask::liveliness_lost(), false);
@@ -1564,6 +1566,14 @@ OfferedIncompatibleQosStatus& DataWriterImpl::update_offered_incompatible_qos(
         }
     }
     return offered_incompatible_qos_status_;
+}
+
+LivelinessLostStatus& DataWriterImpl::update_liveliness_lost_status(
+        const fastrtps::LivelinessLostStatus& liveliness_lost_status)
+{
+    liveliness_lost_status_.total_count = liveliness_lost_status.total_count;
+    liveliness_lost_status_.total_count_change += liveliness_lost_status.total_count;
+    return liveliness_lost_status_;
 }
 
 void DataWriterImpl::set_qos(

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -466,7 +466,10 @@ protected:
     PublicationMatchedStatus publication_matched_status_;
 
     //! The offered deadline missed status
-    fastrtps::OfferedDeadlineMissedStatus deadline_missed_status_;
+    OfferedDeadlineMissedStatus deadline_missed_status_;
+
+    //! The liveliness lost status
+    LivelinessLostStatus liveliness_lost_status_;
 
     //! The offered incompatible qos status
     OfferedIncompatibleQosStatus offered_incompatible_qos_status_;
@@ -597,6 +600,15 @@ protected:
 
     OfferedIncompatibleQosStatus& update_offered_incompatible_qos(
             PolicyMask incompatible_policies);
+
+    /*!
+     * @brief Updates liveliness lost status.
+     *
+     * @param[in] liveliness_lost_status Liveliness lost status coming from RTPS layer.
+     * @return Current liveliness lost status.
+     */
+    LivelinessLostStatus& update_liveliness_lost_status(
+            const fastrtps::LivelinessLostStatus& liveliness_lost_status);
 
     /**
      * Returns the most appropriate listener to handle the callback for the given status,


### PR DESCRIPTION
## Description

RTPS layer always reset `LivelinessLostStatus::total_changes` after calling the `on_liveliness_lost()` listener callback.
This PR fixes this adding its own `LivelinessLostStatus` to `DataWriterImpl`.

@Mergifyio backport 2.5.x

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] *n/a* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] *n/a* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] *n/a* Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] *n/a* New feature has been added to the `versions.md` file (if applicable).
- [ ] *n/a* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
