### PR TITLE
[15155] Fixed validation on ParameterPropertyList_t

### DIFF
--- a/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
@@ -672,7 +672,7 @@ inline bool ParameterSerializer<ParameterPropertyList_t>::read_content_from_cdr_
     //Nproperties_ = num_properties;
 
     uint32_t length_diff = cdr_message->pos - pos_ref;
-    valid &= (parameter_length == length_diff);
+    valid &= (parameter_length >= length_diff);
     return valid;
 }
 

--- a/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
+++ b/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
@@ -15,8 +15,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <fastrtps/rtps/builtin/data/WriterProxyData.h>
+#include <fastrtps/rtps/builtin/data/ParticipantProxyData.h>
 #include <fastrtps/rtps/builtin/data/ReaderProxyData.h>
+#include <fastrtps/rtps/builtin/data/WriterProxyData.h>
 #include <fastrtps/rtps/network/NetworkFactory.h>
 #include <fastdds/core/policy/ParameterSerializer.hpp>
 
@@ -345,6 +346,83 @@ TEST(BuiltinDataSerializationTests, ignore_unsupported_type_object)
         WriterProxyData out(max_unicast_locators, max_multicast_locators);
         EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, network, false)));
     }
+}
+
+TEST(BuiltinDataSerializationTests, property_list_with_binary_properties)
+{
+    octet data_p_buffer[] =
+    {
+        // Encapsulation
+        0x00, 0x03, 0x00, 0x00,
+
+        // PID_PROPERTY_LIST
+        0x59, 0, 104, 0,
+        // 3 properties
+        0x03, 0x00, 0x00, 0x00,
+        // key-1
+        0x0e, 0x00, 0x00, 0x00,
+        0x5f, 0x5f, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x4e, 0x61, 0x6d, 0x65, 0x00, 0x00, 0x00,
+        // value-1
+        0x07, 0x00, 0x00, 0x00,
+        0x74, 0x61, 0x6c, 0x6b, 0x65, 0x72, 0x00, 0x00,
+        // key-2
+        0x06, 0x00, 0x00, 0x00,
+        0x5f, 0x5f, 0x50, 0x69, 0x64, 0x00, 0x00, 0x00,
+        // value-2
+        0x05, 0x00, 0x00, 0x00,
+        0x32, 0x35, 0x31, 0x39, 0x00, 0x00, 0x00, 0x00,
+        // key-3
+        0x0b, 0x00, 0x00, 0x00,
+        0x5f, 0x5f, 0x48, 0x6f, 0x73, 0x74, 0x6e, 0x61, 0x6d, 0x65, 0x00, 0x00,
+        // value-3
+        0x11, 0x00, 0x00, 0x00,
+        0x6e, 0x6f, 0x6e, 0x5f, 0x77, 0x6f, 0x72, 0x6b, 0x69, 0x6e, 0x67, 0x5f, 0x68, 0x61, 0x73, 0x68,
+        0x00, 0x00, 0x00, 0x00,
+        // 0 binary properties
+        0x00, 0x00, 0x00, 0x00,
+
+        // PID_PROTOCOL_VERSION
+        0x15, 0, 4, 0,
+        2, 1, 0, 0,
+
+        // PID_VENDORID
+        0x16, 0, 4, 0,
+        1, 16, 0, 0,
+
+        // PID_PARTICIPANT_LEASE_DURATION
+        0x02, 0, 8, 0,
+        10, 0, 0, 0, 0, 0, 0, 0,
+
+        // PID_PARTICIPANT_GUID
+        0x50, 0, 16, 0,
+        1, 16, 54, 83, 136, 247, 149, 252, 47, 105, 174, 141, 0, 0, 1, 193,
+
+        // PID_BUILTIN_ENDPOINT_SET
+        0x58, 0, 4, 0,
+        63, 12, 0, 0,
+
+        // PID_DOMAIN_ID
+        0x0f, 0, 4, 0,
+        0, 0, 0, 0,
+
+        // PID_DEFAULT_UNICAST_LOCATOR
+        0x31, 0, 24, 0,
+        1, 0, 0, 0, 68, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 31, 133, 54,
+
+        // PID_METATRAFFIC_UNICAST_LOCATOR
+        0x32, 0, 24, 0,
+        1, 0, 0, 0, 68, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 31, 133, 54,
+
+        // PID_SENTINEL
+        0x01, 0, 0, 0
+    };
+
+    CDRMessage_t msg(0);
+    msg.init(data_p_buffer, static_cast<uint32_t>(sizeof(data_p_buffer)));
+    msg.length = msg.max_size;
+
+    ParticipantProxyData out(RTPSParticipantAllocationAttributes{});
+    EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, true, network, false)));
 }
 
 /*!

--- a/test/unittest/rtps/builtin/CMakeLists.txt
+++ b/test/unittest/rtps/builtin/CMakeLists.txt
@@ -21,9 +21,13 @@ set(BUILTIN_DATA_SERIALIZATION_TESTS_SOURCE BuiltinDataSerializationTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/policy/ParameterList.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/publisher/qos/WriterQos.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/subscriber/qos/ReaderQos.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/data/WriterProxyData.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/flowcontrol/FlowControllerConsts.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/ResourceEvent.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEvent.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEventImpl.cpp
 
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
 
@@ -54,6 +58,7 @@ set(BUILTIN_DATA_SERIALIZATION_TESTS_SOURCE BuiltinDataSerializationTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPLocator.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/utils/md5.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/utils/string_convert.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/utils/TimedConditionVariable.cpp
     )
 
 if(WIN32)


### PR DESCRIPTION
Signed-off-by: Miguel Company <MiguelCompany@eprosima.com>

<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
A parameter on a parameter list should not be considered invalid if its length is greater than expected.
This should fix interoperability issues like [this one](https://github.com/eclipse-cyclonedds/cyclonedds/issues/1328)

Draft till we add a test

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should also be merged.
    Please uncomment the following line with the corresponding branches.
-->
@Mergifyio backport 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
    - [x] Only the new test has been run
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
