### PR TITLE
[15766] Update shared_mutex thirdparty to don't prioritize writers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,15 +266,6 @@ endif()
 
 option(SQLITE3_SUPPORT "Activate SQLITE3 support" ON)
 
-option(USE_THIRDPARTY_SHARED_MUTEX [=[
-Forces the use of a Boost-based shared_mutex implementation
-instead of the framework one. Useful to cope with issues on
-framework implementations like misguided sanitizer reports.
-This implementation will be used by default on frameworks
-lacking the shared_mutex feature like those not fulfilling
-C++17.
-]=] OFF)
-
 ###############################################################################
 # SHM as Default transport
 ###############################################################################

--- a/cmake/common/gtest.cmake
+++ b/cmake/common/gtest.cmake
@@ -59,6 +59,11 @@ macro(add_gtest)
             # Normal tests
             file(STRINGS ${GTEST_SOURCE_FILE} GTEST_TEST_NAMES REGEX "^([T][Y][P][E][D][_])?TEST")
             foreach(GTEST_TEST_NAME ${GTEST_TEST_NAMES})
+
+                if(GTEST_TEST_NAME MATCHES "TYPED_TEST_SUITE")
+                    continue()
+                endif()
+
                 string(REGEX REPLACE ["\) \(,"] ";" GTEST_TEST_NAME ${GTEST_TEST_NAME})
                 list(GET GTEST_TEST_NAME 1 GTEST_GROUP_NAME)
                 list(GET GTEST_TEST_NAME 3 GTEST_TEST_NAME)

--- a/cmake/modules/check_shared_mutex_priority.cpp
+++ b/cmake/modules/check_shared_mutex_priority.cpp
@@ -1,0 +1,69 @@
+// Copyright 2022 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file check_shared_mutex_priority.cpp
+ *
+ */
+
+#include <atomic>
+#include <condition_variable>
+#include <iostream>
+#include <mutex>
+#include <shared_mutex>
+#include <thread>
+
+using namespace std;
+
+int main()
+{
+    shared_mutex sm;
+    atomic_bool mark = false;
+
+    // take first shared lock
+    sm.lock_shared();
+
+    // signal is taken
+    thread exclusive([&]()
+            {
+                mark = true;
+                lock_guard<shared_mutex> guard(sm);
+            });
+
+    // Wait till the thread takes the lock
+    do
+    {
+        this_thread::sleep_for(chrono::milliseconds(100));
+    }
+    while (!mark);
+
+    // try take the second shared lock
+    bool success = sm.try_lock_shared();
+    if (success)
+    {
+        sm.unlock_shared();
+        cout << "PTHREAD_RWLOCK_PREFER_READER_NP" << endl;
+    }
+    else
+    {
+        cout << "PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP" << endl;
+    }
+
+    // release first lock
+    sm.unlock_shared();
+    // wait for the main thread
+    exclusive.join();
+
+    return 0;
+}

--- a/include/fastrtps/utils/ProxyPool.hpp
+++ b/include/fastrtps/utils/ProxyPool.hpp
@@ -154,6 +154,9 @@ class ProxyPool
 
         // return the resource
         mask_.set(idx);
+
+        // notify the resource is free
+        cv_.notify_one();
     }
 
 public:

--- a/include/fastrtps/utils/shared_mutex.hpp
+++ b/include/fastrtps/utils/shared_mutex.hpp
@@ -573,14 +573,18 @@ template <class Mutex>
 template <class Clock, class Duration>
 bool
 shared_lock<Mutex>::try_lock_until(
-                       const std::chrono::time_point<Clock, Duration>& abs_time)
+        const std::chrono::time_point<Clock, Duration>& abs_time)
 {
     if (m_ == nullptr)
+    {
         throw std::system_error(std::error_code(EPERM, std::system_category()),
-                          "shared_lock::try_lock_until: references null mutex");
+                      "shared_lock::try_lock_until: references null mutex");
+    }
     if (owns_)
+    {
         throw std::system_error(std::error_code(EDEADLK, std::system_category()),
-                                 "shared_lock::try_lock_until: already locked");
+                      "shared_lock::try_lock_until: already locked");
+    }
     owns_ = m_->try_lock_shared_until(abs_time);
     return owns_;
 }
@@ -590,8 +594,10 @@ void
 shared_lock<Mutex>::unlock()
 {
     if (!owns_)
+    {
         throw std::system_error(std::error_code(EPERM, std::system_category()),
-                                "shared_lock::unlock: not locked");
+                      "shared_lock::unlock: not locked");
+    }
     m_->unlock_shared();
     owns_ = false;
 }
@@ -599,7 +605,9 @@ shared_lock<Mutex>::unlock()
 template <class Mutex>
 inline
 void
-swap(shared_lock<Mutex>&  x, shared_lock<Mutex>&  y)
+swap(
+        shared_lock<Mutex>&  x,
+        shared_lock<Mutex>&  y)
 {
     x.swap(y);
 }

--- a/include/fastrtps/utils/shared_mutex.hpp
+++ b/include/fastrtps/utils/shared_mutex.hpp
@@ -207,6 +207,7 @@ class shared_mutex<shared_mutex_type::PTHREAD_RWLOCK_PREFER_READER_NP>
     : public shared_mutex_base
 {
     count_t writer_waiting_ = 0;
+
 public:
 
     void lock()
@@ -229,11 +230,12 @@ public:
         state_ |= num_readers;
 
         if ((writer_waiting_ && num_readers == 0)
-             || (num_readers == n_readers_ - 1))
+                || (num_readers == n_readers_ - 1))
         {
             gate1_.notify_one();
         }
     }
+
 };
 
 // Debugger wrapper class that provides insight
@@ -329,9 +331,9 @@ public:
 
       PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP will deadlock.  before T1
       takes S twice. That happens because:
-        + T1's second S will wait for E (writer is prioritized)
-        + E will wait for T1's first S lock (writer needs atomic access)
-        + T1's first S cannot unlock because is blocked in the second S.
+ + T1's second S will wait for E (writer is prioritized)
+ + E will wait for T1's first S lock (writer needs atomic access)
+ + T1's first S cannot unlock because is blocked in the second S.
 
       Thus, shared_mutex<PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP> is
       non-recursive.
@@ -349,9 +351,9 @@ public:
 
       PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP will deadlock if T3 takes E
       before T1 takes S. That happens because:
-        + T1's S will wait for E (writer is prioritized)
-        + E will wait for T2's S lock (writer needs atomic access)
-        + T2's S cannot unlock because is blocked in P (owned by T1).
+ + T1's S will wait for E (writer is prioritized)
+ + E will wait for T2's S lock (writer needs atomic access)
+ + T2's S cannot unlock because is blocked in P (owned by T1).
 
       Thus, shared_mutex<PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP> must be
       managed like an ordinary mutex in deadlock sense.

--- a/include/fastrtps/utils/shared_mutex.hpp
+++ b/include/fastrtps/utils/shared_mutex.hpp
@@ -245,8 +245,8 @@ public:
 
     bool try_lock()
     {
-        std::lock_guard<std::mutex> _(wm_);
         bool res = sm::try_lock();
+        std::lock_guard<std::mutex> _(wm_);
         if (res)
         {
             exclusive_owner_ = std::this_thread::get_id();
@@ -256,8 +256,8 @@ public:
 
     void unlock()
     {
-        std::lock_guard<std::mutex> _(wm_);
         sm::unlock();
+        std::lock_guard<std::mutex> _(wm_);
         exclusive_owner_ = std::thread::id();
     }
 
@@ -272,8 +272,8 @@ public:
 
     bool try_lock_shared()
     {
-        std::lock_guard<std::mutex> _(wm_);
         bool res = sm::try_lock_shared();
+        std::lock_guard<std::mutex> _(wm_);
         if (res)
         {
             ++shared_owners_[std::this_thread::get_id()];
@@ -283,8 +283,8 @@ public:
 
     void unlock_shared()
     {
-        std::lock_guard<std::mutex> _(wm_);
         sm::unlock_shared();
+        std::lock_guard<std::mutex> _(wm_);
         auto owner = shared_owners_.find(std::this_thread::get_id());
         if ( owner != shared_owners_.end() && 0 == --owner->second )
         {

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -386,6 +386,44 @@ if(APPLE)
     set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
 endif()
 
+# Check if the shared_mutex provided by the platform STL library
+# prioritizes writes
+
+try_run(SM_RUN_RESULT SM_COMPILE_RESULT
+        "${CMAKE_CURRENT_BINARY_DIR}/shmtest"
+        "${CMAKE_SOURCE_DIR}/cmake/modules/check_shared_mutex_priority.cpp"
+        LINK_LIBRARIES ${CMAKE_THREAD_LIBS_INIT}
+        RUN_OUTPUT_VARIABLE SM_RUN_OUTPUT)
+
+if(SM_COMPILE_RESULT AND NOT SM_RUN_RESULT)
+    string(STRIP ${SM_RUN_OUTPUT} SM_RUN_OUTPUT)
+    message(STATUS "Framework's shared_mutex is ${SM_RUN_OUTPUT}")
+endif()
+
+if(SM_RUN_OUTPUT STREQUAL "PTHREAD_RWLOCK_PREFER_READER_NP")
+    set(USER_CAN_CHOOSE_SHARED_MEMORY_THIRDPARTY ON)
+else()
+    message(STATUS "Forcing third party shared_mutex")
+    set(USE_THIRDPARTY_SHARED_MUTEX ON)
+endif()
+
+cmake_dependent_option(
+    USE_THIRDPARTY_SHARED_MUTEX [=[
+Forces the use of a Boost-based shared_mutex implementation
+instead of the framework one. Useful to cope with issues on
+framework implementations like misguided sanitizer reports.
+This implementation will be used by default on frameworks
+lacking the shared_mutex feature like those not fulfilling
+C++17.
+]=] OFF
+    "USER_CAN_CHOOSE_SHARED_MEMORY_THIRDPARTY"
+    ON)
+
+unset(USER_CAN_CHOOSE_SHARED_MEMORY_THIRDPARTY)
+unset(SM_RUN_RESULT)
+unset(SM_COMPILE_RESULT)
+unset(SM_RUN_OUTPUT)
+
 #Create library
 add_library(${PROJECT_NAME} ${${PROJECT_NAME}_source_files})
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${PROJECT_VERSION})

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -386,13 +386,22 @@ if(APPLE)
     set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
 endif()
 
+# Find out if libatomic link is required in this platform
+find_package(Atomic MODULE)
+
 # Check if the shared_mutex provided by the platform STL library
 # prioritizes writes
+
+# try_run cannot manage targets yet
+get_target_property(CMAKE_ATOMIC_LIB eProsima_atomic INTERFACE_LINK_LIBRARIES)    
+if(NOT CMAKE_ATOMIC_LIB)
+    set(CMAKE_ATOMIC_LIB)
+endif()
 
 try_run(SM_RUN_RESULT SM_COMPILE_RESULT
         "${CMAKE_CURRENT_BINARY_DIR}/shmtest"
         "${CMAKE_SOURCE_DIR}/cmake/modules/check_shared_mutex_priority.cpp"
-        LINK_LIBRARIES ${CMAKE_THREAD_LIBS_INIT}
+        LINK_LIBRARIES ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_ATOMIC_LIB}
         RUN_OUTPUT_VARIABLE SM_RUN_OUTPUT)
 
 if(SM_COMPILE_RESULT AND NOT SM_RUN_RESULT)
@@ -423,6 +432,7 @@ unset(USER_CAN_CHOOSE_SHARED_MEMORY_THIRDPARTY)
 unset(SM_RUN_RESULT)
 unset(SM_COMPILE_RESULT)
 unset(SM_RUN_OUTPUT)
+unset(CMAKE_ATOMIC_LIB)
 
 #Create library
 add_library(${PROJECT_NAME} ${${PROJECT_NAME}_source_files})
@@ -470,9 +480,6 @@ if(BUILD_SHARED_LIBS AND MSVC)
 else()
     set(PRIVACY "PUBLIC")
 endif()
-
-# Find out if libatomic link is required in this platform
-find_package(Atomic MODULE)
 
 # Link library to external libraries.
 target_link_libraries(${PROJECT_NAME} ${PRIVACY} fastcdr foonathan_memory

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -371,9 +371,6 @@ else()
     set(HAVE_STRICT_REALTIME 0)
 endif()
 
-configure_file(${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}/config.h.in
-    ${PROJECT_BINARY_DIR}/include/${PROJECT_NAME}/config.h)
-
 if(NOT ANDROID)
     find_package(Threads REQUIRED)
 endif()
@@ -433,6 +430,10 @@ unset(SM_RUN_RESULT)
 unset(SM_COMPILE_RESULT)
 unset(SM_RUN_OUTPUT)
 unset(CMAKE_ATOMIC_LIB)
+
+# Generate the proper configure file
+configure_file(${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}/config.h.in
+    ${PROJECT_BINARY_DIR}/include/${PROJECT_NAME}/config.h)
 
 #Create library
 add_library(${PROJECT_NAME} ${${PROJECT_NAME}_source_files})

--- a/src/cpp/rtps/history/TopicPayloadPool.cpp
+++ b/src/cpp/rtps/history/TopicPayloadPool.cpp
@@ -189,20 +189,18 @@ TopicPayloadPool::PayloadNode* TopicPayloadPool::allocate(
 TopicPayloadPool::PayloadNode* TopicPayloadPool::do_allocate(
         uint32_t size)
 {
-    PayloadNode* payload = nullptr;
+    PayloadNode* payload = new (std::nothrow) PayloadNode(size);
 
-    try
+    if (payload != nullptr)
     {
-        payload = new PayloadNode(size);
+        payload->data_index(static_cast<uint32_t>(all_payloads_.size()));
+        all_payloads_.push_back(payload);
     }
-    catch (std::bad_alloc& exception)
+    else
     {
-        logWarning(RTPS_HISTORY, "Failure to create a new payload " << exception.what());
-        return nullptr;
+        logWarning(RTPS_HISTORY, "Failure to create a new payload ");
     }
 
-    payload->data_index(static_cast<uint32_t>(all_payloads_.size()));
-    all_payloads_.push_back(payload);
     return payload;
 }
 
@@ -253,7 +251,11 @@ void TopicPayloadPool::reserve (
     for (size_t i = all_payloads_.size(); i < min_num_payloads; ++i)
     {
         PayloadNode* payload = do_allocate(size);
-        free_payloads_.push_back(payload);
+
+        if (payload != nullptr)
+        {
+            free_payloads_.push_back(payload);
+        }
     }
 }
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -68,8 +68,6 @@ using UDPv4TransportDescriptor = fastdds::rtps::UDPv4TransportDescriptor;
 using TCPTransportDescriptor = fastdds::rtps::TCPTransportDescriptor;
 using SharedMemTransportDescriptor = fastdds::rtps::SharedMemTransportDescriptor;
 
-thread_local RTPSParticipantImpl* RTPSParticipantImpl::collections_mutex_owner_ = nullptr;
-
 static EntityId_t TrustedWriter(
         const EntityId_t& reader)
 {

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -204,9 +204,17 @@ TEST(DDSBasic, MultithreadedReaderCreation)
     Subscriber* subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
     ASSERT_NE(nullptr, subscriber);
 
+    // Create publisher
+    Publisher* publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT);
+    ASSERT_NE(nullptr, publisher);
+
     // Create Topic
     Topic* topic = participant->create_topic(TEST_TOPIC_NAME, type_support.get_type_name(), TOPIC_QOS_DEFAULT);
     ASSERT_NE(nullptr, topic);
+
+    // Create DataWriter
+    DataWriter* writer = publisher->create_datawriter(topic, DATAWRITER_QOS_DEFAULT);
+    ASSERT_NE(nullptr, writer);
 
     std::mutex mtx;
     std::condition_variable cv;
@@ -247,6 +255,8 @@ TEST(DDSBasic, MultithreadedReaderCreation)
         }
     }
 
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, publisher->delete_datawriter(writer));
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, participant->delete_publisher(publisher));
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, participant->delete_subscriber(subscriber));
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, participant->delete_topic(topic));
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, factory->delete_participant(participant));

--- a/test/unittest/utils/CMakeLists.txt
+++ b/test/unittest/utils/CMakeLists.txt
@@ -139,6 +139,12 @@ target_include_directories(SystemInfoTests PRIVATE
 target_link_libraries(SystemInfoTests GTest::gtest)
 add_gtest(SystemInfoTests SOURCES ${SYSTEMINFOTESTS_SOURCE})
 
+add_executable(SharedMutexTests shared_mutex_tests.cpp)
+target_compile_definitions(SharedMutexTests PUBLIC USE_THIRDPARTY_SHARED_MUTEX=1)
+target_include_directories(SharedMutexTests PUBLIC ${PROJECT_SOURCE_DIR}/include)
+target_link_libraries(SharedMutexTests PUBLIC GTest::gtest)
+add_gtest(SharedMutexTests SOURCES shared_mutex_tests.cpp)
+
 ###############################################################################
 # Necessary files
 ###############################################################################

--- a/test/unittest/utils/shared_mutex_tests.cpp
+++ b/test/unittest/utils/shared_mutex_tests.cpp
@@ -57,7 +57,7 @@ using SharedMutexTypes = ::testing::Types<
     detail::debug_wrapper<detail::shared_mutex<detail::shared_mutex_type::PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP>>,
     detail::debug_wrapper<detail::shared_mutex<detail::shared_mutex_type::PTHREAD_RWLOCK_PREFER_READER_NP>>>;
 
-TYPED_TEST_SUITE(SharedMutexTest, SharedMutexTypes);
+TYPED_TEST_SUITE(SharedMutexTest, SharedMutexTypes, );
 
 TYPED_TEST(SharedMutexTest, test_one_writer)
 {

--- a/test/unittest/utils/shared_mutex_tests.cpp
+++ b/test/unittest/utils/shared_mutex_tests.cpp
@@ -231,15 +231,15 @@ TYPED_TEST(SharedMutexTest, test_try_lock_and_try_lock_shared)
 TYPED_TEST(SharedMutexTest, test_mutex_priority)
 {
     TypeParam sm;
-    atomic_bool mark = false;
+    atomic_bool mark{false};
 
     // take first shared lock
     sm.lock_shared();
 
     // signal is taken
-    thread exclusive([&]()
+    thread exclusive([&]
             {
-                mark = true;
+                mark.store(true);
                 lock_guard<TypeParam> guard(sm);
             });
 

--- a/test/unittest/utils/shared_mutex_tests.cpp
+++ b/test/unittest/utils/shared_mutex_tests.cpp
@@ -1,0 +1,221 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Excerpts from: STL/main/tests/std/tests/Dev11_1150223_shared_mutex/test.cpp
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <thread>
+#include <vector>
+
+#include <fastrtps/utils/shared_mutex.hpp>
+#include <gtest/gtest.h>
+
+using namespace std;
+using namespace eprosima;
+
+template<class T>
+class SharedMutexTest : public testing::Test
+{
+
+public:
+
+    using Mutex = T;
+
+    void join_and_clear(
+            vector<thread>& threads)
+    {
+        for (auto& t : threads)
+        {
+            t.join();
+        }
+
+        threads.clear();
+    }
+
+};
+
+using SharedMutexTypes = ::testing::Types<
+    detail::shared_mutex<detail::shared_mutex_type::PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP>,
+    detail::shared_mutex<detail::shared_mutex_type::PTHREAD_RWLOCK_PREFER_READER_NP>,
+    detail::debug_wrapper<detail::shared_mutex<detail::shared_mutex_type::PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP>>,
+    detail::debug_wrapper<detail::shared_mutex<detail::shared_mutex_type::PTHREAD_RWLOCK_PREFER_READER_NP>>>;
+
+TYPED_TEST_SUITE(SharedMutexTest, SharedMutexTypes);
+
+TYPED_TEST(SharedMutexTest, test_one_writer)
+{
+    // One simultaneous writer.
+    atomic<int> atom(-1);
+    Mutex mut;
+    vector<thread> threads;
+
+    for (int i = 0; i < 4; ++i)
+    {
+        threads.emplace_back([&atom, &mut]
+                {
+                    while (atom == -1)
+                    {
+                    }
+                    lock_guard<Mutex> ExclusiveLock(mut);
+                    const int val = ++atom;
+                    this_thread::sleep_for(25ms); // Not a timing assumption.
+                    ASSERT_EQ(atom, val);
+                });
+    }
+
+    ASSERT_EQ(atom.exchange(0), -1);
+    join_and_clear(threads);
+    ASSERT_EQ(atom, 4);
+}
+
+TYPED_TEST(SharedMutexTest, test_multiple_readers)
+{
+    // Many simultaneous readers.
+    atomic<int> atom(-1);
+    Mutex mut;
+    vector<thread> threads;
+
+    for (int i = 0; i < 4; ++i)
+    {
+        threads.emplace_back([&atom, &mut]
+                {
+                    while (atom == -1)
+                    {
+                    }
+                    shared_lock<Mutex> SharedLock(mut);
+                    ++atom;
+                    while (atom < 4)
+                    {
+                    }
+                });
+    }
+
+    ASSERT_EQ(atom.exchange(0), -1);
+    join_and_clear(threads);
+    ASSERT_EQ(atom, 4);
+}
+
+TYPED_TEST(SharedMutexTest, test_writer_blocking_readers)
+{
+    // One writer blocking many readers.
+    atomic<int> atom(-4);
+    Mutex mut;
+    vector<thread> threads;
+
+    threads.emplace_back([&atom, &mut]
+            {
+                while (atom < 0)
+                {
+                }
+                lock_guard<Mutex> ExclusiveLock(mut);
+                ASSERT_EQ(atom.exchange(1000), 0);
+                this_thread::sleep_for(50ms); // Not a timing assumption.
+                ASSERT_EQ(atom.exchange(1729), 1000);
+            });
+
+    for (int i = 0; i < 4; ++i)
+    {
+        threads.emplace_back([&atom, &mut]
+                {
+                    ++atom;
+                    while (atom < 1000)
+                    {
+                    }
+                    shared_lock<Mutex> SharedLock(mut);
+                    ASSERT_EQ(atom, 1729);
+                });
+    }
+
+    join_and_clear(threads);
+    ASSERT_EQ(atom, 1729);
+}
+
+TYPED_TEST(SharedMutexTest, test_readers_blocking_writer)
+{
+    // Many readers blocking one writer.
+    atomic<int> atom(-5);
+    Mutex mut;
+    vector<thread> threads;
+
+    for (int i = 0; i < 4; ++i)
+    {
+        threads.emplace_back([&atom, &mut]
+                {
+                    shared_lock<Mutex> SharedLock(mut);
+                    ++atom;
+                    while (atom < 0)
+                    {
+                    }
+                    this_thread::sleep_for(50ms); // Not a timing assumption.
+                    atom += 10;
+                });
+    }
+
+    threads.emplace_back([&atom, &mut]
+            {
+                ++atom;
+                while (atom < 0)
+                {
+                }
+                lock_guard<Mutex> ExclusiveLock(mut);
+                ASSERT_EQ(atom, 40);
+            });
+
+    join_and_clear(threads);
+    ASSERT_EQ(atom, 40);
+}
+
+TYPED_TEST(SharedMutexTest, test_try_lock_and_try_lock_shared)
+{
+    // Test try_lock() and try_lock_shared().
+    Mutex mut;
+
+    {
+        unique_lock<Mutex> MainExclusive(mut, try_to_lock);
+        ASSERT_TRUE(MainExclusive.owns_lock());
+
+        thread t([&mut]
+                {
+                    {
+                        unique_lock<Mutex> ExclusiveLock(mut, try_to_lock);
+                        ASSERT_FALSE(ExclusiveLock.owns_lock());
+                    }
+
+                    {
+                        shared_lock<Mutex> SharedLock(mut, try_to_lock);
+                        ASSERT_FALSE(SharedLock.owns_lock());
+                    }
+                });
+
+        t.join();
+    }
+
+    {
+        shared_lock<Mutex> MainShared(mut, try_to_lock);
+        ASSERT_TRUE(MainShared.owns_lock());
+
+        thread t([&mut]
+                {
+                    {
+                        unique_lock<Mutex> ExclusiveLock(mut, try_to_lock);
+                        ASSERT_FALSE(ExclusiveLock.owns_lock());
+                    }
+
+                    {
+                        shared_lock<Mutex> SharedLock(mut, try_to_lock);
+                        ASSERT_TRUE(SharedLock.owns_lock());
+                    }
+                });
+
+        t.join();
+    }
+}
+
+int main(
+        int argc,
+        char** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
The C++ standard requirements for `shared_mutex` do not specify if exclusive lock operation should preempt the shared lock one. Posix allows both behaviors but defaults to not preempting shared locks. STL implementations are split on this subject:
- Windows, boost ->  preemption (`PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP`)
- Linux, Mac -> not preemption (` PTHREAD_RWLOCK_PREFER_READER_NP`)

In order to prevent deadlock scenarios:
- out third party implementation avoids preemption.
- if the framework's defaults to preemption the third party is forced.
- code checks used to avoid deadlock on the preemption scenario have been removed.

Documentation: https://github.com/eProsima/Fast-DDS-docs/pull/413

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [] NA New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
