### PR TITLE
[15015] Improve read/take performance

### DIFF
--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -476,7 +476,7 @@ ReturnCode_t DataReaderImpl::read_or_take(
 
     set_read_communication_status(false);
 
-    auto it = history_.lookup_instance(handle, exact_instance);
+    auto it = history_.lookup_available_instance(handle, exact_instance);
     if (!it.first)
     {
         return exact_instance ? ReturnCode_t::RETCODE_BAD_PARAMETER : ReturnCode_t::RETCODE_NO_DATA;
@@ -656,7 +656,7 @@ ReturnCode_t DataReaderImpl::read_or_take_next_sample(
 
     set_read_communication_status(false);
 
-    auto it = history_.lookup_instance(HANDLE_NIL, false);
+    auto it = history_.lookup_available_instance(HANDLE_NIL, false);
     if (!it.first)
     {
         return ReturnCode_t::RETCODE_NO_DATA;

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1708,8 +1708,7 @@ InstanceHandle_t DataReaderImpl::lookup_instance(
     {
         if (type_->getKey(const_cast<void*>(instance), &handle, false))
         {
-            auto it = history_.lookup_instance(handle, true);
-            if (!it.first)
+            if (!history_.is_instance_present(handle))
             {
                 handle = HANDLE_NIL;
             }

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -479,7 +479,14 @@ ReturnCode_t DataReaderImpl::read_or_take(
     auto it = history_.lookup_available_instance(handle, exact_instance);
     if (!it.first)
     {
-        return exact_instance ? ReturnCode_t::RETCODE_BAD_PARAMETER : ReturnCode_t::RETCODE_NO_DATA;
+        if (exact_instance && !history_.is_instance_present(handle))
+        {
+            return ReturnCode_t::RETCODE_BAD_PARAMETER;
+        }
+        else
+        {
+            return ReturnCode_t::RETCODE_NO_DATA;
+        }
     }
 
     code = prepare_loan(data_values, sample_infos, max_samples);

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
@@ -293,7 +293,7 @@ private:
             return false;
         }
 
-        auto result = history_.lookup_instance(handle_, false);
+        auto result = history_.next_available_instance_nts(handle_, instance_);
         if (!result.first)
         {
             finished_ = true;

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
@@ -77,13 +77,13 @@ struct ReadTakeCommand
         , remaining_samples_(max_samples)
         , states_(states)
         , instance_(instance)
-        , handle_(instance.first)
+        , handle_(instance->first)
         , single_instance_(single_instance)
     {
         assert(0 <= remaining_samples_);
 
         current_slot_ = data_values_.length();
-        finished_ = nullptr == instance.second;
+        finished_ = false;
     }
 
     ~ReadTakeCommand()
@@ -108,8 +108,8 @@ struct ReadTakeCommand
         // Traverse changes on current instance
         bool ret_val = false;
         LoanableCollection::size_type first_slot = current_slot_;
-        auto it = instance_.second->cache_changes.begin();
-        while (!finished_ && it != instance_.second->cache_changes.end())
+        auto it = instance_->second->cache_changes.begin();
+        while (!finished_ && it != instance_->second->cache_changes.end())
         {
             CacheChange_t* change = *it;
             SampleStateKind check;
@@ -180,7 +180,7 @@ struct ReadTakeCommand
 
         if (current_slot_ > first_slot)
         {
-            instance_.second->view_state = ViewStateKind::NOT_NEW_VIEW_STATE;
+            instance_->second->view_state = ViewStateKind::NOT_NEW_VIEW_STATE;
             ret_val = true;
 
             // complete sample infos
@@ -279,8 +279,8 @@ private:
     bool is_current_instance_valid()
     {
         // Check instance_state against states_.instance_states and view_state against states_.view_states
-        auto instance_state = instance_.second->instance_state;
-        auto view_state = instance_.second->view_state;
+        auto instance_state = instance_->second->instance_state;
+        auto view_state = instance_->second->view_state;
         return (0 != (states_.instance_states & instance_state)) && (0 != (states_.view_states & view_state));
     }
 
@@ -301,7 +301,7 @@ private:
         }
 
         instance_ = result.second;
-        handle_ = instance_.first;
+        handle_ = instance_->first;
         return true;
     }
 
@@ -376,7 +376,7 @@ private:
         }
 
         SampleInfo& info = sample_infos_[current_slot_];
-        generate_info(info, *instance_.second, item);
+        generate_info(info, *instance_->second, item);
     }
 
     bool check_datasharing_validity(

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
@@ -594,11 +594,18 @@ std::pair<bool, DataReaderHistory::instance_info> DataReaderHistory::lookup_inst
     }
     else
     {
-        auto comp = [](const InstanceHandle_t& h, const InstanceCollection::value_type& it)
-                {
-                    return h < it.first;
-                };
-        it = std::upper_bound(keyed_changes_.begin(), keyed_changes_.end(), handle, comp);
+        if (!handle.isDefined())
+        {
+            it = keyed_changes_.begin();
+        }
+        else
+        {
+            auto comp = [](const InstanceHandle_t& h, const InstanceCollection::value_type& it)
+            {
+                return h < it.first;
+            };
+            it = std::upper_bound(keyed_changes_.begin(), keyed_changes_.end(), handle, comp);
+        }
     }
 
     return { it != keyed_changes_.end(), it };

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
@@ -608,6 +608,14 @@ std::pair<bool, DataReaderHistory::instance_info> DataReaderHistory::lookup_inst
     return { false, {InstanceHandle_t(), nullptr} };
 }
 
+std::pair<bool, DataReaderHistory::instance_info> DataReaderHistory::next_available_instance_nts(
+        const InstanceHandle_t& handle,
+        const DataReaderHistory::instance_info& current_info)
+{
+    static_cast<void>(current_info);
+    return lookup_instance(handle, false);
+}
+
 void DataReaderHistory::check_and_remove_instance(
         DataReaderHistory::instance_info& instance_info)
 {

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
@@ -552,6 +552,12 @@ uint64_t DataReaderHistory::get_unread_count(
     return mp_reader->get_unread_count(mark_as_read);
 }
 
+bool DataReaderHistory::is_instance_present(
+        const InstanceHandle_t& handle) const
+{
+    return has_keys_ && keyed_changes_.find(handle) != keyed_changes_.end();
+}
+
 std::pair<bool, DataReaderHistory::instance_info> DataReaderHistory::lookup_instance(
         const InstanceHandle_t& handle,
         bool exact) const

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
@@ -561,7 +561,7 @@ bool DataReaderHistory::is_instance_present(
     return has_keys_ && instances_.find(handle) != instances_.end();
 }
 
-std::pair<bool, DataReaderHistory::instance_info> DataReaderHistory::lookup_instance(
+std::pair<bool, DataReaderHistory::instance_info> DataReaderHistory::lookup_available_instance(
         const InstanceHandle_t& handle,
         bool exact)
 {

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
@@ -560,7 +560,7 @@ bool DataReaderHistory::is_instance_present(
 
 std::pair<bool, DataReaderHistory::instance_info> DataReaderHistory::lookup_instance(
         const InstanceHandle_t& handle,
-        bool exact) const
+        bool exact)
 {
     if (!has_keys_)
     {

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
@@ -99,7 +99,7 @@ DataReaderHistory::DataReaderHistory(
         key_changes_allocation_.initial = resource_limited_qos_.allocated_samples;
         key_changes_allocation_.maximum = resource_limited_qos_.max_samples;
 
-        keyed_changes_.emplace(c_InstanceHandle_Unknown,
+        instances_.emplace(c_InstanceHandle_Unknown,
                 std::make_shared<DataReaderInstance>(key_changes_allocation_, key_writers_allocation_));
     }
 
@@ -357,8 +357,8 @@ bool DataReaderHistory::get_first_untaken_info(
     WriterProxy* wp = nullptr;
     if (mp_reader->nextUntakenCache(&change, &wp))
     {
-        auto it = keyed_changes_.find(change->instanceHandle);
-        assert(it != keyed_changes_.end());
+        auto it = instances_.find(change->instanceHandle);
+        assert(it != instances_.end());
         auto& instance_changes = it->second->cache_changes;
         auto item =
                 std::find_if(instance_changes.cbegin(), instance_changes.cend(),
@@ -379,26 +379,26 @@ bool DataReaderHistory::find_key(
         InstanceCollection::iterator& vit_out)
 {
     InstanceCollection::iterator vit;
-    vit = keyed_changes_.find(handle);
-    if (vit != keyed_changes_.end())
+    vit = instances_.find(handle);
+    if (vit != instances_.end())
     {
         vit_out = vit;
         return true;
     }
 
-    if (keyed_changes_.size() < static_cast<size_t>(resource_limited_qos_.max_instances))
+    if (instances_.size() < static_cast<size_t>(resource_limited_qos_.max_instances))
     {
-        vit_out = keyed_changes_.emplace(handle,
+        vit_out = instances_.emplace(handle,
                         std::make_shared<DataReaderInstance>(key_changes_allocation_, key_writers_allocation_)).first;
         return true;
     }
 
-    for (vit = keyed_changes_.begin(); vit != keyed_changes_.end(); ++vit)
+    for (vit = instances_.begin(); vit != instances_.end(); ++vit)
     {
         if (InstanceStateKind::ALIVE_INSTANCE_STATE != vit->second->instance_state)
         {
-            keyed_changes_.erase(vit);
-            vit_out = keyed_changes_.emplace(handle,
+            instances_.erase(vit);
+            vit_out = instances_.emplace(handle,
                             std::make_shared<DataReaderInstance>(key_changes_allocation_, key_writers_allocation_)).first;
             return true;
         }
@@ -513,8 +513,8 @@ bool DataReaderHistory::set_next_deadline(
         return false;
     }
     std::lock_guard<RecursiveTimedMutex> guard(*mp_mutex);
-    auto it = keyed_changes_.find(handle);
-    if (it == keyed_changes_.end())
+    auto it = instances_.find(handle);
+    if (it == instances_.end())
     {
         return false;
     }
@@ -533,8 +533,8 @@ bool DataReaderHistory::get_next_deadline(
         return false;
     }
     std::lock_guard<RecursiveTimedMutex> guard(*mp_mutex);
-    auto min = std::min_element(keyed_changes_.begin(),
-                    keyed_changes_.end(),
+    auto min = std::min_element(instances_.begin(),
+                    instances_.end(),
                     [](
                         const InstanceCollection::value_type& lhs,
                         const InstanceCollection::value_type& rhs)
@@ -555,7 +555,7 @@ uint64_t DataReaderHistory::get_unread_count(
 bool DataReaderHistory::is_instance_present(
         const InstanceHandle_t& handle) const
 {
-    return has_keys_ && keyed_changes_.find(handle) != keyed_changes_.end();
+    return has_keys_ && instances_.find(handle) != instances_.end();
 }
 
 std::pair<bool, DataReaderHistory::instance_info> DataReaderHistory::lookup_instance(
@@ -571,32 +571,32 @@ std::pair<bool, DataReaderHistory::instance_info> DataReaderHistory::lookup_inst
             // - Looking for a specific instance (exact = true)
             // - Looking for the next instance to the ficticious one (exact = false)
             // In both cases, no instance should be returned
-            return { false, keyed_changes_.end() };
+            return { false, instances_.end() };
         }
 
         if (exact)
         {
             // Looking for HANDLE_NIL, nothing to return
-            return { false, keyed_changes_.end() };
+            return { false, instances_.end() };
         }
 
         // Looking for the first instance, return the ficticious one containing all changes
         InstanceHandle_t tmp;
         tmp.value[0] = 1;
-        return { true, keyed_changes_.begin() };
+        return { true, instances_.begin() };
     }
 
     InstanceCollection::iterator it;
 
     if (exact)
     {
-        it = keyed_changes_.find(handle);
+        it = instances_.find(handle);
     }
     else
     {
         if (!handle.isDefined())
         {
-            it = keyed_changes_.begin();
+            it = instances_.begin();
         }
         else
         {
@@ -604,11 +604,11 @@ std::pair<bool, DataReaderHistory::instance_info> DataReaderHistory::lookup_inst
             {
                 return h < it.first;
             };
-            it = std::upper_bound(keyed_changes_.begin(), keyed_changes_.end(), handle, comp);
+            it = std::upper_bound(instances_.begin(), instances_.end(), handle, comp);
         }
     }
 
-    return { it != keyed_changes_.end(), it };
+    return { it != instances_.end(), it };
 }
 
 std::pair<bool, DataReaderHistory::instance_info> DataReaderHistory::next_available_instance_nts(
@@ -621,7 +621,7 @@ std::pair<bool, DataReaderHistory::instance_info> DataReaderHistory::next_availa
         ++it;
     }
 
-    return { it != keyed_changes_.end(), it };
+    return { it != instances_.end(), it };
 }
 
 void DataReaderHistory::check_and_remove_instance(
@@ -632,7 +632,7 @@ void DataReaderHistory::check_and_remove_instance(
             (InstanceStateKind::ALIVE_INSTANCE_STATE != instance->instance_state) &&
             instance_info->first.isDefined())
     {
-        instance_info = keyed_changes_.erase(instance_info);
+        instance_info = instances_.erase(instance_info);
     }
 }
 
@@ -647,17 +647,16 @@ ReaderHistory::iterator DataReaderHistory::remove_change_nts(
         if (!has_keys_ || p_sample->is_fully_assembled())
         {
             // clean any references to this CacheChange in the key state collection
-            auto it = keyed_changes_.find(p_sample->instanceHandle);
+            auto it = instances_.find(p_sample->instanceHandle);
 
             // if keyed and in history must be in the map
             // There is a case when the sample could not be in the keyed map. The first received fragment of a
             // fragmented sample is stored in the history, and when it is completed it is stored in the keyed map.
             // But it can occur it is rejected when the sample is completed and removed without being stored in the
             // keyed map.
-            if (it != keyed_changes_.end())
+            if (it != instances_.end())
             {
-                auto& c = it->second->cache_changes;
-                c.erase(std::remove(c.begin(), c.end(), p_sample), c.end());
+                it->second->cache_changes.remove(p_sample);
             }
         }
     }
@@ -765,9 +764,9 @@ void DataReaderHistory::update_instance_nts(
         CacheChange_t* const change)
 {
     InstanceCollection::iterator vit;
-    vit = keyed_changes_.find(change->instanceHandle);
+    vit = instances_.find(change->instanceHandle);
 
-    assert(vit != keyed_changes_.end());
+    assert(vit != instances_.end());
     vit->second->update_state(change->kind, change->writerGUID);
     change->reader_info.disposed_generation_count = vit->second->disposed_generation_count;
     change->reader_info.no_writers_generation_count = vit->second->no_writers_generation_count;
@@ -776,7 +775,7 @@ void DataReaderHistory::update_instance_nts(
 void DataReaderHistory::writer_not_alive(
         const fastrtps::rtps::GUID_t& writer_guid)
 {
-    for (auto& it : keyed_changes_)
+    for (auto& it : instances_)
     {
         it.second->writer_removed(writer_guid);
     }

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
@@ -402,7 +402,8 @@ bool DataReaderHistory::find_key(
             data_available_instances_.erase(vit->first);
             instances_.erase(vit);
             vit_out = instances_.emplace(handle,
-                            std::make_shared<DataReaderInstance>(key_changes_allocation_, key_writers_allocation_)).first;
+                            std::make_shared<DataReaderInstance>(key_changes_allocation_,
+                            key_writers_allocation_)).first;
             return true;
         }
     }
@@ -604,9 +605,9 @@ std::pair<bool, DataReaderHistory::instance_info> DataReaderHistory::lookup_avai
         else
         {
             auto comp = [](const InstanceHandle_t& h, const InstanceCollection::value_type& it)
-            {
-                return h < it.first;
-            };
+                    {
+                        return h < it.first;
+                    };
             it = std::upper_bound(data_available_instances_.begin(), data_available_instances_.end(), handle, comp);
         }
     }
@@ -633,7 +634,7 @@ void DataReaderHistory::check_and_remove_instance(
     if (instance_info->second->cache_changes.empty())
     {
         if ((InstanceStateKind::ALIVE_INSTANCE_STATE != instance_info->second->instance_state) &&
-            instance_info->first.isDefined())
+                instance_info->first.isDefined())
         {
             instances_.erase(instance_info->first);
         }

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
@@ -571,22 +571,22 @@ std::pair<bool, DataReaderHistory::instance_info> DataReaderHistory::lookup_inst
             // - Looking for a specific instance (exact = true)
             // - Looking for the next instance to the ficticious one (exact = false)
             // In both cases, no instance should be returned
-            return { false, {InstanceHandle_t(), nullptr} };
+            return { false, keyed_changes_.end() };
         }
 
         if (exact)
         {
             // Looking for HANDLE_NIL, nothing to return
-            return { false, {InstanceHandle_t(), nullptr} };
+            return { false, keyed_changes_.end() };
         }
 
         // Looking for the first instance, return the ficticious one containing all changes
         InstanceHandle_t tmp;
         tmp.value[0] = 1;
-        return { true, {tmp, const_cast<DataReaderInstance*>(keyed_changes_.begin()->second.get())} };
+        return { true, keyed_changes_.begin() };
     }
 
-    InstanceCollection::const_iterator it;
+    InstanceCollection::iterator it;
 
     if (exact)
     {
@@ -601,31 +601,31 @@ std::pair<bool, DataReaderHistory::instance_info> DataReaderHistory::lookup_inst
         it = std::upper_bound(keyed_changes_.begin(), keyed_changes_.end(), handle, comp);
     }
 
-    if (it != keyed_changes_.end())
-    {
-        return { true, {it->first, const_cast<DataReaderInstance*>(it->second.get())} };
-    }
-    return { false, {InstanceHandle_t(), nullptr} };
+    return { it != keyed_changes_.end(), it };
 }
 
 std::pair<bool, DataReaderHistory::instance_info> DataReaderHistory::next_available_instance_nts(
         const InstanceHandle_t& handle,
         const DataReaderHistory::instance_info& current_info)
 {
-    static_cast<void>(current_info);
-    return lookup_instance(handle, false);
+    instance_info it = current_info;
+    if (it->first == handle)
+    {
+        ++it;
+    }
+
+    return { it != keyed_changes_.end(), it };
 }
 
 void DataReaderHistory::check_and_remove_instance(
         DataReaderHistory::instance_info& instance_info)
 {
-    DataReaderInstance* instance = instance_info.second;
+    DataReaderInstance* instance = instance_info->second.get();
     if (instance->cache_changes.empty() &&
             (InstanceStateKind::ALIVE_INSTANCE_STATE != instance->instance_state) &&
-            instance_info.first.isDefined())
+            instance_info->first.isDefined())
     {
-        keyed_changes_.erase(instance_info.first);
-        instance_info.second = nullptr;
+        instance_info = keyed_changes_.erase(instance_info);
     }
 }
 

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <limits>
+#include <memory>
 #include <mutex>
 
 #include "DataReaderHistory.hpp"
@@ -99,7 +100,7 @@ DataReaderHistory::DataReaderHistory(
         key_changes_allocation_.maximum = resource_limited_qos_.max_samples;
 
         keyed_changes_.emplace(c_InstanceHandle_Unknown,
-                DataReaderInstance{ key_changes_allocation_, key_writers_allocation_ });
+                std::make_shared<DataReaderInstance>(key_changes_allocation_, key_writers_allocation_));
     }
 
     using std::placeholders::_1;
@@ -225,11 +226,11 @@ bool DataReaderHistory::received_change_keep_all(
     InstanceCollection::iterator vit;
     if (find_key(a_change->instanceHandle, vit))
     {
-        DataReaderInstance::ChangeCollection& instance_changes = vit->second.cache_changes;
+        DataReaderInstance::ChangeCollection& instance_changes = vit->second->cache_changes;
         size_t total_size = instance_changes.size() + unknown_missing_changes_up_to;
         if (total_size < static_cast<size_t>(resource_limited_qos_.max_samples_per_instance))
         {
-            ret_value =  add_received_change_with_key(a_change, vit->second, rejection_reason);
+            ret_value =  add_received_change_with_key(a_change, *vit->second, rejection_reason);
         }
         else
         {
@@ -261,7 +262,7 @@ bool DataReaderHistory::received_change_keep_last(
     InstanceCollection::iterator vit;
     if (find_key(a_change->instanceHandle, vit))
     {
-        DataReaderInstance::ChangeCollection& instance_changes = vit->second.cache_changes;
+        DataReaderInstance::ChangeCollection& instance_changes = vit->second->cache_changes;
         if (instance_changes.size() < static_cast<size_t>(history_qos_.depth))
         {
             ret_value = true;
@@ -284,7 +285,7 @@ bool DataReaderHistory::received_change_keep_last(
 
         if (ret_value)
         {
-            ret_value = add_received_change_with_key(a_change, vit->second, rejection_reason);
+            ret_value = add_received_change_with_key(a_change, *vit->second, rejection_reason);
         }
     }
     else
@@ -358,14 +359,14 @@ bool DataReaderHistory::get_first_untaken_info(
     {
         auto it = keyed_changes_.find(change->instanceHandle);
         assert(it != keyed_changes_.end());
-        auto& instance_changes = it->second.cache_changes;
+        auto& instance_changes = it->second->cache_changes;
         auto item =
                 std::find_if(instance_changes.cbegin(), instance_changes.cend(),
                         [change](const DataReaderCacheChange& v)
                         {
                             return v == change;
                         });
-        ReadTakeCommand::generate_info(info, it->second, *item);
+        ReadTakeCommand::generate_info(info, *(it->second), *item);
         mp_reader->change_read_by_user(change, wp, false);
         return true;
     }
@@ -388,17 +389,17 @@ bool DataReaderHistory::find_key(
     if (keyed_changes_.size() < static_cast<size_t>(resource_limited_qos_.max_instances))
     {
         vit_out = keyed_changes_.emplace(handle,
-                        DataReaderInstance{key_changes_allocation_, key_writers_allocation_}).first;
+                        std::make_shared<DataReaderInstance>(key_changes_allocation_, key_writers_allocation_)).first;
         return true;
     }
 
     for (vit = keyed_changes_.begin(); vit != keyed_changes_.end(); ++vit)
     {
-        if (InstanceStateKind::ALIVE_INSTANCE_STATE != vit->second.instance_state)
+        if (InstanceStateKind::ALIVE_INSTANCE_STATE != vit->second->instance_state)
         {
             keyed_changes_.erase(vit);
             vit_out = keyed_changes_.emplace(handle,
-                            DataReaderInstance{ key_changes_allocation_, key_writers_allocation_ }).first;
+                            std::make_shared<DataReaderInstance>(key_changes_allocation_, key_writers_allocation_)).first;
             return true;
         }
     }
@@ -432,12 +433,12 @@ bool DataReaderHistory::remove_change_sub(
     InstanceCollection::iterator vit;
     if (find_key(change->instanceHandle, vit))
     {
-        for (auto chit = vit->second.cache_changes.begin(); chit != vit->second.cache_changes.end(); ++chit)
+        for (auto chit = vit->second->cache_changes.begin(); chit != vit->second->cache_changes.end(); ++chit)
         {
             if ((*chit)->sequenceNumber == change->sequenceNumber &&
                     (*chit)->writerGUID == change->writerGUID)
             {
-                vit->second.cache_changes.erase(chit);
+                vit->second->cache_changes.erase(chit);
                 found = true;
                 break;
             }
@@ -472,13 +473,13 @@ bool DataReaderHistory::remove_change_sub(
     InstanceCollection::iterator vit;
     if (find_key(change->instanceHandle, vit))
     {
-        for (auto chit = vit->second.cache_changes.begin(); chit != vit->second.cache_changes.end(); ++chit)
+        for (auto chit = vit->second->cache_changes.begin(); chit != vit->second->cache_changes.end(); ++chit)
         {
             if ((*chit)->sequenceNumber == change->sequenceNumber &&
                     (*chit)->writerGUID == change->writerGUID)
             {
                 assert(it == chit);
-                it = vit->second.cache_changes.erase(chit);
+                it = vit->second->cache_changes.erase(chit);
                 found = true;
                 break;
             }
@@ -518,7 +519,7 @@ bool DataReaderHistory::set_next_deadline(
         return false;
     }
 
-    it->second.next_deadline_us = next_deadline_us;
+    it->second->next_deadline_us = next_deadline_us;
     return true;
 }
 
@@ -535,13 +536,13 @@ bool DataReaderHistory::get_next_deadline(
     auto min = std::min_element(keyed_changes_.begin(),
                     keyed_changes_.end(),
                     [](
-                        const std::pair<InstanceHandle_t, DataReaderInstance>& lhs,
-                        const std::pair<InstanceHandle_t, DataReaderInstance>& rhs)
+                        const InstanceCollection::value_type& lhs,
+                        const InstanceCollection::value_type& rhs)
                     {
-                        return lhs.second.next_deadline_us < rhs.second.next_deadline_us;
+                        return lhs.second->next_deadline_us < rhs.second->next_deadline_us;
                     });
     handle = min->first;
-    next_deadline_us = min->second.next_deadline_us;
+    next_deadline_us = min->second->next_deadline_us;
     return true;
 }
 
@@ -576,7 +577,7 @@ std::pair<bool, DataReaderHistory::instance_info> DataReaderHistory::lookup_inst
         // Looking for the first instance, return the ficticious one containing all changes
         InstanceHandle_t tmp;
         tmp.value[0] = 1;
-        return { true, {tmp, const_cast<DataReaderInstance*>(&keyed_changes_.begin()->second)} };
+        return { true, {tmp, const_cast<DataReaderInstance*>(keyed_changes_.begin()->second.get())} };
     }
 
     InstanceCollection::const_iterator it;
@@ -587,7 +588,7 @@ std::pair<bool, DataReaderHistory::instance_info> DataReaderHistory::lookup_inst
     }
     else
     {
-        auto comp = [](const InstanceHandle_t& h, const std::pair<InstanceHandle_t, DataReaderInstance>& it)
+        auto comp = [](const InstanceHandle_t& h, const InstanceCollection::value_type& it)
                 {
                     return h < it.first;
                 };
@@ -596,7 +597,7 @@ std::pair<bool, DataReaderHistory::instance_info> DataReaderHistory::lookup_inst
 
     if (it != keyed_changes_.end())
     {
-        return { true, {it->first, const_cast<DataReaderInstance*>(&(it->second))} };
+        return { true, {it->first, const_cast<DataReaderInstance*>(it->second.get())} };
     }
     return { false, {InstanceHandle_t(), nullptr} };
 }
@@ -634,7 +635,7 @@ ReaderHistory::iterator DataReaderHistory::remove_change_nts(
             // keyed map.
             if (it != keyed_changes_.end())
             {
-                auto& c = it->second.cache_changes;
+                auto& c = it->second->cache_changes;
                 c.erase(std::remove(c.begin(), c.end(), p_sample), c.end());
             }
         }
@@ -668,7 +669,7 @@ bool DataReaderHistory::completed_change(
             if (find_key(change->instanceHandle, vit))
             {
                 ret_value = !change->instanceHandle.isDefined() ||
-                        complete_fn_(change, vit->second, unknown_missing_changes_up_to, rejection_reason);
+                        complete_fn_(change, *vit->second, unknown_missing_changes_up_to, rejection_reason);
             }
             else
             {
@@ -746,9 +747,9 @@ void DataReaderHistory::update_instance_nts(
     vit = keyed_changes_.find(change->instanceHandle);
 
     assert(vit != keyed_changes_.end());
-    vit->second.update_state(change->kind, change->writerGUID);
-    change->reader_info.disposed_generation_count = vit->second.disposed_generation_count;
-    change->reader_info.no_writers_generation_count = vit->second.no_writers_generation_count;
+    vit->second->update_state(change->kind, change->writerGUID);
+    change->reader_info.disposed_generation_count = vit->second->disposed_generation_count;
+    change->reader_info.no_writers_generation_count = vit->second->no_writers_generation_count;
 }
 
 void DataReaderHistory::writer_not_alive(
@@ -756,7 +757,7 @@ void DataReaderHistory::writer_not_alive(
 {
     for (auto& it : keyed_changes_)
     {
-        it.second.writer_removed(writer_guid);
+        it.second->writer_removed(writer_guid);
     }
 }
 

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
@@ -67,7 +67,9 @@ public:
     using instance_info = InstanceCollection::iterator;
 
     /**
-     * Constructor. Requires information about the DataReader.
+     * Constructor.
+     * Requires information about the DataReader.
+     *
      * @param type  Type information. Needed to know if the type is keyed, as long as the maximum serialized size.
      * @param topic Topic description. Topic and type name are used on debug messages.
      * @param qos   DataReaderQoS policy. History related limits are taken from here.
@@ -81,9 +83,11 @@ public:
 
     /**
      * Remove a specific change from the history.
-     * No Thread Safe
+     * No Thread Safe.
+     *
      * @param removal iterator to the CacheChange_t to remove.
      * @param release defaults to true and hints if the CacheChange_t should return to the pool
+     *
      * @return iterator to the next CacheChange_t or end iterator.
      */
     iterator remove_change_nts(
@@ -111,23 +115,31 @@ public:
             bool& will_never_be_accepted) const override;
 
     /**
-     * Called when a change is received by the Subscriber. Will add the change to the history.
+     * Called when a change is received by the RTPS reader.
+     * Will add the change to the history.
+     *
      * @pre Change should not be already present in the history.
+     *
      * @param[in] change The received change
      * @param unknown_missing_changes_up_to Number of missing changes before this one
-     * @return
+     *
+     * @return Whether the operation succeeded.
      */
     bool received_change(
             CacheChange_t* change,
             size_t unknown_missing_changes_up_to) override;
 
-    /*!
-     * Called when a change is received by the Subscriber. Will add the change to the history.
+    /**
+     * Called when a change is received by the RTPS reader.
+     * Will add the change to the history.
+     *
      * @pre Change should not be already present in the history.
+     *
      * @param[in] change The received change
      * @param[in] unknown_missing_changes_up_to Number of missing changes before this one
      * @param[out] rejection_reason In case of been rejected the sample, it will contain the reason of the rejection.
-     * @return
+     *
+     * @return Whether the operation succeeded.
      */
     bool received_change(
             CacheChange_t* change,
@@ -135,22 +147,29 @@ public:
             SampleRejectedStatusKind& rejection_reason) override;
 
     /**
-     * Called when a fragmented change is received completely by the Subscriber. Will find its instance and store it.
+     * Called when a fragmented change is received completely by the RTPS reader.
+     * Will find its instance and store it.
+     *
      * @pre Change should be already present in the history.
+     *
      * @param[in] change The received change
-     * @param[in] unknown_missing_changes_up_to Number of missing changes before this one
-     * @return
+     *
+     * @return Whether the operation succeeded.
      */
     bool completed_change(
             CacheChange_t* change) override;
 
-    /*!
-     * Called when a fragmented change is received completely by the Subscriber. Will find its instance and store it.
+    /**
+     * Called when a fragmented change is received completely by the RTPS reader.
+     * Will find its instance and store it.
+     *
      * @pre Change should be already present in the history.
+     *
      * @param[in] change The received change
      * @param[in] unknown_missing_changes_up_to Number of missing changes before this one
      * @param[out] rejection_reason In case of been rejected the sample, it will contain the reason of the rejection.
-     * @return
+     *
+     * @return Whether the operation succeeded.
      */
     bool completed_change(
             CacheChange_t* change,
@@ -159,24 +178,30 @@ public:
 
     /**
      * @brief Returns information about the first untaken sample.
+     *
      * @param [out] info SampleInfo structure to store first untaken sample information.
-     * @return true if sample info was returned. false if there is no sample to take.
+     *
+     * @return true if sample info was returned, false if there is no sample to take.
      */
     bool get_first_untaken_info(
             SampleInfo& info);
 
     /**
-     * This method is called to remove a change from the SubscriberHistory.
+     * This method is called to remove a change from the DataReaderHistory.
+     *
      * @param change Pointer to the CacheChange_t.
+     *
      * @return True if removed.
      */
     bool remove_change_sub(
             CacheChange_t* change);
 
     /**
-     * This method is called to remove a change from the SubscriberHistory.
+     * This method is called to remove a change from the DataReaderHistory.
+     *
      * @param [in]     change Pointer to the CacheChange_t.
      * @param [in,out] it     Iterator pointing to change on input. Will point to next valid change on output.
+     *
      * @return True if removed.
      */
     bool remove_change_sub(
@@ -197,9 +222,11 @@ public:
             const SequenceNumber_t& last_notified_seq) override;
 
     /**
-     * @brief A method to set the next deadline for the given instance
+     * @brief A method to set the next deadline for the given instance.
+     *
      * @param handle The handle to the instance
      * @param next_deadline_us The time point when the deadline will occur
+     *
      * @return True if the deadline was set correctly
      */
     bool set_next_deadline(
@@ -207,9 +234,11 @@ public:
             const std::chrono::steady_clock::time_point& next_deadline_us);
 
     /**
-     * @brief A method to get the next instance handle that will miss the deadline and the time when the deadline will occur
+     * @brief A method to get the next instance handle that will miss the deadline and the time when the deadline will occur.
+     *
      * @param handle The handle to the instance
      * @param next_deadline_us The time point when the instance will miss the deadline
+     *
      * @return True if the deadline was retrieved successfully
      */
     bool get_next_deadline(
@@ -228,7 +257,9 @@ public:
 
     /**
      * @brief Check whether an instance handle is present in the history.
+     *
      * @param handle The handle of the instance to check.
+     *
      * @return true when the topic has keys and the handle corresponds to an instance present in the history.
      * @return false otherwise.
      */
@@ -236,15 +267,15 @@ public:
             const InstanceHandle_t& handle) const;
 
     /**
-     * @brief Get the list of changes corresponding to an instance handle.
+     * @brief Get an iterator to an instance with available data.
+     *
      * @param handle The handle to the instance.
      * @param exact  Indicates if the handle should match exactly (true) or if the first instance greater than the
      *               input handle should be returned.
+     *
      * @return A pair where:
      *         - @c first is a boolean indicating if an instance was found
-     *         - @c second is a pair where:
-     *           - @c first is the handle of the returned instance
-     *           - @c second is a pointer to a DataReaderInstance that holds information about the returned instance
+     *         - @c second is an iterator to the data available instances collection
      *
      * @remarks When used on a NO_KEY topic, an instance will only be returned when called with
      *          `handle = HANDLE_NIL` and `exact = false`.
@@ -253,6 +284,17 @@ public:
             const InstanceHandle_t& handle,
             bool exact);
 
+    /**
+     * @brief Advance an iterator to an instance with available data to the next instance.
+     *
+     * @param handle        The handle of the instance returned by a previous call to lookup_available_instance or
+     *                      next_available_instance_nts.
+     * @param current_info  The iterator to be advanced.
+     *
+     * @return A pair where:
+     *         - @c first is a boolean indicating if another instance with available data is present
+     *         - @c second is an iterator pointing to the next instance with available data
+     */
     std::pair<bool, instance_info> next_available_instance_nts(
             const InstanceHandle_t& handle,
             const instance_info& current_info);

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
@@ -285,7 +285,7 @@ public:
             bool exact);
 
     /**
-     * @brief Advance an iterator to an instance with available data to the next instance.
+     * @brief Given an instance advance the iterator to the next instance with available data.
      *
      * @param handle        The handle of the instance returned by a previous call to lookup_available_instance or
      *                      next_available_instance_nts.

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <functional>
 #include <map>
+#include <memory>
 #include <utility>
 
 #include <fastdds/dds/core/policy/QosPolicies.hpp>
@@ -253,7 +254,7 @@ public:
 
 private:
 
-    using InstanceCollection = std::map<InstanceHandle_t, DataReaderInstance>;
+    using InstanceCollection = std::map<InstanceHandle_t, std::shared_ptr<DataReaderInstance>>;
 
     //!Resource limits for allocating the array of changes per instance
     eprosima::fastrtps::ResourceLimitedContainerConfig key_changes_allocation_;

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
@@ -250,7 +250,7 @@ public:
      */
     std::pair<bool, instance_info> lookup_instance(
             const InstanceHandle_t& handle,
-            bool exact) const;
+            bool exact);
 
 
     void update_instance_nts(

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
@@ -252,6 +252,9 @@ public:
             const InstanceHandle_t& handle,
             bool exact);
 
+    std::pair<bool, instance_info> next_available_instance_nts(
+            const InstanceHandle_t& handle,
+            const instance_info& current_info);
 
     void update_instance_nts(
             CacheChange_t* const change);

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
@@ -272,8 +272,8 @@ private:
     eprosima::fastrtps::ResourceLimitedContainerConfig key_changes_allocation_;
     //!Resource limits for allocating the array of alive writers per instance
     eprosima::fastrtps::ResourceLimitedContainerConfig key_writers_allocation_;
-    //!Map where keys are instance handles and values vectors of cache changes
-    InstanceCollection keyed_changes_;
+    //!Collection of DataReaderInstance objects accessible by their handle
+    InstanceCollection instances_;
     //!HistoryQosPolicy values.
     HistoryQosPolicy history_qos_;
     //!ResourceLimitsQosPolicy values.

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
@@ -249,7 +249,7 @@ public:
      * @remarks When used on a NO_KEY topic, an instance will only be returned when called with
      *          `handle = HANDLE_NIL` and `exact = false`.
      */
-    std::pair<bool, instance_info> lookup_instance(
+    std::pair<bool, instance_info> lookup_available_instance(
             const InstanceHandle_t& handle,
             bool exact);
 

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
@@ -226,6 +226,15 @@ public:
             bool mark_as_read);
 
     /**
+     * @brief Check whether an instance handle is present in the history.
+     * @param handle The handle of the instance to check.
+     * @return true when the topic has keys and the handle corresponds to an instance present in the history.
+     * @return false otherwise.
+     */
+    bool is_instance_present(
+            const InstanceHandle_t& handle) const;
+
+    /**
      * @brief Get the list of changes corresponding to an instance handle.
      * @param handle The handle to the instance.
      * @param exact  Indicates if the handle should match exactly (true) or if the first instance greater than the
@@ -242,6 +251,7 @@ public:
     std::pair<bool, instance_info> lookup_instance(
             const InstanceHandle_t& handle,
             bool exact) const;
+
 
     void update_instance_nts(
             CacheChange_t* const change);

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
@@ -63,7 +63,8 @@ public:
     using GUID_t = eprosima::fastrtps::rtps::GUID_t;
     using SequenceNumber_t = eprosima::fastrtps::rtps::SequenceNumber_t;
 
-    using instance_info = std::pair<InstanceHandle_t, DataReaderInstance*>;
+    using InstanceCollection = std::map<InstanceHandle_t, std::shared_ptr<DataReaderInstance>>;
+    using instance_info = InstanceCollection::iterator;
 
     /**
      * Constructor. Requires information about the DataReader.
@@ -266,8 +267,6 @@ public:
             instance_info& instance_info);
 
 private:
-
-    using InstanceCollection = std::map<InstanceHandle_t, std::shared_ptr<DataReaderInstance>>;
 
     //!Resource limits for allocating the array of changes per instance
     eprosima::fastrtps::ResourceLimitedContainerConfig key_changes_allocation_;

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
@@ -274,6 +274,8 @@ private:
     eprosima::fastrtps::ResourceLimitedContainerConfig key_writers_allocation_;
     //!Collection of DataReaderInstance objects accessible by their handle
     InstanceCollection instances_;
+    //!Collection of DataReaderInstance objects with available data, accessible by their handle
+    InstanceCollection data_available_instances_;
     //!HistoryQosPolicy values.
     HistoryQosPolicy history_qos_;
     //!ResourceLimitsQosPolicy values.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR highly improves the performance of read / take methods when the number of instances on a keyed topic is high.

The main ideas behind it are:
* Using iterators on ReadTakeCommand
* Using a specific collection for instances with available data on DataReaderHistory

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->

This should fix #2779.

<!-- @Mergifyio backport (branch/es) -->
@mergifyio backport 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
    - [x] DataReaderTests
    - [x] BlackboxTests_DDS_PIM.PubSubBasic
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
