### PR TITLE
[15915] Send GAPs correctly when using separate sending

### DIFF
--- a/include/fastdds/rtps/writer/StatefulWriter.h
+++ b/include/fastdds/rtps/writer/StatefulWriter.h
@@ -472,6 +472,11 @@ private:
     void prepare_datasharing_delivery(
             CacheChange_t* change);
 
+    /**
+     * Check the StatefulWriter's sequence numbers and add the required GAP messages to the provided message group.
+     *
+     * @param group     Reference to the Message Group to which the GAP messages are to be added.
+     */
     void add_gaps_for_holes_in_history_(
             RTPSMessageGroup& group);
 

--- a/include/fastdds/rtps/writer/StatefulWriter.h
+++ b/include/fastdds/rtps/writer/StatefulWriter.h
@@ -472,6 +472,9 @@ private:
     void prepare_datasharing_delivery(
             CacheChange_t* change);
 
+    void add_gaps_for_holes_in_history_(
+            RTPSMessageGroup& group);
+
     //! True to disable piggyback heartbeats
     bool disable_heartbeat_piggyback_;
     //! True to disable positive ACKs

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1779,6 +1779,10 @@ void StatefulWriter::send_heartbeat_nts_(
             return;
         }
     }
+    else
+    {
+        assert(firstSeq <= lastSeq);
+    }
 
     incrementHBCount();
     message_group.add_heartbeat(firstSeq, lastSeq, m_heartbeatCount, final, liveliness);

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -600,6 +600,7 @@ void StatefulWriter::send_heartbeat_to_all_readers()
             assert((SequenceNumber_t::unknown() == first_seq && SequenceNumber_t::unknown() == last_seq) ||
                     (SequenceNumber_t::unknown() != first_seq && SequenceNumber_t::unknown() != last_seq));
 
+
             if (SequenceNumber_t::unknown() != first_seq &&
                     last_seq.to64long() - first_seq.to64long() + 1 != mp_history->getHistorySize())
             {
@@ -1792,6 +1793,15 @@ void StatefulWriter::send_heartbeat_nts_(
     else
     {
         assert(firstSeq <= lastSeq);
+
+        if (!liveliness)
+        {
+            if (SequenceNumber_t::unknown() != firstSeq &&
+                    lastSeq.to64long() - firstSeq.to64long() + 1 != mp_history->getHistorySize())
+            {
+                logError(RTPS_WRITER, "GAP should have been sent here" );
+            }
+        }
 
         // Check if it has to be sent a GAP with the gaps in the history
     }

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -593,12 +593,10 @@ void StatefulWriter::send_heartbeat_to_all_readers()
             RTPSMessageGroup group(mp_RTPSParticipant, this, &locator_selector_general_);
             select_all_readers_nts(group, locator_selector_general_);
 
-            // Send a GAP with holes in the history.
-            SequenceNumber_t first_seq = get_seq_num_min();
-            SequenceNumber_t last_seq = get_seq_num_max();
-
-            assert((SequenceNumber_t::unknown() == first_seq && SequenceNumber_t::unknown() == last_seq) ||
-                    (SequenceNumber_t::unknown() != first_seq && SequenceNumber_t::unknown() != last_seq));
+            assert(
+                (SequenceNumber_t::unknown() == get_seq_num_min() && SequenceNumber_t::unknown() == get_seq_num_max()) ||
+                (SequenceNumber_t::unknown() != get_seq_num_min() &&
+                SequenceNumber_t::unknown() != get_seq_num_max()));
 
             add_gaps_for_holes_in_history_(group);
 

--- a/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
@@ -15,6 +15,7 @@
 #include "BlackboxTests.hpp"
 
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <thread>
 
@@ -514,7 +515,7 @@ TEST(RTPS, RTPSUnavailableSampleGapWhenSeparateSending)
     reader.startReception();
 
     // Send data
-    int index = 0;
+    uint16_t index = 0;
     message.index(++index);
 
     data.push_back(message);

--- a/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
@@ -469,6 +469,97 @@ TEST_P(RTPS, RTPSAsReliableWithRegistrationAndHolesInHistory)
     late_joiner.block_for_all();
 }
 
+/*
+ * This test checks that GAPs are properly sent when a writer is sending data to
+ * each reader separately.
+ */
+
+TEST_P(RTPS, RTPSUnavailableSampleGapWhenSeparateSending)
+{
+    RTPSWithRegistrationReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+    RTPSWithRegistrationWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+
+    // To simulate lossy conditions
+    auto testTransport = std::make_shared<rtps::test_UDPv4TransportDescriptor>();
+
+    reader.
+            durability(eprosima::fastrtps::rtps::DurabilityKind_t::TRANSIENT_LOCAL).
+            history_depth(3).
+            reliability(eprosima::fastrtps::rtps::ReliabilityKind_t::RELIABLE).init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    // set_separate_sending
+
+    writer.durability(eprosima::fastrtps::rtps::DurabilityKind_t::TRANSIENT_LOCAL).
+            disable_builtin_transport().
+            reliability(eprosima::fastrtps::rtps::ReliabilityKind_t::RELIABLE).
+            history_depth(3).
+            add_user_transport_to_pparams(testTransport).init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    writer.set_separate_sending(true);
+
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    HelloWorld message;
+    message.message("HelloWorld");
+
+    std::list<HelloWorld> data;
+    std::list<HelloWorld> expected;
+
+    reader.startReception();
+
+    // Send data
+    int index = 0;
+    message.index(++index);
+
+    data.push_back(message);
+    expected.push_back(message);
+    reader.expected_data(expected);
+    writer.send(data);
+
+    test_UDPv4Transport::test_UDPv4Transport_ShutdownAllNetwork = true;
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    message.index(++index);
+    data.push_back(message);
+    writer.send(data);
+
+    message.index(++index);
+    data.push_back(message);
+    expected.push_back(message);
+    reader.expected_data(expected);
+    writer.send(data);
+
+    writer.remove_change({0, 2});
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    test_UDPv4Transport::test_UDPv4Transport_ShutdownAllNetwork = false;
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    message.index(++index);
+    data.push_back(message);
+    expected.push_back(message);
+    reader.expected_data(expected);
+
+    writer.send(data);
+
+    // Block reader until reception finished or timeout.
+    reader.block_for_all(std::chrono::seconds(1));
+    // Block until all data is ACK'd
+    writer.waitForAllAcked(std::chrono::seconds(1));
+
+    EXPECT_EQ(reader.getReceivedCount(), static_cast<unsigned int>(expected.size()));
+
+}
+
 
 TEST_P(RTPS, RTPSAsReliableVolatileTwoWritersConsecutives)
 {

--- a/test/blackbox/common/RTPSWithRegistrationReader.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationReader.hpp
@@ -407,6 +407,13 @@ public:
         return *this;
     }
 
+    RTPSWithRegistrationReader& history_depth(
+            const int32_t depth)
+    {
+        topic_attr_.historyQos.depth = depth;
+        return *this;
+    }
+
     RTPSWithRegistrationReader& reliability(
             const eprosima::fastrtps::rtps::ReliabilityKind_t kind)
     {

--- a/test/blackbox/common/RTPSWithRegistrationWriter.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationWriter.hpp
@@ -453,6 +453,12 @@ public:
         return *this;
     }
 
+    void set_separate_sending(
+            bool separate_sending)
+    {
+        writer_->set_separate_sending(separate_sending);
+    }
+
     uint32_t get_matched() const
     {
         return matched_;


### PR DESCRIPTION
Signed-off-by: Javier Santiago <javiersantiago@eprosima.com>

<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

When using separate sending, in the event of a change with a sequence number lower than the last one being no longer available in the Writer History a GAP was not being properly sent. This leads to the Reader and Writer being stuck on a cycle of HEARTBEATs and ACKNACKs that request the missing change.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
