### PR TITLE
Protect creation/destruction of boost's named_mutex [16273]

### DIFF
--- a/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
@@ -460,7 +460,7 @@ public:
                     // recursive lock of port_mutex in create_port()
                     if (node_->is_port_ok)
                     {
-                        std::unique_ptr<SharedMemSegment::named_mutex> port_mutex =
+                        deleted_unique_ptr<SharedMemSegment::named_mutex> port_mutex =
                                 SharedMemSegment::try_open_and_lock_named_mutex(segment_name + "_mutex");
 
                         std::unique_lock<SharedMemSegment::named_mutex> port_lock(*port_mutex, std::adopt_lock);
@@ -987,7 +987,7 @@ private:
         logInfo(RTPS_TRANSPORT_SHM, THREADID << "Opening "
                                              << port_segment_name);
 
-        std::unique_ptr<SharedMemSegment::named_mutex> port_mutex =
+        deleted_unique_ptr<SharedMemSegment::named_mutex> port_mutex =
                 SharedMemSegment::open_or_create_and_lock_named_mutex(port_segment_name + "_mutex");
 
         std::unique_lock<SharedMemSegment::named_mutex> port_lock(*port_mutex, std::adopt_lock);

--- a/src/cpp/rtps/transport/shared_mem/SharedMemLog.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemLog.hpp
@@ -30,7 +30,7 @@ private:
 
     uint16_t dump_id_ = 0;
     FILE* f_;
-    std::unique_ptr<SharedMemSegment::named_mutex> f_mutex_;
+    deleted_unique_ptr<SharedMemSegment::named_mutex> f_mutex_;
 
 public:
 

--- a/src/cpp/utils/shared_memory/SharedMemSegment.hpp
+++ b/src/cpp/utils/shared_memory/SharedMemSegment.hpp
@@ -50,7 +50,7 @@ namespace rtps {
 using Log = fastdds::dds::Log;
 
 template<typename T>
-using deleted_unique_ptr = std::unique_ptr<T,std::function<void(T*)>>;
+using deleted_unique_ptr = std::unique_ptr<T, std::function<void (T*)>>;
 
 /**
  * Provides shared memory functionallity abstrating from
@@ -113,7 +113,8 @@ public:
             std::lock_guard<std::mutex> lock(mtx_());
 
             named_mutex = deleted_unique_ptr<SharedSegmentBase::named_mutex>(
-                new SharedSegmentBase::named_mutex(boost::interprocess::open_or_create, mutex_name.c_str()), [](SharedSegmentBase::named_mutex* p)
+                new SharedSegmentBase::named_mutex(boost::interprocess::open_or_create, mutex_name.c_str()),
+                [](SharedSegmentBase::named_mutex* p)
                 {
                     std::lock_guard<std::mutex> lock(mtx_());
                     delete p;
@@ -133,7 +134,8 @@ public:
                 std::lock_guard<std::mutex> lock(mtx_());
 
                 named_mutex = deleted_unique_ptr<SharedSegmentBase::named_mutex>(
-                    new SharedSegmentBase::named_mutex(boost::interprocess::open_or_create, mutex_name.c_str()), [](SharedSegmentBase::named_mutex* p)
+                    new SharedSegmentBase::named_mutex(boost::interprocess::open_or_create, mutex_name.c_str()),
+                    [](SharedSegmentBase::named_mutex* p)
                     {
                         std::lock_guard<std::mutex> lock(mtx_());
                         delete p;
@@ -158,7 +160,8 @@ public:
             std::lock_guard<std::mutex> lock(mtx_());
 
             named_mutex = deleted_unique_ptr<SharedSegmentBase::named_mutex>(
-                new SharedSegmentBase::named_mutex(boost::interprocess::open_only, mutex_name.c_str()), [](SharedSegmentBase::named_mutex* p)
+                new SharedSegmentBase::named_mutex(boost::interprocess::open_only, mutex_name.c_str()),
+                [](SharedSegmentBase::named_mutex* p)
                 {
                     std::lock_guard<std::mutex> lock(mtx_());
                     delete p;
@@ -187,7 +190,8 @@ public:
             std::lock_guard<std::mutex> lock(mtx_());
 
             named_mutex = deleted_unique_ptr<SharedSegmentBase::named_mutex>(
-                new SharedSegmentBase::named_mutex(boost::interprocess::open_or_create, mutex_name.c_str()), [](SharedSegmentBase::named_mutex* p)
+                new SharedSegmentBase::named_mutex(boost::interprocess::open_or_create, mutex_name.c_str()),
+                [](SharedSegmentBase::named_mutex* p)
                 {
                     std::lock_guard<std::mutex> lock(mtx_());
                     delete p;
@@ -208,7 +212,8 @@ public:
             std::lock_guard<std::mutex> lock(mtx_());
 
             named_mutex = deleted_unique_ptr<SharedSegmentBase::named_mutex>(
-                new SharedSegmentBase::named_mutex(boost::interprocess::open_only, mutex_name.c_str()), [](SharedSegmentBase::named_mutex* p)
+                new SharedSegmentBase::named_mutex(boost::interprocess::open_only, mutex_name.c_str()),
+                [](SharedSegmentBase::named_mutex* p)
                 {
                     std::lock_guard<std::mutex> lock(mtx_());
                     delete p;
@@ -304,6 +309,7 @@ private:
         static std::mutex mtx_;
         return mtx_;
     }
+
 };
 
 template<typename T, typename U>

--- a/test/unittest/transport/SharedMemTests.cpp
+++ b/test/unittest/transport/SharedMemTests.cpp
@@ -2211,8 +2211,8 @@ TEST_F(SHMTransportTests, named_mutex_concurrent_open)
                 // lock has to be done in another thread because
                 // boost::inteprocess_named_mutex and  interprocess_mutex are recursive in Win32
                 auto port_mutex = port_mocker.get_port_mutex(domain_name, 0);
-                bool locked;
-                if ((locked = port_mutex->try_lock()))
+                bool locked = port_mutex->try_lock();
+                if (locked)
                 {
                     ++lock_count;
                 }
@@ -2236,8 +2236,8 @@ TEST_F(SHMTransportTests, named_mutex_concurrent_open)
             );
 
     auto port_mutex = port_mocker.get_port_mutex(domain_name, 0);
-    bool locked;
-    if ((locked = port_mutex->try_lock()))
+    bool locked = port_mutex->try_lock();
+    if (locked)
     {
         ++lock_count;
     }

--- a/test/unittest/transport/SharedMemTests.cpp
+++ b/test/unittest/transport/SharedMemTests.cpp
@@ -2161,6 +2161,108 @@ TEST_F(SHMTransportTests, dump_file)
     std::remove(log_file.c_str());
 }
 
+TEST_F(SHMTransportTests, named_mutex_concurrent_open_create)
+{
+    const std::string domain_name("SHMTests");
+
+    auto shared_mem_manager = SharedMemManager::create(domain_name);
+    SharedMemGlobal* shared_mem_global = shared_mem_manager->global_segment();
+    MockPortSharedMemGlobal port_mocker;
+
+    port_mocker.remove_port_mutex(domain_name, 0);
+
+    Semaphore sem_get_port;
+    Semaphore sem_end_thread_get_port;
+    std::thread thread_get_port([&]
+            {
+                auto port_mutex = port_mocker.get_port_mutex(domain_name, 0, false);
+
+                sem_get_port.post();
+                sem_end_thread_get_port.wait();
+            }
+            );
+
+    auto global_port = shared_mem_global->open_port(0, 1, 1000);
+
+    sem_get_port.wait();
+    sem_end_thread_get_port.post();
+    thread_get_port.join();
+}
+
+TEST_F(SHMTransportTests, named_mutex_concurrent_open)
+{
+    const std::string domain_name("SHMTests");
+
+    auto shared_mem_manager = SharedMemManager::create(domain_name);
+    SharedMemGlobal* shared_mem_global = shared_mem_manager->global_segment();
+    MockPortSharedMemGlobal port_mocker;
+
+    port_mocker.remove_port_mutex(domain_name, 0);
+
+    auto global_port = shared_mem_global->open_port(0, 1, 1000);
+
+    Semaphore sem_lock_done;
+    Semaphore sem_second_lock;
+    Semaphore sem_second_lock_done;
+    Semaphore sem_end_thread_locker;
+    std::atomic<int> lock_count(0);
+    std::thread thread_locker([&]
+            {
+                // lock has to be done in another thread because
+                // boost::inteprocess_named_mutex and  interprocess_mutex are recursive in Win32
+                auto port_mutex = port_mocker.get_port_mutex(domain_name, 0);
+                bool locked;
+                if ((locked = port_mutex->try_lock()))
+                {
+                    ++lock_count;
+                }
+
+                sem_lock_done.post();
+                sem_second_lock.wait();
+
+                if (locked)
+                {
+                    port_mutex->unlock();
+                }
+                else
+                {
+                    port_mutex->lock();
+                    ++lock_count;
+                }
+
+                sem_second_lock_done.post();
+                sem_end_thread_locker.wait();
+            }
+            );
+
+    auto port_mutex = port_mocker.get_port_mutex(domain_name, 0);
+    bool locked;
+    if ((locked = port_mutex->try_lock()))
+    {
+        ++lock_count;
+    }
+
+    sem_lock_done.wait();
+    ASSERT_EQ(lock_count, 1);
+
+    sem_second_lock.post();
+    if (locked)
+    {
+        port_mutex->unlock();
+    }
+    else
+    {
+        port_mutex->lock();
+        ++lock_count;
+    }
+
+    sem_second_lock_done.wait();
+    ASSERT_EQ(lock_count, 2);
+
+    sem_end_thread_locker.post();
+    thread_locker.join();
+}
+
 int main(
         int argc,
         char** argv)

--- a/test/unittest/transport/mock/SharedMemGlobalMock.hpp
+++ b/test/unittest/transport/mock/SharedMemGlobalMock.hpp
@@ -21,7 +21,7 @@ namespace eprosima{
 namespace fastdds{
 namespace rtps{
 
-class MockPortSharedMemGlobal 
+class MockPortSharedMemGlobal
 {
 public:
 
@@ -32,18 +32,15 @@ public:
         SharedMemSegment::named_mutex::remove(port_segment_name.c_str());
     }
 
-    static std::unique_ptr<SharedMemSegment::named_mutex> get_port_mutex(const std::string& domain_name, uint32_t port_id)
-    {        
+    static deleted_unique_ptr<SharedMemSegment::named_mutex> get_port_mutex(const std::string& domain_name, uint32_t port_id)
+    {
         auto port_segment_name = domain_name + "_port" + std::to_string(port_id);
 
-        std::unique_ptr<SharedMemSegment::named_mutex> port_mutex = 
-                SharedMemSegment::open_named_mutex(port_segment_name + "_mutex");
-
-        return std::unique_ptr<SharedMemSegment::named_mutex>(SharedMemSegment::open_named_mutex(port_segment_name + "_mutex"));
+        return deleted_unique_ptr<SharedMemSegment::named_mutex>(SharedMemSegment::open_named_mutex(port_segment_name + "_mutex"));
     }
 
     static bool lock_empty_cv_mutex(SharedMemGlobal::Port& port)
-    {        
+    {
         return port.node_->empty_cv_mutex.try_lock();
     }
 
@@ -60,7 +57,7 @@ public:
         (void)listener;
 
         std::unique_lock<SharedMemSegment::mutex> lock(port.node_->empty_cv_mutex);
-        
+
         port.node_->waiting_count++;
         auto& status = port.node_->listeners_status[listener_index];
         status.is_waiting = 1;

--- a/test/unittest/transport/mock/SharedMemGlobalMock.hpp
+++ b/test/unittest/transport/mock/SharedMemGlobalMock.hpp
@@ -17,37 +17,44 @@
 
 #include <rtps/transport/shared_mem/SharedMemGlobal.hpp>
 
-namespace eprosima{
-namespace fastdds{
-namespace rtps{
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
 
 class MockPortSharedMemGlobal
 {
 public:
 
-    static void remove_port_mutex(const std::string& domain_name, uint32_t port_id)
+    static void remove_port_mutex(
+            const std::string& domain_name,
+            uint32_t port_id)
     {
         auto port_segment_name = domain_name + "_port" + std::to_string(port_id);
 
         SharedMemSegment::named_mutex::remove(port_segment_name.c_str());
     }
 
-    static deleted_unique_ptr<SharedMemSegment::named_mutex> get_port_mutex(const std::string& domain_name, uint32_t port_id, bool open_only=true)
+    static deleted_unique_ptr<SharedMemSegment::named_mutex> get_port_mutex(
+            const std::string& domain_name,
+            uint32_t port_id,
+            bool open_only = true)
     {
         auto port_segment_name = domain_name + "_port" + std::to_string(port_id);
 
         if (open_only)
         {
-            return deleted_unique_ptr<SharedMemSegment::named_mutex>(SharedMemSegment::open_named_mutex(port_segment_name + "_mutex"));
+            return deleted_unique_ptr<SharedMemSegment::named_mutex>(SharedMemSegment::open_named_mutex(
+                               port_segment_name + "_mutex"));
         }
         else
         {
-            return deleted_unique_ptr<SharedMemSegment::named_mutex>(SharedMemSegment::open_or_create_named_mutex(port_segment_name + "_mutex"));
+            return deleted_unique_ptr<SharedMemSegment::named_mutex>(SharedMemSegment::open_or_create_named_mutex(
+                               port_segment_name + "_mutex"));
         }
     }
 
-
-    static bool lock_empty_cv_mutex(SharedMemGlobal::Port& port)
+    static bool lock_empty_cv_mutex(
+            SharedMemGlobal::Port& port)
     {
         return port.node_->empty_cv_mutex.try_lock();
     }
@@ -70,34 +77,38 @@ public:
         auto& status = port.node_->listeners_status[listener_index];
         status.is_waiting = 1;
 
-        port.node_->empty_cv.wait(lock, [&] {
-                return is_listener_closed.load();
-            });
+        port.node_->empty_cv.wait(lock, [&]
+                {
+                    return is_listener_closed.load();
+                });
 
         status.is_waiting = 0;
         port.node_->waiting_count--;
     }
 
     static void unblock_wait_pop(
-        SharedMemGlobal::Port& port,
-        std::atomic<bool>& is_listener_closed)
+            SharedMemGlobal::Port& port,
+            std::atomic<bool>& is_listener_closed)
     {
         is_listener_closed.exchange(true);
         port.node_->empty_cv.notify_all();
     }
 
-    static void set_port_not_ok(SharedMemGlobal::Port& port)
+    static void set_port_not_ok(
+            SharedMemGlobal::Port& port)
     {
         port.node_->is_port_ok = false;
     }
 
-    static void forze_listener_leak(SharedMemGlobal::Port& port)
+    static void forze_listener_leak(
+            SharedMemGlobal::Port& port)
     {
         port.node_->ref_counter.fetch_add(1);
         auto listener = port.buffer_->register_listener();
         listener.release();
         port.node_->num_listeners++;
     }
+
 };
 
 } // namespace rtps

--- a/test/unittest/transport/mock/SharedMemGlobalMock.hpp
+++ b/test/unittest/transport/mock/SharedMemGlobalMock.hpp
@@ -32,12 +32,20 @@ public:
         SharedMemSegment::named_mutex::remove(port_segment_name.c_str());
     }
 
-    static deleted_unique_ptr<SharedMemSegment::named_mutex> get_port_mutex(const std::string& domain_name, uint32_t port_id)
+    static deleted_unique_ptr<SharedMemSegment::named_mutex> get_port_mutex(const std::string& domain_name, uint32_t port_id, bool open_only=true)
     {
         auto port_segment_name = domain_name + "_port" + std::to_string(port_id);
 
-        return deleted_unique_ptr<SharedMemSegment::named_mutex>(SharedMemSegment::open_named_mutex(port_segment_name + "_mutex"));
+        if (open_only)
+        {
+            return deleted_unique_ptr<SharedMemSegment::named_mutex>(SharedMemSegment::open_named_mutex(port_segment_name + "_mutex"));
+        }
+        else
+        {
+            return deleted_unique_ptr<SharedMemSegment::named_mutex>(SharedMemSegment::open_or_create_named_mutex(port_segment_name + "_mutex"));
+        }
     }
+
 
     static bool lock_empty_cv_mutex(SharedMemGlobal::Port& port)
     {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
Thread sanitizer reports a data race when attempting to create a boost's named_mutex for the same port from different threads (in the same process). This situation occurs, for example, when a two participants in the same process discover another one from a different process at the same time. Both attempt to create and lock a named_mutex corresponding to the same port (remote participant's) through boost library, which seems not to be thread safe according to thread sanitizer. Likewise, opening and creating a named_mutex for the same port from different threads results in a data race being reported. Same goes for destroying and opening/creating a named_mutex.

This PR attempts to solve this data race by protecting the creation/destruction of a named_mutex with a static mutex in `SharedMemSegment`. Note that this solution is sub-optimal, since now there would be blocking when trying to create any two named_mutexes concurrently, even if they do not correspond to the same port.
<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
