### PR TITLE
Export required LogConsumer API on Windows platforms

### DIFF
--- a/include/fastdds/dds/log/Log.hpp
+++ b/include/fastdds/dds/log/Log.hpp
@@ -179,27 +179,27 @@ public:
 
 protected:
 
-    void print_timestamp(
+    RTPS_DllAPI void print_timestamp(
             std::ostream& stream,
             const Log::Entry&,
             bool color) const;
 
-    void print_header(
+    RTPS_DllAPI void print_header(
             std::ostream& stream,
             const Log::Entry&,
             bool color) const;
 
-    void print_context(
+    RTPS_DllAPI void print_context(
             std::ostream& stream,
             const Log::Entry&,
             bool color) const;
 
-    void print_message(
+    RTPS_DllAPI void print_message(
             std::ostream& stream,
             const Log::Entry&,
             bool color) const;
 
-    void print_new_line(
+    RTPS_DllAPI void print_new_line(
             std::ostream& stream,
             bool color) const;
 };

--- a/test/blackbox/common/BlackboxTestsLogConsumer.cpp
+++ b/test/blackbox/common/BlackboxTestsLogConsumer.cpp
@@ -1,0 +1,67 @@
+// Copyright 2022 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "BlackboxTests.hpp"
+
+#include <regex>
+
+#include <gtest/gtest.h>
+
+#include <fastdds/dds/log/Log.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+
+class CustomLogConsumer : public LogConsumer
+{
+public:
+
+    virtual void Consume(
+            const Log::Entry& entry)
+    {
+        print_timestamp(stream_, entry, false);
+        print_header(stream_, entry, false);
+        print_message(stream_, entry, false);
+        print_context(stream_, entry, false);
+        print_new_line(stream_, false);
+
+        std::regex re("^(.+)CUSTOM_LOG_CONSUMER_TEST(.+)Testing log consumer protected functions -> (.+)$");
+        EXPECT_TRUE(std::regex_match(stream_.str(), re));
+
+        stream_.str("");
+    }
+
+private:
+
+    std::stringstream stream_;
+};
+
+TEST(LogConsumer, CheckLogConsumerPrintMemberFunctions)
+{
+    CustomLogConsumer* custom_consumer = new CustomLogConsumer();
+
+    Log::RegisterConsumer(std::unique_ptr<LogConsumer>(custom_consumer));
+    Log::SetVerbosity(Log::Warning);
+    Log::SetCategoryFilter(std::regex("(CUSTOM_LOG_CONSUMER_TEST)"));
+
+    logError(CUSTOM_LOG_CONSUMER_TEST, "Testing log consumer protected functions")
+}
+
+
+
+} // namespace dds
+} // namespace fastdds
+} // namespace eprosima

--- a/test/blackbox/common/BlackboxTestsLogConsumer.cpp
+++ b/test/blackbox/common/BlackboxTestsLogConsumer.cpp
@@ -32,21 +32,17 @@ public:
     virtual void Consume(
             const Log::Entry& entry)
     {
-        print_timestamp(stream_, entry, false);
-        print_header(stream_, entry, false);
-        print_message(stream_, entry, false);
-        print_context(stream_, entry, false);
-        print_new_line(stream_, false);
+        std::stringstream stream;
+        print_timestamp(stream, entry, false);
+        print_header(stream, entry, false);
+        print_message(stream, entry, false);
+        print_context(stream, entry, false);
+        print_new_line(stream, false);
 
         std::regex re("^(.+)CUSTOM_LOG_CONSUMER_TEST(.+)Testing log consumer protected functions -> (.+)$");
-        EXPECT_TRUE(std::regex_match(stream_.str(), re));
-
-        stream_.str("");
+        EXPECT_TRUE(std::regex_match(stream.str(), re));
     }
 
-private:
-
-    std::stringstream stream_;
 };
 
 TEST(LogConsumer, CheckLogConsumerPrintMemberFunctions)


### PR DESCRIPTION
Current version of Shapes Demo does not compile on Windows due to un-exported Fast DDS LogConsomer functions. 

See the error below:

```
mainwindow.obj : error LNK2019: unresolved external symbol "protected: void __cdecl eprosima::fastdds::dds::LogConsumer::print_header(class std::basic_ostream<char,struct std::char_traits<char> > &,struct eprosima::fastdds::dds::Log::Entry const &,bool)const " (?print_header@LogConsumer@dds@fastdds@eprosima@@IEBAXAEAV?$basic_ostream@DU?$char_traits@D@std@@@std@@AEBUEntry@Log@234@_N@Z) referenced in function "public: virtual void __cdecl ShapesDemoLogConsumer::Consume(struct eprosima::fastdds::dds::Log::Entry const &)" (?Consume@ShapesDemoLogConsumer@@UEAAXAEBUEntry@Log@dds@fastdds@eprosima@@@Z) [C:\Users\eProsima\eProsima\shapesdemo\build\ShapesDemo\ShapesDemo.vcxproj]
mainwindow.obj : error LNK2019: unresolved external symbol "protected: void __cdecl eprosima::fastdds::dds::LogConsumer::print_context(class std::basic_ostream<char,struct std::char_traits<char> > &,struct eprosima::fastdds::dds::Log::Entry const &,bool)const " (?print_context@LogConsumer@dds@fastdds@eprosima@@IEBAXAEAV?$basic_ostream@DU?$char_traits@D@std@@@std@@AEBUEntry@Log@234@_N@Z) referenced in function "public: virtual void __cdecl ShapesDemoLogConsumer::Consume(struct eprosima::fastdds::dds::Log::Entry const &)" (?Consume@ShapesDemoLogConsumer@@UEAAXAEBUEntry@Log@dds@fastdds@eprosima@@@Z) [C:\Users\eProsima\eProsima\shapesdemo\build\ShapesDemo\ShapesDemo.vcxproj]
mainwindow.obj : error LNK2019: unresolved external symbol "protected: void __cdecl eprosima::fastdds::dds::LogConsumer::print_message(class std::basic_ostream<char,struct std::char_traits<char> > &,struct eprosima::fastdds::dds::Log::Entry const &,bool)const " (?print_message@LogConsumer@dds@fastdds@eprosima@@IEBAXAEAV?$basic_ostream@DU?$char_traits@D@std@@@std@@AEBUEntry@Log@234@_N@Z) referenced in function "public: virtual void __cdecl ShapesDemoLogConsumer::Consume(struct eprosima::fastdds::dds::Log::Entry const &)" (?Consume@ShapesDemoLogConsumer@@UEAAXAEBUEntry@Log@dds@fastdds@eprosima@@@Z) [C:\Users\eProsima\eProsima\shapesdemo\build\ShapesDemo\ShapesDemo.vcxproj]
C:\Users\eProsima\eProsima\shapesdemo\build\ShapesDemo\Release\ShapesDemo.exe : fatal error LNK1120: 3 unresolved externals [C:\Users\eProsima\eProsima\shapesdemo\build\ShapesDemo\ShapesDemo.vcxproj]
Failed   <<< ShapesDemo [1.92s, exited with code 1]
```

<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [ ] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
