### PR TITLE
Fix acknowledge in Datasharing

### DIFF
--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -930,6 +930,17 @@ bool StatefulReader::change_removed_by_history(
                     --total_unread_;
                 }
 
+                WriterProxy* proxy = wp;
+
+                if (nullptr == proxy)
+                {
+                    if (!findWriterProxy(a_change->writerGUID, &proxy))
+                    {
+                        return false;
+                    }
+
+                    send_ack_if_datasharing(this, mp_history, proxy, a_change->sequenceNumber);
+                }
             }
         }
         else

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -929,18 +929,18 @@ bool StatefulReader::change_removed_by_history(
                 {
                     --total_unread_;
                 }
+            }
 
-                WriterProxy* proxy = wp;
+            WriterProxy* proxy = wp;
 
-                if (nullptr == proxy)
+            if (nullptr == proxy)
+            {
+                if (!findWriterProxy(a_change->writerGUID, &proxy))
                 {
-                    if (!findWriterProxy(a_change->writerGUID, &proxy))
-                    {
-                        return false;
-                    }
-
-                    send_ack_if_datasharing(this, mp_history, proxy, a_change->sequenceNumber);
+                    return false;
                 }
+
+                send_ack_if_datasharing(this, mp_history, proxy, a_change->sequenceNumber);
             }
         }
         else

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -691,8 +691,13 @@ public:
     bool waitForAllAcked(
             const std::chrono::duration<_Rep, _Period>& max_wait)
     {
+        auto nsecs = std::chrono::duration_cast<std::chrono::nanoseconds>(max_wait);
+        auto secs = std::chrono::duration_cast<std::chrono::seconds>(nsecs);
+        nsecs -= secs;
+        eprosima::fastrtps::Duration_t timeout {static_cast<int32_t>(secs.count()),
+                                                static_cast<uint32_t>(nsecs.count())};
         return (ReturnCode_t::RETCODE_OK ==
-               datawriter_->wait_for_acknowledgments(eprosima::fastrtps::Time_t((int32_t)max_wait.count(), 0)));
+               datawriter_->wait_for_acknowledgments(timeout));
     }
 
     template<class _Rep,
@@ -703,9 +708,13 @@ public:
             const eprosima::fastrtps::rtps::InstanceHandle_t& instance_handle,
             const std::chrono::duration<_Rep, _Period>& max_wait)
     {
+        auto nsecs = std::chrono::duration_cast<std::chrono::nanoseconds>(max_wait);
+        auto secs = std::chrono::duration_cast<std::chrono::seconds>(nsecs);
+        nsecs -= secs;
+        eprosima::fastrtps::Duration_t timeout {static_cast<int32_t>(secs.count()),
+                                                static_cast<uint32_t>(nsecs.count())};
         return (ReturnCode_t::RETCODE_OK ==
-               datawriter_->wait_for_acknowledgments(data, instance_handle,
-               eprosima::fastrtps::Time_t(static_cast<int32_t>(max_wait.count()), 0)));
+               datawriter_->wait_for_acknowledgments(data, instance_handle, timeout));
     }
 
     void block_until_discover_topic(

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
@@ -576,7 +576,12 @@ public:
     bool waitForAllAcked(
             const std::chrono::duration<_Rep, _Period>& max_wait)
     {
-        return publisher_->wait_for_all_acked(eprosima::fastrtps::Time_t((int32_t)max_wait.count(), 0));
+        auto nsecs = std::chrono::duration_cast<std::chrono::nanoseconds>(max_wait);
+        auto secs = std::chrono::duration_cast<std::chrono::seconds>(nsecs);
+        nsecs -= secs;
+        eprosima::fastrtps::Duration_t timeout {static_cast<int32_t>(secs.count()),
+                                                static_cast<uint32_t>(nsecs.count())};
+        return publisher_->wait_for_all_acked(timeout);
     }
 
     void block_until_discover_topic(

--- a/test/blackbox/common/DDSBlackboxTestsDataSharing.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataSharing.cpp
@@ -892,6 +892,7 @@ TEST(DDSDataSharing, acknack_reception_when_get_unread_count)
 
     reader.startReception(data_recv);
     reader.block_for_all();
+    now = std::chrono::steady_clock::now();
     writer.waitForAllAcked(std::chrono::milliseconds(2000));
     ASSERT_LT(std::chrono::steady_clock::now() - now, std::chrono::milliseconds(1900));
 

--- a/test/blackbox/common/DDSBlackboxTestsDataSharing.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataSharing.cpp
@@ -54,6 +54,7 @@ TEST(DDSDataSharing, BasicCommunication)
 
     reader.history_depth(100)
             .add_user_transport_to_pparams(testTransport)
+            .disable_builtin_transport()
             .datasharing_on(".").loan_sample_validation()
             .reliability(BEST_EFFORT_RELIABILITY_QOS).init();
 
@@ -61,6 +62,7 @@ TEST(DDSDataSharing, BasicCommunication)
 
     writer.history_depth(100)
             .add_user_transport_to_pparams(testTransport)
+            .disable_builtin_transport()
             .datasharing_on(".")
             .reliability(BEST_EFFORT_RELIABILITY_QOS).init();
 
@@ -109,6 +111,7 @@ TEST(DDSDataSharing, TransientReader)
 
     writer.history_depth(writer_history_depth)
             .add_user_transport_to_pparams(testTransport)
+            .disable_builtin_transport()
             .datasharing_on(".")
             .reliability(BEST_EFFORT_RELIABILITY_QOS).init();
 
@@ -130,6 +133,7 @@ TEST(DDSDataSharing, TransientReader)
 
     reader.history_depth(writer_sent_data)
             .add_user_transport_to_pparams(testTransport)
+            .disable_builtin_transport()
             .datasharing_on(".")
             .reliability(BEST_EFFORT_RELIABILITY_QOS)
             .durability_kind(TRANSIENT_LOCAL_DURABILITY_QOS).init();
@@ -172,6 +176,7 @@ TEST(DDSDataSharing, BestEffortDirtyPayloads)
 
     writer.history_depth(writer_history_depth)
             .add_user_transport_to_pparams(testTransport)
+            .disable_builtin_transport()
             .datasharing_on(".")
             .reliability(BEST_EFFORT_RELIABILITY_QOS)
             .resource_limits_extra_samples(1).init();
@@ -180,6 +185,7 @@ TEST(DDSDataSharing, BestEffortDirtyPayloads)
 
     read_reader.history_depth(writer_sent_data)
             .add_user_transport_to_pparams(testTransport)
+            .disable_builtin_transport()
             .datasharing_on(".")
             .reliability(BEST_EFFORT_RELIABILITY_QOS).init();
 
@@ -232,6 +238,7 @@ TEST(DDSDataSharing, ReliableDirtyPayloads)
 
     writer.history_depth(writer_history_depth)
             .add_user_transport_to_pparams(testTransport)
+            .disable_builtin_transport()
             .datasharing_on(".")
             .reliability(RELIABLE_RELIABILITY_QOS)
             .resource_limits_extra_samples(1).init();
@@ -240,6 +247,7 @@ TEST(DDSDataSharing, ReliableDirtyPayloads)
 
     read_reader.history_depth(writer_sent_data)
             .add_user_transport_to_pparams(testTransport)
+            .disable_builtin_transport()
             .datasharing_on(".")
             .reliability(RELIABLE_RELIABILITY_QOS).init();
 
@@ -657,6 +665,7 @@ TEST(DDSDataSharing, DataSharingDefaultDirectory)
 
     reader.history_depth(100)
             .add_user_transport_to_pparams(testTransport)
+            .disable_builtin_transport()
             .datasharing_auto()
             .reliability(BEST_EFFORT_RELIABILITY_QOS).init();
 
@@ -664,6 +673,7 @@ TEST(DDSDataSharing, DataSharingDefaultDirectory)
 
     writer.history_depth(100)
             .add_user_transport_to_pparams(testTransport)
+            .disable_builtin_transport()
             .datasharing_auto()
             .reliability(BEST_EFFORT_RELIABILITY_QOS).init();
 
@@ -683,4 +693,67 @@ TEST(DDSDataSharing, DataSharingDefaultDirectory)
     ASSERT_TRUE(data.empty());
     // Block reader until reception finished or timeout.
     reader.block_for_all();
+}
+
+/*!
+ * @test Regression test for bug #15176.
+ */
+TEST(DDSDataSharing, acknack_reception_when_change_removed_by_history)
+{
+    PubSubReader<FixedSizedPubSubType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<FixedSizedPubSubType> writer(TEST_TOPIC_NAME);
+
+    // Disable transports to ensure we are using datasharing
+    auto testTransport = std::make_shared<test_UDPv4TransportDescriptor>();
+    testTransport->dropDataMessagesPercentage = 100;
+
+    writer.history_depth(100)
+            .add_user_transport_to_pparams(testTransport)
+            .disable_builtin_transport()
+            .datasharing_on(".")
+            .reliability(RELIABLE_RELIABILITY_QOS)
+            .lifespan_period({5, 0})
+            .init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    reader.history_depth(100)
+            .add_user_transport_to_pparams(testTransport)
+            .disable_builtin_transport()
+            .datasharing_on(".").loan_sample_validation()
+            .reliability(RELIABLE_RELIABILITY_QOS)
+            .durability_kind(TRANSIENT_LOCAL_DURABILITY_QOS)
+            .lifespan_period({0, 10})
+            .init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Because its volatile the durability
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    auto data = default_fixed_sized_data_generator(10);
+
+    // Send data
+    writer.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+
+    // Check that the shared files are created on the correct directory
+    ASSERT_TRUE(check_shared_file(".", reader.datareader_guid()));
+    ASSERT_TRUE(check_shared_file(".", writer.datawriter_guid()));
+
+    reader.startReception(data);
+    auto now = std::chrono::steady_clock::now();
+    writer.waitForAllAcked(std::chrono::milliseconds(10000));
+    ASSERT_LT(std::chrono::steady_clock::now() - now, std::chrono::milliseconds(5000));
+
+    // Destroy reader and writer and see if there are dangling files
+    reader.destroy();
+    writer.destroy();
+
+    // Check that the shared files are created on the correct directory
+    ASSERT_FALSE(check_shared_file(".", reader.datareader_guid()));
+    ASSERT_FALSE(check_shared_file(".", writer.datawriter_guid()));
 }


### PR DESCRIPTION
## Description

Implementing Ownership it was detected this bug. A change removed by history (and not read yet by user) is not being
acked correctly.

This PR fixes this.

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
