### PR TITLE
[13824] Feature/check xml static discovery testing

### DIFF
--- a/include/fastrtps/xmlparser/XMLEndpointParser.h
+++ b/include/fastrtps/xmlparser/XMLEndpointParser.h
@@ -85,7 +85,8 @@ public:
     virtual ~XMLEndpointParser();
     /**
      * Load the XML file
-     * @param filename Name of the file to load and parse.
+     * @param filename Name or data of the file to load and parse.
+     * The string could contain a filename (file://) or the XML content directly (data://), filename assumed if neither
      * @return True if correct.
      */
     XMLP_ret loadXMLFile(

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -26,6 +26,7 @@
 #include <fastrtps/types/DynamicTypeBuilderFactory.h>
 #include <fastrtps/types/TypeObjectFactory.h>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
+#include <fastrtps/xmlparser/XMLEndpointParser.h>
 
 #include <fastdds/domain/DomainParticipantImpl.hpp>
 #include <rtps/history/TopicPayloadPoolRegistry.hpp>
@@ -418,10 +419,13 @@ ReturnCode_t DomainParticipantFactory::load_XML_profiles_string(
 ReturnCode_t DomainParticipantFactory::check_xml_static_discovery(
         std::string& xml_file)
 {
-    // Not suported yet
-    (void)xml_file;
-
-    return ReturnCode_t::RETCODE_UNSUPPORTED;
+    eprosima::fastrtps::xmlparser::XMLEndpointParser parser;
+    if (XMLP_ret::XML_OK != parser.loadXMLFile(xml_file))
+    {
+        logError(DOMAIN, "Error parsing xml file");
+        return ReturnCode_t::RETCODE_ERROR;
+    }
+    return ReturnCode_t::RETCODE_OK;
 }
 
 ReturnCode_t DomainParticipantFactory::get_qos(

--- a/src/cpp/rtps/xmlparser/XMLEndpointParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLEndpointParser.cpp
@@ -64,15 +64,28 @@ XMLEndpointParser::~XMLEndpointParser()
 XMLP_ret XMLEndpointParser::loadXMLFile(
         std::string& filename)
 {
-    logInfo(RTPS_EDP, "File: " << filename);
-
     tinyxml2::XMLDocument doc;
-    doc.LoadFile(filename.c_str());
-    tinyxml2::XMLError eResult = doc.LoadFile(filename.c_str());
+    tinyxml2::XMLError eResult;
+
+    if (0 == filename.rfind("data://", 0))
+    {
+        logInfo(RTPS_EDP, filename);
+        eResult = doc.Parse(filename.c_str() + 7, filename.size() - 7);
+    }
+    else if (0 == filename.rfind("file://", 0))
+    {
+        logInfo(RTPS_EDP, filename);
+        eResult = doc.LoadFile(filename.substr(7).c_str());
+    }
+    else
+    {
+        logInfo(RTPS_EDP, "FileName: " << filename);
+        eResult = doc.LoadFile(filename.c_str());
+    }
 
     if (tinyxml2::XML_SUCCESS != eResult)
     {
-        logError(RTPS_EDP, filename << " bad file (bad path?)");
+        logError(RTPS_EDP, filename << " bad file");
         return XMLP_ret::XML_ERROR;
     }
 
@@ -82,7 +95,6 @@ XMLP_ret XMLEndpointParser::loadXMLFile(
         logError(RTPS_EDP, filename << " XML has errors");
         return XMLP_ret::XML_ERROR;
     }
-
 
     tinyxml2::XMLElement* xml_RTPSParticipant = root->FirstChildElement();
 

--- a/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
@@ -569,8 +569,8 @@ TEST(DDSDiscovery, ParticipantProxyPhysicalData)
 }
 
 /**
- * This test checks the missing file DomainParticipantFactory->check_xml_static_discovery
- * method and checks it returns RETCODE_UNSUPPORTED
+ * This test checks the missing file case of DomainParticipantFactory->check_xml_static_discovery
+ * method and checks it returns RETCODE_ERROR
  */
 TEST(DDSDiscovery, CheckMissingFileXmlStaticDiscoveryFile)
 {
@@ -580,7 +580,7 @@ TEST(DDSDiscovery, CheckMissingFileXmlStaticDiscoveryFile)
 }
 
 /**
- * This test checks the correct data DomainParticipantFactory->check_xml_static_discovery
+ * This test checks the correct data case of DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_OK
  */
 TEST(DDSDiscovery, CheckCorrectXmlStaticDiscoveryFile)
@@ -618,7 +618,7 @@ TEST(DDSDiscovery, CheckCorrectXmlStaticDiscoveryFile)
 }
 
 /**
- * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * This test checks the incorrect <staticdiscovery> case of DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_OK
  */
 TEST(DDSDiscovery, CheckIncorrectStaticdiscoveryXmlStaticDiscoveryFile)
@@ -656,7 +656,7 @@ TEST(DDSDiscovery, CheckIncorrectStaticdiscoveryXmlStaticDiscoveryFile)
 }
 
 /**
- * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * This test checks the incorrect <participant> case of DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_OK
  */
 TEST(DDSDiscovery, CheckIncorrectParticipantXmlStaticDiscoveryFile)
@@ -694,7 +694,7 @@ TEST(DDSDiscovery, CheckIncorrectParticipantXmlStaticDiscoveryFile)
 }
 
 /**
- * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * This test checks the incorrect <reader> case of DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_OK
  */
 TEST(DDSDiscovery, CheckIncorrectReaderXmlStaticDiscoveryFile)
@@ -732,7 +732,7 @@ TEST(DDSDiscovery, CheckIncorrectReaderXmlStaticDiscoveryFile)
 }
 
 /**
- * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * This test checks the incorrect reader <userId> case of DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_OK
  */
 TEST(DDSDiscovery, CheckIncorrectReaderUserIDXmlStaticDiscoveryFile)
@@ -769,7 +769,7 @@ TEST(DDSDiscovery, CheckIncorrectReaderUserIDXmlStaticDiscoveryFile)
     ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_ERROR);
 }
 /**
- * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * This test checks the incorrect reader <entityID> case of DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_OK
  */
 TEST(DDSDiscovery, CheckIncorrectReaderEntityIDXmlStaticDiscoveryFile)
@@ -807,7 +807,7 @@ TEST(DDSDiscovery, CheckIncorrectReaderEntityIDXmlStaticDiscoveryFile)
 }
 
 /**
- * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * This test checks the incorrect reader <topicName> case of DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_OK
  */
 TEST(DDSDiscovery, CheckIncorrectReaderTopicNameXmlStaticDiscoveryFile)
@@ -845,7 +845,7 @@ TEST(DDSDiscovery, CheckIncorrectReaderTopicNameXmlStaticDiscoveryFile)
 }
 
 /**
- * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * This test checks the incorrect data case of DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_OK
  */
 TEST(DDSDiscovery, CheckIncorrectReaderTopicDataTypeXmlStaticDiscoveryFile)
@@ -883,7 +883,7 @@ TEST(DDSDiscovery, CheckIncorrectReaderTopicDataTypeXmlStaticDiscoveryFile)
 }
 
 /**
- * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * This test checks the incorrect reader <topicKind> case of DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_OK
  */
 TEST(DDSDiscovery, CheckIncorrectReaderTopicKindXmlStaticDiscoveryFile)
@@ -921,7 +921,7 @@ TEST(DDSDiscovery, CheckIncorrectReaderTopicKindXmlStaticDiscoveryFile)
 }
 
 /**
- * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * This test checks the incorrect reader <partitionQos> case of DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_OK
  */
 TEST(DDSDiscovery, CheckIncorrectReaderPartitionQosXmlStaticDiscoveryFile)
@@ -959,7 +959,7 @@ TEST(DDSDiscovery, CheckIncorrectReaderPartitionQosXmlStaticDiscoveryFile)
 }
 
 /**
- * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * This test checks the incorrect reader <reliabilityQos> case of DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_OK
  */
 TEST(DDSDiscovery, CheckIncorrectReaderReliabilityQosXmlStaticDiscoveryFile)
@@ -997,7 +997,7 @@ TEST(DDSDiscovery, CheckIncorrectReaderReliabilityQosXmlStaticDiscoveryFile)
 }
 
 /**
- * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * This test checks the incorrect reader <durabilityQos> case of DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_OK
  */
 TEST(DDSDiscovery, CheckIncorrectReaderDurabilityQosXmlStaticDiscoveryFile)
@@ -1035,7 +1035,7 @@ TEST(DDSDiscovery, CheckIncorrectReaderDurabilityQosXmlStaticDiscoveryFile)
 }
 
 /**
- * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * This test checks the incorrect reader <multicastLocator> case of DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_OK
  */
 TEST(DDSDiscovery, CheckIncorrectReaderMulticastLocatorXmlStaticDiscoveryFile)
@@ -1073,7 +1073,7 @@ TEST(DDSDiscovery, CheckIncorrectReaderMulticastLocatorXmlStaticDiscoveryFile)
 }
 
 /**
- * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * This test checks the incorrect <writer> case of DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_OK
  */
 TEST(DDSDiscovery, CheckIncorrectWriterXmlStaticDiscoveryFile)
@@ -1111,7 +1111,7 @@ TEST(DDSDiscovery, CheckIncorrectWriterXmlStaticDiscoveryFile)
 }
 
 /**
- * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * This test checks the incorrect writer <userId> case of DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_OK
  */
 TEST(DDSDiscovery, CheckIncorrectWriterUserIDXmlStaticDiscoveryFile)
@@ -1149,7 +1149,7 @@ TEST(DDSDiscovery, CheckIncorrectWriterUserIDXmlStaticDiscoveryFile)
 }
 
 /**
- * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * This test checks the incorrect writer <entityID> case of DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_OK
  */
 TEST(DDSDiscovery, CheckIncorrectWriterEntityIDXmlStaticDiscoveryFile)
@@ -1187,7 +1187,7 @@ TEST(DDSDiscovery, CheckIncorrectWriterEntityIDXmlStaticDiscoveryFile)
 }
 
 /**
- * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * This test checks the incorrect writer <topicName> case of DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_OK
  */
 TEST(DDSDiscovery, CheckIncorrectWriterTopicNameXmlStaticDiscoveryFile)
@@ -1225,7 +1225,7 @@ TEST(DDSDiscovery, CheckIncorrectWriterTopicNameXmlStaticDiscoveryFile)
 }
 
 /**
- * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * This test checks the incorrect writer <topicDataType> case of DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_OK
  */
 TEST(DDSDiscovery, CheckIncorrectWriterTopicDataTypeXmlStaticDiscoveryFile)
@@ -1263,7 +1263,7 @@ TEST(DDSDiscovery, CheckIncorrectWriterTopicDataTypeXmlStaticDiscoveryFile)
 }
 
 /**
- * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * This test checks the incorrect writer <topicKind> case of DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_OK
  */
 TEST(DDSDiscovery, CheckIncorrectWriterTopicKindXmlStaticDiscoveryFile)
@@ -1301,7 +1301,7 @@ TEST(DDSDiscovery, CheckIncorrectWriterTopicKindXmlStaticDiscoveryFile)
 }
 
 /**
- * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * This test checks the incorrect writer <partitionQos> case of DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_OK
  */
 TEST(DDSDiscovery, CheckIncorrectWriterPartitionQosXmlStaticDiscoveryFile)
@@ -1339,7 +1339,7 @@ TEST(DDSDiscovery, CheckIncorrectWriterPartitionQosXmlStaticDiscoveryFile)
 }
 
 /**
- * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * This test checks the incorrect writer <reliabilityQos> case of DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_OK
  */
 TEST(DDSDiscovery, CheckIncorrectWriterReliabilityQosXmlStaticDiscoveryFile)
@@ -1377,7 +1377,7 @@ TEST(DDSDiscovery, CheckIncorrectWriterReliabilityQosXmlStaticDiscoveryFile)
 }
 
 /**
- * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * This test checks the incorrect writer <durabilityQos> case of DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_OK
  */
 TEST(DDSDiscovery, CheckIncorrectWriterDurabilityQosXmlStaticDiscoveryFile)

--- a/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
@@ -569,12 +569,847 @@ TEST(DDSDiscovery, ParticipantProxyPhysicalData)
 }
 
 /**
- * This test checks the unsupported DomainParticipantFactory->check_xml_static_discovery
+ * This test checks the missing file DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_UNSUPPORTED
  */
-TEST(DDSDiscovery, CheckUnsupportedXmlStaticDiscoveryFile)
+TEST(DDSDiscovery, CheckMissingFileXmlStaticDiscoveryFile)
 {
-    std::string file = "Unsupported.xml";
+    std::string file = "MissingFile.xml";
     DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
-    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_UNSUPPORTED);
+    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_ERROR);
+}
+
+/**
+ * This test checks the correct data DomainParticipantFactory->check_xml_static_discovery
+ * method and checks it returns RETCODE_OK
+ */
+TEST(DDSDiscovery, CheckCorrectXmlStaticDiscoveryFile)
+{
+    std::string file = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
+            "<staticdiscovery>" \
+            "<participant>" \
+            "<name>SPMDEETISS10_DefaultPartition</name>" \
+            "<reader>" \
+            "<userId>11</userId>" \
+            "<entityID>11</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "<multicastLocator address=\"239.255.0.1\" port=\"7401\" />" \
+            "</reader>" \
+            "<writer>" \
+            "<userId>12</userId>" \
+            "<entityID>12</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "</writer>" \
+            "</participant>" \
+            "</staticdiscovery>";
+
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_OK);
+}
+
+/**
+ * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * method and checks it returns RETCODE_OK
+ */
+TEST(DDSDiscovery, CheckIncorrectStaticdiscoveryXmlStaticDiscoveryFile)
+{
+    std::string file = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
+            "<staticdiscovery>" \
+            "<participant>" \
+            "<name>SPMDEETISS10_DefaultPartition</name>" \
+            "<reader>" \
+            "<userId>11</userId>" \
+            "<entityID>11</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "<multicastLocator address=\"239.255.0.1\" port=\"7401\" />" \
+            "</reader>" \
+            "<writer>" \
+            "<userId>12</userId>" \
+            "<entityID>12</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "</writer>" \
+            "</participant>" \
+            "</staticdiscoveryBROKEN>";
+
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_ERROR);
+}
+
+/**
+ * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * method and checks it returns RETCODE_OK
+ */
+TEST(DDSDiscovery, CheckIncorrectParticipantXmlStaticDiscoveryFile)
+{
+    std::string file = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
+            "<staticdiscovery>" \
+            "<participant>" \
+            "<name>SPMDEETISS10_DefaultPartition</name>" \
+            "<reader>" \
+            "<userId>11</userId>" \
+            "<entityID>11</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "<multicastLocator address=\"239.255.0.1\" port=\"7401\" />" \
+            "</reader>" \
+            "<writer>" \
+            "<userId>12</userId>" \
+            "<entityID>12</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "</writer>" \
+            "</participantBROKEN>" \
+            "</staticdiscovery>";
+
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_ERROR);
+}
+
+/**
+ * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * method and checks it returns RETCODE_OK
+ */
+TEST(DDSDiscovery, CheckIncorrectReaderXmlStaticDiscoveryFile)
+{
+    std::string file = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
+            "<staticdiscovery>" \
+            "<participant>" \
+            "<name>SPMDEETISS10_DefaultPartition</name>" \
+            "<reader>" \
+            "<userId>11</userId>" \
+            "<entityID>11</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "<multicastLocator address=\"239.255.0.1\" port=\"7401\" />" \
+            "</readerBROKEN>" \
+            "<writer>" \
+            "<userId>12</userId>" \
+            "<entityID>12</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "</writer>" \
+            "</participant>" \
+            "</staticdiscovery>";
+
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_ERROR);
+}
+
+/**
+ * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * method and checks it returns RETCODE_OK
+ */
+TEST(DDSDiscovery, CheckIncorrectReaderUserIDXmlStaticDiscoveryFile)
+{
+    std::string file = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
+            "<staticdiscovery>" \
+            "<participant>" \
+            "<name>SPMDEETISS10_DefaultPartition</name>" \
+            "<reader>" \
+            "<userId>11</userIdBROKEN>" \
+            "<entityID>11</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "<multicastLocator address=\"239.255.0.1\" port=\"7401\" />" \
+            "</reader>" \
+            "<writer>" \
+            "<userId>12</userId>" \
+            "<entityID>12</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "</writer>" \
+            "</participant>" \
+            "</staticdiscovery>";
+
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_ERROR);
+}
+/**
+ * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * method and checks it returns RETCODE_OK
+ */
+TEST(DDSDiscovery, CheckIncorrectReaderEntityIDXmlStaticDiscoveryFile)
+{
+    std::string file = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
+            "<staticdiscovery>" \
+            "<participant>" \
+            "<name>SPMDEETISS10_DefaultPartition</name>" \
+            "<reader>" \
+            "<userId>11</userId>" \
+            "<entityID>11</entityIDBROKEN>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "<multicastLocator address=\"239.255.0.1\" port=\"7401\" />" \
+            "</reader>" \
+            "<writer>" \
+            "<userId>12</userId>" \
+            "<entityID>12</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "</writer>" \
+            "</participant>" \
+            "</staticdiscovery>";
+
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_ERROR);
+}
+
+/**
+ * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * method and checks it returns RETCODE_OK
+ */
+TEST(DDSDiscovery, CheckIncorrectReaderTopicNameXmlStaticDiscoveryFile)
+{
+    std::string file = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
+            "<staticdiscovery>" \
+            "<participant>" \
+            "<name>SPMDEETISS10_DefaultPartition</name>" \
+            "<reader>" \
+            "<userId>11</userId>" \
+            "<entityID>11</entityID>" \
+            "<topicName>topic1</topicNameBROKEN>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "<multicastLocator address=\"239.255.0.1\" port=\"7401\" />" \
+            "</reader>" \
+            "<writer>" \
+            "<userId>12</userId>" \
+            "<entityID>12</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "</writer>" \
+            "</participant>" \
+            "</staticdiscovery>";
+
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_ERROR);
+}
+
+/**
+ * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * method and checks it returns RETCODE_OK
+ */
+TEST(DDSDiscovery, CheckIncorrectReaderTopicDataTypeXmlStaticDiscoveryFile)
+{
+    std::string file = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
+            "<staticdiscovery>" \
+            "<participant>" \
+            "<name>SPMDEETISS10_DefaultPartition</name>" \
+            "<reader>" \
+            "<userId>11</userId>" \
+            "<entityID>11</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataTypeBROKEN>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "<multicastLocator address=\"239.255.0.1\" port=\"7401\" />" \
+            "</reader>" \
+            "<writer>" \
+            "<userId>12</userId>" \
+            "<entityID>12</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "</writer>" \
+            "</participant>" \
+            "</staticdiscovery>";
+
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_ERROR);
+}
+
+/**
+ * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * method and checks it returns RETCODE_OK
+ */
+TEST(DDSDiscovery, CheckIncorrectReaderTopicKindXmlStaticDiscoveryFile)
+{
+    std::string file = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
+            "<staticdiscovery>" \
+            "<participant>" \
+            "<name>SPMDEETISS10_DefaultPartition</name>" \
+            "<reader>" \
+            "<userId>11</userId>" \
+            "<entityID>11</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKindBROKEN>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "<multicastLocator address=\"239.255.0.1\" port=\"7401\" />" \
+            "</reader>" \
+            "<writer>" \
+            "<userId>12</userId>" \
+            "<entityID>12</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "</writer>" \
+            "</participant>" \
+            "</staticdiscovery>";
+
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_ERROR);
+}
+
+/**
+ * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * method and checks it returns RETCODE_OK
+ */
+TEST(DDSDiscovery, CheckIncorrectReaderPartitionQosXmlStaticDiscoveryFile)
+{
+    std::string file = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
+            "<staticdiscovery>" \
+            "<participant>" \
+            "<name>SPMDEETISS10_DefaultPartition</name>" \
+            "<reader>" \
+            "<userId>11</userId>" \
+            "<entityID>11</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQosBROKEN>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "<multicastLocator address=\"239.255.0.1\" port=\"7401\" />" \
+            "</reader>" \
+            "<writer>" \
+            "<userId>12</userId>" \
+            "<entityID>12</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "</writer>" \
+            "</participant>" \
+            "</staticdiscovery>";
+
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_ERROR);
+}
+
+/**
+ * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * method and checks it returns RETCODE_OK
+ */
+TEST(DDSDiscovery, CheckIncorrectReaderReliabilityQosXmlStaticDiscoveryFile)
+{
+    std::string file = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
+            "<staticdiscovery>" \
+            "<participant>" \
+            "<name>SPMDEETISS10_DefaultPartition</name>" \
+            "<reader>" \
+            "<userId>11</userId>" \
+            "<entityID>11</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQosBROKEN>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "<multicastLocator address=\"239.255.0.1\" port=\"7401\" />" \
+            "</reader>" \
+            "<writer>" \
+            "<userId>12</userId>" \
+            "<entityID>12</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "</writer>" \
+            "</participant>" \
+            "</staticdiscovery>";
+
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_ERROR);
+}
+
+/**
+ * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * method and checks it returns RETCODE_OK
+ */
+TEST(DDSDiscovery, CheckIncorrectReaderDurabilityQosXmlStaticDiscoveryFile)
+{
+    std::string file = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
+            "<staticdiscovery>" \
+            "<participant>" \
+            "<name>SPMDEETISS10_DefaultPartition</name>" \
+            "<reader>" \
+            "<userId>11</userId>" \
+            "<entityID>11</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQosBROKEN>" \
+            "<multicastLocator address=\"239.255.0.1\" port=\"7401\" />" \
+            "</reader>" \
+            "<writer>" \
+            "<userId>12</userId>" \
+            "<entityID>12</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "</writer>" \
+            "</participant>" \
+            "</staticdiscovery>";
+
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_ERROR);
+}
+
+/**
+ * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * method and checks it returns RETCODE_OK
+ */
+TEST(DDSDiscovery, CheckIncorrectReaderMulticastLocatorXmlStaticDiscoveryFile)
+{
+    std::string file = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
+            "<staticdiscovery>" \
+            "<participant>" \
+            "<name>SPMDEETISS10_DefaultPartition</name>" \
+            "<reader>" \
+            "<userId>11</userId>" \
+            "<entityID>11</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "<multicastLocator address=\"239.255.0.1\" port=\"7401\" BROKEN/>" \
+            "</reader>" \
+            "<writer>" \
+            "<userId>12</userId>" \
+            "<entityID>12</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "</writer>" \
+            "</participant>" \
+            "</staticdiscovery>";
+
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_ERROR);
+}
+
+/**
+ * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * method and checks it returns RETCODE_OK
+ */
+TEST(DDSDiscovery, CheckIncorrectWriterXmlStaticDiscoveryFile)
+{
+    std::string file = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
+            "<staticdiscovery>" \
+            "<participant>" \
+            "<name>SPMDEETISS10_DefaultPartition</name>" \
+            "<reader>" \
+            "<userId>11</userId>" \
+            "<entityID>11</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "<multicastLocator address=\"239.255.0.1\" port=\"7401\" />" \
+            "</reader>" \
+            "<writer>" \
+            "<userId>12</userId>" \
+            "<entityID>12</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "</writerBROKEN>" \
+            "</participant>" \
+            "</staticdiscovery>";
+
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_ERROR);
+}
+
+/**
+ * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * method and checks it returns RETCODE_OK
+ */
+TEST(DDSDiscovery, CheckIncorrectWriterUserIDXmlStaticDiscoveryFile)
+{
+    std::string file = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
+            "<staticdiscovery>" \
+            "<participant>" \
+            "<name>SPMDEETISS10_DefaultPartition</name>" \
+            "<reader>" \
+            "<userId>11</userId>" \
+            "<entityID>11</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "<multicastLocator address=\"239.255.0.1\" port=\"7401\" />" \
+            "</reader>" \
+            "<writer>" \
+            "<userId>12</userIdBROKEN>" \
+            "<entityID>12</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "</writer>" \
+            "</participant>" \
+            "</staticdiscovery>";
+
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_ERROR);
+}
+
+/**
+ * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * method and checks it returns RETCODE_OK
+ */
+TEST(DDSDiscovery, CheckIncorrectWriterEntityIDXmlStaticDiscoveryFile)
+{
+    std::string file = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
+            "<staticdiscovery>" \
+            "<participant>" \
+            "<name>SPMDEETISS10_DefaultPartition</name>" \
+            "<reader>" \
+            "<userId>11</userId>" \
+            "<entityID>11</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "<multicastLocator address=\"239.255.0.1\" port=\"7401\" />" \
+            "</reader>" \
+            "<writer>" \
+            "<userId>12</userId>" \
+            "<entityID>12</entityIDBROKEN>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "</writer>" \
+            "</participant>" \
+            "</staticdiscovery>";
+
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_ERROR);
+}
+
+/**
+ * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * method and checks it returns RETCODE_OK
+ */
+TEST(DDSDiscovery, CheckIncorrectWriterTopicNameXmlStaticDiscoveryFile)
+{
+    std::string file = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
+            "<staticdiscovery>" \
+            "<participant>" \
+            "<name>SPMDEETISS10_DefaultPartition</name>" \
+            "<reader>" \
+            "<userId>11</userId>" \
+            "<entityID>11</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "<multicastLocator address=\"239.255.0.1\" port=\"7401\" />" \
+            "</reader>" \
+            "<writer>" \
+            "<userId>12</userId>" \
+            "<entityID>12</entityID>" \
+            "<topicName>topic1</topicNameBROKEN>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "</writer>" \
+            "</participant>" \
+            "</staticdiscovery>";
+
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_ERROR);
+}
+
+/**
+ * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * method and checks it returns RETCODE_OK
+ */
+TEST(DDSDiscovery, CheckIncorrectWriterTopicDataTypeXmlStaticDiscoveryFile)
+{
+    std::string file = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
+            "<staticdiscovery>" \
+            "<participant>" \
+            "<name>SPMDEETISS10_DefaultPartition</name>" \
+            "<reader>" \
+            "<userId>11</userId>" \
+            "<entityID>11</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "<multicastLocator address=\"239.255.0.1\" port=\"7401\" />" \
+            "</reader>" \
+            "<writer>" \
+            "<userId>12</userId>" \
+            "<entityID>12</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataTypeBROKEN>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "</writer>" \
+            "</participant>" \
+            "</staticdiscovery>";
+
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_ERROR);
+}
+
+/**
+ * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * method and checks it returns RETCODE_OK
+ */
+TEST(DDSDiscovery, CheckIncorrectWriterTopicKindXmlStaticDiscoveryFile)
+{
+    std::string file = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
+            "<staticdiscovery>" \
+            "<participant>" \
+            "<name>SPMDEETISS10_DefaultPartition</name>" \
+            "<reader>" \
+            "<userId>11</userId>" \
+            "<entityID>11</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "<multicastLocator address=\"239.255.0.1\" port=\"7401\" />" \
+            "</reader>" \
+            "<writer>" \
+            "<userId>12</userId>" \
+            "<entityID>12</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKindBROKEN>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "</writer>" \
+            "</participant>" \
+            "</staticdiscovery>";
+
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_ERROR);
+}
+
+/**
+ * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * method and checks it returns RETCODE_OK
+ */
+TEST(DDSDiscovery, CheckIncorrectWriterPartitionQosXmlStaticDiscoveryFile)
+{
+    std::string file = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
+            "<staticdiscovery>" \
+            "<participant>" \
+            "<name>SPMDEETISS10_DefaultPartition</name>" \
+            "<reader>" \
+            "<userId>11</userId>" \
+            "<entityID>11</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "<multicastLocator address=\"239.255.0.1\" port=\"7401\" />" \
+            "</reader>" \
+            "<writer>" \
+            "<userId>12</userId>" \
+            "<entityID>12</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQosBROKEN>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "</writer>" \
+            "</participant>" \
+            "</staticdiscovery>";
+
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_ERROR);
+}
+
+/**
+ * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * method and checks it returns RETCODE_OK
+ */
+TEST(DDSDiscovery, CheckIncorrectWriterReliabilityQosXmlStaticDiscoveryFile)
+{
+    std::string file = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
+            "<staticdiscovery>" \
+            "<participant>" \
+            "<name>SPMDEETISS10_DefaultPartition</name>" \
+            "<reader>" \
+            "<userId>11</userId>" \
+            "<entityID>11</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "<multicastLocator address=\"239.255.0.1\" port=\"7401\" />" \
+            "</reader>" \
+            "<writer>" \
+            "<userId>12</userId>" \
+            "<entityID>12</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQosBROKEN>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "</writer>" \
+            "</participant>" \
+            "</staticdiscovery>";
+
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_ERROR);
+}
+
+/**
+ * This test checks the incorrect data DomainParticipantFactory->check_xml_static_discovery
+ * method and checks it returns RETCODE_OK
+ */
+TEST(DDSDiscovery, CheckIncorrectWriterDurabilityQosXmlStaticDiscoveryFile)
+{
+    std::string file = "data://<?xml version=\"1.0\" encoding=\"utf-8\"?>" \
+            "<staticdiscovery>" \
+            "<participant>" \
+            "<name>SPMDEETISS10_DefaultPartition</name>" \
+            "<reader>" \
+            "<userId>11</userId>" \
+            "<entityID>11</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQos>" \
+            "<multicastLocator address=\"239.255.0.1\" port=\"7401\" />" \
+            "</reader>" \
+            "<writer>" \
+            "<userId>12</userId>" \
+            "<entityID>12</entityID>" \
+            "<topicName>topic1</topicName>" \
+            "<topicDataType>Topic1</topicDataType>" \
+            "<topicKind>WITH_KEY</topicKind>" \
+            "<partitionQos>DefaultPartition</partitionQos>" \
+            "<reliabilityQos>RELIABLE_RELIABILITY_QOS</reliabilityQos>" \
+            "<durabilityQos>TRANSIENT_LOCAL_DURABILITY_QOS</durabilityQosBROKEN>" \
+            "</writer>" \
+            "</participant>" \
+            "</staticdiscovery>";
+
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_EQ(factory->check_xml_static_discovery(file), ReturnCode_t::RETCODE_ERROR);
 }

--- a/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
@@ -619,7 +619,7 @@ TEST(DDSDiscovery, CheckCorrectXmlStaticDiscoveryFile)
 
 /**
  * This test checks the incorrect <staticdiscovery> case of DomainParticipantFactory->check_xml_static_discovery
- * method and checks it returns RETCODE_OK
+ * method and checks it returns RETCODE_ERROR
  */
 TEST(DDSDiscovery, CheckIncorrectStaticdiscoveryXmlStaticDiscoveryFile)
 {
@@ -657,7 +657,7 @@ TEST(DDSDiscovery, CheckIncorrectStaticdiscoveryXmlStaticDiscoveryFile)
 
 /**
  * This test checks the incorrect <participant> case of DomainParticipantFactory->check_xml_static_discovery
- * method and checks it returns RETCODE_OK
+ * method and checks it returns RETCODE_ERROR
  */
 TEST(DDSDiscovery, CheckIncorrectParticipantXmlStaticDiscoveryFile)
 {
@@ -695,7 +695,7 @@ TEST(DDSDiscovery, CheckIncorrectParticipantXmlStaticDiscoveryFile)
 
 /**
  * This test checks the incorrect <reader> case of DomainParticipantFactory->check_xml_static_discovery
- * method and checks it returns RETCODE_OK
+ * method and checks it returns RETCODE_ERROR
  */
 TEST(DDSDiscovery, CheckIncorrectReaderXmlStaticDiscoveryFile)
 {
@@ -733,7 +733,7 @@ TEST(DDSDiscovery, CheckIncorrectReaderXmlStaticDiscoveryFile)
 
 /**
  * This test checks the incorrect reader <userId> case of DomainParticipantFactory->check_xml_static_discovery
- * method and checks it returns RETCODE_OK
+ * method and checks it returns RETCODE_ERROR
  */
 TEST(DDSDiscovery, CheckIncorrectReaderUserIDXmlStaticDiscoveryFile)
 {
@@ -770,7 +770,7 @@ TEST(DDSDiscovery, CheckIncorrectReaderUserIDXmlStaticDiscoveryFile)
 }
 /**
  * This test checks the incorrect reader <entityID> case of DomainParticipantFactory->check_xml_static_discovery
- * method and checks it returns RETCODE_OK
+ * method and checks it returns RETCODE_ERROR
  */
 TEST(DDSDiscovery, CheckIncorrectReaderEntityIDXmlStaticDiscoveryFile)
 {
@@ -808,7 +808,7 @@ TEST(DDSDiscovery, CheckIncorrectReaderEntityIDXmlStaticDiscoveryFile)
 
 /**
  * This test checks the incorrect reader <topicName> case of DomainParticipantFactory->check_xml_static_discovery
- * method and checks it returns RETCODE_OK
+ * method and checks it returns RETCODE_ERROR
  */
 TEST(DDSDiscovery, CheckIncorrectReaderTopicNameXmlStaticDiscoveryFile)
 {
@@ -846,7 +846,7 @@ TEST(DDSDiscovery, CheckIncorrectReaderTopicNameXmlStaticDiscoveryFile)
 
 /**
  * This test checks the incorrect data case of DomainParticipantFactory->check_xml_static_discovery
- * method and checks it returns RETCODE_OK
+ * method and checks it returns RETCODE_ERROR
  */
 TEST(DDSDiscovery, CheckIncorrectReaderTopicDataTypeXmlStaticDiscoveryFile)
 {
@@ -884,7 +884,7 @@ TEST(DDSDiscovery, CheckIncorrectReaderTopicDataTypeXmlStaticDiscoveryFile)
 
 /**
  * This test checks the incorrect reader <topicKind> case of DomainParticipantFactory->check_xml_static_discovery
- * method and checks it returns RETCODE_OK
+ * method and checks it returns RETCODE_ERROR
  */
 TEST(DDSDiscovery, CheckIncorrectReaderTopicKindXmlStaticDiscoveryFile)
 {
@@ -922,7 +922,7 @@ TEST(DDSDiscovery, CheckIncorrectReaderTopicKindXmlStaticDiscoveryFile)
 
 /**
  * This test checks the incorrect reader <partitionQos> case of DomainParticipantFactory->check_xml_static_discovery
- * method and checks it returns RETCODE_OK
+ * method and checks it returns RETCODE_ERROR
  */
 TEST(DDSDiscovery, CheckIncorrectReaderPartitionQosXmlStaticDiscoveryFile)
 {
@@ -960,7 +960,7 @@ TEST(DDSDiscovery, CheckIncorrectReaderPartitionQosXmlStaticDiscoveryFile)
 
 /**
  * This test checks the incorrect reader <reliabilityQos> case of DomainParticipantFactory->check_xml_static_discovery
- * method and checks it returns RETCODE_OK
+ * method and checks it returns RETCODE_ERROR
  */
 TEST(DDSDiscovery, CheckIncorrectReaderReliabilityQosXmlStaticDiscoveryFile)
 {
@@ -998,7 +998,7 @@ TEST(DDSDiscovery, CheckIncorrectReaderReliabilityQosXmlStaticDiscoveryFile)
 
 /**
  * This test checks the incorrect reader <durabilityQos> case of DomainParticipantFactory->check_xml_static_discovery
- * method and checks it returns RETCODE_OK
+ * method and checks it returns RETCODE_ERROR
  */
 TEST(DDSDiscovery, CheckIncorrectReaderDurabilityQosXmlStaticDiscoveryFile)
 {
@@ -1036,7 +1036,7 @@ TEST(DDSDiscovery, CheckIncorrectReaderDurabilityQosXmlStaticDiscoveryFile)
 
 /**
  * This test checks the incorrect reader <multicastLocator> case of DomainParticipantFactory->check_xml_static_discovery
- * method and checks it returns RETCODE_OK
+ * method and checks it returns RETCODE_ERROR
  */
 TEST(DDSDiscovery, CheckIncorrectReaderMulticastLocatorXmlStaticDiscoveryFile)
 {
@@ -1074,7 +1074,7 @@ TEST(DDSDiscovery, CheckIncorrectReaderMulticastLocatorXmlStaticDiscoveryFile)
 
 /**
  * This test checks the incorrect <writer> case of DomainParticipantFactory->check_xml_static_discovery
- * method and checks it returns RETCODE_OK
+ * method and checks it returns RETCODE_ERROR
  */
 TEST(DDSDiscovery, CheckIncorrectWriterXmlStaticDiscoveryFile)
 {
@@ -1112,7 +1112,7 @@ TEST(DDSDiscovery, CheckIncorrectWriterXmlStaticDiscoveryFile)
 
 /**
  * This test checks the incorrect writer <userId> case of DomainParticipantFactory->check_xml_static_discovery
- * method and checks it returns RETCODE_OK
+ * method and checks it returns RETCODE_ERROR
  */
 TEST(DDSDiscovery, CheckIncorrectWriterUserIDXmlStaticDiscoveryFile)
 {
@@ -1150,7 +1150,7 @@ TEST(DDSDiscovery, CheckIncorrectWriterUserIDXmlStaticDiscoveryFile)
 
 /**
  * This test checks the incorrect writer <entityID> case of DomainParticipantFactory->check_xml_static_discovery
- * method and checks it returns RETCODE_OK
+ * method and checks it returns RETCODE_ERROR
  */
 TEST(DDSDiscovery, CheckIncorrectWriterEntityIDXmlStaticDiscoveryFile)
 {
@@ -1188,7 +1188,7 @@ TEST(DDSDiscovery, CheckIncorrectWriterEntityIDXmlStaticDiscoveryFile)
 
 /**
  * This test checks the incorrect writer <topicName> case of DomainParticipantFactory->check_xml_static_discovery
- * method and checks it returns RETCODE_OK
+ * method and checks it returns RETCODE_ERROR
  */
 TEST(DDSDiscovery, CheckIncorrectWriterTopicNameXmlStaticDiscoveryFile)
 {
@@ -1226,7 +1226,7 @@ TEST(DDSDiscovery, CheckIncorrectWriterTopicNameXmlStaticDiscoveryFile)
 
 /**
  * This test checks the incorrect writer <topicDataType> case of DomainParticipantFactory->check_xml_static_discovery
- * method and checks it returns RETCODE_OK
+ * method and checks it returns RETCODE_ERROR
  */
 TEST(DDSDiscovery, CheckIncorrectWriterTopicDataTypeXmlStaticDiscoveryFile)
 {
@@ -1264,7 +1264,7 @@ TEST(DDSDiscovery, CheckIncorrectWriterTopicDataTypeXmlStaticDiscoveryFile)
 
 /**
  * This test checks the incorrect writer <topicKind> case of DomainParticipantFactory->check_xml_static_discovery
- * method and checks it returns RETCODE_OK
+ * method and checks it returns RETCODE_ERROR
  */
 TEST(DDSDiscovery, CheckIncorrectWriterTopicKindXmlStaticDiscoveryFile)
 {
@@ -1302,7 +1302,7 @@ TEST(DDSDiscovery, CheckIncorrectWriterTopicKindXmlStaticDiscoveryFile)
 
 /**
  * This test checks the incorrect writer <partitionQos> case of DomainParticipantFactory->check_xml_static_discovery
- * method and checks it returns RETCODE_OK
+ * method and checks it returns RETCODE_ERROR
  */
 TEST(DDSDiscovery, CheckIncorrectWriterPartitionQosXmlStaticDiscoveryFile)
 {
@@ -1340,7 +1340,7 @@ TEST(DDSDiscovery, CheckIncorrectWriterPartitionQosXmlStaticDiscoveryFile)
 
 /**
  * This test checks the incorrect writer <reliabilityQos> case of DomainParticipantFactory->check_xml_static_discovery
- * method and checks it returns RETCODE_OK
+ * method and checks it returns RETCODE_ERROR
  */
 TEST(DDSDiscovery, CheckIncorrectWriterReliabilityQosXmlStaticDiscoveryFile)
 {
@@ -1378,7 +1378,7 @@ TEST(DDSDiscovery, CheckIncorrectWriterReliabilityQosXmlStaticDiscoveryFile)
 
 /**
  * This test checks the incorrect writer <durabilityQos> case of DomainParticipantFactory->check_xml_static_discovery
- * method and checks it returns RETCODE_OK
+ * method and checks it returns RETCODE_ERROR
  */
 TEST(DDSDiscovery, CheckIncorrectWriterDurabilityQosXmlStaticDiscoveryFile)
 {

--- a/test/mock/rtps/XMLEndPointParser/fastrtps/xmlparser/XMLEndpointParser.h
+++ b/test/mock/rtps/XMLEndPointParser/fastrtps/xmlparser/XMLEndpointParser.h
@@ -1,0 +1,69 @@
+// Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file XMLEndpointParser.h
+ *
+ */
+
+#ifndef XMLENDPOINTPARSER_H_
+#define XMLENDPOINTPARSER_H_
+#ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+
+
+
+namespace eprosima {
+namespace fastrtps {
+namespace xmlparser {
+
+
+
+/**
+ * Class XMLEndpointParser used to parse the XML file that contains information about remote endpoints.
+ * @ingroup DISCVOERYMODULE
+ */
+class XMLEndpointParser
+{
+public:
+
+    XMLEndpointParser()
+    {
+    }
+
+    virtual ~XMLEndpointParser()
+    {
+    }
+
+    /**
+     * Load the XML file
+     * @param filename Name of the file to load and parse.
+     * @return True if correct.
+     */
+    XMLP_ret loadXMLFile(
+            std::string&)
+    {
+        return XMLP_ret::XML_OK;
+    }
+
+private:
+
+};
+
+
+} /* xmlparser */
+} /* namespace */
+} /* namespace eprosima */
+
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+#endif /* XMLENDPOINTPARSER_H_ */

--- a/test/unittest/dds/status/CMakeLists.txt
+++ b/test/unittest/dds/status/CMakeLists.txt
@@ -172,6 +172,7 @@ target_include_directories(ListenerTests PRIVATE
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/SharedMemTransportDescriptor
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/TypeLookupManager
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/WLP
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/XMLEndPointParser
     ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
     ${PROJECT_SOURCE_DIR}/src/cpp
     ${THIRDPARTY_BOOST_INCLUDE_DIR}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
Adding tests to check_xml_static_discovery() and funtionality to loadXMLFile()

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR adds a negative tets for each field in the XML files to be checked by DomainParticipantFactory::check_xml_static_discovery().
Also adds the posibility of using "flags" for XMLEndpointParser::loadXMLFile(std::string& filename). The string  could contain a filename (file://) or the XML content directly (data://), filename assumed if neither.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [ ] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [ ] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
