### PR TITLE
Fix sequence of nested structs.

### DIFF
--- a/src/cpp/dynamic-types/DynamicTypeBuilderFactory.cpp
+++ b/src/cpp/dynamic-types/DynamicTypeBuilderFactory.cpp
@@ -1188,18 +1188,24 @@ void DynamicTypeBuilderFactory::build_sequence_type_code(
         object.complete().sequence_type().element().common().element_flags().IS_KEY(false);
         object.complete().sequence_type().element().common().element_flags().IS_DEFAULT(false);
 
-        //TypeIdentifier ident;
-        //build_type_identifier(descriptor->get_base_type()->descriptor_, ident);
         TypeObject obj;
         build_type_object(descriptor->get_element_type(), obj, complete);
-        TypeIdentifier ident = *TypeObjectFactory::get_instance()->get_type_identifier(
-            descriptor->get_element_type()->get_name());
 
-        object.complete().sequence_type().element().common().type(ident);
+        DynamicType_ptr element_type = descriptor->get_element_type();
+        if (element_type == nullptr) {
+          throw std::runtime_error("Could not get the element type");
+        }
+
+        const TypeIdentifier * ident_ptr = TypeObjectFactory::get_instance()->get_type_identifier(element_type->get_name(), true);
+        if (ident_ptr == nullptr) {
+          throw std::runtime_error("Could not get complete type identifier");
+        }
+
+        object.complete().sequence_type().element().common().type(*ident_ptr);
 
         const TypeIdentifier* identifier =
                 TypeObjectFactory::get_instance()->get_sequence_identifier(
-            descriptor->get_element_type()->get_name(),
+            element_type->get_name(),
             descriptor->get_bounds(),
             true);
 
@@ -1225,18 +1231,24 @@ void DynamicTypeBuilderFactory::build_sequence_type_code(
         object.minimal().sequence_type().element().common().element_flags().IS_KEY(false);
         object.minimal().sequence_type().element().common().element_flags().IS_DEFAULT(false);
 
-        //TypeIdentifier ident;
-        //build_type_identifier(descriptor->get_base_type()->descriptor_, ident);
         TypeObject obj;
         build_type_object(descriptor->get_element_type(), obj);
-        TypeIdentifier ident = *TypeObjectFactory::get_instance()->get_type_identifier(
-            descriptor->get_element_type()->get_name());
 
-        object.minimal().sequence_type().element().common().type(ident);
+        DynamicType_ptr element_type = descriptor->get_element_type();
+        if (element_type == nullptr) {
+          throw std::runtime_error("Could not get the element type");
+        }
+
+        const TypeIdentifier * ident_ptr = TypeObjectFactory::get_instance()->get_type_identifier(element_type->get_name());
+        if (ident_ptr == nullptr) {
+          throw std::runtime_error("Could not get minimal type identifier");
+        }
+
+        object.minimal().sequence_type().element().common().type(*ident_ptr);
 
         const TypeIdentifier* identifier =
                 TypeObjectFactory::get_instance()->get_sequence_identifier(
-            descriptor->get_element_type()->get_name(),
+            element_type->get_name(),
             descriptor->get_bounds(),
             false);
 

--- a/src/cpp/dynamic-types/TypeObjectFactory.cpp
+++ b/src/cpp/dynamic-types/TypeObjectFactory.cpp
@@ -1121,7 +1121,7 @@ const TypeIdentifier* TypeObjectFactory::get_stored_type_identifier(
     {
         return nullptr;
     }
-    if (identifier->_d() == EK_COMPLETE)
+    if (is_type_identifier_complete(identifier))
     {
         for (auto& it : complete_identifiers_)
         {
@@ -1157,7 +1157,7 @@ std::string TypeObjectFactory::get_type_name(
     {
         return "<NULLPTR>";
     }
-    if (identifier->_d() == EK_COMPLETE)
+    if (is_type_identifier_complete(identifier))
     {
         for (auto& it : complete_identifiers_)
         {
@@ -1289,7 +1289,7 @@ std::string TypeObjectFactory::generate_name_and_store_type_identifier(
 const TypeIdentifier* TypeObjectFactory::try_get_complete(
         const TypeIdentifier* identifier) const
 {
-    if (identifier->_d() == EK_COMPLETE)
+    if (is_type_identifier_complete(identifier))
     {
         return identifier;
     }
@@ -1392,7 +1392,14 @@ void TypeObjectFactory::add_type_object(
         {
             if (object->_d() == EK_MINIMAL)
             {
-                const TypeIdentifier* typeId = identifiers_[type_name];
+                // Use find instead of [] so no nullptr is created in case it does not exist
+                auto it = identifiers_.find(type_name);
+                const TypeIdentifier* typeId = nullptr;
+
+                if (it != identifiers_.end())
+                {
+                    typeId = it->second;
+                }
                 if (objects_.find(typeId) == objects_.end())
                 {
                     TypeObject* obj = new TypeObject();
@@ -1402,7 +1409,13 @@ void TypeObjectFactory::add_type_object(
             }
             else if (object->_d() == EK_COMPLETE)
             {
-                const TypeIdentifier* typeId = complete_identifiers_[type_name];
+                auto it = complete_identifiers_.find(type_name);
+                const TypeIdentifier* typeId = nullptr;
+
+                if (it != complete_identifiers_.end())
+                {
+                    typeId = it->second;
+                }
                 if (complete_objects_.find(typeId) == complete_objects_.end())
                 {
                     TypeObject* obj = new TypeObject();
@@ -1413,7 +1426,13 @@ void TypeObjectFactory::add_type_object(
         }
         else
         {
-            const TypeIdentifier* typeId = identifiers_[type_name];
+            auto it = identifiers_.find(type_name);
+            const TypeIdentifier* typeId = nullptr;
+
+            if (it != identifiers_.end())
+            {
+                typeId = it->second;
+            }
             if (object->_d() == EK_MINIMAL)
             {
                 if (objects_.find(typeId) == objects_.end())

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1457,7 +1457,7 @@ bool DomainParticipantImpl::register_dynamic_type_to_factories(
             TypeObject typeObj;
             dynFactory->build_type_object(dpst->GetDynamicType()->get_type_descriptor(), typeObj, &members);
             // Minimal too
-            dynFactory->build_type_object(dpst->GetDynamicType()->get_type_descriptor(), typeObj, &members, false);
+            //dynFactory->build_type_object(dpst->GetDynamicType()->get_type_descriptor(), typeObj, &members, false);
             const TypeIdentifier* type_id2 = objectFactory->get_type_identifier(dpst->getName());
             const TypeObject* type_obj = objectFactory->get_type_object(dpst->getName());
             if (type_id2 == nullptr)


### PR DESCRIPTION
It turns out that with the current XTypes code, attempting to create a sequence of nested structs ends up in a segfault. See https://github.com/eProsima/Fast-DDS/issues/2969 for the details.

After tracing through, it looks like what is happening is that there is some confusion on what should be registered as a "complete" type vs a "minimal" type, according to XTypes 1.3.  In particular, what is happening is that the nested structure is being created as a complete type, but then when we go to look it up, we look it up as both a complete type and a minimal type.  The former succeeds, and the latter fails, leading to the crash.

This attempted fix just skips trying to look it up as a minimal type at all.  This is enough to fix the crash.  This is probably not the correct fix, but it is unclear whether:

1.  We should be "building" the type as both a complete and minimal one at build() time, or
2.  We should only look it up as either a complete or minimal

I'm looking for feedback on which way to go here.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [ ] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [ ] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.