### PR TITLE
Fix datarace on WriterProxy stop while TimedEvent being triggered [16341]

### DIFF
--- a/include/fastdds/rtps/reader/StatefulReader.h
+++ b/include/fastdds/rtps/reader/StatefulReader.h
@@ -186,6 +186,12 @@ public:
     }
 
     /**
+     * Get reference to associated RTPS partiicipant's \c ResourceEvent
+     * @return Reference to associated RTPS partiicipant's \c ResourceEvent
+     */
+    ResourceEvent& getEventResource() const;
+
+    /**
      * Read the next unread CacheChange_t from the history
      * @param change Pointer to pointer of CacheChange_t
      * @param wpout Pointer to pointer the matched writer proxy

--- a/include/fastdds/rtps/reader/StatefulReader.h
+++ b/include/fastdds/rtps/reader/StatefulReader.h
@@ -93,6 +93,11 @@ public:
             const GUID_t& writer_guid,
             bool removed_by_lease = false) override;
 
+    std::mutex& wp_manipulation_mutex()
+    {
+        return wp_manipulation_mutex_;
+    }
+
     /**
      * Tells us if a specific Writer is matched against this reader.
      * @param writer_guid GUID of the writer to check.
@@ -359,6 +364,7 @@ private:
     ResourceLimitedVector<WriterProxy*> matched_writers_;
     //! Vector containing pointers to all the inactive, ready for reuse, WriterProxies.
     ResourceLimitedVector<WriterProxy*> matched_writers_pool_;
+    std::mutex wp_manipulation_mutex_;
     //!
     ResourceLimitedContainerConfig proxy_changes_config_;
     //! True to disable positive ACKs

--- a/include/fastdds/rtps/reader/StatefulReader.h
+++ b/include/fastdds/rtps/reader/StatefulReader.h
@@ -93,11 +93,6 @@ public:
             const GUID_t& writer_guid,
             bool removed_by_lease = false) override;
 
-    std::mutex& wp_manipulation_mutex()
-    {
-        return wp_manipulation_mutex_;
-    }
-
     /**
      * Tells us if a specific Writer is matched against this reader.
      * @param writer_guid GUID of the writer to check.
@@ -364,7 +359,6 @@ private:
     ResourceLimitedVector<WriterProxy*> matched_writers_;
     //! Vector containing pointers to all the inactive, ready for reuse, WriterProxies.
     ResourceLimitedVector<WriterProxy*> matched_writers_pool_;
-    std::mutex wp_manipulation_mutex_;
     //!
     ResourceLimitedContainerConfig proxy_changes_config_;
     //! True to disable positive ACKs

--- a/include/fastdds/rtps/resources/TimedEvent.h
+++ b/include/fastdds/rtps/resources/TimedEvent.h
@@ -132,6 +132,12 @@ public:
     void restart_timer(
             const std::chrono::steady_clock::time_point& timeout);
 
+    /*!
+     * @brief Unregisters the event, sets its state to INACTIVE, and re-registers it.
+     * It may be seen as a blocking version of \c cancel_timer
+     */
+    void recreate_timer();
+
     /**
      * Update event interval.
      * When updating the interval, the timer is not restarted and the new interval will only be used the next time you call restart_timer().

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -187,6 +187,7 @@ bool StatefulReader::matched_writer_add(
     ReaderListener* listener = nullptr;
 
     {
+        std::lock_guard<std::mutex> wp_guard(wp_manipulation_mutex_);
         std::unique_lock<RecursiveTimedMutex> guard(mp_mutex);
 
         if (!is_alive_)
@@ -281,7 +282,7 @@ bool StatefulReader::matched_writer_add(
                 EPROSIMA_LOG_ERROR(RTPS_READER, "Failed to add Writer Proxy " << wdata.guid()
                                                                               << " to " << this->m_guid.entityId
                                                                               << " with data sharing.");
-                wp->stop();
+                wp->stop(true);
                 matched_writers_pool_.push_back(wp);
                 return false;
             }
@@ -357,6 +358,7 @@ bool StatefulReader::matched_writer_remove(
         }
     }
 
+    std::lock_guard<std::mutex> wp_guard(wp_manipulation_mutex_);
     std::unique_lock<RecursiveTimedMutex> lock(mp_mutex);
     WriterProxy* wproxy = nullptr;
     if (is_alive_)
@@ -389,7 +391,7 @@ bool StatefulReader::matched_writer_remove(
                 (void)removed_from_listener;
                 remove_changes_from(writer_guid, true);
             }
-            wproxy->stop();
+            wproxy->stop(true);
             matched_writers_pool_.push_back(wproxy);
             if (nullptr != mp_listener)
             {

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -187,7 +187,6 @@ bool StatefulReader::matched_writer_add(
     ReaderListener* listener = nullptr;
 
     {
-        std::lock_guard<std::mutex> wp_guard(wp_manipulation_mutex_);
         std::unique_lock<RecursiveTimedMutex> guard(mp_mutex);
 
         if (!is_alive_)
@@ -282,7 +281,7 @@ bool StatefulReader::matched_writer_add(
                 EPROSIMA_LOG_ERROR(RTPS_READER, "Failed to add Writer Proxy " << wdata.guid()
                                                                               << " to " << this->m_guid.entityId
                                                                               << " with data sharing.");
-                wp->stop(true);
+                wp->stop();
                 matched_writers_pool_.push_back(wp);
                 return false;
             }
@@ -358,7 +357,6 @@ bool StatefulReader::matched_writer_remove(
         }
     }
 
-    std::lock_guard<std::mutex> wp_guard(wp_manipulation_mutex_);
     std::unique_lock<RecursiveTimedMutex> lock(mp_mutex);
     WriterProxy* wproxy = nullptr;
     if (is_alive_)
@@ -391,7 +389,7 @@ bool StatefulReader::matched_writer_remove(
                 (void)removed_from_listener;
                 remove_changes_from(writer_guid, true);
             }
-            wproxy->stop(true);
+            wproxy->stop();
             matched_writers_pool_.push_back(wproxy);
             if (nullptr != mp_listener)
             {

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -1221,6 +1221,11 @@ void StatefulReader::remove_changes_from(
     }
 }
 
+ResourceEvent& StatefulReader::getEventResource() const
+{
+    return mp_RTPSParticipant->getEventResource();
+}
+
 bool StatefulReader::nextUntakenCache(
         CacheChange_t** change,
         WriterProxy** wpout)

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -281,7 +281,13 @@ bool StatefulReader::matched_writer_add(
                 EPROSIMA_LOG_ERROR(RTPS_READER, "Failed to add Writer Proxy " << wdata.guid()
                                                                               << " to " << this->m_guid.entityId
                                                                               << " with data sharing.");
-                wp->stop();
+                {
+                    // Release reader's lock to avoid deadlock when waiting for event (requiring mutex) to finish
+                    guard.unlock();
+                    assert(!guard.owns_lock());
+                    wp->stop();
+                    guard.lock();
+                }
                 matched_writers_pool_.push_back(wp);
                 return false;
             }
@@ -389,7 +395,13 @@ bool StatefulReader::matched_writer_remove(
                 (void)removed_from_listener;
                 remove_changes_from(writer_guid, true);
             }
-            wproxy->stop();
+            {
+                // Release reader's lock to avoid deadlock when waiting for event (requiring mutex) to finish
+                lock.unlock();
+                assert(!lock.owns_lock());
+                wproxy->stop();
+                lock.lock();
+            }
             matched_writers_pool_.push_back(wproxy);
             if (nullptr != mp_listener)
             {

--- a/src/cpp/rtps/reader/WriterProxy.cpp
+++ b/src/cpp/rtps/reader/WriterProxy.cpp
@@ -168,19 +168,27 @@ void WriterProxy::update(
             reader_->getAttributes().external_unicast_locators, reader_->getAttributes().ignore_non_matching_locators);
 }
 
-void WriterProxy::stop()
+void WriterProxy::stop(bool locked)
 {
     StateCode prev_code;
     if ((prev_code = state_.exchange(StateCode::STOPPED)) == StateCode::BUSY)
     {
-        // Initial ack_nack being performed, wait for it to finish
+        if (locked)
+        {
+            // Unlock prior to wait after having modified state to avoid deadlock (wait with reader mutex taken)
+            reader_->wp_manipulation_mutex().unlock();
+        }
+        // TimedEvent being performed, wait for it to finish.
+        // It does not matter which of the two events is the one on execution, but we must wait on initial_acknack_ as
+        // it could be restarted if only cancelled while its callback is being triggered.
+        heartbeat_response_->cancel_timer();
         initial_acknack_->recreate_timer();
     }
     else
     {
+        heartbeat_response_->cancel_timer();
         initial_acknack_->cancel_timer();
     }
-    heartbeat_response_->cancel_timer();
 
     clear();
 }
@@ -512,8 +520,12 @@ bool WriterProxy::perform_initial_ack_nack()
         {
             if (0 == last_heartbeat_count_)
             {
-                reader_->send_acknack(this, sns, this, false);
-                ret_value = true;
+                std::lock_guard<std::mutex> _(reader_->wp_manipulation_mutex());
+                if (state_ != StateCode::STOPPED)
+                {
+                    reader_->send_acknack(this, sns, this, false);
+                    ret_value = true;
+                }
             }
         }
     }
@@ -526,7 +538,21 @@ bool WriterProxy::perform_initial_ack_nack()
 
 void WriterProxy::perform_heartbeat_response()
 {
-    reader_->send_acknack(this, this, heartbeat_final_flag_.load());
+    StateCode expected = StateCode::IDLE;
+    if (!state_.compare_exchange_strong(expected, StateCode::BUSY))
+    {
+        // Stopped from another thread -> abort
+        return;
+    }
+
+    std::lock_guard<std::mutex> _(reader_->wp_manipulation_mutex());
+    if (state_.load() != StateCode::STOPPED)
+    {
+        reader_->send_acknack(this, this, heartbeat_final_flag_.load());
+    }
+
+    expected = StateCode::BUSY;
+    state_.compare_exchange_strong(expected, StateCode::IDLE);
 }
 
 bool WriterProxy::process_heartbeat(
@@ -544,7 +570,7 @@ bool WriterProxy::process_heartbeat(
 #endif // SHOULD_DEBUG_LINUX
 
     assert_liveliness = false;
-    if (last_heartbeat_count_ < count)
+    if (state_ != StateCode::STOPPED && last_heartbeat_count_ < count)
     {
         // If it is the first heartbeat message, we can try to cancel initial ack.
         // TODO: This timer cancelling should be checked if needed with the liveliness implementation.

--- a/src/cpp/rtps/reader/WriterProxy.cpp
+++ b/src/cpp/rtps/reader/WriterProxy.cpp
@@ -90,6 +90,7 @@ WriterProxy::WriterProxy(
     , locators_entry_(loc_alloc.max_unicast_locators, loc_alloc.max_multicast_locators)
     , is_datasharing_writer_(false)
     , received_at_least_one_heartbeat_(false)
+    , state_(StateCode::STOPPED)
 {
     //Create Events
     ResourceEvent& event_manager = reader_->getRTPSParticipant()->getEventResource();
@@ -144,6 +145,7 @@ void WriterProxy::start(
     filter_remote_locators(locators_entry_,
             reader_->getAttributes().external_unicast_locators, reader_->getAttributes().ignore_non_matching_locators);
     is_datasharing_writer_ = is_datasharing;
+    state_.store(StateCode::IDLE);
     initial_acknack_->restart_timer();
     loaded_from_storage(initial_sequence);
     received_at_least_one_heartbeat_ = false;
@@ -168,7 +170,16 @@ void WriterProxy::update(
 
 void WriterProxy::stop()
 {
-    initial_acknack_->cancel_timer();
+    StateCode prev_code;
+    if ((prev_code = state_.exchange(StateCode::STOPPED)) == StateCode::BUSY)
+    {
+        // Initial ack_nack being performed, wait for it to finish
+        initial_acknack_->recreate_timer();
+    }
+    else
+    {
+        initial_acknack_->cancel_timer();
+    }
     heartbeat_response_->cancel_timer();
 
     clear();
@@ -477,6 +488,13 @@ bool WriterProxy::perform_initial_ack_nack()
 {
     bool ret_value = false;
 
+    StateCode expected = StateCode::IDLE;
+    if (!state_.compare_exchange_strong(expected, StateCode::BUSY))
+    {
+        // Stopped from another thread -> abort
+        return ret_value;
+    }
+
     if (!is_datasharing_writer_)
     {
         // Send initial NACK.
@@ -499,6 +517,9 @@ bool WriterProxy::perform_initial_ack_nack()
             }
         }
     }
+
+    expected = StateCode::BUSY;
+    state_.compare_exchange_strong(expected, StateCode::IDLE);
 
     return ret_value;
 }

--- a/src/cpp/rtps/reader/WriterProxy.cpp
+++ b/src/cpp/rtps/reader/WriterProxy.cpp
@@ -93,7 +93,7 @@ WriterProxy::WriterProxy(
     , state_(StateCode::STOPPED)
 {
     //Create Events
-    ResourceEvent& event_manager = reader_->getRTPSParticipant()->getEventResource();
+    ResourceEvent& event_manager = reader_->getEventResource();
     auto heartbeat_lambda = [this]() -> bool
             {
                 perform_heartbeat_response();

--- a/src/cpp/rtps/reader/WriterProxy.h
+++ b/src/cpp/rtps/reader/WriterProxy.h
@@ -349,6 +349,13 @@ public:
 
 private:
 
+    enum StateCode
+    {
+        IDLE = 0, //! Writer Proxy is not performing any critical operations.
+        BUSY, //! Writer Proxy is performing a critical operation. Some actions (e.g. stop) should wait for its completion.
+        STOPPED, //! Writer Proxy has been requested to \c stop.
+    };
+
     /**
      * Set initial value for last acked sequence number.
      * @param[in] seq_num last acked sequence number.
@@ -408,6 +415,8 @@ private:
     bool is_datasharing_writer_;
     //! Wether at least one heartbeat was recevied.
     bool received_at_least_one_heartbeat_;
+    //! Current state of this Writer Proxy
+    std::atomic<StateCode> state_;
 
     using ChangeIterator = decltype(changes_received_)::iterator;
 

--- a/src/cpp/rtps/reader/WriterProxy.h
+++ b/src/cpp/rtps/reader/WriterProxy.h
@@ -100,10 +100,8 @@ public:
 
     /**
      * Disable this proxy.
-     * @param locked Whether this function is called with \c StatefulReader::wp_manipulation_mutex_ locked. If locked, unlock prior to wait.
-     * @warning Call with \c StatefulReader::wp_manipulation_mutex_ locked (and \c locked=true) to avoid data races.
      */
-    void stop(bool locked=false);
+    void stop();
 
     /**
      * Get the maximum sequenceNumber received from this Writer.

--- a/src/cpp/rtps/reader/WriterProxy.h
+++ b/src/cpp/rtps/reader/WriterProxy.h
@@ -100,8 +100,10 @@ public:
 
     /**
      * Disable this proxy.
+     * @param locked Whether this function is called with \c StatefulReader::wp_manipulation_mutex_ locked. If locked, unlock prior to wait.
+     * @warning Call with \c StatefulReader::wp_manipulation_mutex_ locked (and \c locked=true) to avoid data races.
      */
-    void stop();
+    void stop(bool locked=false);
 
     /**
      * Get the maximum sequenceNumber received from this Writer.

--- a/src/cpp/rtps/resources/TimedEvent.cpp
+++ b/src/cpp/rtps/resources/TimedEvent.cpp
@@ -70,6 +70,13 @@ void TimedEvent::restart_timer(
     }
 }
 
+void TimedEvent::recreate_timer()
+{
+    service_.unregister_timer(impl_);
+    impl_->go_cancel();
+    service_.register_timer(impl_);
+}
+
 bool TimedEvent::update_interval(
         const Duration_t& inter)
 {

--- a/test/mock/rtps/StatefulReader/fastdds/rtps/reader/StatefulReader.h
+++ b/test/mock/rtps/StatefulReader/fastdds/rtps/reader/StatefulReader.h
@@ -15,6 +15,7 @@
 #ifndef _FASTDDS_RTPS_READER_STATEFULREADER_H_
 #define _FASTDDS_RTPS_READER_STATEFULREADER_H_
 
+#include <fastdds/rtps/resources/ResourceEvent.h>
 #include <fastrtps/rtps/reader/RTPSReader.h>
 #include <fastrtps/rtps/attributes/ReaderAttributes.h>
 #include <fastrtps/rtps/common/Guid.h>
@@ -33,7 +34,11 @@ class StatefulReader : public RTPSReader
 {
 public:
 
-    StatefulReader() = default;
+    StatefulReader()
+    {
+        ON_CALL(*this, getEventResource())
+                .WillByDefault(::testing::ReturnRef(service_));
+    }
 
     StatefulReader(
             ReaderHistory* history,
@@ -88,6 +93,8 @@ public:
         return nullptr;
     }
 
+    MOCK_METHOD0(getEventResource, ResourceEvent & ());
+
     bool send_sync_nts(
             CDRMessage_t* /*message*/,
             const LocatorsIterator& /*destination_locators_begin*/,
@@ -100,6 +107,7 @@ public:
 private:
 
     ReaderTimes times_;
+    ResourceEvent service_;
 };
 
 } // namespace rtps

--- a/test/mock/rtps/StatefulReader/fastdds/rtps/reader/StatefulReader.h
+++ b/test/mock/rtps/StatefulReader/fastdds/rtps/reader/StatefulReader.h
@@ -56,8 +56,6 @@ public:
 
     MOCK_METHOD2(matched_writer_remove, bool(const GUID_t&, bool));
 
-    MOCK_METHOD0(wp_manipulation_mutex, std::mutex&());
-
     MOCK_METHOD1(liveliness_expired, bool(const GUID_t&));
 
     MOCK_METHOD2(change_received, bool(CacheChange_t* a_change, WriterProxy* prox));

--- a/test/mock/rtps/StatefulReader/fastdds/rtps/reader/StatefulReader.h
+++ b/test/mock/rtps/StatefulReader/fastdds/rtps/reader/StatefulReader.h
@@ -56,6 +56,8 @@ public:
 
     MOCK_METHOD2(matched_writer_remove, bool(const GUID_t&, bool));
 
+    MOCK_METHOD0(wp_manipulation_mutex, std::mutex&());
+
     MOCK_METHOD1(liveliness_expired, bool(const GUID_t&));
 
     MOCK_METHOD2(change_received, bool(CacheChange_t* a_change, WriterProxy* prox));

--- a/test/mock/rtps/TimedEvent/fastdds/rtps/resources/TimedEvent.h
+++ b/test/mock/rtps/TimedEvent/fastdds/rtps/resources/TimedEvent.h
@@ -41,6 +41,7 @@ public:
     MOCK_METHOD0(restart_timer, void());
     MOCK_METHOD1(restart_timer, void(const std::chrono::steady_clock::time_point& timeout));
     MOCK_METHOD0(cancel_timer, void());
+    MOCK_METHOD0(recreate_timer, void());
     MOCK_METHOD1(update_interval, bool(const Duration_t&));
     MOCK_METHOD1(update_interval_millisec, bool(double));
 };

--- a/test/unittest/rtps/history/CMakeLists.txt
+++ b/test/unittest/rtps/history/CMakeLists.txt
@@ -71,6 +71,7 @@ target_compile_definitions(ReaderHistoryTests PRIVATE FASTRTPS_NO_LIB
     )
 target_include_directories(ReaderHistoryTests PRIVATE
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/Endpoint
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/ResourceEvent
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/RTPSReader
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/StatefulReader
     ${PROJECT_SOURCE_DIR}/src/cpp

--- a/test/unittest/rtps/reader/CMakeLists.txt
+++ b/test/unittest/rtps/reader/CMakeLists.txt
@@ -71,10 +71,11 @@ set(WRITERPROXYSTOPTEST_SOURCE WriterProxyStopTest.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
-    ${PROJECT_SOURCE_DIR}/src/cpp/utils/SystemInfo.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEventImpl.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEvent.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/ResourceEvent.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/utils/SystemInfo.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/utils/TimedConditionVariable.cpp
     )
 
 if(WIN32)

--- a/test/unittest/rtps/reader/CMakeLists.txt
+++ b/test/unittest/rtps/reader/CMakeLists.txt
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+###########################################################################
+# WriterProxyTests
+###########################################################################
 set(WRITERPROXYTESTS_SOURCE WriterProxyTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/publisher/qos/WriterQos.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
@@ -19,7 +23,8 @@ set(WRITERPROXYTESTS_SOURCE WriterProxyTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
-    ${PROJECT_SOURCE_DIR}/src/cpp/utils/SystemInfo.cpp)
+    ${PROJECT_SOURCE_DIR}/src/cpp/utils/SystemInfo.cpp
+    )
 
 if(WIN32)
     add_definitions(-D_WIN32_WINNT=0x0601)
@@ -53,4 +58,53 @@ add_gtest(WriterProxyTests SOURCES ${WRITERPROXYTESTS_SOURCE})
 
 if(ANDROID)
     set_property(TARGET WriterProxyTests PROPERTY CROSSCOMPILING_EMULATOR "adb;shell;cd;${CMAKE_CURRENT_BINARY_DIR};&&")
+endif()
+
+
+###########################################################################
+# WriterProxyStopTest
+###########################################################################
+set(WRITERPROXYSTOPTEST_SOURCE WriterProxyStopTest.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/publisher/qos/WriterQos.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/utils/SystemInfo.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEventImpl.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEvent.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/ResourceEvent.cpp
+    )
+
+if(WIN32)
+    add_definitions(-D_WIN32_WINNT=0x0601)
+endif()
+
+add_executable(WriterProxyStopTest ${WRITERPROXYSTOPTEST_SOURCE})
+target_compile_definitions(WriterProxyStopTest PRIVATE FASTRTPS_NO_LIB
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
+target_include_directories(WriterProxyStopTest PRIVATE
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/Endpoint
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/ExternalLocatorsProcessor
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/RTPSReader
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/RTPSWriter
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/RTPSParticipantImpl
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/RTPSDomainImpl
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/StatefulReader
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/WriterProxyData
+    ${PROJECT_SOURCE_DIR}/test/mock/dds/QosPolicies
+    ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
+    ${PROJECT_SOURCE_DIR}/src/cpp
+    )
+target_link_libraries(WriterProxyStopTest foonathan_memory
+    GTest::gmock
+    ${CMAKE_DL_LIBS})
+add_gtest(WriterProxyStopTest SOURCES ${WRITERPROXYSTOPTEST_SOURCE})
+
+if(ANDROID)
+    set_property(TARGET WriterProxyStopTest PROPERTY CROSSCOMPILING_EMULATOR "adb;shell;cd;${CMAKE_CURRENT_BINARY_DIR};&&")
 endif()

--- a/test/unittest/rtps/reader/WriterProxyStopTest.cpp
+++ b/test/unittest/rtps/reader/WriterProxyStopTest.cpp
@@ -1,0 +1,134 @@
+// Copyright 2022 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <future>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <rtps/reader/WriterProxy.h>
+#include <rtps/participant/RTPSParticipantImpl.h>
+#include <fastrtps/rtps/reader/RTPSReader.h>
+#include <fastrtps/rtps/reader/StatefulReader.h>
+#include <fastrtps/rtps/builtin/data/WriterProxyData.h>
+#include <fastrtps/rtps/resources/ResourceEvent.h>
+#include <fastrtps/rtps/resources/TimedEvent.h>
+
+#include <rtps/reader/WriterProxy.cpp>
+
+namespace testing {
+namespace internal {
+using namespace eprosima::fastrtps::rtps;
+using namespace eprosima::fastrtps;
+
+class WriterProxyTest : public WriterProxy
+{
+public:
+
+    WriterProxyTest(
+            StatefulReader* reader,
+            const RemoteLocatorsAllocationAttributes& loc_alloc,
+            const ResourceLimitedContainerConfig& changes_allocation,
+            eprosima::fastrtps::rtps::ResourceEvent& service,
+            std::promise<void>& promise)
+        : WriterProxy(reader, loc_alloc, changes_allocation)
+        , reader_(reader)
+    {
+        auto acknack_lambda_test = [this, &promise]() -> bool
+                {
+                    promise.set_value();
+                    perform_initial_ack_nack();
+                    return false;
+                };
+
+        initial_acknack_test_ = new TimedEvent(service, acknack_lambda_test, 0);
+    }
+
+    ~WriterProxyTest()
+    {
+        delete(initial_acknack_test_);
+    }
+
+    void start(
+            const WriterProxyData& attributes,
+            const SequenceNumber_t& initial_sequence)
+    {
+        WriterProxy::start(attributes, initial_sequence);
+        initial_acknack_test_->update_interval(reader_->getTimes().initialAcknackDelay);
+        initial_acknack_test_->restart_timer();
+    }
+
+    void stop()
+    {
+        initial_acknack_test_->cancel_timer();
+        WriterProxy::stop();
+    }
+
+private:
+
+    StatefulReader* reader_;
+    TimedEvent* initial_acknack_test_;
+};
+
+} // namespace internal
+} // namespace testing
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+
+/**
+ * This test checks that stopping a WriterProxy while one of its TimedEvents is being executed is thread safe.
+ * In other words, no data races should be reported when running this test with a thread sanitizer.
+ */
+TEST(WriterProxyTests, WriterProxyStop)
+{
+    // Create actual events service
+    eprosima::fastrtps::rtps::ResourceEvent* service;
+    service = new eprosima::fastrtps::rtps::ResourceEvent();
+    service->init_thread();
+
+    // Synchronization primitives
+    std::promise<void> promise;
+    std::future<void> future = promise.get_future();
+
+    // Create and initialize WriterProxyTest
+    WriterProxyData wattr(4u, 1u);
+    StatefulReader readerMock;
+
+    ON_CALL(readerMock, getEventResource())
+            .WillByDefault(::testing::ReturnRef(*service));
+    EXPECT_CALL(readerMock, getEventResource()).Times(1u);
+    testing::internal::WriterProxyTest* wproxy = new testing::internal::WriterProxyTest(&readerMock,
+                    RemoteLocatorsAllocationAttributes(), ResourceLimitedContainerConfig(), *service, promise);
+    wproxy->start(wattr, SequenceNumber_t());
+
+    // Stopping a proxy in the middle of a TimedEvent execution is thread safe
+    future.wait();
+    wproxy->stop();
+
+    delete wproxy;
+    delete service;
+}
+
+} // namespace rtps
+} // namespace fastrtps
+} // namespace eprosima
+
+int main(
+        int argc,
+        char** argv)
+{
+    testing::InitGoogleMock(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/unittest/rtps/reader/WriterProxyTests.cpp
+++ b/test/unittest/rtps/reader/WriterProxyTests.cpp
@@ -105,6 +105,7 @@ TEST(WriterProxyTests, MissingChangesUpdate)
     StatefulReader readerMock; // avoid annoying uninteresting call warnings
 
     // Testing the Timed events are properly configured
+    EXPECT_CALL(readerMock, getEventResource()).Times(1u);
     WriterProxy wproxy(&readerMock, RemoteLocatorsAllocationAttributes(), ResourceLimitedContainerConfig());
     EXPECT_CALL(*wproxy.initial_acknack_, update_interval(readerMock.getTimes().initialAcknackDelay)).Times(1u);
     EXPECT_CALL(*wproxy.heartbeat_response_, update_interval(readerMock.getTimes().heartbeatResponseDelay)).Times(1u);
@@ -303,6 +304,7 @@ TEST(WriterProxyTests, LostChangesUpdate)
 {
     WriterProxyData wattr(4u, 1u);
     StatefulReader readerMock;
+    EXPECT_CALL(readerMock, getEventResource()).Times(1u);
     WriterProxy wproxy(&readerMock, RemoteLocatorsAllocationAttributes(), ResourceLimitedContainerConfig());
     EXPECT_CALL(*wproxy.initial_acknack_, update_interval(readerMock.getTimes().initialAcknackDelay)).Times(1u);
     EXPECT_CALL(*wproxy.heartbeat_response_, update_interval(readerMock.getTimes().heartbeatResponseDelay)).Times(1u);
@@ -421,6 +423,7 @@ TEST(WriterProxyTests, ReceivedChangeSet)
 {
     WriterProxyData wattr(4u, 1u);
     StatefulReader readerMock;
+    EXPECT_CALL(readerMock, getEventResource()).Times(1u);
     WriterProxy wproxy(&readerMock,
             RemoteLocatorsAllocationAttributes(),
             ResourceLimitedContainerConfig());
@@ -597,6 +600,7 @@ TEST(WriterProxyTests, IrrelevantChangeSet)
 {
     WriterProxyData wattr(4u, 1u);
     StatefulReader readerMock;
+    EXPECT_CALL(readerMock, getEventResource()).Times(1u);
     WriterProxy wproxy(&readerMock, RemoteLocatorsAllocationAttributes(), ResourceLimitedContainerConfig());
     EXPECT_CALL(*wproxy.initial_acknack_, update_interval(readerMock.getTimes().initialAcknackDelay)).Times(1u);
     EXPECT_CALL(*wproxy.heartbeat_response_, update_interval(readerMock.getTimes().heartbeatResponseDelay)).Times(1u);

--- a/test/unittest/rtps/resources/timedevent/TimedEventTests.cpp
+++ b/test/unittest/rtps/resources/timedevent/TimedEventTests.cpp
@@ -111,6 +111,43 @@ TEST(TimedEvent, Event_RestartEvents)
 }
 
 /*!
+ * @fn TEST(TimedEvent, Event_RecreateEvents)
+ * @brief This test checks the correct behavior of recreating events.
+ * First it is checked that recreating and restarting an event multiple times is possible.
+ * The event is then recreated (blocking cancel), and an object shared with the callback is modified in the main thread.
+ * A data race would be reported by thread sanitizer if cancelling (\c cancel_timer) the event instead.
+ */
+TEST(TimedEvent, Event_RecreateEvents)
+{
+    int num = 0;
+    auto callback = [&num]() -> void
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                num++;
+            };
+
+    MockEvent event(*env->service_, 100, false, callback);
+
+    for (int i = 0; i < 10; ++i)
+    {
+        event.event().recreate_timer();
+        event.event().restart_timer();
+        event.wait();
+    }
+
+    // Recreate timer (blocking cancel) and modify object shared with callback
+    // A data race would be reported by thread sanitizer if using cancel_timer instead
+    event.event().recreate_timer();
+    num = 10;
+
+    ASSERT_FALSE(event.wait(120));
+
+    int successed = event.successed_.load(std::memory_order_relaxed);
+
+    ASSERT_EQ(successed, 10);
+}
+
+/*!
  * @fn TEST(TimedEvent, EventOnSuccessAutoDestruc_QuickCancelEvents)
  * @brief This test checks the event is not destroyed when it is canceled.
  * This test launches an event, configured to destroy itself when the event is executed successfully,

--- a/test/unittest/rtps/resources/timedevent/mock/MockEvent.cpp
+++ b/test/unittest/rtps/resources/timedevent/mock/MockEvent.cpp
@@ -19,10 +19,12 @@ using namespace eprosima::fastrtps::rtps;
 MockEvent::MockEvent(
         eprosima::fastrtps::rtps::ResourceEvent& service,
         double milliseconds,
-        bool autorestart)
+        bool autorestart,
+        std::function<void()> inner_callback)
     : successed_(0)
     , sem_count_(0)
     , autorestart_(autorestart)
+    , inner_callback_(inner_callback)
     , event_(service, std::bind(&MockEvent::callback, this), milliseconds)
 {
 }
@@ -37,7 +39,7 @@ bool MockEvent::callback()
 
     successed_.fetch_add(1, std::memory_order_relaxed);
 
-    if(autorestart_)
+    if (autorestart_)
     {
         restart = true;
     }
@@ -47,6 +49,11 @@ bool MockEvent::callback()
     sem_mutex_.unlock();
     sem_cond_.notify_one();
 
+    if (inner_callback_)
+    {
+        inner_callback_();
+    }
+
     return restart;
 }
 
@@ -54,7 +61,10 @@ void MockEvent::wait()
 {
     std::unique_lock<std::mutex> lock(sem_mutex_);
 
-    sem_cond_.wait(lock, [&]() -> bool { return sem_count_ != 0; } );
+    sem_cond_.wait(lock, [&]() -> bool
+            {
+                return sem_count_ != 0;
+            } );
 
     --sem_count_;
 }
@@ -65,17 +75,24 @@ void MockEvent::wait_success()
 
     while (successed_.load(std::memory_order_relaxed) == 0)
     {
-        sem_cond_.wait(lock, [&]() -> bool { return sem_count_ != 0; } );
+        sem_cond_.wait(lock, [&]() -> bool
+                {
+                    return sem_count_ != 0;
+                } );
         --sem_count_;
     }
 }
 
-bool MockEvent::wait(unsigned int milliseconds)
+bool MockEvent::wait(
+        unsigned int milliseconds)
 {
     std::unique_lock<std::mutex> lock(sem_mutex_);
 
-    if(!sem_cond_.wait_for(lock, std::chrono::milliseconds(milliseconds),
-                [&]() -> bool { return sem_count_ != 0; } ))
+    if (!sem_cond_.wait_for(lock, std::chrono::milliseconds(milliseconds),
+            [&]() -> bool
+            {
+                return sem_count_ != 0;
+            } ))
     {
         return false;
     }

--- a/test/unittest/rtps/resources/timedevent/mock/MockEvent.h
+++ b/test/unittest/rtps/resources/timedevent/mock/MockEvent.h
@@ -24,34 +24,40 @@
 
 class MockEvent
 {
-    public:
+public:
 
-        MockEvent(
-                eprosima::fastrtps::rtps::ResourceEvent& service,
-                double milliseconds,
-                bool autorestart);
+    MockEvent(
+            eprosima::fastrtps::rtps::ResourceEvent& service,
+            double milliseconds,
+            bool autorestart,
+            std::function<void()> inner_callback = {});
 
-        virtual ~MockEvent();
+    virtual ~MockEvent();
 
-        eprosima::fastrtps::rtps::TimedEvent& event() { return event_; }
+    eprosima::fastrtps::rtps::TimedEvent& event()
+    {
+        return event_;
+    }
 
-        bool callback();
+    bool callback();
 
-        void wait();
+    void wait();
 
-        void wait_success();
+    void wait_success();
 
-        bool wait(unsigned int milliseconds);
+    bool wait(
+            unsigned int milliseconds);
 
-        std::atomic<int> successed_;
+    std::atomic<int> successed_;
 
-    private:
+private:
 
-        int sem_count_;
-        std::mutex sem_mutex_;
-        std::condition_variable sem_cond_;
-        bool autorestart_;
-        eprosima::fastrtps::rtps::TimedEvent event_;
+    int sem_count_;
+    std::mutex sem_mutex_;
+    std::condition_variable sem_cond_;
+    bool autorestart_;
+    std::function<void()> inner_callback_;
+    eprosima::fastrtps::rtps::TimedEvent event_;
 };
 
 #endif // _TEST_RTPS_RESOURCES_TIMEDEVENT_MOCKEVENT_H_


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR is a revision of #3046, in which the data race between `WriterProxy::stop` and `perform_initial_acknack` was addressed by forcing the thread invoking the former to wait for the completion of the latter. However, a deadlock may occur as the reader waiting for the event to end does so with `Endpoint::mp_mutex` locked, which is also locked when sending an acknack at `perform_initial_acknack`.

Two different solutions are suggested:
- Introducing a new mutex in `StatefulReader` which is taken before reader's, and released after modifying the writer proxy's state and before waiting for the executing event to finish.
- Releasing reader's mutex before stopping a `WriterProxy`, and locking it again after doing so. This solution implies that `StatefulReader::matched_writer_add` and `StatefulReader::matched_writer_remove` may no longer be executed "atomically", a relevant change that should be carefully analyzed.

In addition, this PR also addresses the potential (rarely or never seen in our tests) datarace that may occur between `WriterProxy::stop` and `perform_heartbeat_response`, as `StatefulReader::send_acknack` reads attributes from `WriterProxy` which are modified when being stopped.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
