### PR TITLE
TCP multiple descriptors

### DIFF
--- a/examples/cpp/dds/HelloWorldExampleTCP/HelloWorldPublisher.cpp
+++ b/examples/cpp/dds/HelloWorldExampleTCP/HelloWorldPublisher.cpp
@@ -55,6 +55,8 @@ bool HelloWorldPublisher::init(
 
     pqos.transport().use_builtin_transports = false;
 
+    /////////////
+
     std::shared_ptr<TCPv4TransportDescriptor> descriptor = std::make_shared<TCPv4TransportDescriptor>();
 
     for (std::string ip : whitelist)
@@ -85,7 +87,33 @@ bool HelloWorldPublisher::init(
         std::cout << wan_ip << ":" << port << std::endl;
     }
     descriptor->add_listener_port(port);
+
+    // pqos.transport().user_transports.push_back(descriptor);
+
+    /////////////
+
+    static_cast<void>(wan_ip);
+    static_cast<void>(use_tls);
+    static_cast<void>(whitelist);
+
+    std::shared_ptr<TCPv4TransportDescriptor> descriptor_local = std::make_shared<TCPv4TransportDescriptor>();
+    descriptor_local->sendBufferSize = 0;
+    descriptor_local->receiveBufferSize = 0;
+    std::string local_ip = "127.0.0.1";
+    port += 10;
+    descriptor_local->set_WAN_address(local_ip);
+    std::cout << local_ip << ":" << port << std::endl;
+
+    descriptor_local->add_listener_port(port);
+    // pqos.transport().user_transports.push_back(descriptor_local);
+
+
+    ///////////////////
+
     pqos.transport().user_transports.push_back(descriptor);
+    pqos.transport().user_transports.push_back(descriptor_local);
+
+    ///////////////////
 
     participant_ = DomainParticipantFactory::get_instance()->create_participant(0, pqos);
 

--- a/include/fastdds/rtps/common/Locator.h
+++ b/include/fastdds/rtps/common/Locator.h
@@ -371,7 +371,10 @@ inline std::ostream& operator <<(
     }
 
     // Stream port
-    output << "]:" << loc.port;
+    auto p_port = IPLocator::getPhysicalPort(loc);
+    auto l_port = IPLocator::getLogicalPort(loc);
+
+    output << "]:" << p_port << ":" << l_port;
 
     return output;
 }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -144,6 +144,50 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     , is_intraprocess_only_(should_be_intraprocess_only(PParam))
     , has_shm_transport_(false)
 {
+
+    std::cout << std::endl;
+    std::cout << "RTPSParticipant Params to construct participnt" << std::endl;
+    for (const auto& x : PParam.builtin.metatrafficMulticastLocatorList)
+    {
+        std::cout << "Metatraffic Multicast Locator: " << x << std::endl;
+    }
+    for (const auto& x : PParam.builtin.metatrafficUnicastLocatorList)
+    {
+        std::cout << "Metatraffic Unicast Locator: " << x << std::endl;
+    }
+    for (const auto& x : PParam.builtin.initialPeersList)
+    {
+        std::cout << "Initial Peers Locator: " << x << std::endl;
+    }
+    for (const auto& x : PParam.defaultMulticastLocatorList)
+    {
+        std::cout << "Default Multicast Locator: " << x << std::endl;
+    }
+    for (const auto& x : PParam.defaultUnicastLocatorList)
+    {
+        std::cout << "Default Unicast Locator: " << x << std::endl;
+    }
+    for (const auto& x : PParam.userTransports)
+    {
+        std::cout << "User Transports: " << x << std::endl;
+        auto y = std::dynamic_pointer_cast<eprosima::fastdds::rtps::TCPv4TransportDescriptor>(x);
+        if (y)
+        {
+            for (const auto& p : y->listening_ports)
+            {
+                std::cout << "Listening Port: " << p << std::endl;
+            }
+            std::cout << "TCPv4TransportDescriptor " <<
+                static_cast<int>(y->wan_addr[0]) << "." <<
+                static_cast<int>(y->wan_addr[1]) << "." <<
+                static_cast<int>(y->wan_addr[2]) << "." <<
+                static_cast<int>(y->wan_addr[3]) << "." <<
+                std::endl;
+        }
+    }
+    std::cout << "End Locators in PParams" << std::endl;
+    std::cout << std::endl;
+
     if (c_GuidPrefix_Unknown != persistence_guid)
     {
         m_persistence_guid = GUID_t(persistence_guid, c_EntityId_RTPSParticipant);
@@ -421,6 +465,48 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         logInfo(RTPS_PARTICIPANT,
                 "RTPSParticipant \"" << m_att.getName() << "\" with guidPrefix: " << m_guid.guidPrefix);
     }
+
+    std::cout << "RTPSParticipant with guidPrefix: " << m_guid.guidPrefix << std::endl;
+    for (const auto& x : m_att.builtin.metatrafficMulticastLocatorList)
+    {
+        std::cout << "Metatraffic Multicast Locator: " << x << std::endl;
+    }
+    for (const auto& x : m_att.builtin.metatrafficUnicastLocatorList)
+    {
+        std::cout << "Metatraffic Unicast Locator: " << x << std::endl;
+    }
+    for (const auto& x : m_att.builtin.initialPeersList)
+    {
+        std::cout << "Initial Peers Locator: " << x << std::endl;
+    }
+    for (const auto& x : m_att.defaultMulticastLocatorList)
+    {
+        std::cout << "Default Multicast Locator: " << x << std::endl;
+    }
+    for (const auto& x : m_att.defaultUnicastLocatorList)
+    {
+        std::cout << "Default Unicast Locator: " << x << std::endl;
+    }
+    for (const auto& x : m_att.userTransports)
+    {
+        std::cout << "User Transports: " << x << std::endl;
+        auto y = std::dynamic_pointer_cast<eprosima::fastdds::rtps::TCPv4TransportDescriptor>(x);
+        if (y)
+        {
+            for (const auto& p : y->listening_ports)
+            {
+                std::cout << "Listening Port: " << p << std::endl;
+            }
+            std::cout << "TCPv4TransportDescriptor " <<
+                static_cast<int>(y->wan_addr[0]) << "." <<
+                static_cast<int>(y->wan_addr[1]) << "." <<
+                static_cast<int>(y->wan_addr[2]) << "." <<
+                static_cast<int>(y->wan_addr[3]) << "." <<
+                std::endl;
+        }
+    }
+    std::cout << "End Locators " << m_guid.guidPrefix << std::endl;
+    std::cout << std::endl;
 
     initialized_ = true;
 }

--- a/test/dds/communication/CMakeLists.txt
+++ b/test/dds/communication/CMakeLists.txt
@@ -111,6 +111,7 @@ list(APPEND TEST_DEFINITIONS
     zero_copy_sub_communication
     mix_zero_copy_communication
     close_TCP_client
+    TCP_multiple_descriptors
     )
 
 
@@ -121,7 +122,9 @@ list(APPEND XML_CONFIGURATION_FILES
     simple_besteffort_zerocopy.xml
     TCP_server.xml
     TCP_client.xml
+    TCP_server_multiple_descriptors.xml
     )
+
 # Python file
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/test_build.py
     ${CMAKE_CURRENT_BINARY_DIR}/test_build.py COPYONLY)

--- a/test/dds/communication/TCP_multiple_descriptors.json
+++ b/test/dds/communication/TCP_multiple_descriptors.json
@@ -1,0 +1,15 @@
+{
+    "description" : "[13540] Test that TCP client does not get stuck when being deleted in the following case: client launched before server and deleted also before server",
+    "participants" : [
+        {
+            "kind" : "subscriber",
+            "samples" : "5",
+            "xmlfile" : "TCP_client.xml"
+        },
+        {
+            "kind" : "publisher",
+            "sleep_before_exec" : "1",
+            "xmlfile" : "TCP_server_multiple_descriptors.xml"
+        }
+    ]
+}

--- a/test/dds/communication/TCP_server_multiple_descriptors.xml
+++ b/test/dds/communication/TCP_server_multiple_descriptors.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<dds xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles">
+    <profiles>
+        <transport_descriptors>
+            <transport_descriptor>
+                <transport_id>tcp_transport_server_1</transport_id>
+                <type>TCPv4</type>
+                <listening_ports>
+                    <port>5100</port>
+                </listening_ports>
+                <wan_addr>127.0.0.1</wan_addr>
+            </transport_descriptor>
+            <transport_descriptor>
+                <transport_id>tcp_transport_server_2</transport_id>
+                <type>TCPv4</type>
+                <listening_ports>
+                    <port>5200</port>
+                </listening_ports>
+                <wan_addr>127.0.0.1</wan_addr>
+            </transport_descriptor>
+        </transport_descriptors>
+
+        <participant profile_name="TCPServer" is_default_profile="true">
+            <rtps>
+                <userTransports>
+                    <!-- Changing the order so 1 is first it works. This way it does not. -->
+                    <transport_id>tcp_transport_server_2</transport_id>
+                    <transport_id>tcp_transport_server_1</transport_id>
+                </userTransports>
+                <useBuiltinTransports>false</useBuiltinTransports>
+            </rtps>
+        </participant>
+    </profiles>
+</dds>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

Add Regression Test of TCP communication with multiple TCP descriptors.

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This test should work as the TCP one and expected not to fail, but the communication is never established and so it fails with timeout.

**NOTE:** there is a commit adding logs to facilitate the debugging of the test.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [ ] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [ ] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [ ] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
