### PR TITLE
Fix bug in Topic creation with differfent Type Name [16242]

### DIFF
--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1324,7 +1324,7 @@ Topic* DomainParticipantImpl::create_topic(
     InstanceHandle_t topic_handle;
     create_instance_handle(topic_handle);
 
-    TopicProxyFactory* factory = new TopicProxyFactory(this, topic_name, mask, type_support, qos, listener);
+    TopicProxyFactory* factory = new TopicProxyFactory(this, topic_name, type_name, mask, type_support, qos, listener);
     TopicProxy* proxy = factory->create_topic();
     Topic* topic = proxy->get_topic();
     topic->set_instance_handle(topic_handle);

--- a/src/cpp/fastdds/topic/TopicProxyFactory.cpp
+++ b/src/cpp/fastdds/topic/TopicProxyFactory.cpp
@@ -28,7 +28,7 @@ namespace dds {
 
 TopicProxy* TopicProxyFactory::create_topic()
 {
-    TopicProxy* ret_val = new TopicProxy(topic_name_, topic_impl_.get_type()->getName(), status_mask_, &topic_impl_);
+    TopicProxy* ret_val = new TopicProxy(topic_name_, type_name_, status_mask_, &topic_impl_);
     proxies_.emplace_back(ret_val);
     return ret_val;
 }

--- a/src/cpp/fastdds/topic/TopicProxyFactory.hpp
+++ b/src/cpp/fastdds/topic/TopicProxyFactory.hpp
@@ -61,11 +61,13 @@ public:
     TopicProxyFactory(
             DomainParticipantImpl* participant,
             const std::string& topic_name,
+            const std::string& type_name,
             const StatusMask& status_mask,
             TypeSupport type_support,
             const TopicQos& qos,
             TopicListener* listener)
         : topic_name_(topic_name)
+        , type_name_(type_name)
         , status_mask_(status_mask)
         , topic_impl_(this, participant, type_support, qos, listener)
     {
@@ -125,6 +127,8 @@ private:
 
     //! Name of the topic managed by the factory.
     std::string topic_name_;
+    //! Name of the topic data type
+    std::string type_name_;
     //! StatusMask of the topic managed by the factory.
     StatusMask status_mask_;
     //! Implementation object for the topic managed by the factory.

--- a/src/cpp/fastdds/topic/TopicProxyFactory.hpp
+++ b/src/cpp/fastdds/topic/TopicProxyFactory.hpp
@@ -53,6 +53,7 @@ public:
      *
      * @param participant   Pointer to the DomainParticipantImpl creating this object.
      * @param topic_name    Name of the topic managed by this factory.
+     * @param type_name     Name of the data type related with this topic.
      * @param status_mask   Initial StatusMask of the topic managed by this factory.
      * @param type_support  TypeSupport to use for the topics created by this factory.
      * @param qos           TopicQos to use on the creation of the implementation object.

--- a/test/unittest/dds/publisher/PublisherTests.cpp
+++ b/test/unittest/dds/publisher/PublisherTests.cpp
@@ -493,32 +493,6 @@ TEST(PublisherTests, CreateDataWriter)
     ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), ReturnCode_t::RETCODE_OK);
 }
 
-TEST(PublisherTests, CreateDataWriterWithDifferentTypeName)
-{
-    DomainParticipant* participant =
-            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
-    ASSERT_NE(participant, nullptr);
-
-    Publisher* publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT);
-    ASSERT_NE(publisher, nullptr);
-
-    std::string type_name = "other_different_type_name_because_of_reasons_eg_mangling";
-    TypeSupport type(new TopicDataTypeMock());
-    type.register_type(participant, type_name);
-
-    Topic* topic = participant->create_topic("footopic", type_name, TOPIC_QOS_DEFAULT);
-    ASSERT_NE(topic, nullptr);
-
-    DataWriter* datawriter = publisher->create_datawriter(topic, DATAWRITER_QOS_DEFAULT);
-    ASSERT_NE(datawriter, nullptr);
-
-    ASSERT_EQ(publisher->delete_datawriter(datawriter), ReturnCode_t::RETCODE_OK);
-    ASSERT_EQ(participant->delete_publisher(publisher), ReturnCode_t::RETCODE_OK);
-    ASSERT_EQ(participant->delete_topic(topic), ReturnCode_t::RETCODE_OK);
-    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), ReturnCode_t::RETCODE_OK);
-}
-
-
 void check_datawriter_with_profile (
         DataWriter* datawriter,
         const std::string& profile_name)

--- a/test/unittest/dds/publisher/PublisherTests.cpp
+++ b/test/unittest/dds/publisher/PublisherTests.cpp
@@ -493,6 +493,31 @@ TEST(PublisherTests, CreateDataWriter)
     ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), ReturnCode_t::RETCODE_OK);
 }
 
+TEST(PublisherTests, CreateDataWriterWithDifferentTypeName)
+{
+    DomainParticipant* participant =
+            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
+
+    Publisher* publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT);
+    ASSERT_NE(publisher, nullptr);
+
+    std::string type_name = "other_different_type_name_because_of_reasons_eg_mangling";
+    TypeSupport type(new TopicDataTypeMock());
+    type.register_type(participant, type_name);
+
+    Topic* topic = participant->create_topic("footopic", type_name, TOPIC_QOS_DEFAULT);
+    ASSERT_NE(topic, nullptr);
+
+    DataWriter* datawriter = publisher->create_datawriter(topic, DATAWRITER_QOS_DEFAULT);
+    ASSERT_NE(datawriter, nullptr);
+
+    ASSERT_EQ(publisher->delete_datawriter(datawriter), ReturnCode_t::RETCODE_OK);
+    ASSERT_EQ(participant->delete_publisher(publisher), ReturnCode_t::RETCODE_OK);
+    ASSERT_EQ(participant->delete_topic(topic), ReturnCode_t::RETCODE_OK);
+    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), ReturnCode_t::RETCODE_OK);
+}
+
 
 void check_datawriter_with_profile (
         DataWriter* datawriter,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
When registering a Type and when creating a Topic, a type name is requested.
However, this type name is not used in Topic creation because it uses internally the type name of the type support, that can actually not be the same as the type name that was registered.

Simple regression test has been uploaded in commit a393cf71424e57a076ccab8931703b1afdac022a that fails before the fix, and passes afterwards.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- NA New feature has been added to the `versions.md` file (if applicable).
- NA New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
