### PR TITLE
[16277] Fix communication with asymmetric ignoreParticipantFlags

### DIFF
--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -153,6 +153,11 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         UDPv4TransportDescriptor descriptor;
         descriptor.sendBufferSize = m_att.sendSocketBufferSize;
         descriptor.receiveBufferSize = m_att.listenSocketBufferSize;
+        if (is_intraprocess_only())
+        {
+            // Avoid multicast leaving the host for intraprocess-only participants
+            descriptor.TTL = 0;
+        }
         m_network_Factory.RegisterTransport(&descriptor, &m_att.properties);
 
 #ifdef SHM_TRANSPORT_BUILTIN

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -161,15 +161,18 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         m_network_Factory.RegisterTransport(&descriptor, &m_att.properties);
 
 #ifdef SHM_TRANSPORT_BUILTIN
-        SharedMemTransportDescriptor shm_transport;
-        // We assume (Linux) UDP doubles the user socket buffer size in kernel, so
-        // the equivalent segment size in SHM would be socket buffer size x 2
-        auto segment_size_udp_equivalent =
-                std::max(m_att.sendSocketBufferSize, m_att.listenSocketBufferSize) * 2;
-        shm_transport.segment_size(segment_size_udp_equivalent);
-        // Use same default max_message_size on both UDP and SHM
-        shm_transport.max_message_size(descriptor.max_message_size());
-        has_shm_transport_ |= m_network_Factory.RegisterTransport(&shm_transport);
+        if (!is_intraprocess_only())
+        {
+            SharedMemTransportDescriptor shm_transport;
+            // We assume (Linux) UDP doubles the user socket buffer size in kernel, so
+            // the equivalent segment size in SHM would be socket buffer size x 2
+            auto segment_size_udp_equivalent =
+                    std::max(m_att.sendSocketBufferSize, m_att.listenSocketBufferSize) * 2;
+            shm_transport.segment_size(segment_size_udp_equivalent);
+            // Use same default max_message_size on both UDP and SHM
+            shm_transport.max_message_size(descriptor.max_message_size());
+            has_shm_transport_ |= m_network_Factory.RegisterTransport(&shm_transport);
+        }
 #endif // ifdef SHM_TRANSPORT_BUILTIN
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Configuring a participant with `ignoreParticipantFlags = FILTER_DIFFERENT_HOST | FILTER_DIFFERENT_PROCESS`, and another one with the default configuration `ignoreParticipantFlags = FILTER_NONE` results in HEARTBEAT and ACKNACK messages sent to the multicast address and port for the builtin endpoints.

This PR fixes that situation by:
1. Make participants that only want intraprocess communications to not announce locators
2. Always ignore participants without locators when they are not on the same process.

As a bonus, participants that only want intraprocess communications set multicast TTL to 0 (so their announcements do not leave the host) and avoids creating the SHM transport.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
@Mergifyio backport 2.7.x 2.6.x 2.1.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
