### PR TITLE
Fix complex member printing for DynamicDataHelper

### DIFF
--- a/src/cpp/dynamic-types/DynamicDataHelper.cpp
+++ b/src/cpp/dynamic-types/DynamicDataHelper.cpp
@@ -262,12 +262,14 @@ void DynamicDataHelper::print_basic_collection(
         print_basic_element(data, data->get_array_index(positions[i]), data->type_->get_element_type()->get_kind());
         std::cout << (i == positions.size() - 1 ? "]" : ", ");
     }
+    std::cout << std::endl;
 }
 
 void DynamicDataHelper::print_complex_collection(
         DynamicData* data,
         const std::string& tabs)
 {
+    std::cout << std::endl;
     const std::vector<uint32_t>& bounds = data->type_->descriptor_->bound_;
 
     std::vector<std::vector<uint32_t>> positions;
@@ -277,7 +279,6 @@ void DynamicDataHelper::print_complex_collection(
     {
         std::cout << tabs << "[" << i << "] = ";
         print_complex_element(data, data->get_array_index(positions[i]), tabs);
-        std::cout << std::endl;
     }
 }
 
@@ -293,7 +294,7 @@ void DynamicDataHelper::print_complex_element(
         case TK_STRUCTURE:
         case TK_BITSET:
         {
-            DynamicData* st_data = data->loan_value(id);
+            std::cout << "<struct/bitset>" << std::endl;
             std::map<types::MemberId, types::DynamicTypeMember*> members;
             st_data->type_->get_all_members(members);
             for (auto it : members)
@@ -304,7 +305,7 @@ void DynamicDataHelper::print_complex_element(
         }
         case TK_UNION:
         {
-            DynamicData* st_data = data->loan_value(id);
+            std::cout << "<union>" << std::endl;
             DynamicTypeMember member;
             st_data->type_->get_member(member, st_data->union_id_);
             print_member(st_data, &member, tabs + "\t");
@@ -318,7 +319,7 @@ void DynamicDataHelper::print_complex_element(
         }
         case TK_MAP:
         {
-            DynamicData* st_data = data->loan_value(id);
+            std::cout << "<map>" << std::endl;
             std::map<types::MemberId, types::DynamicTypeMember*> members;
             st_data->type_->get_all_members(members);
             size_t size = st_data->get_item_count();
@@ -337,7 +338,7 @@ void DynamicDataHelper::print_complex_element(
         default:
             break;
     }
-    std::cout << std::endl;
+    data->return_loaned_value(st_data);
 }
 
 void DynamicDataHelper::print_member(
@@ -369,12 +370,14 @@ void DynamicDataHelper::print_member(
         case TK_BITMASK:
         {
             print_basic_element(data, type->get_id(), desc->get_kind());
+            std::cout << std::endl;
             break;
         }
         case TK_STRUCTURE:
         case TK_BITSET:
         {
             DynamicData* st_data = data->loan_value(type->get_id());
+            std::cout << "<struct/bitset>" << std::endl;
             std::map<types::MemberId, types::DynamicTypeMember*> members;
             desc->get_type()->get_all_members(members);
             for (auto it : members)
@@ -386,6 +389,7 @@ void DynamicDataHelper::print_member(
         }
         case TK_UNION:
         {
+            std::cout << "<union>" << std::endl;
             DynamicData* st_data = data->loan_value(type->get_id());
             DynamicTypeMember member;
             desc->get_type()->get_member(member, data->union_id_);
@@ -402,6 +406,7 @@ void DynamicDataHelper::print_member(
         }
         case TK_MAP:
         {
+            std::cout << "<map>" << std::endl;
             DynamicData* st_data = data->loan_value(type->get_id());
             std::map<types::MemberId, types::DynamicTypeMember*> members;
             desc->get_type()->get_all_members(members);
@@ -422,5 +427,4 @@ void DynamicDataHelper::print_member(
         default:
             break;
     }
-    std::cout << std::endl;
 }

--- a/src/cpp/dynamic-types/DynamicDataHelper.cpp
+++ b/src/cpp/dynamic-types/DynamicDataHelper.cpp
@@ -286,7 +286,8 @@ void DynamicDataHelper::print_complex_element(
         MemberId id,
         const std::string& tabs)
 {
-    const TypeDescriptor* desc = data->type_->get_type_descriptor();
+    DynamicData* st_data = data->loan_value(id);
+    const TypeDescriptor* desc = st_data->type_->get_type_descriptor();
     switch (desc->get_kind())
     {
         case TK_STRUCTURE:
@@ -294,47 +295,43 @@ void DynamicDataHelper::print_complex_element(
         {
             DynamicData* st_data = data->loan_value(id);
             std::map<types::MemberId, types::DynamicTypeMember*> members;
-            data->type_->get_all_members(members);
+            st_data->type_->get_all_members(members);
             for (auto it : members)
             {
                 print_member(st_data, it.second, tabs + "\t");
             }
-            data->return_loaned_value(st_data);
             break;
         }
         case TK_UNION:
         {
             DynamicData* st_data = data->loan_value(id);
             DynamicTypeMember member;
-            data->type_->get_member(member, data->union_id_);
+            st_data->type_->get_member(member, st_data->union_id_);
             print_member(st_data, &member, tabs + "\t");
             break;
         }
         case TK_SEQUENCE:
         case TK_ARRAY:
         {
-            DynamicData* st_data = data->loan_value(id);
             print_collection(st_data, tabs + "\t");
-            data->return_loaned_value(st_data);
             break;
         }
         case TK_MAP:
         {
             DynamicData* st_data = data->loan_value(id);
             std::map<types::MemberId, types::DynamicTypeMember*> members;
-            data->type_->get_all_members(members);
-            size_t size = data->get_item_count();
+            st_data->type_->get_all_members(members);
+            size_t size = st_data->get_item_count();
             for (size_t i = 0; i < size; ++i)
             {
                 size_t index = i * 2;
-                MemberId member_id = data->get_member_id_at_index(static_cast<uint32_t>(index));
+                MemberId member_id = st_data->get_member_id_at_index(static_cast<uint32_t>(index));
                 std::cout << "Key: ";
                 print_member(st_data, members[member_id], tabs + "\t");
                 member_id = data->get_member_id_at_index(static_cast<uint32_t>(index + 1));
                 std::cout << "Value: ";
                 print_member(st_data, members[member_id], tabs + "\t");
             }
-            data->return_loaned_value(st_data);
             break;
         }
         default:


### PR DESCRIPTION
## Description
This is a bugfix for the `DynamicDataHelper`.

The printing methods for the helper segfault on attempting to print sequences of nested structs. This is because the `print_complex_member()` function uses the wrong `DynamicData*`. With the changes that this PR introduces, the segfaults disappear.

Additionally, this PR also cleans up the printing and adds useful tags for complex types.

Also, the `DynamicDataHelper` still has other bugs that are not addressed by this PR. Namely printing of dynamic sequences, which is addressed in https://github.com/eProsima/Fast-DDS/pull/2827 . I've tested that PR, and it's ready to merge, despite being listed as DRAFT.

### Suitable Backports
https://github.com/Mergifyio?type=source backport (branch/2.7.x)
https://github.com/Mergifyio?type=source backport (branch/2.6.x)
Maybe more...

### Example
The following is an example printout of a triply nested DynamicData instance.

```shell
nested_field: <struct/bitset>
	nested_char_field: 
	nested_bool_field: false
	nested_bool_seq_static_array_field: [false, false, false, false, false]
	nested_str_seq_bounded_array_field: [false, false, false, false, false, false, false, false, false, false]
	double_nested_field: <struct/bitset>
		double_nested_char_field: 
		triple_nested_field: <struct/bitset>
			triple_nested_char_field: 
			triple_nested_bool_seq_static_array_field: [false, false, false, false, false]
	double_nested_static_array_field: 		[0] = <struct/bitset>
			double_nested_char_field: 
			triple_nested_field: <struct/bitset>
				triple_nested_char_field: 
				triple_nested_bool_seq_static_array_field: [false, false, false, false, false]

		[1] = <struct/bitset>
			double_nested_char_field: 
			triple_nested_field: <struct/bitset>
				triple_nested_char_field: 
				triple_nested_bool_seq_static_array_field: [false, false, false, false, false]

		[2] = <struct/bitset>
			double_nested_char_field: 
			triple_nested_field: <struct/bitset>
				triple_nested_char_field: 
				triple_nested_bool_seq_static_array_field: [false, false, false, false, false]

non_nested_byte_field: 0
```

## Contributor Checklist
- [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [ ] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [ ] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [ ] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
