### PR TITLE
[15997] Construct with decltype when inserting to map on FlowControllerFactory

### DIFF
--- a/src/cpp/rtps/flowcontrol/FlowControllerFactory.cpp
+++ b/src/cpp/rtps/flowcontrol/FlowControllerFactory.cpp
@@ -21,26 +21,26 @@ void FlowControllerFactory::init(
     // Create default flow controllers.
 
     // PureSyncFlowController -> used by volatile besteffort writers.
-    flow_controllers_.insert(std::make_pair<std::string, std::unique_ptr<FlowController>>(
+    flow_controllers_.insert(decltype(flow_controllers_)::value_type(
                 pure_sync_flow_controller_name,
                 std::unique_ptr<FlowController>(
                     new FlowControllerImpl<FlowControllerPureSyncPublishMode,
                     FlowControllerFifoSchedule>(participant_, nullptr))));
     // SyncFlowController -> used by rest of besteffort writers.
-    flow_controllers_.insert(std::make_pair<std::string, std::unique_ptr<FlowController>>(
+    flow_controllers_.insert(decltype(flow_controllers_)::value_type(
                 sync_flow_controller_name,
                 std::unique_ptr<FlowController>(
                     new FlowControllerImpl<FlowControllerSyncPublishMode,
                     FlowControllerFifoSchedule>(participant_, nullptr))));
     // AsyncFlowController
-    flow_controllers_.insert(std::make_pair<std::string, std::unique_ptr<FlowController>>(
+    flow_controllers_.insert(decltype(flow_controllers_)::value_type(
                 async_flow_controller_name,
                 std::unique_ptr<FlowController>(
                     new FlowControllerImpl<FlowControllerAsyncPublishMode,
                     FlowControllerFifoSchedule>(participant_, nullptr))));
 
 #ifdef FASTDDS_STATISTICS
-    flow_controllers_.insert(std::make_pair<std::string, std::unique_ptr<FlowController>>(
+    flow_controllers_.insert(decltype(flow_controllers_)::value_type(
                 async_statistics_flow_controller_name,
                 std::unique_ptr<FlowController>(
                     new FlowControllerImpl<FlowControllerAsyncPublishMode,
@@ -63,31 +63,35 @@ void FlowControllerFactory::register_flow_controller (
         switch (flow_controller_descr.scheduler)
         {
             case FlowControllerSchedulerPolicy::FIFO:
-                flow_controllers_.insert({flow_controller_descr.name,
-                                          std::unique_ptr<FlowController>(
-                                              new FlowControllerImpl<FlowControllerLimitedAsyncPublishMode,
-                                              FlowControllerFifoSchedule>(participant_, &flow_controller_descr))});
+                flow_controllers_.insert(decltype(flow_controllers_)::value_type(
+                            flow_controller_descr.name,
+                            std::unique_ptr<FlowController>(
+                                new FlowControllerImpl<FlowControllerLimitedAsyncPublishMode,
+                                FlowControllerFifoSchedule>(participant_, &flow_controller_descr))));
                 break;
             case FlowControllerSchedulerPolicy::ROUND_ROBIN:
-                flow_controllers_.insert({flow_controller_descr.name,
-                                          std::unique_ptr<FlowController>(
-                                              new FlowControllerImpl<FlowControllerLimitedAsyncPublishMode,
-                                              FlowControllerRoundRobinSchedule>(participant_,
-                                              &flow_controller_descr))});
+                flow_controllers_.insert(decltype(flow_controllers_)::value_type(
+                            flow_controller_descr.name,
+                            std::unique_ptr<FlowController>(
+                                new FlowControllerImpl<FlowControllerLimitedAsyncPublishMode,
+                                FlowControllerRoundRobinSchedule>(participant_,
+                                &flow_controller_descr))));
                 break;
             case FlowControllerSchedulerPolicy::HIGH_PRIORITY:
-                flow_controllers_.insert({flow_controller_descr.name,
-                                          std::unique_ptr<FlowController>(
-                                              new FlowControllerImpl<FlowControllerLimitedAsyncPublishMode,
-                                              FlowControllerHighPrioritySchedule>(participant_,
-                                              &flow_controller_descr))});
+                flow_controllers_.insert(decltype(flow_controllers_)::value_type(
+                            flow_controller_descr.name,
+                            std::unique_ptr<FlowController>(
+                                new FlowControllerImpl<FlowControllerLimitedAsyncPublishMode,
+                                FlowControllerHighPrioritySchedule>(participant_,
+                                &flow_controller_descr))));
                 break;
             case FlowControllerSchedulerPolicy::PRIORITY_WITH_RESERVATION:
-                flow_controllers_.insert({flow_controller_descr.name,
-                                          std::unique_ptr<FlowController>(
-                                              new FlowControllerImpl<FlowControllerLimitedAsyncPublishMode,
-                                              FlowControllerPriorityWithReservationSchedule>(participant_,
-                                              &flow_controller_descr))});
+                flow_controllers_.insert(decltype(flow_controllers_)::value_type(
+                            flow_controller_descr.name,
+                            std::unique_ptr<FlowController>(
+                                new FlowControllerImpl<FlowControllerLimitedAsyncPublishMode,
+                                FlowControllerPriorityWithReservationSchedule>(participant_,
+                                &flow_controller_descr))));
                 break;
             default:
                 assert(false);
@@ -98,31 +102,35 @@ void FlowControllerFactory::register_flow_controller (
         switch (flow_controller_descr.scheduler)
         {
             case FlowControllerSchedulerPolicy::FIFO:
-                flow_controllers_.insert({flow_controller_descr.name,
-                                          std::unique_ptr<FlowController>(
-                                              new FlowControllerImpl<FlowControllerAsyncPublishMode,
-                                              FlowControllerFifoSchedule>(participant_, &flow_controller_descr))});
+                flow_controllers_.insert(decltype(flow_controllers_)::value_type(
+                            flow_controller_descr.name,
+                            std::unique_ptr<FlowController>(
+                                new FlowControllerImpl<FlowControllerAsyncPublishMode,
+                                FlowControllerFifoSchedule>(participant_, &flow_controller_descr))));
                 break;
             case FlowControllerSchedulerPolicy::ROUND_ROBIN:
-                flow_controllers_.insert({flow_controller_descr.name,
-                                          std::unique_ptr<FlowController>(
-                                              new FlowControllerImpl<FlowControllerAsyncPublishMode,
-                                              FlowControllerRoundRobinSchedule>(participant_,
-                                              &flow_controller_descr))});
+                flow_controllers_.insert(decltype(flow_controllers_)::value_type(
+                            flow_controller_descr.name,
+                            std::unique_ptr<FlowController>(
+                                new FlowControllerImpl<FlowControllerAsyncPublishMode,
+                                FlowControllerRoundRobinSchedule>(participant_,
+                                &flow_controller_descr))));
                 break;
             case FlowControllerSchedulerPolicy::HIGH_PRIORITY:
-                flow_controllers_.insert({flow_controller_descr.name,
-                                          std::unique_ptr<FlowController>(
-                                              new FlowControllerImpl<FlowControllerAsyncPublishMode,
-                                              FlowControllerHighPrioritySchedule>(participant_,
-                                              &flow_controller_descr))});
+                flow_controllers_.insert(decltype(flow_controllers_)::value_type(
+                            flow_controller_descr.name,
+                            std::unique_ptr<FlowController>(
+                                new FlowControllerImpl<FlowControllerAsyncPublishMode,
+                                FlowControllerHighPrioritySchedule>(participant_,
+                                &flow_controller_descr))));
                 break;
             case FlowControllerSchedulerPolicy::PRIORITY_WITH_RESERVATION:
-                flow_controllers_.insert({flow_controller_descr.name,
-                                          std::unique_ptr<FlowController>(
-                                              new FlowControllerImpl<FlowControllerAsyncPublishMode,
-                                              FlowControllerPriorityWithReservationSchedule>(participant_,
-                                              &flow_controller_descr))});
+                flow_controllers_.insert(decltype(flow_controllers_)::value_type(
+                            flow_controller_descr.name,
+                            std::unique_ptr<FlowController>(
+                                new FlowControllerImpl<FlowControllerAsyncPublishMode,
+                                FlowControllerPriorityWithReservationSchedule>(participant_,
+                                &flow_controller_descr))));
                 break;
             default:
                 assert(false);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This should fix building with old compilers that cannot deduce they should use the move constructor of unique_ptr.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
@Mergifyio backport 2.7.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
