### PR TITLE
[15897] Fix StatisticsQosTests & RTPSStatisticsTests fixture linking

### DIFF
--- a/test/unittest/statistics/dds/StatisticsQosTests.cpp
+++ b/test/unittest/statistics/dds/StatisticsQosTests.cpp
@@ -127,7 +127,7 @@ public:
  * 3. Pull mode enabled
  * 4. Publication mode ASYNCHRONOUS with custom flow controller
  * 5. History kind KEEP LAST
- * 6. History depth 1
+ * 6. History depth 10
  */
 TEST(StatisticsQosTests, StatisticsDataWriterQosTest)
 {
@@ -141,7 +141,7 @@ TEST(StatisticsQosTests, StatisticsDataWriterQosTest)
     EXPECT_EQ(STATISTICS_DATAWRITER_QOS.publish_mode().flow_controller_name,
             eprosima::fastdds::rtps::FASTDDS_STATISTICS_FLOW_CONTROLLER_DEFAULT);
     EXPECT_EQ(STATISTICS_DATAWRITER_QOS.history().kind, eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS);
-    EXPECT_EQ(STATISTICS_DATAWRITER_QOS.history().depth, 1);
+    EXPECT_EQ(STATISTICS_DATAWRITER_QOS.history().depth, 10);
 }
 
 /*

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -13,6 +13,11 @@
 // limitations under the License.
 
 #include <map>
+#if defined(_WIN32)
+#include <process.h>
+#else
+#include <unistd.h>
+#endif // if defined(_WIN32)
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -231,7 +236,13 @@ public:
         p_attr.userTransports.push_back(descriptor);
 
         // random domain_id
-        uint32_t domain_id = SystemInfo::instance().process_id() % 100;
+#if defined(__cplusplus_winrt)
+        uint32_t domain_id = static_cast<uint32_t>(GetCurrentProcessId()) % 100;
+#elif defined(_WIN32)
+        uint32_t domain_id = static_cast<uint32_t>(_getpid()) % 100;
+#else
+        uint32_t domain_id = static_cast<uint32_t>(getpid()) % 100;
+#endif // if defined(__cplusplus_winrt)
 
         participant_ = RTPSDomain::createParticipant(
             domain_id, true, p_attr);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR fixes a regression in `StatisticsQosTests.StatisticsDataWriterQosTest` introduced by #2998 , and also a linking problem in `RTPSStatisticsTests` on Windows 

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- *N/A*: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A*: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- *N/A*: Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- *N/A*: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A*: Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- *N/A*: New feature has been added to the `versions.md` file (if applicable).
- *N/A*: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
