### PR TITLE
Get WAN address API in TCPv4 transport descriptors

### DIFF
--- a/include/fastdds/rtps/transport/TCPv4TransportDescriptor.h
+++ b/include/fastdds/rtps/transport/TCPv4TransportDescriptor.h
@@ -73,7 +73,10 @@ struct TCPv4TransportDescriptor : public TCPTransportDescriptor
     std::string get_WAN_address()
     {
         std::stringstream ss;
-        ss << wan_addr[0] << "." << wan_addr[1] << "." << wan_addr[2] << "." << wan_addr[3];
+        ss << static_cast<int>(wan_addr[0]) << "."
+           << static_cast<int>(wan_addr[1]) << "."
+           << static_cast<int>(wan_addr[2]) << "."
+           << static_cast<int>(wan_addr[3]);
         return ss.str();
     }
 

--- a/include/fastdds/rtps/transport/TCPv4TransportDescriptor.h
+++ b/include/fastdds/rtps/transport/TCPv4TransportDescriptor.h
@@ -69,6 +69,14 @@ struct TCPv4TransportDescriptor : public TCPTransportDescriptor
         wan_addr[3] = (fastrtps::rtps::octet)d;
     }
 
+    //! Get the public IP address
+    std::string get_WAN_address()
+    {
+        std::stringstream ss;
+        ss << wan_addr[0] << "." << wan_addr[1] << "." << wan_addr[2] << "." << wan_addr[3];
+        return ss.str();
+    }
+
     //! Constructor
     RTPS_DllAPI TCPv4TransportDescriptor();
 

--- a/test/blackbox/common/BlackboxTestsTransportTCP.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportTCP.cpp
@@ -497,6 +497,15 @@ TEST_P(TransportTCP, TCPv4_copy)
     EXPECT_EQ(tcpv4_transport_copy, tcpv4_transport);
 }
 
+// Test get_WAN_address member function
+TEST_P(TransportTCP, TCPv4_get_WAN_address)
+{
+    // TCPv4TransportDescriptor
+    TCPv4TransportDescriptor tcpv4_transport;
+    tcpv4_transport.set_WAN_address("80.80.99.45");
+    ASSERT_EQ(tcpv4_transport.get_WAN_address(), "80.80.99.45");
+}
+
 // Test == operator for TCPv6
 TEST_P(TransportTCP, TCPv6_equal_operator)
 {

--- a/versions.md
+++ b/versions.md
@@ -1,6 +1,8 @@
 Forthcoming
 -----------
 
+* Added API get the WAN address of TCPv4 transport descriptors (API extension)
+
 Version 2.7.1
 -------------
 


### PR DESCRIPTION
Add function to `TCPv4TransportDescriptor` to get the WAN address. 

<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- ❌ Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A*: Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- *N/A*: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
