### PR TITLE
[14958] Instance allocation consistency

### DIFF
--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -1727,19 +1727,19 @@ public:
      * @brief Specifies the maximum number of data-samples the DataWriter (or DataReader) can manage across all the
      * instances associated with it. Represents the maximum samples the middleware can store for any one DataWriter
      * (or DataReader). <br>
-     * By default, 5000.
+     * By default, o (infinite).
      *
      * @warning It is inconsistent for this value to be less than max_samples_per_instance.
      */
     int32_t max_samples;
     /**
      * @brief Represents the maximum number of instances DataWriter (or DataReader) can manage. <br>
-     * By default, 10.
+     * By default, 0 (infinite).
      */
     int32_t max_instances;
     /**
      * @brief Represents the maximum number of samples of any one instance a DataWriter(or DataReader) can manage. <br>
-     * By default, 400.
+     * By default, 0 (infinite).
      *
      * @warning It is inconsistent for this value to be greater than max_samples.
      */

--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -1729,19 +1729,21 @@ public:
      * (or DataReader). <br>
      * By default, 5000.
      *
-     * @warning It is inconsistent for this value to be less than max_samples_per_instance.
+     * @warning It is inconsistent if `max_samples < (max_instances * max_samples_per_instance)`.
      */
     int32_t max_samples;
     /**
      * @brief Represents the maximum number of instances DataWriter (or DataReader) can manage. <br>
      * By default, 10.
+     * 
+     * @warning It is inconsistent if `(max_instances * max_samples_per_instance) > max_samples`.
      */
     int32_t max_instances;
     /**
      * @brief Represents the maximum number of samples of any one instance a DataWriter(or DataReader) can manage. <br>
      * By default, 400.
      *
-     * @warning It is inconsistent for this value to be greater than max_samples.
+     * @warning It is inconsistent if `(max_instances * max_samples_per_instance) > max_samples`.
      */
     int32_t max_samples_per_instance;
     /**

--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -1735,7 +1735,7 @@ public:
     /**
      * @brief Represents the maximum number of instances DataWriter (or DataReader) can manage. <br>
      * By default, 10.
-     * 
+     *
      * @warning It is inconsistent if `(max_instances * max_samples_per_instance) > max_samples`.
      */
     int32_t max_instances;

--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -1727,19 +1727,19 @@ public:
      * @brief Specifies the maximum number of data-samples the DataWriter (or DataReader) can manage across all the
      * instances associated with it. Represents the maximum samples the middleware can store for any one DataWriter
      * (or DataReader). <br>
-     * By default, o (infinite).
+     * By default, 5000.
      *
      * @warning It is inconsistent for this value to be less than max_samples_per_instance.
      */
     int32_t max_samples;
     /**
      * @brief Represents the maximum number of instances DataWriter (or DataReader) can manage. <br>
-     * By default, 0 (infinite).
+     * By default, 10.
      */
     int32_t max_instances;
     /**
      * @brief Represents the maximum number of samples of any one instance a DataWriter(or DataReader) can manage. <br>
-     * By default, 0 (infinite).
+     * By default, 400.
      *
      * @warning It is inconsistent for this value to be greater than max_samples.
      */
@@ -1761,9 +1761,9 @@ public:
     RTPS_DllAPI ResourceLimitsQosPolicy()
         : Parameter_t(PID_RESOURCE_LIMITS, 4 + 4 + 4)
         , QosPolicy(false)
-        , max_samples(0)
-        , max_instances(0)
-        , max_samples_per_instance(0)
+        , max_samples(5000)
+        , max_instances(10)
+        , max_samples_per_instance(400)
         , allocated_samples(100)
         , extra_samples(1)
     {

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1349,7 +1349,7 @@ Topic* DomainParticipantImpl::create_topic(
         return nullptr;
     }
 
-    if (!TopicImpl::check_qos(qos))
+    if (!TopicImpl::check_qos_including_resource_limits(qos, type_support))
     {
         logError(PARTICIPANT, "TopicQos inconsistent or not supported");
         return nullptr;

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1086,7 +1086,7 @@ ReturnCode_t DataWriterImpl::set_qos(
     // Default qos is always considered consistent
     if (&qos != &DATAWRITER_QOS_DEFAULT)
     {
-        ReturnCode_t ret_val = check_qos(qos_to_set);
+        ReturnCode_t ret_val = check_qos_including_resource_limits(qos_to_set, type_);
         if (!ret_val)
         {
             return ret_val;

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1694,21 +1694,13 @@ ReturnCode_t DataWriterImpl::check_qos_including_resource_limits(
         const DataWriterQos& qos,
         const TypeSupport& type)
 {
-    ReturnCode_t check_qos_return;
-    check_qos_return = check_qos(qos);
-    if (!check_qos_return)
+    ReturnCode_t check_qos_return = check_qos(qos);
+    if (ReturnCode_t::RETCODE_OK == check_qos_return &&
+            type->m_isGetKeyDefined)
     {
-        return check_qos_return;
+            check_qos_return = check_allocation_consistency(qos);
     }
-    if (type->m_isGetKeyDefined)
-    {
-        check_qos_return = check_allocation_consistency(qos);
-        if (!check_qos_return)
-        {
-            return check_qos_return;
-        }
-    }
-    return ReturnCode_t::RETCODE_OK;
+    return check_qos_return;
 }
 
 ReturnCode_t DataWriterImpl::check_qos(

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1764,7 +1764,7 @@ ReturnCode_t DataWriterImpl::check_allocation_consistency(
         const DataWriterQos& qos)
 {
     if ((qos.resource_limits().max_samples > 0) &&
-            (qos.resource_limits().max_samples <=
+            (qos.resource_limits().max_samples <
             (qos.resource_limits().max_instances * qos.resource_limits().max_samples_per_instance)))
     {
         logError(DDS_QOS_CHECK,

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1698,7 +1698,7 @@ ReturnCode_t DataWriterImpl::check_qos_including_resource_limits(
     if (ReturnCode_t::RETCODE_OK == check_qos_return &&
             type->m_isGetKeyDefined)
     {
-            check_qos_return = check_allocation_consistency(qos);
+        check_qos_return = check_allocation_consistency(qos);
     }
     return check_qos_return;
 }

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1765,20 +1765,6 @@ ReturnCode_t DataWriterImpl::check_qos(
         logError(RTPS_QOS_CHECK, "DATA_SHARING cannot be used with memory policies other than PREALLOCATED.");
         return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
     }
-    if ((qos.resource_limits().max_samples > 0) &&
-            (qos.resource_limits().max_samples <=
-            (qos.resource_limits().max_instances * qos.resource_limits().max_samples_per_instance)))
-    {
-        logError(DDS_QOS_CHECK, "max_samples should be greater than max_instances * max_samples_per_instance");
-        return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
-    }
-    if ((qos.resource_limits().max_instances <= 0 || qos.resource_limits().max_samples_per_instance <= 0) &&
-            (qos.resource_limits().max_samples > 0))
-    {
-        logError(DDS_QOS_CHECK,
-                "max_samples should be infinite when max_instances or max_samples_per_instance are infinite");
-        return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
-    }
     return ReturnCode_t::RETCODE_OK;
 }
 

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -589,7 +589,14 @@ protected:
             const DataWriterQos& from,
             bool is_default);
 
+    static ReturnCode_t check_qos_including_resource_limits(
+            const DataWriterQos& qos,
+            const TypeSupport& type);
+
     static ReturnCode_t check_qos(
+            const DataWriterQos& qos);
+
+    static ReturnCode_t check_allocation_consistency(
             const DataWriterQos& qos);
 
     static bool can_qos_be_updated(

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -589,13 +589,30 @@ protected:
             const DataWriterQos& from,
             bool is_default);
 
+    /**
+     * Extends the check_qos() call, including the check for
+     * resource limits policy.
+     * @param qos Pointer to the qos to be checked.
+     * @param type Pointer to the associated TypeSupport object.
+     * @return True if correct.
+     */
     static ReturnCode_t check_qos_including_resource_limits(
             const DataWriterQos& qos,
             const TypeSupport& type);
 
+    /**
+     * Checks the consistency of the qos configuration.
+     * @param qos Pointer to the qos to be checked.
+     * @return True if correct.
+     */
     static ReturnCode_t check_qos(
             const DataWriterQos& qos);
 
+    /**
+     * Checks resource limits policy: Instance allocation consistency
+     * @param qos Pointer to the qos to be checked.
+     * @return True if correct.
+     */
     static ReturnCode_t check_allocation_consistency(
             const DataWriterQos& qos);
 

--- a/src/cpp/fastdds/publisher/PublisherImpl.cpp
+++ b/src/cpp/fastdds/publisher/PublisherImpl.cpp
@@ -280,7 +280,7 @@ DataWriter* PublisherImpl::create_datawriter(
         return nullptr;
     }
 
-    if (!DataWriterImpl::check_qos(qos))
+    if (!DataWriterImpl::check_qos_including_resource_limits(qos, type_support))
     {
         return nullptr;
     }

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -812,7 +812,7 @@ ReturnCode_t DataReaderImpl::set_qos(
             return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
         }
 
-        ReturnCode_t check_result = check_qos(qos_to_set);
+        ReturnCode_t check_result = check_qos_including_resource_limits(qos_to_set, type_);
         if (!check_result)
         {
             return check_result;

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1444,20 +1444,6 @@ ReturnCode_t DataReaderImpl::check_qos(
         logError(DDS_QOS_CHECK, "unique_network_request cannot be set along specific locators");
         return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
     }
-    if ((qos.resource_limits().max_samples > 0) &&
-            (qos.resource_limits().max_samples <
-            (qos.resource_limits().max_instances * qos.resource_limits().max_samples_per_instance)))
-    {
-        logError(DDS_QOS_CHECK, "max_samples should be greater than max_instances * max_samples_per_instance");
-        return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
-    }
-    if ((qos.resource_limits().max_instances <= 0 || qos.resource_limits().max_samples_per_instance <= 0) &&
-            (qos.resource_limits().max_samples > 0))
-    {
-        logError(DDS_QOS_CHECK,
-                "max_samples should be infinite when max_instances or max_samples_per_instance are infinite");
-        return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
-    }
     return ReturnCode_t::RETCODE_OK;
 }
 

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1395,6 +1395,27 @@ const SampleLostStatus& DataReaderImpl::update_sample_lost_status(
     return sample_lost_status_;
 }
 
+ReturnCode_t DataReaderImpl::check_qos_including_resource_limits(
+        const DataReaderQos& qos,
+        const TypeSupport& type)
+{
+    ReturnCode_t check_qos_return;
+    check_qos_return = check_qos(qos);
+    if (!check_qos_return)
+    {
+        return check_qos_return;
+    }
+    if (type->m_isGetKeyDefined)
+    {
+        check_qos_return = check_allocation_consistency(qos);
+        if (!check_qos_return)
+        {
+            return check_qos_return;
+        }
+    }
+    return ReturnCode_t::RETCODE_OK;
+}
+
 ReturnCode_t DataReaderImpl::check_qos(
         const DataReaderQos& qos)
 {
@@ -1428,6 +1449,27 @@ ReturnCode_t DataReaderImpl::check_qos(
             (qos.resource_limits().max_instances * qos.resource_limits().max_samples_per_instance)))
     {
         logError(DDS_QOS_CHECK, "max_samples should be greater than max_instances * max_samples_per_instance");
+        return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
+    }
+    if ((qos.resource_limits().max_instances <= 0 || qos.resource_limits().max_samples_per_instance <= 0) &&
+            (qos.resource_limits().max_samples > 0))
+    {
+        logError(DDS_QOS_CHECK,
+                "max_samples should be infinite when max_instances or max_samples_per_instance are infinite");
+        return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
+    }
+    return ReturnCode_t::RETCODE_OK;
+}
+
+ReturnCode_t DataReaderImpl::check_allocation_consistency(
+        const DataReaderQos& qos)
+{
+    if ((qos.resource_limits().max_samples > 0) &&
+            (qos.resource_limits().max_samples <=
+            (qos.resource_limits().max_instances * qos.resource_limits().max_samples_per_instance)))
+    {
+        logError(DDS_QOS_CHECK,
+                "max_samples should be greater than max_instances * max_samples_per_instance");
         return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
     }
     if ((qos.resource_limits().max_instances <= 0 || qos.resource_limits().max_samples_per_instance <= 0) &&

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1399,21 +1399,13 @@ ReturnCode_t DataReaderImpl::check_qos_including_resource_limits(
         const DataReaderQos& qos,
         const TypeSupport& type)
 {
-    ReturnCode_t check_qos_return;
-    check_qos_return = check_qos(qos);
-    if (!check_qos_return)
-    {
-        return check_qos_return;
-    }
-    if (type->m_isGetKeyDefined)
+    ReturnCode_t check_qos_return = check_qos(qos);
+    if (ReturnCode_t::RETCODE_OK == check_qos_return &&
+            type->m_isGetKeyDefined)
     {
         check_qos_return = check_allocation_consistency(qos);
-        if (!check_qos_return)
-        {
-            return check_qos_return;
-        }
     }
-    return ReturnCode_t::RETCODE_OK;
+    return check_qos_return;
 }
 
 ReturnCode_t DataReaderImpl::check_qos(

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1443,7 +1443,7 @@ ReturnCode_t DataReaderImpl::check_allocation_consistency(
         const DataReaderQos& qos)
 {
     if ((qos.resource_limits().max_samples > 0) &&
-            (qos.resource_limits().max_samples <=
+            (qos.resource_limits().max_samples <
             (qos.resource_limits().max_instances * qos.resource_limits().max_samples_per_instance)))
     {
         logError(DDS_QOS_CHECK,

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -293,8 +293,10 @@ public:
     //! Remove all listeners in the hierarchy to allow a quiet destruction
     virtual void disable();
 
-    /* Check whether values in the DataReaderQos are compatible among them or not
-     * Checks also resource limits related policy
+    /* Extends the check_qos() call, including the check for
+     * resource limits policy.
+     * @param qos Pointer to the qos to be checked.
+     * @param type Pointer to the associated TypeSupport object.
      * @return True if correct.
      */
     static ReturnCode_t check_qos_including_resource_limits(
@@ -302,13 +304,14 @@ public:
             const TypeSupport& type);
 
     /* Check whether values in the DataReaderQos are compatible among them or not
+     * @param qos Pointer to the qos to be checked.
      * @return True if correct.
      */
     static ReturnCode_t check_qos (
             const DataReaderQos& qos);
 
-    /* Check whether values in the DataReaderQos resource limits related policy
-     * are compatible among them or not
+    /* Checks resource limits policy: Instance allocation consistency
+     * @param qos Pointer to the qos to be checked.
      * @return True if correct.
      */
     static ReturnCode_t check_allocation_consistency(

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -294,9 +294,24 @@ public:
     virtual void disable();
 
     /* Check whether values in the DataReaderQos are compatible among them or not
+     * Checks also resource limits related policy
+     * @return True if correct.
+     */
+    static ReturnCode_t check_qos_including_resource_limits(
+            const DataReaderQos& qos,
+            const TypeSupport& type);
+
+    /* Check whether values in the DataReaderQos are compatible among them or not
      * @return True if correct.
      */
     static ReturnCode_t check_qos (
+            const DataReaderQos& qos);
+
+    /* Check whether values in the DataReaderQos resource limits related policy
+     * are compatible among them or not
+     * @return True if correct.
+     */
+    static ReturnCode_t check_allocation_consistency(
             const DataReaderQos& qos);
 
     /* Check whether the DataReaderQos can be updated with the values provided. This method DOES NOT update anything.

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -247,7 +247,7 @@ DataReader* SubscriberImpl::create_datareader(
         return nullptr;
     }
 
-    if (!DataReaderImpl::check_qos(qos))
+    if (!DataReaderImpl::check_qos_including_resource_limits(qos, type_support))
     {
         return nullptr;
     }

--- a/src/cpp/fastdds/topic/TopicImpl.cpp
+++ b/src/cpp/fastdds/topic/TopicImpl.cpp
@@ -54,21 +54,13 @@ ReturnCode_t TopicImpl::check_qos_including_resource_limits(
         const TopicQos& qos,
         const TypeSupport& type)
 {
-    ReturnCode_t check_qos_return;
-    check_qos_return = check_qos(qos);
-    if (!check_qos_return)
-    {
-        return check_qos_return;
-    }
-    if (type->m_isGetKeyDefined)
+    ReturnCode_t check_qos_return = check_qos(qos);
+    if (ReturnCode_t::RETCODE_OK == check_qos_return &&
+            type->m_isGetKeyDefined)
     {
         check_qos_return = check_allocation_consistency(qos);
-        if (!check_qos_return)
-        {
-            return check_qos_return;
-        }
     }
-    return ReturnCode_t::RETCODE_OK;
+    return check_qos_return;
 }
 
 ReturnCode_t TopicImpl::check_qos(

--- a/src/cpp/fastdds/topic/TopicImpl.cpp
+++ b/src/cpp/fastdds/topic/TopicImpl.cpp
@@ -165,7 +165,7 @@ ReturnCode_t TopicImpl::set_qos(
         return ReturnCode_t::RETCODE_OK;
     }
 
-    ReturnCode_t ret_val = check_qos(qos);
+    ReturnCode_t ret_val = check_qos_including_resource_limits(qos, type_support_);
     if (!ret_val)
     {
         return ret_val;

--- a/src/cpp/fastdds/topic/TopicImpl.cpp
+++ b/src/cpp/fastdds/topic/TopicImpl.cpp
@@ -50,6 +50,27 @@ TopicImpl::~TopicImpl()
 {
 }
 
+ReturnCode_t TopicImpl::check_qos_including_resource_limits(
+        const TopicQos& qos,
+        const TypeSupport& type)
+{
+    ReturnCode_t check_qos_return;
+    check_qos_return = check_qos(qos);
+    if (!check_qos_return)
+    {
+        return check_qos_return;
+    }
+    if (type->m_isGetKeyDefined)
+    {
+        check_qos_return = check_allocation_consistency(qos);
+        if (!check_qos_return)
+        {
+            return check_qos_return;
+        }
+    }
+    return ReturnCode_t::RETCODE_OK;
+}
+
 ReturnCode_t TopicImpl::check_qos(
         const TopicQos& qos)
 {
@@ -84,6 +105,27 @@ ReturnCode_t TopicImpl::check_qos(
             (qos.resource_limits().max_instances * qos.resource_limits().max_samples_per_instance)))
     {
         logError(DDS_QOS_CHECK, "max_samples should be greater than max_instances * max_samples_per_instance");
+        return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
+    }
+    if ((qos.resource_limits().max_instances <= 0 || qos.resource_limits().max_samples_per_instance <= 0) &&
+            (qos.resource_limits().max_samples > 0))
+    {
+        logError(DDS_QOS_CHECK,
+                "max_samples should be infinite when max_instances or max_samples_per_instance are infinite");
+        return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
+    }
+    return ReturnCode_t::RETCODE_OK;
+}
+
+ReturnCode_t TopicImpl::check_allocation_consistency(
+        const TopicQos& qos)
+{
+    if ((qos.resource_limits().max_samples > 0) &&
+            (qos.resource_limits().max_samples <=
+            (qos.resource_limits().max_instances * qos.resource_limits().max_samples_per_instance)))
+    {
+        logError(DDS_QOS_CHECK,
+                "max_samples should be greater than max_instances * max_samples_per_instance");
         return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
     }
     if ((qos.resource_limits().max_instances <= 0 || qos.resource_limits().max_samples_per_instance <= 0) &&

--- a/src/cpp/fastdds/topic/TopicImpl.cpp
+++ b/src/cpp/fastdds/topic/TopicImpl.cpp
@@ -100,20 +100,6 @@ ReturnCode_t TopicImpl::check_qos(
             return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
         }
     }
-    if ((qos.resource_limits().max_samples > 0) &&
-            (qos.resource_limits().max_samples <=
-            (qos.resource_limits().max_instances * qos.resource_limits().max_samples_per_instance)))
-    {
-        logError(DDS_QOS_CHECK, "max_samples should be greater than max_instances * max_samples_per_instance");
-        return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
-    }
-    if ((qos.resource_limits().max_instances <= 0 || qos.resource_limits().max_samples_per_instance <= 0) &&
-            (qos.resource_limits().max_samples > 0))
-    {
-        logError(DDS_QOS_CHECK,
-                "max_samples should be infinite when max_instances or max_samples_per_instance are infinite");
-        return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
-    }
     return ReturnCode_t::RETCODE_OK;
 }
 

--- a/src/cpp/fastdds/topic/TopicImpl.cpp
+++ b/src/cpp/fastdds/topic/TopicImpl.cpp
@@ -99,7 +99,7 @@ ReturnCode_t TopicImpl::check_allocation_consistency(
         const TopicQos& qos)
 {
     if ((qos.resource_limits().max_samples > 0) &&
-            (qos.resource_limits().max_samples <=
+            (qos.resource_limits().max_samples <
             (qos.resource_limits().max_instances * qos.resource_limits().max_samples_per_instance)))
     {
         logError(DDS_QOS_CHECK,

--- a/src/cpp/fastdds/topic/TopicImpl.hpp
+++ b/src/cpp/fastdds/topic/TopicImpl.hpp
@@ -50,7 +50,14 @@ public:
             const TopicQos& qos,
             TopicListener* listen);
 
+    static ReturnCode_t check_qos_including_resource_limits(
+            const TopicQos& qos,
+            const TypeSupport& type);
+
     static ReturnCode_t check_qos(
+            const TopicQos& qos);
+
+    static ReturnCode_t check_allocation_consistency(
             const TopicQos& qos);
 
     static bool can_qos_be_updated(

--- a/src/cpp/fastdds/topic/TopicImpl.hpp
+++ b/src/cpp/fastdds/topic/TopicImpl.hpp
@@ -50,6 +50,10 @@ public:
             const TopicQos& qos,
             TopicListener* listen);
 
+    /**
+     * Extends the check_qos() call, including the check for
+     * resource limits policy.
+     */
     static ReturnCode_t check_qos_including_resource_limits(
             const TopicQos& qos,
             const TypeSupport& type);

--- a/src/cpp/fastdds/topic/TopicImpl.hpp
+++ b/src/cpp/fastdds/topic/TopicImpl.hpp
@@ -53,16 +53,26 @@ public:
     /**
      * Extends the check_qos() call, including the check for
      * resource limits policy.
+     * @param qos Pointer to the qos to be checked.
+     * @param type Pointer to the associated TypeSupport object.
+     * @return True if correct.
      */
     static ReturnCode_t check_qos_including_resource_limits(
             const TopicQos& qos,
             const TypeSupport& type);
 
+    /**
+     * Checks the consistency of the qos configuration.
+     * @param qos Pointer to the qos to be checked.
+     * @return True if correct.
+     */
     static ReturnCode_t check_qos(
             const TopicQos& qos);
 
     /**
      * Checks resource limits policy: Instance allocation consistency
+     * @param qos Pointer to the qos to be checked.
+     * @return True if correct.
      */
     static ReturnCode_t check_allocation_consistency(
             const TopicQos& qos);

--- a/src/cpp/fastdds/topic/TopicImpl.hpp
+++ b/src/cpp/fastdds/topic/TopicImpl.hpp
@@ -61,6 +61,9 @@ public:
     static ReturnCode_t check_qos(
             const TopicQos& qos);
 
+    /**
+     * Checks resource limits policy: Instance allocation consistency
+     */
     static ReturnCode_t check_allocation_consistency(
             const TopicQos& qos);
 

--- a/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
@@ -822,7 +822,7 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepAllWithKeyAndMaxSamples)
     ASSERT_TRUE(reader.isInitialized());
 
     writer.resource_limits_max_instances(keys)
-            .resource_limits_max_samples(2)
+            .resource_limits_max_samples(4)
             .resource_limits_allocated_samples(2)
             .resource_limits_max_samples_per_instance(2)
             .history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS)

--- a/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
@@ -733,6 +733,7 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepAllWithKeyAndInfiniteMaxSamplesPerInst
     ASSERT_TRUE(reader.isInitialized());
 
     writer.resource_limits_max_instances(keys)
+            .resource_limits_max_samples(0)
             .resource_limits_max_samples_per_instance(0)
             .history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS)
             .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
@@ -777,7 +778,8 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepAllWithKeyAndInfiniteMaxInstances)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    writer.resource_limits_max_instances(0)
+    writer.resource_limits_max_samples(0)
+            .resource_limits_max_instances(0)
             .history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS)
             .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
             .mem_policy(mem_policy_).init();

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -1700,7 +1700,9 @@ TEST(DDSStatus, sample_rejected_key_re_dw_re_dr_keep_all_max_samples_2)
 
     writer.history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS);
     reader.history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
-            .resource_limits_max_samples(2);
+            .resource_limits_max_samples(2)
+            .resource_limits_max_instances(2)
+            .resource_limits_max_samples_per_instance(1);
 
     sample_rejected_test_dw_init(writer);
 

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -1890,7 +1890,9 @@ TEST(DDSStatus, sample_rejected_key_re_dw_re_dr_keep_last_max_samples_2)
 
     writer.history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS);
     reader.history_kind(eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS)
-            .resource_limits_max_samples(2);
+            .resource_limits_max_samples(2)
+            .resource_limits_max_instances(2)
+            .resource_limits_max_samples_per_instance(1);
 
     sample_rejected_test_dw_init(writer);
 

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -1798,7 +1798,9 @@ TEST(DDSStatus, sample_rejected_key_large_re_dw_re_dr_keep_all_max_samples_2)
             .add_throughput_controller_descriptor_to_pparams( // Avoid losing more frangments
         eprosima::fastdds::rtps::FlowControllerSchedulerPolicy::FIFO, 132000, 50);
     reader.history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
-            .resource_limits_max_samples(2);
+            .resource_limits_max_samples(2)
+            .resource_limits_max_instances(2)
+            .resource_limits_max_samples_per_instance(1);
 
     sample_rejected_test_dw_init(writer);
 

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -1988,7 +1988,9 @@ TEST(DDSStatus, sample_rejected_key_large_re_dw_re_dr_keep_last_max_samples_2)
             .add_throughput_controller_descriptor_to_pparams( // Avoid losing more frangments
         eprosima::fastdds::rtps::FlowControllerSchedulerPolicy::FIFO, 132000, 50);
     reader.history_kind(eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS)
-            .resource_limits_max_samples(2);
+            .resource_limits_max_samples(2)
+            .resource_limits_max_instances(2)
+            .resource_limits_max_samples_per_instance(1);
 
     sample_rejected_test_dw_init(writer);
 

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -1813,6 +1813,15 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyKeyed)
     DataWriter* data_writer4 = publisher->create_datawriter(topic, qos);
     ASSERT_NE(data_writer4, nullptr);
 
+    // Next QoS config checks that if user sets max_samples = ( max_instances * max_samples_per_instance ) ,
+    // create_datawriter() should not return nullptr.
+    qos.resource_limits().max_samples = 5000;
+    qos.resource_limits().max_instances = 10;
+    qos.resource_limits().max_samples_per_instance = 500;
+
+    DataWriter* data_writer5 = publisher->create_datawriter(topic, qos);
+    ASSERT_NE(data_writer5, nullptr);
+
     // Next QoS config checks that if user sets max_samples infinite
     // and ( max_instances * max_samples_per_instance ) finite,
     // create_datawriter() should not return nullptr.
@@ -1820,8 +1829,8 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyKeyed)
     qos.resource_limits().max_instances = 10;
     qos.resource_limits().max_samples_per_instance = 500;
 
-    DataWriter* data_writer5 = publisher->create_datawriter(topic, qos);
-    ASSERT_NE(data_writer5, nullptr);
+    DataWriter* data_writer6 = publisher->create_datawriter(topic, qos);
+    ASSERT_NE(data_writer6, nullptr);
 
     // Next QoS config checks the default qos configuration,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0, as the by default values are already infinite.
@@ -1848,6 +1857,14 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyKeyed)
     // Next QoS config checks that if user sets max_samples > ( max_instances * max_samples_per_instance ) ,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0.
     qos2.resource_limits().max_samples = 5001;
+    qos2.resource_limits().max_instances = 10;
+    qos2.resource_limits().max_samples_per_instance = 500;
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_writer1->set_qos(qos2));
+
+    // Next QoS config checks that if user sets max_samples = ( max_instances * max_samples_per_instance ) ,
+    // set_qos() should return ReturnCode_t::RETCODE_OK = 0.
+    qos2.resource_limits().max_samples = 5000;
     qos2.resource_limits().max_instances = 10;
     qos2.resource_limits().max_samples_per_instance = 500;
 

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -1671,8 +1671,7 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyNotKeyed)
     ASSERT_NE(data_writer1, nullptr);
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
-    // which also means infinite value.
-    // By not using instances, this does not make any change.
+    // which also means infinite value, and does not make any change.
     qos.resource_limits().max_instances = -1;
 
     DataWriter* data_writer2 = publisher->create_datawriter(topic, qos);
@@ -1680,7 +1679,7 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyNotKeyed)
 
     // Next QoS config checks that if user sets max_samples < ( max_instances * max_samples_per_instance ) ,
     // create_datawriter() should NOT return nullptr.
-    // By not using instances, this does not make any change.
+    // By not using instances, instance allocation consistency is not checked.
     qos.resource_limits().max_samples = 4999;
     qos.resource_limits().max_instances = 10;
     qos.resource_limits().max_samples_per_instance = 500;
@@ -1688,9 +1687,19 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyNotKeyed)
     DataWriter* data_writer3 = publisher->create_datawriter(topic, qos);
     ASSERT_NE(data_writer3, nullptr);
 
+    // Next QoS config checks that if user sets max_samples > ( max_instances * max_samples_per_instance ) ,
+    // create_datawriter() should NOT return nullptr.
+    // By not using instances, instance allocation consistency is not checked.
+    qos.resource_limits().max_samples = 5001;
+    qos.resource_limits().max_instances = 10;
+    qos.resource_limits().max_samples_per_instance = 500;
+
+    DataWriter* data_writer4 = publisher->create_datawriter(topic, qos);
+    ASSERT_NE(data_writer4, nullptr);
+
     // Next QoS config checks that if user sets max_instances to inf and leaves max_samples by default,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0
-    // By not using instances, this does not make any change.
+    // By not using instances, instance allocation consistency is not checked.
     DataWriterQos qos2 = DATAWRITER_QOS_DEFAULT;
     DataWriter* default_data_writer1 = publisher->create_datawriter(topic, qos2);
     ASSERT_NE(default_data_writer1, nullptr);
@@ -1701,15 +1710,24 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyNotKeyed)
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
     // which also means infinite value.
-    // By not using instances, this does not make any change.
+    // By not using instances, instance allocation consistency is not checked.
     qos2.resource_limits().max_instances = -1;
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_writer1->set_qos(qos2));
 
     // Next QoS config checks that if user sets max_samples < ( max_instances * max_samples_per_instance ) ,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0
-    // By not using instances, this does not make any change.
+    // By not using instances, instance allocation consistency is not checked.
     qos2.resource_limits().max_samples = 4999;
+    qos2.resource_limits().max_instances = 10;
+    qos2.resource_limits().max_samples_per_instance = 500;
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_writer1->set_qos(qos2));
+
+    // Next QoS config checks that if user sets max_samples > ( max_instances * max_samples_per_instance ) ,
+    // set_qos() should return ReturnCode_t::RETCODE_OK = 0
+    // By not using instances, instance allocation consistency is not checked.
+    qos2.resource_limits().max_samples = 5001;
     qos2.resource_limits().max_instances = 10;
     qos2.resource_limits().max_samples_per_instance = 500;
 

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -1784,6 +1784,15 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyKeyed)
     DataWriter* data_writer3 = publisher->create_datawriter(topic, qos);
     ASSERT_EQ(data_writer3, nullptr);
 
+    // Next QoS config checks that if user sets max_samples > ( max_instances * max_samples_per_instance ) ,
+    // create_datawriter() should not return nullptr.
+    qos.resource_limits().max_samples = 5001;
+    qos.resource_limits().max_instances = 10;
+    qos.resource_limits().max_samples_per_instance = 500;
+
+    DataWriter* data_writer4 = publisher->create_datawriter(topic, qos);
+    ASSERT_NE(data_writer4, nullptr);
+
     // Next QoS config checks the default qos configuration,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0, as the by default values are already infinite.
     DataWriterQos qos2 = DATAWRITER_QOS_DEFAULT;
@@ -1805,6 +1814,14 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyKeyed)
     qos2.resource_limits().max_samples_per_instance = 500;
 
     ASSERT_NE(ReturnCode_t::RETCODE_OK, default_data_writer1->set_qos(qos2));
+
+    // Next QoS config checks that if user sets max_samples > ( max_instances * max_samples_per_instance ) ,
+    // set_qos() should return ReturnCode_t::RETCODE_OK = 0.
+    qos2.resource_limits().max_samples = 5001;
+    qos2.resource_limits().max_instances = 10;
+    qos2.resource_limits().max_samples_per_instance = 500;
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_writer1->set_qos(qos2));
 }
 
 } // namespace dds

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -1697,6 +1697,17 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyNotKeyed)
     DataWriter* data_writer4 = publisher->create_datawriter(topic, qos);
     ASSERT_NE(data_writer4, nullptr);
 
+    // Next QoS config checks that if user sets max_samples infinite
+    // and ( max_instances * max_samples_per_instance ) finite,
+    // create_datawriter() should NOT return nullptr.
+    // By not using instances, instance allocation consistency is not checked.
+    qos.resource_limits().max_samples = 0;
+    qos.resource_limits().max_instances = 10;
+    qos.resource_limits().max_samples_per_instance = 500;
+
+    DataWriter* data_writer5 = publisher->create_datawriter(topic, qos);
+    ASSERT_NE(data_writer5, nullptr);
+
     // Next QoS config checks the default qos configuration,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0
     DataWriterQos qos2 = DATAWRITER_QOS_DEFAULT;
@@ -1725,6 +1736,16 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyNotKeyed)
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0
     // By not using instances, instance allocation consistency is not checked.
     qos2.resource_limits().max_samples = 5001;
+    qos2.resource_limits().max_instances = 10;
+    qos2.resource_limits().max_samples_per_instance = 500;
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_writer1->set_qos(qos2));
+
+    // Next QoS config checks that if user sets max_samples infinite
+    // and ( max_instances * max_samples_per_instance ) finite,
+    // set_qos() should return ReturnCode_t::RETCODE_OK = 0
+    // By not using instances, instance allocation consistency is not checked.
+    qos2.resource_limits().max_samples = 0;
     qos2.resource_limits().max_instances = 10;
     qos2.resource_limits().max_samples_per_instance = 500;
 
@@ -1792,6 +1813,16 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyKeyed)
     DataWriter* data_writer4 = publisher->create_datawriter(topic, qos);
     ASSERT_NE(data_writer4, nullptr);
 
+    // Next QoS config checks that if user sets max_samples infinite
+    // and ( max_instances * max_samples_per_instance ) finite,
+    // create_datawriter() should not return nullptr.
+    qos.resource_limits().max_samples = 0;
+    qos.resource_limits().max_instances = 10;
+    qos.resource_limits().max_samples_per_instance = 500;
+
+    DataWriter* data_writer5 = publisher->create_datawriter(topic, qos);
+    ASSERT_NE(data_writer5, nullptr);
+
     // Next QoS config checks the default qos configuration,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0, as the by default values are already infinite.
     DataWriterQos qos2 = DATAWRITER_QOS_DEFAULT;
@@ -1817,6 +1848,15 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyKeyed)
     // Next QoS config checks that if user sets max_samples > ( max_instances * max_samples_per_instance ) ,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0.
     qos2.resource_limits().max_samples = 5001;
+    qos2.resource_limits().max_instances = 10;
+    qos2.resource_limits().max_samples_per_instance = 500;
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_writer1->set_qos(qos2));
+
+    // Next QoS config checks that if user sets max_samples infinite
+    // and ( max_instances * max_samples_per_instance ) finite,
+    // set_qos() should return ReturnCode_t::RETCODE_OK = 0.
+    qos2.resource_limits().max_samples = 0;
     qos2.resource_limits().max_instances = 10;
     qos2.resource_limits().max_samples_per_instance = 500;
 

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -1709,7 +1709,7 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyNotKeyed)
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_writer1->set_qos(qos2));
 
     // Next QoS config checks that if user sets max_samples < ( max_instances * max_samples_per_instance ) ,
-    // create_datawriter() should return ReturnCode_t::RETCODE_OK = 0
+    // set_qos() should return ReturnCode_t::RETCODE_OK = 0
     // By not using instances, this does not make any change.
     qos2.resource_limits().max_samples = 4999;
     qos2.resource_limits().max_instances = 10;

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -1785,7 +1785,7 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyKeyed)
     // which also means infinite value.
     qos2.resource_limits().max_instances = -1;
 
-    ASSERT_EQ(ReturnCode_t::RETCODE_OK,default_data_writer1->set_qos(qos2));
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_writer1->set_qos(qos2));
 
     // Next QoS config checks that if user sets max_samples < ( max_instances * max_samples_per_instance ) ,
     // set_qos() should return a value != 0 (not OK)

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -1790,6 +1790,7 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyKeyed)
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
     // which also means infinite value.
+    qos.resource_limits().max_samples = 0;
     qos.resource_limits().max_instances = -1;
 
     DataWriter* data_writer2 = publisher->create_datawriter(topic, qos);
@@ -1842,6 +1843,7 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyKeyed)
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
     // which also means infinite value.
+    qos2.resource_limits().max_samples = 0;
     qos2.resource_limits().max_instances = -1;
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_writer1->set_qos(qos2));

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -1697,14 +1697,12 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyNotKeyed)
     DataWriter* data_writer4 = publisher->create_datawriter(topic, qos);
     ASSERT_NE(data_writer4, nullptr);
 
-    // Next QoS config checks that if user sets max_instances to inf and leaves max_samples by default,
+    // Next QoS config checks the default qos configuration,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0
     // By not using instances, instance allocation consistency is not checked.
     DataWriterQos qos2 = DATAWRITER_QOS_DEFAULT;
     DataWriter* default_data_writer1 = publisher->create_datawriter(topic, qos2);
     ASSERT_NE(default_data_writer1, nullptr);
-
-    qos2.resource_limits().max_instances = 0;
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_writer1->set_qos(qos2));
 
@@ -1786,13 +1784,11 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyKeyed)
     DataWriter* data_writer3 = publisher->create_datawriter(topic, qos);
     ASSERT_EQ(data_writer3, nullptr);
 
-    // Next QoS config checks that if user sets max_instances to inf and leaves max_samples by default,
+    // Next QoS config checks the default qos configuration,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0, as the by default values are already infinite.
     DataWriterQos qos2 = DATAWRITER_QOS_DEFAULT;
     DataWriter* default_data_writer1 = publisher->create_datawriter(topic, qos2);
     ASSERT_NE(default_data_writer1, nullptr);
-
-    qos2.resource_limits().max_instances = 0;
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_writer1->set_qos(qos2));
 

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -1694,28 +1694,28 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyNotKeyed)
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0
     // By not using instances, this does not make any change.
     DataWriterQos qos2 = DATAWRITER_QOS_DEFAULT;
-    DataWriter* default_data_writer1 = publisher->create_datawriter(topic, qos);
+    DataWriter* default_data_writer1 = publisher->create_datawriter(topic, qos2);
     ASSERT_NE(default_data_writer1, nullptr);
 
     qos2.resource_limits().max_instances = 0;
 
-    ASSERT_FALSE(default_data_writer1->set_qos(qos2));
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_writer1->set_qos(qos2));
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
     // which also means infinite value.
     // By not using instances, this does not make any change.
     qos2.resource_limits().max_instances = -1;
 
-    ASSERT_FALSE(default_data_writer1->set_qos(qos2));
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_writer1->set_qos(qos2));
 
     // Next QoS config checks that if user sets max_samples < ( max_instances * max_samples_per_instance ) ,
-    // create_datawriter() should NOT return nullptr.
+    // create_datawriter() should return ReturnCode_t::RETCODE_OK = 0
     // By not using instances, this does not make any change.
     qos2.resource_limits().max_samples = 4999;
     qos2.resource_limits().max_instances = 10;
     qos2.resource_limits().max_samples_per_instance = 500;
 
-    ASSERT_FALSE(default_data_writer1->set_qos(qos2));
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_writer1->set_qos(qos2));
 }
 
 /*

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -1745,10 +1745,9 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyKeyed)
     Topic* topic = participant->create_topic("footopic", type.get_type_name(), TOPIC_QOS_DEFAULT);
     ASSERT_NE(topic, nullptr);
 
-    // Next QoS config checks that if user sets max_instances to inf and leaves max_samples by default,
-    // create_datawriter() should not return nullptr, as the by default values are already infinite.
+    // Next QoS config checks the default qos configuration,
+    // create_datawriter() should not return nullptr.
     DataWriterQos qos = DATAWRITER_QOS_DEFAULT;
-    qos.resource_limits().max_instances = 0;
 
     DataWriter* data_writer1 = publisher->create_datawriter(topic, qos);
     ASSERT_NE(data_writer1, nullptr);

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -1663,11 +1663,9 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyNotKeyed)
     Topic* topic = participant->create_topic("footopic", type.get_type_name(), TOPIC_QOS_DEFAULT);
     ASSERT_NE(topic, nullptr);
 
-    // Next QoS config checks that if user sets max_instances to inf and leaves max_samples by default,
+    // Next QoS config checks the default qos configuration,
     // create_datawriter() should NOT return nullptr.
-    // By not using instances, this does not make any change.
     DataWriterQos qos = DATAWRITER_QOS_DEFAULT;
-    qos.resource_limits().max_instances = 0;
 
     DataWriter* data_writer1 = publisher->create_datawriter(topic, qos);
     ASSERT_NE(data_writer1, nullptr);

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -1638,13 +1638,16 @@ TEST_F(DataWriterUnsupportedTests, UnsupportedDataWriterMethods)
 }
 
 /*
- * This test checks the allocation consistency when using instances.
+ * This test checks the allocation consistency when NOT using instances.
+ * If the topic is keyed,
  * max_samples should be greater or equal than max_instances * max_samples_per_instance.
  * If that condition is not met, the endpoint creation should fail.
+ * If not keyed (not using instances), the only property that is used is max_samples,
+ * thus, should not fail with the previously mentioned configuration.
  * The following method is checked:
  * 1. create_datawriter
  */
-TEST(DataWriterTests, InstancePolicyAllocationConsistency)
+TEST(DataWriterTests, InstancePolicyAllocationConsistencyNotKeyed)
 {
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
@@ -1660,28 +1663,31 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistency)
     ASSERT_NE(topic, nullptr);
 
     // Next QoS config checks that if user sets max_instances to inf and leaves max_samples by default,
-    // create_datawriter() should return nullptr
+    // create_datawriter() should NOT return nullptr.
+    // By not using instances, this does not make any change.
     DataWriterQos qos = DATAWRITER_QOS_DEFAULT;
     qos.resource_limits().max_instances = 0;
 
     DataWriter* data_writer1 = publisher->create_datawriter(topic, qos);
-    ASSERT_EQ(data_writer1, nullptr);
+    ASSERT_NE(data_writer1, nullptr);
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
-    // which also means infinite value
+    // which also means infinite value.
+    // By not using instances, this does not make any change.
     qos.resource_limits().max_instances = -1;
 
     DataWriter* data_writer2 = publisher->create_datawriter(topic, qos);
-    ASSERT_EQ(data_writer2, nullptr);
+    ASSERT_NE(data_writer2, nullptr);
 
     // Next QoS config checks that if user sets max_samples < ( max_instances * max_samples_per_instance ) ,
-    // create_datawriter() should return nullptr
+    // create_datawriter() should NOT return nullptr.
+    // By not using instances, this does not make any change.
     qos.resource_limits().max_samples = 4999;
     qos.resource_limits().max_instances = 10;
     qos.resource_limits().max_samples_per_instance = 500;
 
     DataWriter* data_writer3 = publisher->create_datawriter(topic, qos);
-    ASSERT_EQ(data_writer3, nullptr);
+    ASSERT_NE(data_writer3, nullptr);
 
 }
 

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -1699,7 +1699,6 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyNotKeyed)
 
     // Next QoS config checks the default qos configuration,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0
-    // By not using instances, instance allocation consistency is not checked.
     DataWriterQos qos2 = DATAWRITER_QOS_DEFAULT;
     DataWriter* default_data_writer1 = publisher->create_datawriter(topic, qos2);
     ASSERT_NE(default_data_writer1, nullptr);

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -3063,18 +3063,15 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyNotKeyed)
     Topic* topic = participant->create_topic("footopic", type.get_type_name(), TOPIC_QOS_DEFAULT);
     ASSERT_NE(topic, nullptr);
 
-    // Next QoS config checks that if user sets max_instances to inf and leaves max_samples by default,
+    // Next QoS config checks the default qos configuration,
     // create_datareader() should NOT return nullptr.
-    // By not using instances, this does not make any change.
     DataReaderQos qos = DATAREADER_QOS_DEFAULT;
-    qos.resource_limits().max_instances = 0;
 
     DataReader* data_reader1 = subscriber->create_datareader(topic, qos);
     ASSERT_NE(data_reader1, nullptr);
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
-    // which also means infinite value.
-    // By not using instances, this does not make any change.
+    // which also means infinite value, and does not make any change.
     qos.resource_limits().max_instances = -1;
 
     DataReader* data_reader2 = subscriber->create_datareader(topic, qos);
@@ -3096,15 +3093,11 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyNotKeyed)
     subscriber_qos.entity_factory().autoenable_created_entities = false;
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, subscriber->set_qos(subscriber_qos));
 
-    // Next QoS config checks that if user sets max_instances to inf and leaves max_samples by default,
+    // Next QoS config checks the default qos configuration,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0
-    // By not using instances, this does not make any change.
     DataReaderQos qos2 = DATAREADER_QOS_DEFAULT;
-
     DataReader* default_data_reader2 = subscriber->create_datareader(topic, qos2);
     ASSERT_NE(default_data_reader2, nullptr);
-
-    qos2.resource_limits().max_instances = 0;
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_reader2->set_qos(qos2));
 
@@ -3154,10 +3147,9 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyKeyed)
     Topic* topic = participant->create_topic("footopic", type.get_type_name(), TOPIC_QOS_DEFAULT);
     ASSERT_NE(topic, nullptr);
 
-    // Next QoS config checks that if user sets max_instances to inf and leaves max_samples by default,
-    // create_datareader() should not return nullptr, as the by default values are already infinite.
+    // Next QoS config checks the default qos configuration,
+    // create_datareader() should not return nullptr.
     DataReaderQos qos = DATAREADER_QOS_DEFAULT;
-    qos.resource_limits().max_instances = 0;
 
     DataReader* data_reader1 = subscriber->create_datareader(topic, qos);
     ASSERT_NE(data_reader1, nullptr);
@@ -3184,14 +3176,11 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyKeyed)
     subscriber_qos.entity_factory().autoenable_created_entities = false;
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, subscriber->set_qos(subscriber_qos));
 
-    // Next QoS config checks that if user sets max_instances to inf and leaves max_samples by default,
+    // Next QoS config checks the default qos configuration,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0, as the by default values are already infinite.
     DataReaderQos qos2 = DATAREADER_QOS_DEFAULT;
-
     DataReader* default_data_reader2 = subscriber->create_datareader(topic, qos2);
     ASSERT_NE(default_data_reader2, nullptr);
-
-    qos2.resource_limits().max_instances = 0;
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_reader2->set_qos(qos2));
 

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -3087,6 +3087,16 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyNotKeyed)
     DataReader* data_reader3 = subscriber->create_datareader(topic, qos);
     ASSERT_NE(data_reader3, nullptr);
 
+    // Next QoS config checks that if user sets max_samples > ( max_instances * max_samples_per_instance ) ,
+    // create_datareader() should NOT return nullptr.
+    // By not using instances, instance allocation consistency is not checked.
+    qos.resource_limits().max_samples = 5001;
+    qos.resource_limits().max_instances = 10;
+    qos.resource_limits().max_samples_per_instance = 500;
+
+    DataReader* data_reader4 = subscriber->create_datareader(topic, qos);
+    ASSERT_NE(data_reader4, nullptr);
+
     // It is needed to disable the creation of enabled entities from the subscriber for following checks.
     // This allows to change inmutable policies
     SubscriberQos subscriber_qos = SUBSCRIBER_QOS_DEFAULT;
@@ -3112,6 +3122,15 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyNotKeyed)
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0
     // By not using instances, instance allocation consistency is not checked.
     qos2.resource_limits().max_samples = 4999;
+    qos2.resource_limits().max_instances = 10;
+    qos2.resource_limits().max_samples_per_instance = 500;
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_reader2->set_qos(qos2));
+
+    // Next QoS config checks that if user sets max_samples > ( max_instances * max_samples_per_instance ) ,
+    // set_qos() should return ReturnCode_t::RETCODE_OK = 0
+    // By not using instances, instance allocation consistency is not checked.
+    qos2.resource_limits().max_samples = 5001;
     qos2.resource_limits().max_instances = 10;
     qos2.resource_limits().max_samples_per_instance = 500;
 
@@ -3170,6 +3189,15 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyKeyed)
     DataReader* data_reader3 = subscriber->create_datareader(topic, qos);
     ASSERT_EQ(data_reader3, nullptr);
 
+    // Next QoS config checks that if user sets max_samples > ( max_instances * max_samples_per_instance ) ,
+    // create_datareader() should not return nullptr.
+    qos.resource_limits().max_samples = 5001;
+    qos.resource_limits().max_instances = 10;
+    qos.resource_limits().max_samples_per_instance = 500;
+
+    DataReader* data_reader4 = subscriber->create_datareader(topic, qos);
+    ASSERT_NE(data_reader4, nullptr);
+
     // It is needed to disable the creation of enabled entities from the subscriber for following checks.
     // This allows to change inmutable policies
     SubscriberQos subscriber_qos = SUBSCRIBER_QOS_DEFAULT;
@@ -3197,6 +3225,14 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyKeyed)
     qos2.resource_limits().max_samples_per_instance = 500;
 
     ASSERT_NE(ReturnCode_t::RETCODE_OK, default_data_reader2->set_qos(qos2));
+
+    // Next QoS config checks that if user sets max_samples > ( max_instances * max_samples_per_instance ) ,
+    // set_qos() should return ReturnCode_t::RETCODE_OK = 0.
+    qos2.resource_limits().max_samples = 5001;
+    qos2.resource_limits().max_instances = 10;
+    qos2.resource_limits().max_samples_per_instance = 500;
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_reader2->set_qos(qos2));
 }
 
 int main(

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -3097,6 +3097,17 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyNotKeyed)
     DataReader* data_reader4 = subscriber->create_datareader(topic, qos);
     ASSERT_NE(data_reader4, nullptr);
 
+    // Next QoS config checks that if user sets max_samples infinite
+    // and ( max_instances * max_samples_per_instance ) finite,
+    // create_datareader() should NOT return nullptr.
+    // By not using instances, instance allocation consistency is not checked.
+    qos.resource_limits().max_samples = 0;
+    qos.resource_limits().max_instances = 10;
+    qos.resource_limits().max_samples_per_instance = 500;
+
+    DataReader* data_reader5 = subscriber->create_datareader(topic, qos);
+    ASSERT_NE(data_reader5, nullptr);
+
     // It is needed to disable the creation of enabled entities from the subscriber for following checks.
     // This allows to change inmutable policies
     SubscriberQos subscriber_qos = SUBSCRIBER_QOS_DEFAULT;
@@ -3131,6 +3142,16 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyNotKeyed)
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0
     // By not using instances, instance allocation consistency is not checked.
     qos2.resource_limits().max_samples = 5001;
+    qos2.resource_limits().max_instances = 10;
+    qos2.resource_limits().max_samples_per_instance = 500;
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_reader2->set_qos(qos2));
+
+    // Next QoS config checks that if user sets max_samples infinite
+    // and ( max_instances * max_samples_per_instance ) finite,
+    // set_qos() should return ReturnCode_t::RETCODE_OK = 0
+    // By not using instances, instance allocation consistency is not checked.
+    qos2.resource_limits().max_samples = 0;
     qos2.resource_limits().max_instances = 10;
     qos2.resource_limits().max_samples_per_instance = 500;
 
@@ -3198,6 +3219,16 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyKeyed)
     DataReader* data_reader4 = subscriber->create_datareader(topic, qos);
     ASSERT_NE(data_reader4, nullptr);
 
+    // Next QoS config checks that if user sets max_samples infinite
+    // and ( max_instances * max_samples_per_instance ) finite,
+    // create_datareader() should not return nullptr.
+    qos.resource_limits().max_samples = 0;
+    qos.resource_limits().max_instances = 10;
+    qos.resource_limits().max_samples_per_instance = 500;
+
+    DataReader* data_reader5 = subscriber->create_datareader(topic, qos);
+    ASSERT_NE(data_reader5, nullptr);
+
     // It is needed to disable the creation of enabled entities from the subscriber for following checks.
     // This allows to change inmutable policies
     SubscriberQos subscriber_qos = SUBSCRIBER_QOS_DEFAULT;
@@ -3229,6 +3260,15 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyKeyed)
     // Next QoS config checks that if user sets max_samples > ( max_instances * max_samples_per_instance ) ,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0.
     qos2.resource_limits().max_samples = 5001;
+    qos2.resource_limits().max_instances = 10;
+    qos2.resource_limits().max_samples_per_instance = 500;
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_reader2->set_qos(qos2));
+
+    // Next QoS config checks that if user sets max_samples infinite
+    // and ( max_instances * max_samples_per_instance ) finite,
+    // set_qos() should return ReturnCode_t::RETCODE_OK = 0.
+    qos2.resource_limits().max_samples = 0;
     qos2.resource_limits().max_instances = 10;
     qos2.resource_limits().max_samples_per_instance = 500;
 

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -3056,6 +3056,9 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyNotKeyed)
     TypeSupport type(new FooTypeSupport());
     type.register_type(participant);
 
+    // This test pretends to use topic with no instances, so the following flag is set false.
+    type.get()->m_isGetKeyDefined = false;
+
     Topic* topic = participant->create_topic("footopic", type.get_type_name(), TOPIC_QOS_DEFAULT);
     ASSERT_NE(topic, nullptr);
 

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -3079,7 +3079,7 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyNotKeyed)
 
     // Next QoS config checks that if user sets max_samples < ( max_instances * max_samples_per_instance ) ,
     // create_datareader() should NOT return nullptr.
-    // By not using instances, this does not make any change.
+    // By not using instances, instance allocation consistency is not checked.
     qos.resource_limits().max_samples = 4999;
     qos.resource_limits().max_instances = 10;
     qos.resource_limits().max_samples_per_instance = 500;
@@ -3103,14 +3103,14 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyNotKeyed)
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
     // which also means infinite value.
-    // By not using instances, this does not make any change.
+    // By not using instances, instance allocation consistency is not checked.
     qos2.resource_limits().max_instances = -1;
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_reader2->set_qos(qos2));
 
     // Next QoS config checks that if user sets max_samples < ( max_instances * max_samples_per_instance ) ,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0
-    // By not using instances, this does not make any change.
+    // By not using instances, instance allocation consistency is not checked.
     qos2.resource_limits().max_samples = 4999;
     qos2.resource_limits().max_instances = 10;
     qos2.resource_limits().max_samples_per_instance = 500;

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -3042,7 +3042,8 @@ TEST_F(DataReaderTests, read_conditions_wait_on_InstanceStateMask)
  * If not keyed (not using instances), the only property that is used is max_samples,
  * thus, should not fail with the previously mentioned configuration.
  * The following method is checked:
- * 1. create_datareader
+ * 1. Subscriber::create_datareader
+ * 2. DataReader::set_qos
  */
 TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyNotKeyed)
 {
@@ -3088,6 +3089,41 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyNotKeyed)
 
     DataReader* data_reader3 = subscriber->create_datareader(topic, qos);
     ASSERT_NE(data_reader3, nullptr);
+
+    // It is needed to disable the creation of enabled entities from the subscriber for following checks.
+    // This allows to change inmutable policies
+    SubscriberQos subscriber_qos = SUBSCRIBER_QOS_DEFAULT;
+    subscriber_qos.entity_factory().autoenable_created_entities = false;
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, subscriber->set_qos(subscriber_qos));
+
+    // Next QoS config checks that if user sets max_instances to inf and leaves max_samples by default,
+    // set_qos() should return ReturnCode_t::RETCODE_OK = 0
+    // By not using instances, this does not make any change.
+    
+    DataReaderQos qos2 = DATAREADER_QOS_DEFAULT;
+    
+    DataReader* default_data_reader2 = subscriber->create_datareader(topic, qos2);
+    ASSERT_NE(default_data_reader2, nullptr);
+
+    qos2.resource_limits().max_instances = 0;
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_reader2->set_qos(qos2));
+
+    // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
+    // which also means infinite value.
+    // By not using instances, this does not make any change.
+    qos2.resource_limits().max_instances = -1;
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_reader2->set_qos(qos2));
+
+    // Next QoS config checks that if user sets max_samples < ( max_instances * max_samples_per_instance ) ,
+    // set_qos() should return ReturnCode_t::RETCODE_OK = 0
+    // By not using instances, this does not make any change.
+    qos2.resource_limits().max_samples = 4999;
+    qos2.resource_limits().max_instances = 10;
+    qos2.resource_limits().max_samples_per_instance = 500;
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_reader2->set_qos(qos2));
 }
 
 /*

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -3035,13 +3035,16 @@ TEST_F(DataReaderTests, read_conditions_wait_on_InstanceStateMask)
 }
 
 /*
- * This test checks the allocation consistency when using instances.
+ * This test checks the allocation consistency when NOT using instances.
+ * If the topic is keyed,
  * max_samples should be greater or equal than max_instances * max_samples_per_instance.
  * If that condition is not met, the endpoint creation should fail.
+ * If not keyed (not using instances), the only property that is used is max_samples,
+ * thus, should not fail with the previously mentioned configuration.
  * The following method is checked:
  * 1. create_datareader
  */
-TEST_F(DataReaderTests, InstancePolicyAllocationConsistency)
+TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyNotKeyed)
 {
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
@@ -3057,28 +3060,31 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistency)
     ASSERT_NE(topic, nullptr);
 
     // Next QoS config checks that if user sets max_instances to inf and leaves max_samples by default,
-    // create_datareader() should return nullptr
+    // create_datareader() should NOT return nullptr.
+    // By not using instances, this does not make any change.
     DataReaderQos qos = DATAREADER_QOS_DEFAULT;
     qos.resource_limits().max_instances = 0;
 
     DataReader* data_reader1 = subscriber->create_datareader(topic, qos);
-    ASSERT_EQ(data_reader1, nullptr);
+    ASSERT_NE(data_reader1, nullptr);
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
-    // which also means infinite value
+    // which also means infinite value.
+    // By not using instances, this does not make any change.
     qos.resource_limits().max_instances = -1;
 
     DataReader* data_reader2 = subscriber->create_datareader(topic, qos);
-    ASSERT_EQ(data_reader2, nullptr);
+    ASSERT_NE(data_reader2, nullptr);
 
     // Next QoS config checks that if user sets max_samples < ( max_instances * max_samples_per_instance ) ,
-    // create_datareader() should return nullptr
+    // create_datareader() should NOT return nullptr.
+    // By not using instances, this does not make any change.
     qos.resource_limits().max_samples = 4999;
     qos.resource_limits().max_instances = 10;
     qos.resource_limits().max_samples_per_instance = 500;
 
     DataReader* data_reader3 = subscriber->create_datareader(topic, qos);
-    ASSERT_EQ(data_reader3, nullptr);
+    ASSERT_NE(data_reader3, nullptr);
 
 }
 

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -3219,6 +3219,15 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyKeyed)
     DataReader* data_reader4 = subscriber->create_datareader(topic, qos);
     ASSERT_NE(data_reader4, nullptr);
 
+    // Next QoS config checks that if user sets max_samples = ( max_instances * max_samples_per_instance ) ,
+    // create_datareader() should not return nullptr.
+    qos.resource_limits().max_samples = 5000;
+    qos.resource_limits().max_instances = 10;
+    qos.resource_limits().max_samples_per_instance = 500;
+
+    DataReader* data_reader5 = subscriber->create_datareader(topic, qos);
+    ASSERT_NE(data_reader5, nullptr);
+
     // Next QoS config checks that if user sets max_samples infinite
     // and ( max_instances * max_samples_per_instance ) finite,
     // create_datareader() should not return nullptr.
@@ -3226,8 +3235,8 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyKeyed)
     qos.resource_limits().max_instances = 10;
     qos.resource_limits().max_samples_per_instance = 500;
 
-    DataReader* data_reader5 = subscriber->create_datareader(topic, qos);
-    ASSERT_NE(data_reader5, nullptr);
+    DataReader* data_reader6 = subscriber->create_datareader(topic, qos);
+    ASSERT_NE(data_reader6, nullptr);
 
     // It is needed to disable the creation of enabled entities from the subscriber for following checks.
     // This allows to change inmutable policies
@@ -3260,6 +3269,14 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyKeyed)
     // Next QoS config checks that if user sets max_samples > ( max_instances * max_samples_per_instance ) ,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0.
     qos2.resource_limits().max_samples = 5001;
+    qos2.resource_limits().max_instances = 10;
+    qos2.resource_limits().max_samples_per_instance = 500;
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_reader2->set_qos(qos2));
+
+    // Next QoS config checks that if user sets max_samples = ( max_instances * max_samples_per_instance ) ,
+    // set_qos() should return ReturnCode_t::RETCODE_OK = 0.
+    qos2.resource_limits().max_samples = 5000;
     qos2.resource_limits().max_instances = 10;
     qos2.resource_limits().max_samples_per_instance = 500;
 

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -3198,6 +3198,7 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyKeyed)
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
     // which also means infinite value.
+    qos.resource_limits().max_samples = 0;
     qos.resource_limits().max_instances = -1;
 
     DataReader* data_reader2 = subscriber->create_datareader(topic, qos);
@@ -3256,6 +3257,7 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyKeyed)
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
     // which also means infinite value.
+    qos2.resource_limits().max_samples = 0;
     qos2.resource_limits().max_instances = -1;
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_reader2->set_qos(qos2));

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -686,7 +686,9 @@ TEST_F(DataReaderTests, InvalidQos)
     const ReturnCode_t inmutable_code = ReturnCode_t::RETCODE_IMMUTABLE_POLICY;
 
     qos = DATAREADER_QOS_DEFAULT;
-    qos.resource_limits().max_samples++;
+    qos.resource_limits().max_samples = 5000;
+    qos.resource_limits().max_instances = 2;
+    qos.resource_limits().max_samples_per_instance = 100;
     EXPECT_EQ(inmutable_code, data_reader_->set_qos(qos));
 
     qos = DATAREADER_QOS_DEFAULT;

--- a/test/unittest/dds/topic/TopicTests.cpp
+++ b/test/unittest/dds/topic/TopicTests.cpp
@@ -308,7 +308,8 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyNotKeyed)
  * If not keyed (not using instances), the only property that is used is max_samples,
  * thus, should not fail with the previously mentioned configuration.
  * The following method is checked:
- * 1. create_topic
+ * 1. DomainParticipant::create_topic
+ * 2. Topic::set_qos
  */
 TEST(TopicTests, InstancePolicyAllocationConsistencyKeyed)
 {
@@ -349,6 +350,30 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyKeyed)
 
     Topic* topic3 = participant->create_topic("footopic3", type.get_type_name(), qos);
     ASSERT_EQ(topic3, nullptr);
+
+    // Next QoS config checks that if user sets max_instances to inf and leaves max_samples by default,
+    // set_qos() should return ReturnCode_t::RETCODE_OK = 0, as the by default values are already infinite.
+    TopicQos qos2 = TOPIC_QOS_DEFAULT;
+    Topic* default_topic1 = participant->create_topic("footopic4", type.get_type_name(), qos2);
+    ASSERT_NE(default_topic1, nullptr);
+
+    qos2.resource_limits().max_instances = 0;
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_topic1->set_qos(qos2));
+
+    // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
+    // which also means infinite value.
+    qos2.resource_limits().max_instances = -1;
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_topic1->set_qos(qos2));
+
+    // Next QoS config checks that if user sets max_samples < ( max_instances * max_samples_per_instance ) ,
+    // set_qos() should return a value != 0 (not OK)
+    qos2.resource_limits().max_samples = 4999;
+    qos2.resource_limits().max_instances = 10;
+    qos2.resource_limits().max_samples_per_instance = 500;
+
+    ASSERT_NE(ReturnCode_t::RETCODE_OK, default_topic1->set_qos(qos2));
 }
 
 } // namespace dds

--- a/test/unittest/dds/topic/TopicTests.cpp
+++ b/test/unittest/dds/topic/TopicTests.cpp
@@ -363,7 +363,7 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyKeyed)
     Topic* topic3 = participant->create_topic("footopic3", type.get_type_name(), qos);
     ASSERT_EQ(topic3, nullptr);
 
-    // Next QoS config checks that if user sets max_samples < ( max_instances * max_samples_per_instance ) ,
+    // Next QoS config checks that if user sets max_samples > ( max_instances * max_samples_per_instance ) ,
     // create_datareader() should not return nullptr.
     qos.resource_limits().max_samples = 5001;
     qos.resource_limits().max_instances = 10;

--- a/test/unittest/dds/topic/TopicTests.cpp
+++ b/test/unittest/dds/topic/TopicTests.cpp
@@ -279,10 +279,21 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyNotKeyed)
     Topic* topic4 = participant->create_topic("footopic4", type.get_type_name(), qos);
     ASSERT_NE(topic4, nullptr);
 
+    // Next QoS config checks that if user sets max_samples infinite
+    // and ( max_instances * max_samples_per_instance ) finite,
+    // create_topic() should NOT return nullptr.
+    // By not using instances, instance allocation consistency is not checked.
+    qos.resource_limits().max_samples = 0;
+    qos.resource_limits().max_instances = 10;
+    qos.resource_limits().max_samples_per_instance = 500;
+
+    Topic* topic5 = participant->create_topic("footopic5", type.get_type_name(), qos);
+    ASSERT_NE(topic5, nullptr);
+
     // Next QoS config checks the default qos configuration,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0
     TopicQos qos2 = TOPIC_QOS_DEFAULT;
-    Topic* default_topic1 = participant->create_topic("footopic5", type.get_type_name(), qos2);
+    Topic* default_topic1 = participant->create_topic("footopic6", type.get_type_name(), qos2);
     ASSERT_NE(default_topic1, nullptr);
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_topic1->set_qos(qos2));
@@ -307,6 +318,16 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyNotKeyed)
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0
     // By not using instances, instance allocation consistency is not checked.
     qos2.resource_limits().max_samples = 5001;
+    qos2.resource_limits().max_instances = 10;
+    qos2.resource_limits().max_samples_per_instance = 500;
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_topic1->set_qos(qos2));
+
+    // Next QoS config checks that if user sets max_samples infinite
+    // and ( max_instances * max_samples_per_instance ) finite,
+    // set_qos() should return ReturnCode_t::RETCODE_OK = 0
+    // By not using instances, instance allocation consistency is not checked.
+    qos2.resource_limits().max_samples = 0;
     qos2.resource_limits().max_instances = 10;
     qos2.resource_limits().max_samples_per_instance = 500;
 
@@ -372,10 +393,20 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyKeyed)
     Topic* topic4 = participant->create_topic("footopic4", type.get_type_name(), qos);
     ASSERT_NE(topic4, nullptr);
 
+    // Next QoS config checks that if user sets max_samples infinite
+    // and ( max_instances * max_samples_per_instance ) finite,
+    // create_datareader() should not return nullptr.
+    qos.resource_limits().max_samples = 0;
+    qos.resource_limits().max_instances = 10;
+    qos.resource_limits().max_samples_per_instance = 500;
+
+    Topic* topic5 = participant->create_topic("footopic5", type.get_type_name(), qos);
+    ASSERT_NE(topic5, nullptr);
+
     // Next QoS config checks the default qos configuration,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0.
     TopicQos qos2 = TOPIC_QOS_DEFAULT;
-    Topic* default_topic1 = participant->create_topic("footopic5", type.get_type_name(), qos2);
+    Topic* default_topic1 = participant->create_topic("footopic6", type.get_type_name(), qos2);
     ASSERT_NE(default_topic1, nullptr);
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_topic1->set_qos(qos2));
@@ -397,6 +428,15 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyKeyed)
     // Next QoS config checks that if user sets max_samples > ( max_instances * max_samples_per_instance ) ,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0.
     qos2.resource_limits().max_samples = 5001;
+    qos2.resource_limits().max_instances = 10;
+    qos2.resource_limits().max_samples_per_instance = 500;
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_topic1->set_qos(qos2));
+
+    // Next QoS config checks that if user sets max_samples infinite
+    // and ( max_instances * max_samples_per_instance ) finite,
+    // set_qos() should return ReturnCode_t::RETCODE_OK = 0.
+    qos2.resource_limits().max_samples = 0;
     qos2.resource_limits().max_instances = 10;
     qos2.resource_limits().max_samples_per_instance = 500;
 

--- a/test/unittest/dds/topic/TopicTests.cpp
+++ b/test/unittest/dds/topic/TopicTests.cpp
@@ -269,10 +269,20 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyNotKeyed)
     Topic* topic3 = participant->create_topic("footopic3", type.get_type_name(), qos);
     ASSERT_NE(topic3, nullptr);
 
+    // Next QoS config checks that if user sets max_samples > ( max_instances * max_samples_per_instance ) ,
+    // create_topic() should NOT return nullptr.
+    // By not using instances, instance allocation consistency is not checked.
+    qos.resource_limits().max_samples = 5001;
+    qos.resource_limits().max_instances = 10;
+    qos.resource_limits().max_samples_per_instance = 500;
+
+    Topic* topic4 = participant->create_topic("footopic4", type.get_type_name(), qos);
+    ASSERT_NE(topic4, nullptr);
+
     // Next QoS config checks the default qos configuration,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0
     TopicQos qos2 = TOPIC_QOS_DEFAULT;
-    Topic* default_topic1 = participant->create_topic("footopic4", type.get_type_name(), qos2);
+    Topic* default_topic1 = participant->create_topic("footopic5", type.get_type_name(), qos2);
     ASSERT_NE(default_topic1, nullptr);
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_topic1->set_qos(qos2));
@@ -288,6 +298,15 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyNotKeyed)
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0
     // By not using instances, instance allocation consistency is not checked.
     qos2.resource_limits().max_samples = 4999;
+    qos2.resource_limits().max_instances = 10;
+    qos2.resource_limits().max_samples_per_instance = 500;
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_topic1->set_qos(qos2));
+
+    // Next QoS config checks that if user sets max_samples > ( max_instances * max_samples_per_instance ) ,
+    // set_qos() should return ReturnCode_t::RETCODE_OK = 0
+    // By not using instances, instance allocation consistency is not checked.
+    qos2.resource_limits().max_samples = 5001;
     qos2.resource_limits().max_instances = 10;
     qos2.resource_limits().max_samples_per_instance = 500;
 
@@ -344,10 +363,19 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyKeyed)
     Topic* topic3 = participant->create_topic("footopic3", type.get_type_name(), qos);
     ASSERT_EQ(topic3, nullptr);
 
+    // Next QoS config checks that if user sets max_samples < ( max_instances * max_samples_per_instance ) ,
+    // create_datareader() should not return nullptr.
+    qos.resource_limits().max_samples = 5001;
+    qos.resource_limits().max_instances = 10;
+    qos.resource_limits().max_samples_per_instance = 500;
+
+    Topic* topic4 = participant->create_topic("footopic4", type.get_type_name(), qos);
+    ASSERT_NE(topic4, nullptr);
+
     // Next QoS config checks the default qos configuration,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0.
     TopicQos qos2 = TOPIC_QOS_DEFAULT;
-    Topic* default_topic1 = participant->create_topic("footopic4", type.get_type_name(), qos2);
+    Topic* default_topic1 = participant->create_topic("footopic5", type.get_type_name(), qos2);
     ASSERT_NE(default_topic1, nullptr);
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_topic1->set_qos(qos2));
@@ -365,6 +393,14 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyKeyed)
     qos2.resource_limits().max_samples_per_instance = 500;
 
     ASSERT_NE(ReturnCode_t::RETCODE_OK, default_topic1->set_qos(qos2));
+
+    // Next QoS config checks that if user sets max_samples > ( max_instances * max_samples_per_instance ) ,
+    // set_qos() should return ReturnCode_t::RETCODE_OK = 0.
+    qos2.resource_limits().max_samples = 5001;
+    qos2.resource_limits().max_instances = 10;
+    qos2.resource_limits().max_samples_per_instance = 500;
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_topic1->set_qos(qos2));
 }
 
 } // namespace dds

--- a/test/unittest/dds/topic/TopicTests.cpp
+++ b/test/unittest/dds/topic/TopicTests.cpp
@@ -370,6 +370,7 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyKeyed)
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
     // which also means infinite value.
+    qos.resource_limits().max_samples = 0;
     qos.resource_limits().max_instances = -1;
 
     Topic* topic2 = participant->create_topic("footopic2", type.get_type_name(), qos);
@@ -422,6 +423,7 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyKeyed)
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
     // which also means infinite value.
+    qos2.resource_limits().max_samples = 0;
     qos2.resource_limits().max_instances = -1;
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_topic1->set_qos(qos2));

--- a/test/unittest/dds/topic/TopicTests.cpp
+++ b/test/unittest/dds/topic/TopicTests.cpp
@@ -223,13 +223,16 @@ TEST(TopicTests, SetListener)
 }
 
 /*
- * This test checks the allocation consistency when using instances.
+ * This test checks the allocation consistency when NOT using instances.
+ * If the topic is keyed,
  * max_samples should be greater or equal than max_instances * max_samples_per_instance.
  * If that condition is not met, the endpoint creation should fail.
+ * If not keyed (not using instances), the only property that is used is max_samples,
+ * thus, should not fail with the previously mentioned configuration.
  * The following method is checked:
  * 1. create_topic
  */
-TEST(TopicTests, InstancePolicyAllocationConsistency)
+TEST(TopicTests, InstancePolicyAllocationConsistencyNotKeyed)
 {
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
@@ -242,28 +245,31 @@ TEST(TopicTests, InstancePolicyAllocationConsistency)
     type.register_type(participant);
 
     // Next QoS config checks that if user sets max_instances to inf and leaves max_samples by default,
-    // create_topic() should return nullptr
+    // create_topic() should NOT return nullptr.
+    // By not using instances, this does not make any change.
     TopicQos qos = TOPIC_QOS_DEFAULT;
     qos.resource_limits().max_instances = 0;
 
     Topic* topic1 = participant->create_topic("footopic1", type.get_type_name(), qos);
-    ASSERT_EQ(topic1, nullptr);
+    ASSERT_NE(topic1, nullptr);
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
-    // which also means infinite value
+    // which also means infinite value.
+    // By not using instances, this does not make any change.
     qos.resource_limits().max_instances = -1;
 
     Topic* topic2 = participant->create_topic("footopic1", type.get_type_name(), qos);
-    ASSERT_EQ(topic2, nullptr);
+    ASSERT_NE(topic2, nullptr);
 
     // Next QoS config checks that if user sets max_samples < ( max_instances * max_samples_per_instance ) ,
-    // create_topic() should return nullptr
+    // create_topic() should NOT return nullptr.
+    // By not using instances, this does not make any change.
     qos.resource_limits().max_samples = 4999;
     qos.resource_limits().max_instances = 10;
     qos.resource_limits().max_samples_per_instance = 500;
 
     Topic* topic3 = participant->create_topic("footopic2", type.get_type_name(), qos);
-    ASSERT_EQ(topic3, nullptr);
+    ASSERT_NE(topic3, nullptr);
 }
 
 } // namespace dds

--- a/test/unittest/dds/topic/TopicTests.cpp
+++ b/test/unittest/dds/topic/TopicTests.cpp
@@ -393,6 +393,15 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyKeyed)
     Topic* topic4 = participant->create_topic("footopic4", type.get_type_name(), qos);
     ASSERT_NE(topic4, nullptr);
 
+    // Next QoS config checks that if user sets max_samples = ( max_instances * max_samples_per_instance ) ,
+    // create_datareader() should not return nullptr.
+    qos.resource_limits().max_samples = 5000;
+    qos.resource_limits().max_instances = 10;
+    qos.resource_limits().max_samples_per_instance = 500;
+
+    Topic* topic5 = participant->create_topic("footopic5", type.get_type_name(), qos);
+    ASSERT_NE(topic5, nullptr);
+
     // Next QoS config checks that if user sets max_samples infinite
     // and ( max_instances * max_samples_per_instance ) finite,
     // create_datareader() should not return nullptr.
@@ -400,13 +409,13 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyKeyed)
     qos.resource_limits().max_instances = 10;
     qos.resource_limits().max_samples_per_instance = 500;
 
-    Topic* topic5 = participant->create_topic("footopic5", type.get_type_name(), qos);
-    ASSERT_NE(topic5, nullptr);
+    Topic* topic6 = participant->create_topic("footopic6", type.get_type_name(), qos);
+    ASSERT_NE(topic6, nullptr);
 
     // Next QoS config checks the default qos configuration,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0.
     TopicQos qos2 = TOPIC_QOS_DEFAULT;
-    Topic* default_topic1 = participant->create_topic("footopic6", type.get_type_name(), qos2);
+    Topic* default_topic1 = participant->create_topic("footopic7", type.get_type_name(), qos2);
     ASSERT_NE(default_topic1, nullptr);
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_topic1->set_qos(qos2));
@@ -428,6 +437,14 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyKeyed)
     // Next QoS config checks that if user sets max_samples > ( max_instances * max_samples_per_instance ) ,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0.
     qos2.resource_limits().max_samples = 5001;
+    qos2.resource_limits().max_instances = 10;
+    qos2.resource_limits().max_samples_per_instance = 500;
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_topic1->set_qos(qos2));
+
+    // Next QoS config checks that if user sets max_samples = ( max_instances * max_samples_per_instance ) ,
+    // set_qos() should return ReturnCode_t::RETCODE_OK = 0.
+    qos2.resource_limits().max_samples = 5000;
     qos2.resource_limits().max_instances = 10;
     qos2.resource_limits().max_samples_per_instance = 500;
 

--- a/test/unittest/dds/topic/TopicTests.cpp
+++ b/test/unittest/dds/topic/TopicTests.cpp
@@ -258,7 +258,7 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyNotKeyed)
     // By not using instances, this does not make any change.
     qos.resource_limits().max_instances = -1;
 
-    Topic* topic2 = participant->create_topic("footopic1", type.get_type_name(), qos);
+    Topic* topic2 = participant->create_topic("footopic2", type.get_type_name(), qos);
     ASSERT_NE(topic2, nullptr);
 
     // Next QoS config checks that if user sets max_samples < ( max_instances * max_samples_per_instance ) ,
@@ -268,8 +268,59 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyNotKeyed)
     qos.resource_limits().max_instances = 10;
     qos.resource_limits().max_samples_per_instance = 500;
 
-    Topic* topic3 = participant->create_topic("footopic2", type.get_type_name(), qos);
+    Topic* topic3 = participant->create_topic("footopic3", type.get_type_name(), qos);
     ASSERT_NE(topic3, nullptr);
+}
+
+/*
+ * This test checks the allocation consistency when USING instances.
+ * If the topic is keyed,
+ * max_samples should be greater or equal than max_instances * max_samples_per_instance.
+ * If that condition is not met, the endpoint creation should fail.
+ * If not keyed (not using instances), the only property that is used is max_samples,
+ * thus, should not fail with the previously mentioned configuration.
+ * The following method is checked:
+ * 1. create_topic
+ */
+TEST(TopicTests, InstancePolicyAllocationConsistencyKeyed)
+{
+
+    DomainParticipant* participant =
+            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
+
+    Publisher* publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT);
+    ASSERT_NE(publisher, nullptr);
+
+    TypeSupport type(new TopicDataTypeMock());
+    type.register_type(participant);
+
+    // This test pretends to use topic with instances, so the following flag is set.
+    type.get()->m_isGetKeyDefined = true;
+
+    // Next QoS config checks that if user sets max_instances to inf and leaves max_samples by default,
+    // create_topic() should not return nullptr, as the by default values are already infinite.
+    TopicQos qos = TOPIC_QOS_DEFAULT;
+    qos.resource_limits().max_instances = 0;
+
+    Topic* topic1 = participant->create_topic("footopic1", type.get_type_name(), qos);
+    ASSERT_NE(topic1, nullptr);
+
+    // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
+    // which also means infinite value.
+    qos.resource_limits().max_instances = -1;
+
+    Topic* topic2 = participant->create_topic("footopic2", type.get_type_name(), qos);
+    ASSERT_NE(topic2, nullptr);
+
+    // Next QoS config checks that if user sets max_samples < ( max_instances * max_samples_per_instance ) ,
+    // create_datareader() should return nullptr.
+    qos.resource_limits().max_samples = 4999;
+    qos.resource_limits().max_instances = 10;
+    qos.resource_limits().max_samples_per_instance = 500;
+
+    Topic* topic3 = participant->create_topic("footopic3", type.get_type_name(), qos);
+    ASSERT_EQ(topic3, nullptr);
 }
 
 } // namespace dds

--- a/test/unittest/dds/topic/TopicTests.cpp
+++ b/test/unittest/dds/topic/TopicTests.cpp
@@ -245,18 +245,15 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyNotKeyed)
     TypeSupport type(new TopicDataTypeMock());
     type.register_type(participant);
 
-    // Next QoS config checks that if user sets max_instances to inf and leaves max_samples by default,
+    // Next QoS config checks the default qos configuration,
     // create_topic() should NOT return nullptr.
-    // By not using instances, this does not make any change.
     TopicQos qos = TOPIC_QOS_DEFAULT;
-    qos.resource_limits().max_instances = 0;
 
     Topic* topic1 = participant->create_topic("footopic1", type.get_type_name(), qos);
     ASSERT_NE(topic1, nullptr);
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
-    // which also means infinite value.
-    // By not using instances, this does not make any change.
+    // which also means infinite value, and does not make any change.
     qos.resource_limits().max_instances = -1;
 
     Topic* topic2 = participant->create_topic("footopic2", type.get_type_name(), qos);
@@ -264,7 +261,7 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyNotKeyed)
 
     // Next QoS config checks that if user sets max_samples < ( max_instances * max_samples_per_instance ) ,
     // create_topic() should NOT return nullptr.
-    // By not using instances, this does not make any change.
+    // By not using instances, instance allocation consistency is not checked.
     qos.resource_limits().max_samples = 4999;
     qos.resource_limits().max_instances = 10;
     qos.resource_limits().max_samples_per_instance = 500;
@@ -272,27 +269,24 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyNotKeyed)
     Topic* topic3 = participant->create_topic("footopic3", type.get_type_name(), qos);
     ASSERT_NE(topic3, nullptr);
 
-    // Next QoS config checks that if user sets max_instances to inf and leaves max_samples by default,
+    // Next QoS config checks the default qos configuration,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0
-    // By not using instances, this does not make any change.
     TopicQos qos2 = TOPIC_QOS_DEFAULT;
     Topic* default_topic1 = participant->create_topic("footopic4", type.get_type_name(), qos2);
     ASSERT_NE(default_topic1, nullptr);
-
-    qos2.resource_limits().max_instances = 0;
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_topic1->set_qos(qos2));
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
     // which also means infinite value.
-    // By not using instances, this does not make any change.
+    // By not using instances, instance allocation consistency is not checked.
     qos2.resource_limits().max_instances = -1;
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_topic1->set_qos(qos2));
 
     // Next QoS config checks that if user sets max_samples < ( max_instances * max_samples_per_instance ) ,
     // set_qos() should return ReturnCode_t::RETCODE_OK = 0
-    // By not using instances, this does not make any change.
+    // By not using instances, instance allocation consistency is not checked.
     qos2.resource_limits().max_samples = 4999;
     qos2.resource_limits().max_instances = 10;
     qos2.resource_limits().max_samples_per_instance = 500;
@@ -327,10 +321,9 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyKeyed)
     // This test pretends to use topic with instances, so the following flag is set.
     type.get()->m_isGetKeyDefined = true;
 
-    // Next QoS config checks that if user sets max_instances to inf and leaves max_samples by default,
-    // create_topic() should not return nullptr, as the by default values are already infinite.
+    // Next QoS config checks the default qos configuration,
+    // create_topic() should not return nullptr.
     TopicQos qos = TOPIC_QOS_DEFAULT;
-    qos.resource_limits().max_instances = 0;
 
     Topic* topic1 = participant->create_topic("footopic1", type.get_type_name(), qos);
     ASSERT_NE(topic1, nullptr);
@@ -351,13 +344,11 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyKeyed)
     Topic* topic3 = participant->create_topic("footopic3", type.get_type_name(), qos);
     ASSERT_EQ(topic3, nullptr);
 
-    // Next QoS config checks that if user sets max_instances to inf and leaves max_samples by default,
-    // set_qos() should return ReturnCode_t::RETCODE_OK = 0, as the by default values are already infinite.
+    // Next QoS config checks the default qos configuration,
+    // set_qos() should return ReturnCode_t::RETCODE_OK = 0.
     TopicQos qos2 = TOPIC_QOS_DEFAULT;
     Topic* default_topic1 = participant->create_topic("footopic4", type.get_type_name(), qos2);
     ASSERT_NE(default_topic1, nullptr);
-
-    qos2.resource_limits().max_instances = 0;
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_topic1->set_qos(qos2));
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
It is needed to verify the consistency of certain configurations of Resource Limits QoS policy when creating `dataReaders`, `dataWriters` and `Topics`. 
Those certain configurations are, when using instances, with parameters set as `max_samples < ( max_instances * max_samples_per_instance )`, in which case the creator should return `nullptr`.

Two unit tests has been created per each object creator, one for not keyed topic, and other for keyed topic. Then, new check rules have been added to each `check_qos()` method, in form of another method that extends it: `check_qos_including_resource_limits()`.
The two new rules cover, using instances, when `max_instances` or `max_samples_per_instance` are set to `inf` (`<= 0`), and max_samples not (`> 0`); and when `max_samples < ( max_instances * max_samples_per_instance )`.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
@Mergifyio backport 2.6.x 2.3.x 2.1.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A*: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally, just for *InstanceAllocationConsistency Tests. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A*: Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- *N/A*: New feature has been added to the `versions.md` file (if applicable).
- *N/A*: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
