### PR TITLE
[15417] Group set_qos_from_attributes free functions into a separate file

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -176,6 +176,7 @@ set(${PROJECT_NAME}_source_files
     fastdds/core/policy/QosPolicyUtils.cpp
     fastdds/publisher/qos/WriterQos.cpp
     fastdds/subscriber/qos/ReaderQos.cpp
+    fastdds/utils/QosConverters.cpp
     rtps/builtin/BuiltinProtocols.cpp
     rtps/builtin/discovery/participant/DirectMessageSender.cpp
     rtps/builtin/discovery/participant/PDP.cpp

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -29,6 +29,7 @@
 #include <fastrtps/xmlparser/XMLEndpointParser.h>
 
 #include <fastdds/domain/DomainParticipantImpl.hpp>
+#include <fastdds/utils/QosConverters.hpp>
 #include <rtps/history/TopicPayloadPoolRegistry.hpp>
 #include <statistics/fastdds/domain/DomainParticipantImpl.hpp>
 #include <utils/SystemInfo.hpp>
@@ -48,57 +49,6 @@ using eprosima::fastrtps::rtps::RTPSParticipant;
 namespace eprosima {
 namespace fastdds {
 namespace dds {
-
-/**
- * @brief Fill DomainParticipantQos from a given attributes RTPSParticipantAttributes object
- *
- * For the case of the non-binary properties, instead of the RTPSParticipantAttributes overriding the
- * property list in the DomainParticipantQos, a merge is performed in the following manner:
- *
- * - If any property from the RTPSParticipantAttributes is not in the DomainParticipantQos, then it is appended
- *   to the DomainParticipantQos.
- * - If any property from the RTPSParticipantAttributes property is also in the DomainParticipantQos, then the
- *   value in the DomainParticipantQos is overridden with that of the RTPSParticipantAttributes.
- *
- * @param[in, out] qos The DomainParticipantQos to set
- * @param[in] attr The RTPSParticipantAttributes from which the @c qos is set.
- */
-static void set_qos_from_attributes(
-        DomainParticipantQos& qos,
-        const eprosima::fastrtps::rtps::RTPSParticipantAttributes& attr)
-{
-    qos.user_data().setValue(attr.userData);
-    qos.allocation() = attr.allocation;
-    qos.wire_protocol().prefix = attr.prefix;
-    qos.wire_protocol().participant_id = attr.participantID;
-    qos.wire_protocol().builtin = attr.builtin;
-    qos.wire_protocol().port = attr.port;
-    qos.wire_protocol().throughput_controller = attr.throughputController;
-    qos.wire_protocol().default_unicast_locator_list = attr.defaultUnicastLocatorList;
-    qos.wire_protocol().default_multicast_locator_list = attr.defaultMulticastLocatorList;
-    qos.transport().user_transports = attr.userTransports;
-    qos.transport().use_builtin_transports = attr.useBuiltinTransports;
-    qos.transport().send_socket_buffer_size = attr.sendSocketBufferSize;
-    qos.transport().listen_socket_buffer_size = attr.listenSocketBufferSize;
-    qos.name() = attr.getName();
-    qos.flow_controllers() = attr.flow_controllers;
-
-    // Merge attributes and qos properties
-    for (auto property : attr.properties.properties())
-    {
-        std::string* property_value = fastrtps::rtps::PropertyPolicyHelper::find_property(
-            qos.properties(), property.name());
-        if (nullptr == property_value)
-        {
-            qos.properties().properties().emplace_back(property);
-        }
-        else
-        {
-            *property_value = property.value();
-        }
-    }
-    qos.properties().binary_properties() = attr.properties.binary_properties();
-}
 
 DomainParticipantFactory::DomainParticipantFactory()
     : default_xml_profiles_loaded(false)

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -220,7 +220,7 @@ DomainParticipant* DomainParticipantFactory::create_participant_with_profile(
     if (XMLP_ret::XML_OK == XMLProfileManager::fillParticipantAttributes(profile_name, attr))
     {
         DomainParticipantQos qos = default_participant_qos_;
-        set_qos_from_attributes(qos, attr.rtps);
+        utils::set_qos_from_attributes(qos, attr.rtps);
         return create_participant(did, qos, listen, mask);
     }
 
@@ -239,7 +239,7 @@ DomainParticipant* DomainParticipantFactory::create_participant_with_profile(
     if (XMLP_ret::XML_OK == XMLProfileManager::fillParticipantAttributes(profile_name, attr))
     {
         DomainParticipantQos qos = default_participant_qos_;
-        set_qos_from_attributes(qos, attr.rtps);
+        utils::set_qos_from_attributes(qos, attr.rtps);
         return create_participant(attr.domainId, qos, listen, mask);
     }
 
@@ -317,7 +317,7 @@ ReturnCode_t DomainParticipantFactory::get_participant_qos_from_profile(
     if (XMLP_ret::XML_OK == XMLProfileManager::fillParticipantAttributes(profile_name, attr))
     {
         qos = default_participant_qos_;
-        set_qos_from_attributes(qos, attr.rtps);
+        utils::set_qos_from_attributes(qos, attr.rtps);
         return ReturnCode_t::RETCODE_OK;
     }
 
@@ -409,7 +409,7 @@ void DomainParticipantFactory::reset_default_participant_qos()
     {
         eprosima::fastrtps::ParticipantAttributes attr;
         XMLProfileManager::getDefaultParticipantAttributes(attr);
-        set_qos_from_attributes(default_participant_qos_, attr.rtps);
+        utils::set_qos_from_attributes(default_participant_qos_, attr.rtps);
     }
 }
 

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -60,6 +60,7 @@
 #include <fastdds/topic/TopicImpl.hpp>
 #include <fastdds/topic/TopicProxy.hpp>
 #include <fastdds/topic/TopicProxyFactory.hpp>
+#include <fastdds/utils/QosConverters.hpp>
 #include <rtps/RTPSDomainImpl.hpp>
 #include <utils/SystemInfo.hpp>
 
@@ -87,54 +88,6 @@ using fastrtps::rtps::GUID_t;
 using fastrtps::rtps::EndpointKind_t;
 using fastrtps::rtps::ResourceEvent;
 using eprosima::fastdds::dds::Log;
-
-static void set_attributes_from_qos(
-        fastrtps::rtps::RTPSParticipantAttributes& attr,
-        const DomainParticipantQos& qos)
-{
-    attr.allocation = qos.allocation();
-    attr.properties = qos.properties();
-    attr.setName(qos.name());
-    attr.prefix = qos.wire_protocol().prefix;
-    attr.participantID = qos.wire_protocol().participant_id;
-    attr.builtin = qos.wire_protocol().builtin;
-    attr.port = qos.wire_protocol().port;
-    attr.throughputController = qos.wire_protocol().throughput_controller;
-    attr.defaultUnicastLocatorList = qos.wire_protocol().default_unicast_locator_list;
-    attr.defaultMulticastLocatorList = qos.wire_protocol().default_multicast_locator_list;
-    attr.userTransports = qos.transport().user_transports;
-    attr.useBuiltinTransports = qos.transport().use_builtin_transports;
-    attr.sendSocketBufferSize = qos.transport().send_socket_buffer_size;
-    attr.listenSocketBufferSize = qos.transport().listen_socket_buffer_size;
-    attr.userData = qos.user_data().data_vec();
-    attr.flow_controllers = qos.flow_controllers();
-}
-
-static void set_qos_from_attributes(
-        TopicQos& qos,
-        const TopicAttributes& attr)
-{
-    qos.history() = attr.historyQos;
-    qos.resource_limits() = attr.resourceLimitsQos;
-}
-
-static void set_qos_from_attributes(
-        SubscriberQos& qos,
-        const SubscriberAttributes& attr)
-{
-    qos.group_data().setValue(attr.qos.m_groupData);
-    qos.partition() = attr.qos.m_partition;
-    qos.presentation() = attr.qos.m_presentation;
-}
-
-static void set_qos_from_attributes(
-        PublisherQos& qos,
-        const PublisherAttributes& attr)
-{
-    qos.group_data().setValue(attr.qos.m_groupData);
-    qos.partition() = attr.qos.m_partition;
-    qos.presentation() = attr.qos.m_presentation;
-}
 
 DomainParticipantImpl::DomainParticipantImpl(
         DomainParticipant* dp,

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -110,15 +110,15 @@ DomainParticipantImpl::DomainParticipantImpl(
 
     PublisherAttributes pub_attr;
     XMLProfileManager::getDefaultPublisherAttributes(pub_attr);
-    set_qos_from_attributes(default_pub_qos_, pub_attr);
+    utils::set_qos_from_attributes(default_pub_qos_, pub_attr);
 
     SubscriberAttributes sub_attr;
     XMLProfileManager::getDefaultSubscriberAttributes(sub_attr);
-    set_qos_from_attributes(default_sub_qos_, sub_attr);
+    utils::set_qos_from_attributes(default_sub_qos_, sub_attr);
 
     TopicAttributes top_attr;
     XMLProfileManager::getDefaultTopicAttributes(top_attr);
-    set_qos_from_attributes(default_topic_qos_, top_attr);
+    utils::set_qos_from_attributes(default_topic_qos_, top_attr);
 
     // Pre calculate participant id and generated guid
     participant_id_ = qos_.wire_protocol().participant_id;
@@ -248,7 +248,7 @@ ReturnCode_t DomainParticipantImpl::enable()
     assert(get_rtps_participant() == nullptr);
 
     fastrtps::rtps::RTPSParticipantAttributes rtps_attr;
-    set_attributes_from_qos(rtps_attr, qos_);
+    utils::set_attributes_from_qos(rtps_attr, qos_);
     rtps_attr.participantID = participant_id_;
 
     // If DEFAULT_ROS2_MASTER_URI is specified then try to create default client if
@@ -359,7 +359,7 @@ ReturnCode_t DomainParticipantImpl::set_qos(
             if (qos_should_be_updated)
             {
                 // Notify the participant that there is a QoS update
-                set_attributes_from_qos(patt, qos_);
+                utils::set_attributes_from_qos(patt, qos_);
             }
             else
             {
@@ -800,7 +800,7 @@ Publisher* DomainParticipantImpl::create_publisher_with_profile(
     if (XMLP_ret::XML_OK == XMLProfileManager::fillPublisherAttributes(profile_name, attr))
     {
         PublisherQos qos = default_pub_qos_;
-        set_qos_from_attributes(qos, attr);
+        utils::set_qos_from_attributes(qos, attr);
         return create_publisher(qos, listener, mask);
     }
 
@@ -996,7 +996,7 @@ void DomainParticipantImpl::reset_default_publisher_qos()
     PublisherImpl::set_qos(default_pub_qos_, PUBLISHER_QOS_DEFAULT, true);
     PublisherAttributes attr;
     XMLProfileManager::getDefaultPublisherAttributes(attr);
-    set_qos_from_attributes(default_pub_qos_, attr);
+    utils::set_qos_from_attributes(default_pub_qos_, attr);
 }
 
 const PublisherQos& DomainParticipantImpl::get_default_publisher_qos() const
@@ -1012,7 +1012,7 @@ const ReturnCode_t DomainParticipantImpl::get_publisher_qos_from_profile(
     if (XMLP_ret::XML_OK == XMLProfileManager::fillPublisherAttributes(profile_name, attr))
     {
         qos = default_pub_qos_;
-        set_qos_from_attributes(qos, attr);
+        utils::set_qos_from_attributes(qos, attr);
         return ReturnCode_t::RETCODE_OK;
     }
 
@@ -1044,7 +1044,7 @@ void DomainParticipantImpl::reset_default_subscriber_qos()
     SubscriberImpl::set_qos(default_sub_qos_, SUBSCRIBER_QOS_DEFAULT, true);
     SubscriberAttributes attr;
     XMLProfileManager::getDefaultSubscriberAttributes(attr);
-    set_qos_from_attributes(default_sub_qos_, attr);
+    utils::set_qos_from_attributes(default_sub_qos_, attr);
 }
 
 const SubscriberQos& DomainParticipantImpl::get_default_subscriber_qos() const
@@ -1060,7 +1060,7 @@ const ReturnCode_t DomainParticipantImpl::get_subscriber_qos_from_profile(
     if (XMLP_ret::XML_OK == XMLProfileManager::fillSubscriberAttributes(profile_name, attr))
     {
         qos = default_sub_qos_;
-        set_qos_from_attributes(qos, attr);
+        utils::set_qos_from_attributes(qos, attr);
         return ReturnCode_t::RETCODE_OK;
     }
 
@@ -1092,7 +1092,7 @@ void DomainParticipantImpl::reset_default_topic_qos()
     TopicImpl::set_qos(default_topic_qos_, TOPIC_QOS_DEFAULT, true);
     TopicAttributes attr;
     XMLProfileManager::getDefaultTopicAttributes(attr);
-    set_qos_from_attributes(default_topic_qos_, attr);
+    utils::set_qos_from_attributes(default_topic_qos_, attr);
 }
 
 const TopicQos& DomainParticipantImpl::get_default_topic_qos() const
@@ -1108,7 +1108,7 @@ const ReturnCode_t DomainParticipantImpl::get_topic_qos_from_profile(
     if (XMLP_ret::XML_OK == XMLProfileManager::fillTopicAttributes(profile_name, attr))
     {
         qos = default_topic_qos_;
-        set_qos_from_attributes(qos, attr);
+        utils::set_qos_from_attributes(qos, attr);
         return ReturnCode_t::RETCODE_OK;
     }
 
@@ -1273,7 +1273,7 @@ Subscriber* DomainParticipantImpl::create_subscriber_with_profile(
     if (XMLP_ret::XML_OK == XMLProfileManager::fillSubscriberAttributes(profile_name, attr))
     {
         SubscriberQos qos = default_sub_qos_;
-        set_qos_from_attributes(qos, attr);
+        utils::set_qos_from_attributes(qos, attr);
         return create_subscriber(qos, listener, mask);
     }
 
@@ -1357,7 +1357,7 @@ Topic* DomainParticipantImpl::create_topic_with_profile(
     if (XMLP_ret::XML_OK == XMLProfileManager::fillTopicAttributes(profile_name, attr))
     {
         TopicQos qos = default_topic_qos_;
-        set_qos_from_attributes(qos, attr);
+        utils::set_qos_from_attributes(qos, attr);
         return create_topic(topic_name, type_name, qos, listener, mask);
     }
 

--- a/src/cpp/fastdds/publisher/PublisherImpl.cpp
+++ b/src/cpp/fastdds/publisher/PublisherImpl.cpp
@@ -22,6 +22,8 @@
 #include <fastdds/domain/DomainParticipantImpl.hpp>
 #include <fastdds/topic/TopicDescriptionImpl.hpp>
 
+#include <fastdds/utils/QosConverters.hpp>
+
 #include <fastdds/dds/publisher/Publisher.hpp>
 #include <fastdds/dds/publisher/PublisherListener.hpp>
 #include <fastdds/dds/publisher/DataWriter.hpp>
@@ -49,7 +51,7 @@ using fastrtps::rtps::InstanceHandle_t;
 using fastrtps::rtps::Property;
 using fastrtps::Duration_t;
 using fastrtps::PublisherAttributes;
-
+/*
 static void set_qos_from_attributes(
         DataWriterQos& qos,
         const PublisherAttributes& attr)
@@ -99,7 +101,7 @@ static void set_qos_from_attributes(
         property.value(std::move(partitions));
         qos.properties().properties().push_back(std::move(property));
     }
-}
+}*/
 
 PublisherImpl::PublisherImpl(
         DomainParticipantImpl* p,

--- a/src/cpp/fastdds/publisher/PublisherImpl.cpp
+++ b/src/cpp/fastdds/publisher/PublisherImpl.cpp
@@ -64,7 +64,7 @@ PublisherImpl::PublisherImpl(
 {
     PublisherAttributes pub_attr;
     XMLProfileManager::getDefaultPublisherAttributes(pub_attr);
-    set_qos_from_attributes(default_datawriter_qos_, pub_attr);
+    utils::set_qos_from_attributes(default_datawriter_qos_, pub_attr);
 }
 
 ReturnCode_t PublisherImpl::enable()
@@ -276,7 +276,7 @@ DataWriter* PublisherImpl::create_datawriter_with_profile(
     if (XMLP_ret::XML_OK == XMLProfileManager::fillPublisherAttributes(profile_name, attr))
     {
         DataWriterQos qos = default_datawriter_qos_;
-        set_qos_from_attributes(qos, attr);
+        utils::set_qos_from_attributes(qos, attr);
         return create_datawriter(topic, qos, listener, mask);
     }
 
@@ -431,7 +431,7 @@ void PublisherImpl::reset_default_datawriter_qos()
     DataWriterImpl::set_qos(default_datawriter_qos_, DATAWRITER_QOS_DEFAULT, true);
     PublisherAttributes attr;
     XMLProfileManager::getDefaultPublisherAttributes(attr);
-    set_qos_from_attributes(default_datawriter_qos_, attr);
+    utils::set_qos_from_attributes(default_datawriter_qos_, attr);
 }
 
 const DataWriterQos& PublisherImpl::get_default_datawriter_qos() const
@@ -447,7 +447,7 @@ const ReturnCode_t PublisherImpl::get_datawriter_qos_from_profile(
     if (XMLP_ret::XML_OK == XMLProfileManager::fillPublisherAttributes(profile_name, attr, false))
     {
         qos = default_datawriter_qos_;
-        set_qos_from_attributes(qos, attr);
+        utils::set_qos_from_attributes(qos, attr);
         return ReturnCode_t::RETCODE_OK;
     }
 

--- a/src/cpp/fastdds/publisher/PublisherImpl.cpp
+++ b/src/cpp/fastdds/publisher/PublisherImpl.cpp
@@ -31,7 +31,6 @@
 #include <fastdds/dds/domain/DomainParticipantListener.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
 
-#include <fastdds/rtps/common/Property.h>
 #include <fastdds/rtps/participant/RTPSParticipant.h>
 #include <fastdds/dds/log/Log.hpp>
 
@@ -48,60 +47,8 @@ namespace dds {
 using fastrtps::xmlparser::XMLProfileManager;
 using fastrtps::xmlparser::XMLP_ret;
 using fastrtps::rtps::InstanceHandle_t;
-using fastrtps::rtps::Property;
 using fastrtps::Duration_t;
 using fastrtps::PublisherAttributes;
-/*
-static void set_qos_from_attributes(
-        DataWriterQos& qos,
-        const PublisherAttributes& attr)
-{
-    qos.writer_resource_limits().matched_subscriber_allocation = attr.matched_subscriber_allocation;
-    qos.properties() = attr.properties;
-    qos.throughput_controller() = attr.throughputController;
-    qos.endpoint().unicast_locator_list = attr.unicastLocatorList;
-    qos.endpoint().multicast_locator_list = attr.multicastLocatorList;
-    qos.endpoint().remote_locator_list = attr.remoteLocatorList;
-    qos.endpoint().history_memory_policy = attr.historyMemoryPolicy;
-    qos.endpoint().user_defined_id = attr.getUserDefinedID();
-    qos.endpoint().entity_id = attr.getEntityID();
-    qos.reliable_writer_qos().times = attr.times;
-    qos.reliable_writer_qos().disable_positive_acks = attr.qos.m_disablePositiveACKs;
-    qos.durability() = attr.qos.m_durability;
-    qos.durability_service() = attr.qos.m_durabilityService;
-    qos.deadline() = attr.qos.m_deadline;
-    qos.latency_budget() = attr.qos.m_latencyBudget;
-    qos.liveliness() = attr.qos.m_liveliness;
-    qos.reliability() = attr.qos.m_reliability;
-    qos.lifespan() = attr.qos.m_lifespan;
-    qos.user_data().setValue(attr.qos.m_userData);
-    qos.ownership() = attr.qos.m_ownership;
-    qos.ownership_strength() = attr.qos.m_ownershipStrength;
-    qos.destination_order() = attr.qos.m_destinationOrder;
-    qos.representation() = attr.qos.representation;
-    qos.publish_mode() = attr.qos.m_publishMode;
-    qos.history() = attr.topic.historyQos;
-    qos.resource_limits() = attr.topic.resourceLimitsQos;
-    qos.data_sharing() = attr.qos.data_sharing;
-    qos.reliable_writer_qos().disable_heartbeat_piggyback = attr.qos.disable_heartbeat_piggyback;
-
-    if (attr.qos.m_partition.size() > 0 )
-    {
-        Property property;
-        property.name("partitions");
-        std::string partitions;
-        bool is_first_partition = true;
-
-        for (auto partition : attr.qos.m_partition.names())
-        {
-            partitions += (is_first_partition ? "" : ";") + partition;
-            is_first_partition = false;
-        }
-
-        property.value(std::move(partitions));
-        qos.properties().properties().push_back(std::move(property));
-    }
-}*/
 
 PublisherImpl::PublisherImpl(
         DomainParticipantImpl* p,

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -29,6 +29,7 @@
 #include <fastdds/dds/subscriber/SubscriberListener.hpp>
 #include <fastdds/dds/subscriber/DataReader.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
+#include <fastdds/utils/QosConverters.hpp>
 
 #include <fastdds/rtps/common/Property.h>
 #include <fastdds/rtps/participant/RTPSParticipant.h>
@@ -48,56 +49,6 @@ using fastrtps::rtps::InstanceHandle_t;
 using fastrtps::rtps::Property;
 using fastrtps::Duration_t;
 using fastrtps::SubscriberAttributes;
-
-static void set_qos_from_attributes(
-        DataReaderQos& qos,
-        const SubscriberAttributes& attr)
-{
-    qos.reader_resource_limits().matched_publisher_allocation = attr.matched_publisher_allocation;
-    qos.properties() = attr.properties;
-    qos.expects_inline_qos(attr.expectsInlineQos);
-    qos.endpoint().unicast_locator_list = attr.unicastLocatorList;
-    qos.endpoint().multicast_locator_list = attr.multicastLocatorList;
-    qos.endpoint().remote_locator_list = attr.remoteLocatorList;
-    qos.endpoint().history_memory_policy = attr.historyMemoryPolicy;
-    qos.endpoint().user_defined_id = attr.getUserDefinedID();
-    qos.endpoint().entity_id = attr.getEntityID();
-    qos.reliable_reader_qos().times = attr.times;
-    qos.reliable_reader_qos().disable_positive_ACKs = attr.qos.m_disablePositiveACKs;
-    qos.durability() = attr.qos.m_durability;
-    qos.durability_service() = attr.qos.m_durabilityService;
-    qos.deadline() = attr.qos.m_deadline;
-    qos.latency_budget() = attr.qos.m_latencyBudget;
-    qos.liveliness() = attr.qos.m_liveliness;
-    qos.reliability() = attr.qos.m_reliability;
-    qos.lifespan() = attr.qos.m_lifespan;
-    qos.user_data().setValue(attr.qos.m_userData);
-    qos.ownership() = attr.qos.m_ownership;
-    qos.destination_order() = attr.qos.m_destinationOrder;
-    qos.type_consistency().type_consistency = attr.qos.type_consistency;
-    qos.type_consistency().representation = attr.qos.representation;
-    qos.time_based_filter() = attr.qos.m_timeBasedFilter;
-    qos.history() = attr.topic.historyQos;
-    qos.resource_limits() = attr.topic.resourceLimitsQos;
-    qos.data_sharing() = attr.qos.data_sharing;
-
-    if (attr.qos.m_partition.size() > 0 )
-    {
-        Property property;
-        property.name("partitions");
-        std::string partitions;
-        bool is_first_partition = true;
-
-        for (auto partition : attr.qos.m_partition.names())
-        {
-            partitions += (is_first_partition ? "" : ";") + partition;
-            is_first_partition = false;
-        }
-
-        property.value(std::move(partitions));
-        qos.properties().properties().push_back(std::move(property));
-    }
-}
 
 SubscriberImpl::SubscriberImpl(
         DomainParticipantImpl* p,

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -64,7 +64,7 @@ SubscriberImpl::SubscriberImpl(
 {
     SubscriberAttributes sub_attr;
     XMLProfileManager::getDefaultSubscriberAttributes(sub_attr);
-    set_qos_from_attributes(default_datareader_qos_, sub_attr);
+    utils::set_qos_from_attributes(default_datareader_qos_, sub_attr);
 }
 
 ReturnCode_t SubscriberImpl::enable()
@@ -237,7 +237,7 @@ DataReader* SubscriberImpl::create_datareader_with_profile(
     if (XMLP_ret::XML_OK == XMLProfileManager::fillSubscriberAttributes(profile_name, attr))
     {
         DataReaderQos qos = default_datareader_qos_;
-        set_qos_from_attributes(qos, attr);
+        utils::set_qos_from_attributes(qos, attr);
         return create_datareader(topic, qos, listener, mask);
     }
 
@@ -369,7 +369,7 @@ void SubscriberImpl::reset_default_datareader_qos()
     DataReaderImpl::set_qos(default_datareader_qos_, DATAREADER_QOS_DEFAULT, true);
     SubscriberAttributes attr;
     XMLProfileManager::getDefaultSubscriberAttributes(attr);
-    set_qos_from_attributes(default_datareader_qos_, attr);
+    utils::set_qos_from_attributes(default_datareader_qos_, attr);
 }
 
 const DataReaderQos& SubscriberImpl::get_default_datareader_qos() const
@@ -408,7 +408,7 @@ const ReturnCode_t SubscriberImpl::get_datareader_qos_from_profile(
     if (XMLP_ret::XML_OK == XMLProfileManager::fillSubscriberAttributes(profile_name, attr, false))
     {
         qos = default_datareader_qos_;
-        set_qos_from_attributes(qos, attr);
+        utils::set_qos_from_attributes(qos, attr);
         return ReturnCode_t::RETCODE_OK;
     }
 

--- a/src/cpp/fastdds/utils/QosConverters.cpp
+++ b/src/cpp/fastdds/utils/QosConverters.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2022 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/cpp/fastdds/utils/QosConverters.cpp
+++ b/src/cpp/fastdds/utils/QosConverters.cpp
@@ -128,20 +128,6 @@ void set_qos_from_attributes(
     }
 }
 
-/**
- * @brief Fill DomainParticipantQos from a given attributes RTPSParticipantAttributes object
- *
- * For the case of the non-binary properties, instead of the RTPSParticipantAttributes overriding the
- * property list in the DomainParticipantQos, a merge is performed in the following manner:
- *
- * - If any property from the RTPSParticipantAttributes is not in the DomainParticipantQos, then it is appended
- *   to the DomainParticipantQos.
- * - If any property from the RTPSParticipantAttributes property is also in the DomainParticipantQos, then the
- *   value in the DomainParticipantQos is overridden with that of the RTPSParticipantAttributes.
- *
- * @param[in, out] qos The DomainParticipantQos to set
- * @param[in] attr The RTPSParticipantAttributes from which the @c qos is set.
- */
 void set_qos_from_attributes(
         DomainParticipantQos& qos,
         const eprosima::fastrtps::rtps::RTPSParticipantAttributes& attr)

--- a/src/cpp/fastdds/utils/QosConverters.cpp
+++ b/src/cpp/fastdds/utils/QosConverters.cpp
@@ -23,6 +23,7 @@
 namespace eprosima {
 namespace fastdds {
 namespace dds {
+namespace utils {
 
 using fastrtps::rtps::Property;
 
@@ -226,6 +227,7 @@ void set_qos_from_attributes(
     qos.presentation() = attr.qos.m_presentation;
 }
 
+} /* namespace utils */
 } /* namespace dds */
 } /* namespace fastdds */
 } /* namespace eprosima */

--- a/src/cpp/fastdds/utils/QosConverters.cpp
+++ b/src/cpp/fastdds/utils/QosConverters.cpp
@@ -1,0 +1,26 @@
+// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * QosConverters.cpp
+ *
+ */
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+
+} /* namespace dds */
+} /* namespace fastdds */
+} /* namespace eprosima */

--- a/src/cpp/fastdds/utils/QosConverters.cpp
+++ b/src/cpp/fastdds/utils/QosConverters.cpp
@@ -77,6 +77,56 @@ void set_qos_from_attributes(
     }
 }
 
+void set_qos_from_attributes(
+        DataReaderQos& qos,
+        const SubscriberAttributes& attr)
+{
+    qos.reader_resource_limits().matched_publisher_allocation = attr.matched_publisher_allocation;
+    qos.properties() = attr.properties;
+    qos.expects_inline_qos(attr.expectsInlineQos);
+    qos.endpoint().unicast_locator_list = attr.unicastLocatorList;
+    qos.endpoint().multicast_locator_list = attr.multicastLocatorList;
+    qos.endpoint().remote_locator_list = attr.remoteLocatorList;
+    qos.endpoint().history_memory_policy = attr.historyMemoryPolicy;
+    qos.endpoint().user_defined_id = attr.getUserDefinedID();
+    qos.endpoint().entity_id = attr.getEntityID();
+    qos.reliable_reader_qos().times = attr.times;
+    qos.reliable_reader_qos().disable_positive_ACKs = attr.qos.m_disablePositiveACKs;
+    qos.durability() = attr.qos.m_durability;
+    qos.durability_service() = attr.qos.m_durabilityService;
+    qos.deadline() = attr.qos.m_deadline;
+    qos.latency_budget() = attr.qos.m_latencyBudget;
+    qos.liveliness() = attr.qos.m_liveliness;
+    qos.reliability() = attr.qos.m_reliability;
+    qos.lifespan() = attr.qos.m_lifespan;
+    qos.user_data().setValue(attr.qos.m_userData);
+    qos.ownership() = attr.qos.m_ownership;
+    qos.destination_order() = attr.qos.m_destinationOrder;
+    qos.type_consistency().type_consistency = attr.qos.type_consistency;
+    qos.type_consistency().representation = attr.qos.representation;
+    qos.time_based_filter() = attr.qos.m_timeBasedFilter;
+    qos.history() = attr.topic.historyQos;
+    qos.resource_limits() = attr.topic.resourceLimitsQos;
+    qos.data_sharing() = attr.qos.data_sharing;
+
+    if (attr.qos.m_partition.size() > 0 )
+    {
+        Property property;
+        property.name("partitions");
+        std::string partitions;
+        bool is_first_partition = true;
+
+        for (auto partition : attr.qos.m_partition.names())
+        {
+            partitions += (is_first_partition ? "" : ";") + partition;
+            is_first_partition = false;
+        }
+
+        property.value(std::move(partitions));
+        qos.properties().properties().push_back(std::move(property));
+    }
+}
+
 /**
  * @brief Fill DomainParticipantQos from a given attributes RTPSParticipantAttributes object
  *

--- a/src/cpp/fastdds/utils/QosConverters.cpp
+++ b/src/cpp/fastdds/utils/QosConverters.cpp
@@ -18,14 +18,12 @@
  */
 
 #include <fastdds/utils/QosConverters.hpp>
-#include <fastrtps/attributes/PublisherAttributes.h>
 #include <fastdds/rtps/common/Property.h>
 
 namespace eprosima {
 namespace fastdds {
 namespace dds {
 
-using fastrtps::PublisherAttributes;
 using fastrtps::rtps::Property;
 
 void set_qos_from_attributes(
@@ -77,6 +75,57 @@ void set_qos_from_attributes(
         property.value(std::move(partitions));
         qos.properties().properties().push_back(std::move(property));
     }
+}
+
+/**
+ * @brief Fill DomainParticipantQos from a given attributes RTPSParticipantAttributes object
+ *
+ * For the case of the non-binary properties, instead of the RTPSParticipantAttributes overriding the
+ * property list in the DomainParticipantQos, a merge is performed in the following manner:
+ *
+ * - If any property from the RTPSParticipantAttributes is not in the DomainParticipantQos, then it is appended
+ *   to the DomainParticipantQos.
+ * - If any property from the RTPSParticipantAttributes property is also in the DomainParticipantQos, then the
+ *   value in the DomainParticipantQos is overridden with that of the RTPSParticipantAttributes.
+ *
+ * @param[in, out] qos The DomainParticipantQos to set
+ * @param[in] attr The RTPSParticipantAttributes from which the @c qos is set.
+ */
+void set_qos_from_attributes(
+        DomainParticipantQos& qos,
+        const eprosima::fastrtps::rtps::RTPSParticipantAttributes& attr)
+{
+    qos.user_data().setValue(attr.userData);
+    qos.allocation() = attr.allocation;
+    qos.wire_protocol().prefix = attr.prefix;
+    qos.wire_protocol().participant_id = attr.participantID;
+    qos.wire_protocol().builtin = attr.builtin;
+    qos.wire_protocol().port = attr.port;
+    qos.wire_protocol().throughput_controller = attr.throughputController;
+    qos.wire_protocol().default_unicast_locator_list = attr.defaultUnicastLocatorList;
+    qos.wire_protocol().default_multicast_locator_list = attr.defaultMulticastLocatorList;
+    qos.transport().user_transports = attr.userTransports;
+    qos.transport().use_builtin_transports = attr.useBuiltinTransports;
+    qos.transport().send_socket_buffer_size = attr.sendSocketBufferSize;
+    qos.transport().listen_socket_buffer_size = attr.listenSocketBufferSize;
+    qos.name() = attr.getName();
+    qos.flow_controllers() = attr.flow_controllers;
+
+    // Merge attributes and qos properties
+    for (auto property : attr.properties.properties())
+    {
+        std::string* property_value = fastrtps::rtps::PropertyPolicyHelper::find_property(
+            qos.properties(), property.name());
+        if (nullptr == property_value)
+        {
+            qos.properties().properties().emplace_back(property);
+        }
+        else
+        {
+            *property_value = property.value();
+        }
+    }
+    qos.properties().binary_properties() = attr.properties.binary_properties();
 }
 
 } /* namespace dds */

--- a/src/cpp/fastdds/utils/QosConverters.cpp
+++ b/src/cpp/fastdds/utils/QosConverters.cpp
@@ -17,9 +17,9 @@
  *
  */
 
+#include <string>
 #include <fastdds/rtps/common/Property.h>
 #include <fastdds/utils/QosConverters.hpp>
-#include <string>
 
 namespace eprosima {
 namespace fastdds {

--- a/src/cpp/fastdds/utils/QosConverters.cpp
+++ b/src/cpp/fastdds/utils/QosConverters.cpp
@@ -128,6 +128,54 @@ void set_qos_from_attributes(
     qos.properties().binary_properties() = attr.properties.binary_properties();
 }
 
+void set_attributes_from_qos(
+        fastrtps::rtps::RTPSParticipantAttributes& attr,
+        const DomainParticipantQos& qos)
+{
+    attr.allocation = qos.allocation();
+    attr.properties = qos.properties();
+    attr.setName(qos.name());
+    attr.prefix = qos.wire_protocol().prefix;
+    attr.participantID = qos.wire_protocol().participant_id;
+    attr.builtin = qos.wire_protocol().builtin;
+    attr.port = qos.wire_protocol().port;
+    attr.throughputController = qos.wire_protocol().throughput_controller;
+    attr.defaultUnicastLocatorList = qos.wire_protocol().default_unicast_locator_list;
+    attr.defaultMulticastLocatorList = qos.wire_protocol().default_multicast_locator_list;
+    attr.userTransports = qos.transport().user_transports;
+    attr.useBuiltinTransports = qos.transport().use_builtin_transports;
+    attr.sendSocketBufferSize = qos.transport().send_socket_buffer_size;
+    attr.listenSocketBufferSize = qos.transport().listen_socket_buffer_size;
+    attr.userData = qos.user_data().data_vec();
+    attr.flow_controllers = qos.flow_controllers();
+}
+
+void set_qos_from_attributes(
+        TopicQos& qos,
+        const TopicAttributes& attr)
+{
+    qos.history() = attr.historyQos;
+    qos.resource_limits() = attr.resourceLimitsQos;
+}
+
+void set_qos_from_attributes(
+        SubscriberQos& qos,
+        const SubscriberAttributes& attr)
+{
+    qos.group_data().setValue(attr.qos.m_groupData);
+    qos.partition() = attr.qos.m_partition;
+    qos.presentation() = attr.qos.m_presentation;
+}
+
+void set_qos_from_attributes(
+        PublisherQos& qos,
+        const PublisherAttributes& attr)
+{
+    qos.group_data().setValue(attr.qos.m_groupData);
+    qos.partition() = attr.qos.m_partition;
+    qos.presentation() = attr.qos.m_presentation;
+}
+
 } /* namespace dds */
 } /* namespace fastdds */
 } /* namespace eprosima */

--- a/src/cpp/fastdds/utils/QosConverters.cpp
+++ b/src/cpp/fastdds/utils/QosConverters.cpp
@@ -17,8 +17,9 @@
  *
  */
 
-#include <fastdds/utils/QosConverters.hpp>
 #include <fastdds/rtps/common/Property.h>
+#include <fastdds/utils/QosConverters.hpp>
+#include <string>
 
 namespace eprosima {
 namespace fastdds {
@@ -26,6 +27,7 @@ namespace dds {
 namespace utils {
 
 using fastrtps::rtps::Property;
+using std::string;
 
 void set_qos_from_attributes(
         DataWriterQos& qos,
@@ -64,7 +66,7 @@ void set_qos_from_attributes(
     {
         Property property;
         property.name("partitions");
-        std::string partitions;
+        string partitions;
         bool is_first_partition = true;
 
         for (auto partition : attr.qos.m_partition.names())
@@ -114,7 +116,7 @@ void set_qos_from_attributes(
     {
         Property property;
         property.name("partitions");
-        std::string partitions;
+        string partitions;
         bool is_first_partition = true;
 
         for (auto partition : attr.qos.m_partition.names())
@@ -151,7 +153,7 @@ void set_qos_from_attributes(
     // Merge attributes and qos properties
     for (auto property : attr.properties.properties())
     {
-        std::string* property_value = fastrtps::rtps::PropertyPolicyHelper::find_property(
+        string* property_value = fastrtps::rtps::PropertyPolicyHelper::find_property(
             qos.properties(), property.name());
         if (nullptr == property_value)
         {

--- a/src/cpp/fastdds/utils/QosConverters.cpp
+++ b/src/cpp/fastdds/utils/QosConverters.cpp
@@ -17,9 +17,67 @@
  *
  */
 
+#include <fastdds/utils/QosConverters.hpp>
+#include <fastrtps/attributes/PublisherAttributes.h>
+#include <fastdds/rtps/common/Property.h>
+
 namespace eprosima {
 namespace fastdds {
 namespace dds {
+
+using fastrtps::PublisherAttributes;
+using fastrtps::rtps::Property;
+
+void set_qos_from_attributes(
+        DataWriterQos& qos,
+        const PublisherAttributes& attr)
+{
+    qos.writer_resource_limits().matched_subscriber_allocation = attr.matched_subscriber_allocation;
+    qos.properties() = attr.properties;
+    qos.throughput_controller() = attr.throughputController;
+    qos.endpoint().unicast_locator_list = attr.unicastLocatorList;
+    qos.endpoint().multicast_locator_list = attr.multicastLocatorList;
+    qos.endpoint().remote_locator_list = attr.remoteLocatorList;
+    qos.endpoint().history_memory_policy = attr.historyMemoryPolicy;
+    qos.endpoint().user_defined_id = attr.getUserDefinedID();
+    qos.endpoint().entity_id = attr.getEntityID();
+    qos.reliable_writer_qos().times = attr.times;
+    qos.reliable_writer_qos().disable_positive_acks = attr.qos.m_disablePositiveACKs;
+    qos.durability() = attr.qos.m_durability;
+    qos.durability_service() = attr.qos.m_durabilityService;
+    qos.deadline() = attr.qos.m_deadline;
+    qos.latency_budget() = attr.qos.m_latencyBudget;
+    qos.liveliness() = attr.qos.m_liveliness;
+    qos.reliability() = attr.qos.m_reliability;
+    qos.lifespan() = attr.qos.m_lifespan;
+    qos.user_data().setValue(attr.qos.m_userData);
+    qos.ownership() = attr.qos.m_ownership;
+    qos.ownership_strength() = attr.qos.m_ownershipStrength;
+    qos.destination_order() = attr.qos.m_destinationOrder;
+    qos.representation() = attr.qos.representation;
+    qos.publish_mode() = attr.qos.m_publishMode;
+    qos.history() = attr.topic.historyQos;
+    qos.resource_limits() = attr.topic.resourceLimitsQos;
+    qos.data_sharing() = attr.qos.data_sharing;
+    qos.reliable_writer_qos().disable_heartbeat_piggyback = attr.qos.disable_heartbeat_piggyback;
+
+    if (attr.qos.m_partition.size() > 0 )
+    {
+        Property property;
+        property.name("partitions");
+        std::string partitions;
+        bool is_first_partition = true;
+
+        for (auto partition : attr.qos.m_partition.names())
+        {
+            partitions += (is_first_partition ? "" : ";") + partition;
+            is_first_partition = false;
+        }
+
+        property.value(std::move(partitions));
+        qos.properties().properties().push_back(std::move(property));
+    }
+}
 
 } /* namespace dds */
 } /* namespace fastdds */

--- a/src/cpp/fastdds/utils/QosConverters.cpp
+++ b/src/cpp/fastdds/utils/QosConverters.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <string>
+
 #include <fastdds/rtps/common/Property.h>
 #include <fastdds/utils/QosConverters.hpp>
 

--- a/src/cpp/fastdds/utils/QosConverters.hpp
+++ b/src/cpp/fastdds/utils/QosConverters.hpp
@@ -58,9 +58,18 @@ void set_qos_from_attributes(
         const SubscriberAttributes& attr);
 
 /**
- * Obtains the corresponding QoS from the attributes provided.
- * @param qos Pointer to the QoS to write on
- * @param attr Pointer to the attributes from which to obtain data
+ * @brief Fill DomainParticipantQos from a given attributes RTPSParticipantAttributes object
+ *
+ * For the case of the non-binary properties, instead of the RTPSParticipantAttributes overriding the
+ * property list in the DomainParticipantQos, a merge is performed in the following manner:
+ *
+ * - If any property from the RTPSParticipantAttributes is not in the DomainParticipantQos, then it is appended
+ *   to the DomainParticipantQos.
+ * - If any property from the RTPSParticipantAttributes property is also in the DomainParticipantQos, then the
+ *   value in the DomainParticipantQos is overridden with that of the RTPSParticipantAttributes.
+ *
+ * @param[in, out] qos The DomainParticipantQos to set
+ * @param[in] attr The RTPSParticipantAttributes from which the @c qos is set.
  */
 void set_qos_from_attributes(
         DomainParticipantQos& qos,

--- a/src/cpp/fastdds/utils/QosConverters.hpp
+++ b/src/cpp/fastdds/utils/QosConverters.hpp
@@ -40,8 +40,8 @@ using fastrtps::TopicAttributes;
 /**
  * Obtains the DataWriterQos from the PublisherAttributes provided.
  *
- * @param qos Pointer to the QoS to write on
- * @param attr Pointer to the attributes from which to obtain data
+ * @param[out] qos Pointer to the QoS to write on
+ * @param[in] attr Pointer to the attributes from which to obtain data
  */
 void set_qos_from_attributes(
         DataWriterQos& qos,
@@ -50,8 +50,8 @@ void set_qos_from_attributes(
 /**
  * Obtains the DataReaderQos from the SubscriberAttributes provided.
  *
- * @param qos Pointer to the QoS to write on
- * @param attr Pointer to the attributes from which to obtain data
+ * @param[out] qos Pointer to the QoS to write on
+ * @param[in] attr Pointer to the attributes from which to obtain data
  */
 void set_qos_from_attributes(
         DataReaderQos& qos,
@@ -68,7 +68,7 @@ void set_qos_from_attributes(
  * - If any property from the RTPSParticipantAttributes property is also in the DomainParticipantQos, then the
  *   value in the DomainParticipantQos is overridden with that of the RTPSParticipantAttributes.
  *
- * @param[in, out] qos The DomainParticipantQos to set
+ * @param[out] qos The DomainParticipantQos to set
  * @param[in] attr The RTPSParticipantAttributes from which the @c qos is set.
  */
 void set_qos_from_attributes(
@@ -78,8 +78,8 @@ void set_qos_from_attributes(
 /**
  * Obtains the RTPSParticipantAttributes from the DomainParticipantQos provided.
  *
- * @param attr Pointer to the attributes from which to obtain data
- * @param qos Pointer to the QoS to write on
+ * @param[out] attr Pointer to the attributes from which to obtain data
+ * @param[in] qos Pointer to the QoS to write on
  */
 void set_attributes_from_qos(
         fastrtps::rtps::RTPSParticipantAttributes& attr,
@@ -88,8 +88,8 @@ void set_attributes_from_qos(
 /**
  * Obtains the TopicQos from the TopicAttributes provided.
  *
- * @param qos Pointer to the QoS to write on
- * @param attr Pointer to the attributes from which to obtain data
+ * @param[out] qos Pointer to the QoS to write on
+ * @param[in] attr Pointer to the attributes from which to obtain data
  */
 void set_qos_from_attributes(
         TopicQos& qos,
@@ -98,8 +98,8 @@ void set_qos_from_attributes(
 /**
  * Obtains the SubscriberQos from the SubscriberAttributes provided.
  *
- * @param qos Pointer to the QoS to write on
- * @param attr Pointer to the attributes from which to obtain data
+ * @param[out] qos Pointer to the QoS to write on
+ * @param[in] attr Pointer to the attributes from which to obtain data
  */
 void set_qos_from_attributes(
         SubscriberQos& qos,
@@ -108,8 +108,8 @@ void set_qos_from_attributes(
 /**
  * Obtains the PublisherQos from the PublisherAttributes provided.
  *
- * @param qos Pointer to the QoS to write on
- * @param attr Pointer to the attributes from which to obtain data
+ * @param[out] qos Pointer to the QoS to write on
+ * @param[in] attr Pointer to the attributes from which to obtain data
  */
 void set_qos_from_attributes(
         PublisherQos& qos,

--- a/src/cpp/fastdds/utils/QosConverters.hpp
+++ b/src/cpp/fastdds/utils/QosConverters.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2022 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/cpp/fastdds/utils/QosConverters.hpp
+++ b/src/cpp/fastdds/utils/QosConverters.hpp
@@ -39,7 +39,7 @@ using fastrtps::TopicAttributes;
 
 /**
  * Obtains the DataWriterQos from the PublisherAttributes provided.
- * 
+ *
  * @param qos Pointer to the QoS to write on
  * @param attr Pointer to the attributes from which to obtain data
  */
@@ -49,7 +49,7 @@ void set_qos_from_attributes(
 
 /**
  * Obtains the DataReaderQos from the SubscriberAttributes provided.
- * 
+ *
  * @param qos Pointer to the QoS to write on
  * @param attr Pointer to the attributes from which to obtain data
  */
@@ -77,7 +77,7 @@ void set_qos_from_attributes(
 
 /**
  * Obtains the RTPSParticipantAttributes from the DomainParticipantQos provided.
- * 
+ *
  * @param attr Pointer to the attributes from which to obtain data
  * @param qos Pointer to the QoS to write on
  */
@@ -87,7 +87,7 @@ void set_attributes_from_qos(
 
 /**
  * Obtains the TopicQos from the TopicAttributes provided.
- * 
+ *
  * @param qos Pointer to the QoS to write on
  * @param attr Pointer to the attributes from which to obtain data
  */
@@ -97,7 +97,7 @@ void set_qos_from_attributes(
 
 /**
  * Obtains the SubscriberQos from the SubscriberAttributes provided.
- * 
+ *
  * @param qos Pointer to the QoS to write on
  * @param attr Pointer to the attributes from which to obtain data
  */
@@ -107,7 +107,7 @@ void set_qos_from_attributes(
 
 /**
  * Obtains the PublisherQos from the PublisherAttributes provided.
- * 
+ *
  * @param qos Pointer to the QoS to write on
  * @param attr Pointer to the attributes from which to obtain data
  */

--- a/src/cpp/fastdds/utils/QosConverters.hpp
+++ b/src/cpp/fastdds/utils/QosConverters.hpp
@@ -68,7 +68,7 @@ void set_qos_from_attributes(
  * - If any property from the RTPSParticipantAttributes property is also in the DomainParticipantQos, then the
  *   value in the DomainParticipantQos is overridden with that of the RTPSParticipantAttributes.
  *
- * @param[out] qos The DomainParticipantQos to set
+ * @param[in, out] qos The DomainParticipantQos to set
  * @param[in] attr The RTPSParticipantAttributes from which the @c qos is set.
  */
 void set_qos_from_attributes(

--- a/src/cpp/fastdds/utils/QosConverters.hpp
+++ b/src/cpp/fastdds/utils/QosConverters.hpp
@@ -22,11 +22,18 @@
 #define _QOS_CONVERTERS_HPP_
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
+#include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
+#include <fastrtps/attributes/PublisherAttributes.h>
+
 namespace eprosima {
 namespace fastdds {
 namespace dds {
 
 using fastrtps::PublisherAttributes;
+
+void set_qos_from_attributes(
+        DataWriterQos& qos,
+        const PublisherAttributes& attr);
 
 } /* namespace dds */
 } /* namespace fastdds */

--- a/src/cpp/fastdds/utils/QosConverters.hpp
+++ b/src/cpp/fastdds/utils/QosConverters.hpp
@@ -39,30 +39,65 @@ using fastrtps::PublisherAttributes;
 using fastrtps::SubscriberAttributes;
 using fastrtps::TopicAttributes;
 
+/**
+ * Obtains the corresponding QoS from the attributes provided.
+ * @param qos Pointer to the QoS to write on
+ * @param attr Pointer to the attributes from which to obtain data
+ */
 void set_qos_from_attributes(
         DataWriterQos& qos,
         const PublisherAttributes& attr);
 
+/**
+ * Obtains the corresponding QoS from the attributes provided.
+ * @param qos Pointer to the QoS to write on
+ * @param attr Pointer to the attributes from which to obtain data
+ */
 void set_qos_from_attributes(
         DataReaderQos& qos,
         const SubscriberAttributes& attr);
 
+/**
+ * Obtains the corresponding QoS from the attributes provided.
+ * @param qos Pointer to the QoS to write on
+ * @param attr Pointer to the attributes from which to obtain data
+ */
 void set_qos_from_attributes(
         DomainParticipantQos& qos,
         const eprosima::fastrtps::rtps::RTPSParticipantAttributes& attr);
 
+/**
+ * Obtains the corresponding attributes from the QoS provided.
+ * @param attr Pointer to the attributes from which to obtain data
+ * @param qos Pointer to the QoS to write on
+ */
 void set_attributes_from_qos(
         fastrtps::rtps::RTPSParticipantAttributes& attr,
         const DomainParticipantQos& qos);
 
+/**
+ * Obtains the corresponding QoS from the attributes provided.
+ * @param qos Pointer to the QoS to write on
+ * @param attr Pointer to the attributes from which to obtain data
+ */
 void set_qos_from_attributes(
         TopicQos& qos,
         const TopicAttributes& attr);
 
+/**
+ * Obtains the corresponding QoS from the attributes provided.
+ * @param qos Pointer to the QoS to write on
+ * @param attr Pointer to the attributes from which to obtain data
+ */
 void set_qos_from_attributes(
         SubscriberQos& qos,
         const SubscriberAttributes& attr);
 
+/**
+ * Obtains the corresponding QoS from the attributes provided.
+ * @param qos Pointer to the QoS to write on
+ * @param attr Pointer to the attributes from which to obtain data
+ */
 void set_qos_from_attributes(
         PublisherQos& qos,
         const PublisherAttributes& attr);

--- a/src/cpp/fastdds/utils/QosConverters.hpp
+++ b/src/cpp/fastdds/utils/QosConverters.hpp
@@ -20,13 +20,13 @@
 #define _FASTDDS_UTILS_QOS_CONVERTERS_HPP_
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
+#include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
+#include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
 #include <fastrtps/attributes/PublisherAttributes.h>
 #include <fastrtps/attributes/SubscriberAttributes.h>
 #include <fastrtps/attributes/TopicAttributes.h>
-#include <fastdds/dds/domain/DomainParticipant.hpp>
-#include <fastdds/rtps/participant/RTPSParticipant.h>
 
 namespace eprosima {
 namespace fastdds {

--- a/src/cpp/fastdds/utils/QosConverters.hpp
+++ b/src/cpp/fastdds/utils/QosConverters.hpp
@@ -24,6 +24,8 @@
 
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
 #include <fastrtps/attributes/PublisherAttributes.h>
+#include <fastdds/dds/domain/DomainParticipant.hpp>
+#include <fastdds/rtps/participant/RTPSParticipant.h>
 
 namespace eprosima {
 namespace fastdds {
@@ -34,6 +36,10 @@ using fastrtps::PublisherAttributes;
 void set_qos_from_attributes(
         DataWriterQos& qos,
         const PublisherAttributes& attr);
+
+void set_qos_from_attributes(
+        DomainParticipantQos& qos,
+        const eprosima::fastrtps::rtps::RTPSParticipantAttributes& attr);
 
 } /* namespace dds */
 } /* namespace fastdds */

--- a/src/cpp/fastdds/utils/QosConverters.hpp
+++ b/src/cpp/fastdds/utils/QosConverters.hpp
@@ -43,6 +43,10 @@ void set_qos_from_attributes(
         const PublisherAttributes& attr);
 
 void set_qos_from_attributes(
+        DataReaderQos& qos,
+        const SubscriberAttributes& attr);
+
+void set_qos_from_attributes(
         DomainParticipantQos& qos,
         const eprosima::fastrtps::rtps::RTPSParticipantAttributes& attr);
 

--- a/src/cpp/fastdds/utils/QosConverters.hpp
+++ b/src/cpp/fastdds/utils/QosConverters.hpp
@@ -33,6 +33,7 @@
 namespace eprosima {
 namespace fastdds {
 namespace dds {
+namespace utils {
 
 using fastrtps::PublisherAttributes;
 using fastrtps::SubscriberAttributes;
@@ -66,6 +67,7 @@ void set_qos_from_attributes(
         PublisherQos& qos,
         const PublisherAttributes& attr);
 
+} /* namespace utils */
 } /* namespace dds */
 } /* namespace fastdds */
 } /* namespace eprosima */

--- a/src/cpp/fastdds/utils/QosConverters.hpp
+++ b/src/cpp/fastdds/utils/QosConverters.hpp
@@ -38,7 +38,8 @@ using fastrtps::SubscriberAttributes;
 using fastrtps::TopicAttributes;
 
 /**
- * Obtains the corresponding QoS from the attributes provided.
+ * Obtains the DataWriterQos from the PublisherAttributes provided.
+ * 
  * @param qos Pointer to the QoS to write on
  * @param attr Pointer to the attributes from which to obtain data
  */
@@ -47,7 +48,8 @@ void set_qos_from_attributes(
         const PublisherAttributes& attr);
 
 /**
- * Obtains the corresponding QoS from the attributes provided.
+ * Obtains the DataReaderQos from the SubscriberAttributes provided.
+ * 
  * @param qos Pointer to the QoS to write on
  * @param attr Pointer to the attributes from which to obtain data
  */
@@ -74,7 +76,8 @@ void set_qos_from_attributes(
         const eprosima::fastrtps::rtps::RTPSParticipantAttributes& attr);
 
 /**
- * Obtains the corresponding attributes from the QoS provided.
+ * Obtains the RTPSParticipantAttributes from the DomainParticipantQos provided.
+ * 
  * @param attr Pointer to the attributes from which to obtain data
  * @param qos Pointer to the QoS to write on
  */
@@ -83,7 +86,8 @@ void set_attributes_from_qos(
         const DomainParticipantQos& qos);
 
 /**
- * Obtains the corresponding QoS from the attributes provided.
+ * Obtains the TopicQos from the TopicAttributes provided.
+ * 
  * @param qos Pointer to the QoS to write on
  * @param attr Pointer to the attributes from which to obtain data
  */
@@ -92,7 +96,8 @@ void set_qos_from_attributes(
         const TopicAttributes& attr);
 
 /**
- * Obtains the corresponding QoS from the attributes provided.
+ * Obtains the SubscriberQos from the SubscriberAttributes provided.
+ * 
  * @param qos Pointer to the QoS to write on
  * @param attr Pointer to the attributes from which to obtain data
  */
@@ -101,7 +106,8 @@ void set_qos_from_attributes(
         const SubscriberAttributes& attr);
 
 /**
- * Obtains the corresponding QoS from the attributes provided.
+ * Obtains the PublisherQos from the PublisherAttributes provided.
+ * 
  * @param qos Pointer to the QoS to write on
  * @param attr Pointer to the attributes from which to obtain data
  */

--- a/src/cpp/fastdds/utils/QosConverters.hpp
+++ b/src/cpp/fastdds/utils/QosConverters.hpp
@@ -23,7 +23,10 @@
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
+#include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 #include <fastrtps/attributes/PublisherAttributes.h>
+#include <fastrtps/attributes/SubscriberAttributes.h>
+#include <fastrtps/attributes/TopicAttributes.h>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/rtps/participant/RTPSParticipant.h>
 
@@ -32,6 +35,8 @@ namespace fastdds {
 namespace dds {
 
 using fastrtps::PublisherAttributes;
+using fastrtps::SubscriberAttributes;
+using fastrtps::TopicAttributes;
 
 void set_qos_from_attributes(
         DataWriterQos& qos,
@@ -40,6 +45,22 @@ void set_qos_from_attributes(
 void set_qos_from_attributes(
         DomainParticipantQos& qos,
         const eprosima::fastrtps::rtps::RTPSParticipantAttributes& attr);
+
+void set_attributes_from_qos(
+        fastrtps::rtps::RTPSParticipantAttributes& attr,
+        const DomainParticipantQos& qos);
+
+void set_qos_from_attributes(
+        TopicQos& qos,
+        const TopicAttributes& attr);
+
+void set_qos_from_attributes(
+        SubscriberQos& qos,
+        const SubscriberAttributes& attr);
+
+void set_qos_from_attributes(
+        PublisherQos& qos,
+        const PublisherAttributes& attr);
 
 } /* namespace dds */
 } /* namespace fastdds */

--- a/src/cpp/fastdds/utils/QosConverters.hpp
+++ b/src/cpp/fastdds/utils/QosConverters.hpp
@@ -16,10 +16,8 @@
  * @file QosConverters.h
  */
 
-
-
-#ifndef _QOS_CONVERTERS_HPP_
-#define _QOS_CONVERTERS_HPP_
+#ifndef _FASTDDS_UTILS_QOS_CONVERTERS_HPP_
+#define _FASTDDS_UTILS_QOS_CONVERTERS_HPP_
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
@@ -116,4 +114,4 @@ void set_qos_from_attributes(
 } /* namespace fastdds */
 } /* namespace eprosima */
 #endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
-#endif /* _QOS_CONVERTERS_HPP_ */
+#endif /* _FASTDDS_UTILS_QOS_CONVERTERS_HPP_ */

--- a/src/cpp/fastdds/utils/QosConverters.hpp
+++ b/src/cpp/fastdds/utils/QosConverters.hpp
@@ -1,0 +1,35 @@
+// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file QosConverters.h
+ */
+
+
+
+#ifndef _QOS_CONVERTERS_HPP_
+#define _QOS_CONVERTERS_HPP_
+#ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+
+using fastrtps::PublisherAttributes;
+
+} /* namespace dds */
+} /* namespace fastdds */
+} /* namespace eprosima */
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+#endif /* _QOS_CONVERTERS_HPP_ */

--- a/test/unittest/dds/publisher/CMakeLists.txt
+++ b/test/unittest/dds/publisher/CMakeLists.txt
@@ -99,6 +99,7 @@ set(DATAWRITERTESTS_SOURCE DataWriterTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/topic/TopicProxyFactory.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/topic/TypeSupport.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/topic/qos/TopicQos.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/utils/QosConverters.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/DataSharing/DataSharingListener.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/DataSharing/DataSharingNotification.cpp

--- a/test/unittest/dds/status/CMakeLists.txt
+++ b/test/unittest/dds/status/CMakeLists.txt
@@ -83,6 +83,7 @@ set(LISTENERTESTS_SOURCE ListenerTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/topic/qos/TopicQos.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/PropertyPolicy.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/utils/QosConverters.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/flowcontrol/FlowControllerConsts.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/flowcontrol/ThroughputControllerDescriptor.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/history/CacheChangePool.cpp

--- a/test/unittest/statistics/dds/CMakeLists.txt
+++ b/test/unittest/statistics/dds/CMakeLists.txt
@@ -147,6 +147,7 @@ if (SQLITE3_SUPPORT AND FASTDDS_STATISTICS)
         ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/topic/TopicProxyFactory.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/topic/TypeSupport.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/topic/qos/TopicQos.cpp
+        ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/utils/QosConverters.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/DataSharing/DataSharingListener.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/DataSharing/DataSharingNotification.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/DataSharing/DataSharingPayloadPool.cpp


### PR DESCRIPTION

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
set_qos_from_attributes() are defined as static free functions. And there is the need to access them from outside the .cpp where they are defined.
This PR should satisfy the following:
- Provide a header and a source 
- Put the new files in src/cpp/fastdds/utils
- Add the free functions into the eprosima::fastdds::dds::utils namespace.
- The new functions cannot be static. We won't inline them either.
- Refactor usage of the functions.

<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [N/A] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [N/A] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [N/A] New feature has been added to the `versions.md` file (if applicable).
- [N/A] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
