### PR TITLE
[15321] Adding DomainParticipantFactory::get_shared_instance() API

### DIFF
--- a/include/fastdds/dds/domain/DomainParticipantFactory.hpp
+++ b/include/fastdds/dds/domain/DomainParticipantFactory.hpp
@@ -26,8 +26,9 @@
 #include <fastdds/dds/domain/qos/DomainParticipantFactoryQos.hpp>
 #include <fastdds/dds/core/status/StatusMask.hpp>
 
-#include <mutex>
 #include <map>
+#include <memory>
+#include <mutex>
 
 using eprosima::fastrtps::types::ReturnCode_t;
 
@@ -50,11 +51,18 @@ class DomainParticipantFactory
 public:
 
     /**
-     * Returns the DomainParticipantFactory singleton.
+     * Returns the DomainParticipantFactory singleton instance.
      *
-     * @return The DomainParticipantFactory singleton.
+     * @return A raw pointer to the DomainParticipantFactory singleton instance.
      */
     RTPS_DllAPI static DomainParticipantFactory* get_instance();
+
+    /**
+     * Returns the DomainParticipantFactory singleton instance.
+     *
+     * @return A shared pointer to the DomainParticipantFactory singleton instance.
+     */
+    RTPS_DllAPI static std::shared_ptr<DomainParticipantFactory> get_shared_instance();
 
     /**
      * Create a Participant.

--- a/include/fastdds/dds/domain/DomainParticipantFactory.hpp
+++ b/include/fastdds/dds/domain/DomainParticipantFactory.hpp
@@ -33,6 +33,15 @@
 using eprosima::fastrtps::types::ReturnCode_t;
 
 namespace eprosima {
+
+namespace fastrtps {
+namespace rtps {
+namespace detail {
+class TopicPayloadPoolRegistry;
+}  // namespace detail
+}  // namespace rtps
+}  // namespace fastrtps
+
 namespace fastdds {
 namespace dds {
 
@@ -292,10 +301,12 @@ protected:
     DomainParticipantFactoryQos factory_qos_;
 
     DomainParticipantQos default_participant_qos_;
+
+    std::shared_ptr<fastrtps::rtps::detail::TopicPayloadPoolRegistry> topic_pool_;
 };
 
-} /* namespace dds */
-} /* namespace fastdds */
-} /* namespace eprosima */
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
 
 #endif /* _FASTDDS_DOMAINPARTICIPANT_HPP_*/

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -103,6 +103,7 @@ static void set_qos_from_attributes(
 DomainParticipantFactory::DomainParticipantFactory()
     : default_xml_profiles_loaded(false)
     , default_participant_qos_(PARTICIPANT_QOS_DEFAULT)
+    , topic_pool_(fastrtps::rtps::TopicPayloadPoolRegistry::instance())
 {
 }
 
@@ -157,10 +158,6 @@ std::shared_ptr<DomainParticipantFactory> DomainParticipantFactory::get_shared_i
 
     };
     static AuxiliaryBoostFunctor boost_functor;
-
-    // Keep a reference to the topic payload pool to avoid it to be destroyed before our own instance
-    using pool_registry_ref = eprosima::fastrtps::rtps::TopicPayloadPoolRegistry::reference;
-    static pool_registry_ref topic_pool_registry = eprosima::fastrtps::rtps::TopicPayloadPoolRegistry::instance();
 
     static std::shared_ptr<DomainParticipantFactory> instance(
         new DomainParticipantFactory(),

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -132,6 +132,11 @@ DomainParticipantFactory::~DomainParticipantFactory()
 
 DomainParticipantFactory* DomainParticipantFactory::get_instance()
 {
+    return get_shared_instance().get();
+}
+
+std::shared_ptr<DomainParticipantFactory> DomainParticipantFactory::get_shared_instance()
+{
     /*
      * The first time an interprocess synchronization object is created by boost, a singleton is instantiated and
      * its destructor is registered with std::atexit(&atexit_work).
@@ -157,8 +162,13 @@ DomainParticipantFactory* DomainParticipantFactory::get_instance()
     using pool_registry_ref = eprosima::fastrtps::rtps::TopicPayloadPoolRegistry::reference;
     static pool_registry_ref topic_pool_registry = eprosima::fastrtps::rtps::TopicPayloadPoolRegistry::instance();
 
-    static DomainParticipantFactory instance;
-    return &instance;
+    static std::shared_ptr<DomainParticipantFactory> instance(
+        new DomainParticipantFactory(),
+        [](DomainParticipantFactory* p)
+        {
+            delete p;
+        });
+    return instance;
 }
 
 ReturnCode_t DomainParticipantFactory::delete_participant(

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -159,6 +159,7 @@ std::shared_ptr<DomainParticipantFactory> DomainParticipantFactory::get_shared_i
     };
     static AuxiliaryBoostFunctor boost_functor;
 
+    // Note we need a custom deleter, since the destructor is protected.
     static std::shared_ptr<DomainParticipantFactory> instance(
         new DomainParticipantFactory(),
         [](DomainParticipantFactory* p)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR addresses #2537 by adding a new API on `DomainParticipantFactory` that returns a shared pointer, and making the old API call the new one and return the raw pointer inside the shared one.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [ ] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
