### PR TITLE
[15628] XML configuration for Ownership QoS

### DIFF
--- a/include/fastdds/dds/publisher/qos/WriterQos.hpp
+++ b/include/fastdds/dds/publisher/qos/WriterQos.hpp
@@ -92,10 +92,10 @@ public:
     //!Time Based Filter Qos, NOT implemented in the library.
     TimeBasedFilterQosPolicy m_timeBasedFilter;
 
-    //!Ownership Qos, NOT implemented in the library.
+    //!Ownership Qos, implemented in the library.
     OwnershipQosPolicy m_ownership;
 
-    //!Owenership Strength Qos, NOT implemented in the library.
+    //!Owenership Strength Qos, implemented in the library.
     OwnershipStrengthQosPolicy m_ownershipStrength;
 
     //!Destination Order Qos, NOT implemented in the library.

--- a/include/fastdds/dds/subscriber/qos/ReaderQos.hpp
+++ b/include/fastdds/dds/subscriber/qos/ReaderQos.hpp
@@ -84,7 +84,7 @@ public:
     //!ReliabilityQos, implemented in the library.
     ReliabilityQosPolicy m_reliability;
 
-    //!Ownership Qos, NOT implemented in the library.
+    //!Ownership Qos, implemented in the library.
     OwnershipQosPolicy m_ownership;
 
     //!Destinatio Order Qos, NOT implemented in the library.

--- a/src/cpp/rtps/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLElementParser.cpp
@@ -2122,11 +2122,11 @@ XMLP_ret XMLParser::getXMLDataSharingQos(
    }
  */
 
-   XMLP_ret XMLParser::getXMLOwnershipQos(
+XMLP_ret XMLParser::getXMLOwnershipQos(
         tinyxml2::XMLElement* elem,
         OwnershipQosPolicy& ownership,
         uint8_t ident)
-   {
+{
     (void)ident;
 
     //    <xs:complexType name="ownershipQosPolicyType">
@@ -2186,14 +2186,14 @@ XMLP_ret XMLParser::getXMLDataSharingQos(
     }
 
     return XMLP_ret::
-    XML_OK;
-   }
+                   XML_OK;
+}
 
-   XMLP_ret XMLParser::getXMLOwnershipStrengthQos(
+XMLP_ret XMLParser::getXMLOwnershipStrengthQos(
         tinyxml2::XMLElement* elem,
         OwnershipStrengthQosPolicy& ownershipStrength,
         uint8_t ident)
-   {
+{
 
     //    <xs:complexType name="ownershipStrengthQosPolicyType">
     //        <xs:all>
@@ -2229,7 +2229,7 @@ XMLP_ret XMLParser::getXMLDataSharingQos(
     }
 
     return XMLP_ret::XML_OK;
-   }
+}
 
 // TODO Implement DestinationOrderQos
 /*

--- a/src/cpp/rtps/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLElementParser.cpp
@@ -1178,13 +1178,12 @@ XMLP_ret XMLParser::getXMLWriterQosPolicies(
             }
         }
         else if (strcmp(name, DURABILITY_SRV) == 0 ||
-                strcmp(name, TIME_FILTER) == 0 || strcmp(name, OWNERSHIP_STRENGTH) == 0 ||
-                strcmp(name, DEST_ORDER) == 0 || strcmp(name, PRESENTATION) == 0)
+                strcmp(name, TIME_FILTER) == 0 || strcmp(name, DEST_ORDER) == 0 ||
+                strcmp(name, PRESENTATION) == 0)
         {
             // TODO: Do not supported for now
             //if (nullptr != (p_aux = elem->FirstChildElement(    DURABILITY_SRV))) getXMLDurabilityServiceQos(p_aux, ident);
             //if (nullptr != (p_aux = elem->FirstChildElement(       TIME_FILTER))) getXMLTimeBasedFilterQos(p_aux, ident);
-            //if (nullptr != (p_aux = elem->FirstChildElement(OWNERSHIP_STRENGTH))) getXMLOwnershipStrengthQos(p_aux, ident);
             //if (nullptr != (p_aux = elem->FirstChildElement(        DEST_ORDER))) getXMLDestinationOrderQos(p_aux, ident);
             //if (nullptr != (p_aux = elem->FirstChildElement(      PRESENTATION))) getXMLPresentationQos(p_aux, ident);
             logError(XMLPARSER, "Quality of Service '" << p_aux0->Value() << "' do not supported for now");
@@ -1201,6 +1200,14 @@ XMLP_ret XMLParser::getXMLWriterQosPolicies(
         {
             //ownership
             if (XMLP_ret::XML_OK != getXMLOwnershipQos(p_aux0, qos.m_ownership, ident))
+            {
+                return XMLP_ret::XML_ERROR;
+            }
+        }
+        else if (strcmp(name, OWNERSHIP_STRENGTH) == 0)
+        {
+            //ownership
+            if (XMLP_ret::XML_OK != getXMLOwnershipStrengthQos(p_aux0, qos.m_ownershipStrength, ident))
             {
                 return XMLP_ret::XML_ERROR;
             }
@@ -1344,8 +1351,8 @@ XMLP_ret XMLParser::getXMLReaderQosPolicies(
             }
         }
         else if (strcmp(name, DURABILITY_SRV) == 0 ||
-                strcmp(name, TIME_FILTER) == 0 || strcmp(name, OWNERSHIP_STRENGTH) == 0 ||
-                strcmp(name, DEST_ORDER) == 0 || strcmp(name, PRESENTATION) == 0)
+                strcmp(name, TIME_FILTER) == 0 || strcmp(name, DEST_ORDER) == 0 ||
+                strcmp(name, PRESENTATION) == 0)
         {
             // TODO: Do not supported for now
             //if (nullptr != (p_aux = elem->FirstChildElement(    DURABILITY_SRV))) getXMLDurabilityServiceQos(p_aux, ident);
@@ -2182,8 +2189,6 @@ XMLP_ret XMLParser::getXMLDataSharingQos(
     XML_OK;
    }
 
-// TODO Implement OwnershipStrengthQos
-/*
    XMLP_ret XMLParser::getXMLOwnershipStrengthQos(
         tinyxml2::XMLElement* elem,
         OwnershipStrengthQosPolicy& ownershipStrength,
@@ -2225,8 +2230,6 @@ XMLP_ret XMLParser::getXMLDataSharingQos(
 
     return XMLP_ret::XML_OK;
    }
- */
-
 
 // TODO Implement DestinationOrderQos
 /*

--- a/src/cpp/rtps/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLElementParser.cpp
@@ -1178,14 +1178,12 @@ XMLP_ret XMLParser::getXMLWriterQosPolicies(
             }
         }
         else if (strcmp(name, DURABILITY_SRV) == 0 ||
-                strcmp(name, TIME_FILTER) == 0 || strcmp(name, OWNERSHIP) == 0 ||
-                strcmp(name, OWNERSHIP_STRENGTH) == 0 || strcmp(name, DEST_ORDER) == 0 ||
-                strcmp(name, PRESENTATION) == 0)
+                strcmp(name, TIME_FILTER) == 0 || strcmp(name, OWNERSHIP_STRENGTH) == 0 ||
+                strcmp(name, DEST_ORDER) == 0 || strcmp(name, PRESENTATION) == 0)
         {
             // TODO: Do not supported for now
             //if (nullptr != (p_aux = elem->FirstChildElement(    DURABILITY_SRV))) getXMLDurabilityServiceQos(p_aux, ident);
             //if (nullptr != (p_aux = elem->FirstChildElement(       TIME_FILTER))) getXMLTimeBasedFilterQos(p_aux, ident);
-            //if (nullptr != (p_aux = elem->FirstChildElement(         OWNERSHIP))) getXMLOwnershipQos(p_aux, ident);
             //if (nullptr != (p_aux = elem->FirstChildElement(OWNERSHIP_STRENGTH))) getXMLOwnershipStrengthQos(p_aux, ident);
             //if (nullptr != (p_aux = elem->FirstChildElement(        DEST_ORDER))) getXMLDestinationOrderQos(p_aux, ident);
             //if (nullptr != (p_aux = elem->FirstChildElement(      PRESENTATION))) getXMLPresentationQos(p_aux, ident);
@@ -1195,6 +1193,14 @@ XMLP_ret XMLParser::getXMLWriterQosPolicies(
         {
             //data sharing
             if (XMLP_ret::XML_OK != getXMLDataSharingQos(p_aux0, qos.data_sharing, ident))
+            {
+                return XMLP_ret::XML_ERROR;
+            }
+        }
+        else if (strcmp(name, OWNERSHIP) == 0)
+        {
+            //ownership
+            if (XMLP_ret::XML_OK != getXMLOwnershipQos(p_aux0, qos.m_ownership, ident))
             {
                 return XMLP_ret::XML_ERROR;
             }
@@ -1338,14 +1344,12 @@ XMLP_ret XMLParser::getXMLReaderQosPolicies(
             }
         }
         else if (strcmp(name, DURABILITY_SRV) == 0 ||
-                strcmp(name, TIME_FILTER) == 0 || strcmp(name, OWNERSHIP) == 0 ||
-                strcmp(name, OWNERSHIP_STRENGTH) == 0 || strcmp(name, DEST_ORDER) == 0 ||
-                strcmp(name, PRESENTATION) == 0)
+                strcmp(name, TIME_FILTER) == 0 || strcmp(name, OWNERSHIP_STRENGTH) == 0 ||
+                strcmp(name, DEST_ORDER) == 0 || strcmp(name, PRESENTATION) == 0)
         {
             // TODO: Do not supported for now
             //if (nullptr != (p_aux = elem->FirstChildElement(    DURABILITY_SRV))) getXMLDurabilityServiceQos(p_aux, ident);
             //if (nullptr != (p_aux = elem->FirstChildElement(       TIME_FILTER))) getXMLTimeBasedFilterQos(p_aux, ident);
-            //if (nullptr != (p_aux = elem->FirstChildElement(         OWNERSHIP))) getXMLOwnershipQos(p_aux, ident);
             //if (nullptr != (p_aux = elem->FirstChildElement(        DEST_ORDER))) getXMLDestinationOrderQos(p_aux, ident);
             //if (nullptr != (p_aux = elem->FirstChildElement(      PRESENTATION))) getXMLPresentationQos(p_aux, ident);
             logError(XMLPARSER, "Quality of Service '" << p_aux0->Value() << "' do not supported for now");
@@ -1354,6 +1358,14 @@ XMLP_ret XMLParser::getXMLReaderQosPolicies(
         {
             //data sharing
             if (XMLP_ret::XML_OK != getXMLDataSharingQos(p_aux0, qos.data_sharing, ident))
+            {
+                return XMLP_ret::XML_ERROR;
+            }
+        }
+        else if (strcmp(name, OWNERSHIP) == 0)
+        {
+            //ownership
+            if (XMLP_ret::XML_OK != getXMLOwnershipQos(p_aux0, qos.m_ownership, ident))
             {
                 return XMLP_ret::XML_ERROR;
             }
@@ -2103,13 +2115,12 @@ XMLP_ret XMLParser::getXMLDataSharingQos(
    }
  */
 
-// TODO Implement OwnershipQos
-/*
    XMLP_ret XMLParser::getXMLOwnershipQos(
         tinyxml2::XMLElement* elem,
         OwnershipQosPolicy& ownership,
         uint8_t ident)
    {
+    (void)ident;
 
     //    <xs:complexType name="ownershipQosPolicyType">
     //        <xs:all>
@@ -2170,7 +2181,6 @@ XMLP_ret XMLParser::getXMLDataSharingQos(
     return XMLP_ret::
     XML_OK;
    }
- */
 
 // TODO Implement OwnershipStrengthQos
 /*

--- a/test/unittest/xmlparser/XMLElementParserTests.cpp
+++ b/test/unittest/xmlparser/XMLElementParserTests.cpp
@@ -3652,5 +3652,58 @@ TEST_F(XMLParserTests, getXMLDataSharingQos_negativeCases)
  */
 TEST_F(XMLParserTests, getXMLOwnershipQos)
 {
+    uint8_t ident = 1;
+    OwnershipQosPolicy ownership_policy;
+    tinyxml2::XMLDocument xml_doc;
+    tinyxml2::XMLElement* titleElement;
 
+    {
+        // Template xml
+        const char* xml_p =
+                "\
+                <data_sharing>\
+                    <kind>%s</kind>\
+                </data_sharing>\
+                ";
+        char xml[1000];
+
+        sprintf(xml, xml_p, "SHARED");
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::propertiesPolicy_wrapper(titleElement, ownership_policy, ident));
+        EXPECT_EQ(ownership_policy.kind, OwnershipQosPolicyKind::SHARED_OWNERSHIP_QOS);
+
+        sprintf(xml, xml_p, "EXCLUSIVE");
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::propertiesPolicy_wrapper(titleElement, ownership_policy, ident));
+        EXPECT_EQ(ownership_policy.kind, OwnershipQosPolicyKind::EXCLUSIVE_OWNERSHIP_QOS);
+    }
+
+    {
+        const char* xml =
+                "\
+                <data_sharing>\
+                </data_sharing>\
+                ";
+
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_ERROR,
+                XMLParserTest::propertiesPolicy_wrapper(titleElement, ownership_policy, ident));
+    }
+
+    {
+        const char* xml =
+                "\
+                <data_sharing>\
+                    <kind>INVALID</kind>\
+                </data_sharing>\
+                ";
+
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_ERROR,
+                XMLParserTest::propertiesPolicy_wrapper(titleElement, ownership_policy, ident));
+    }
 }

--- a/test/unittest/xmlparser/XMLElementParserTests.cpp
+++ b/test/unittest/xmlparser/XMLElementParserTests.cpp
@@ -3730,7 +3730,7 @@ TEST_F(XMLParserTests, getXMLOwnershipStrengthQos)
         titleElement = xml_doc.RootElement();
         EXPECT_EQ(XMLP_ret::XML_OK,
                 XMLParserTest::propertiesPolicy_wrapper(titleElement, ownership_strength_policy, ident));
-        EXPECT_EQ(ownership_strength_policy.value, 100);
+        EXPECT_EQ(ownership_strength_policy.value, 100u);
     }
 
     {

--- a/test/unittest/xmlparser/XMLElementParserTests.cpp
+++ b/test/unittest/xmlparser/XMLElementParserTests.cpp
@@ -3710,4 +3710,58 @@ TEST_F(XMLParserTests, getXMLOwnershipQos)
  */
 TEST_F(XMLParserTests, getXMLOwnershipStrengthQos)
 {
+    uint8_t ident = 1;
+    OwnershipStrengthQosPolicy ownership_strength_policy;
+    tinyxml2::XMLDocument xml_doc;
+    tinyxml2::XMLElement* titleElement;
+
+    {
+        // Template xml
+        const char* xml_p =
+                "\
+                <ownershipStrength>\
+                    <value>%s</value>\
+                </ownershipStrength>\
+                ";
+        char xml[1000];
+
+        sprintf(xml, xml_p, "0");
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::propertiesPolicy_wrapper(titleElement, ownership_strength_policy, ident));
+        EXPECT_EQ(ownership_strength_policy.value, 0);
+
+        sprintf(xml, xml_p, "100");
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::propertiesPolicy_wrapper(titleElement, ownership_strength_policy, ident));
+        EXPECT_EQ(ownership_strength_policy.value, 100);
+    }
+
+    {
+        const char* xml =
+                "\
+                <ownershipStrength>\
+                </ownershipStrength>\
+                ";
+
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_ERROR,
+                XMLParserTest::propertiesPolicy_wrapper(titleElement, ownership_strength_policy, ident));
+    }
+
+    {
+        const char* xml =
+                "\
+                <ownershipStrength>\
+                    <value>INVALID</value>\
+                </ownershipStrength>\
+                ";
+
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_ERROR,
+                XMLParserTest::propertiesPolicy_wrapper(titleElement, ownership_strength_policy, ident));
+    }
 }

--- a/test/unittest/xmlparser/XMLElementParserTests.cpp
+++ b/test/unittest/xmlparser/XMLElementParserTests.cpp
@@ -1535,13 +1535,6 @@ TEST_F(XMLParserTests, getXMLWriterReaderUnsupportedQosPolicies)
     EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLWriterQosPolicies_wrapper(titleElement, wqos, ident));
     EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLReaderQosPolicies_wrapper(titleElement, rqos, ident));
 
-    // Check that there is a logError when trying to set up the <ownership> Qos.
-    sprintf(xml, xml_p, "<ownership></ownership>");
-    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
-    titleElement = xml_doc.RootElement();
-    EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLWriterQosPolicies_wrapper(titleElement, wqos, ident));
-    EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLReaderQosPolicies_wrapper(titleElement, rqos, ident));
-
     // Check that there is a logError when trying to set up the <ownershipStrength> Qos.
     sprintf(xml, xml_p, "<ownershipStrength></ownershipStrength>");
     ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
@@ -1563,7 +1556,7 @@ TEST_F(XMLParserTests, getXMLWriterReaderUnsupportedQosPolicies)
     EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLWriterQosPolicies_wrapper(titleElement, wqos, ident));
     EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLReaderQosPolicies_wrapper(titleElement, rqos, ident));
 
-    helper_block_for_at_least_entries(12);
+    helper_block_for_at_least_entries(10);
     auto consumed_entries = mock_consumer->ConsumedEntries();
     // Expect 18 log errors.
     uint32_t num_errors = 0;
@@ -1574,7 +1567,7 @@ TEST_F(XMLParserTests, getXMLWriterReaderUnsupportedQosPolicies)
             num_errors++;
         }
     }
-    EXPECT_EQ(num_errors, 12u);
+    EXPECT_EQ(num_errors, 10u);
 }
 
 /*

--- a/test/unittest/xmlparser/XMLElementParserTests.cpp
+++ b/test/unittest/xmlparser/XMLElementParserTests.cpp
@@ -3721,13 +3721,15 @@ TEST_F(XMLParserTests, getXMLOwnershipStrengthQos)
         sprintf(xml, xml_p, "0");
         ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
         titleElement = xml_doc.RootElement();
-        EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::propertiesPolicy_wrapper(titleElement, ownership_strength_policy, ident));
+        EXPECT_EQ(XMLP_ret::XML_OK,
+                XMLParserTest::propertiesPolicy_wrapper(titleElement, ownership_strength_policy, ident));
         EXPECT_EQ(ownership_strength_policy.value, 0);
 
         sprintf(xml, xml_p, "100");
         ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
         titleElement = xml_doc.RootElement();
-        EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::propertiesPolicy_wrapper(titleElement, ownership_strength_policy, ident));
+        EXPECT_EQ(XMLP_ret::XML_OK,
+                XMLParserTest::propertiesPolicy_wrapper(titleElement, ownership_strength_policy, ident));
         EXPECT_EQ(ownership_strength_policy.value, 100);
     }
 

--- a/test/unittest/xmlparser/XMLElementParserTests.cpp
+++ b/test/unittest/xmlparser/XMLElementParserTests.cpp
@@ -3642,3 +3642,15 @@ TEST_F(XMLParserTests, getXMLDataSharingQos_negativeCases)
                 XMLParserTest::propertiesPolicy_wrapper(titleElement, datasharing_policy, ident));
     }
 }
+
+/*
+ * This test checks the proper parsing of the <ownership> xml elements to a OwnershipQosPolicy object.
+ * 1. Correct parsing of a valid <ownership> set to SHARED.
+ * 2. Correct parsing of a valid <ownership> set to EXCLUSIVE.
+ * 3. Check no kind.
+ * 4. Check an invalid kind.
+ */
+TEST_F(XMLParserTests, getXMLOwnershipQos)
+{
+
+}

--- a/test/unittest/xmlparser/XMLElementParserTests.cpp
+++ b/test/unittest/xmlparser/XMLElementParserTests.cpp
@@ -1535,13 +1535,6 @@ TEST_F(XMLParserTests, getXMLWriterReaderUnsupportedQosPolicies)
     EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLWriterQosPolicies_wrapper(titleElement, wqos, ident));
     EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLReaderQosPolicies_wrapper(titleElement, rqos, ident));
 
-    // Check that there is a logError when trying to set up the <ownershipStrength> Qos.
-    sprintf(xml, xml_p, "<ownershipStrength></ownershipStrength>");
-    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
-    titleElement = xml_doc.RootElement();
-    EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLWriterQosPolicies_wrapper(titleElement, wqos, ident));
-    EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLReaderQosPolicies_wrapper(titleElement, rqos, ident));
-
     // Check that there is a logError when trying to set up the <destinationOrder> Qos.
     sprintf(xml, xml_p, "<destinationOrder></destinationOrder>");
     ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
@@ -1556,7 +1549,7 @@ TEST_F(XMLParserTests, getXMLWriterReaderUnsupportedQosPolicies)
     EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLWriterQosPolicies_wrapper(titleElement, wqos, ident));
     EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLReaderQosPolicies_wrapper(titleElement, rqos, ident));
 
-    helper_block_for_at_least_entries(10);
+    helper_block_for_at_least_entries(8);
     auto consumed_entries = mock_consumer->ConsumedEntries();
     // Expect 18 log errors.
     uint32_t num_errors = 0;
@@ -1567,7 +1560,7 @@ TEST_F(XMLParserTests, getXMLWriterReaderUnsupportedQosPolicies)
             num_errors++;
         }
     }
-    EXPECT_EQ(num_errors, 10u);
+    EXPECT_EQ(num_errors, 8u);
 }
 
 /*

--- a/test/unittest/xmlparser/XMLElementParserTests.cpp
+++ b/test/unittest/xmlparser/XMLElementParserTests.cpp
@@ -3654,9 +3654,9 @@ TEST_F(XMLParserTests, getXMLOwnershipQos)
         // Template xml
         const char* xml_p =
                 "\
-                <data_sharing>\
+                <ownership>\
                     <kind>%s</kind>\
-                </data_sharing>\
+                </ownership>\
                 ";
         char xml[1000];
 
@@ -3676,8 +3676,8 @@ TEST_F(XMLParserTests, getXMLOwnershipQos)
     {
         const char* xml =
                 "\
-                <data_sharing>\
-                </data_sharing>\
+                <ownership>\
+                </ownership>\
                 ";
 
         ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
@@ -3689,9 +3689,9 @@ TEST_F(XMLParserTests, getXMLOwnershipQos)
     {
         const char* xml =
                 "\
-                <data_sharing>\
+                <ownership>\
                     <kind>INVALID</kind>\
-                </data_sharing>\
+                </ownership>\
                 ";
 
         ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
@@ -3699,4 +3699,15 @@ TEST_F(XMLParserTests, getXMLOwnershipQos)
         EXPECT_EQ(XMLP_ret::XML_ERROR,
                 XMLParserTest::propertiesPolicy_wrapper(titleElement, ownership_policy, ident));
     }
+}
+
+/*
+ * This test checks the proper parsing of the <ownershipStrength> xml elements to a OwnershipQosPolicy object.
+ * 1. Correct parsing of a valid <ownershipStrength> value set to 0.
+ * 2. Correct parsing of a valid <ownershipStrength> value set to 100.
+ * 3. Check no value.
+ * 4. Check an invalid value.
+ */
+TEST_F(XMLParserTests, getXMLOwnershipStrengthQos)
+{
 }

--- a/test/unittest/xmlparser/XMLElementParserTests.cpp
+++ b/test/unittest/xmlparser/XMLElementParserTests.cpp
@@ -3723,7 +3723,7 @@ TEST_F(XMLParserTests, getXMLOwnershipStrengthQos)
         titleElement = xml_doc.RootElement();
         EXPECT_EQ(XMLP_ret::XML_OK,
                 XMLParserTest::propertiesPolicy_wrapper(titleElement, ownership_strength_policy, ident));
-        EXPECT_EQ(ownership_strength_policy.value, 0);
+        EXPECT_EQ(ownership_strength_policy.value, 0u);
 
         sprintf(xml, xml_p, "100");
         ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));

--- a/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
+++ b/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
@@ -109,6 +109,13 @@ public:
     {
         return getXMLDataSharingQos(elem, datasharingQos, ident);
     }
+    static XMLP_ret propertiesPolicy_wrapper(
+            tinyxml2::XMLElement* elem,
+            OwnershipQosPolicy& ownershipQos,
+            uint8_t ident)
+    {
+        return getXMLOwnershipQos(elem, ownershipQos, ident);
+    }
 
     static XMLP_ret propertiesPolicy_wrapper(
             tinyxml2::XMLElement* elem,

--- a/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
+++ b/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
@@ -109,12 +109,21 @@ public:
     {
         return getXMLDataSharingQos(elem, datasharingQos, ident);
     }
+
     static XMLP_ret propertiesPolicy_wrapper(
             tinyxml2::XMLElement* elem,
             OwnershipQosPolicy& ownershipQos,
             uint8_t ident)
     {
         return getXMLOwnershipQos(elem, ownershipQos, ident);
+    }
+
+    static XMLP_ret propertiesPolicy_wrapper(
+            tinyxml2::XMLElement* elem,
+            OwnershipStrengthQosPolicy& ownershipStrengthQos,
+            uint8_t ident)
+    {
+        return getXMLOwnershipStrengthQos(elem, ownershipStrengthQos, ident);
     }
 
     static XMLP_ret propertiesPolicy_wrapper(

--- a/versions.md
+++ b/versions.md
@@ -4,6 +4,7 @@ Forthcoming
 * Added API get the WAN address of TCPv4 transport descriptors (API extension)
 * Support `propagate` attribute for Properties in PropertyQoSPolicies so they could be
   set by user and sent in PDP
+* Added possibility to configure Ownership and Ownership Strength QoS Policies from XML profiles file
 
 Version 2.7.1
 -------------


### PR DESCRIPTION
This PR Adds the possibility to configure Ownership and Ownership Strength QoS from XML.

## Description

This PR covers the following tasks:

- Creation of two new tests, to check the configuration of Ownership and Ownership Strength QoS in XML profile.
- Uncomment the already developed functions `getXMLOwnershipQos()` and `getXMLOwnershipStrengthQos()`.
- Arrange the correct call to those two methods from `getXMLWriterQosPolicies()`.
- Erase previous logs and comments that stated ownership was not supported.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [N/A] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [N/A] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [N/A] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
Related documentation PR: eProsima/Fast-DDS-docs#403 (PR)


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
