### PR TITLE
[16042] Fixing read/take_next_instance

### DIFF
--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -314,8 +314,6 @@ public:
             InstanceStateMask instance_states = ANY_INSTANCE_STATE);
 
     /**
-     * NOT YET IMPLEMENTED
-     *
      * This operation accesses via ‘read’ the samples that match the criteria specified in the ReadCondition.
      * This operation is especially useful in combination with QueryCondition to filter data samples based on the
      * content.
@@ -453,8 +451,6 @@ public:
             InstanceStateMask instance_states = ANY_INSTANCE_STATE);
 
     /**
-     * NOT YET IMPLEMENTED
-     *
      * This operation accesses a collection of Data values from the DataReader. The behavior is identical to
      * @ref read_next_instance except that all samples returned satisfy the specified condition. In other words, on
      * success all returned samples belong to the same instance, and the instance is the instance with
@@ -553,8 +549,6 @@ public:
             InstanceStateMask instance_states = ANY_INSTANCE_STATE);
 
     /**
-     * NOT YET IMPLEMENTED
-     *
      * This operation is analogous to @ref read_w_condition except it accesses samples via the ‘take’ operation.
      *
      * The specified ReadCondition must be attached to the DataReader; otherwise the operation will fail and return
@@ -658,8 +652,6 @@ public:
             InstanceStateMask instance_states = ANY_INSTANCE_STATE);
 
     /**
-     * NOT YET IMPLEMENTED
-     *
      * This operation accesses a collection of Data values from the DataReader. The behavior is identical to
      * @ref read_next_instance except that all samples returned satisfy the specified condition. In other words, on
      * success all returned samples belong to the same instance, and the instance is the instance with ‘smallest’

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -720,7 +720,7 @@ ReturnCode_t DataReaderImpl::read_or_take_next_sample(
     StackAllocatedSequence<SampleInfo, 1> sample_infos;
 
     detail::StateFilter states{ NOT_READ_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE };
-    detail::ReadTakeCommand cmd(*this, data_values, sample_infos, 1, states, it.second, false);
+    detail::ReadTakeCommand cmd(*this, data_values, sample_infos, 1, states, it.second, false, false);
     while (!cmd.is_finished())
     {
         cmd.add_instance(should_take);

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -530,7 +530,16 @@ ReturnCode_t DataReaderImpl::read_or_take(
     }
 
     detail::StateFilter states = { sample_states, view_states, instance_states };
-    detail::ReadTakeCommand cmd(*this, data_values, sample_infos, max_samples, states, it.second, single_instance);
+    detail::ReadTakeCommand cmd(
+            *this,
+             data_values,
+             sample_infos,
+             max_samples,
+             states,
+             it.second,
+             single_instance,
+             !exact_instance);
+
     while (!cmd.is_finished())
     {
         cmd.add_instance(should_take);

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -531,14 +531,14 @@ ReturnCode_t DataReaderImpl::read_or_take(
 
     detail::StateFilter states = { sample_states, view_states, instance_states };
     detail::ReadTakeCommand cmd(
-            *this,
-             data_values,
-             sample_infos,
-             max_samples,
-             states,
-             it.second,
-             single_instance,
-             !exact_instance);
+        *this,
+        data_values,
+        sample_infos,
+        max_samples,
+        states,
+        it.second,
+        single_instance,
+        !exact_instance);
 
     while (!cmd.is_finished())
     {

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
@@ -201,6 +201,7 @@ struct ReadTakeCommand
         if (single_instance_ && (!loop_for_data_ || (loop_for_data_ && ret_val)))
         {
             finished_ = true;
+            history_.check_and_remove_instance(instance_);
         }
         else
         {

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
@@ -197,7 +197,8 @@ struct ReadTakeCommand
             }
         }
 
-        if (single_instance_)
+        // Check if further iteration is required
+        if (single_instance_ && (!loop_for_data_ || (loop_for_data_ && ret_val)))
         {
             finished_ = true;
         }

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
@@ -65,7 +65,8 @@ struct ReadTakeCommand
             int32_t max_samples,
             const StateFilter& states,
             const history_type::instance_info& instance,
-            bool single_instance = false)
+            bool single_instance = false,
+            bool loop_for_data = false)
         : type_(reader.type_)
         , loan_manager_(reader.loan_manager_)
         , history_(reader.history_)
@@ -79,6 +80,7 @@ struct ReadTakeCommand
         , instance_(instance)
         , handle_(instance->first)
         , single_instance_(single_instance)
+        , loop_for_data_(loop_for_data)
     {
         assert(0 <= remaining_samples_);
 
@@ -195,7 +197,15 @@ struct ReadTakeCommand
             }
         }
 
-        next_instance();
+        if (single_instance_)
+        {
+            finished_ = true;
+        }
+        else
+        {
+            next_instance();
+        }
+
         return ret_val;
     }
 
@@ -259,6 +269,7 @@ private:
     history_type::instance_info instance_;
     InstanceHandle_t handle_;
     bool single_instance_;
+    bool loop_for_data_;
 
     bool finished_ = false;
     ReturnCode_t return_value_ = ReturnCode_t::RETCODE_NO_DATA;
@@ -269,11 +280,13 @@ private:
     {
         while (!is_current_instance_valid())
         {
-            if (!next_instance())
+            if ((single_instance_ && !loop_for_data_) || !next_instance())
             {
+                finished_ = true;
                 return false;
             }
         }
+
         return true;
     }
 
@@ -288,11 +301,6 @@ private:
     bool next_instance()
     {
         history_.check_and_remove_instance(instance_);
-        if (single_instance_)
-        {
-            finished_ = true;
-            return false;
-        }
 
         auto result = history_.next_available_instance_nts(handle_, instance_);
         if (!result.first)

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
@@ -65,8 +65,8 @@ struct ReadTakeCommand
             int32_t max_samples,
             const StateFilter& states,
             const history_type::instance_info& instance,
-            bool single_instance = false,
-            bool loop_for_data = false)
+            bool single_instance,
+            bool loop_for_data)
         : type_(reader.type_)
         , loan_manager_(reader.loan_manager_)
         , history_(reader.history_)

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
@@ -655,12 +655,16 @@ void DataReaderHistory::check_and_remove_instance(
         DataReaderHistory::instance_info& instance_info)
 {
     DataReaderInstance* instance = instance_info->second.get();
-    if (instance->cache_changes.empty() &&
-            (InstanceStateKind::ALIVE_INSTANCE_STATE != instance->instance_state) &&
-            instance->alive_writers.empty() &&
-            instance_info->first.isDefined())
+
+    if (instance->cache_changes.empty())
     {
-        instances_.erase(instance_info->first);
+        if (InstanceStateKind::ALIVE_INSTANCE_STATE != instance->instance_state &&
+                instance->alive_writers.empty() &&
+                instance_info->first.isDefined())
+        {
+            instances_.erase(instance_info->first);
+        }
+
         instance_info = data_available_instances_.erase(instance_info);
     }
 }

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -18,6 +18,7 @@
 #include <forward_list>
 #include <iostream>
 #include <thread>
+#include <type_traits>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -2091,11 +2092,11 @@ TEST_F(DataReaderTests, check_read_take_iteration)
     }
     while ( received < max_handles && !timeout);
 
-    ASSERT_FALSE(timeout);
+    EXPECT_FALSE(timeout);
     received = 0;
 
     // Take only the even handles
-    for (int i = 0; i < max_handles; i += 2, ++received )
+    for (typename std::remove_const<decltype(max_handles)>::type i = 0; i < max_handles; i += 2, ++received )
     {
         FooSeq data;
         SampleInfoSeq infos;
@@ -2103,7 +2104,7 @@ TEST_F(DataReaderTests, check_read_take_iteration)
         EXPECT_EQ(data_reader_->take_instance(data, infos, 1, handles[i]),
                 ReturnCode_t::RETCODE_OK);
 
-        ASSERT_EQ(i, std::atoi(data[0].message().data()));
+        EXPECT_EQ(i, std::atoi(data[0].message().data()));
 
         EXPECT_EQ(ReturnCode_t::RETCODE_OK, data_reader_->return_loan(data, infos));
     }
@@ -2128,13 +2129,13 @@ TEST_F(DataReaderTests, check_read_take_iteration)
         {
             received += data.length();
             handle = infos[0].instance_handle;
-            ASSERT_TRUE(std::atoi(data[0].message().data()) % 2 == 1);
+            EXPECT_TRUE(std::atoi(data[0].message().data()) % 2 == 1);
             EXPECT_EQ(ReturnCode_t::RETCODE_OK, data_reader_->return_loan(data, infos));
         }
     }
     while (ret == ReturnCode_t::RETCODE_OK);
 
-    ASSERT_EQ(received, max_handles);
+    EXPECT_EQ(received, max_handles);
 
     // Iterate over available instances and check all are removed
     received = pending;
@@ -2155,13 +2156,13 @@ TEST_F(DataReaderTests, check_read_take_iteration)
         {
             received += data.length();
             handle = infos[0].instance_handle;
-            ASSERT_TRUE(std::atoi(data[0].message().data()) % 2 == 1);
+            EXPECT_TRUE(std::atoi(data[0].message().data()) % 2 == 1);
             EXPECT_EQ(ReturnCode_t::RETCODE_OK, data_reader_->return_loan(data, infos));
         }
     }
     while (ret == ReturnCode_t::RETCODE_OK);
 
-    ASSERT_EQ(received, max_handles);
+    EXPECT_EQ(received, max_handles);
 }
 
 /*

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <array>
 #include <cassert>
+#include <chrono>
 #include <forward_list>
+#include <iostream>
 #include <thread>
 
 #include <gmock/gmock.h>
@@ -1988,6 +1991,172 @@ TEST_F(DataReaderTests, sample_info)
 
     // Run test again
     state.run_test(data_reader_, steps);
+}
+
+struct arraybuf : public std::streambuf
+{
+    template <std::size_t Size> arraybuf(
+            std::array<char, Size>& array)
+    {
+        this->setp(array.data(), array.data() + Size - 1);
+        array.fill(0);
+    }
+
+};
+
+struct oarraystream : virtual arraybuf, std::ostream
+{
+    template <std::size_t Size> oarraystream(
+            std::array<char, Size>& array)
+        : arraybuf(array)
+        , std::ostream(this)
+    {
+    }
+
+};
+
+TEST_F(DataReaderTests, check_read_take_iteration)
+{
+    const std::size_t max_handles = 100;
+    std::array<InstanceHandle_t, max_handles> handles;
+    auto loop_timeout = std::chrono::seconds(5);
+
+    // Allocate resources
+    DataReaderQos reader_qos;
+    DataWriterQos writer_qos;
+    SubscriberQos subscriber_qos = SUBSCRIBER_QOS_DEFAULT;
+    PublisherQos publisher_qos = PUBLISHER_QOS_DEFAULT;
+
+    reader_qos.history().kind = KEEP_LAST_HISTORY_QOS;
+    reader_qos.history().depth = 1;
+    writer_qos.history(reader_qos.history());
+
+    reader_qos.durability().kind = TRANSIENT_LOCAL_DURABILITY_QOS;
+    writer_qos.durability(reader_qos.durability());
+
+    reader_qos.resource_limits().max_instances = max_handles;
+    reader_qos.resource_limits().max_samples_per_instance = 1;
+    writer_qos.resource_limits(reader_qos.resource_limits());
+
+    create_entities(nullptr, reader_qos, subscriber_qos, writer_qos, publisher_qos);
+
+    {
+        // Populate the test handles and write on all instances
+        FooType data;
+        for (uint32_t i = 0; i < max_handles; ++i )
+        {
+            // calculate key
+            data.index(i);
+            type_.get_key(&data, &handles[i]);
+
+            // write the index as message
+            oarraystream out(data.message());
+            out << i;
+
+            EXPECT_EQ(data_writer_->write(&data, handles[i]), ReturnCode_t::RETCODE_OK);
+        }
+    }
+
+    // Loop till all samples are received
+    std::size_t received = 0;
+    auto start = std::chrono::system_clock::now();
+    bool timeout = false;
+
+    do
+    {
+        FooSeq data;
+        SampleInfoSeq infos;
+
+        auto ret = data_reader_->read(data, infos, max_handles,
+                        NOT_READ_SAMPLE_STATE,
+                        NEW_VIEW_STATE,
+                        ALIVE_INSTANCE_STATE);
+
+        if ( ret == ReturnCode_t::RETCODE_OK)
+        {
+            received += data.length();
+            EXPECT_EQ(ReturnCode_t::RETCODE_OK, data_reader_->return_loan(data, infos));
+        }
+        else
+        {
+            timeout = (std::chrono::system_clock::now() - start) < loop_timeout;
+            std::this_thread::yield();
+        }
+
+    }
+    while ( received < max_handles && !timeout);
+
+    ASSERT_FALSE(timeout);
+    received = 0;
+
+    // Take only the even handles
+    for (int i = 0; i < max_handles; i += 2, ++received )
+    {
+        FooSeq data;
+        SampleInfoSeq infos;
+
+        EXPECT_EQ(data_reader_->take_instance(data, infos, 1, handles[i]),
+                ReturnCode_t::RETCODE_OK);
+
+        ASSERT_EQ(i, std::atoi(data[0].message().data()));
+
+        EXPECT_EQ(ReturnCode_t::RETCODE_OK, data_reader_->return_loan(data, infos));
+    }
+
+    // Iterate over available instances with data and check all are retrieved
+    auto pending = received;
+    InstanceHandle_t handle = HANDLE_NIL;
+    ReturnCode_t ret;
+
+    do
+    {
+        FooSeq data;
+        SampleInfoSeq infos;
+
+        ret = data_reader_->read_next_instance(
+            data,
+            infos,
+            1,
+            handle);
+
+        if (!!ret)
+        {
+            received += data.length();
+            handle = infos[0].instance_handle;
+            ASSERT_TRUE(std::atoi(data[0].message().data()) % 2 == 1);
+            EXPECT_EQ(ReturnCode_t::RETCODE_OK, data_reader_->return_loan(data, infos));
+        }
+    }
+    while (ret == ReturnCode_t::RETCODE_OK);
+
+    ASSERT_EQ(received, max_handles);
+
+    // Iterate over available instances and check all are removed
+    received = pending;
+    handle = HANDLE_NIL;
+
+    do
+    {
+        FooSeq data;
+        SampleInfoSeq infos;
+
+        ret = data_reader_->take_next_instance(
+            data,
+            infos,
+            1,
+            handle);
+
+        if (!!ret)
+        {
+            received += data.length();
+            handle = infos[0].instance_handle;
+            ASSERT_TRUE(std::atoi(data[0].message().data()) % 2 == 1);
+            EXPECT_EQ(ReturnCode_t::RETCODE_OK, data_reader_->return_loan(data, infos));
+        }
+    }
+    while (ret == ReturnCode_t::RETCODE_OK);
+
+    ASSERT_EQ(received, max_handles);
 }
 
 /*

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -2015,6 +2015,11 @@ struct oarraystream : virtual arraybuf, std::ostream
 
 };
 
+/*
+ *  This test deals with issues covered on PR #3044.
+ *  It checks (read|take)_next_instance methods iterate properly over all
+ *  instances in the history.
+ */
 TEST_F(DataReaderTests, check_read_take_iteration)
 {
     const std::size_t max_handles = 100;


### PR DESCRIPTION
Signed-off-by: Miguel Barro <miguelbarro@eprosima.com>

<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

DataReader APIs rely on `DataReaderImpl::read_or_take()'  method:
```
    ReturnCode_t read( LoanableCollection& data_values, SampleInfoSeq& sample_infos,...)
        return read_or_take(data_values, sample_infos, max_samples, HANDLE_NIL,
                            sample_states, view_states, instance_states, false, false, false);

    ReturnCode_t read_instance( LoanableCollection& data_values, SampleInfoSeq& sample_infos, ...)
        return read_or_take(data_values, sample_infos, max_samples, a_handle,
                            sample_states, view_states, instance_states, true, true, false);

    ReturnCode_t read_next_instance( LoanableCollection& data_values, SampleInfoSeq& sample_infos, ...)
        return read_or_take(data_values, sample_infos, max_samples, previous_handle,
                            sample_states, view_states, instance_states, false, true, false);

    ReturnCode_t read_next_sample( void* data, SampleInfo* info)
        return read_or_take_next_sample(data, info, false);
        doesn't rely on read_or_take but uses ReadTakeCommand directly specifying:
            single_instance = false
```
take commands follow the same pattern. Basically the last three arguments specify the behaviour:
+ *exact_instance*
+ *single_instance*. propagated to `ReadTakeCommand`
+ *should_take*. propagated to `ReadTakeCommand`

because *exact_instance* is not propagated to `ReadTakeCommand` it cannot differentiate from `read|take_instance` and `read|take_next_instance` thus no iteration for valid instances is performed.


<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
