### PR TITLE
[15482] UDPv6 support for fast-discovery-server tool and ROS_DISCOVERY_SERVER

### DIFF
--- a/include/fastdds/rtps/attributes/ServerAttributes.h
+++ b/include/fastdds/rtps/attributes/ServerAttributes.h
@@ -110,6 +110,7 @@ public:
         return metatrafficUnicastLocatorList.has_kind<kind>() ||
                metatrafficMulticastLocatorList.has_kind<kind>();
     }
+
 };
 
 typedef std::list<RemoteServerAttributes> RemoteServerList_t;

--- a/include/fastdds/rtps/attributes/ServerAttributes.h
+++ b/include/fastdds/rtps/attributes/ServerAttributes.h
@@ -102,6 +102,14 @@ public:
 
     // Live participant proxy reference
     const fastrtps::rtps::ParticipantProxyData* proxy{};
+
+    // Check if there are specific transport locators associated
+    // the template parameter is the locator kind (e.g. LOCATOR_KIND_UDPv4)
+    template<int kind> bool requires_transport() const
+    {
+        return metatrafficUnicastLocatorList.has_kind<kind>() ||
+               metatrafficMulticastLocatorList.has_kind<kind>();
+    }
 };
 
 typedef std::list<RemoteServerAttributes> RemoteServerList_t;

--- a/include/fastdds/rtps/common/LocatorList.hpp
+++ b/include/fastdds/rtps/common/LocatorList.hpp
@@ -380,6 +380,21 @@ public:
         this->m_locators.swap(locatorList.m_locators);
     }
 
+    // Check if there are specific transport locators associated
+    // the template parameter is the locator kind (e.g. LOCATOR_KIND_UDPv4)
+    template<int kind> bool has_kind() const
+    {
+        for(auto& loc : m_locators)
+        {
+            if ( kind == loc.kind )
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
 private:
 
     std::vector<Locator> m_locators;

--- a/include/fastdds/rtps/common/LocatorList.hpp
+++ b/include/fastdds/rtps/common/LocatorList.hpp
@@ -384,7 +384,7 @@ public:
     // the template parameter is the locator kind (e.g. LOCATOR_KIND_UDPv4)
     template<int kind> bool has_kind() const
     {
-        for(auto& loc : m_locators)
+        for (auto& loc : m_locators)
         {
             if ( kind == loc.kind )
             {

--- a/include/fastdds/rtps/common/LocatorList.hpp
+++ b/include/fastdds/rtps/common/LocatorList.hpp
@@ -96,6 +96,8 @@ class LocatorList
 {
 public:
 
+    using value_type = typename std::vector<Locator>::value_type;
+
     /// Constructor
     RTPS_DllAPI LocatorList()
     {

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -513,9 +513,9 @@ RTPSParticipant* RTPSDomain::clientServerEnvironmentCreationOverride(
     }
 
     // check if some server requires the UDPv6 transport
-    for(auto& server : server_list)
+    for (auto& server : server_list)
     {
-        if(server.requires_transport<LOCATOR_KIND_UDPv6>())
+        if (server.requires_transport<LOCATOR_KIND_UDPv6>())
         {
             // extend builtin transports with the UDPv6 transport
             auto descriptor = std::make_shared<fastdds::rtps::UDPv6TransportDescriptor>();

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -499,17 +499,31 @@ RTPSParticipant* RTPSDomain::clientServerEnvironmentCreationOverride(
         return nullptr;
     }
 
-    // we only make the attributes copy when we are sure is worth
+    // We only make the attributes copy when we are sure is worth
+    // Is up to the caller guarantee the att argument is not modified during the call
     RTPSParticipantAttributes client_att(att);
 
     // Retrieve the info from the environment variable
-    // TODO(jlbueno) This should be protected with the PDP mutex.
-    if (load_environment_server_info(client_att.builtin.discovery_config.m_DiscoveryServers) &&
-            client_att.builtin.discovery_config.m_DiscoveryServers.empty())
+    RemoteServerList_t& server_list = client_att.builtin.discovery_config.m_DiscoveryServers;
+    if (load_environment_server_info(server_list) && server_list.empty())
     {
         // it's not an error, the environment variable may not be set. Any issue with environment
         // variable syntax is logError already
         return nullptr;
+    }
+
+    // check if some server requires the UDPv6 transport
+    for(auto& server : server_list)
+    {
+        if(server.requires_transport<LOCATOR_KIND_UDPv6>())
+        {
+            // extend builtin transports with the UDPv6 transport
+            auto descriptor = std::make_shared<fastdds::rtps::UDPv6TransportDescriptor>();
+            descriptor->sendBufferSize = client_att.sendSocketBufferSize;
+            descriptor->receiveBufferSize = client_att.listenSocketBufferSize;
+            client_att.userTransports.push_back(std::move(descriptor));
+            break;
+        }
     }
 
     logInfo(DOMAIN, "Detected auto client-server environment variable."

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -666,7 +666,7 @@ bool load_environment_server_info(
      **/
     const static std::regex ROS2_SERVER_LIST_PATTERN(R"(([^;]*);?)");
     const static std::regex ROS2_IPV4_ADDRESSPORT_PATTERN(R"(^((?:[0-9]{1,3}\.){3}[0-9]{1,3})?:?(?:(\d+))?$)");
-    const static std::regex ROS2_IPV6_ADDRESSPORT_PATTERN(R"(^\[?((?:[0-9a-fA-F]{0,4}\:){7}[0-9a-fA-F]{0,4})?(?:\])?:?(?:(\d+))?$)");
+    const static std::regex ROS2_IPV6_ADDRESSPORT_PATTERN(R"(^\[?((?:[0-9a-fA-F]{0,4}\:){0,7}[0-9a-fA-F]{0,4})?(?:\])?:?(?:(\d+))?$)");
     const static std::regex ROS2_DNS_DOMAINPORT_PATTERN(R"(^([\w\.-]{0,63}):?(?:(\d+))?$)");
 
     // Filling port info
@@ -742,9 +742,6 @@ bool load_environment_server_info(
                 if(locator.empty())
                 {
                     // it's intencionally empty to hint us to ignore this server
-                    // advance to the next server if any
-                    ++server_it;
-                    ++server_id;
                 }
                 // Try first with IPv4
                 else if (std::regex_match(locator, mr, ROS2_IPV4_ADDRESSPORT_PATTERN, std::regex_constants::match_not_null))
@@ -888,6 +885,10 @@ bool load_environment_server_info(
                     throw std::invalid_argument(ss.str());
                 }
             }
+
+            // advance to the next server if any
+            ++server_id;
+            ++server_it;
         }
 
         // Check for server info

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -19,7 +19,11 @@
 
 #include <rtps/builtin/discovery/participant/PDPClient.h>
 
+#include <algorithm>
+#include <forward_list>
+#include <iterator>
 #include <string>
+#include <tuple>
 
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
@@ -656,16 +660,65 @@ bool load_environment_server_info(
         return true;
     }
 
-    /* Parsing ancillary regex */
-    // Address should be <letter,numbers,dots>:<number>. We do not need to verify that the first part
-    // is an IPv4 address, as it is done latter.
-    const static std::regex ROS2_ADDRESS_PATTERN(R"(^([A-Za-z0-9-.]+)?:?(?:(\d+))?$)");
+    /* Parsing ancillary regex
+     * Addresses should be ; separated. IPLocator functions are used to identify them in the order:
+     * IPv4, IPv6 or try dns resolution.
+     **/
     const static std::regex ROS2_SERVER_LIST_PATTERN(R"(([^;]*);?)");
+    const static std::regex ROS2_IPV4_ADDRESSPORT_PATTERN(R"(^((?:[0-9]{1,3}\.){3}[0-9]{1,3})?:?(?:(\d+))?$)");
+    const static std::regex ROS2_IPV6_ADDRESSPORT_PATTERN(R"(^\[?((?:[0-9a-fA-F]{0,4}\:){7}[0-9a-fA-F]{0,4})?(?:\])?:?(?:(\d+))?$)");
+    const static std::regex ROS2_DNS_DOMAINPORT_PATTERN(R"(^([\w\.-]{0,63}):?(?:(\d+))?$)");
+
+    // Filling port info
+    auto process_port = [](int port, Locator_t& server)
+    {
+        if (port > std::numeric_limits<uint16_t>::max())
+        {
+            throw std::out_of_range("Too large udp port passed into the server's list");
+        }
+
+        if (!IPLocator::setPhysicalPort(server, static_cast<uint16_t>(port)))
+        {
+            std::stringstream ss;
+            ss << "Wrong udp port passed into the server's list " << port;
+            throw std::invalid_argument(ss.str());
+        }
+    };
+
+    // Add new server
+    auto add_server2qos = [](int id, std::forward_list<Locator>&& locators, RemoteServerList_t& attributes)
+    {
+        RemoteServerAttributes server_att;
+
+            // add the server to the list
+            if (!get_server_client_default_guidPrefix(id, server_att.guidPrefix))
+            {
+                throw std::invalid_argument("The maximum number of default discovery servers has been reached");
+            }
+
+        // split multi and unicast locators
+        auto unicast = std::partition(locators.begin(), locators.end(), IPLocator::isMulticast);
+
+        LocatorList mlist;
+        std::copy(locators.begin(), unicast, std::back_inserter(mlist));
+        if (!mlist.empty())
+        {
+            server_att.metatrafficMulticastLocatorList.push_back(std::move(mlist));
+        }
+
+        LocatorList ulist;
+        std::copy(unicast, locators.end(), std::back_inserter(ulist));
+        if (!ulist.empty())
+        {
+            server_att.metatrafficUnicastLocatorList.push_back(std::move(ulist));
+        }
+
+        attributes.push_back(std::move(server_att));
+    };
 
     try
     {
         // Do the parsing and populate the list
-        RemoteServerAttributes server_att;
         Locator_t server_locator(LOCATOR_KIND_UDPv4, DEFAULT_ROS2_SERVER_PORT);
         int server_id = 0;
 
@@ -677,6 +730,7 @@ bool load_environment_server_info(
 
         while (server_it != std::sregex_iterator())
         {
+            // Retrieve the address (IPv4, IPv6 or DNS name)
             const std::smatch::value_type sm = *++(server_it->cbegin());
 
             if (sm.matched)
@@ -684,25 +738,24 @@ bool load_environment_server_info(
                 // now we must parse the inner expression
                 std::smatch mr;
                 std::string locator(sm);
-                if (std::regex_match(locator, mr, ROS2_ADDRESS_PATTERN, std::regex_constants::match_not_null))
+
+                if(locator.empty())
+                {
+                    // it's intencionally empty to hint us to ignore this server
+                    // advance to the next server if any
+                    ++server_it;
+                    ++server_id;
+                }
+                // Try first with IPv4
+                else if (std::regex_match(locator, mr, ROS2_IPV4_ADDRESSPORT_PATTERN, std::regex_constants::match_not_null))
                 {
                     std::smatch::iterator it = mr.cbegin();
 
-                    while (++it != mr.cend())
+                    // traverse submatches
+                    if (++it != mr.cend())
                     {
                         std::string address = it->str();
-
-                        // Check whether the address is IPv4
-                        if (!IPLocator::isIPv4(address))
-                        {
-                            auto response = rtps::IPLocator::resolveNameDNS(address);
-
-                            // Add the first valid IPv4 address that we can find
-                            if (response.first.size() > 0)
-                            {
-                                address = response.first.begin()->data();
-                            }
-                        }
+                        server_locator.kind = LOCATOR_KIND_UDPv4;
 
                         if (!IPLocator::setIPv4(server_locator, address))
                         {
@@ -717,55 +770,124 @@ bool load_environment_server_info(
                             IPLocator::setIPv4(server_locator, "127.0.0.1");
                         }
 
-                        if (++it != mr.cend())
+                        // get port if any
+                        int port = DEFAULT_ROS2_SERVER_PORT;
+                        if (++it != mr.cend() && it->matched)
                         {
-                            // reset the locator to default
-                            IPLocator::setPhysicalPort(server_locator, DEFAULT_ROS2_SERVER_PORT);
-
-                            if (it->matched)
-                            {
-                                // note stoi throws also an invalid_argument
-                                int port = stoi(it->str());
-
-                                if (port > std::numeric_limits<uint16_t>::max())
-                                {
-                                    throw std::out_of_range("Too large udp port passed into the server's list");
-                                }
-
-                                if (!IPLocator::setPhysicalPort(server_locator, static_cast<uint16_t>(port)))
-                                {
-                                    std::stringstream ss;
-                                    ss << "Wrong udp port passed into the server's list " << it->str();
-                                    throw std::invalid_argument(ss.str());
-                                }
-                            }
+                            port = stoi(it->str());
                         }
+
+                        process_port( port, server_locator);
                     }
 
-                    // add the server to the list
-                    if (!get_server_client_default_guidPrefix(server_id, server_att.guidPrefix))
+                    // add server to the list
+                    add_server2qos(server_id, std::forward_list<Locator>{server_locator}, attributes);
+                }
+                // Try IPv6 next
+                else if (std::regex_match(locator, mr, ROS2_IPV6_ADDRESSPORT_PATTERN, std::regex_constants::match_not_null))
+                {
+                    std::smatch::iterator it = mr.cbegin();
+
+                    // traverse submatches
+                    if (++it != mr.cend())
                     {
-                        throw std::invalid_argument("The maximum number of default discovery servers has been reached");
+                        std::string address = it->str();
+                        server_locator.kind = LOCATOR_KIND_UDPv6;
+
+                        if (!IPLocator::setIPv6(server_locator, address))
+                        {
+                            std::stringstream ss;
+                            ss << "Wrong ipv6 address passed into the server's list " << address;
+                            throw std::invalid_argument(ss.str());
+                        }
+
+                        if (IPLocator::isAny(server_locator))
+                        {
+                            // A server cannot be reach in all interfaces, it's clearly a localhost call
+                            IPLocator::setIPv6(server_locator, "::1");
+                        }
+
+                        // get port if any
+                        int port = DEFAULT_ROS2_SERVER_PORT;
+                        if (++it != mr.cend() && it->matched)
+                        {
+                            port = stoi(it->str());
+                        }
+
+                        process_port( port, server_locator);
                     }
 
-                    server_att.metatrafficUnicastLocatorList.clear();
-                    server_att.metatrafficUnicastLocatorList.push_back(server_locator);
-                    attributes.push_back(server_att);
+                    // add server to the list
+                    add_server2qos(server_id, std::forward_list<Locator>{server_locator}, attributes);
+                }
+                // try resolve DNS
+                else if (std::regex_match(locator, mr, ROS2_DNS_DOMAINPORT_PATTERN, std::regex_constants::match_not_null))
+                {
+                    std::smatch::iterator it = mr.cbegin();
+
+                    // traverse submatches
+                    if (++it != mr.cend())
+                    {
+                        std::string domain_name = it->str();
+                        std::set<std::string> ipv4, ipv6;
+                        std::tie(ipv4, ipv6) = IPLocator::resolveNameDNS(domain_name);
+
+                        // get port if any
+                        int port = DEFAULT_ROS2_SERVER_PORT;
+                        if (++it != mr.cend() && it->matched)
+                        {
+                            port = stoi(it->str());
+                        }
+
+                        std::forward_list<Locator> flist;
+                        for( const std::string& loc : ipv4 )
+                        {
+                            server_locator.kind = LOCATOR_KIND_UDPv4;
+                            IPLocator::setIPv4(server_locator, loc);
+
+                            if (IPLocator::isAny(server_locator))
+                            {
+                                // A server cannot be reach in all interfaces, it's clearly a localhost call
+                                IPLocator::setIPv4(server_locator, "127.0.0.1");
+                            }
+
+                            process_port( port, server_locator);
+                            flist.push_front(server_locator);
+                        }
+
+                        for( const std::string& loc : ipv6 )
+                        {
+                            server_locator.kind = LOCATOR_KIND_UDPv6;
+                            IPLocator::setIPv6(server_locator, loc);
+
+                            if (IPLocator::isAny(server_locator))
+                            {
+                                // A server cannot be reach in all interfaces, it's clearly a localhost call
+                                IPLocator::setIPv6(server_locator, "::1");
+                            }
+
+                            process_port( port, server_locator);
+                            flist.push_front(server_locator);
+                        }
+
+                        if(flist.empty())
+                        {
+                            std::stringstream ss;
+                            ss << "Wrong domain name passed into the server's list " << locator;
+                            throw std::invalid_argument(ss.str());
+                        }
+
+                        // add server to the list
+                        add_server2qos(server_id, std::move(flist), attributes);
+                    }
                 }
                 else
                 {
-                    if (!locator.empty())
-                    {
-                        std::stringstream ss;
-                        ss << "Wrong locator passed into the server's list " << locator;
-                        throw std::invalid_argument(ss.str());
-                    }
-                    // else: it's intencionally empty to hint us to ignore this server
+                    std::stringstream ss;
+                    ss << "Wrong locator passed into the server's list " << locator;
+                    throw std::invalid_argument(ss.str());
                 }
             }
-            // advance to the next server if any
-            ++server_it;
-            ++server_id;
         }
 
         // Check for server info

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -849,9 +849,8 @@ bool load_environment_server_info(
                     {
                         case LOCATOR_KIND_UDPv4:
                         case LOCATOR_KIND_UDPv6:
-                        {
                             flist.push_front(server_locator);
-                        }
+                            break;
                         case LOCATOR_KIND_INVALID:
                         {
                             std::smatch::iterator it = mr.cbegin();

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1303,7 +1303,7 @@ void RTPSParticipantImpl::update_attributes(
             }
             if (!contained)
             {
-                logWarning(RTPS_QOS_CHECK,
+                logError(RTPS_QOS_CHECK,
                         "Discovery Servers cannot be removed from the list; they can only be added");
                 return;
             }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,15 @@ endif()
 file(TO_CMAKE_PATH "${PROJECT_SOURCE_DIR}/valgrind.supp" MEMORYCHECK_SUPPRESSIONS_FILE_TMP)
 set(MEMORYCHECK_SUPPRESSIONS_FILE ${MEMORYCHECK_SUPPRESSIONS_FILE_TMP} CACHE FILEPATH "Valgrind suppresions file")
 
+# Check if /etc/hosts file has been modified to add dummy host test subjects
+if(WIN32)
+    execute_process(COMMAND powershell -C Resolve-DNSName www.acme.com.test
+        RESULT_VARIABLE EPROSIMA_TEST_DNS_NOT_SET_UP OUTPUT_QUIET ERROR_QUIET)
+else(WIN32)
+    execute_process(COMMAND nslookup www.acme.com.test
+        RESULT_VARIABLE EPROSIMA_TEST_DNS_NOT_SET_UP OUTPUT_QUIET ERROR_QUIET)
+endif(WIN32)
+
 ###############################################################################
 # Testing
 ###############################################################################

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,7 +30,7 @@ if(WIN32)
     execute_process(COMMAND powershell -C Resolve-DNSName www.acme.com.test
         RESULT_VARIABLE EPROSIMA_TEST_DNS_NOT_SET_UP OUTPUT_QUIET ERROR_QUIET)
 else(WIN32)
-    execute_process(COMMAND nslookup www.acme.com.test
+    execute_process(COMMAND getent hosts www.acme.com.test
         RESULT_VARIABLE EPROSIMA_TEST_DNS_NOT_SET_UP OUTPUT_QUIET ERROR_QUIET)
 endif(WIN32)
 

--- a/test/blackbox/CMakeLists.txt
+++ b/test/blackbox/CMakeLists.txt
@@ -64,7 +64,7 @@ macro(add_blackbox_gtest)
                 # decide if disable
                 unset(GTEST_USER_DISABLED)
                 foreach(GTEST_USER_FILTER ${GTEST_IGNORE})
-                    string(REGEX MATCH ${GTEST_USER_FILTER} GTEST_USER_DISABLED ${GTEST_TEST_NAME})
+                    string(REGEX MATCH ${GTEST_USER_FILTER} GTEST_USER_DISABLED ${GTEST_GROUP_NAME}.${GTEST_TEST_NAME})
                     if(GTEST_USER_DISABLED)
                         break()
                     endif()
@@ -97,7 +97,7 @@ macro(add_blackbox_gtest)
                 # decide if disable
                 unset(GTEST_USER_DISABLED)
                 foreach(GTEST_USER_FILTER ${GTEST_IGNORE})
-                    string(REGEX MATCH ${GTEST_USER_FILTER} GTEST_USER_DISABLED ${GTEST_TEST_NAME})
+                    string(REGEX MATCH ${GTEST_USER_FILTER} GTEST_USER_DISABLED ${GTEST_GROUP_NAME}.${GTEST_TEST_NAME})
                     if(GTEST_USER_DISABLED)
                         break()
                     endif()
@@ -236,6 +236,10 @@ if(NOT LibP11_FOUND)
     endif() # GTEST_INDIVIDUAL
 endif() # LibP11_FOUND
 
+if(EPROSIMA_TEST_DNS_NOT_SET_UP)
+    set(dns_filter "Discovery.ServerClientEnvironmentSetUpDNS")
+endif()
+
 file(GLOB RTPS_BLACKBOXTESTS_TEST_SOURCE "common/RTPSBlackboxTests*.cpp")
 set(RTPS_BLACKBOXTESTS_SOURCE ${RTPS_BLACKBOXTESTS_TEST_SOURCE}
     types/HelloWorld.cxx
@@ -359,7 +363,7 @@ if(FASTRTPS_API_TESTS)
         GTest::gtest
         $<$<BOOL:${LibP11_FOUND}>:eProsima_p11>  # $<TARGET_NAME_IF_EXISTS:eProsima_p11>
         )
-       
+
     add_blackbox_gtest(BlackboxTests_FastRTPS SOURCES ${BLACKBOXTESTS_TEST_SOURCE}
         ENVIRONMENTS "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs"
         "TOPIC_RANDOM_NUMBER=${TOPIC_RANDOM_NUMBER}"
@@ -367,7 +371,7 @@ if(FASTRTPS_API_TESTS)
         "R_UNICAST_PORT_RANDOM_NUMBER=${R_UNICAST_PORT_RANDOM_NUMBER}"
         "MULTICAST_PORT_RANDOM_NUMBER=${MULTICAST_PORT_RANDOM_NUMBER}"
         $<$<BOOL:${OPENSSL_CONF}>:OPENSSL_CONF=${OPENSSL_CONF}>
-        IGNORE ${pkcs_filter}
+        IGNORE ${pkcs_filter} ${dns_filter}
         )
 endif(FASTRTPS_API_TESTS)
 
@@ -414,7 +418,7 @@ if(FASTDDS_PIM_API_TESTS)
         "R_UNICAST_PORT_RANDOM_NUMBER=${R_UNICAST_PORT_RANDOM_NUMBER}"
         "MULTICAST_PORT_RANDOM_NUMBER=${MULTICAST_PORT_RANDOM_NUMBER}"
         $<$<BOOL:${OPENSSL_CONF}>:OPENSSL_CONF=${OPENSSL_CONF}>
-        IGNORE ${pkcs_filter}
+        IGNORE ${pkcs_filter} ${dns_filter}
         )
 endif(FASTDDS_PIM_API_TESTS)
 
@@ -437,3 +441,6 @@ endforeach()
 # Necessary files
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/environment_file.json
     ${CMAKE_CURRENT_BINARY_DIR}/environment_file.json COPYONLY)
+
+unset(dns_filter)
+unset(pkcs_filter)

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -1196,7 +1196,7 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
 
     RemoteServerList_t output, standard;
     RemoteServerAttributes att;
-    Locator_t loc;
+    Locator_t loc, loc6(LOCATOR_KIND_UDPv6,0);
 
     // We are going to use several test string and check they are properly parsed and turn into RemoteServerList_t
     // 1. single server address without specific port provided
@@ -1332,9 +1332,12 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
     standard.clear();
 
     att.clear();
-    IPLocator::setIPv4(loc, string("127.0.0.1"));
+    IPLocator::setIPv4(loc, "127.0.0.1");
     IPLocator::setPhysicalPort(loc, 12345);
     att.metatrafficUnicastLocatorList.push_back(loc);
+    IPLocator::setIPv6(loc6, "::1");
+    IPLocator::setPhysicalPort(loc6, 12345);
+    att.metatrafficUnicastLocatorList.push_back(loc6);
     get_server_client_default_guidPrefix(0, att.guidPrefix);
     standard.push_back(att);
 
@@ -1358,6 +1361,9 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
     IPLocator::setIPv4(loc, string("127.0.0.1"));
     IPLocator::setPhysicalPort(loc, 12345);
     att.metatrafficUnicastLocatorList.push_back(loc);
+    IPLocator::setIPv6(loc6, string("::1"));
+    IPLocator::setPhysicalPort(loc6, 12345);
+    att.metatrafficUnicastLocatorList.push_back(loc6);
     get_server_client_default_guidPrefix(1, att.guidPrefix);
     standard.push_back(att);
 

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -1214,7 +1214,22 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
     ASSERT_TRUE(load_environment_server_info(text, output));
     ASSERT_EQ(output, standard);
 
-    // 2. single server address specifying a custom listening port
+    // 2. single server IPv6 address without specific port provided
+    text = "2a02:26f0:dd:499::356e";
+
+    att.clear();
+    output.clear();
+    standard.clear();
+    IPLocator::setIPv6(loc6, text);
+    IPLocator::setPhysicalPort(loc6, DEFAULT_ROS2_SERVER_PORT);
+    att.metatrafficUnicastLocatorList.push_back(loc6);
+    get_server_client_default_guidPrefix(0, att.guidPrefix);
+    standard.push_back(att);
+
+    ASSERT_TRUE(load_environment_server_info(text, output));
+    ASSERT_EQ(output, standard);
+
+    // 3. single server address specifying a custom listening port
     text = "192.168.36.34:14520";
 
     att.clear();
@@ -1229,35 +1244,57 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
     ASSERT_TRUE(load_environment_server_info(text, output));
     ASSERT_EQ(output, standard);
 
-    // 3. check any locator is turned into localhost
-    text = "0.0.0.0:14520";
+    // 4. single server IPv6 address specifying a custom listening port
+    text = "[2001:470:142:5::116]:14520";
 
     att.clear();
     output.clear();
     standard.clear();
-    IPLocator::setIPv4(loc, string("127.0.0.1"));
-    IPLocator::setPhysicalPort(loc, 14520);
-    att.metatrafficUnicastLocatorList.push_back(loc);
+    IPLocator::setIPv6(loc6, "2001:470:142:5::116");
+    IPLocator::setPhysicalPort(loc6, 14520);
+    att.metatrafficUnicastLocatorList.push_back(loc6);
     get_server_client_default_guidPrefix(0, att.guidPrefix);
     standard.push_back(att);
 
     ASSERT_TRUE(load_environment_server_info(text, output));
     ASSERT_EQ(output, standard);
 
-    // 4. check empty string scenario is handled
+    // 5. check any locator is turned into localhost
+    text = "0.0.0.0:14520;[::]:14520";
+
+    att.clear();
+    output.clear();
+    standard.clear();
+    IPLocator::setIPv4(loc, "127.0.0.1");
+    IPLocator::setPhysicalPort(loc, 14520);
+    att.metatrafficUnicastLocatorList.push_back(loc);
+    get_server_client_default_guidPrefix(0, att.guidPrefix);
+    standard.push_back(att);
+
+    att.clear();
+    IPLocator::setIPv6(loc6, "::1");
+    IPLocator::setPhysicalPort(loc6, 14520);
+    att.metatrafficUnicastLocatorList.push_back(loc6);
+    get_server_client_default_guidPrefix(1, att.guidPrefix);
+    standard.push_back(att);
+
+    ASSERT_TRUE(load_environment_server_info(text, output));
+    ASSERT_EQ(output, standard);
+
+    // 6. check empty string scenario is handled
     text = "";
     output.clear();
 
     ASSERT_TRUE(load_environment_server_info(text, output));
     ASSERT_TRUE(output.empty());
 
-    // 5. check at least one server be present scenario is hadled
+    // 7. check at least one server be present scenario is hadled
     text = ";;;;";
     output.clear();
 
     ASSERT_FALSE(load_environment_server_info(text, output));
 
-    // 6. check several server scenario
+    // 8. check several server scenario
     text = "192.168.36.34:14520;172.29.55.77:8783;172.30.80.1:31090";
 
     output.clear();
@@ -1287,7 +1324,60 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
     ASSERT_TRUE(load_environment_server_info(text, output));
     ASSERT_EQ(output, standard);
 
-    // 7. check ignore some servers scenario
+    // 9. check several server scenario with IPv6 addresses too
+    text = "192.168.36.34:14520;[2a02:ec80:600:ed1a::3]:8783;172.30.80.1:31090";
+
+    output.clear();
+    standard.clear();
+
+    att.clear();
+    IPLocator::setIPv4(loc, "192.168.36.34");
+    IPLocator::setPhysicalPort(loc, 14520);
+    att.metatrafficUnicastLocatorList.push_back(loc);
+    get_server_client_default_guidPrefix(0, att.guidPrefix);
+    standard.push_back(att);
+
+    att.clear();
+    IPLocator::setIPv6(loc6, "2a02:ec80:600:ed1a::3");
+    IPLocator::setPhysicalPort(loc6, 8783);
+    att.metatrafficUnicastLocatorList.push_back(loc6);
+    get_server_client_default_guidPrefix(1, att.guidPrefix);
+    standard.push_back(att);
+
+    att.clear();
+    IPLocator::setIPv4(loc, string("172.30.80.1"));
+    IPLocator::setPhysicalPort(loc, 31090);
+    att.metatrafficUnicastLocatorList.push_back(loc);
+    get_server_client_default_guidPrefix(2, att.guidPrefix);
+    standard.push_back(att);
+
+    ASSERT_TRUE(load_environment_server_info(text, output));
+    ASSERT_EQ(output, standard);
+
+    // 10. check multicast addresses are identified as such
+    text = "239.255.0.1;ff1e::ffff:efff:1";
+
+    output.clear();
+    standard.clear();
+
+    att.clear();
+    IPLocator::setIPv4(loc, "239.255.0.1");
+    IPLocator::setPhysicalPort(loc, DEFAULT_ROS2_SERVER_PORT);
+    att.metatrafficMulticastLocatorList.push_back(loc);
+    get_server_client_default_guidPrefix(0, att.guidPrefix);
+    standard.push_back(att);
+
+    att.clear();
+    IPLocator::setIPv6(loc6, "ff1e::ffff:efff:1");
+    IPLocator::setPhysicalPort(loc6, DEFAULT_ROS2_SERVER_PORT);
+    att.metatrafficMulticastLocatorList.push_back(loc6);
+    get_server_client_default_guidPrefix(1, att.guidPrefix);
+    standard.push_back(att);
+
+    ASSERT_TRUE(load_environment_server_info(text, output));
+    ASSERT_EQ(output, standard);
+
+    // 11. check ignore some servers scenario
     text = ";192.168.36.34:14520;;172.29.55.77:8783;172.30.80.1:31090;";
 
     output.clear();
@@ -1317,7 +1407,7 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
     ASSERT_TRUE(load_environment_server_info(text, output));
     ASSERT_EQ(output, standard);
 
-    // 8. Check that env var cannot specify more than 256 servers
+    // 12. Check that env var cannot specify more than 256 servers
     text = ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;"
             ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;"
             ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;192.168.36.34:14520";
@@ -1325,7 +1415,7 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
 
     ASSERT_FALSE(load_environment_server_info(text, output));
 
-    // 9. Check addresses as dns name
+    // 13. Check addresses as dns name
     text = "localhost:12345";
 
     output.clear();
@@ -1344,7 +1434,7 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
     ASSERT_TRUE(load_environment_server_info(text, output));
     ASSERT_EQ(output, standard);
 
-    // 10. Check mixed scenario with addresses and dns
+    // 14. Check mixed scenario with addresses and dns
     text = "192.168.36.34:14520;localhost:12345;172.30.80.1:31090;";
 
     output.clear();
@@ -1376,4 +1466,53 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
 
     ASSERT_TRUE(load_environment_server_info(text, output));
     ASSERT_EQ(output, standard);
+}
+
+//! Tests the server-client setup using environment variable works fine using DNS
+TEST(Discovery, ServerClientEnvironmentSetUpDNS)
+{
+    using namespace std;
+    using namespace eprosima::fastdds::rtps;
+
+    RemoteServerList_t output, standard;
+    RemoteServerAttributes att;
+    Locator_t loc, loc6(LOCATOR_KIND_UDPv6,0);
+
+    // 1. single server DNS address resolution without specific port provided
+    std::string text = "www.acme.com.test";
+
+    att.clear();
+    output.clear();
+    standard.clear();
+    IPLocator::setIPv6(loc6, "2a00:1450:400e:803::2004");
+    IPLocator::setPhysicalPort(loc6, DEFAULT_ROS2_SERVER_PORT);
+    att.metatrafficUnicastLocatorList.push_back(loc6);
+    IPLocator::setIPv4(loc, "216.58.215.164");
+    IPLocator::setPhysicalPort(loc, DEFAULT_ROS2_SERVER_PORT);
+    att.metatrafficUnicastLocatorList.push_back(loc);
+    get_server_client_default_guidPrefix(0, att.guidPrefix);
+    standard.push_back(att);
+
+    ASSERT_TRUE(load_environment_server_info(text, output));
+    ASSERT_EQ(output, standard);
+
+    // 2. single server DNS address specifying a custom listening port
+    text = "www.acme.com.test:14520";
+
+    att.clear();
+    output.clear();
+    standard.clear();
+    IPLocator::setIPv6(loc6, "2a00:1450:400e:803::2004");
+    IPLocator::setPhysicalPort(loc6, 14520);
+    att.metatrafficUnicastLocatorList.push_back(loc6);
+    IPLocator::setIPv4(loc, "216.58.215.164");
+    IPLocator::setPhysicalPort(loc, 14520);
+    att.metatrafficUnicastLocatorList.push_back(loc);
+    get_server_client_default_guidPrefix(0, att.guidPrefix);
+    standard.push_back(att);
+
+    ASSERT_TRUE(load_environment_server_info(text, output));
+    ASSERT_EQ(output, standard);
+
+
 }

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -1196,7 +1196,7 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
 
     RemoteServerList_t output, standard;
     RemoteServerAttributes att;
-    Locator_t loc, loc6(LOCATOR_KIND_UDPv6,0);
+    Locator_t loc, loc6(LOCATOR_KIND_UDPv6, 0);
 
     // We are going to use several test string and check they are properly parsed and turn into RemoteServerList_t
     // 1. single server address without specific port provided
@@ -1476,7 +1476,7 @@ TEST(Discovery, ServerClientEnvironmentSetUpDNS)
 
     RemoteServerList_t output, standard;
     RemoteServerAttributes att;
-    Locator_t loc, loc6(LOCATOR_KIND_UDPv6,0);
+    Locator_t loc, loc6(LOCATOR_KIND_UDPv6, 0);
 
     // 1. single server DNS address resolution without specific port provided
     std::string text = "www.acme.com.test";

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -1415,7 +1415,7 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
 
     ASSERT_FALSE(load_environment_server_info(text, output));
 
-    // 13. Check addresses as dns name
+    // 13. Check addresses as dns name (test domain urls are checked on a specific test)
     text = "localhost:12345";
 
     output.clear();
@@ -1514,5 +1514,101 @@ TEST(Discovery, ServerClientEnvironmentSetUpDNS)
     ASSERT_TRUE(load_environment_server_info(text, output));
     ASSERT_EQ(output, standard);
 
+    // 3. single server DNS address specifying a custom locator type
+    // UDPv4
+    text = "UDPv4:[www.acme.com.test]";
 
+    att.clear();
+    output.clear();
+    standard.clear();
+    IPLocator::setIPv4(loc, "216.58.215.164");
+    IPLocator::setPhysicalPort(loc, DEFAULT_ROS2_SERVER_PORT);
+    att.metatrafficUnicastLocatorList.push_back(loc);
+    get_server_client_default_guidPrefix(0, att.guidPrefix);
+    standard.push_back(att);
+
+    ASSERT_TRUE(load_environment_server_info(text, output));
+    ASSERT_EQ(output, standard);
+
+    // UDPv6
+    text = "UDPv6:[www.acme.com.test]";
+
+    att.clear();
+    output.clear();
+    standard.clear();
+    IPLocator::setIPv6(loc6, "2a00:1450:400e:803::2004");
+    IPLocator::setPhysicalPort(loc6, DEFAULT_ROS2_SERVER_PORT);
+    att.metatrafficUnicastLocatorList.push_back(loc6);
+    get_server_client_default_guidPrefix(0, att.guidPrefix);
+    standard.push_back(att);
+
+    ASSERT_TRUE(load_environment_server_info(text, output));
+    ASSERT_EQ(output, standard);
+
+    // 4. single server DNS address specifying a custom locator type and listening port
+    // UDPv4
+    text = "UDPv4:[www.acme.com.test]:14520";
+
+    att.clear();
+    output.clear();
+    standard.clear();
+    IPLocator::setIPv4(loc, "216.58.215.164");
+    IPLocator::setPhysicalPort(loc, 14520);
+    att.metatrafficUnicastLocatorList.push_back(loc);
+    get_server_client_default_guidPrefix(0, att.guidPrefix);
+    standard.push_back(att);
+
+    ASSERT_TRUE(load_environment_server_info(text, output));
+    ASSERT_EQ(output, standard);
+
+    // UDPv6
+    text = "UDPv6:[www.acme.com.test]:14520";
+
+    att.clear();
+    output.clear();
+    standard.clear();
+    IPLocator::setIPv6(loc6, "2a00:1450:400e:803::2004");
+    IPLocator::setPhysicalPort(loc6, 14520);
+    att.metatrafficUnicastLocatorList.push_back(loc6);
+    get_server_client_default_guidPrefix(0, att.guidPrefix);
+    standard.push_back(att);
+
+    ASSERT_TRUE(load_environment_server_info(text, output));
+    ASSERT_EQ(output, standard);
+
+    // Any other Locator kind should fail
+    text = "TCPv4:[www.acme.com.test]";
+
+    output.clear();
+    ASSERT_FALSE(load_environment_server_info(text, output));
+
+    // 5. Check mixed scenario with addresses and dns
+    text = "192.168.36.34:14520;UDPv6:[www.acme.com.test]:14520;172.30.80.1:31090;";
+
+    output.clear();
+    standard.clear();
+
+    att.clear();
+    IPLocator::setIPv4(loc, string("192.168.36.34"));
+    IPLocator::setPhysicalPort(loc, 14520);
+    att.metatrafficUnicastLocatorList.push_back(loc);
+    get_server_client_default_guidPrefix(0, att.guidPrefix);
+    standard.push_back(att);
+
+    att.clear();
+    IPLocator::setIPv6(loc6, "2a00:1450:400e:803::2004");
+    IPLocator::setPhysicalPort(loc6, 14520);
+    att.metatrafficUnicastLocatorList.push_back(loc6);
+    get_server_client_default_guidPrefix(1, att.guidPrefix);
+    standard.push_back(att);
+
+    att.clear();
+    IPLocator::setIPv4(loc, string("172.30.80.1"));
+    IPLocator::setPhysicalPort(loc, 31090);
+    att.metatrafficUnicastLocatorList.push_back(loc);
+    get_server_client_default_guidPrefix(2, att.guidPrefix);
+    standard.push_back(att);
+
+    ASSERT_TRUE(load_environment_server_info(text, output));
+    ASSERT_EQ(output, standard);
 }

--- a/test/system/tools/fds/CMakeLists.txt
+++ b/test/system/tools/fds/CMakeLists.txt
@@ -22,6 +22,7 @@ if(PYTHONINTERP_FOUND)
 
     set(TESTS
         test_fast_discovery_closure
+        test_fast_discovery_udpv6_address
         test_fast_discovery_parse_XML_file_default_profile
         test_fast_discovery_parse_XML_file_URI_profile
         test_fast_discovery_prefix_override

--- a/test/system/tools/fds/tests.py
+++ b/test/system/tools/fds/tests.py
@@ -25,11 +25,23 @@
 
     Available tests:
 
-        test_fast_discovery_closure
-        test_fast_discovery_parse_XML_file_prefix_OK
-        test_fast_discovery_parse_XML_file_prefix_OK_URI
-        test_fast_discovery_parse_XML_file_server_address
-        test_fast_discovery_parse_XML_file_server_address_URI
+        test_fast_discovery_closure,
+        test_fast_discovery_udpv6_address,
+        test_fast_discovery_parse_XML_file_default_profile,
+        test_fast_discovery_parse_XML_file_URI_profile,
+        test_fast_discovery_prefix_override,
+        test_fast_discovery_locator_address_override,
+        test_fast_discovery_locator_override_same_address,
+        test_fast_discovery_locator_port_override,
+        test_fast_discovery_locator_override_same_port,
+        test_fast_discovery_backup,
+        test_fast_discovery_no_XML,
+        test_fast_discovery_incorrect_participant,
+        test_fast_discovery_no_prefix,
+        test_fast_discovery_several_server_ids,
+        test_fast_discovery_invalid_locator,
+        test_fast_discovery_non_existent_profile,
+
 """
 
 import argparse
@@ -157,6 +169,31 @@ def test_fast_discovery_closure(fast_discovery_tool):
 
     sys.exit(exit_code)
 
+def test_fast_discovery_udpv6_address(fast_discovery_tool):
+    """Test that discovery command manages IPv4 and IPv6 correctly."""
+
+    command = [
+        fast_discovery_tool, '-i', '1', '-l', '154.56.134.194', '-p',
+        '32123', '-l', '2a02:ec80:600:ed1a::3', '-p', '14520'
+    ]
+
+    output, err, exit_code = send_command(command)
+
+    if exit_code != 0:
+        print(output)
+        sys.exit(exit_code)
+
+    EXPECTED_OUTPUTS = [
+        "UDPv4:[154.56.134.194]:32123",
+        "UDPv6:[2a02:ec80:600:ed1a::3]:14520",
+    ]
+
+    for pattern in EXPECTED_OUTPUTS:
+        exit_code = check_output(output, err, pattern, False)
+        if exit_code != 0:
+            break
+
+    sys.exit(exit_code)
 
 def test_fast_discovery_parse_XML_file_default_profile(fast_discovery_tool):
     """Test that discovery command read XML default profile correctly."""
@@ -267,7 +304,7 @@ def test_fast_discovery_locator_address_override(fast_discovery_tool):
 
     XML_file_path = 'test_xml_discovery_server.xml'
     default_profile = XML_parse_profile(XML_file_path, "")
-   
+
     prefix = default_profile.getElementsByTagName('prefix')
     PREFIX = prefix[0].firstChild.data
     EXPECTED_SERVER_ID = "Server GUID prefix: " + PREFIX.lower()
@@ -306,7 +343,7 @@ def test_fast_discovery_locator_override_same_address(fast_discovery_tool):
 
     XML_file_path = 'test_xml_discovery_server.xml'
     default_profile = XML_parse_profile(XML_file_path, "")
-   
+
     prefix = default_profile.getElementsByTagName('prefix')
     PREFIX = prefix[0].firstChild.data
     EXPECTED_SERVER_ID = "Server GUID prefix: " + PREFIX.lower()
@@ -345,7 +382,7 @@ def test_fast_discovery_locator_port_override(fast_discovery_tool):
 
     XML_file_path = 'test_xml_discovery_server.xml'
     default_profile = XML_parse_profile(XML_file_path, "")
-   
+
     prefix = default_profile.getElementsByTagName('prefix')
     PREFIX = prefix[0].firstChild.data
     EXPECTED_SERVER_ID = "Server GUID prefix: " + PREFIX.lower()
@@ -384,7 +421,7 @@ def test_fast_discovery_locator_override_same_port(fast_discovery_tool):
 
     XML_file_path = 'test_xml_discovery_server.xml'
     default_profile = XML_parse_profile(XML_file_path, "")
-   
+
     prefix = default_profile.getElementsByTagName('prefix')
     PREFIX = prefix[0].firstChild.data
     EXPECTED_SERVER_ID = "Server GUID prefix: " + PREFIX.lower()
@@ -546,8 +583,10 @@ if __name__ == '__main__':
 
     # Tests dictionary
     tests = {
-        'test_fast_discovery_closure': lambda: test_fast_discovery_closure(
-            args.binary_path),
+        'test_fast_discovery_closure': lambda:
+            test_fast_discovery_closure(args.binary_path),
+        'test_fast_discovery_udpv6_address': lambda:
+            test_fast_discovery_udpv6_address(args.binary_path),
         'test_fast_discovery_parse_XML_file_default_profile': lambda:
             test_fast_discovery_parse_XML_file_default_profile(args.binary_path),
         'test_fast_discovery_parse_XML_file_URI_profile': lambda:

--- a/test/unittest/dds/participant/CMakeLists.txt
+++ b/test/unittest/dds/participant/CMakeLists.txt
@@ -37,4 +37,11 @@ target_include_directories(ParticipantTests PRIVATE
 target_link_libraries(ParticipantTests fastrtps fastcdr foonathan_memory
     GTest::gmock
     ${CMAKE_DL_LIBS})
-add_gtest(ParticipantTests SOURCES ${PARTICIPANTTESTS_SOURCE})
+
+if(EPROSIMA_TEST_DNS_NOT_SET_UP)
+    set(dns_filter "ParticipantTests.SimpleParticipantRemoteServerListConfigurationDNS")
+endif()
+
+add_gtest(ParticipantTests SOURCES ${PARTICIPANTTESTS_SOURCE} IGNORE ${dns_filter})
+
+unset(dns_filter)

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -808,17 +808,17 @@ TEST(ParticipantTests, SimpleParticipantRemoteServerListConfiguration)
 
     // check UDPv6 transport is there
     auto udpv6_check = [](fastrtps::rtps::RTPSParticipantAttributes& attributes) -> bool
-    {
-        for (auto& transportDescriptor : attributes.userTransports)
-        {
-            if( nullptr != dynamic_cast<fastdds::rtps::UDPv6TransportDescriptor*>(transportDescriptor.get()))
             {
-                return true;
-            }
-        }
+                for (auto& transportDescriptor : attributes.userTransports)
+                {
+                    if ( nullptr != dynamic_cast<fastdds::rtps::UDPv6TransportDescriptor*>(transportDescriptor.get()))
+                    {
+                        return true;
+                    }
+                }
 
-        return false;
-    };
+                return false;
+            };
     EXPECT_TRUE(udpv6_check(attributes));
 
     DomainParticipantQos result_qos = participant->get_qos();
@@ -856,7 +856,8 @@ TEST(ParticipantTests, SimpleParticipantDynamicAdditionRemoteServers)
     // Modify environment file
 #ifndef __APPLE__
     std::ofstream file(filename);
-    file << "{\"ROS_DISCOVERY_SERVER\": \"84.22.253.128:8888;192.168.1.133:64863;UDPv4:[localhost]:1234;[2a02:ec80:600:ed1a::3]:8783\"}";
+    file <<
+        "{\"ROS_DISCOVERY_SERVER\": \"84.22.253.128:8888;192.168.1.133:64863;UDPv4:[localhost]:1234;[2a02:ec80:600:ed1a::3]:8783\"}";
     file.close();
 
     // Wait long enought for the file watch callback

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <fstream>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <thread>
 
@@ -27,8 +28,8 @@
 #include <dds/domain/qos/DomainParticipantQos.hpp>
 #include <dds/pub/Publisher.hpp>
 #include <dds/pub/qos/PublisherQos.hpp>
-#include <dds/sub/qos/SubscriberQos.hpp>
 #include <dds/sub/Subscriber.hpp>
+#include <dds/sub/qos/SubscriberQos.hpp>
 #include <dds/topic/Topic.hpp>
 #include <fastdds/dds/builtin/topic/ParticipantBuiltinTopicData.hpp>
 #include <fastdds/dds/builtin/topic/TopicBuiltinTopicData.hpp>
@@ -40,13 +41,14 @@
 #include <fastdds/dds/publisher/Publisher.hpp>
 #include <fastdds/dds/publisher/qos/PublisherQos.hpp>
 #include <fastdds/dds/subscriber/DataReader.hpp>
-#include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
 #include <fastdds/dds/subscriber/Subscriber.hpp>
+#include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
 #include <fastdds/dds/topic/qos/TopicQos.hpp>
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
 #include <fastdds/rtps/attributes/ServerAttributes.h>
 #include <fastdds/rtps/common/Locator.h>
 #include <fastdds/rtps/participant/RTPSParticipant.h>
+#include <fastdds/rtps/transport/UDPv6TransportDescriptor.h>
 #include <fastrtps/attributes/PublisherAttributes.h>
 #include <fastrtps/attributes/SubscriberAttributes.h>
 #include <fastrtps/types/DynamicDataFactory.h>
@@ -656,6 +658,12 @@ void expected_remote_server_list_output(
     server.metatrafficUnicastLocatorList.push_back(locator);
     get_server_client_default_guidPrefix(2, server.guidPrefix);
     output.push_back(server);
+
+    std::istringstream("UDPv6:[2a02:ec80:600:ed1a::3]:8783") >> locator;
+    server.clear();
+    server.metatrafficUnicastLocatorList.push_back(locator);
+    get_server_client_default_guidPrefix(3, server.guidPrefix);
+    output.push_back(server);
 }
 
 void set_participant_qos(
@@ -691,7 +699,7 @@ void set_server_qos(
 
 void set_environment_variable()
 {
-    std::string environment_servers = "84.22.253.128:8888;;localhost:1234";
+    std::string environment_servers = "84.22.253.128:8888;;UDPv4:[localhost]:1234;[2a02:ec80:600:ed1a::3]:8783";
 #ifdef _WIN32
     ASSERT_EQ(0, _putenv_s(rtps::DEFAULT_ROS2_MASTER_URI, environment_servers.c_str()));
 #else
@@ -798,6 +806,21 @@ TEST(ParticipantTests, SimpleParticipantRemoteServerListConfiguration)
     EXPECT_EQ(attributes.builtin.discovery_config.discoveryProtocol, fastrtps::rtps::DiscoveryProtocol::CLIENT);
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, output);
 
+    // check UDPv6 transport is there
+    auto udpv6_check = [](fastrtps::rtps::RTPSParticipantAttributes& attributes) -> bool
+    {
+        for (auto& transportDescriptor : attributes.userTransports)
+        {
+            if( nullptr != dynamic_cast<fastdds::rtps::UDPv6TransportDescriptor*>(transportDescriptor.get()))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    };
+    EXPECT_TRUE(udpv6_check(attributes));
+
     DomainParticipantQos result_qos = participant->get_qos();
     EXPECT_EQ(result_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers, qos_output);
     EXPECT_EQ(ReturnCode_t::RETCODE_OK, participant->set_qos(result_qos));
@@ -833,7 +856,7 @@ TEST(ParticipantTests, SimpleParticipantDynamicAdditionRemoteServers)
     // Modify environment file
 #ifndef __APPLE__
     std::ofstream file(filename);
-    file << "{\"ROS_DISCOVERY_SERVER\": \"84.22.253.128:8888;192.168.1.133:64863;localhost:1234\"}";
+    file << "{\"ROS_DISCOVERY_SERVER\": \"84.22.253.128:8888;192.168.1.133:64863;UDPv4:[localhost]:1234;[2a02:ec80:600:ed1a::3]:8783\"}";
     file.close();
 
     // Wait long enought for the file watch callback
@@ -1072,7 +1095,7 @@ TEST(ParticipantTests, ServerParticipantCorrectRemoteServerListConfiguration)
 
     std::ofstream file;
     file.open(filename);
-    file << "{\"ROS_DISCOVERY_SERVER\": \";localhost:1234\"}";
+    file << "{\"ROS_DISCOVERY_SERVER\": \";UDPv4:[localhost]:1234\"}";
     file.close();
 
     DomainParticipantQos qos;
@@ -1113,7 +1136,7 @@ TEST(ParticipantTests, ServerParticipantCorrectRemoteServerListConfiguration)
     // Try to be consistent: add already known server
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     file.open(filename);
-    file << "{\"ROS_DISCOVERY_SERVER\": \"172.17.0.5:4321;localhost:1234;192.168.1.133:64863\"}";
+    file << "{\"ROS_DISCOVERY_SERVER\": \"172.17.0.5:4321;UDPv4:[localhost]:1234;192.168.1.133:64863\"}";
     file.close();
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     server.clear();

--- a/test/unittest/utils/CMakeLists.txt
+++ b/test/unittest/utils/CMakeLists.txt
@@ -111,7 +111,11 @@ target_include_directories(LocatorTests PRIVATE
     ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include ${Asio_INCLUDE_DIR}
     ${PROJECT_SOURCE_DIR}/src/cpp)
 target_link_libraries(LocatorTests GTest::gtest ${MOCKS})
-add_gtest(LocatorTests SOURCES ${LOCATORTESTS_SOURCE})
+if(EPROSIMA_TEST_DNS_NOT_SET_UP)
+    set(IGNORE_COMMAND LocatorDNSTests)
+endif()
+add_gtest(LocatorTests SOURCES ${LOCATORTESTS_SOURCE} IGNORE ${IGNORE_COMMAND})
+unset(IGNORE_COMMAND)
 # Skip DNS related tests when not running on our CI
 if(NOT(EPROSIMA_BUILD))
     message(STATUS "Ignoring DNS tests")
@@ -120,7 +124,6 @@ if(NOT(EPROSIMA_BUILD))
         LocatorDNSTests
         )
 endif()
-
 
 add_executable(FixedSizeQueueTests ${FIXEDSIZEQUEUETESTS_SOURCE})
 target_compile_definitions(FixedSizeQueueTests PRIVATE FASTRTPS_NO_LIB)

--- a/thirdparty/optionparser/optionparser.hpp
+++ b/thirdparty/optionparser/optionparser.hpp
@@ -24,7 +24,7 @@
 #ifdef _MSC_VER
 #include <intrin.h>
 #pragma intrinsic(_BitScanReverse)
-#endif
+#endif // ifdef _MSC_VER
 
 namespace eprosima {
 
@@ -32,7 +32,7 @@ namespace eprosima {
 #define NESTED_OPTIONPARSER_H_INCLUDED_
 // allow including again the header because is in another namespace
 #undef OPTIONPARSER_H_
-#endif
+#endif // ifdef OPTIONPARSER_H_
 
 #include "./optionparser/optionparser.h"
 
@@ -41,7 +41,7 @@ namespace eprosima {
 #undef OPTIONPARSER_H_
 #else
 #undef NESTED_OPTIONPARSER_H_INCLUDED_
-#endif
+#endif // ifndef NESTED_OPTIONPARSER_H_INCLUDED_
 
 } // namespace eprosima
 

--- a/thirdparty/optionparser/optionparser.hpp
+++ b/thirdparty/optionparser/optionparser.hpp
@@ -20,6 +20,12 @@
 #ifndef FASTDDS_OPTIONPARSER_HPP_
 #define FASTDDS_OPTIONPARSER_HPP_
 
+// specific optionparser.h includes must be moved out of the namespace to prevent macro issues
+#ifdef _MSC_VER
+#include <intrin.h>
+#pragma intrinsic(_BitScanReverse)
+#endif
+
 namespace eprosima {
 
 #ifdef OPTIONPARSER_H_

--- a/thirdparty/optionparser/optionparser/optionparser.h
+++ b/thirdparty/optionparser/optionparser/optionparser.h
@@ -218,11 +218,6 @@
 #ifndef OPTIONPARSER_H_
 #define OPTIONPARSER_H_
 
-#ifdef _MSC_VER
-#include <intrin.h>
-#pragma intrinsic(_BitScanReverse)
-#endif
-
 /** @brief The namespace of The Lean Mean C++ Option Parser. */
 namespace option
 {

--- a/tools/fds/CMakeLists.txt
+++ b/tools/fds/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 cmake_minimum_required(VERSION 3.16.3)
 
-project(fast-discovery-server VERSION 1.0.0 LANGUAGES CXX)
+project(fast-discovery-server VERSION 1.0.1 LANGUAGES CXX)
 
 ###############################################################################
 # Load external dependencies

--- a/tools/fds/server.cpp
+++ b/tools/fds/server.cpp
@@ -296,11 +296,11 @@ int fastdds_discovery_server(
             int type = LOCATOR_PORT_INVALID;
 
             // Trial order IPv4, IPv6 & DNS
-            if(IPLocator::isIPv4(address) && IPLocator::setIPv4(locator4, address))
+            if (IPLocator::isIPv4(address) && IPLocator::setIPv4(locator4, address))
             {
                 type = LOCATOR_KIND_UDPv4;
             }
-            else if(IPLocator::isIPv6(address) && IPLocator::setIPv6(locator6, address))
+            else if (IPLocator::isIPv6(address) && IPLocator::setIPv6(locator6, address))
             {
                 type = LOCATOR_KIND_UDPv6;
             }
@@ -312,7 +312,7 @@ int fastdds_discovery_server(
                 if (response.first.size() > 0)
                 {
                     address = response.first.begin()->data();
-                    if(IPLocator::setIPv4(locator4, address))
+                    if (IPLocator::setIPv4(locator4, address))
                     {
                         type = LOCATOR_KIND_UDPv4;
                     }
@@ -320,7 +320,7 @@ int fastdds_discovery_server(
                 else if (response.second.size() > 0)
                 {
                     address = response.second.begin()->data();
-                    if(IPLocator::setIPv6(locator6, address))
+                    if (IPLocator::setIPv6(locator6, address))
                     {
                         type = LOCATOR_KIND_UDPv6;
                     }
@@ -342,9 +342,9 @@ int fastdds_discovery_server(
                 uint16_t id;
 
                 if (!(is >> id
-                            && is.eof()
-                            && IPLocator::setPhysicalPort(locator4, id)
-                            && IPLocator::setPhysicalPort(locator6, id)))
+                        && is.eof()
+                        && IPLocator::setPhysicalPort(locator4, id)
+                        && IPLocator::setPhysicalPort(locator6, id)))
                 {
                     std::cout << "Invalid listening locator port specified:" << id << std::endl;
                     return 1;
@@ -353,7 +353,7 @@ int fastdds_discovery_server(
 
             // Add the locator
             participantQos.wire_protocol().builtin.metatrafficUnicastLocatorList
-                .push_back( LOCATOR_KIND_UDPv4 == type ? locator4 : locator6 );
+                    .push_back( LOCATOR_KIND_UDPv4 == type ? locator4 : locator6 );
 
             pOp = pOp->next();
             if (pO_port)
@@ -363,12 +363,12 @@ int fastdds_discovery_server(
             else
             {
                 std::cout << "Warning: the number of specified ports doesn't match the ip" << std::endl
-                    << "         addresses provided. Locators share its port number." << std::endl;
+                          << "         addresses provided. Locators share its port number." << std::endl;
             }
         }
 
         // add UDPv6 transport if required
-        if(participantQos.wire_protocol().builtin.metatrafficUnicastLocatorList.has_kind<LOCATOR_KIND_UDPv6>())
+        if (participantQos.wire_protocol().builtin.metatrafficUnicastLocatorList.has_kind<LOCATOR_KIND_UDPv6>())
         {
             // extend builtin transports with the UDPv6 transport
             auto descriptor = std::make_shared<fastdds::rtps::UDPv6TransportDescriptor>();

--- a/tools/fds/server.cpp
+++ b/tools/fds/server.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "server.h"
+
 #include <condition_variable>
 #include <csignal>
 #include <iostream>
@@ -21,11 +23,6 @@
 #include <stdlib.h>
 #include <string>
 #include <vector>
-
-// Even though this header should be the first, as it includes optionparser.hpp, a conflict arises between this file
-// and <condition_variable> in Windows platform.
-#include "server.h"
-#include <optionparser.hpp>
 
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>

--- a/tools/fds/server.h
+++ b/tools/fds/server.h
@@ -60,8 +60,8 @@ const option::Descriptor usage[] = {
       "\t             position in ROS_DISCOVERY_SERVER environment variable.\n" },
 
     { IPADDRESS, 0, "l", "ip-address",   Arg::required,
-      "  -l \t--ip-address IPv4 address chosen to listen the clients. Defaults\n"
-      "\t             to any (0.0.0.0). Instead of an address, a name can\n"
+      "  -l \t--ip-address IPv4/IPv6 address chosen to listen the clients. Defaults\n"
+      "\t             to any (0.0.0.0/::0). Instead of an address, a name can\n"
       "\t             be specified."},
 
     { PORT,      0, "p",  "port",         Arg::check_udp_port,
@@ -90,28 +90,32 @@ const option::Descriptor usage[] = {
       "\t   can reach the server using as ROS_DISCOVERY_SERVER=;127.0.0.1:14520\n\n"
       "\t$ " FAST_SERVER_BINARY " -i 1 -l 127.0.0.1 -p 14520\n\n"
 
-      "\t3. Launch a default server with id 2 (third on ROS_DISCOVERY_SERVER)\n"
-      "\t   listening on Wi-Fi (192.168.36.34) and Ethernet (172.20.96.1) local\n"
+      "\t3. Launch a default server with id 1 (second on ROS_DISCOVERY_SERVER)\n"
+      "\t   listening on UDPv6 address with UDP port 14520.\n\n"
+      "\t$ " FAST_SERVER_BINARY " -i 1 -l 2a02:ec80:600:ed1a::3 -p 14520\n\n"
+
+      "\t4. Launch a default server with id 2 (third on ROS_DISCOVERY_SERVER)\n"
+      "\t   listening on Wi-Fi (192.163.6.34) and Ethernet (172.20.96.1) local\n"
       "\t   interfaces with UDP ports 8783 and 51083 respectively\n"
       "\t   (addresses and ports are made up for the example).\n\n"
-      "\t$ " FAST_SERVER_BINARY " -i 2 -l 192.168.36.34 -p 8783 -l 172.20.96.1 -p 51083\n\n"
+      "\t$ " FAST_SERVER_BINARY " -i 2 -l 192.163.6.34 -p 8783 -l 172.20.96.1 -p 51083\n\n"
 
-      "\t4. Launch a default server with id 3 (fourth on ROS_DISCOVERY_SERVER)\n"
-      "\t   listening on 172.30.144.1 with UDP port 12345 and provided with a\n"
+      "\t5. Launch a default server with id 3 (fourth on ROS_DISCOVERY_SERVER)\n"
+      "\t   listening on 172.31.44.1 with UDP port 12345 and provided with a\n"
       "\t   backup file. If the server crashes it will automatically restore its\n"
       "\t   previous state when reenacted.\n\n"
-      "\t$ " FAST_SERVER_BINARY " -i 3 -l 172.30.144.1 -p 12345 -b\n\n"
+      "\t$ " FAST_SERVER_BINARY " -i 3 -l 172.31.44.1 -p 12345 -b\n\n"
 
-      "\t5. Launch a default server with id 0 (first on ROS_DISCOVERY_SERVER)\n"
-      "\t   listening on localhost with UDP port 14520. Only localhost clients\n"
-      "\t   can reach the server defining as ROS_DISCOVERY_SERVER=localhost:14520.\n\n"
+      "\t6. Launch a default server with id 0 (first on ROS_DISCOVERY_SERVER)\n"
+      "\t   listening on localhost with UDP port 14520 Only localhost clients\n"
+      "\t   can reach the server defining as ROS_DISCOVERY_SERVER=localhost:14520\n\n"
       "\t$ " FAST_SERVER_BINARY " -i 0 -l localhost -p 14520\n\n"
 
-      "\t6. Launch a server with id 0 (first on ROS_DISCOVERY_SERVER) reading\n"
+      "\t7. Launch a server with id 0 (first on ROS_DISCOVERY_SERVER) reading\n"
       "\t   default configuration from XML file.\n\n"
       "\t$ " FAST_SERVER_BINARY " -i 0 -x config.xml\n\n"
 
-      "\t6. Launch a server with id 0 (first on ROS_DISCOVERY_SERVER) reading\n"
+      "\t6 Launch a server with id 0 (first on ROS_DISCOVERY_SERVER) reading\n"
       "\t   specific profile_name configuration from XML file.\n\n"
       "\t$ " FAST_SERVER_BINARY " -i 0 -x profile_name@config.xml"},
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
### [ROS_DISCOVERY_SERVER](https://fast-dds.docs.eprosima.com/en/latest/fastdds/env_vars/env_vars.html#ros-discovery-server)
+ Now supports IPv6 addresses for UDP.
+ The DNS names can be decorated to specify which address family to use if IPv4 and IPv6 addresses are available.

### [fast-discovery-server](https://fast-dds.docs.eprosima.com/en/latest/fastddscli/cli/cli.html#discovery)
+ Now IPv6 addresses can be specified at the cli.
+ DNS resolution supports IPv6 but available IPv4 addresses will take precedence for backward compatibility.

Testing has been updated to take into account IPv6 addresses.

Documentation https://github.com/eProsima/Fast-DDS-docs/pull/401

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
