### PR TITLE
Fix datarace on DomainParticipant disable [16040]

### DIFF
--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -159,7 +159,6 @@ void DomainParticipantImpl::disable()
     {
         participant->set_listener(nullptr);
     }
-    rtps_listener_.participant_ = nullptr;
 
     // The function to disable the DomainParticipantImpl is called from
     // DomainParticipantFactory::delete_participant() and DomainParticipantFactory destructor.
@@ -1533,9 +1532,12 @@ void DomainParticipantImpl::MyRTPSParticipantListener::onParticipantDiscovery(
         ParticipantDiscoveryInfo&& info)
 {
     DomainParticipantListener* listener = nullptr;
-    if (participant_ != nullptr && (listener = participant_->get_listener()) != nullptr)
+    DomainParticipant* participant = nullptr;
+    if (participant_ != nullptr
+            && (participant = participant_->get_participant()) != nullptr
+            && (listener = participant_->get_listener()) != nullptr)
     {
-        listener->on_participant_discovery(participant_->participant_, std::move(info));
+        listener->on_participant_discovery(participant, std::move(info));
     }
 }
 
@@ -1545,9 +1547,12 @@ void DomainParticipantImpl::MyRTPSParticipantListener::onParticipantAuthenticati
         ParticipantAuthenticationInfo&& info)
 {
     DomainParticipantListener* listener = nullptr;
-    if (participant_ != nullptr && (listener = participant_->get_listener()) != nullptr)
+    DomainParticipant* participant = nullptr;
+    if (participant_ != nullptr
+            && (participant = participant_->get_participant()) != nullptr
+            && (listener = participant_->get_listener()) != nullptr)
     {
-        listener->onParticipantAuthentication(participant_->participant_, std::move(info));
+        listener->onParticipantAuthentication(participant, std::move(info));
     }
 }
 
@@ -1558,9 +1563,12 @@ void DomainParticipantImpl::MyRTPSParticipantListener::onReaderDiscovery(
         ReaderDiscoveryInfo&& info)
 {
     DomainParticipantListener* listener = nullptr;
-    if (participant_ != nullptr && (listener = participant_->get_listener()) != nullptr)
+    DomainParticipant* participant = nullptr;
+    if (participant_ != nullptr
+            && (participant = participant_->get_participant()) != nullptr
+            && (listener = participant_->get_listener()) != nullptr)
     {
-        listener->on_subscriber_discovery(participant_->participant_, std::move(info));
+        listener->on_subscriber_discovery(participant, std::move(info));
     }
 }
 
@@ -1569,9 +1577,12 @@ void DomainParticipantImpl::MyRTPSParticipantListener::onWriterDiscovery(
         WriterDiscoveryInfo&& info)
 {
     DomainParticipantListener* listener = nullptr;
-    if (participant_ != nullptr && (listener = participant_->get_listener()) != nullptr)
+    DomainParticipant* participant = nullptr;
+    if (participant_ != nullptr
+            && (participant = participant_->get_participant()) != nullptr
+            && (listener = participant_->get_listener()) != nullptr)
     {
-        listener->on_publisher_discovery(participant_->participant_, std::move(info));
+        listener->on_publisher_discovery(participant, std::move(info));
     }
 }
 
@@ -1584,10 +1595,13 @@ void DomainParticipantImpl::MyRTPSParticipantListener::on_type_discovery(
         fastrtps::types::DynamicType_ptr dyn_type)
 {
     DomainParticipantListener* listener = nullptr;
-    if (participant_ != nullptr && (listener = participant_->get_listener()) != nullptr)
+    DomainParticipant* participant = nullptr;
+    if (participant_ != nullptr
+            && (participant = participant_->get_participant()) != nullptr
+            && (listener = participant_->get_listener()) != nullptr)
     {
         listener->on_type_discovery(
-            participant_->participant_,
+            participant,
             request_sample_id,
             topic,
             identifier,
@@ -1604,10 +1618,13 @@ void DomainParticipantImpl::MyRTPSParticipantListener::on_type_dependencies_repl
         const fastrtps::types::TypeIdentifierWithSizeSeq& dependencies)
 {
     DomainParticipantListener* listener = nullptr;
-    if (participant_ != nullptr && (listener = participant_->get_listener()) != nullptr)
+    DomainParticipant* participant = nullptr;
+    if (participant_ != nullptr
+            && (participant = participant_->get_participant()) != nullptr
+            && (listener = participant_->get_listener()) != nullptr)
     {
         listener->on_type_dependencies_reply(
-            participant_->participant_, request_sample_id, dependencies);
+            participant, request_sample_id, dependencies);
     }
 
     participant_->check_get_dependencies_request(request_sample_id, dependencies);


### PR DESCRIPTION
Signed-off-by: Juan López Fernández <juanlopez@eprosima.com>

<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Avoid dataraces on RTPS listener callbacks triggered while disabling a DomainParticipant (participant). The listener's pointer to participant is unset without protection in ``DomainParticipantImpl::disable``. Unsetting this reference is not required as it is enough to unset the (DomainParticipant)listener, which is thread safe. 

An alternative solution would be to unset the RTPS listener beforehand (before unsetting the DomainParticipant's listener). This solution may prevent other dataraces, but should be thoroughly analyzed.

Although in principle not required, DomainParticipant getters within RTPS listener callbacks are now also protected.

**Note** that for this case (`DomainParticipantImpl` disable before destruction when deleting a `DomainParticipant` via factory) it is possible that the `DomainParticipantListener` is set to `nullptr` (from `DomainParticipantImpl::disable`) in the middle of a RTPS listener callback, but no undefined behaviour should occur as the user should not be able to destroy the listener object at least until the delete operation is over, and this is a blocking operation waiting for the reception and event threads to join (thus assuring all callback operations are concluded by then).
However, this may not be the case when setting the `DomainParticipantListener` in other situations, see #3089 
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
