### PR TITLE
Fix datarace using writer's locator selectors [15289]

### DIFF
--- a/include/fastdds/rtps/writer/ReaderLocator.h
+++ b/include/fastdds/rtps/writer/ReaderLocator.h
@@ -79,12 +79,17 @@ public:
 
     const GUID_t& remote_guid() const
     {
-        return locator_info_.remote_guid;
+        return general_locator_info_.remote_guid;
     }
 
-    LocatorSelectorEntry* locator_selector_entry()
+    LocatorSelectorEntry* general_locator_selector_entry()
     {
-        return &locator_info_;
+        return &general_locator_info_;
+    }
+
+    LocatorSelectorEntry* async_locator_selector_entry()
+    {
+        return &async_locator_info_;
     }
 
     /**
@@ -153,7 +158,7 @@ public:
      */
     GuidPrefix_t destination_guid_prefix() const override
     {
-        return locator_info_.remote_guid.guidPrefix;
+        return general_locator_info_.remote_guid.guidPrefix;
     }
 
     /**
@@ -215,15 +220,15 @@ public:
 
     size_t locators_size() const
     {
-        if (locator_info_.remote_guid != c_Guid_Unknown && !is_local_reader_)
+        if (general_locator_info_.remote_guid != c_Guid_Unknown && !is_local_reader_)
         {
-            if (locator_info_.unicast.size() > 0)
+            if (general_locator_info_.unicast.size() > 0)
             {
-                return locator_info_.unicast.size();
+                return general_locator_info_.unicast.size();
             }
             else
             {
-                return locator_info_.multicast.size();
+                return general_locator_info_.multicast.size();
             }
         }
 
@@ -251,7 +256,8 @@ private:
 
     RTPSWriter* owner_;
     RTPSParticipantImpl* participant_owner_;
-    LocatorSelectorEntry locator_info_;
+    LocatorSelectorEntry general_locator_info_;
+    LocatorSelectorEntry async_locator_info_;
     bool expects_inline_qos_;
     bool is_local_reader_;
     RTPSReader* local_reader_;

--- a/include/fastdds/rtps/writer/ReaderProxy.h
+++ b/include/fastdds/rtps/writer/ReaderProxy.h
@@ -354,9 +354,14 @@ public:
     void update_nack_supression_interval(
             const Duration_t& interval);
 
-    LocatorSelectorEntry* locator_selector_entry()
+    LocatorSelectorEntry* general_locator_selector_entry()
     {
-        return locator_info_.locator_selector_entry();
+        return locator_info_.general_locator_selector_entry();
+    }
+
+    LocatorSelectorEntry* async_locator_selector_entry()
+    {
+        return locator_info_.async_locator_selector_entry();
     }
 
     RTPSMessageSenderInterface* message_sender()

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1069,8 +1069,8 @@ bool StatefulWriter::matched_reader_add(
 
     // Add info of new datareader.
     rp->start(rdata, is_datasharing_compatible_with(rdata));
-    locator_selector_general_.locator_selector.add_entry(rp->locator_selector_entry());
-    locator_selector_async_.locator_selector.add_entry(rp->locator_selector_entry());
+    locator_selector_general_.locator_selector.add_entry(rp->general_locator_selector_entry());
+    locator_selector_async_.locator_selector.add_entry(rp->async_locator_selector_entry());
 
     if (rp->is_local_reader())
     {

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -484,7 +484,7 @@ bool StatelessWriter::matched_reader_add(
             data.m_expectsInlineQos,
             is_datasharing_compatible_with(data));
 
-    locator_selector_.locator_selector.add_entry(new_reader->locator_selector_entry());
+    locator_selector_.locator_selector.add_entry(new_reader->general_locator_selector_entry());
 
     if (new_reader->is_local_reader())
     {

--- a/test/mock/rtps/ReaderLocator/fastdds/rtps/writer/ReaderLocator.h
+++ b/test/mock/rtps/ReaderLocator/fastdds/rtps/writer/ReaderLocator.h
@@ -65,7 +65,12 @@ public:
     {
     }
 
-    LocatorSelectorEntry* locator_selector_entry()
+    LocatorSelectorEntry* general_locator_selector_entry()
+    {
+        return nullptr;
+    }
+
+    LocatorSelectorEntry* async_locator_selector_entry()
     {
         return nullptr;
     }


### PR DESCRIPTION
## Description

Fix the TSAN warning.

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
