### PR TITLE
Syscall param ioctl(SIOCGIFHWADDR) points to uninitialised byte(s)

### DIFF
--- a/src/cpp/utils/IPFinder.cpp
+++ b/src/cpp/utils/IPFinder.cpp
@@ -335,7 +335,7 @@ bool IPFinder::getAllMACAddress(
     IPFinder::getIPs(&ips);
     for (auto& ip : ips)
     {
-        struct ifreq ifr;
+        struct ifreq ifr = {};
         strncpy(ifr.ifr_name, ip.dev.c_str(), sizeof(ifr.ifr_name) - 1);
         int fd = socket(PF_INET, SOCK_DGRAM, 0);
         if (fd == -1)


### PR DESCRIPTION
Signed-off-by: Tomoya Fujita <Tomoya.Fujita@sony.com>

## Description

Syscall param ioctl(SIOCGIFHWADDR) points to uninitialised byte(s): (valgrind)

```bash
root@tomoyafujita:~/ros2_ws/colcon_ws# valgrind --leak-check=full ./build/demo_nodes_cpp/talker
==207805== Memcheck, a memory error detector
==207805== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==207805== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==207805== Command: ./build/demo_nodes_cpp/talker
==207805==
==207805== Syscall param ioctl(SIOCGIFHWADDR) points to uninitialised byte(s)
==207805==    at 0x4F21AFF: ioctl (ioctl.c:36)
==207805==    by 0x5F984EE: eprosima::fastrtps::rtps::IPFinder::getAllMACAddress(std::vector<eprosima::fastrtps::rtps::IPFinder::info_MAC, std::allocator<eprosima::fastrtps::rtps::IPFinder::info_MAC> >*) (in /root/ros2_ws/colcon_ws/install/fastrtps/lib/libfastrtps.so.2.8.0)
==207805==    by 0x5CAEE29: eprosima::fastdds::rtps::GuidUtils::GuidUtils() (in /root/ros2_ws/colcon_ws/install/fastrtps/lib/libfastrtps.so.2.8.0)
==207805==    by 0x5CA951A: eprosima::fastrtps::rtps::RTPSDomainImpl::create_participant_guid(int&, eprosima::fastrtps::rtps::GUID_t&) (in /root/ros2_ws/colcon_ws/install/fastrtps/lib/libfastrtps.so.2.8.0)
==207805==    by 0x5D64747: eprosima::fastdds::dds::DomainParticipantImpl::DomainParticipantImpl(eprosima::fastdds::dds::DomainParticipant*, unsigned int, eprosima::fastdds::dds::DomainParticipantQos const&, eprosima::fastdds::dds::DomainParticipantListener*) (in /root/ros2_ws/colcon_ws/install/fastrtps/lib/libfastrtps.so.2.8.0)
==207805==    by 0x5D4CC7E: eprosima::fastdds::dds::DomainParticipantFactory::create_participant(unsigned int, eprosima::fastdds::dds::DomainParticipantQos const&, eprosima::fastdds::dds::DomainParticipantListener*, eprosima::fastdds::dds::StatusMask const&) (in /root/ros2_ws/colcon_ws/install/fastrtps/lib/libfastrtps.so.2.8.0)
==207805==    by 0x58A9729: __create_participant(char const*, eprosima::fastdds::dds::DomainParticipantQos const&, bool, publishing_mode_t, rmw_dds_common::Context*, unsigned long) (in /root/ros2_ws/colcon_ws/install/rmw_fastrtps_shared_cpp/lib/librmw_fastrtps_shared_cpp.so)
==207805==    by 0x58AA282: rmw_fastrtps_shared_cpp::create_participant(char const*, unsigned long, rmw_security_options_s const*, bool, char const*, rmw_dds_common::Context*) (in /root/ros2_ws/colcon_ws/install/rmw_fastrtps_shared_cpp/lib/librmw_fastrtps_shared_cpp.so)
==207805==    by 0x57499BF: init_context_impl(rmw_context_s*) (in /root/ros2_ws/colcon_ws/build/rmw_fastrtps_cpp/librmw_fastrtps_cpp.so)
==207805==    by 0x574A100: rmw_fastrtps_cpp::increment_context_impl_ref_count(rmw_context_s*) (in /root/ros2_ws/colcon_ws/build/rmw_fastrtps_cpp/librmw_fastrtps_cpp.so)
==207805==    by 0x576FB0B: rmw_create_node (in /root/ros2_ws/colcon_ws/build/rmw_fastrtps_cpp/librmw_fastrtps_cpp.so)
==207805==    by 0x505C0C5: rcl_node_init (in /root/ros2_ws/colcon_ws/install/rcl/lib/librcl.so)
==207805==  Address 0x1ffefdff5f is on thread 1's stack
==207805==  in frame #1, created by eprosima::fastrtps::rtps::IPFinder::getAllMACAddress(std::vector<eprosima::fastrtps::rtps::IPFinder::info_MAC, std::allocator<eprosima::fastrtps::rtps::IPFinder::info_MAC> >*) (???:)
==207805==
[INFO] [1663255182.400603270] [talker]: Publishing: 'Hello World: 1'
```

related issue: https://github.com/ros2/rcl/issues/1009

## Contributor Checklist
- [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [ ] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [ ] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [ ] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->

## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
