### PR TITLE
[15118] Adding DataReader::get_unread_count (bool mark_as_read)

### DIFF
--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -810,6 +810,16 @@ public:
     RTPS_DllAPI uint64_t get_unread_count() const;
 
     /**
+     * Get the number of samples pending to be read.
+     *
+     * @param mark_as_read  Whether the unread samples should be marked as read or not.
+     *
+     * @return the number of samples on the reader history that have never been read.
+     */
+    RTPS_DllAPI uint64_t get_unread_count(
+            bool mark_as_read) const;
+
+    /**
      * Get associated GUID.
      *
      * @return Associated GUID

--- a/include/fastdds/rtps/reader/RTPSReader.h
+++ b/include/fastdds/rtps/reader/RTPSReader.h
@@ -238,6 +238,9 @@ public:
 
     RTPS_DllAPI uint64_t get_unread_count() const;
 
+    RTPS_DllAPI uint64_t get_unread_count(
+            bool mark_as_read);
+
     /**
      * @return True if the reader expects Inline QOS.
      */

--- a/src/cpp/fastdds/subscriber/DataReader.cpp
+++ b/src/cpp/fastdds/subscriber/DataReader.cpp
@@ -255,6 +255,12 @@ uint64_t DataReader::get_unread_count() const
     return impl_->get_unread_count(false);
 }
 
+uint64_t DataReader::get_unread_count(
+        bool mark_as_read) const
+{
+    return impl_->get_unread_count(mark_as_read);
+}
+
 const GUID_t& DataReader::guid()
 {
     return impl_->guid();

--- a/src/cpp/fastdds/subscriber/DataReader.cpp
+++ b/src/cpp/fastdds/subscriber/DataReader.cpp
@@ -252,7 +252,7 @@ ReturnCode_t DataReader::get_first_untaken_info(
 
 uint64_t DataReader::get_unread_count() const
 {
-    return impl_->get_unread_count();
+    return impl_->get_unread_count(false);
 }
 
 const GUID_t& DataReader::guid()

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -710,9 +710,10 @@ ReturnCode_t DataReaderImpl::get_first_untaken_info(
     return ReturnCode_t::RETCODE_NO_DATA;
 }
 
-uint64_t DataReaderImpl::get_unread_count() const
+uint64_t DataReaderImpl::get_unread_count(
+        bool mark_as_read)
 {
-    return reader_ ? reader_->get_unread_count() : 0;
+    return reader_ ? history_.get_unread_count(mark_as_read) : 0;
 }
 
 const GUID_t& DataReaderImpl::guid() const

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -196,9 +196,14 @@ public:
             SampleInfo* info);
 
     /**
-     * @return the number of samples pending to be read.
+     * Get the number of samples pending to be read.
+     *
+     * @param mark_as_read  Whether the unread samples should be marked as read or not.
+     *
+     * @return the number of samples on the reader history that have never been read.
      */
-    uint64_t get_unread_count() const;
+    uint64_t get_unread_count(
+            bool mark_as_read);
 
     /**
      * Get associated GUID

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
@@ -545,6 +545,12 @@ bool DataReaderHistory::get_next_deadline(
     return true;
 }
 
+uint64_t DataReaderHistory::get_unread_count(
+        bool mark_as_read)
+{
+    return mp_reader->get_unread_count(mark_as_read);
+}
+
 std::pair<bool, DataReaderHistory::instance_info> DataReaderHistory::lookup_instance(
         const InstanceHandle_t& handle,
         bool exact) const

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
@@ -215,6 +215,16 @@ public:
             std::chrono::steady_clock::time_point& next_deadline_us);
 
     /**
+     * Get the number of samples pending to be read.
+     *
+     * @param mark_as_read  Whether the unread samples should be marked as read or not.
+     *
+     * @return the number of samples on the reader history that have never been read.
+     */
+    uint64_t get_unread_count(
+            bool mark_as_read);
+
+    /**
      * @brief Get the list of changes corresponding to an instance handle.
      * @param handle The handle to the instance.
      * @param exact  Indicates if the handle should match exactly (true) or if the first instance greater than the

--- a/src/cpp/rtps/reader/RTPSReader.cpp
+++ b/src/cpp/rtps/reader/RTPSReader.cpp
@@ -375,13 +375,16 @@ uint64_t RTPSReader::get_unread_count(
 
     if (mark_as_read)
     {
-        for (auto it = mp_history->changesBegin(); it != mp_history->changesEnd(); ++it)
+        for (auto it = mp_history->changesBegin(); 0 < total_unread_ && it != mp_history->changesEnd(); ++it)
         {
             CacheChange_t* change = *it;
-            change->isRead = false;
+            if (!change->isRead)
+            {
+                change->isRead = true;
+                --total_unread_;
+            }
         }
-
-        total_unread_ = 0;
+        assert(0 == total_unread_);
     }
     return ret_val;
 }

--- a/src/cpp/rtps/reader/RTPSReader.cpp
+++ b/src/cpp/rtps/reader/RTPSReader.cpp
@@ -383,7 +383,7 @@ uint64_t RTPSReader::get_unread_count(
 
         total_unread_ = 0;
     }
-    return total_unread_;
+    return ret_val;
 }
 
 bool RTPSReader::is_datasharing_compatible_with(

--- a/src/cpp/rtps/reader/RTPSReader.cpp
+++ b/src/cpp/rtps/reader/RTPSReader.cpp
@@ -367,6 +367,25 @@ uint64_t RTPSReader::get_unread_count() const
     return total_unread_;
 }
 
+uint64_t RTPSReader::get_unread_count(
+        bool mark_as_read)
+{
+    std::unique_lock<RecursiveTimedMutex> lock(mp_mutex);
+    uint64_t ret_val = total_unread_;
+
+    if (mark_as_read)
+    {
+        for (auto it = mp_history->changesBegin(); it != mp_history->changesEnd(); ++it)
+        {
+            CacheChange_t* change = *it;
+            change->isRead = false;
+        }
+
+        total_unread_ = 0;
+    }
+    return total_unread_;
+}
+
 bool RTPSReader::is_datasharing_compatible_with(
         const WriterProxyData& wdata)
 {

--- a/test/mock/rtps/RTPSReader/fastdds/rtps/reader/RTPSReader.h
+++ b/test/mock/rtps/RTPSReader/fastdds/rtps/reader/RTPSReader.h
@@ -115,6 +115,8 @@ public:
 
     MOCK_METHOD0(get_unread_count, uint64_t());
 
+    MOCK_METHOD1(get_unread_count, uint64_t(bool));
+
     MOCK_METHOD1(set_content_filter, void (eprosima::fastdds::rtps::IReaderDataFilter* filter));
 
     // *INDENT-ON*

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -1599,14 +1599,24 @@ TEST_F(DataReaderTests, get_unread_count)
         EXPECT_EQ(num_samples_check, data_reader_->get_unread_count());
     }
 
+    SampleInfo sample_info;
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, data_reader_->get_first_untaken_info(&sample_info));
+    ASSERT_EQ(SampleStateKind::NOT_READ_SAMPLE_STATE, sample_info.sample_state);
+
     // Calling get_unread_count(false) several times should always return the same value
     for (char i = 0; i < num_samples; ++i)
     {
         EXPECT_EQ(num_samples_check, data_reader_->get_unread_count(false));
     }
 
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, data_reader_->get_first_untaken_info(&sample_info));
+    ASSERT_EQ(SampleStateKind::NOT_READ_SAMPLE_STATE, sample_info.sample_state);
+
     // Calling get_unread_count(true) once will return the correct value
     EXPECT_EQ(num_samples_check, data_reader_->get_unread_count(true));
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, data_reader_->get_first_untaken_info(&sample_info));
+    ASSERT_EQ(SampleStateKind::READ_SAMPLE_STATE, sample_info.sample_state);
 
     // All variants should then return 0
     EXPECT_EQ(0, data_reader_->get_unread_count(true));


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR adds an overload of `DataReader::get_unread_count` that receives a boolean indicating whether the unread changes should be marked as read.

This allows the application to implement a pattern where the number of newly available samples is obtained inside `on_data_available()`.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
