### PR TITLE
[15611] Improve GUID_t operator< performance

### DIFF
--- a/include/fastdds/rtps/common/EntityId_t.hpp
+++ b/include/fastdds/rtps/common/EntityId_t.hpp
@@ -210,7 +210,9 @@ struct RTPS_DllAPI EntityId_t
      * @return < 0 if \c entity1 is lower than \c entity2 .
      * @return > 0 if \c entity1 is higher than \c entity2 .
      */
-    static int cmp(const EntityId_t& entity1, const EntityId_t& entity2)
+    static int cmp(
+            const EntityId_t& entity1,
+            const EntityId_t& entity2)
     {
         return std::memcmp(entity1.value, entity2.value, size);
     }
@@ -264,7 +266,7 @@ inline bool operator !=(
 {
     // Use == operator as it is faster enough.
     // NOTE: this could be done comparing the entities backwards (starting in [3]) as it would probably be faster.
-    return !(operator==(id1, id2));
+    return !(operator ==(id1, id2));
 }
 
 #endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC

--- a/include/fastdds/rtps/common/EntityId_t.hpp
+++ b/include/fastdds/rtps/common/EntityId_t.hpp
@@ -192,7 +192,7 @@ struct RTPS_DllAPI EntityId_t
     /**
      * Entity Id minor operator
      * @param other Second entity id to compare
-     * @return True if other is higher or equal this
+     * @return True if \c other is higher than this
      */
     bool operator <(
             const EntityId_t& other) const
@@ -200,9 +200,19 @@ struct RTPS_DllAPI EntityId_t
         return std::memcmp(value, other.value, size) < 0;
     }
 
-    static int cmp(const EntityId_t& prefix1, const EntityId_t& prefix2)
+    /**
+     * Entity Id compare static method.
+     *
+     * @param entity1 First entity id to compare
+     * @param entity2 Second entity id to compare
+     *
+     * @return 0 if \c entity1 is equal to \c entity2 .
+     * @return < 0 if \c entity1 is lower than \c entity2 .
+     * @return > 0 if \c entity1 is higher than \c entity2 .
+     */
+    static int cmp(const EntityId_t& entity1, const EntityId_t& entity2)
     {
-        return std::memcmp(prefix1.value, prefix2.value, size);
+        return std::memcmp(entity1.value, entity2.value, size);
     }
 
 };
@@ -210,7 +220,7 @@ struct RTPS_DllAPI EntityId_t
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 /**
- * Guid prefix comparison operator
+ * Entity Id comparison operator
  * @param id1 EntityId to compare
  * @param id2 ID prefix to compare
  * @return True if equal
@@ -230,7 +240,7 @@ inline bool operator ==(
 }
 
 /**
- * Guid prefix comparison operator
+ * Entity Id comparison operator
  * @param id1 First EntityId to compare
  * @param id2 Second EntityId to compare
  * @return True if equal
@@ -239,14 +249,7 @@ inline bool operator ==(
         const EntityId_t& id1,
         const EntityId_t& id2)
 {
-    for (uint8_t i = 0; i < 4; ++i)
-    {
-        if (id1.value[i] != id2.value[i])
-        {
-            return false;
-        }
-    }
-    return true;
+    return EntityId_t::cmp(id1, id2) == 0;
 }
 
 /**
@@ -259,14 +262,9 @@ inline bool operator !=(
         const EntityId_t& id1,
         const EntityId_t& id2)
 {
-    for (uint8_t i = 0; i < 4; ++i)
-    {
-        if (id1.value[i] != id2.value[i])
-        {
-            return true;
-        }
-    }
-    return false;
+    // Use == operator as it is faster enough.
+    // NOTE: this could be done comparing the entities backwards (starting in [3]) as it would probably be faster.
+    return !(operator==(id1, id2));
 }
 
 #endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC

--- a/include/fastdds/rtps/common/EntityId_t.hpp
+++ b/include/fastdds/rtps/common/EntityId_t.hpp
@@ -189,6 +189,22 @@ struct RTPS_DllAPI EntityId_t
         return 0x2u & to_uint32() && !is_reader();
     }
 
+    /**
+     * Entity Id minor operator
+     * @param other Second entity id to compare
+     * @return True if other is higher or equal this
+     */
+    bool operator <(
+            const EntityId_t& other) const
+    {
+        return std::memcmp(value, other.value, size) < 0;
+    }
+
+    static int cmp(const EntityId_t& prefix1, const EntityId_t& prefix2)
+    {
+        return std::memcmp(prefix1.value, prefix2.value, size);
+    }
+
 };
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC

--- a/include/fastdds/rtps/common/Guid.h
+++ b/include/fastdds/rtps/common/Guid.h
@@ -121,7 +121,6 @@ struct RTPS_DllAPI GUID_t
     {
         return *reinterpret_cast<const InstanceHandle_t*>(this);
     }
-
 };
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
@@ -170,29 +169,19 @@ inline bool operator <(
         const GUID_t& g1,
         const GUID_t& g2)
 {
-    for (uint8_t i = 0; i < 12; ++i)
+    auto prefix_cmp = GuidPrefix_t::cmp(g1.guidPrefix, g2.guidPrefix);
+    if (prefix_cmp < 0)
     {
-        if (g1.guidPrefix.value[i] < g2.guidPrefix.value[i])
-        {
-            return true;
-        }
-        else if (g1.guidPrefix.value[i] > g2.guidPrefix.value[i])
-        {
-            return false;
-        }
+        return true;
     }
-    for (uint8_t i = 0; i < 4; ++i)
+    else if (prefix_cmp > 0)
     {
-        if (g1.entityId.value[i] < g2.entityId.value[i])
-        {
-            return true;
-        }
-        else if (g1.entityId.value[i] > g2.entityId.value[i])
-        {
-            return false;
-        }
+        return false;
     }
-    return false;
+    else
+    {
+        return g1.entityId < g2.entityId;
+    }
 }
 
 #endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC

--- a/include/fastdds/rtps/common/GuidPrefix_t.hpp
+++ b/include/fastdds/rtps/common/GuidPrefix_t.hpp
@@ -76,12 +76,17 @@ struct RTPS_DllAPI GuidPrefix_t
     /**
      * Guid prefix minor operator
      * @param prefix Second guid prefix to compare
-     * @return True if prefix is higher
+     * @return True if prefix is higher or equal this
      */
     bool operator <(
             const GuidPrefix_t& prefix) const
     {
         return std::memcmp(value, prefix.value, size) < 0;
+    }
+
+    static int cmp(const GuidPrefix_t& prefix1, const GuidPrefix_t& prefix2)
+    {
+        return std::memcmp(prefix1.value, prefix2.value, size);
     }
 
 #endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC

--- a/include/fastdds/rtps/common/GuidPrefix_t.hpp
+++ b/include/fastdds/rtps/common/GuidPrefix_t.hpp
@@ -94,7 +94,9 @@ struct RTPS_DllAPI GuidPrefix_t
      * @return < 0 if \c prefix1 is lower than \c prefix2 .
      * @return > 0 if \c prefix1 is higher than \c prefix2 .
      */
-    static int cmp(const GuidPrefix_t& prefix1, const GuidPrefix_t& prefix2)
+    static int cmp(
+            const GuidPrefix_t& prefix1,
+            const GuidPrefix_t& prefix2)
     {
         return std::memcmp(prefix1.value, prefix2.value, size);
     }

--- a/include/fastdds/rtps/common/GuidPrefix_t.hpp
+++ b/include/fastdds/rtps/common/GuidPrefix_t.hpp
@@ -76,7 +76,7 @@ struct RTPS_DllAPI GuidPrefix_t
     /**
      * Guid prefix minor operator
      * @param prefix Second guid prefix to compare
-     * @return True if prefix is higher or equal this
+     * @return True if prefix is higher than this
      */
     bool operator <(
             const GuidPrefix_t& prefix) const
@@ -84,6 +84,16 @@ struct RTPS_DllAPI GuidPrefix_t
         return std::memcmp(value, prefix.value, size) < 0;
     }
 
+    /**
+     * Guid Prefix compare static method.
+     *
+     * @param prefix1 First guid prefix to compare
+     * @param prefix2 Second guid prefix to compare
+     *
+     * @return 0 if \c prefix1 is equal to \c prefix2 .
+     * @return < 0 if \c prefix1 is lower than \c prefix2 .
+     * @return > 0 if \c prefix1 is higher than \c prefix2 .
+     */
     static int cmp(const GuidPrefix_t& prefix1, const GuidPrefix_t& prefix2)
     {
         return std::memcmp(prefix1.value, prefix2.value, size);

--- a/test/unittest/rtps/common/CMakeLists.txt
+++ b/test/unittest/rtps/common/CMakeLists.txt
@@ -78,3 +78,54 @@ target_include_directories(PortParametersTests PRIVATE
     ${PROJECT_SOURCE_DIR}/src/cpp)
 target_link_libraries(PortParametersTests GTest::gtest)
 add_gtest(PortParametersTests SOURCES ${PORTPARAMETERSTESTS_SOURCE} LABELS "NoMemoryCheck")
+
+###################
+# GuifPrefix test #
+###################
+
+set(GUIDPREFIXTESTS_SOURCE GuidPrefixTests.cpp)
+
+add_executable(GuidPrefixTests ${GUIDPREFIXTESTS_SOURCE})
+target_compile_definitions(GuidPrefixTests PRIVATE FASTRTPS_NO_LIB
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
+target_include_directories(GuidPrefixTests PRIVATE
+    ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
+    ${PROJECT_SOURCE_DIR}/src/cpp)
+target_link_libraries(GuidPrefixTests GTest::gtest)
+add_gtest(GuidPrefixTests SOURCES ${GUIDPREFIXTESTS_SOURCE} LABELS "NoMemoryCheck")
+
+#################
+# EntityId test #
+#################
+
+set(ENTITYIDTESTS_SOURCE EntityIdTests.cpp)
+
+add_executable(EntityIdTests ${ENTITYIDTESTS_SOURCE})
+target_compile_definitions(EntityIdTests PRIVATE FASTRTPS_NO_LIB
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
+target_include_directories(EntityIdTests PRIVATE
+    ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
+    ${PROJECT_SOURCE_DIR}/src/cpp)
+target_link_libraries(EntityIdTests GTest::gtest)
+add_gtest(EntityIdTests SOURCES ${ENTITYIDTESTS_SOURCE} LABELS "NoMemoryCheck")
+
+#############
+# Guid test #
+#############
+
+set(GUIDTESTS_SOURCE GuidTests.cpp)
+
+add_executable(GuidTests ${GUIDTESTS_SOURCE})
+target_compile_definitions(GuidTests PRIVATE FASTRTPS_NO_LIB
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
+target_include_directories(GuidTests PRIVATE
+    ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
+    ${PROJECT_SOURCE_DIR}/src/cpp)
+target_link_libraries(GuidTests GTest::gtest)
+add_gtest(GuidTests SOURCES ${GUIDTESTS_SOURCE} LABELS "NoMemoryCheck")

--- a/test/unittest/rtps/common/EntityIdTests.cpp
+++ b/test/unittest/rtps/common/EntityIdTests.cpp
@@ -150,6 +150,38 @@ TEST(EntityIdTests, minor_opertor)
     }
 }
 
+/**
+ * @brief This test checks Entity Id compare \c operator== and \c operator!= method.
+ *
+ * Uses a manually sorted vector of entities to check cmp result.
+ *
+ * @note this method checks cmp sign, it does not use memcmp as testing the function with itself would not give info.
+ */
+TEST(EntityIdTests, equality)
+{
+    auto manually_sorted_entities = test::get_sorted_entityid_vector();
+
+    for (std::size_t i=0; i<manually_sorted_entities.size(); ++i)
+    {
+        for (std::size_t j=0; j<manually_sorted_entities.size(); ++j)
+        {
+            bool result_equal = manually_sorted_entities[i] == manually_sorted_entities[j];
+            bool result_non_equal = manually_sorted_entities[i] != manually_sorted_entities[j];
+
+            if (i == j)
+            {
+                ASSERT_TRUE(result_equal);
+                ASSERT_FALSE(result_non_equal);
+            }
+            else
+            {
+                ASSERT_FALSE(result_equal);
+                ASSERT_TRUE(result_non_equal);
+            }
+        }
+    }
+}
+
 int main(
         int argc,
         char** argv)

--- a/test/unittest/rtps/common/EntityIdTests.cpp
+++ b/test/unittest/rtps/common/EntityIdTests.cpp
@@ -18,8 +18,7 @@
 
 using EntityId = eprosima::fastrtps::rtps::EntityId_t;
 
-namespace test
-{
+namespace test {
 
 /**
  * @brief Get a manually sorted entityid vector object
@@ -89,9 +88,9 @@ TEST(EntityIdTests, cmp)
 {
     auto manually_sorted_entities = test::get_sorted_entityid_vector();
 
-    for (std::size_t i=0; i<manually_sorted_entities.size(); ++i)
+    for (std::size_t i = 0; i < manually_sorted_entities.size(); ++i)
     {
-        for (std::size_t j=0; j<manually_sorted_entities.size(); ++j)
+        for (std::size_t j = 0; j < manually_sorted_entities.size(); ++j)
         {
             int result = EntityId::cmp(manually_sorted_entities[i], manually_sorted_entities[j]);
 
@@ -125,9 +124,9 @@ TEST(EntityIdTests, minor_opertor)
 {
     auto manually_sorted_entities = test::get_sorted_entityid_vector();
 
-    for (std::size_t i=0; i<manually_sorted_entities.size(); ++i)
+    for (std::size_t i = 0; i < manually_sorted_entities.size(); ++i)
     {
-        for (std::size_t j=0; j<manually_sorted_entities.size(); ++j)
+        for (std::size_t j = 0; j < manually_sorted_entities.size(); ++j)
         {
             bool result = manually_sorted_entities[i] < manually_sorted_entities[j];
 
@@ -161,9 +160,9 @@ TEST(EntityIdTests, equality)
 {
     auto manually_sorted_entities = test::get_sorted_entityid_vector();
 
-    for (std::size_t i=0; i<manually_sorted_entities.size(); ++i)
+    for (std::size_t i = 0; i < manually_sorted_entities.size(); ++i)
     {
-        for (std::size_t j=0; j<manually_sorted_entities.size(); ++j)
+        for (std::size_t j = 0; j < manually_sorted_entities.size(); ++j)
         {
             bool result_equal = manually_sorted_entities[i] == manually_sorted_entities[j];
             bool result_non_equal = manually_sorted_entities[i] != manually_sorted_entities[j];

--- a/test/unittest/rtps/common/EntityIdTests.cpp
+++ b/test/unittest/rtps/common/EntityIdTests.cpp
@@ -1,0 +1,159 @@
+// Copyright 2022 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <fastdds/rtps/common/EntityId_t.hpp>
+
+using EntityId = eprosima::fastrtps::rtps::EntityId_t;
+
+namespace test
+{
+
+/**
+ * @brief Get a manually sorted entityid vector object
+ *
+ * @note To test more entities just add to this vector new entities sorted manually.
+ */
+std::vector<EntityId> get_sorted_entityid_vector()
+{
+    std::vector<EntityId> result_vector;
+
+    // Create entities with different values to compare them afterwards
+    // All zeros
+    {
+        EntityId entity; // Default constructor
+        result_vector.push_back(entity);
+    }
+
+    // Last value one
+    {
+        EntityId entity; // Default constructor
+        entity.value[entity.size - 1] = 0x01;
+        result_vector.push_back(entity);
+    }
+
+    // Last value ff
+    {
+        EntityId entity; // Default constructor
+        entity.value[entity.size - 1] = 0xff;
+        result_vector.push_back(entity);
+    }
+
+    // 2 value 0x66
+    {
+        EntityId entity; // Default constructor
+        entity.value[2] = 0x66;
+        result_vector.push_back(entity);
+    }
+
+    // First value one
+    {
+        EntityId entity; // Default constructor
+        entity.value[0] = 0x01;
+        result_vector.push_back(entity);
+    }
+
+    // First value ff
+    {
+        EntityId entity; // Default constructor
+        entity.value[0] = 0xff;
+        result_vector.push_back(entity);
+    }
+
+    // Create a vector that is sorted
+    return result_vector;
+}
+
+} // namespace test
+
+/**
+ * @brief This test checks Entity Id compare \c cmp method.
+ *
+ * Uses a manually sorted vector of entities to check cmp result.
+ *
+ * @note this method checks cmp sign, it does not use memcmp as testing the function with itself would not give info.
+ */
+TEST(EntityIdTests, cmp)
+{
+    auto manually_sorted_entities = test::get_sorted_entityid_vector();
+
+    for (std::size_t i=0; i<manually_sorted_entities.size(); ++i)
+    {
+        for (std::size_t j=0; j<manually_sorted_entities.size(); ++j)
+        {
+            int result = EntityId::cmp(manually_sorted_entities[i], manually_sorted_entities[j]);
+
+            if (i == j)
+            {
+                // [i] == [j] so cmp should be 0
+                ASSERT_EQ(result, 0);
+            }
+            else if (i < j)
+            {
+                // [i] < [j] so cmp should be negative
+                ASSERT_LT(result, 0);
+            }
+            else
+            {
+                // [i] > [j] so cmp should be negative
+                ASSERT_GT(result, 0);
+            }
+        }
+    }
+}
+
+/**
+ * @brief This test checks Entity Id compare \c operator< method.
+ *
+ * Uses a manually sorted vector of entities to check operator< result.
+ *
+ * @note this method checks cmp sign, it does not use memcmp as testing the function with itself would not give info.
+ */
+TEST(EntityIdTests, minor_opertor)
+{
+    auto manually_sorted_entities = test::get_sorted_entityid_vector();
+
+    for (std::size_t i=0; i<manually_sorted_entities.size(); ++i)
+    {
+        for (std::size_t j=0; j<manually_sorted_entities.size(); ++j)
+        {
+            bool result = manually_sorted_entities[i] < manually_sorted_entities[j];
+
+            if (i == j)
+            {
+                // [i] == [j] so false
+                ASSERT_FALSE(result);
+            }
+            else if (i < j)
+            {
+                // [i] < [j] so true
+                ASSERT_TRUE(result);
+            }
+            else
+            {
+                // [i] > [j] so false
+                ASSERT_FALSE(result);
+            }
+        }
+    }
+}
+
+int main(
+        int argc,
+        char** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/unittest/rtps/common/GuidPrefixTests.cpp
+++ b/test/unittest/rtps/common/GuidPrefixTests.cpp
@@ -150,6 +150,38 @@ TEST(GuidPrefixTests, minor_opertor)
     }
 }
 
+/**
+ * @brief This test checks Guid Prefix compare \c operator== and \c operator!= method.
+ *
+ * Uses a manually sorted vector of entities to check cmp result.
+ *
+ * @note this method checks cmp sign, it does not use memcmp as testing the function with itself would not give info.
+ */
+TEST(GuidPrefixTests, equality)
+{
+    auto manually_sorted_entities = test::get_sorted_guidprefix_vector();
+
+    for (std::size_t i=0; i<manually_sorted_entities.size(); ++i)
+    {
+        for (std::size_t j=0; j<manually_sorted_entities.size(); ++j)
+        {
+            bool result_equal = manually_sorted_entities[i] == manually_sorted_entities[j];
+            bool result_non_equal = manually_sorted_entities[i] != manually_sorted_entities[j];
+
+            if (i == j)
+            {
+                ASSERT_TRUE(result_equal);
+                ASSERT_FALSE(result_non_equal);
+            }
+            else
+            {
+                ASSERT_FALSE(result_equal);
+                ASSERT_TRUE(result_non_equal);
+            }
+        }
+    }
+}
+
 int main(
         int argc,
         char** argv)

--- a/test/unittest/rtps/common/GuidPrefixTests.cpp
+++ b/test/unittest/rtps/common/GuidPrefixTests.cpp
@@ -18,8 +18,7 @@
 
 using GuidPrefix = eprosima::fastrtps::rtps::GuidPrefix_t;
 
-namespace test
-{
+namespace test {
 
 /**
  * @brief Get a manually sorted guidprefix vector object
@@ -89,9 +88,9 @@ TEST(GuidPrefixTests, cmp)
 {
     auto manually_sorted_prefixes = test::get_sorted_guidprefix_vector();
 
-    for (std::size_t i=0; i<manually_sorted_prefixes.size(); ++i)
+    for (std::size_t i = 0; i < manually_sorted_prefixes.size(); ++i)
     {
-        for (std::size_t j=0; j<manually_sorted_prefixes.size(); ++j)
+        for (std::size_t j = 0; j < manually_sorted_prefixes.size(); ++j)
         {
             int result = GuidPrefix::cmp(manually_sorted_prefixes[i], manually_sorted_prefixes[j]);
 
@@ -125,9 +124,9 @@ TEST(GuidPrefixTests, minor_opertor)
 {
     auto manually_sorted_prefixes = test::get_sorted_guidprefix_vector();
 
-    for (std::size_t i=0; i<manually_sorted_prefixes.size(); ++i)
+    for (std::size_t i = 0; i < manually_sorted_prefixes.size(); ++i)
     {
-        for (std::size_t j=0; j<manually_sorted_prefixes.size(); ++j)
+        for (std::size_t j = 0; j < manually_sorted_prefixes.size(); ++j)
         {
             bool result = manually_sorted_prefixes[i] < manually_sorted_prefixes[j];
 
@@ -161,9 +160,9 @@ TEST(GuidPrefixTests, equality)
 {
     auto manually_sorted_entities = test::get_sorted_guidprefix_vector();
 
-    for (std::size_t i=0; i<manually_sorted_entities.size(); ++i)
+    for (std::size_t i = 0; i < manually_sorted_entities.size(); ++i)
     {
-        for (std::size_t j=0; j<manually_sorted_entities.size(); ++j)
+        for (std::size_t j = 0; j < manually_sorted_entities.size(); ++j)
         {
             bool result_equal = manually_sorted_entities[i] == manually_sorted_entities[j];
             bool result_non_equal = manually_sorted_entities[i] != manually_sorted_entities[j];

--- a/test/unittest/rtps/common/GuidPrefixTests.cpp
+++ b/test/unittest/rtps/common/GuidPrefixTests.cpp
@@ -1,0 +1,159 @@
+// Copyright 2022 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <fastdds/rtps/common/GuidPrefix_t.hpp>
+
+using GuidPrefix = eprosima::fastrtps::rtps::GuidPrefix_t;
+
+namespace test
+{
+
+/**
+ * @brief Get a manually sorted guidprefix vector object
+ *
+ * @note To test more prefixes just add to this vector new prefixes sorted manually.
+ */
+std::vector<GuidPrefix> get_sorted_guidprefix_vector()
+{
+    std::vector<GuidPrefix> result_vector;
+
+    // Create prefixes with different values to compare them afterwards
+    // All zeros
+    {
+        GuidPrefix prefix; // Default constructor
+        result_vector.push_back(prefix);
+    }
+
+    // Last value one
+    {
+        GuidPrefix prefix; // Default constructor
+        prefix.value[prefix.size - 1] = 0x01;
+        result_vector.push_back(prefix);
+    }
+
+    // Last value ff
+    {
+        GuidPrefix prefix; // Default constructor
+        prefix.value[prefix.size - 1] = 0xff;
+        result_vector.push_back(prefix);
+    }
+
+    // 6 value 0x66
+    {
+        GuidPrefix prefix; // Default constructor
+        prefix.value[6] = 0x66;
+        result_vector.push_back(prefix);
+    }
+
+    // First value one
+    {
+        GuidPrefix prefix; // Default constructor
+        prefix.value[0] = 0x01;
+        result_vector.push_back(prefix);
+    }
+
+    // First value ff
+    {
+        GuidPrefix prefix; // Default constructor
+        prefix.value[0] = 0xff;
+        result_vector.push_back(prefix);
+    }
+
+    // Create a vector that is sorted
+    return result_vector;
+}
+
+} // namespace test
+
+/**
+ * @brief This test checks Guid Prefix compare \c cmp method.
+ *
+ * Uses a manually sorted vector of prefixes to check cmp result.
+ *
+ * @note this method checks cmp sign, it does not use memcmp as testing the function with itself would not give info.
+ */
+TEST(GuidPrefixTests, cmp)
+{
+    auto manually_sorted_prefixes = test::get_sorted_guidprefix_vector();
+
+    for (std::size_t i=0; i<manually_sorted_prefixes.size(); ++i)
+    {
+        for (std::size_t j=0; j<manually_sorted_prefixes.size(); ++j)
+        {
+            int result = GuidPrefix::cmp(manually_sorted_prefixes[i], manually_sorted_prefixes[j]);
+
+            if (i == j)
+            {
+                // [i] == [j] so cmp should be 0
+                ASSERT_EQ(result, 0);
+            }
+            else if (i < j)
+            {
+                // [i] < [j] so cmp should be negative
+                ASSERT_LT(result, 0);
+            }
+            else
+            {
+                // [i] > [j] so cmp should be negative
+                ASSERT_GT(result, 0);
+            }
+        }
+    }
+}
+
+/**
+ * @brief This test checks Guid Prefix compare \c operator< method.
+ *
+ * Uses a manually sorted vector of prefixes to check operator< result.
+ *
+ * @note this method checks cmp sign, it does not use memcmp as testing the function with itself would not give info.
+ */
+TEST(GuidPrefixTests, minor_opertor)
+{
+    auto manually_sorted_prefixes = test::get_sorted_guidprefix_vector();
+
+    for (std::size_t i=0; i<manually_sorted_prefixes.size(); ++i)
+    {
+        for (std::size_t j=0; j<manually_sorted_prefixes.size(); ++j)
+        {
+            bool result = manually_sorted_prefixes[i] < manually_sorted_prefixes[j];
+
+            if (i == j)
+            {
+                // [i] == [j] so false
+                ASSERT_FALSE(result);
+            }
+            else if (i < j)
+            {
+                // [i] < [j] so true
+                ASSERT_TRUE(result);
+            }
+            else
+            {
+                // [i] > [j] so false
+                ASSERT_FALSE(result);
+            }
+        }
+    }
+}
+
+int main(
+        int argc,
+        char** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/unittest/rtps/common/GuidTests.cpp
+++ b/test/unittest/rtps/common/GuidTests.cpp
@@ -142,6 +142,38 @@ TEST(GuidTests, minor_opertor)
     }
 }
 
+/**
+ * @brief This test checks Guid compare \c operator== and \c operator!= method.
+ *
+ * Uses a manually sorted vector of entities to check cmp result.
+ *
+ * @note this method checks cmp sign, it does not use memcmp as testing the function with itself would not give info.
+ */
+TEST(GuidTests, equality)
+{
+    auto manually_sorted_entities = test::get_sorted_guid_vector();
+
+    for (std::size_t i=0; i<manually_sorted_entities.size(); ++i)
+    {
+        for (std::size_t j=0; j<manually_sorted_entities.size(); ++j)
+        {
+            bool result_equal = manually_sorted_entities[i] == manually_sorted_entities[j];
+            bool result_non_equal = manually_sorted_entities[i] != manually_sorted_entities[j];
+
+            if (i == j)
+            {
+                ASSERT_TRUE(result_equal);
+                ASSERT_FALSE(result_non_equal);
+            }
+            else
+            {
+                ASSERT_FALSE(result_equal);
+                ASSERT_TRUE(result_non_equal);
+            }
+        }
+    }
+}
+
 int main(
         int argc,
         char** argv)

--- a/test/unittest/rtps/common/GuidTests.cpp
+++ b/test/unittest/rtps/common/GuidTests.cpp
@@ -1,0 +1,151 @@
+// Copyright 2022 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <fastdds/rtps/common/Guid.h>
+
+using Guid = eprosima::fastrtps::rtps::GUID_t;
+
+namespace test
+{
+
+/**
+ * @brief Get a manually sorted guid vector object
+ *
+ * @note To test more guids just add to this vector new guids sorted manually.
+ */
+std::vector<Guid> get_sorted_guid_vector()
+{
+    std::vector<Guid> result_vector;
+
+    // Create guids with different values to compare them afterwards
+    // All zeros
+    {
+        Guid guid; // Default constructor
+        result_vector.push_back(guid);
+    }
+
+    // Last value of entity one
+    {
+        Guid guid; // Default constructor
+        guid.entityId.value[guid.entityId.size - 1] = 0x01;
+        result_vector.push_back(guid);
+    }
+
+    // Last value of entity ff
+    {
+        Guid guid; // Default constructor
+        guid.entityId.value[guid.entityId.size - 1] = 0xff;
+        result_vector.push_back(guid);
+    }
+
+    // Value in Entity 2 to 0x66
+    {
+        Guid guid; // Default constructor
+        guid.entityId.value[2] = 0x66;
+        result_vector.push_back(guid);
+    }
+
+    // Last value of prefix one
+    {
+        Guid guid; // Default constructor
+        guid.guidPrefix.value[guid.guidPrefix.size - 1] = 0x01;
+        result_vector.push_back(guid);
+    }
+
+    // Last value of prefix one and last value of entity ff
+    {
+        Guid guid; // Default constructor
+        guid.guidPrefix.value[guid.guidPrefix.size - 1] = 0x01;
+        guid.entityId.value[guid.entityId.size - 1] = 0xff;
+        result_vector.push_back(guid);
+    }
+
+    // Value in Prefix 2 to 0x66
+    {
+        Guid guid; // Default constructor
+        guid.guidPrefix.value[6] = 0x66;
+        result_vector.push_back(guid);
+    }
+
+    // First value one
+    {
+        Guid guid; // Default constructor
+        guid.guidPrefix.value[0] = 0x01;
+        result_vector.push_back(guid);
+    }
+
+    // First value ff
+    {
+        Guid guid; // Default constructor
+        guid.guidPrefix.value[0] = 0xff;
+        result_vector.push_back(guid);
+    }
+
+    // Create a vector that is sorted
+    return result_vector;
+}
+
+} // namespace test
+
+/**
+ * @brief This test checks Guid compare \c operator< method.
+ *
+ * Uses a manually sorted vector of guids to check operator< result.
+ *
+ * @note this method checks cmp sign, it does not use memcmp as testing the function with itself would not give info.
+ */
+TEST(GuidTests, minor_opertor)
+{
+    auto manually_sorted_guids = test::get_sorted_guid_vector();
+
+    for (std::size_t i=0; i<manually_sorted_guids.size(); ++i)
+    {
+        for (std::size_t j=0; j<manually_sorted_guids.size(); ++j)
+        {
+            bool result = manually_sorted_guids[i] < manually_sorted_guids[j];
+
+            if (i == j)
+            {
+                // [i] == [j] so false
+                ASSERT_FALSE(result) <<
+                    "[" << i << "] " << manually_sorted_guids[i] << " < " <<
+                    "[" << j << "] " << manually_sorted_guids[j] ;
+            }
+            else if (i < j)
+            {
+                // [i] < [j] so true
+                ASSERT_TRUE(result) <<
+                    "[" << i << "] " << manually_sorted_guids[i] << " < " <<
+                    "[" << j << "] " << manually_sorted_guids[j] ;
+            }
+            else
+            {
+                // [i] > [j] so false
+                ASSERT_FALSE(result) <<
+                    "[" << i << "] " << manually_sorted_guids[i] << " < " <<
+                    "[" << j << "] " << manually_sorted_guids[j] ;
+            }
+        }
+    }
+}
+
+int main(
+        int argc,
+        char** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/unittest/rtps/common/GuidTests.cpp
+++ b/test/unittest/rtps/common/GuidTests.cpp
@@ -18,8 +18,7 @@
 
 using Guid = eprosima::fastrtps::rtps::GUID_t;
 
-namespace test
-{
+namespace test {
 
 /**
  * @brief Get a manually sorted guid vector object
@@ -111,9 +110,9 @@ TEST(GuidTests, minor_opertor)
 {
     auto manually_sorted_guids = test::get_sorted_guid_vector();
 
-    for (std::size_t i=0; i<manually_sorted_guids.size(); ++i)
+    for (std::size_t i = 0; i < manually_sorted_guids.size(); ++i)
     {
-        for (std::size_t j=0; j<manually_sorted_guids.size(); ++j)
+        for (std::size_t j = 0; j < manually_sorted_guids.size(); ++j)
         {
             bool result = manually_sorted_guids[i] < manually_sorted_guids[j];
 
@@ -122,21 +121,21 @@ TEST(GuidTests, minor_opertor)
                 // [i] == [j] so false
                 ASSERT_FALSE(result) <<
                     "[" << i << "] " << manually_sorted_guids[i] << " < " <<
-                    "[" << j << "] " << manually_sorted_guids[j] ;
+                    "[" << j << "] " << manually_sorted_guids[j];
             }
             else if (i < j)
             {
                 // [i] < [j] so true
                 ASSERT_TRUE(result) <<
                     "[" << i << "] " << manually_sorted_guids[i] << " < " <<
-                    "[" << j << "] " << manually_sorted_guids[j] ;
+                    "[" << j << "] " << manually_sorted_guids[j];
             }
             else
             {
                 // [i] > [j] so false
                 ASSERT_FALSE(result) <<
                     "[" << i << "] " << manually_sorted_guids[i] << " < " <<
-                    "[" << j << "] " << manually_sorted_guids[j] ;
+                    "[" << j << "] " << manually_sorted_guids[j];
             }
         }
     }
@@ -153,9 +152,9 @@ TEST(GuidTests, equality)
 {
     auto manually_sorted_entities = test::get_sorted_guid_vector();
 
-    for (std::size_t i=0; i<manually_sorted_entities.size(); ++i)
+    for (std::size_t i = 0; i < manually_sorted_entities.size(); ++i)
     {
-        for (std::size_t j=0; j<manually_sorted_entities.size(); ++j)
+        for (std::size_t j = 0; j < manually_sorted_entities.size(); ++j)
         {
             bool result_equal = manually_sorted_entities[i] == manually_sorted_entities[j];
             bool result_non_equal = manually_sorted_entities[i] != manually_sorted_entities[j];


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

### What
This PR improves the performance of `GUID_t::operator<`.

### Why
`GUID_t::operator<` is an operation highly used in Fast-DDS because of maps where GUID is key.

### How
Changing the for comparison loop for `std::memcmp` (used from underly clases).

### Results
Some tests have been run manually* and the result is that `memcmp` tends** to be x10 faster.

\* using char[16] and checking time elapsed in 1000000 iterations
\** the time changes a lot if the different byte is the first or the last one, or one in the middle.
 
### Description of Changes added
- Added methods `cmp` to GuidPrefix and EntityId, and used in `Guid::operator<`.
- Added tests for `cmp` methods and `operator<` methods that did not exist.
- 

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
