### PR TITLE
Check if not null before calling delete.

### DIFF
--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -414,8 +414,14 @@ ReturnCode_t DataWriterImpl::check_delete_preconditions()
 
 DataWriterImpl::~DataWriterImpl()
 {
-    delete lifespan_timer_;
-    delete deadline_timer_;
+    if (lifespan_timer_) {
+        delete lifespan_timer_;
+        lifespan_timer_ = nullptr;
+    }
+    if (deadline_timer_) {
+        delete deadline_timer_;
+        deadline_timer_ = nullptr;
+    }
 
     if (writer_ != nullptr)
     {

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -289,8 +289,14 @@ void DataReaderImpl::disable()
 
 void DataReaderImpl::stop()
 {
-    delete lifespan_timer_;
-    delete deadline_timer_;
+    if (lifespan_timer_) {
+        delete lifespan_timer_;
+        lifespan_timer_ = nullptr;
+    }
+    if (deadline_timer_) {
+        delete deadline_timer_;
+        deadline_timer_ = nullptr;
+    }
 
     auto content_topic = dynamic_cast<ContentFilteredTopicImpl*>(topic_->get_impl());
     if (nullptr != content_topic)

--- a/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.cpp
+++ b/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.cpp
@@ -97,8 +97,14 @@ PublisherImpl::PublisherImpl(
 
 PublisherImpl::~PublisherImpl()
 {
-    delete(lifespan_timer_);
-    delete(deadline_timer_);
+    if (lifespan_timer_) {
+        delete lifespan_timer_;
+        lifespan_timer_ = nullptr;
+    }
+    if (deadline_timer_) {
+        delete deadline_timer_;
+        deadline_timer_ = nullptr;
+    }
 
     if (mp_writer != nullptr)
     {

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberImpl.cpp
@@ -88,8 +88,14 @@ SubscriberImpl::SubscriberImpl(
 
 SubscriberImpl::~SubscriberImpl()
 {
-    delete(lifespan_timer_);
-    delete(deadline_timer_);
+    if (lifespan_timer_) {
+        delete lifespan_timer_;
+        lifespan_timer_ = nullptr;
+    }
+    if (deadline_timer_) {
+        delete deadline_timer_;
+        deadline_timer_ = nullptr;
+    }
 
     if (mp_reader != nullptr)
     {


### PR DESCRIPTION
general code improvement with null check before delete.

Signed-off-by: Tomoya.Fujita <Tomoya.Fujita@sony.com>

## Description

If these objects are not create as expected when it fails to create entity successfully, this will lead to segmentation fault.

## Contributor Checklist

- [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [ ] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->

## Reviewer Checklist

- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
