### PR TITLE
Add atomic variable to prevent datarace in FlowController

### DIFF
--- a/include/fastdds/rtps/common/CacheChange.h
+++ b/include/fastdds/rtps/common/CacheChange.h
@@ -20,6 +20,7 @@
 #define _FASTDDS_RTPS_CACHECHANGE_H_
 
 #include <cassert>
+#include <atomic>
 
 #include <fastdds/rtps/common/ChangeKind_t.hpp>
 #include <fastdds/rtps/common/FragmentNumber.h>
@@ -48,6 +49,8 @@ struct CacheChangeWriterInfo_t
     //! Used to link with next node in a list. Used by FlowControllerImpl.
     //! Cannot be cached because there are several comparisons without locking.
     CacheChange_t* volatile next = nullptr;
+    //! Used to know if the object is already in a list.
+    std::atomic_bool is_linked {false};
 };
 
 /*!

--- a/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp
+++ b/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp
@@ -129,10 +129,14 @@ private:
         void add_change(
                 fastrtps::rtps::CacheChange_t* change) noexcept
         {
-            change->writer_info.previous = tail.writer_info.previous;
-            change->writer_info.previous->writer_info.next = change;
-            tail.writer_info.previous = change;
-            change->writer_info.next = &tail;
+            bool expected = false;
+            if (change->writer_info.is_linked.compare_exchange_strong(expected, true))
+            {
+                change->writer_info.previous = tail.writer_info.previous;
+                change->writer_info.previous->writer_info.next = change;
+                tail.writer_info.previous = change;
+                change->writer_info.next = &tail;
+            }
         }
 
         void add_list(
@@ -1101,8 +1105,7 @@ private:
             fastrtps::rtps::CacheChange_t* change,
             const std::chrono::time_point<std::chrono::steady_clock>& /* TODO max_blocking_time*/)
     {
-        assert(nullptr == change->writer_info.previous &&
-                nullptr == change->writer_info.next);
+        assert(!change->writer_info.is_linked.load());
         // Sync delivery failed. Try to store for asynchronous delivery.
         std::unique_lock<std::mutex> lock(async_mode.changes_interested_mutex);
         sched.add_new_sample(writer, change);
@@ -1177,13 +1180,7 @@ private:
             fastrtps::rtps::CacheChange_t* change,
             const std::chrono::time_point<std::chrono::steady_clock>& /* TODO max_blocking_time*/)
     {
-        // This comparison is thread-safe, because we ensure the change to a problematic state is always protected for
-        // its writer's mutex.
-        // Problematic states:
-        // - Being added: change both pointers from nullptr to a pointer values.
-        // - Being removed: change both pointer from pointer values to nullptr.
-        if (nullptr == change->writer_info.previous &&
-                nullptr == change->writer_info.next)
+        if (!change->writer_info.is_linked.load())
         {
             std::unique_lock<std::mutex> lock(async_mode.changes_interested_mutex);
             sched.add_old_sample(writer, change);
@@ -1218,13 +1215,7 @@ private:
     remove_change_impl(
             fastrtps::rtps::CacheChange_t* change)
     {
-        // This comparison is thread-safe, because we ensure the change to a problematic state is always protected for
-        // its writer's mutex.
-        // Problematic states:
-        // - Being added: change both pointers from nullptr to a pointer values.
-        // - Being removed: change both pointer from pointer values to nullptr.
-        if (nullptr != change->writer_info.previous ||
-                nullptr != change->writer_info.next)
+        if (change->writer_info.is_linked.load())
         {
             ++async_mode.writers_interested_in_remove;
             std::unique_lock<std::mutex> lock(mutex_);
@@ -1235,8 +1226,7 @@ private:
                     nullptr != change->writer_info.next) ||
                     (nullptr == change->writer_info.previous &&
                     nullptr == change->writer_info.next));
-            if (nullptr != change->writer_info.previous &&
-                    nullptr != change->writer_info.next)
+            if (change->writer_info.is_linked.load())
             {
 
                 // Try to join previous node and next node.
@@ -1244,6 +1234,7 @@ private:
                 change->writer_info.next->writer_info.previous = change->writer_info.previous;
                 change->writer_info.previous = nullptr;
                 change->writer_info.next = nullptr;
+                change->writer_info.is_linked.store(false);
             }
             --async_mode.writers_interested_in_remove;
         }
@@ -1336,6 +1327,7 @@ private:
                 next->writer_info.previous = previous;
                 change_to_process->writer_info.previous = nullptr;
                 change_to_process->writer_info.next = nullptr;
+                change_to_process->writer_info.is_linked.store(false);
 
                 fastrtps::rtps::DeliveryRetCode ret_delivery = current_writer->deliver_sample_nts(
                     change_to_process, async_mode.group, locator_selector,
@@ -1344,6 +1336,7 @@ private:
                 if (fastrtps::rtps::DeliveryRetCode::DELIVERED != ret_delivery)
                 {
                     // If delivery fails, put the change again in the queue.
+                    change_to_process->writer_info.is_linked.store(true);
                     previous->writer_info.next = change_to_process;
                     next->writer_info.previous = change_to_process;
                     change_to_process->writer_info.previous = previous;


### PR DESCRIPTION
## Description

As title says.

## Contributor Checklist
- [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [ ] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [ ] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [ ] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
