### PR TITLE
[15168] Notify changes in bulk on RTPS readers

### DIFF
--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
@@ -29,6 +29,8 @@
 #include <fastdds/rtps/reader/RTPSReader.h>
 
 #include <fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp>
+
+#include <rtps/common/ChangeComparison.hpp>
 #include <rtps/reader/WriterProxy.h>
 #include <utils/collections/sorted_vector_insert.hpp>
 
@@ -338,11 +340,7 @@ void DataReaderHistory::add_to_instance(
 {
     // ADD TO KEY VECTOR
     DataReaderCacheChange item = a_change;
-    eprosima::utilities::collections::sorted_vector_insert(instance.cache_changes, item,
-            [](const DataReaderCacheChange& lhs, const DataReaderCacheChange& rhs)
-            {
-                return lhs->sourceTimestamp < rhs->sourceTimestamp;
-            });
+    eprosima::utilities::collections::sorted_vector_insert(instance.cache_changes, item, rtps::history_order_cmp);
     data_available_instances_[a_change->instanceHandle] = instances_[a_change->instanceHandle];
 
     logInfo(SUBSCRIBER, mp_reader->getGuid().entityId

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -28,6 +28,8 @@
 #include <fastdds/rtps/reader/RTPSReader.h>
 
 #include <fastrtps_deprecated/subscriber/SubscriberImpl.h>
+
+#include <rtps/common/ChangeComparison.hpp>
 #include <rtps/reader/WriterProxy.h>
 #include <utils/collections/sorted_vector_insert.hpp>
 
@@ -348,10 +350,7 @@ bool SubscriberHistory::add_received_change_with_key(
 
         //ADD TO KEY VECTOR
         eprosima::utilities::collections::sorted_vector_insert(instance_changes, a_change,
-                [](const CacheChange_t* lhs, const CacheChange_t* rhs)
-                {
-                    return lhs->sourceTimestamp < rhs->sourceTimestamp;
-                });
+                fastdds::rtps::history_order_cmp);
 
         logInfo(SUBSCRIBER, mp_reader->getGuid().entityId
                 << ": Change " << a_change->sequenceNumber << " added from: "
@@ -745,10 +744,7 @@ bool SubscriberHistory::completed_change_keep_all_with_key(
             {
                 //ADD TO KEY VECTOR
                 eprosima::utilities::collections::sorted_vector_insert(instance_changes, a_change,
-                        [](const CacheChange_t* lhs, const CacheChange_t* rhs)
-                        {
-                            return lhs->sourceTimestamp < rhs->sourceTimestamp;
-                        });
+                        fastdds::rtps::history_order_cmp);
                 ret_value = true;
 
                 logInfo(SUBSCRIBER, mp_reader->getGuid().entityId
@@ -804,10 +800,7 @@ bool SubscriberHistory::completed_change_keep_last_with_key(
             {
                 //ADD TO KEY VECTOR
                 eprosima::utilities::collections::sorted_vector_insert(instance_changes, a_change,
-                        [](const CacheChange_t* lhs, const CacheChange_t* rhs)
-                        {
-                            return lhs->sourceTimestamp < rhs->sourceTimestamp;
-                        });
+                        fastdds::rtps::history_order_cmp);
                 ret_value = true;
 
                 logInfo(SUBSCRIBER, mp_reader->getGuid().entityId

--- a/src/cpp/rtps/common/ChangeComparison.hpp
+++ b/src/cpp/rtps/common/ChangeComparison.hpp
@@ -1,0 +1,41 @@
+// Copyright 2022 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file ChangeComparison.hpp
+ */
+
+#ifndef _RTPS_COMMON_CHANGECOMPARISON_HPP
+#define _RTPS_COMMON_CHANGECOMPARISON_HPP
+
+#include <fastdds/rtps/common/CacheChange.h>
+
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+
+inline bool history_order_cmp(
+        const eprosima::fastrtps::rtps::CacheChange_t* lhs,
+        const eprosima::fastrtps::rtps::CacheChange_t* rhs)
+{
+    return lhs->writerGUID == rhs->writerGUID ?
+           lhs->sequenceNumber < rhs->sequenceNumber :
+           lhs->sourceTimestamp < rhs->sourceTimestamp;
+}
+
+} /* namespace rtps */
+} /* namespace fastdds */
+} /* namespace eprosima */
+
+#endif  // _RTPS_COMMON_CHANGECOMPARISON_HPP

--- a/src/cpp/rtps/history/ReaderHistory.cpp
+++ b/src/cpp/rtps/history/ReaderHistory.cpp
@@ -24,6 +24,7 @@
 #include <fastdds/rtps/reader/RTPSReader.h>
 #include <fastdds/rtps/reader/ReaderListener.h>
 
+#include <rtps/common/ChangeComparison.hpp>
 #include <utils/collections/sorted_vector_insert.hpp>
 
 #include <mutex>
@@ -103,11 +104,7 @@ bool ReaderHistory::add_change(
         logError(RTPS_READER_HISTORY, "The Writer GUID_t must be defined");
     }
 
-    eprosima::utilities::collections::sorted_vector_insert(m_changes, a_change,
-            [](const CacheChange_t* lhs, const CacheChange_t* rhs)
-            {
-                return lhs->sourceTimestamp < rhs->sourceTimestamp;
-            });
+    eprosima::utilities::collections::sorted_vector_insert(m_changes, a_change, fastdds::rtps::history_order_cmp);
     logInfo(RTPS_READER_HISTORY,
             "Change " << a_change->sequenceNumber << " added with " << a_change->serializedPayload.length << " bytes");
 

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -1089,48 +1089,61 @@ bool StatefulReader::change_received(
 void StatefulReader::NotifyChanges(
         WriterProxy* prox)
 {
+    CacheChange_t* aux_ch = nullptr;
     GUID_t proxGUID = prox->guid();
     SequenceNumber_t max_seq = prox->available_changes_max();
-    update_last_notified(proxGUID, max_seq);
-    SequenceNumber_t nextChangeToNotify = prox->next_cache_change_to_be_notified();
+    SequenceNumber_t first_seq = prox->next_cache_change_to_be_notified();
 
+    bool new_data_available = false;
+
+    // Update state before notifying
+    update_last_notified(proxGUID, max_seq);
+    History::const_iterator it = mp_history->changesBegin();
+    SequenceNumber_t next_seq = first_seq;
+    while (next_seq != c_SequenceNumber_Unknown &&
+            mp_history->changesEnd() != (it = mp_history->get_change_nts(next_seq, proxGUID, &aux_ch, it)) &&
+            (*it)->sequenceNumber <= max_seq)
+    {
+        aux_ch = *it;
+        assert(false == aux_ch->isRead);
+        new_data_available = true;
+        ++total_unread_;
+        on_data_notify(proxGUID, aux_ch->sourceTimestamp);
+
+        ++it;
+        do
+        {
+            next_seq = prox->next_cache_change_to_be_notified();
+        } while (next_seq != c_SequenceNumber_Unknown && next_seq <= aux_ch->sequenceNumber);
+    }
+    // Ensure correct state of proxy when max_seq is not present in history
+    while (c_SequenceNumber_Unknown != prox->next_cache_change_to_be_notified())
+    {
+    }
+
+    // Notify listener if new data is available
     auto listener = getListener();
-    bool notify_individual = false;
-    bool new_data_available = (nextChangeToNotify != SequenceNumber_t::unknown()) &&
-            (max_seq >= nextChangeToNotify);
     if (new_data_available && (nullptr != listener))
     {
-        listener->on_data_available(this, proxGUID, nextChangeToNotify, max_seq, notify_individual);
-    }
+        bool notify_individual = false;
+        listener->on_data_available(this, proxGUID, first_seq, max_seq, notify_individual);
 
-    while (nextChangeToNotify != SequenceNumber_t::unknown())
-    {
-        CacheChange_t* ch_to_give = nullptr;
-
-        if (mp_history->get_change(nextChangeToNotify, proxGUID, &ch_to_give))
+        if (notify_individual)
         {
-            if (!ch_to_give->isRead)
+            it = mp_history->changesBegin();
+            next_seq = first_seq;
+            while (next_seq <= max_seq &&
+                    mp_history->changesEnd() != (it = mp_history->get_change_nts(next_seq, proxGUID, &aux_ch, it)) &&
+                    (*it)->sequenceNumber <= max_seq)
             {
-                ++total_unread_;
-
-                on_data_notify(ch_to_give->writerGUID, ch_to_give->sourceTimestamp);
-
-                if (notify_individual && (nullptr != listener))
-                {
-                    listener->onNewCacheChangeAdded((RTPSReader*)this, ch_to_give);
-                }
+                aux_ch = *it;
+                next_seq = aux_ch->sequenceNumber + 1;
+                listener->onNewCacheChangeAdded(this, aux_ch);
             }
         }
-
-        // Search again the WriterProxy because could be removed after the unlock.
-        if (!findWriterProxy(proxGUID, &prox))
-        {
-            break;
-        }
-
-        nextChangeToNotify = prox->next_cache_change_to_be_notified();
     }
 
+    // Notify in case someone is waiting for unread messages
     if (new_data_available)
     {
         new_notification_cv_.notify_all();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR implements calls to the new `on_data_available` callback of `rtps::ReaderListener`
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
