### PR TITLE
[16119] Correctly handle builtin endpoints mask

### DIFF
--- a/src/cpp/fastdds/builtin/typelookup/TypeLookupManager.cpp
+++ b/src/cpp/fastdds/builtin/typelookup/TypeLookupManager.cpp
@@ -150,7 +150,6 @@ bool TypeLookupManager::assign_remote_endpoints(
 {
     const NetworkFactory& network = participant_->network_factory();
     uint32_t endp = pdata.m_availableBuiltinEndpoints;
-    uint32_t partdet = endp;
     uint32_t auxendp = endp;
 
     std::lock_guard<std::mutex> data_guard(temp_data_lock_);
@@ -172,10 +171,9 @@ bool TypeLookupManager::assign_remote_endpoints(
 
     EPROSIMA_LOG_INFO(TYPELOOKUP_SERVICE, "for RTPSParticipant: " << pdata.m_guid);
 
-    partdet &= DISC_BUILTIN_ENDPOINT_PARTICIPANT_DETECTOR; //Habria que quitar esta linea que comprueba si tiene PDP.
     auxendp &= BUILTIN_ENDPOINT_TYPELOOKUP_SERVICE_REQUEST_DATA_WRITER;
 
-    if ((auxendp != 0 || partdet != 0) && builtin_request_reader_ != nullptr)
+    if (auxendp != 0 && builtin_request_reader_ != nullptr)
     {
         EPROSIMA_LOG_INFO(TYPELOOKUP_SERVICE, "Adding remote writer to the local Builtin Request Reader");
         temp_writer_proxy_data_.guid().entityId = fastrtps::rtps::c_EntityId_TypeLookup_request_writer;
@@ -186,7 +184,7 @@ bool TypeLookupManager::assign_remote_endpoints(
     auxendp = endp;
     auxendp &= BUILTIN_ENDPOINT_TYPELOOKUP_SERVICE_REPLY_DATA_WRITER;
 
-    if ((auxendp != 0 || partdet != 0) && builtin_reply_reader_ != nullptr)
+    if (auxendp != 0 && builtin_reply_reader_ != nullptr)
     {
         EPROSIMA_LOG_INFO(TYPELOOKUP_SERVICE, "Adding remote writer to the local Builtin Reply Reader");
         temp_writer_proxy_data_.guid().entityId = fastrtps::rtps::c_EntityId_TypeLookup_reply_writer;
@@ -197,7 +195,7 @@ bool TypeLookupManager::assign_remote_endpoints(
     auxendp = endp;
     auxendp &= BUILTIN_ENDPOINT_TYPELOOKUP_SERVICE_REQUEST_DATA_READER;
 
-    if ((auxendp != 0 || partdet != 0) && builtin_request_writer_ != nullptr)
+    if (auxendp != 0 && builtin_request_writer_ != nullptr)
     {
         EPROSIMA_LOG_INFO(TYPELOOKUP_SERVICE, "Adding remote reader to the local Builtin Request Writer");
         temp_reader_proxy_data_.guid().entityId = fastrtps::rtps::c_EntityId_TypeLookup_request_reader;
@@ -207,7 +205,7 @@ bool TypeLookupManager::assign_remote_endpoints(
     auxendp = endp;
     auxendp &= BUILTIN_ENDPOINT_TYPELOOKUP_SERVICE_REPLY_DATA_READER;
 
-    if ((auxendp != 0 || partdet != 0) && builtin_reply_writer_ != nullptr)
+    if (auxendp != 0 && builtin_reply_writer_ != nullptr)
     {
         EPROSIMA_LOG_INFO(TYPELOOKUP_SERVICE, "Adding remote reader to the local Builtin Reply Writer");
         temp_reader_proxy_data_.guid().entityId = fastrtps::rtps::c_EntityId_TypeLookup_reply_reader;

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -765,10 +765,9 @@ void EDPSimple::assignRemoteEndpoints(
     EPROSIMA_LOG_INFO(RTPS_EDP, "New DPD received, adding remote endpoints to our SimpleEDP endpoints");
     const NetworkFactory& network = mp_RTPSParticipant->network_factory();
     uint32_t endp = pdata.m_availableBuiltinEndpoints;
-    uint32_t auxendp = endp;
+    uint32_t auxendp;
     bool use_multicast_locators = !mp_PDP->getRTPSParticipant()->getAttributes().builtin.avoid_builtin_multicast ||
             pdata.metatraffic_locators.unicast.empty();
-    auxendp &= DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER;
 
     auto temp_reader_proxy_data = get_temporary_reader_proxies_pool().get();
 
@@ -788,8 +787,8 @@ void EDPSimple::assignRemoteEndpoints(
     temp_writer_proxy_data->m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
     temp_writer_proxy_data->m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
 
-    //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
-    //auxendp = 1;
+    auxendp = endp;
+    auxendp &= DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER;
     if (auxendp != 0 && publications_reader_.first != nullptr) //Exist Pub Writer and i have pub reader
     {
         EPROSIMA_LOG_INFO(RTPS_EDP, "Adding SEDP Pub Writer to my Pub Reader");
@@ -799,8 +798,6 @@ void EDPSimple::assignRemoteEndpoints(
     }
     auxendp = endp;
     auxendp &= DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR;
-    //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
-    //auxendp = 1;
     if (auxendp != 0 && publications_writer_.first != nullptr) //Exist Pub Detector
     {
         EPROSIMA_LOG_INFO(RTPS_EDP, "Adding SEDP Pub Reader to my Pub Writer");
@@ -809,8 +806,6 @@ void EDPSimple::assignRemoteEndpoints(
     }
     auxendp = endp;
     auxendp &= DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER;
-    //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
-    //auxendp = 1;
     if (auxendp != 0 && subscriptions_reader_.first != nullptr) //Exist Pub Announcer
     {
         EPROSIMA_LOG_INFO(RTPS_EDP, "Adding SEDP Sub Writer to my Sub Reader");
@@ -820,8 +815,6 @@ void EDPSimple::assignRemoteEndpoints(
     }
     auxendp = endp;
     auxendp &= DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_DETECTOR;
-    //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
-    //auxendp = 1;
     if (auxendp != 0 && subscriptions_writer_.first != nullptr) //Exist Pub Announcer
     {
         EPROSIMA_LOG_INFO(RTPS_EDP, "Adding SEDP Sub Reader to my Sub Writer");
@@ -832,8 +825,6 @@ void EDPSimple::assignRemoteEndpoints(
 #if HAVE_SECURITY
     auxendp = endp;
     auxendp &= DISC_BUILTIN_ENDPOINT_PUBLICATION_SECURE_ANNOUNCER;
-    //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
-    //auxendp = 1;
     if (auxendp != 0 && publications_secure_reader_.first != nullptr)
     {
         temp_writer_proxy_data->guid().entityId = sedp_builtin_publications_secure_writer;
@@ -850,8 +841,6 @@ void EDPSimple::assignRemoteEndpoints(
 
     auxendp = endp;
     auxendp &= DISC_BUILTIN_ENDPOINT_PUBLICATION_SECURE_DETECTOR;
-    //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
-    //auxendp = 1;
     if (auxendp != 0 && publications_secure_writer_.first != nullptr)
     {
         temp_reader_proxy_data->guid().entityId = sedp_builtin_publications_secure_reader;
@@ -866,8 +855,6 @@ void EDPSimple::assignRemoteEndpoints(
 
     auxendp = endp;
     auxendp &= DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_SECURE_ANNOUNCER;
-    //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
-    //auxendp = 1;
     if (auxendp != 0 && subscriptions_secure_reader_.first != nullptr)
     {
         temp_writer_proxy_data->guid().entityId = sedp_builtin_subscriptions_secure_writer;
@@ -884,8 +871,6 @@ void EDPSimple::assignRemoteEndpoints(
 
     auxendp = endp;
     auxendp &= DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_SECURE_DETECTOR;
-    //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
-    //auxendp = 1;
     if (auxendp != 0 && subscriptions_secure_writer_.first != nullptr)
     {
         EPROSIMA_LOG_INFO(RTPS_EDP, "Adding SEDP Sub Reader to my Sub Writer");
@@ -912,8 +897,6 @@ void EDPSimple::removeRemoteEndpoints(
     uint32_t endp = pdata->m_availableBuiltinEndpoints;
     uint32_t auxendp = endp;
     auxendp &= DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER;
-    //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
-    //auxendp = 1;
     if (auxendp != 0 && publications_reader_.first != nullptr) //Exist Pub Writer and i have pub reader
     {
         tmp_guid.entityId = c_EntityId_SEDPPubWriter;
@@ -921,8 +904,6 @@ void EDPSimple::removeRemoteEndpoints(
     }
     auxendp = endp;
     auxendp &= DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR;
-    //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
-    //auxendp = 1;
     if (auxendp != 0 && publications_writer_.first != nullptr) //Exist Pub Detector
     {
         tmp_guid.entityId = c_EntityId_SEDPPubReader;
@@ -930,8 +911,6 @@ void EDPSimple::removeRemoteEndpoints(
     }
     auxendp = endp;
     auxendp &= DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER;
-    //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
-    //auxendp = 1;
     if (auxendp != 0 && subscriptions_reader_.first != nullptr) //Exist Pub Announcer
     {
         EPROSIMA_LOG_INFO(RTPS_EDP, "Adding SEDP Sub Writer to my Sub Reader");
@@ -940,8 +919,6 @@ void EDPSimple::removeRemoteEndpoints(
     }
     auxendp = endp;
     auxendp &= DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_DETECTOR;
-    //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
-    //auxendp = 1;
     if (auxendp != 0 && subscriptions_writer_.first != nullptr) //Exist Pub Announcer
     {
         EPROSIMA_LOG_INFO(RTPS_EDP, "Adding SEDP Sub Reader to my Sub Writer");
@@ -952,8 +929,6 @@ void EDPSimple::removeRemoteEndpoints(
 #if HAVE_SECURITY
     auxendp = endp;
     auxendp &= DISC_BUILTIN_ENDPOINT_PUBLICATION_SECURE_ANNOUNCER;
-    //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
-    //auxendp = 1;
     if (auxendp != 0 && publications_secure_reader_.first != nullptr)
     {
         tmp_guid.entityId = sedp_builtin_publications_secure_writer;
@@ -966,8 +941,6 @@ void EDPSimple::removeRemoteEndpoints(
 
     auxendp = endp;
     auxendp &= DISC_BUILTIN_ENDPOINT_PUBLICATION_SECURE_DETECTOR;
-    //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
-    //auxendp = 1;
     if (auxendp != 0 && publications_secure_writer_.first != nullptr)
     {
         tmp_guid.entityId = sedp_builtin_publications_secure_reader;
@@ -980,8 +953,6 @@ void EDPSimple::removeRemoteEndpoints(
 
     auxendp = endp;
     auxendp &= DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_SECURE_ANNOUNCER;
-    //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
-    //auxendp = 1;
     if (auxendp != 0 && subscriptions_secure_reader_.first != nullptr)
     {
         EPROSIMA_LOG_INFO(RTPS_EDP, "Adding SEDP Sub Writer to my Sub Reader");
@@ -994,8 +965,6 @@ void EDPSimple::removeRemoteEndpoints(
     }
     auxendp = endp;
     auxendp &= DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_SECURE_DETECTOR;
-    //FIXME: FIX TO NOT FAIL WITH BAD BUILTIN ENDPOINT SET
-    //auxendp = 1;
     if (auxendp != 0 && subscriptions_secure_writer_.first != nullptr)
     {
         EPROSIMA_LOG_INFO(RTPS_EDP, "Adding SEDP Sub Reader to my Sub Writer");

--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -483,7 +483,6 @@ bool WLP::assignRemoteEndpoints(
 {
     const NetworkFactory& network = mp_participant->network_factory();
     uint32_t endp = pdata.m_availableBuiltinEndpoints;
-    uint32_t partdet = endp;
     uint32_t auxendp = endp;
     bool use_multicast_locators = !mp_participant->getAttributes().builtin.avoid_builtin_multicast ||
             pdata.metatraffic_locators.unicast.empty();
@@ -505,10 +504,8 @@ bool WLP::assignRemoteEndpoints(
     temp_reader_proxy_data_.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
     temp_reader_proxy_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
 
-    partdet &= DISC_BUILTIN_ENDPOINT_PARTICIPANT_DETECTOR; //Habria que quitar esta linea que comprueba si tiene PDP.
     auxendp &= BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_WRITER;
-
-    if ((auxendp != 0 || partdet != 0) && this->mp_builtinReader != nullptr)
+    if (auxendp != 0 && this->mp_builtinReader != nullptr)
     {
         EPROSIMA_LOG_INFO(RTPS_LIVELINESS, "Adding remote writer to my local Builtin Reader");
         temp_writer_proxy_data_.guid().entityId = c_EntityId_WriterLiveliness;
@@ -517,7 +514,7 @@ bool WLP::assignRemoteEndpoints(
     }
     auxendp = endp;
     auxendp &= BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_READER;
-    if ((auxendp != 0 || partdet != 0) && this->mp_builtinWriter != nullptr)
+    if (auxendp != 0 && this->mp_builtinWriter != nullptr)
     {
         EPROSIMA_LOG_INFO(RTPS_LIVELINESS, "Adding remote reader to my local Builtin Writer");
         temp_reader_proxy_data_.guid().entityId = c_EntityId_ReaderLiveliness;
@@ -527,7 +524,7 @@ bool WLP::assignRemoteEndpoints(
 #if HAVE_SECURITY
     auxendp = endp;
     auxendp &= BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_SECURE_DATA_WRITER;
-    if ((auxendp != 0 || partdet != 0) && this->mp_builtinReaderSecure != nullptr)
+    if (auxendp != 0 && this->mp_builtinReaderSecure != nullptr)
     {
         EPROSIMA_LOG_INFO(RTPS_LIVELINESS, "Adding remote writer to my local Builtin Secure Reader");
         temp_writer_proxy_data_.guid().entityId = c_EntityId_WriterLivelinessSecure;
@@ -543,7 +540,7 @@ bool WLP::assignRemoteEndpoints(
     }
     auxendp = endp;
     auxendp &= BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_SECURE_DATA_READER;
-    if ((auxendp != 0 || partdet != 0) && this->mp_builtinWriterSecure != nullptr)
+    if (auxendp != 0 && this->mp_builtinWriterSecure != nullptr)
     {
         EPROSIMA_LOG_INFO(RTPS_LIVELINESS, "Adding remote reader to my local Builtin Secure Writer");
         temp_reader_proxy_data_.guid().entityId = c_EntityId_ReaderLivelinessSecure;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR fixes the way the builtin endpoints mask from the DATA(p) is processed, so communication is not enforced on certain builtin endpoints when they are not present on the mask.

Regression tests will be added on a follow-up, since we have other changes depending on this.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
@Mergifyio backport 2.9.x 2.8.x 2.6.x 2.1.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- Tests that thoroughly check the regression **will be added on a follow-up PR**
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
