### PR TITLE
[15341] Protect access to reader listeners

### DIFF
--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1639,13 +1639,16 @@ fastrtps::TopicAttributes DataReaderImpl::topic_attributes() const
 DataReaderListener* DataReaderImpl::get_listener_for(
         const StatusMask& status)
 {
-    std::lock_guard<std::mutex> _(listener_mutex_);
-
-    if (listener_ != nullptr &&
-            user_datareader_->get_status_mask().is_active(status))
     {
-        return listener_;
+        std::lock_guard<std::mutex> _(listener_mutex_);
+
+        if (listener_ != nullptr &&
+                user_datareader_->get_status_mask().is_active(status))
+        {
+            return listener_;
+        }
     }
+
     return subscriber_->get_listener_for(status);
 }
 

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1227,12 +1227,14 @@ bool DataReaderImpl::lifespan_expired()
 ReturnCode_t DataReaderImpl::set_listener(
         DataReaderListener* listener)
 {
+    std::lock_guard<std::mutex> _(listener_mutex_);
     listener_ = listener;
     return ReturnCode_t::RETCODE_OK;
 }
 
 const DataReaderListener* DataReaderImpl::get_listener() const
 {
+    std::lock_guard<std::mutex> _(listener_mutex_);
     return listener_;
 }
 
@@ -1637,6 +1639,8 @@ fastrtps::TopicAttributes DataReaderImpl::topic_attributes() const
 DataReaderListener* DataReaderImpl::get_listener_for(
         const StatusMask& status)
 {
+    std::lock_guard<std::mutex> _(listener_mutex_);
+
     if (listener_ != nullptr &&
             user_datareader_->get_status_mask().is_active(status))
     {

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -380,6 +380,7 @@ protected:
 
     //!Listener
     DataReaderListener* listener_ = nullptr;
+    mutable std::mutex listener_mutex_;
 
     fastrtps::rtps::GUID_t guid_;
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This should fix dataraces involving access to the listener on `RTPSReader` and `DataReaderImpl`.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
