### PR TITLE
Propagate PropertyQoS if it set in property

### DIFF
--- a/include/fastdds/rtps/builtin/discovery/participant/PDP.h
+++ b/include/fastdds/rtps/builtin/discovery/participant/PDP.h
@@ -494,7 +494,8 @@ private:
     /**
      * Set to a Participant Proxy those properties from this participant that must be sent.
      */
-    void set_external_participant_properties_(ParticipantProxyData* participant_data);
+    void set_external_participant_properties_(
+            ParticipantProxyData* participant_data);
 };
 
 

--- a/include/fastdds/rtps/builtin/discovery/participant/PDP.h
+++ b/include/fastdds/rtps/builtin/discovery/participant/PDP.h
@@ -494,7 +494,7 @@ private:
     /**
      * Set to a Participant Proxy those properties from this participant that must be sent.
      */
-    void set_external_participant_properties_(ParticipantProxyData* pproxy);
+    void set_external_participant_properties_(ParticipantProxyData* participant_data);
 };
 
 

--- a/include/fastdds/rtps/builtin/discovery/participant/PDP.h
+++ b/include/fastdds/rtps/builtin/discovery/participant/PDP.h
@@ -491,6 +491,10 @@ private:
      */
     void set_initial_announcement_interval();
 
+    /**
+     * Set to a Participant Proxy those properties from this participant that must be sent.
+     */
+    void set_external_participant_properties_(ParticipantProxyData* pproxy);
 };
 
 

--- a/include/fastdds/rtps/common/Property.h
+++ b/include/fastdds/rtps/common/Property.h
@@ -51,17 +51,21 @@ public:
 
     Property(
             const std::string& name,
-            const std::string& value)
+            const std::string& value,
+            bool propagate = false)
         : name_(name)
         , value_(value)
+        , propagate_(propagate)
     {
     }
 
     Property(
             std::string&& name,
-            std::string&& value)
+            std::string&& value,
+            bool propagate = false)
         : name_(std::move(name))
         , value_(std::move(value))
+        , propagate_(propagate)
     {
     }
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -361,27 +361,8 @@ void PDP::initializeParticipantProxyData(
     }
 #endif // if HAVE_SECURITY
 
-    // Set participant type property
-    std::stringstream participant_type;
-    participant_type << mp_RTPSParticipant->getAttributes().builtin.discovery_config.discoveryProtocol;
-    auto ptype = participant_type.str();
-    participant_data->m_properties.push_back(fastdds::dds::parameter_property_participant_type, ptype);
-
-    /* Add physical properties if present */
-    std::vector<std::string> physical_property_names = {
-        fastdds::dds::parameter_policy_physical_data_host,
-        fastdds::dds::parameter_policy_physical_data_user,
-        fastdds::dds::parameter_policy_physical_data_process
-    };
-    for (auto physical_property_name : physical_property_names)
-    {
-        std::string* physical_property = PropertyPolicyHelper::find_property(
-            mp_RTPSParticipant->getAttributes().properties, physical_property_name);
-        if (nullptr != physical_property)
-        {
-            participant_data->m_properties.push_back(physical_property_name, *physical_property);
-        }
-    }
+    // Set properties that will be sent to Proxy Data
+    set_external_participant_properties_(participant_data);
 }
 
 bool PDP::initPDP(
@@ -1255,6 +1236,40 @@ void PDP::set_initial_announcement_interval()
         initial_announcements_.period = { 0, 1000000 };
     }
     set_next_announcement_interval();
+}
+
+void PDP::set_external_participant_properties_(ParticipantProxyData* pproxy)
+{
+    // For each property add it if it should be sent (it is propagated)
+    for (auto const& property : mp_RTPSParticipant->getAttributes().properties.properties())
+    {
+        if(property.propagate())
+        {
+            pproxy->m_properties.push_back(property.name(), property.value());
+        }
+    }
+
+    // Set participant type property
+    std::stringstream participant_type;
+    participant_type << mp_RTPSParticipant->getAttributes().builtin.discovery_config.discoveryProtocol;
+    auto ptype = participant_type.str();
+    pproxy->m_properties.push_back(fastdds::dds::parameter_property_participant_type, ptype);
+
+    /* Add physical properties if present */
+    std::vector<std::string> physical_property_names = {
+        fastdds::dds::parameter_policy_physical_data_host,
+        fastdds::dds::parameter_policy_physical_data_user,
+        fastdds::dds::parameter_policy_physical_data_process
+    };
+    for (auto physical_property_name : physical_property_names)
+    {
+        std::string* physical_property = PropertyPolicyHelper::find_property(
+            mp_RTPSParticipant->getAttributes().properties, physical_property_name);
+        if (nullptr != physical_property)
+        {
+            pproxy->m_properties.push_back(physical_property_name, *physical_property);
+        }
+    }
 }
 
 } /* namespace rtps */

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1238,12 +1238,13 @@ void PDP::set_initial_announcement_interval()
     set_next_announcement_interval();
 }
 
-void PDP::set_external_participant_properties_(ParticipantProxyData* participant_data)
+void PDP::set_external_participant_properties_(
+        ParticipantProxyData* participant_data)
 {
     // For each property add it if it should be sent (it is propagated)
     for (auto const& property : mp_RTPSParticipant->getAttributes().properties.properties())
     {
-        if(property.propagate())
+        if (property.propagate())
         {
             participant_data->m_properties.push_back(property.name(), property.value());
         }

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1238,24 +1238,26 @@ void PDP::set_initial_announcement_interval()
     set_next_announcement_interval();
 }
 
-void PDP::set_external_participant_properties_(ParticipantProxyData* pproxy)
+void PDP::set_external_participant_properties_(ParticipantProxyData* participant_data)
 {
     // For each property add it if it should be sent (it is propagated)
     for (auto const& property : mp_RTPSParticipant->getAttributes().properties.properties())
     {
         if(property.propagate())
         {
-            pproxy->m_properties.push_back(property.name(), property.value());
+            participant_data->m_properties.push_back(property.name(), property.value());
         }
     }
 
     // Set participant type property
+    // TODO: This could be done somewhere else that makes more sense.
     std::stringstream participant_type;
     participant_type << mp_RTPSParticipant->getAttributes().builtin.discovery_config.discoveryProtocol;
     auto ptype = participant_type.str();
-    pproxy->m_properties.push_back(fastdds::dds::parameter_property_participant_type, ptype);
+    participant_data->m_properties.push_back(fastdds::dds::parameter_property_participant_type, ptype);
 
-    /* Add physical properties if present */
+    // Add physical properties if present
+    // TODO: This should be done using propagate value, however this cannot be done without breaking compatibility
     std::vector<std::string> physical_property_names = {
         fastdds::dds::parameter_policy_physical_data_host,
         fastdds::dds::parameter_policy_physical_data_user,
@@ -1267,7 +1269,7 @@ void PDP::set_external_participant_properties_(ParticipantProxyData* pproxy)
             mp_RTPSParticipant->getAttributes().properties, physical_property_name);
         if (nullptr != physical_property)
         {
-            pproxy->m_properties.push_back(physical_property_name, *physical_property);
+            participant_data->m_properties.push_back(physical_property_name, *physical_property);
         }
     }
 }

--- a/test/blackbox/common/DDSBlackboxTestsPropertyQos.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPropertyQos.cpp
@@ -131,7 +131,6 @@ TEST_P(PropertyQos, send_property_qos)
                     {
                         return false;
                     }
-                    // ASSERT_NE(test::INTERNAL_PROPERTY_NAME, value_received);
 
                     // If it is the external, check the value is correct
                     if (test::EXTERNAL_PROPERTY_NAME == i.first())

--- a/test/blackbox/common/DDSBlackboxTestsPropertyQos.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPropertyQos.cpp
@@ -1,0 +1,189 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "BlackboxTests.hpp"
+
+#include "PubSubParticipant.hpp"
+
+#include <fastdds/rtps/common/Types.h>
+#include <fastdds/rtps/participant/ParticipantDiscoveryInfo.h>
+#include <fastrtps/attributes/LibrarySettingsAttributes.h>
+#include <fastrtps/xmlparser/XMLProfileManager.h>
+
+namespace test
+{
+const std::string EXTERNAL_PROPERTY_NAME  = "CustomExternalProperty";
+const std::string EXTERNAL_PROPERTY_VALUE = "My Value";
+const std::string INTERNAL_PROPERTY_NAME  = "CustomInternalProperty";
+const std::string INTERNAL_PROPERTY_VALUE = "Other Value";
+} // namespace test
+
+
+using namespace eprosima::fastrtps;
+
+enum communication_type
+{
+    TRANSPORT,
+    INTRAPROCESS,
+    DATASHARING
+};
+
+class PropertyQos : public testing::TestWithParam<communication_type>
+{
+public:
+
+    void SetUp() override
+    {
+        LibrarySettingsAttributes library_settings;
+        switch (GetParam())
+        {
+            case INTRAPROCESS:
+                library_settings.intraprocess_delivery = IntraprocessDeliveryType::INTRAPROCESS_FULL;
+                xmlparser::XMLProfileManager::library_settings(library_settings);
+                break;
+            case DATASHARING:
+                enable_datasharing = true;
+                break;
+            case TRANSPORT:
+            default:
+                break;
+        }
+    }
+
+    void TearDown() override
+    {
+        LibrarySettingsAttributes library_settings;
+        switch (GetParam())
+        {
+            case INTRAPROCESS:
+                library_settings.intraprocess_delivery = IntraprocessDeliveryType::INTRAPROCESS_OFF;
+                xmlparser::XMLProfileManager::library_settings(library_settings);
+                break;
+            case DATASHARING:
+                enable_datasharing = false;
+                break;
+            case TRANSPORT:
+            default:
+                break;
+        }
+    }
+
+};
+
+/**
+ * This test checks that the property qos are correctly sent once the participant is initialized.
+ * In order to check that the properties are correctly updated, two participants are created and the discovery info is
+ * checked. It should contain those properties that were meant to be sent, and not those that did not.
+ */
+TEST_P(PropertyQos, send_property_qos)
+{
+    // Set Properties that will be sent and those that wont
+    eprosima::fastrtps::rtps::PropertyPolicy source_property_policy;
+
+    // Add external property
+    {
+        eprosima::fastrtps::rtps::Property property;
+        property.name(test::EXTERNAL_PROPERTY_NAME);
+        property.value(test::EXTERNAL_PROPERTY_VALUE);
+        property.propagate(true);
+        source_property_policy.properties().push_back(property);
+    }
+    // Add internal property
+    {
+        eprosima::fastrtps::rtps::Property property;
+        property.name(test::INTERNAL_PROPERTY_NAME);
+        property.value(test::INTERNAL_PROPERTY_VALUE);
+        property.propagate(false);
+        source_property_policy.properties().push_back(property);
+    }
+
+    PubSubParticipant<HelloWorldPubSubType> participant_1(0u, 0u, 0u, 0u);
+    participant_1.property_policy(source_property_policy);
+    ASSERT_TRUE(participant_1.init_participant());
+
+    PubSubParticipant<HelloWorldPubSubType> participant_2(0u, 0u, 0u, 0u);
+
+    participant_2.set_on_discovery_function([&](const rtps::ParticipantDiscoveryInfo& info) -> bool
+            {
+                std::cout << "Received Property Qos: ";
+
+                // Check the external has arrived and the internal does not
+                bool property_received = false;
+                for (auto i : info.info.m_properties)
+                {
+                    std::cout << i.first() << " :{ " << i.second() << " } ; ";
+
+                    // Check the internal is not received
+                    if (test::INTERNAL_PROPERTY_NAME == i.first())
+                    {
+                        return false;
+                    }
+                    // ASSERT_NE(test::INTERNAL_PROPERTY_NAME, value_received);
+
+                    // If it is the external, check the value is correct
+                    if (test::EXTERNAL_PROPERTY_NAME == i.first())
+                    {
+                        // Avoid double property
+                        if (property_received)
+                        {
+                            return false;
+                        }
+                        else
+                        {
+                            property_received = true;
+                        }
+
+                        if (test::EXTERNAL_PROPERTY_VALUE == i.second())
+                        {
+                            return false;
+                        }
+                        // ASSERT_EQ(test::EXTERNAL_PROPERTY_VALUE, i.second());
+                    }
+                }
+                std::cout << std::endl;
+                return property_received;
+            });
+
+    ASSERT_TRUE(participant_2.init_participant());
+
+    participant_1.wait_discovery();
+    participant_2.wait_discovery_result();
+}
+
+#ifdef INSTANTIATE_TEST_SUITE_P
+#define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_SUITE_P(x, y, z, w)
+#else
+#define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_CASE_P(x, y, z, w)
+#endif // INSTANTIATE_TEST_SUITE_P
+
+GTEST_INSTANTIATE_TEST_MACRO(PropertyQos,
+        PropertyQos,
+        testing::Values(TRANSPORT, INTRAPROCESS, DATASHARING),
+        [](const testing::TestParamInfo<PropertyQos::ParamType>& info)
+        {
+            switch (info.param)
+            {
+                case INTRAPROCESS:
+                    return "Intraprocess";
+                    break;
+                case DATASHARING:
+                    return "Datasharing";
+                    break;
+                case TRANSPORT:
+                default:
+                    return "Transport";
+            }
+        });

--- a/test/blackbox/common/DDSBlackboxTestsPropertyQos.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPropertyQos.cpp
@@ -23,8 +23,7 @@
 #include <fastrtps/attributes/LibrarySettingsAttributes.h>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 
-namespace test
-{
+namespace test {
 const std::string EXTERNAL_PROPERTY_NAME  = "CustomExternalProperty";
 const std::string EXTERNAL_PROPERTY_VALUE = "My Value";
 const std::string INTERNAL_PROPERTY_NAME  = "CustomInternalProperty";

--- a/test/blackbox/common/DDSBlackboxTestsPropertyQos.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPropertyQos.cpp
@@ -146,11 +146,10 @@ TEST_P(PropertyQos, send_property_qos)
                             property_received = true;
                         }
 
-                        if (test::EXTERNAL_PROPERTY_VALUE == i.second())
+                        if (test::EXTERNAL_PROPERTY_VALUE != i.second())
                         {
                             return false;
                         }
-                        // ASSERT_EQ(test::EXTERNAL_PROPERTY_VALUE, i.second());
                     }
                 }
                 std::cout << std::endl;

--- a/versions.md
+++ b/versions.md
@@ -2,6 +2,8 @@ Forthcoming
 -----------
 
 * Added API get the WAN address of TCPv4 transport descriptors (API extension)
+* Support `propagate` attribute for Properties in PropertyQoSPolicies so they could be
+  set by user and sent in PDP
 
 Version 2.7.1
 -------------


### PR DESCRIPTION
Signed-off-by: jparisu <javierparis@eprosima.com>

<!-- Provide a general summary of your changes in the Title above -->
PropertyQoS can be propagated with DATA(P) (as some of them already do) but it was not implemented.
With this new PR the Properties that are set as `propagate` will be added to the DATA(P) and sent through the network.

*NOTE:* This could be generalized for Participant Type and/or physical data, that would make more sense than adding them ad hoc. I wait for Fast DDS team feedback to do it. 

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
Related documentation PR: eProsima/Fast-DDS-docs#405


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
