### PR TITLE
[16038] Fix SegFault in delete_contained_entities() when compiled with statistics

### DIFF
--- a/examples/cpp/dds/BasicConfigurationExample/BasicConfigurationPublisher.cpp
+++ b/examples/cpp/dds/BasicConfigurationExample/BasicConfigurationPublisher.cpp
@@ -232,6 +232,7 @@ HelloWorldPublisher::~HelloWorldPublisher()
 
         std::cout << "deleting contained entities" << std::endl;
         participant_->delete_contained_entities();
+        std::cout << "deleting participant" << std::endl;
         DomainParticipantFactory::get_instance()->delete_participant(participant_);
     }
 }

--- a/examples/cpp/dds/BasicConfigurationExample/BasicConfigurationPublisher.cpp
+++ b/examples/cpp/dds/BasicConfigurationExample/BasicConfigurationPublisher.cpp
@@ -214,25 +214,7 @@ HelloWorldPublisher::~HelloWorldPublisher()
 {
     if (participant_ != nullptr)
     {
-        /*if (publisher_ != nullptr)
-        {
-            if (writer_ != nullptr)
-            {
-                std::cout << "deleting writer" << std::endl;
-                publisher_->delete_datawriter(writer_);
-            }
-            std::cout << "deleting publisher" << std::endl;
-            participant_->delete_publisher(publisher_);
-        }
-        if (topic_ != nullptr)
-        {
-            std::cout << "deleting topic" << std::endl;
-            participant_->delete_topic(topic_);
-        }*/
-
-        std::cout << "deleting contained entities" << std::endl;
         participant_->delete_contained_entities();
-        std::cout << "deleting participant" << std::endl;
         DomainParticipantFactory::get_instance()->delete_participant(participant_);
     }
 }

--- a/examples/cpp/dds/BasicConfigurationExample/BasicConfigurationPublisher.cpp
+++ b/examples/cpp/dds/BasicConfigurationExample/BasicConfigurationPublisher.cpp
@@ -214,18 +214,24 @@ HelloWorldPublisher::~HelloWorldPublisher()
 {
     if (participant_ != nullptr)
     {
-        if (publisher_ != nullptr)
+        /*if (publisher_ != nullptr)
         {
             if (writer_ != nullptr)
             {
+                std::cout << "deleting writer" << std::endl;
                 publisher_->delete_datawriter(writer_);
             }
+            std::cout << "deleting publisher" << std::endl;
             participant_->delete_publisher(publisher_);
         }
         if (topic_ != nullptr)
         {
+            std::cout << "deleting topic" << std::endl;
             participant_->delete_topic(topic_);
-        }
+        }*/
+
+        std::cout << "deleting contained entities" << std::endl;
+        participant_->delete_contained_entities();
         DomainParticipantFactory::get_instance()->delete_participant(participant_);
     }
 }

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -129,7 +129,6 @@ ReturnCode_t DomainParticipantFactory::delete_participant(
     {
         std::lock_guard<std::mutex> guard(mtx_participants_);
 #ifdef FASTDDS_STATISTICS
-        std::cout << "Deleting builtin statistics" << std::endl;
         // Delete builtin statistics entities
         eprosima::fastdds::statistics::dds::DomainParticipantImpl* stat_part_impl =
                 static_cast<eprosima::fastdds::statistics::dds::DomainParticipantImpl*>(part->impl_);

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -129,6 +129,7 @@ ReturnCode_t DomainParticipantFactory::delete_participant(
     {
         std::lock_guard<std::mutex> guard(mtx_participants_);
 #ifdef FASTDDS_STATISTICS
+        std::cout << "Deleting builtin statistics" << std::endl;
         // Delete builtin statistics entities
         eprosima::fastdds::statistics::dds::DomainParticipantImpl* stat_part_impl =
                 static_cast<eprosima::fastdds::statistics::dds::DomainParticipantImpl*>(part->impl_);

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -332,7 +332,7 @@ public:
 
     DomainId_t get_domain_id() const;
 
-    ReturnCode_t delete_contained_entities();
+    virtual ReturnCode_t delete_contained_entities();
 
     ReturnCode_t assert_liveliness();
 

--- a/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.cpp
@@ -265,6 +265,19 @@ void DomainParticipantImpl::disable()
     efd::DomainParticipantImpl::disable();
 }
 
+ReturnCode_t DomainParticipantImpl::delete_contained_entities()
+{
+    ReturnCode_t ret = efd::DomainParticipantImpl::delete_contained_entities();
+
+    if (ret == ReturnCode_t::RETCODE_OK)
+    {
+        builtin_publisher_impl_ = nullptr;
+        builtin_publisher_ = nullptr;
+    }
+
+    return ret;
+}
+
 efd::PublisherImpl* DomainParticipantImpl::create_publisher_impl(
         const efd::PublisherQos& qos,
         efd::PublisherListener* listener)

--- a/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.hpp
@@ -115,6 +115,13 @@ public:
     static bool is_statistics_topic_name(
             const std::string& topic_name) noexcept;
 
+     /**
+     * @brief This override calls the parent method and returns builtin publishers to nullptr
+     *
+     * @return RETCODE_OK if successful
+     */
+     ReturnCode_t delete_contained_entities() override;
+
 protected:
 
     /**

--- a/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.hpp
@@ -115,12 +115,12 @@ public:
     static bool is_statistics_topic_name(
             const std::string& topic_name) noexcept;
 
-     /**
+    /**
      * @brief This override calls the parent method and returns builtin publishers to nullptr
      *
      * @return RETCODE_OK if successful
      */
-     ReturnCode_t delete_contained_entities() override;
+    ReturnCode_t delete_contained_entities() override;
 
 protected:
 

--- a/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
+++ b/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
@@ -591,7 +591,7 @@ public:
         return false;
     }
 
-    ReturnCode_t delete_contained_entities()
+    virtual ReturnCode_t delete_contained_entities()
     {
         bool can_be_deleted = true;
 

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantTests.cpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantTests.cpp
@@ -698,6 +698,48 @@ TEST_F(StatisticsDomainParticipantTests, EnableStatisticsDataWriterFailureIncomp
 #endif // FASTDDS_STATISTICS
 }
 
+/**
+ * This test checks that a participant is correctly deleted by the factory
+ * after calling delete_contained_entities() method
+ * 1. Create a statistics participant, register type
+ * 2. Create a sample topic
+ * 3. Perform a delete_contained_entities() in the statistics participant
+ * 4. Delete the participant
+ */
+TEST_F(StatisticsDomainParticipantTests, DeleteParticipantAfterDeleteContainedEntitiesFailure)
+{
+#ifdef FASTDDS_STATISTICS
+
+    eprosima::fastdds::dds::TypeSupport count_type(new EntityCountPubSubType);
+
+    // 1. Create DomainParticipant with statistics
+    eprosima::fastdds::dds::DomainParticipant* participant =
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->
+                    create_participant(0, eprosima::fastdds::dds::PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
+
+    // Register type
+    participant->register_type(count_type);
+
+    // 2. Create a sample topic
+    participant->create_topic(HEARTBEAT_COUNT_TOPIC,
+                    count_type->getName(), eprosima::fastdds::dds::TOPIC_QOS_DEFAULT);
+
+    DomainParticipant* statistics_participant = DomainParticipant::narrow(participant);
+    ASSERT_NE(statistics_participant, nullptr);
+
+    EXPECT_EQ(ReturnCode_t::RETCODE_OK, statistics_participant->enable_statistics_datawriter(HEARTBEAT_COUNT_TOPIC,
+            STATISTICS_DATAWRITER_QOS));
+
+    // 3. Perform a delete_contained_entities() in the statistics participant
+    EXPECT_EQ(statistics_participant->delete_contained_entities(), ReturnCode_t::RETCODE_OK);
+
+    // 4. Delete the participant
+    EXPECT_EQ(eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->
+                    delete_participant(participant), ReturnCode_t::RETCODE_OK);
+#endif // FASTDDS_STATISTICS
+}
+
 } // namespace dds
 } // namespace statistics
 } // namespace fastdds

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantTests.cpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantTests.cpp
@@ -733,7 +733,7 @@ TEST_F(StatisticsDomainParticipantTests, DeleteParticipantAfterDeleteContainedEn
             STATISTICS_DATAWRITER_QOS));
 
     // 3. Perform a delete_contained_entities() in the statistics participant
-    EXPECT_EQ(statistics_participant->delete_contained_entities(), ReturnCode_t::RETCODE_OK);
+    EXPECT_EQ(participant->delete_contained_entities(), ReturnCode_t::RETCODE_OK);
 
     // 4. Delete the participant
     EXPECT_EQ(eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantTests.cpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantTests.cpp
@@ -699,6 +699,7 @@ TEST_F(StatisticsDomainParticipantTests, EnableStatisticsDataWriterFailureIncomp
 }
 
 /**
+
  * This test checks that a participant is correctly deleted by the factory
  * after calling delete_contained_entities() method
  * 1. Create a statistics participant, register type
@@ -723,7 +724,7 @@ TEST_F(StatisticsDomainParticipantTests, DeleteParticipantAfterDeleteContainedEn
 
     // 2. Create a sample topic
     participant->create_topic(HEARTBEAT_COUNT_TOPIC,
-                    count_type->getName(), eprosima::fastdds::dds::TOPIC_QOS_DEFAULT);
+            count_type->getName(), eprosima::fastdds::dds::TOPIC_QOS_DEFAULT);
 
     DomainParticipant* statistics_participant = DomainParticipant::narrow(participant);
     ASSERT_NE(statistics_participant, nullptr);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
If compiled with statistics, when a participant calls delete_contained_entities() followed by a call to Factory::delete_participant(), a SegFault was produced.

Proposed solution changes:
Making ParticipantImpl delete_contained_entities() virtual so that the statistics participant can set the builtin_publishers to nullptr. 

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
@Mergifyio backport 2.7.x 2.6.x 2.3.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. amd64 <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
