### PR TITLE
Fix wrong usage of std::remove_if [15204]

### DIFF
--- a/include/fastdds/rtps/history/ReaderHistory.h
+++ b/include/fastdds/rtps/history/ReaderHistory.h
@@ -221,10 +221,17 @@ protected:
         assert(nullptr != mp_mutex);
 
         std::lock_guard<RecursiveTimedMutex> guard(*mp_mutex);
-        std::vector<CacheChange_t*>::iterator new_end = std::remove_if(m_changes.begin(), m_changes.end(), pred);
-        while (new_end != m_changes.end())
+        std::vector<CacheChange_t*>::iterator chit = m_changes.begin();
+        while (chit != m_changes.end())
         {
-            new_end = remove_change_nts(new_end);
+            if (pred(*chit))
+            {
+                chit = remove_change_nts(chit);
+            }
+            else
+            {
+                ++chit;
+            }
         }
     }
 

--- a/src/cpp/rtps/history/CacheChangePool.cpp
+++ b/src/cpp/rtps/history/CacheChangePool.cpp
@@ -106,6 +106,7 @@ void CacheChangePool::return_cache_to_pool(
     ch->setFragmentSize(0);
     ch->inline_qos.pos = 0;
     ch->inline_qos.length = 0;
+    assert(free_caches_.end() == std::find(free_caches_.begin(), free_caches_.end(), ch));
     free_caches_.push_back(ch);
 }
 


### PR DESCRIPTION
## Description

Function `ReaderHistory::remove_changes_with_pred()` is using `std::remove_if` in a wrong way. According to the
standard `std::remove_if` uses moveable assigments and the returned iterators contains unexpected data.

But this function is used the returned iterators to release CacheChanges and it is releasing wrong ones.

This PR fixes this.

This PR also fixes issue #2533.

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
