### PR TITLE
[16271] Fix Deadlock in remove_participant (ResourceEvent thread) when compiled WITH_SECURITY

### DIFF
--- a/include/fastdds/rtps/resources/ResourceEvent.h
+++ b/include/fastdds/rtps/resources/ResourceEvent.h
@@ -122,6 +122,9 @@ private:
     //! Collection of registered events waiting completion.
     std::vector<TimedEventImpl*> active_timers_;
 
+    //! Prevents iterator invalidation when active_timers are manipulated inside loops
+    std::atomic<bool> skip_checking_active_timers_;
+
     //! Current time as seen by the execution thread.
     std::chrono::steady_clock::time_point current_time_;
 

--- a/src/cpp/rtps/resources/ResourceEvent.cpp
+++ b/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -75,10 +75,16 @@ void ResourceEvent::unregister_timer(
 {
     std::unique_lock<TimedMutex> lock(mutex_);
 
-    cv_manipulation_.wait(lock, [&]()
-            {
-                return allow_vector_manipulation_;
-            });
+    bool is_service_thread = std::this_thread::get_id() == thread_.get_id();
+
+    //! Let the service thread to manipulate resources
+    if (!is_service_thread)
+    {
+        cv_manipulation_.wait(lock, [&]()
+                {
+                    return allow_vector_manipulation_;
+                });
+    }
 
     bool should_notify = false;
     std::vector<TimedEventImpl*>::iterator it;
@@ -96,6 +102,14 @@ void ResourceEvent::unregister_timer(
     if (it != active_timers_.end())
     {
         active_timers_.erase(it);
+
+        if (is_service_thread)
+        {
+            //! Warn the do_timer_actions loop to skip checking the rest of active_timers
+            //! in this iteration to prevent iterator invalidation
+            skip_checking_active_timers_.store(true);
+        }
+
         should_notify = true;
     }
 
@@ -247,12 +261,19 @@ void ResourceEvent::do_timer_actions()
     }
 
     // Trigger active timers
+    skip_checking_active_timers_.store(false);
     for (TimedEventImpl* tp : active_timers_)
     {
         if (tp->next_trigger_time() <= current_time_)
         {
             did_something = true;
             tp->trigger(current_time_, cancel_time);
+
+            //! skip this iteration as active_timers has been manipulated
+            if (skip_checking_active_timers_.load())
+            {
+                break;
+            }
         }
         else
         {

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -3347,6 +3347,145 @@ static void BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_validation
     reader.block_for_all();
 }
 
+// Regression test of Refs #16168, Github #.
+TEST_P(Security, RemoveParticipantProxyDataonSecurityManagerLeaseExpired_validation_no_deadlock)
+{
+    std::string governance_file("governance_helloworld_disable_liveliness.smime");
+    std::string permissions_file("permissions_helloworld.smime");
+
+    //!Lambda for configuring publisher participant qos and security properties
+    auto secure_participant_pub_configurator = [&governance_file,
+                    &permissions_file](const std::shared_ptr<PubSubWriter<HelloWorldPubSubType>>& part,
+                    const std::shared_ptr<eprosima::fastdds::rtps::TransportDescriptorInterface>& interface)
+            {
+                part->lease_duration(3, 1);
+                part->disable_builtin_transport().add_user_transport_to_pparams(interface);
+
+                PropertyPolicy property_policy;
+
+                property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
+                        "builtin.PKI-DH"));
+                property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
+                        "file://" + std::string(certs_path) + "/maincacert.pem"));
+                property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
+                        "builtin.AES-GCM-GMAC"));
+                property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
+                        "builtin.Access-Permissions"));
+                property_policy.properties().emplace_back(Property(
+                            "dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                            "file://" + std::string(certs_path) + "/maincacert.pem"));
+                property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
+                        "file://" + std::string(certs_path) + "/mainpubcert.pem"));
+                property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
+                        "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+                property_policy.properties().emplace_back(Property(
+                            "dds.sec.access.builtin.Access-Permissions.governance",
+                            "file://" + std::string(certs_path) + "/" + governance_file));
+                property_policy.properties().emplace_back(Property(
+                            "dds.sec.access.builtin.Access-Permissions.permissions",
+                            "file://" + std::string(certs_path) + "/" + permissions_file));
+
+                std::cout << " Configuring Publisher Participant Properties " << std::endl;
+
+                part->property_policy(property_policy);
+
+            };
+    //!Lambda for configuring subscriber participant qos and security properties
+    auto secure_participant_sub_configurator = [&governance_file,
+                    &permissions_file](const std::shared_ptr<PubSubReader<HelloWorldPubSubType>>& part,
+                    const std::shared_ptr<eprosima::fastdds::rtps::TransportDescriptorInterface>& interface)
+            {
+                part->lease_duration(3, 1);
+                part->disable_builtin_transport().add_user_transport_to_pparams(interface);
+
+                PropertyPolicy property_policy;
+
+                property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
+                        "builtin.PKI-DH"));
+                property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
+                        "file://" + std::string(certs_path) + "/maincacert.pem"));
+                property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
+                        "builtin.AES-GCM-GMAC"));
+                property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
+                        "builtin.Access-Permissions"));
+                property_policy.properties().emplace_back(Property(
+                            "dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                            "file://" + std::string(certs_path) + "/maincacert.pem"));
+                property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
+                        "file://" + std::string(certs_path) + "/mainsubcert.pem"));
+                property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
+                        "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+                property_policy.properties().emplace_back(Property(
+                            "dds.sec.access.builtin.Access-Permissions.governance",
+                            "file://" + std::string(certs_path) + "/" + governance_file));
+                property_policy.properties().emplace_back(Property(
+                            "dds.sec.access.builtin.Access-Permissions.permissions",
+                            "file://" + std::string(certs_path) + "/" + permissions_file));
+
+                std::cout << " Configuring Subscriber Participant Properties " << std::endl;
+
+                part->property_policy(property_policy);
+
+            };
+
+    //! 1.Spawn a couple of participants writer/reader
+    std::string topic_name = "HelloWorldTopic";
+    auto pubsub_writer = std::make_shared<PubSubWriter<HelloWorldPubSubType>>(topic_name);
+    auto pubsub_reader = std::make_shared<PubSubReader<HelloWorldPubSubType>>(topic_name);
+
+    // Initialization of all the participants
+    std::cout << "Initializing PubSubs for topic " << topic_name << std::endl;
+
+    auto test_udptransport = std::make_shared<test_UDPv4TransportDescriptor>();
+    auto udp_transport = std::make_shared<UDPv4TransportDescriptor>();
+
+    // 2.Configure the participants
+    secure_participant_pub_configurator(pubsub_writer, test_udptransport);
+    pubsub_writer->init();
+    ASSERT_EQ(pubsub_writer->isInitialized(), true);
+
+    secure_participant_sub_configurator(pubsub_reader, udp_transport);
+    pubsub_reader->init();
+    ASSERT_EQ(pubsub_reader->isInitialized(), true);
+
+    std::cout << std::endl << "Waiting discovery between participants." << std::endl;
+
+    // 3.Wait for authorization
+    pubsub_reader->waitAuthorized();
+    pubsub_writer->waitAuthorized();
+
+    // 4.Wait for discovery.
+    pubsub_reader->wait_discovery();
+    pubsub_writer->wait_discovery();
+
+    auto data = default_helloworld_data_generator();
+
+    pubsub_reader->startReception(data);
+
+    // 5.Send data
+    pubsub_writer->send(data);
+
+    // 6.Block reader until reception finished or timeout.
+    pubsub_reader->block_for_at_least(2);
+
+    std::cout << "Reader received at least two samples, shutting down publisher " << std::endl;
+
+    //! 7.Simulate a force-quit (cntrl+c) on the publisher by dropping connection
+    test_UDPv4Transport::test_UDPv4Transport_ShutdownAllNetwork = true;
+
+    bool pubsub_writer_undiscovered;
+
+    //! 8.Wait reader to remove writer participant
+    //! Writer participant lease duration will expire in 3 secs
+    //! Check if deadlock is produced when accessing ResourceEvent collection
+    //! to unregister a TimedEvent() in ResourceEvent
+    pubsub_writer_undiscovered = pubsub_reader->wait_participant_undiscovery(std::chrono::seconds(6));
+
+    //! 9.Assert if last operation timed out
+    ASSERT_TRUE(pubsub_writer_undiscovered);
+
+}
+
 // *INDENT-OFF*
 TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_PermissionsDisableDiscoveryDisableAccessEncrypt_validation_ok_enable_discovery_enable_access_encrypt)
 // *INDENT-ON*

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -3347,7 +3347,7 @@ static void BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_validation
     reader.block_for_all();
 }
 
-// Regression test of Refs #16168, Github #.
+// Regression test of Refs #16168, Github #3102.
 TEST_P(Security, RemoveParticipantProxyDataonSecurityManagerLeaseExpired_validation_no_deadlock)
 {
     std::string governance_file("governance_helloworld_disable_liveliness.smime");

--- a/test/certs/governance_helloworld_disable_liveliness.smime
+++ b/test/certs/governance_helloworld_disable_liveliness.smime
@@ -1,0 +1,72 @@
+MIME-Version: 1.0
+Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----7819E0ABBCF1010ACA42E23CCBE8BCF2"
+
+This is an S/MIME signed message
+
+------7819E0ABBCF1010ACA42E23CCBE8BCF2
+Content-Type: text/plain
+
+<?xml version="1.0" encoding="utf-8"?>
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="omg_shared_ca_domain_governance.xsd">
+    <domain_access_rules>
+        <domain_rule>
+            <domains>
+                <id_range>
+                    <min>0</min>
+                    <max>230</max>
+                </id_range>
+            </domains>
+            <allow_unauthenticated_participants>false</allow_unauthenticated_participants>
+            <enable_join_access_control>true</enable_join_access_control>
+            <discovery_protection_kind>ENCRYPT</discovery_protection_kind>
+            <liveliness_protection_kind>ENCRYPT</liveliness_protection_kind>
+            <rtps_protection_kind>ENCRYPT</rtps_protection_kind>
+            <topic_access_rules>
+                <topic_rule>
+                    <topic_expression>HelloWorldTopic_*</topic_expression>
+                    <enable_discovery_protection>true</enable_discovery_protection>
+                    <enable_liveliness_protection>false</enable_liveliness_protection>
+                    <enable_read_access_control>true</enable_read_access_control>
+                    <enable_write_access_control>true</enable_write_access_control>
+                    <metadata_protection_kind>ENCRYPT</metadata_protection_kind>
+                    <data_protection_kind>ENCRYPT</data_protection_kind>
+                </topic_rule>
+            </topic_access_rules>
+        </domain_rule>
+    </domain_access_rules>
+</dds>
+
+
+------7819E0ABBCF1010ACA42E23CCBE8BCF2
+Content-Type: application/x-pkcs7-signature; name="smime.p7s"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="smime.p7s"
+
+MIIEeAYJKoZIhvcNAQcCoIIEaTCCBGUCAQExDzANBglghkgBZQMEAgEFADALBgkq
+hkiG9w0BBwGgggJAMIICPDCCAeOgAwIBAgIJALZwpgo2sxthMAoGCCqGSM49BAMC
+MIGaMQswCQYDVQQGEwJFUzELMAkGA1UECAwCTUExFDASBgNVBAcMC1RyZXMgQ2Fu
+dG9zMREwDwYDVQQKDAhlUHJvc2ltYTERMA8GA1UECwwIZVByb3NpbWExHjAcBgNV
+BAMMFWVQcm9zaW1hIE1haW4gVGVzdCBDQTEiMCAGCSqGSIb3DQEJARYTbWFpbmNh
+QGVwcm9zaW1hLmNvbTAeFw0xNzA5MDYwOTAzMDNaFw0yNzA5MDQwOTAzMDNaMIGa
+MQswCQYDVQQGEwJFUzELMAkGA1UECAwCTUExFDASBgNVBAcMC1RyZXMgQ2FudG9z
+MREwDwYDVQQKDAhlUHJvc2ltYTERMA8GA1UECwwIZVByb3NpbWExHjAcBgNVBAMM
+FWVQcm9zaW1hIE1haW4gVGVzdCBDQTEiMCAGCSqGSIb3DQEJARYTbWFpbmNhQGVw
+cm9zaW1hLmNvbTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABGLlhB3WQ8l1fpUE
+3DfOoulA/de38Zfj7hmpKtOnxiH2q6RJbwhxvJeA7R7mkmAKaJKmzx695BjyiXVS
+7bE7vgejEDAOMAwGA1UdEwQFMAMBAf8wCgYIKoZIzj0EAwIDRwAwRAIgVTY1BEvT
+4pw3GyBMzaUqmp69wi0kBkyOgq04OhyJ13UCICR125vvt0fUhXsXaxOAx28E4Ac9
+SVxpI+3UYs2kV5n0MYIB/DCCAfgCAQEwgagwgZoxCzAJBgNVBAYTAkVTMQswCQYD
+VQQIDAJNQTEUMBIGA1UEBwwLVHJlcyBDYW50b3MxETAPBgNVBAoMCGVQcm9zaW1h
+MREwDwYDVQQLDAhlUHJvc2ltYTEeMBwGA1UEAwwVZVByb3NpbWEgTWFpbiBUZXN0
+IENBMSIwIAYJKoZIhvcNAQkBFhNtYWluY2FAZXByb3NpbWEuY29tAgkAtnCmCjaz
+G2EwDQYJYIZIAWUDBAIBBQCggeQwGAYJKoZIhvcNAQkDMQsGCSqGSIb3DQEHATAc
+BgkqhkiG9w0BCQUxDxcNMjIxMTE4MTYzNzUyWjAvBgkqhkiG9w0BCQQxIgQgY+hs
+6Zqj4SL1Gon52t4ylDF39tCNZKZB+9XrkikoYXgweQYJKoZIhvcNAQkPMWwwajAL
+BglghkgBZQMEASowCwYJYIZIAWUDBAEWMAsGCWCGSAFlAwQBAjAKBggqhkiG9w0D
+BzAOBggqhkiG9w0DAgICAIAwDQYIKoZIhvcNAwICAUAwBwYFKw4DAgcwDQYIKoZI
+hvcNAwICASgwCgYIKoZIzj0EAwIERjBEAiBdHx77p+BNU7cKV4fyJN0edVyD6TlF
+Nr+tp6RF1/dkQwIgBYDcKIBKIkGa37Jv6HQKrl/dTCbu9a/147503zmP8C0=
+
+------7819E0ABBCF1010ACA42E23CCBE8BCF2--
+

--- a/test/certs/governance_helloworld_disable_liveliness.xml
+++ b/test/certs/governance_helloworld_disable_liveliness.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="omg_shared_ca_domain_governance.xsd">
+    <domain_access_rules>
+        <domain_rule>
+            <domains>
+                <id_range>
+                    <min>0</min>
+                    <max>230</max>
+                </id_range>
+            </domains>
+            <allow_unauthenticated_participants>false</allow_unauthenticated_participants>
+            <enable_join_access_control>true</enable_join_access_control>
+            <discovery_protection_kind>ENCRYPT</discovery_protection_kind>
+            <liveliness_protection_kind>ENCRYPT</liveliness_protection_kind>
+            <rtps_protection_kind>ENCRYPT</rtps_protection_kind>
+            <topic_access_rules>
+                <topic_rule>
+                    <topic_expression>HelloWorldTopic_*</topic_expression>
+                    <enable_discovery_protection>true</enable_discovery_protection>
+                    <enable_liveliness_protection>false</enable_liveliness_protection>
+                    <enable_read_access_control>true</enable_read_access_control>
+                    <enable_write_access_control>true</enable_write_access_control>
+                    <metadata_protection_kind>ENCRYPT</metadata_protection_kind>
+                    <data_protection_kind>ENCRYPT</data_protection_kind>
+                </topic_rule>
+            </topic_access_rules>
+        </domain_rule>
+    </domain_access_rules>
+</dds>
+

--- a/test/unittest/rtps/resources/timedevent/TimedEventTests.cpp
+++ b/test/unittest/rtps/resources/timedevent/TimedEventTests.cpp
@@ -407,6 +407,56 @@ TEST(TimedEventMultithread, PendingRaceCheck)
     delete checking_thr;
 }
 
+/*!
+ * @fn TEST(TimedEvent, Event_UnregisterEventWithinCallbackOfAnotherEvent)
+ * @brief This test checks the ability to unregister a TimedEvent
+ * inside another TimedEvent callback
+ */
+TEST(TimedEvent, Event_UnregisterEventWithinCallbackOfAnotherEvent)
+{
+    using TimedEvent = eprosima::fastrtps::rtps::TimedEvent;
+
+    constexpr auto expiration_ms = std::chrono::milliseconds(100);
+    bool success = false;
+
+    // Dummy callback event
+    auto simple_callback = []()
+            {
+                return false;
+            };
+
+    //! 1. Create a simple event with longer period
+    TimedEvent* simple_event = new TimedEvent(*env->service_, simple_callback, 3.0 * expiration_ms.count());
+
+    // Tester callback event that will unregister simple_event
+    auto tester_callback = [&]()
+            {
+
+                //! This will call unregister under the hood
+                if (nullptr != simple_event)
+                {
+                    delete simple_event;
+                    success = true;
+                }
+
+                return false;
+            };
+
+    //! 2. Create a second event with shorter period
+    TimedEvent tester_event(*env->service_, tester_callback, 1.0 * expiration_ms.count());
+
+    //! 3. Start event timers
+    simple_event->restart_timer();
+    tester_event.restart_timer();
+
+    //! 4. Give enough time fot events to trigger
+    std::this_thread::sleep_for(6.0 * expiration_ms);
+
+    //! 5. Assert unregister_timer() operation was ok
+    ASSERT_TRUE(success);
+
+}
+
 int main(
         int argc,
         char** argv)


### PR DESCRIPTION
Signed-off-by: Mario Dominguez <mariodominguez@eprosima.com>

<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
When a participant compiled WITH_SECURITY checks for the liveliness of a matched remote participant (served in the event_service() of Resource Manager), and this one has expired, security_manager tries to remove the remote participant proxy data, which, in turn, destroys AuthInfo; within its destructor, the destruction of timedEvent is performed with the subsequent unregister_timer() call into ResourceManager. At this point there is a deadlock when evaluating the condition variable for accessing the collection as it is the same execution thread.

Proposed solution changes:
Grant timer collections access to the execution thread within unregister_events(). Prevent  active_timers collection from iterator invalidation.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
@Mergifyio backport 2.7.x 2.6.x 2.3.x 2.1.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
