### PR TITLE
[15250] Fixing datarace on listener callbacks

### DIFF
--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -784,6 +784,8 @@ public:
     /**
      * @brief Getter for the resource event
      *
+     * @pre The DomainParticipant is enabled.
+     *
      * @return A reference to the resource event
      */
     RTPS_DllAPI fastrtps::rtps::ResourceEvent& get_resource_event() const;

--- a/include/fastdds/rtps/network/ReceiverResource.h
+++ b/include/fastdds/rtps/network/ReceiverResource.h
@@ -15,9 +15,11 @@
 #ifndef _FASTDDS_RTPS_RECEIVER_RESOURCE_H
 #define _FASTDDS_RTPS_RECEIVER_RESOURCE_H
 
+#include <condition_variable>
 #include <functional>
-#include <vector>
 #include <memory>
+#include <vector>
+
 #include <fastdds/rtps/messages/MessageReceiver.h>
 #include <fastdds/rtps/transport/TransportInterface.h>
 
@@ -34,39 +36,46 @@ namespace rtps {
  */
 class ReceiverResource : public fastdds::rtps::TransportReceiverInterface
 {
-   //! Only NetworkFactory is ever allowed to construct a ReceiverResource from scratch.
-   //! In doing so, it guarantees the transport and channel are in a valid state for
-   //! this resource to exist.
+    //! Only NetworkFactory is ever allowed to construct a ReceiverResource from scratch.
+    //! In doing so, it guarantees the transport and channel are in a valid state for
+    //! this resource to exist.
     friend class NetworkFactory;
 
 public:
+
     /**
-    * Method called by the transport when receiving data.
-    * @param data Pointer to the received data.
-    * @param size Number of bytes received.
-    * @param localLocator Locator identifying the local endpoint.
-    * @param remoteLocator Locator identifying the remote endpoint.
-    */
-    virtual void OnDataReceived(const octet* data, const uint32_t size,
-        const Locator_t& localLocator, const Locator_t& remoteLocator) override;
+     * Method called by the transport when receiving data.
+     * @param data Pointer to the received data.
+     * @param size Number of bytes received.
+     * @param localLocator Locator identifying the local endpoint.
+     * @param remoteLocator Locator identifying the remote endpoint.
+     */
+    virtual void OnDataReceived(
+            const octet* data,
+            const uint32_t size,
+            const Locator_t& localLocator,
+            const Locator_t& remoteLocator) override;
 
     /**
      * Reports whether this resource supports the given local locator (i.e., said locator
      * maps to the transport channel managed by this resource).
      */
-    bool SupportsLocator(const Locator_t& localLocator);
+    bool SupportsLocator(
+            const Locator_t& localLocator);
 
     /**
      * Register a MessageReceiver object to be called upon reception of data.
      * @param receiver The message receiver to register.
      */
-    void RegisterReceiver(MessageReceiver* receiver);
+    void RegisterReceiver(
+            MessageReceiver* receiver);
 
     /**
-    * Unregister a MessageReceiver object to be called upon reception of data.
-    * @param receiver The message receiver to unregister.
-    */
-    void UnregisterReceiver(MessageReceiver* receiver);
+     * Unregister a MessageReceiver object to be called upon reception of data.
+     * @param receiver The message receiver to unregister.
+     */
+    void UnregisterReceiver(
+            MessageReceiver* receiver);
 
     /**
      * Closes related ChannelResources.
@@ -82,23 +91,32 @@ public:
      * Resources can only be transfered through move semantics. Copy, assignment, and
      * construction outside of the factory are forbidden.
      */
-    ReceiverResource(ReceiverResource&&);
+    ReceiverResource(
+            ReceiverResource&&);
 
     ~ReceiverResource() override;
 
 private:
-    ReceiverResource() = delete;
-    ReceiverResource(const ReceiverResource&) = delete;
-    ReceiverResource& operator=(const ReceiverResource&) = delete;
 
-    ReceiverResource(fastdds::rtps::TransportInterface&, const Locator_t&, uint32_t);
+    ReceiverResource() = delete;
+    ReceiverResource(
+            const ReceiverResource&) = delete;
+    ReceiverResource& operator =(
+            const ReceiverResource&) = delete;
+
+    ReceiverResource(
+            fastdds::rtps::TransportInterface&,
+            const Locator_t&,
+            uint32_t);
     std::function<void()> Cleanup;
     std::function<bool(const Locator_t&)> LocatorMapsToManagedChannel;
     bool mValid; // Post-construction validity check for the NetworkFactory
 
     std::mutex mtx;
+    std::condition_variable cv_;
     MessageReceiver* receiver;
     uint32_t max_message_size_;
+    int active_callbacks_;
 };
 
 } // namespace rtps

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1708,13 +1708,19 @@ ResourceEvent& DomainParticipantImpl::get_resource_event() const
 fastrtps::rtps::SampleIdentity DomainParticipantImpl::get_type_dependencies(
         const fastrtps::types::TypeIdentifierSeq& in) const
 {
-    return get_rtps_participant()->typelookup_manager()->get_type_dependencies(in);
+    const fastrtps::rtps::RTPSParticipant* rtps_participant = get_rtps_participant();
+    return nullptr != rtps_participant ?
+           rtps_participant->typelookup_manager()->get_type_dependencies(in) :
+           builtin::INVALID_SAMPLE_IDENTITY;
 }
 
 fastrtps::rtps::SampleIdentity DomainParticipantImpl::get_types(
         const fastrtps::types::TypeIdentifierSeq& in) const
 {
-    return get_rtps_participant()->typelookup_manager()->get_types(in);
+    const fastrtps::rtps::RTPSParticipant* rtps_participant = get_rtps_participant();
+    return nullptr != rtps_participant ?
+           rtps_participant->typelookup_manager()->get_types(in) :
+           builtin::INVALID_SAMPLE_IDENTITY;
 }
 
 ReturnCode_t DomainParticipantImpl::register_remote_type(
@@ -2348,7 +2354,7 @@ DomainParticipantListener* DomainParticipantImpl::get_listener_for(
 {
     if (get_participant()->get_status_mask().is_active(status))
     {
-        return listener_;
+        return get_listener();
     }
     return nullptr;
 }

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1561,9 +1561,10 @@ void DomainParticipantImpl::MyRTPSParticipantListener::onParticipantDiscovery(
         RTPSParticipant*,
         ParticipantDiscoveryInfo&& info)
 {
-    if (participant_ != nullptr && participant_->get_listener() != nullptr)
+    DomainParticipantListener* listener = nullptr;
+    if (participant_ != nullptr && (listener = participant_->get_listener()) != nullptr)
     {
-        participant_->get_listener()->on_participant_discovery(participant_->participant_, std::move(info));
+        listener->on_participant_discovery(participant_->participant_, std::move(info));
     }
 }
 
@@ -1572,9 +1573,10 @@ void DomainParticipantImpl::MyRTPSParticipantListener::onParticipantAuthenticati
         RTPSParticipant*,
         ParticipantAuthenticationInfo&& info)
 {
-    if (participant_ != nullptr && participant_->get_listener() != nullptr)
+    DomainParticipantListener* listener = nullptr;
+    if (participant_ != nullptr && (listener = participant_->get_listener()) != nullptr)
     {
-        participant_->get_listener()->onParticipantAuthentication(participant_->participant_, std::move(info));
+        listener->onParticipantAuthentication(participant_->participant_, std::move(info));
     }
 }
 
@@ -1584,9 +1586,10 @@ void DomainParticipantImpl::MyRTPSParticipantListener::onReaderDiscovery(
         RTPSParticipant*,
         ReaderDiscoveryInfo&& info)
 {
-    if (participant_ != nullptr && participant_->get_listener() != nullptr)
+    DomainParticipantListener* listener = nullptr;
+    if (participant_ != nullptr && (listener = participant_->get_listener()) != nullptr)
     {
-        participant_->get_listener()->on_subscriber_discovery(participant_->participant_, std::move(info));
+        listener->on_subscriber_discovery(participant_->participant_, std::move(info));
     }
 }
 
@@ -1594,9 +1597,10 @@ void DomainParticipantImpl::MyRTPSParticipantListener::onWriterDiscovery(
         RTPSParticipant*,
         WriterDiscoveryInfo&& info)
 {
-    if (participant_ != nullptr && participant_->get_listener() != nullptr)
+    DomainParticipantListener* listener = nullptr;
+    if (participant_ != nullptr && (listener = participant_->get_listener()) != nullptr)
     {
-        participant_->get_listener()->on_publisher_discovery(participant_->participant_, std::move(info));
+        listener->on_publisher_discovery(participant_->participant_, std::move(info));
     }
 }
 
@@ -1608,9 +1612,10 @@ void DomainParticipantImpl::MyRTPSParticipantListener::on_type_discovery(
         const fastrtps::types::TypeObject* object,
         fastrtps::types::DynamicType_ptr dyn_type)
 {
-    if (participant_ != nullptr && participant_->get_listener() != nullptr)
+    DomainParticipantListener* listener = nullptr;
+    if (participant_ != nullptr && (listener = participant_->get_listener()) != nullptr)
     {
-        participant_->get_listener()->on_type_discovery(
+        listener->on_type_discovery(
             participant_->participant_,
             request_sample_id,
             topic,
@@ -1627,7 +1632,8 @@ void DomainParticipantImpl::MyRTPSParticipantListener::on_type_dependencies_repl
         const fastrtps::rtps::SampleIdentity& request_sample_id,
         const fastrtps::types::TypeIdentifierWithSizeSeq& dependencies)
 {
-    if (participant_ != nullptr && participant_->get_listener() != nullptr)
+    DomainParticipantListener* listener = nullptr;
+    if (participant_ != nullptr && (listener = participant_->get_listener()) != nullptr)
     {
         participant_->get_listener()->on_type_dependencies_reply(
             participant_->participant_, request_sample_id, dependencies);
@@ -1642,13 +1648,17 @@ void DomainParticipantImpl::MyRTPSParticipantListener::on_type_information_recei
         const fastrtps::string_255& type_name,
         const fastrtps::types::TypeInformation& type_information)
 {
-    if (participant_ != nullptr && participant_->get_listener() != nullptr)
+    DomainParticipantListener* listener = nullptr;
+    DomainParticipant* participant = nullptr;
+    if (participant_ != nullptr
+            && (participant = participant_->get_participant()) != nullptr
+            && (listener = participant_->get_listener()) != nullptr)
     {
         if (type_information.complete().typeid_with_size().type_id()._d() > 0
                 || type_information.minimal().typeid_with_size().type_id()._d() > 0)
         {
-            participant_->get_listener()->on_type_information_received(
-                participant_->participant_, topic_name, type_name, type_information);
+            listener->on_type_information_received(
+                participant, topic_name, type_name, type_information);
         }
     }
 }

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -200,17 +200,17 @@ DomainParticipantImpl::DomainParticipantImpl(
 
 void DomainParticipantImpl::disable()
 {
-    if (participant_)
+    if (get_participant())
     {
-        participant_->set_listener(nullptr);
+        get_participant()->set_listener(nullptr);
     }
     rtps_listener_.participant_ = nullptr;
 
     // The function to disable the DomainParticipantImpl is called from
     // DomainParticipantFactory::delete_participant() and DomainParticipantFactory destructor.
-    if (rtps_participant_ != nullptr)
+    if (get_rtps_participant() != nullptr)
     {
-        rtps_participant_->set_listener(nullptr);
+        get_rtps_participant()->set_listener(nullptr);
 
         {
             std::lock_guard<std::mutex> lock(mtx_pubs_);
@@ -266,6 +266,8 @@ DomainParticipantImpl::~DomainParticipantImpl()
         topics_by_handle_.clear();
     }
 
+    std::lock_guard<std::mutex> _(mtx_gs_);
+
     if (rtps_participant_ != nullptr)
     {
         RTPSDomain::removeRTPSParticipant(rtps_participant_);
@@ -286,6 +288,8 @@ DomainParticipantImpl::~DomainParticipantImpl()
 
 ReturnCode_t DomainParticipantImpl::enable()
 {
+    std::lock_guard<std::mutex> _(mtx_gs_);
+
     // Should not have been previously enabled
     assert(rtps_participant_ == nullptr);
 
@@ -363,7 +367,7 @@ ReturnCode_t DomainParticipantImpl::enable()
 ReturnCode_t DomainParticipantImpl::set_qos(
         const DomainParticipantQos& qos)
 {
-    bool enabled = (rtps_participant_ != nullptr);
+    bool enabled = (get_rtps_participant() != nullptr);
     const DomainParticipantQos& qos_to_set = (&qos == &PARTICIPANT_QOS_DEFAULT) ?
             DomainParticipantFactory::get_instance()->get_default_participant_qos() : qos;
 
@@ -389,12 +393,12 @@ ReturnCode_t DomainParticipantImpl::set_qos(
             // Notify the participant that there is a QoS update
             fastrtps::rtps::RTPSParticipantAttributes patt;
             set_attributes_from_qos(patt, qos_);
-            rtps_participant_->update_attributes(patt);
+            get_rtps_participant()->update_attributes(patt);
         }
         else
         {
             // Trigger update of network interfaces by calling update_attributes
-            rtps_participant_->update_attributes(rtps_participant_->getRTPSParticipantAttributes());
+            get_rtps_participant()->update_attributes(get_rtps_participant()->getRTPSParticipantAttributes());
         }
     }
 
@@ -404,19 +408,21 @@ ReturnCode_t DomainParticipantImpl::set_qos(
 ReturnCode_t DomainParticipantImpl::get_qos(
         DomainParticipantQos& qos) const
 {
+    std::lock_guard<std::mutex> _(mtx_gs_);
     qos = qos_;
     return ReturnCode_t::RETCODE_OK;
 }
 
 const DomainParticipantQos& DomainParticipantImpl::get_qos() const
 {
+    std::lock_guard<std::mutex> _(mtx_gs_);
     return qos_;
 }
 
 ReturnCode_t DomainParticipantImpl::delete_publisher(
         const Publisher* pub)
 {
-    if (participant_ != pub->get_participant())
+    if (get_participant() != pub->get_participant())
     {
         return ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;
     }
@@ -444,7 +450,7 @@ ReturnCode_t DomainParticipantImpl::delete_publisher(
 ReturnCode_t DomainParticipantImpl::delete_subscriber(
         const Subscriber* sub)
 {
-    if (participant_ != sub->get_participant())
+    if (get_participant() != sub->get_participant())
     {
         return ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;
     }
@@ -578,7 +584,7 @@ ContentFilteredTopic* DomainParticipantImpl::create_contentfilteredtopic(
         return nullptr;
     }
 
-    if (related_topic->get_participant() != this->participant_)
+    if (related_topic->get_participant() != this->get_participant())
     {
         logError(PARTICIPANT, "Creating ContentFilteredTopic with name " << name <<
                 ": related_topic not from this participant");
@@ -783,9 +789,8 @@ Publisher* DomainParticipantImpl::create_publisher(
     PublisherImpl* pubimpl = create_publisher_impl(qos, listener);
     Publisher* pub = new Publisher(pubimpl, mask);
     pubimpl->user_publisher_ = pub;
-    pubimpl->rtps_participant_ = rtps_participant_;
-
-    bool enabled = rtps_participant_ != nullptr;
+    pubimpl->rtps_participant_ = get_rtps_participant();
+    bool enabled = get_rtps_participant() != nullptr;
 
     // Create InstanceHandle for the new publisher
     InstanceHandle_t pub_handle;
@@ -973,14 +978,14 @@ ReturnCode_t DomainParticipantImpl::delete_contained_entities()
 
 ReturnCode_t DomainParticipantImpl::assert_liveliness()
 {
-    if (rtps_participant_ == nullptr)
+    if (get_rtps_participant() == nullptr)
     {
         return ReturnCode_t::RETCODE_NOT_ENABLED;
     }
 
-    if (rtps_participant_->wlp() != nullptr)
+    if (get_rtps_participant()->wlp() != nullptr)
     {
-        if (rtps_participant_->wlp()->assert_liveliness_manual_by_participant())
+        if (get_rtps_participant()->wlp()->assert_liveliness_manual_by_participant())
         {
             return ReturnCode_t::RETCODE_OK;
         }
@@ -1235,16 +1240,31 @@ ReturnCode_t DomainParticipantImpl::get_current_time(
 
 const DomainParticipant* DomainParticipantImpl::get_participant() const
 {
+    std::lock_guard<std::mutex> _(mtx_gs_);
     return participant_;
 }
 
 DomainParticipant* DomainParticipantImpl::get_participant()
 {
+    std::lock_guard<std::mutex> _(mtx_gs_);
     return participant_;
+}
+
+const fastrtps::rtps::RTPSParticipant* DomainParticipantImpl::get_rtps_participant() const
+{
+    std::lock_guard<std::mutex> _(mtx_gs_);
+    return rtps_participant_;
+}
+
+fastrtps::rtps::RTPSParticipant* DomainParticipantImpl::get_rtps_participant()
+{
+    std::lock_guard<std::mutex> _(mtx_gs_);
+    return rtps_participant_;
 }
 
 std::vector<std::string> DomainParticipantImpl::get_participant_names() const
 {
+    std::lock_guard<std::mutex> _(mtx_gs_);
     return rtps_participant_ == nullptr ?
            std::vector<std::string> {}
            :
@@ -1268,11 +1288,11 @@ Subscriber* DomainParticipantImpl::create_subscriber(
     SubscriberImpl* subimpl = create_subscriber_impl(qos, listener);
     Subscriber* sub = new Subscriber(subimpl, mask);
     subimpl->user_subscriber_ = sub;
-    subimpl->rtps_participant_ = this->rtps_participant_;
+    subimpl->rtps_participant_ = get_rtps_participant();
 
     // Create InstanceHandle for the new subscriber
     InstanceHandle_t sub_handle;
-    bool enabled = rtps_participant_ != nullptr;
+    bool enabled = get_rtps_participant() != nullptr;
 
     // Create InstanceHandle for the new subscriber
     create_instance_handle(sub_handle);
@@ -1339,7 +1359,7 @@ Topic* DomainParticipantImpl::create_topic(
         return nullptr;
     }
 
-    bool enabled = rtps_participant_ != nullptr;
+    bool enabled = get_rtps_participant() != nullptr;
 
     std::lock_guard<std::mutex> lock(mtx_topics_);
 
@@ -1562,9 +1582,9 @@ void DomainParticipantImpl::MyRTPSParticipantListener::onParticipantDiscovery(
         RTPSParticipant*,
         ParticipantDiscoveryInfo&& info)
 {
-    if (participant_ != nullptr && participant_->listener_ != nullptr)
+    if (participant_ != nullptr && participant_->get_listener() != nullptr)
     {
-        participant_->listener_->on_participant_discovery(participant_->participant_, std::move(info));
+        participant_->get_listener()->on_participant_discovery(participant_->participant_, std::move(info));
     }
 }
 
@@ -1573,9 +1593,9 @@ void DomainParticipantImpl::MyRTPSParticipantListener::onParticipantAuthenticati
         RTPSParticipant*,
         ParticipantAuthenticationInfo&& info)
 {
-    if (participant_ != nullptr && participant_->listener_ != nullptr)
+    if (participant_ != nullptr && participant_->get_listener() != nullptr)
     {
-        participant_->listener_->onParticipantAuthentication(participant_->participant_, std::move(info));
+        participant_->get_listener()->onParticipantAuthentication(participant_->participant_, std::move(info));
     }
 }
 
@@ -1585,9 +1605,9 @@ void DomainParticipantImpl::MyRTPSParticipantListener::onReaderDiscovery(
         RTPSParticipant*,
         ReaderDiscoveryInfo&& info)
 {
-    if (participant_ != nullptr && participant_->listener_ != nullptr)
+    if (participant_ != nullptr && participant_->get_listener() != nullptr)
     {
-        participant_->listener_->on_subscriber_discovery(participant_->participant_, std::move(info));
+        participant_->get_listener()->on_subscriber_discovery(participant_->participant_, std::move(info));
     }
 }
 
@@ -1595,9 +1615,9 @@ void DomainParticipantImpl::MyRTPSParticipantListener::onWriterDiscovery(
         RTPSParticipant*,
         WriterDiscoveryInfo&& info)
 {
-    if (participant_ != nullptr && participant_->listener_ != nullptr)
+    if (participant_ != nullptr && participant_->get_listener() != nullptr)
     {
-        participant_->listener_->on_publisher_discovery(participant_->participant_, std::move(info));
+        participant_->get_listener()->on_publisher_discovery(participant_->participant_, std::move(info));
     }
 }
 
@@ -1609,9 +1629,9 @@ void DomainParticipantImpl::MyRTPSParticipantListener::on_type_discovery(
         const fastrtps::types::TypeObject* object,
         fastrtps::types::DynamicType_ptr dyn_type)
 {
-    if (participant_ != nullptr && participant_->listener_ != nullptr)
+    if (participant_ != nullptr && participant_->get_listener() != nullptr)
     {
-        participant_->listener_->on_type_discovery(
+        participant_->get_listener()->on_type_discovery(
             participant_->participant_,
             request_sample_id,
             topic,
@@ -1628,9 +1648,9 @@ void DomainParticipantImpl::MyRTPSParticipantListener::on_type_dependencies_repl
         const fastrtps::rtps::SampleIdentity& request_sample_id,
         const fastrtps::types::TypeIdentifierWithSizeSeq& dependencies)
 {
-    if (participant_ != nullptr && participant_->listener_ != nullptr)
+    if (participant_ != nullptr && participant_->get_listener() != nullptr)
     {
-        participant_->listener_->on_type_dependencies_reply(
+        participant_->get_listener()->on_type_dependencies_reply(
             participant_->participant_, request_sample_id, dependencies);
     }
 
@@ -1643,12 +1663,12 @@ void DomainParticipantImpl::MyRTPSParticipantListener::on_type_information_recei
         const fastrtps::string_255& type_name,
         const fastrtps::types::TypeInformation& type_information)
 {
-    if (participant_ != nullptr && participant_->listener_ != nullptr)
+    if (participant_ != nullptr && participant_->get_listener() != nullptr)
     {
         if (type_information.complete().typeid_with_size().type_id()._d() > 0
                 || type_information.minimal().typeid_with_size().type_id()._d() > 0)
         {
-            participant_->listener_->on_type_information_received(
+            participant_->get_listener()->on_type_information_received(
                 participant_->participant_, topic_name, type_name, type_information);
         }
     }
@@ -1659,15 +1679,15 @@ bool DomainParticipantImpl::new_remote_endpoint_discovered(
         uint16_t endpointId,
         EndpointKind_t kind)
 {
-    if (rtps_participant_ != nullptr)
+    if (get_rtps_participant() != nullptr)
     {
         if (kind == fastrtps::rtps::WRITER)
         {
-            return rtps_participant_->newRemoteWriterDiscovered(partguid, static_cast<int16_t>(endpointId));
+            return get_rtps_participant()->newRemoteWriterDiscovered(partguid, static_cast<int16_t>(endpointId));
         }
         else
         {
-            return rtps_participant_->newRemoteReaderDiscovered(partguid, static_cast<int16_t>(endpointId));
+            return get_rtps_participant()->newRemoteReaderDiscovered(partguid, static_cast<int16_t>(endpointId));
         }
     }
 
@@ -1676,19 +1696,19 @@ bool DomainParticipantImpl::new_remote_endpoint_discovered(
 
 ResourceEvent& DomainParticipantImpl::get_resource_event() const
 {
-    return rtps_participant_->get_resource_event();
+    return get_rtps_participant()->get_resource_event();
 }
 
 fastrtps::rtps::SampleIdentity DomainParticipantImpl::get_type_dependencies(
         const fastrtps::types::TypeIdentifierSeq& in) const
 {
-    return rtps_participant_->typelookup_manager()->get_type_dependencies(in);
+    return get_rtps_participant()->typelookup_manager()->get_type_dependencies(in);
 }
 
 fastrtps::rtps::SampleIdentity DomainParticipantImpl::get_types(
         const fastrtps::types::TypeIdentifierSeq& in) const
 {
-    return rtps_participant_->typelookup_manager()->get_types(in);
+    return get_rtps_participant()->typelookup_manager()->get_types(in);
 }
 
 ReturnCode_t DomainParticipantImpl::register_remote_type(
@@ -1698,7 +1718,7 @@ ReturnCode_t DomainParticipantImpl::register_remote_type(
 {
     using namespace fastrtps::types;
 
-    if (rtps_participant_ == nullptr)
+    if (get_rtps_participant() == nullptr)
     {
         return ReturnCode_t::RETCODE_NOT_ENABLED;
     }
@@ -1739,7 +1759,7 @@ ReturnCode_t DomainParticipantImpl::register_remote_type(
             return register_dynamic_type(dyn);
         }
     }
-    else if (rtps_participant_->typelookup_manager() != nullptr)
+    else if (get_rtps_participant()->typelookup_manager() != nullptr)
     {
         TypeIdentifierSeq dependencies;
         TypeIdentifierSeq retrieve_objects;
@@ -2014,7 +2034,7 @@ ReturnCode_t DomainParticipantImpl::register_dynamic_type(
         fastrtps::types::DynamicType_ptr dyn_type)
 {
     TypeSupport type(new fastrtps::types::DynamicPubSubType(dyn_type));
-    return participant_->register_type(type);
+    return get_participant()->register_type(type);
 }
 
 void DomainParticipantImpl::remove_parent_request(
@@ -2320,7 +2340,7 @@ void DomainParticipantImpl::create_instance_handle(
 DomainParticipantListener* DomainParticipantImpl::get_listener_for(
         const StatusMask& status)
 {
-    if (participant_->get_status_mask().is_active(status))
+    if (get_participant()->get_status_mask().is_active(status))
     {
         return listener_;
     }

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1702,6 +1702,7 @@ bool DomainParticipantImpl::new_remote_endpoint_discovered(
 
 ResourceEvent& DomainParticipantImpl::get_resource_event() const
 {
+    assert(nullptr != get_rtps_participant());
     return get_rtps_participant()->get_resource_event();
 }
 

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1238,30 +1238,6 @@ ReturnCode_t DomainParticipantImpl::get_current_time(
     return ReturnCode_t::RETCODE_OK;
 }
 
-const DomainParticipant* DomainParticipantImpl::get_participant() const
-{
-    std::lock_guard<std::mutex> _(mtx_gs_);
-    return participant_;
-}
-
-DomainParticipant* DomainParticipantImpl::get_participant()
-{
-    std::lock_guard<std::mutex> _(mtx_gs_);
-    return participant_;
-}
-
-const fastrtps::rtps::RTPSParticipant* DomainParticipantImpl::get_rtps_participant() const
-{
-    std::lock_guard<std::mutex> _(mtx_gs_);
-    return rtps_participant_;
-}
-
-fastrtps::rtps::RTPSParticipant* DomainParticipantImpl::get_rtps_participant()
-{
-    std::lock_guard<std::mutex> _(mtx_gs_);
-    return rtps_participant_;
-}
-
 std::vector<std::string> DomainParticipantImpl::get_participant_names() const
 {
     std::lock_guard<std::mutex> _(mtx_gs_);

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -109,12 +109,14 @@ public:
     ReturnCode_t set_listener(
             DomainParticipantListener* listener)
     {
+        std::lock_guard<std::mutex> _(mtx_gs_);
         listener_ = listener;
         return ReturnCode_t::RETCODE_OK;
     }
 
-    const DomainParticipantListener* get_listener() const
+    DomainParticipantListener* get_listener() const
     {
+        std::lock_guard<std::mutex> _(mtx_gs_);
         return listener_;
     }
 
@@ -399,15 +401,9 @@ public:
 
     DomainParticipant* get_participant();
 
-    const fastrtps::rtps::RTPSParticipant* rtps_participant() const
-    {
-        return rtps_participant_;
-    }
+    const fastrtps::rtps::RTPSParticipant* get_rtps_participant() const;
 
-    fastrtps::rtps::RTPSParticipant* rtps_participant()
-    {
-        return rtps_participant_;
-    }
+    fastrtps::rtps::RTPSParticipant* get_rtps_participant();
 
     const TypeSupport find_type(
             const std::string& type_name) const;
@@ -496,6 +492,9 @@ protected:
 
     //!Participant Listener
     DomainParticipantListener* listener_;
+
+    //! getter/setter mutex
+    mutable std::mutex mtx_gs_;
 
     //!Publisher maps
     std::map<Publisher*, PublisherImpl*> publishers_;

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -397,13 +397,29 @@ public:
     ReturnCode_t get_current_time(
             fastrtps::Time_t& current_time) const;
 
-    const DomainParticipant* get_participant() const;
+    const DomainParticipant* get_participant() const
+    {
+        std::lock_guard<std::mutex> _(mtx_gs_);
+        return participant_;
+    }
 
-    DomainParticipant* get_participant();
+    DomainParticipant* get_participant()
+    {
+        std::lock_guard<std::mutex> _(mtx_gs_);
+        return participant_;
+    }
 
-    const fastrtps::rtps::RTPSParticipant* get_rtps_participant() const;
+    const fastrtps::rtps::RTPSParticipant* get_rtps_participant() const
+    {
+        std::lock_guard<std::mutex> _(mtx_gs_);
+        return rtps_participant_;
+    }
 
-    fastrtps::rtps::RTPSParticipant* get_rtps_participant();
+    fastrtps::rtps::RTPSParticipant* get_rtps_participant()
+    {
+        std::lock_guard<std::mutex> _(mtx_gs_);
+        return rtps_participant_;
+    }
 
     const TypeSupport find_type(
             const std::string& type_name) const;

--- a/src/cpp/fastdds/publisher/PublisherImpl.cpp
+++ b/src/cpp/fastdds/publisher/PublisherImpl.cpp
@@ -110,7 +110,7 @@ PublisherImpl::PublisherImpl(
     , listener_(listen)
     , publisher_listener_(this)
     , user_publisher_(nullptr)
-    , rtps_participant_(p->rtps_participant())
+    , rtps_participant_(p->get_rtps_participant())
     , default_datawriter_qos_(DATAWRITER_QOS_DEFAULT)
 {
     PublisherAttributes pub_attr;

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -108,7 +108,7 @@ SubscriberImpl::SubscriberImpl(
     , listener_(listen)
     , subscriber_listener_(this)
     , user_subscriber_(nullptr)
-    , rtps_participant_(p->rtps_participant())
+    , rtps_participant_(p->get_rtps_participant())
     , default_datareader_qos_(DATAREADER_QOS_DEFAULT)
 {
     SubscriberAttributes sub_attr;

--- a/src/cpp/rtps/network/ReceiverResource.cpp
+++ b/src/cpp/rtps/network/ReceiverResource.cpp
@@ -70,6 +70,7 @@ ReceiverResource::ReceiverResource(
     rValueResource.mValid = false;
     max_message_size_ = rValueResource.max_message_size_;
     active_callbacks_ = rValueResource.active_callbacks_;
+    rValueResource.active_callbacks_ = 0;
 }
 
 bool ReceiverResource::SupportsLocator(

--- a/src/cpp/rtps/network/ReceiverResource.cpp
+++ b/src/cpp/rtps/network/ReceiverResource.cpp
@@ -34,6 +34,7 @@ ReceiverResource::ReceiverResource(
     , LocatorMapsToManagedChannel(nullptr)
     , mValid(false)
     , mtx()
+    , cv_()
     , receiver(nullptr)
     , max_message_size_(max_recv_buffer_size)
     , active_callbacks_(0)
@@ -148,7 +149,7 @@ void ReceiverResource::disable()
     std::unique_lock<std::mutex> lock(mtx);
     cv_.wait(lock, [this]
             {
-                return active_callbacks_ == 0;
+                return active_callbacks_ <= 0;
             });
     // no more callbacks
     active_callbacks_ = -1;

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -448,13 +448,8 @@ void RTPSParticipantImpl::enable()
 
 void RTPSParticipantImpl::disable()
 {
-    if (nullptr == mp_builtinProtocols)
-    {
-        return;
-    }
-
-    // Ensure that other participants will not accidentally discover this one
-    stopRTPSParticipantAnnouncement();
+    // Disabling even thread disables participant announcement
+    mp_event_thr.stop_thread();
 
     // Disable Retries on Transports
     m_network_Factory.Shutdown();
@@ -468,10 +463,11 @@ void RTPSParticipantImpl::disable()
 
     deleteAllUserEndpoints();
 
-    mp_event_thr.stop_thread();
-
-    delete(mp_builtinProtocols);
-    mp_builtinProtocols = nullptr;
+    if (nullptr != mp_builtinProtocols)
+    {
+        delete(mp_builtinProtocols);
+        mp_builtinProtocols = nullptr;
+    }
 }
 
 const std::vector<RTPSWriter*>& RTPSParticipantImpl::getAllWriters() const

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -448,7 +448,8 @@ void RTPSParticipantImpl::enable()
 
 void RTPSParticipantImpl::disable()
 {
-    // Disabling even thread disables participant announcement
+    // Disabling event thread also disables participant announcement, so there is no need to call
+    // stopRTPSParticipantAnnouncement()
     mp_event_thr.stop_thread();
 
     // Disable Retries on Transports

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -321,6 +321,7 @@ public:
      */
     inline RTPSParticipantListener* getListener()
     {
+        std::lock_guard<std::recursive_mutex> _(*getParticipantMutex());
         return mp_participantListener;
     }
 
@@ -331,6 +332,7 @@ public:
     void set_listener(
             RTPSParticipantListener* listener)
     {
+        std::lock_guard<std::recursive_mutex> _(*getParticipantMutex());
         mp_participantListener = listener;
     }
 

--- a/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
+++ b/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
@@ -502,7 +502,7 @@ public:
         return participant_;
     }
 
-    fastrtps::rtps::RTPSParticipant* rtps_participant()
+    fastrtps::rtps::RTPSParticipant* get_rtps_participant()
     {
         return rtps_participant_;
     }

--- a/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.h
+++ b/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.h
@@ -131,7 +131,7 @@ public:
                 const GUID_t& pguid,
                 int16_t userDefinedId));
 
-    ResourceEvent& get_resource_event()
+    ResourceEvent& get_resource_event() const
     {
         return mp_event_thr;
     }
@@ -194,7 +194,7 @@ public:
 
     RTPSParticipantListener* listener_;
     const GUID_t m_guid;
-    ResourceEvent mp_event_thr;
+    mutable ResourceEvent mp_event_thr;
     RTPSParticipantAttributes attributes_;
 };
 

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -617,7 +617,7 @@ void get_rtps_attributes(
     ASSERT_NE(nullptr, participant_test);
     const DomainParticipantImpl* participant_impl = participant_test->get_impl();
     ASSERT_NE(nullptr, participant_impl);
-    att = participant_impl->rtps_participant()->getRTPSParticipantAttributes();
+    att = participant_impl->get_rtps_participant()->getRTPSParticipantAttributes();
 }
 
 void helper_wait_for_at_least_entries(


### PR DESCRIPTION
Signed-off-by: Miguel Barro <miguelbarro@eprosima.com>

<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Avoid data races on listener callbacks by:
- protecting DomainParticipantImpl getters and setters
- protecting RTPSParticipantImpl getters and setters
- Force ReceiverResource disable() method to wait for all concurrent callbacks.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
