### PR TITLE
[15652] Adding protection to id_counter access

### DIFF
--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -103,6 +103,7 @@ DomainParticipantImpl::DomainParticipantImpl(
     , default_pub_qos_(PUBLISHER_QOS_DEFAULT)
     , default_sub_qos_(SUBSCRIBER_QOS_DEFAULT)
     , default_topic_qos_(TOPIC_QOS_DEFAULT)
+    , id_counter_(0)
 #pragma warning (disable : 4355 )
     , rtps_listener_(this)
 {

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -21,6 +21,7 @@
 #define _FASTDDS_PARTICIPANTIMPL_HPP_
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
+#include <atomic>
 #include <mutex>
 #include <condition_variable>
 
@@ -478,7 +479,7 @@ public:
     DomainParticipantListener* get_listener_for(
             const StatusMask& status);
 
-    uint32_t& id_counter()
+    std::atomic<uint32_t>& id_counter()
     {
         return id_counter_;
     }
@@ -556,7 +557,7 @@ protected:
     // All parent's child requests
     std::map<fastrtps::rtps::SampleIdentity, std::vector<fastrtps::rtps::SampleIdentity>> parent_requests_;
 
-    uint32_t id_counter_ = 0;
+    std::atomic<uint32_t> id_counter_;
 
     class MyRTPSParticipantListener : public fastrtps::rtps::RTPSParticipantListener
     {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -546,6 +546,7 @@ bool RTPSParticipantImpl::preprocess_endpoint_attributes(
         }
         else
         {
+            std::lock_guard<std::mutex> _(getCounterMutex());
             idnum = ++id_counter;
         }
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -507,7 +507,7 @@ RTPSParticipantImpl::~RTPSParticipantImpl()
 template <EndpointKind_t kind, octet no_key, octet with_key>
 bool RTPSParticipantImpl::preprocess_endpoint_attributes(
         const EntityId_t& entity_id,
-        uint32_t& id_counter,
+        std::atomic<uint32_t>& id_counter,
         EndpointAttributes& att,
         EntityId_t& entId)
 {
@@ -546,7 +546,6 @@ bool RTPSParticipantImpl::preprocess_endpoint_attributes(
         }
         else
         {
-            std::lock_guard<std::mutex> _(getCounterMutex());
             idnum = ++id_counter;
         }
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -533,7 +533,7 @@ private:
     //!Semaphore to wait for the listen thread creation.
     Semaphore* mp_ResourceSemaphore;
     //!Id counter to correctly assign the ids to writers and readers.
-    uint32_t IdCounter;
+    std::atomic<uint32_t> IdCounter;
     //! Mutex to safely access endpoints collections
     mutable shared_mutex endpoints_list_mutex;
     //! This member avoids shared_mutex reentrancy by tracking last participant into traversing the endpoints collections
@@ -1018,15 +1018,9 @@ public:
     template <EndpointKind_t kind, octet no_key, octet with_key>
     static bool preprocess_endpoint_attributes(
             const EntityId_t& entity_id,
-            uint32_t& id_count,
+            std::atomic<uint32_t>& id_count,
             EndpointAttributes& att,
             EntityId_t& entId);
-
-    static std::mutex& getCounterMutex()
-    {
-        static std::mutex counter_mutex;
-        return counter_mutex;
-    }
 
 #if HAVE_SECURITY
     void set_endpoint_rtps_protection_supports(

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -1022,6 +1022,12 @@ public:
             EndpointAttributes& att,
             EntityId_t& entId);
 
+    static std::mutex& getCounterMutex()
+    {
+        static std::mutex counter_mutex;
+        return counter_mutex;
+    }
+
 #if HAVE_SECURITY
     void set_endpoint_rtps_protection_supports(
             Endpoint* endpoint,

--- a/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
+++ b/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
@@ -15,6 +15,7 @@
 #ifndef _FASTDDS_PARTICIPANTIMPL_HPP_
 #define _FASTDDS_PARTICIPANTIMPL_HPP_
 
+#include <atomic>
 #include <map>
 #include <mutex>
 #include <string>
@@ -79,6 +80,7 @@ protected:
         , default_topic_qos_(TOPIC_QOS_DEFAULT)
 #pragma warning (disable : 4355)
         , rtps_listener_(this)
+        , id_counter_(0)
     {
         participant_->impl_ = this;
 
@@ -672,7 +674,7 @@ public:
         return nullptr;
     }
 
-    uint32_t& id_counter()
+    std::atomic<uint32_t>& id_counter()
     {
         return id_counter_;
     }
@@ -696,7 +698,7 @@ protected:
     std::map<std::string, TypeSupport> types_;
     mutable std::mutex mtx_types_;
     TopicQos default_topic_qos_;
-    uint32_t id_counter_ = 0;
+    std::atomic<uint32_t> id_counter_;
 
     class MyRTPSParticipantListener : public fastrtps::rtps::RTPSParticipantListener
     {

--- a/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
+++ b/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
@@ -33,6 +33,7 @@
 
 #include <gmock/gmock.h>
 
+#include <atomic>
 #include <map>
 #include <sstream>
 
@@ -284,7 +285,7 @@ public:
     template <EndpointKind_t kind, octet no_key, octet with_key>
     static bool preprocess_endpoint_attributes(
             const EntityId_t&,
-            uint32_t&,
+            std::atomic<uint32_t>&,
             EndpointAttributes&,
             EntityId_t&)
     {


### PR DESCRIPTION
Signed-off-by: Javier Santiago <javiersantiago@eprosima.com>

<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds protection to the `id_counter` access and modification inside the `preprocess_endpoint_attributes` function.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [ ] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
