### PR TITLE
Add std::string::compare API to fixed_string [15351]

### DIFF
--- a/include/fastrtps/utils/fixed_size_string.hpp
+++ b/include/fastrtps/utils/fixed_size_string.hpp
@@ -170,6 +170,12 @@ public:
         return string_len;
     }
 
+    int compare(
+            const std::string& str ) const
+    {
+        return strncmp(string_data, str.c_str(), MAX_CHARS);
+    }
+
 private:
 
     void set(

--- a/include/fastrtps/utils/fixed_size_string.hpp
+++ b/include/fastrtps/utils/fixed_size_string.hpp
@@ -175,7 +175,7 @@ public:
      *
      * @param str C string to be compared with.
      *
-     * @return Integer value with the result of the comparison as described in `std.:string::compare()`.
+     * @return Integer value with the result of the comparison as described in `std::string::compare()`.
      */
     int compare(
             const char* str) const noexcept
@@ -188,7 +188,7 @@ public:
      *
      * @param str std::string to be compared with.
      *
-     * @return Integer value with the result of the comparison as described in `std.:string::compare()`.
+     * @return Integer value with the result of the comparison as described in `std::string::compare()`.
      */
     int compare(
             const std::string& str) const noexcept
@@ -201,7 +201,7 @@ public:
      *
      * @param str fixed_string to be compared with.
      *
-     * @return Integer value with the result of the comparison as described in `std.:string::compare()`.
+     * @return Integer value with the result of the comparison as described in `std::string::compare()`.
      */
     template<size_t N>  int compare(
             const fixed_string<N>& str) const noexcept

--- a/include/fastrtps/utils/fixed_size_string.hpp
+++ b/include/fastrtps/utils/fixed_size_string.hpp
@@ -171,6 +171,19 @@ public:
     }
 
     /*!
+     * Compare with a C string.
+     *
+     * @param str C string to be compared with.
+     *
+     * @return Integer value with the result of the comparison as described in `std.:string::compare()`.
+     */
+    int compare(
+            const char* str) const noexcept
+    {
+        return strncmp(string_data, str, MAX_CHARS);
+    }
+
+    /*!
      * Compare with a std::string.
      *
      * @param str std::string to be compared with.
@@ -178,7 +191,20 @@ public:
      * @return Integer value with the result of the comparison as described in `std.:string::compare()`.
      */
     int compare(
-            const std::string& str ) const
+            const std::string& str) const noexcept
+    {
+        return strncmp(string_data, str.c_str(), MAX_CHARS);
+    }
+
+    /*!
+     * Compare with a fixed_string
+     *
+     * @param str fixed_string to be compared with.
+     *
+     * @return Integer value with the result of the comparison as described in `std.:string::compare()`.
+     */
+    template<size_t N>  int compare(
+            const fixed_string<N>& str) const noexcept
     {
         return strncmp(string_data, str.c_str(), MAX_CHARS);
     }

--- a/include/fastrtps/utils/fixed_size_string.hpp
+++ b/include/fastrtps/utils/fixed_size_string.hpp
@@ -171,7 +171,7 @@ public:
     }
 
     /*!
-     * Compare with a std:.string.
+     * Compare with a std::string.
      *
      * @param str std::string to be compared with.
      *

--- a/include/fastrtps/utils/fixed_size_string.hpp
+++ b/include/fastrtps/utils/fixed_size_string.hpp
@@ -170,6 +170,13 @@ public:
         return string_len;
     }
 
+    /*!
+     * Compare with a std:.string.
+     *
+     * @param str std::string to be compared with.
+     *
+     * @return Integer value with the result of the comparison as described in `std.:string::compare()`.
+     */
     int compare(
             const std::string& str ) const
     {

--- a/test/unittest/utils/FixedSizeStringTests.cpp
+++ b/test/unittest/utils/FixedSizeStringTests.cpp
@@ -20,11 +20,12 @@ using namespace eprosima::fastrtps;
 constexpr size_t MAX_CHARS = 255;
 constexpr size_t OTHER_MAX_CHARS = 127;
 
-class FixedSizeStringTests: public ::testing::Test
+class FixedSizeStringTests : public ::testing::Test
 {
-    public:
-        char const *pattern0 = "foo/bar/baz";
-        char const *long_pattern =
+public:
+
+    char const* pattern0 = "foo/bar/baz";
+    char const* long_pattern =
             "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
             "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
             "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
@@ -34,7 +35,7 @@ class FixedSizeStringTests: public ::testing::Test
             "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
             "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF";
 
-        size_t pattern0_len = strlen(pattern0);
+    size_t pattern0_len = strlen(pattern0);
 };
 
 TEST_F(FixedSizeStringTests, default_constructor)
@@ -166,7 +167,64 @@ TEST_F(FixedSizeStringTests, different_fixed_sizes)
     ASSERT_EQ(s1, s2);
 }
 
-int main(int argc, char **argv)
+TEST_F(FixedSizeStringTests, comparisons)
+{
+    const char* c_string_short = "test string";
+    const char* c_string_a = "test string a";
+    const char* c_string_b = "test string b";
+    const char* c_string_c = "test string c";
+    const char* c_string_large = "test string b ";
+    std::string std_string_short = "test string";
+    std::string std_string_a = "test string a";
+    std::string std_string_b = "test string b";
+    std::string std_string_c = "test string c";
+    std::string std_string_large = "test string b ";
+    fixed_string<MAX_CHARS> fixed_short = "test string";
+    fixed_string<MAX_CHARS> fixed_a = "test string a";
+    fixed_string<MAX_CHARS> fixed_b = "test string b";
+    fixed_string<MAX_CHARS> fixed_c = "test string c";
+    fixed_string<MAX_CHARS> fixed_large = "test string b ";
+
+    ASSERT_NE(fixed_b, c_string_short);
+    ASSERT_NE(fixed_b, c_string_a);
+    ASSERT_EQ(fixed_b, c_string_b);
+    ASSERT_NE(fixed_b, c_string_c);
+    ASSERT_NE(fixed_b, c_string_large);
+
+    ASSERT_LT(0, fixed_b.compare(c_string_short));
+    ASSERT_LT(0, fixed_b.compare(c_string_a));
+    ASSERT_EQ(0, fixed_b.compare(c_string_b));
+    ASSERT_GT(0, fixed_b.compare(c_string_c));
+    ASSERT_GT(0, fixed_b.compare(c_string_large));
+
+    ASSERT_NE(fixed_b, std_string_short);
+    ASSERT_NE(fixed_b, std_string_a);
+    ASSERT_EQ(fixed_b, std_string_b);
+    ASSERT_NE(fixed_b, std_string_c);
+    ASSERT_NE(fixed_b, std_string_large);
+
+    ASSERT_LE(0, fixed_b.compare(std_string_short));
+    ASSERT_LE(0, fixed_b.compare(std_string_a));
+    ASSERT_EQ(0, fixed_b.compare(std_string_b));
+    ASSERT_GT(0, fixed_b.compare(std_string_c));
+    ASSERT_GT(0, fixed_b.compare(std_string_large));
+
+    ASSERT_NE(fixed_b, fixed_short);
+    ASSERT_NE(fixed_b, fixed_a);
+    ASSERT_EQ(fixed_b, fixed_b);
+    ASSERT_NE(fixed_b, fixed_c);
+    ASSERT_NE(fixed_b, fixed_large);
+
+    ASSERT_LE(0, fixed_b.compare(fixed_short));
+    ASSERT_LE(0, fixed_b.compare(fixed_a));
+    ASSERT_EQ(0, fixed_b.compare(fixed_b));
+    ASSERT_GT(0, fixed_b.compare(fixed_c));
+    ASSERT_GT(0, fixed_b.compare(fixed_large));
+}
+
+int main(
+        int argc,
+        char** argv)
 {
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
## Description

Updating generated code from IDL files with last fastddsgen version breaks the compilation of several tests because
`fixed_string` doesn't implement `std::string::compare`. This PR implements this function.

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
