### PR TITLE
Improve rediscovery on lossy environments [15165]

### DIFF
--- a/src/cpp/rtps/reader/WriterProxy.cpp
+++ b/src/cpp/rtps/reader/WriterProxy.cpp
@@ -468,23 +468,26 @@ bool WriterProxy::perform_initial_ack_nack()
 {
     bool ret_value = false;
 
-    // Send initial NACK.
-    SequenceNumberSet_t sns(SequenceNumber_t(0, 0));
-    if (is_on_same_process_)
+    if (!is_datasharing_writer_)
     {
-        RTPSWriter* writer = RTPSDomainImpl::find_local_writer(guid());
-        if (writer)
+        // Send initial NACK.
+        SequenceNumberSet_t sns(SequenceNumber_t(0, 0));
+        if (is_on_same_process_)
         {
-            bool tmp;
-            writer->process_acknack(guid(), reader_->getGuid(), 1, SequenceNumberSet_t(), false, tmp);
+            RTPSWriter* writer = RTPSDomainImpl::find_local_writer(guid());
+            if (writer)
+            {
+                bool tmp;
+                writer->process_acknack(guid(), reader_->getGuid(), 1, SequenceNumberSet_t(), false, tmp);
+            }
         }
-    }
-    else
-    {
-        if (0 == last_heartbeat_count_)
+        else
         {
-            reader_->send_acknack(this, sns, this, false);
-            ret_value = true;
+            if (0 == last_heartbeat_count_)
+            {
+                reader_->send_acknack(this, sns, this, false);
+                ret_value = true;
+            }
         }
     }
 

--- a/src/cpp/rtps/reader/WriterProxy.cpp
+++ b/src/cpp/rtps/reader/WriterProxy.cpp
@@ -481,7 +481,7 @@ bool WriterProxy::perform_initial_ack_nack()
     }
     else
     {
-        if (last_heartbeat_count_ == 0)
+        if (0 == last_heartbeat_count_)
         {
             reader_->send_acknack(this, sns, this, false);
             ret_value = true;

--- a/src/cpp/rtps/reader/WriterProxy.h
+++ b/src/cpp/rtps/reader/WriterProxy.h
@@ -234,7 +234,7 @@ public:
     /**
      * Sends a preemptive acknack to the writer represented by this proxy.
      */
-    void perform_initial_ack_nack();
+    bool perform_initial_ack_nack();
 
     /**
      * Sends the necessary acknac and nackfrag messages to answer the last received heartbeat message.

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1911,6 +1911,7 @@ bool StatefulWriter::process_acknack(
                                         {
                                             // Send heartbeat if requested
                                             send_heartbeat_to_nts(*remote_reader, false, true);
+                                            periodic_hb_event_->restart_timer();
                                         }
                                     }
 


### PR DESCRIPTION
## Description

In lossy environments one participant can drop another one due to exceed the lease duration. We found that in the
process of rediscovering the dropped participant, the PDP works but the EDP could fail. The corner cases where this
could happen are:

1. First initial ACKNACK (preemptive ACKNACK) is lost and the remote EDP builtin datawriter not reload the information.
2. Initial ACKNACK is received, the remote EDP builtin datawriter answer with a HEARTBEAT, and this message is answered
   with a normal ACKNACK which is lost. Never again a HEARTBEAT is sent.

To fix these corner cases this PR adds:

1. Send recursively the preemptive ACKNACK until a HEARTBEAT is received.
2. The reception of a preemptive ACKNACK causes sending a HEARTBEAT message but also restart the periodic heartbeat
   event.

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
