### PR TITLE
Protect DomainParticipant set_listener [16040]

### DIFF
--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -135,13 +135,35 @@ public:
      * Modifies the DomainParticipantListener, sets the mask to StatusMask::all()
      *
      * @param listener New value for the DomainParticipantListener
+     * @return RETCODE_OK if successful, RETCODE_ERROR otherwise.
+     * @warning Do not call this method from a \c DomainParticipantListener callback.
+     */
+    RTPS_DllAPI ReturnCode_t set_listener(
+            DomainParticipantListener* listener);
+
+    /**
+     * Modifies the DomainParticipantListener, sets the mask to StatusMask::all()
+     *
+     * @param listener New value for the DomainParticipantListener
      * @param timeout Maximum time to wait for executing callbacks to finish.
      * @return RETCODE_OK if successful, RETCODE_ERROR if failed (timeout expired).
      * @warning Do not call this method from a \c DomainParticipantListener callback.
      */
     RTPS_DllAPI ReturnCode_t set_listener(
             DomainParticipantListener* listener,
-            const std::chrono::seconds timeout = std::chrono::seconds::max());
+            const std::chrono::seconds timeout);
+
+    /**
+     * Modifies the DomainParticipantListener.
+     *
+     * @param listener New value for the DomainParticipantListener
+     * @param mask StatusMask that holds statuses the listener responds to
+     * @return RETCODE_OK if successful, RETCODE_ERROR otherwise.
+     * @warning Do not call this method from a \c DomainParticipantListener callback.
+     */
+    RTPS_DllAPI ReturnCode_t set_listener(
+            DomainParticipantListener* listener,
+            const StatusMask& mask);
 
     /**
      * Modifies the DomainParticipantListener.
@@ -155,7 +177,7 @@ public:
     RTPS_DllAPI ReturnCode_t set_listener(
             DomainParticipantListener* listener,
             const StatusMask& mask,
-            const std::chrono::seconds timeout = std::chrono::seconds::max());
+            const std::chrono::seconds timeout);
 
     /**
      * @brief This operation enables the DomainParticipant

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -135,27 +135,27 @@ public:
      * Modifies the DomainParticipantListener, sets the mask to StatusMask::all()
      *
      * @param listener New value for the DomainParticipantListener
-     * @param timeout Maximum time to wait for executing callbacks to finish. Defaults to 0: no wait limit.
+     * @param timeout Maximum time to wait for executing callbacks to finish.
      * @return RETCODE_OK if successful, RETCODE_ERROR if failed (timeout expired).
      * @warning Do not call this method from a \c DomainParticipantListener callback.
      */
     RTPS_DllAPI ReturnCode_t set_listener(
             DomainParticipantListener* listener,
-            const std::chrono::seconds timeout = std::chrono::seconds::zero());
+            const std::chrono::seconds timeout = std::chrono::seconds::max());
 
     /**
      * Modifies the DomainParticipantListener.
      *
      * @param listener New value for the DomainParticipantListener
      * @param mask StatusMask that holds statuses the listener responds to
-     * @param timeout Maximum time to wait for executing callbacks to finish. Defaults to 0: no wait limit.
+     * @param timeout Maximum time to wait for executing callbacks to finish.
      * @return RETCODE_OK if successful, RETCODE_ERROR if failed (timeout expired)
      * @warning Do not call this method from a \c DomainParticipantListener callback.
      */
     RTPS_DllAPI ReturnCode_t set_listener(
             DomainParticipantListener* listener,
             const StatusMask& mask,
-            const std::chrono::seconds timeout = std::chrono::seconds::zero());
+            const std::chrono::seconds timeout = std::chrono::seconds::max());
 
     /**
      * @brief This operation enables the DomainParticipant

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -134,22 +134,28 @@ public:
     /**
      * Modifies the DomainParticipantListener, sets the mask to StatusMask::all()
      *
-     * @param listener new value for the DomainParticipantListener
-     * @return RETCODE_OK
+     * @param listener New value for the DomainParticipantListener
+     * @param timeout Maximum time to wait for executing callbacks to finish. Defaults to 0: no wait limit.
+     * @return RETCODE_OK if successful, RETCODE_ERROR if failed (timeout expired).
+     * @warning Do not call this method from a \c DomainParticipantListener callback.
      */
     RTPS_DllAPI ReturnCode_t set_listener(
-            DomainParticipantListener* listener);
+            DomainParticipantListener* listener,
+            const std::chrono::seconds timeout = std::chrono::seconds::zero());
 
     /**
      * Modifies the DomainParticipantListener.
      *
-     * @param listener new value for the DomainParticipantListener
+     * @param listener New value for the DomainParticipantListener
      * @param mask StatusMask that holds statuses the listener responds to
-     * @return RETCODE_OK
+     * @param timeout Maximum time to wait for executing callbacks to finish. Defaults to 0: no wait limit.
+     * @return RETCODE_OK if successful, RETCODE_ERROR if failed (timeout expired)
+     * @warning Do not call this method from a \c DomainParticipantListener callback.
      */
     RTPS_DllAPI ReturnCode_t set_listener(
             DomainParticipantListener* listener,
-            const StatusMask& mask);
+            const StatusMask& mask,
+            const std::chrono::seconds timeout = std::chrono::seconds::zero());
 
     /**
      * @brief This operation enables the DomainParticipant

--- a/src/cpp/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipant.cpp
@@ -66,16 +66,18 @@ const DomainParticipantListener* DomainParticipant::get_listener() const
 }
 
 ReturnCode_t DomainParticipant::set_listener(
-        DomainParticipantListener* listener)
+        DomainParticipantListener* listener,
+        const std::chrono::seconds timeout)
 {
-    return set_listener(listener, StatusMask::all());
+    return set_listener(listener, StatusMask::all(), timeout);
 }
 
 ReturnCode_t DomainParticipant::set_listener(
         DomainParticipantListener* listener,
-        const StatusMask& mask)
+        const StatusMask& mask,
+        const std::chrono::seconds timeout)
 {
-    ReturnCode_t ret_val = impl_->set_listener(listener);
+    ReturnCode_t ret_val = impl_->set_listener(listener, timeout);
     if (ret_val == ReturnCode_t::RETCODE_OK)
     {
         status_mask_ = mask;

--- a/src/cpp/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipant.cpp
@@ -66,10 +66,23 @@ const DomainParticipantListener* DomainParticipant::get_listener() const
 }
 
 ReturnCode_t DomainParticipant::set_listener(
+        DomainParticipantListener* listener)
+{
+    return set_listener(listener, std::chrono::seconds::max());
+}
+
+ReturnCode_t DomainParticipant::set_listener(
         DomainParticipantListener* listener,
         const std::chrono::seconds timeout)
 {
     return set_listener(listener, StatusMask::all(), timeout);
+}
+
+ReturnCode_t DomainParticipant::set_listener(
+        DomainParticipantListener* listener,
+        const StatusMask& mask)
+{
+    return set_listener(listener, mask, std::chrono::seconds::max());
 }
 
 ReturnCode_t DomainParticipant::set_listener(

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1531,13 +1531,17 @@ void DomainParticipantImpl::MyRTPSParticipantListener::onParticipantDiscovery(
         RTPSParticipant*,
         ParticipantDiscoveryInfo&& info)
 {
-    DomainParticipantListener* listener = nullptr;
-    DomainParticipant* participant = nullptr;
-    if (participant_ != nullptr
-            && (participant = participant_->get_participant()) != nullptr
-            && (listener = participant_->get_listener()) != nullptr)
+    Sentry sentinel(this);
+    if (sentinel)
     {
-        listener->on_participant_discovery(participant, std::move(info));
+        DomainParticipantListener* listener = nullptr;
+        DomainParticipant* participant = nullptr;
+        if (participant_ != nullptr
+                && (participant = participant_->get_participant()) != nullptr
+                && (listener = participant_->get_listener()) != nullptr)
+        {
+            listener->on_participant_discovery(participant, std::move(info));
+        }
     }
 }
 
@@ -1546,13 +1550,17 @@ void DomainParticipantImpl::MyRTPSParticipantListener::onParticipantAuthenticati
         RTPSParticipant*,
         ParticipantAuthenticationInfo&& info)
 {
-    DomainParticipantListener* listener = nullptr;
-    DomainParticipant* participant = nullptr;
-    if (participant_ != nullptr
-            && (participant = participant_->get_participant()) != nullptr
-            && (listener = participant_->get_listener()) != nullptr)
+    Sentry sentinel(this);
+    if (sentinel)
     {
-        listener->onParticipantAuthentication(participant, std::move(info));
+        DomainParticipantListener* listener = nullptr;
+        DomainParticipant* participant = nullptr;
+        if (participant_ != nullptr
+                && (participant = participant_->get_participant()) != nullptr
+                && (listener = participant_->get_listener()) != nullptr)
+        {
+            listener->onParticipantAuthentication(participant, std::move(info));
+        }
     }
 }
 
@@ -1562,13 +1570,17 @@ void DomainParticipantImpl::MyRTPSParticipantListener::onReaderDiscovery(
         RTPSParticipant*,
         ReaderDiscoveryInfo&& info)
 {
-    DomainParticipantListener* listener = nullptr;
-    DomainParticipant* participant = nullptr;
-    if (participant_ != nullptr
-            && (participant = participant_->get_participant()) != nullptr
-            && (listener = participant_->get_listener()) != nullptr)
+    Sentry sentinel(this);
+    if (sentinel)
     {
-        listener->on_subscriber_discovery(participant, std::move(info));
+        DomainParticipantListener* listener = nullptr;
+        DomainParticipant* participant = nullptr;
+        if (participant_ != nullptr
+                && (participant = participant_->get_participant()) != nullptr
+                && (listener = participant_->get_listener()) != nullptr)
+        {
+            listener->on_subscriber_discovery(participant, std::move(info));
+        }
     }
 }
 
@@ -1576,13 +1588,17 @@ void DomainParticipantImpl::MyRTPSParticipantListener::onWriterDiscovery(
         RTPSParticipant*,
         WriterDiscoveryInfo&& info)
 {
-    DomainParticipantListener* listener = nullptr;
-    DomainParticipant* participant = nullptr;
-    if (participant_ != nullptr
-            && (participant = participant_->get_participant()) != nullptr
-            && (listener = participant_->get_listener()) != nullptr)
+    Sentry sentinel(this);
+    if (sentinel)
     {
-        listener->on_publisher_discovery(participant, std::move(info));
+        DomainParticipantListener* listener = nullptr;
+        DomainParticipant* participant = nullptr;
+        if (participant_ != nullptr
+                && (participant = participant_->get_participant()) != nullptr
+                && (listener = participant_->get_listener()) != nullptr)
+        {
+            listener->on_publisher_discovery(participant, std::move(info));
+        }
     }
 }
 
@@ -1594,22 +1610,26 @@ void DomainParticipantImpl::MyRTPSParticipantListener::on_type_discovery(
         const fastrtps::types::TypeObject* object,
         fastrtps::types::DynamicType_ptr dyn_type)
 {
-    DomainParticipantListener* listener = nullptr;
-    DomainParticipant* participant = nullptr;
-    if (participant_ != nullptr
-            && (participant = participant_->get_participant()) != nullptr
-            && (listener = participant_->get_listener()) != nullptr)
+    Sentry sentinel(this);
+    if (sentinel)
     {
-        listener->on_type_discovery(
-            participant,
-            request_sample_id,
-            topic,
-            identifier,
-            object,
-            dyn_type);
-    }
+        DomainParticipantListener* listener = nullptr;
+        DomainParticipant* participant = nullptr;
+        if (participant_ != nullptr
+                && (participant = participant_->get_participant()) != nullptr
+                && (listener = participant_->get_listener()) != nullptr)
+        {
+            listener->on_type_discovery(
+                participant,
+                request_sample_id,
+                topic,
+                identifier,
+                object,
+                dyn_type);
+        }
 
-    participant_->check_get_type_request(request_sample_id, identifier, object, dyn_type);
+        participant_->check_get_type_request(request_sample_id, identifier, object, dyn_type);
+    }
 }
 
 void DomainParticipantImpl::MyRTPSParticipantListener::on_type_dependencies_reply(
@@ -1617,17 +1637,21 @@ void DomainParticipantImpl::MyRTPSParticipantListener::on_type_dependencies_repl
         const fastrtps::rtps::SampleIdentity& request_sample_id,
         const fastrtps::types::TypeIdentifierWithSizeSeq& dependencies)
 {
-    DomainParticipantListener* listener = nullptr;
-    DomainParticipant* participant = nullptr;
-    if (participant_ != nullptr
-            && (participant = participant_->get_participant()) != nullptr
-            && (listener = participant_->get_listener()) != nullptr)
+    Sentry sentinel(this);
+    if (sentinel)
     {
-        listener->on_type_dependencies_reply(
-            participant, request_sample_id, dependencies);
-    }
+        DomainParticipantListener* listener = nullptr;
+        DomainParticipant* participant = nullptr;
+        if (participant_ != nullptr
+                && (participant = participant_->get_participant()) != nullptr
+                && (listener = participant_->get_listener()) != nullptr)
+        {
+            listener->on_type_dependencies_reply(
+                participant, request_sample_id, dependencies);
+        }
 
-    participant_->check_get_dependencies_request(request_sample_id, dependencies);
+        participant_->check_get_dependencies_request(request_sample_id, dependencies);
+    }
 }
 
 void DomainParticipantImpl::MyRTPSParticipantListener::on_type_information_received(
@@ -1636,17 +1660,21 @@ void DomainParticipantImpl::MyRTPSParticipantListener::on_type_information_recei
         const fastrtps::string_255& type_name,
         const fastrtps::types::TypeInformation& type_information)
 {
-    DomainParticipantListener* listener = nullptr;
-    DomainParticipant* participant = nullptr;
-    if (participant_ != nullptr
-            && (participant = participant_->get_participant()) != nullptr
-            && (listener = participant_->get_listener()) != nullptr)
+    Sentry sentinel(this);
+    if (sentinel)
     {
-        if (type_information.complete().typeid_with_size().type_id()._d() > 0
-                || type_information.minimal().typeid_with_size().type_id()._d() > 0)
+        DomainParticipantListener* listener = nullptr;
+        DomainParticipant* participant = nullptr;
+        if (participant_ != nullptr
+                && (participant = participant_->get_participant()) != nullptr
+                && (listener = participant_->get_listener()) != nullptr)
         {
-            listener->on_type_information_received(
-                participant, topic_name, type_name, type_information);
+            if (type_information.complete().typeid_with_size().type_id()._d() > 0
+                    || type_information.minimal().typeid_with_size().type_id()._d() > 0)
+            {
+                listener->on_type_information_received(
+                    participant, topic_name, type_name, type_information);
+            }
         }
     }
 }

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -232,14 +232,11 @@ DomainParticipantImpl::~DomainParticipantImpl()
         types_.clear();
     }
 
-    // Proceed if no callbacks are being executed.
+    std::lock_guard<std::mutex> _(mtx_gs_);
+
+    // Assert no callbacks are being executed.
     // Note that this should never occur since reception and events threads joined when removing rtps_participant.
-    std::unique_lock<std::mutex> _(mtx_gs_);
-    cv_gs_.wait(_, [this]
-            {
-                assert(!(rtps_listener_.callback_counter_ > 0));
-                return !(rtps_listener_.callback_counter_ > 0);
-            });
+    assert(!(rtps_listener_.callback_counter_ > 0));
 
     if (participant_)
     {

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -159,7 +159,6 @@ void DomainParticipantImpl::disable()
     {
         participant->set_listener(nullptr);
     }
-    rtps_listener_.participant_ = nullptr;
 
     // The function to disable the DomainParticipantImpl is called from
     // DomainParticipantFactory::delete_participant() and DomainParticipantFactory destructor.
@@ -1533,9 +1532,12 @@ void DomainParticipantImpl::MyRTPSParticipantListener::onParticipantDiscovery(
         ParticipantDiscoveryInfo&& info)
 {
     DomainParticipantListener* listener = nullptr;
-    if (participant_ != nullptr && (listener = participant_->get_listener()) != nullptr)
+    DomainParticipant* participant = nullptr;
+    if (participant_ != nullptr
+            && (participant = participant_->get_participant()) != nullptr
+            && (listener = participant_->get_listener()) != nullptr)
     {
-        listener->on_participant_discovery(participant_->participant_, std::move(info));
+        listener->on_participant_discovery(participant, std::move(info));
     }
 }
 
@@ -1545,9 +1547,12 @@ void DomainParticipantImpl::MyRTPSParticipantListener::onParticipantAuthenticati
         ParticipantAuthenticationInfo&& info)
 {
     DomainParticipantListener* listener = nullptr;
-    if (participant_ != nullptr && (listener = participant_->get_listener()) != nullptr)
+    DomainParticipant* participant = nullptr;
+    if (participant_ != nullptr
+            && (participant = participant_->get_participant()) != nullptr
+            && (listener = participant_->get_listener()) != nullptr)
     {
-        listener->onParticipantAuthentication(participant_->participant_, std::move(info));
+        listener->onParticipantAuthentication(participant, std::move(info));
     }
 }
 
@@ -1558,9 +1563,12 @@ void DomainParticipantImpl::MyRTPSParticipantListener::onReaderDiscovery(
         ReaderDiscoveryInfo&& info)
 {
     DomainParticipantListener* listener = nullptr;
-    if (participant_ != nullptr && (listener = participant_->get_listener()) != nullptr)
+    DomainParticipant* participant = nullptr;
+    if (participant_ != nullptr
+            && (participant = participant_->get_participant()) != nullptr
+            && (listener = participant_->get_listener()) != nullptr)
     {
-        listener->on_subscriber_discovery(participant_->participant_, std::move(info));
+        listener->on_subscriber_discovery(participant, std::move(info));
     }
 }
 
@@ -1569,9 +1577,12 @@ void DomainParticipantImpl::MyRTPSParticipantListener::onWriterDiscovery(
         WriterDiscoveryInfo&& info)
 {
     DomainParticipantListener* listener = nullptr;
-    if (participant_ != nullptr && (listener = participant_->get_listener()) != nullptr)
+    DomainParticipant* participant = nullptr;
+    if (participant_ != nullptr
+            && (participant = participant_->get_participant()) != nullptr
+            && (listener = participant_->get_listener()) != nullptr)
     {
-        listener->on_publisher_discovery(participant_->participant_, std::move(info));
+        listener->on_publisher_discovery(participant, std::move(info));
     }
 }
 
@@ -1584,10 +1595,13 @@ void DomainParticipantImpl::MyRTPSParticipantListener::on_type_discovery(
         fastrtps::types::DynamicType_ptr dyn_type)
 {
     DomainParticipantListener* listener = nullptr;
-    if (participant_ != nullptr && (listener = participant_->get_listener()) != nullptr)
+    DomainParticipant* participant = nullptr;
+    if (participant_ != nullptr
+            && (participant = participant_->get_participant()) != nullptr
+            && (listener = participant_->get_listener()) != nullptr)
     {
         listener->on_type_discovery(
-            participant_->participant_,
+            participant,
             request_sample_id,
             topic,
             identifier,
@@ -1604,10 +1618,13 @@ void DomainParticipantImpl::MyRTPSParticipantListener::on_type_dependencies_repl
         const fastrtps::types::TypeIdentifierWithSizeSeq& dependencies)
 {
     DomainParticipantListener* listener = nullptr;
-    if (participant_ != nullptr && (listener = participant_->get_listener()) != nullptr)
+    DomainParticipant* participant = nullptr;
+    if (participant_ != nullptr
+            && (participant = participant_->get_participant()) != nullptr
+            && (listener = participant_->get_listener()) != nullptr)
     {
         listener->on_type_dependencies_reply(
-            participant_->participant_, request_sample_id, dependencies);
+            participant, request_sample_id, dependencies);
     }
 
     participant_->check_get_dependencies_request(request_sample_id, dependencies);

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -582,7 +582,9 @@ protected:
                 : listener_(listener)
                 , on_guard_(false)
             {
-                if (listener_ != nullptr && listener_->participant_ != nullptr)
+                if (listener_ != nullptr && listener_->participant_ != nullptr &&
+                        listener_->participant_->listener_ != nullptr &&
+                        listener_->participant_->participant_ != nullptr)
                 {
                     std::lock_guard<std::mutex> _(listener_->participant_->mtx_gs_);
                     if (listener_->callback_counter_ >= 0)
@@ -597,7 +599,9 @@ protected:
             {
                 if (on_guard_)
                 {
-                    assert(listener_ != nullptr && listener_->participant_ != nullptr);
+                    assert(
+                        listener_ != nullptr && listener_->participant_ != nullptr && listener_->participant_->listener_ != nullptr &&
+                        listener_->participant_->participant_ != nullptr);
                     bool notify = false;
                     {
                         std::lock_guard<std::mutex> lock(listener_->participant_->mtx_gs_);

--- a/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
+++ b/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
@@ -142,6 +142,13 @@ public:
         return ReturnCode_t::RETCODE_OK;
     }
 
+    ReturnCode_t set_listener(
+            DomainParticipantListener* /*listener*/,
+            const std::chrono::seconds /*timeout*/)
+    {
+        return ReturnCode_t::RETCODE_OK;
+    }
+
     const DomainParticipantListener* get_listener() const
     {
         return listener_;

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -2189,8 +2189,15 @@ public:
             eprosima::fastdds::dds::DomainParticipant*,
             eprosima::fastrtps::rtps::ParticipantDiscoveryInfo&&) override
     {
-        promise_.set_value();
-        std::this_thread::sleep_for(std::chrono::seconds(2));
+        try
+        {
+            promise_.set_value();
+            std::this_thread::sleep_for(std::chrono::seconds(2));
+        }
+        catch (std::future_error&)
+        {
+            // do nothing
+        }
     }
 
 private:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Related to #3040 
 This PR modifies the current behaviour of `DomainParitcipant::set_listener`, so that for it to proceed no callbacks should be on execution at that moment. This would prevent the following situation: user sets participant's listener to `nullptr` and destroys the object (listener), while `DomainParticipantImpl::MyRTPSParticipantListener` is about to invoke participant's listener callback (obtained reference was still not `nullptr`), hence resulting in undefined behaviour.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
