### PR TITLE
[16284] Avoid statistics calculations for not enabled statistics DataWriters

### DIFF
--- a/include/fastdds/rtps/participant/RTPSParticipant.h
+++ b/include/fastdds/rtps/participant/RTPSParticipant.h
@@ -19,6 +19,7 @@
 #ifndef _FASTDDS_RTPS_RTPSParticipant_H_
 #define _FASTDDS_RTPS_RTPSParticipant_H_
 
+#include <cstdint>
 #include <cstdlib>
 #include <memory>
 
@@ -276,7 +277,7 @@ public:
 
 #ifdef FASTDDS_STATISTICS
 
-    /*
+    /**
      * Add a listener to receive statistics backend callbacks
      * @param listener
      * @param kind combination of fastdds::statistics::EventKind flags used as a mask. Events to notify.
@@ -286,7 +287,7 @@ public:
             std::shared_ptr<fastdds::statistics::IListener> listener,
             uint32_t kind);
 
-    /*
+    /**
      * Remove a listener from receiving statistics backend callbacks
      * @param listener
      * @param kind combination of fastdds::statistics::EventKind flags used as a mask. Events to ignore.
@@ -295,6 +296,14 @@ public:
     bool remove_statistics_listener(
             std::shared_ptr<fastdds::statistics::IListener> listener,
             uint32_t kind);
+
+    /**
+     * @brief Set the enabled statistics writers mask
+     *
+     * @param enabled_writers The new mask to set
+     */
+    void set_enabled_statistics_writers_mask(
+            uint32_t enabled_writers);
 
 #endif // FASTDDS_STATISTICS
 

--- a/include/fastdds/rtps/reader/RTPSReader.h
+++ b/include/fastdds/rtps/reader/RTPSReader.h
@@ -361,7 +361,7 @@ public:
 
 #ifdef FASTDDS_STATISTICS
 
-    /*
+    /**
      * Add a listener to receive statistics backend callbacks
      * @param listener
      * @return true if successfully added
@@ -369,13 +369,21 @@ public:
     RTPS_DllAPI bool add_statistics_listener(
             std::shared_ptr<fastdds::statistics::IListener> listener);
 
-    /*
+    /**
      * Remove a listener from receiving statistics backend callbacks
      * @param listener
      * @return true if successfully removed
      */
     RTPS_DllAPI bool remove_statistics_listener(
             std::shared_ptr<fastdds::statistics::IListener> listener);
+
+    /**
+     * @brief Set the enabled statistics writers mask
+     *
+     * @param enabled_writers The new mask to set
+     */
+    RTPS_DllAPI void set_enabled_statistics_writers_mask(
+            uint32_t enabled_writers);
 
 #endif // FASTDDS_STATISTICS
 

--- a/include/fastdds/rtps/writer/RTPSWriter.h
+++ b/include/fastdds/rtps/writer/RTPSWriter.h
@@ -304,7 +304,7 @@ public:
 
 #ifdef FASTDDS_STATISTICS
 
-    /*
+    /**
      * Add a listener to receive statistics backend callbacks
      * @param listener
      * @return true if successfully added
@@ -312,13 +312,21 @@ public:
     RTPS_DllAPI bool add_statistics_listener(
             std::shared_ptr<fastdds::statistics::IListener> listener);
 
-    /*
+    /**
      * Remove a listener from receiving statistics backend callbacks
      * @param listener
      * @return true if successfully removed
      */
     RTPS_DllAPI bool remove_statistics_listener(
             std::shared_ptr<fastdds::statistics::IListener> listener);
+
+    /**
+     * @brief Set the enabled statistics writers mask
+     *
+     * @param enabled_writers The new mask to set
+     */
+    RTPS_DllAPI void set_enabled_statistics_writers_mask(
+            uint32_t enabled_writers);
 
 #endif // FASTDDS_STATISTICS
 

--- a/include/fastdds/statistics/rtps/StatisticsCommon.hpp
+++ b/include/fastdds/statistics/rtps/StatisticsCommon.hpp
@@ -101,6 +101,15 @@ protected:
             uint32_t enabled_writers);
 
     /**
+     * @brief Check whether the statistics writers in the input mask are enabled
+     *
+     * @param checked_enabled_writers The mask of writers to check
+     * @return True if all enabled, false otherwise
+     */
+    bool are_statistics_writers_enabled(
+            uint32_t checked_enabled_writers);
+
+    /**
      * Lambda function to traverse the listener collection
      * @param f function object to apply to each listener
      * @return function object after being applied to each listener

--- a/include/fastdds/statistics/rtps/StatisticsCommon.hpp
+++ b/include/fastdds/statistics/rtps/StatisticsCommon.hpp
@@ -93,6 +93,14 @@ protected:
             std::shared_ptr<fastdds::statistics::IListener> listener);
 
     /**
+     * @brief Set the enabled statistics writers mask
+     *
+     * @param enabled_writers The new mask to set
+     */
+    void set_enabled_statistics_writers_mask_impl(
+            uint32_t enabled_writers);
+
+    /**
      * Lambda function to traverse the listener collection
      * @param f function object to apply to each listener
      * @return function object after being applied to each listener

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -210,6 +210,12 @@ bool RTPSParticipant::remove_statistics_listener(
     return mp_impl->remove_statistics_listener(listener, kind);
 }
 
+void RTPSParticipant::set_enabled_statistics_writers_mask(
+        uint32_t enabled_writers)
+{
+    mp_impl->set_enabled_statistics_writers_mask(enabled_writers);
+}
+
 #endif // FASTDDS_STATISTICS
 
 } /* namespace rtps */

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -2586,6 +2586,25 @@ bool RTPSParticipantImpl::unregister_in_reader(
     return res;
 }
 
+void RTPSParticipantImpl::set_enabled_statistics_writers_mask(
+        uint32_t enabled_writers)
+{
+    StatisticsParticipantImpl::set_enabled_statistics_writers_mask(enabled_writers);
+
+    // Propagate mask to all readers and writers
+    shared_lock<shared_mutex> _(endpoints_list_mutex);
+
+    for (auto reader : m_userReaderList)
+    {
+        reader->set_enabled_statistics_writers_mask(enabled_writers);
+    }
+
+    for (auto writer : m_userWriterList)
+    {
+        writer->set_enabled_statistics_writers_mask(enabled_writers);
+    }
+}
+
 #endif // FASTDDS_STATISTICS
 
 } /* namespace rtps */

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -1042,6 +1042,14 @@ public:
     bool unregister_in_reader(
             std::shared_ptr<fastdds::statistics::IListener> listener) override;
 
+    /**
+     * @brief Set the enabled statistics writers mask
+     *
+     * @param enabled_writers The new mask to set
+     */
+    void set_enabled_statistics_writers_mask(
+            uint32_t enabled_writers) override;
+
 #endif // FASTDDS_STATISTICS
 
 };

--- a/src/cpp/rtps/reader/RTPSReader.cpp
+++ b/src/cpp/rtps/reader/RTPSReader.cpp
@@ -445,6 +445,12 @@ bool RTPSReader::remove_statistics_listener(
     return remove_statistics_listener_impl(listener);
 }
 
+void RTPSReader::set_enabled_statistics_writers_mask(
+        uint32_t enabled_writers)
+{
+    set_enabled_statistics_writers_mask_impl(enabled_writers);
+}
+
 #endif // FASTDDS_STATISTICS
 
 } /* namespace rtps */

--- a/src/cpp/rtps/writer/RTPSWriter.cpp
+++ b/src/cpp/rtps/writer/RTPSWriter.cpp
@@ -455,6 +455,12 @@ bool RTPSWriter::remove_statistics_listener(
     return remove_statistics_listener_impl(listener);
 }
 
+void RTPSWriter::set_enabled_statistics_writers_mask(
+        uint32_t enabled_writers)
+{
+    set_enabled_statistics_writers_mask_impl(enabled_writers);
+}
+
 #endif // FASTDDS_STATISTICS
 
 void RTPSWriter::add_statistics_sent_submessage(

--- a/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.cpp
@@ -169,6 +169,7 @@ ReturnCode_t DomainParticipantImpl::enable_statistics_datawriter(
             else
             {
                 statistics_listener_->set_datawriter(event_kind, data_writer);
+                rtps_participant_->set_enabled_statistics_writers_mask(statistics_listener_->enabled_writers_mask());
             }
         }
         return ReturnCode_t::RETCODE_OK;
@@ -227,12 +228,14 @@ ReturnCode_t DomainParticipantImpl::disable_statistics_datawriter(
     {
         // Avoid calling DataWriter from listener callback
         statistics_listener_->set_datawriter(event_kind, nullptr);
+        rtps_participant_->set_enabled_statistics_writers_mask(statistics_listener_->enabled_writers_mask());
 
         // Delete the DataWriter
         if (ReturnCode_t::RETCODE_OK != builtin_publisher_->delete_datawriter(writer))
         {
             // Restore writer on listener before returning the error
             statistics_listener_->set_datawriter(event_kind, writer);
+            rtps_participant_->set_enabled_statistics_writers_mask(statistics_listener_->enabled_writers_mask());
             ret = ReturnCode_t::RETCODE_ERROR;
         }
 

--- a/src/cpp/statistics/fastdds/domain/DomainParticipantStatisticsListener.cpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipantStatisticsListener.cpp
@@ -34,6 +34,17 @@ void DomainParticipantStatisticsListener::set_datawriter(
 {
     std::lock_guard<std::mutex> guard(mtx_);
     writers_[kind] = writer;
+
+    // If the writer is being activated then activate the corresponding bit in mask,
+    // else deactivate it.
+    if (writer)
+    {
+        enabled_writers_mask_ |= kind;
+    }
+    else
+    {
+        enabled_writers_mask_ &= ~kind;
+    }
 }
 
 void DomainParticipantStatisticsListener::on_statistics_data(

--- a/src/cpp/statistics/fastdds/domain/DomainParticipantStatisticsListener.cpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipantStatisticsListener.cpp
@@ -104,6 +104,11 @@ void DomainParticipantStatisticsListener::on_statistics_data(
     }
 }
 
+uint32_t DomainParticipantStatisticsListener::enabled_writers_mask()
+{
+    return enabled_writers_mask_;
+}
+
 } // dds
 } // statistics
 } // fastdds

--- a/src/cpp/statistics/fastdds/domain/DomainParticipantStatisticsListener.hpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipantStatisticsListener.hpp
@@ -23,9 +23,8 @@
 
 #ifdef FASTDDS_STATISTICS
 
-#include <cstdint>
-
 #include <atomic>
+#include <cstdint>
 #include <map>
 #include <mutex>
 

--- a/src/cpp/statistics/fastdds/domain/DomainParticipantStatisticsListener.hpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipantStatisticsListener.hpp
@@ -23,6 +23,9 @@
 
 #ifdef FASTDDS_STATISTICS
 
+#include <cstdint>
+
+#include <atomic>
 #include <map>
 #include <mutex>
 
@@ -47,10 +50,13 @@ struct DomainParticipantStatisticsListener : public IListener
     void on_statistics_data(
             const Data& statistics_data) override;
 
+    uint32_t enabled_writers_mask();
+
 private:
 
     std::mutex mtx_;
     std::map<EventKind, DataWriter*> writers_;
+    std::atomic<uint32_t> enabled_writers_mask_{0};
 };
 
 } // dds

--- a/src/cpp/statistics/rtps/StatisticsBase.cpp
+++ b/src/cpp/statistics/rtps/StatisticsBase.cpp
@@ -128,6 +128,16 @@ bool StatisticsListenersImpl::remove_statistics_listener_impl(
     return 1 == members_->listeners.erase(listener);
 }
 
+void StatisticsListenersImpl::set_enabled_statistics_writers_mask_impl(
+        uint32_t enabled_writers)
+{
+    std::unique_lock<fastrtps::RecursiveTimedMutex> lock(get_statistics_mutex());
+    if (members_)
+    {
+        members_->enabled_writers_mask.store(enabled_writers);
+    }
+}
+
 const eprosima::fastrtps::rtps::GUID_t& StatisticsParticipantImpl::get_guid() const
 {
     using eprosima::fastrtps::rtps::RTPSParticipantImpl;

--- a/src/cpp/statistics/rtps/StatisticsBase.cpp
+++ b/src/cpp/statistics/rtps/StatisticsBase.cpp
@@ -343,7 +343,6 @@ void StatisticsParticipantImpl::set_enabled_statistics_writers_mask(
         uint32_t enabled_writers)
 {
     enabled_writers_mask_.store(enabled_writers);
-    // TODO(eduponz): Propagate mask to all writers and readers
 }
 
 void StatisticsParticipantImpl::on_network_statistics(

--- a/src/cpp/statistics/rtps/StatisticsBase.cpp
+++ b/src/cpp/statistics/rtps/StatisticsBase.cpp
@@ -138,6 +138,18 @@ void StatisticsListenersImpl::set_enabled_statistics_writers_mask_impl(
     }
 }
 
+bool StatisticsListenersImpl::are_statistics_writers_enabled(
+        uint32_t checked_enabled_writers)
+{
+    // Check if the corresponding writer is enabled
+    std::unique_lock<fastrtps::RecursiveTimedMutex> lock(get_statistics_mutex());
+    if (members_)
+    {
+        return (members_->enabled_writers_mask & checked_enabled_writers);
+    }
+    return false;
+}
+
 const eprosima::fastrtps::rtps::GUID_t& StatisticsParticipantImpl::get_guid() const
 {
     using eprosima::fastrtps::rtps::RTPSParticipantImpl;
@@ -152,6 +164,12 @@ const eprosima::fastrtps::rtps::GUID_t& StatisticsParticipantImpl::get_guid() co
 std::recursive_mutex& StatisticsParticipantImpl::get_statistics_mutex()
 {
     return statistics_mutex_;
+}
+
+bool StatisticsParticipantImpl::are_statistics_writers_enabled(
+        uint32_t checked_enabled_writers)
+{
+    return (enabled_writers_mask_ & checked_enabled_writers);
 }
 
 void StatisticsParticipantImpl::ListenerProxy::on_statistics_data(
@@ -365,6 +383,11 @@ void StatisticsParticipantImpl::process_network_timestamp(
 {
     using namespace eprosima::fastrtps::rtps;
 
+    if (!are_statistics_writers_enabled(EventKind::NETWORK_LATENCY))
+    {
+        return;
+    }
+
     Time_t source_ts(ts.seconds, ts.fraction);
     Time_t current_ts;
     Time_t::now(current_ts);
@@ -398,6 +421,11 @@ void StatisticsParticipantImpl::process_network_sequence(
         const rtps::StatisticsSubmessageData::Sequence& seq,
         uint64_t datagram_size)
 {
+    if (!are_statistics_writers_enabled(EventKind::RTPS_LOST))
+    {
+        return;
+    }
+
     lost_traffic_key key(source_participant, reception_locator);
     bool should_notify = false;
     Entity2LocatorTraffic notification;
@@ -467,6 +495,11 @@ void StatisticsParticipantImpl::on_rtps_sent(
     using namespace std;
     using eprosima::fastrtps::rtps::RTPSParticipantImpl;
 
+    if (!are_statistics_writers_enabled(EventKind::RTPS_SENT))
+    {
+        return;
+    }
+
     // Compose callback and update the inner state
     Entity2LocatorTraffic notification;
     notification.src_guid(to_statistics_type(get_guid()));
@@ -497,6 +530,11 @@ void StatisticsParticipantImpl::on_entity_discovery(
         const fastdds::dds::ParameterPropertyList_t& properties)
 {
     using namespace fastrtps;
+
+    if (!are_statistics_writers_enabled(EventKind::DISCOVERED_ENTITY))
+    {
+        return;
+    }
 
     /**
      * @brief Get the value of a property from a property list.
@@ -552,6 +590,11 @@ void StatisticsParticipantImpl::on_entity_discovery(
 void StatisticsParticipantImpl::on_pdp_packet(
         const uint32_t packages)
 {
+    if (!are_statistics_writers_enabled(EventKind::PDP_PACKETS))
+    {
+        return;
+    }
+
     EntityCount notification;
     notification.guid(to_statistics_type(get_guid()));
 
@@ -576,6 +619,11 @@ void StatisticsParticipantImpl::on_pdp_packet(
 void StatisticsParticipantImpl::on_edp_packet(
         const uint32_t packages)
 {
+    if (!are_statistics_writers_enabled(EventKind::EDP_PACKETS))
+    {
+        return;
+    }
+
     EntityCount notification;
     notification.guid(to_statistics_type(get_guid()));
 

--- a/src/cpp/statistics/rtps/StatisticsBase.cpp
+++ b/src/cpp/statistics/rtps/StatisticsBase.cpp
@@ -329,6 +329,13 @@ bool StatisticsParticipantImpl::remove_statistics_listener(
            && ((old_mask & mask) == mask); // return false if there were unregistered entities
 }
 
+void StatisticsParticipantImpl::set_enabled_statistics_writers_mask(
+        uint32_t enabled_writers)
+{
+    enabled_writers_mask_.store(enabled_writers);
+    // TODO(eduponz): Propagate mask to all writers and readers
+}
+
 void StatisticsParticipantImpl::on_network_statistics(
         const fastrtps::rtps::GuidPrefix_t& source_participant,
         const fastrtps::rtps::Locator_t& source_locator,

--- a/src/cpp/statistics/rtps/StatisticsBase.hpp
+++ b/src/cpp/statistics/rtps/StatisticsBase.hpp
@@ -440,7 +440,7 @@ public:
      *
      * @param enabled_writers The new mask to set
      */
-    void set_enabled_statistics_writers_mask(
+    virtual void set_enabled_statistics_writers_mask(
             uint32_t enabled_writers);
 };
 

--- a/src/cpp/statistics/rtps/StatisticsBase.hpp
+++ b/src/cpp/statistics/rtps/StatisticsBase.hpp
@@ -199,6 +199,15 @@ protected:
     // retrieve the participant mutex
     std::recursive_mutex& get_statistics_mutex();
 
+    /**
+     * @brief Check whether the statistics writers in the input mask are enabled
+     *
+     * @param checked_enabled_writers The mask of writers to check
+     * @return True if all enabled, false otherwise
+     */
+    bool are_statistics_writers_enabled(
+            uint32_t checked_enabled_writers);
+
     /** Register a listener in participant RTPSWriter entities.
      * @param listener smart pointer to the listener interface to register
      * @param guid RTPSWriter identifier. If unknown the listener is registered in all enable ones

--- a/src/cpp/statistics/rtps/StatisticsBase.hpp
+++ b/src/cpp/statistics/rtps/StatisticsBase.hpp
@@ -56,6 +56,7 @@ namespace statistics {
 struct StatisticsAncillary
 {
     std::set<std::shared_ptr<IListener>> listeners;
+    std::atomic<uint32_t> enabled_writers_mask{0};
 };
 
 struct StatisticsWriterAncillary

--- a/src/cpp/statistics/rtps/StatisticsBase.hpp
+++ b/src/cpp/statistics/rtps/StatisticsBase.hpp
@@ -19,6 +19,9 @@
 #ifndef _STATISTICS_RTPS_STATISTICSBASE_HPP_
 #define _STATISTICS_RTPS_STATISTICSBASE_HPP_
 
+#include <cstdint>
+
+#include <atomic>
 #include <mutex>
 #include <set>
 
@@ -128,6 +131,9 @@ private:
     unsigned long long pdp_counter_ = {};
     // EDP_PACKETS ancillary
     unsigned long long edp_counter_ = {};
+
+    // Mask of enabled statistics writers
+    std::atomic<uint32_t> enabled_writers_mask_{0};
 
     /*
      * Retrieve the GUID_t from derived class
@@ -408,7 +414,7 @@ protected:
 
 public:
 
-    /*
+    /**
      * Registers a listener in participant's statistics callback queue
      * @param listener smart pointer to the listener being registered
      * @param kind combination of fastdds::statistics::EventKind flags used as a mask
@@ -418,7 +424,7 @@ public:
             std::shared_ptr<fastdds::statistics::IListener> listener,
             uint32_t kind);
 
-    /*
+    /**
      * Unregisters a listener in participant's statistics callback queue
      * @param listener smart pointer to the listener being unregistered
      * @param kind combination of fastdds::statistics::EventKind flags used as a mask
@@ -427,6 +433,14 @@ public:
     bool remove_statistics_listener(
             std::shared_ptr<fastdds::statistics::IListener> listener,
             uint32_t kind);
+
+    /**
+     * @brief Set the enabled statistics writers mask
+     *
+     * @param enabled_writers The new mask to set
+     */
+    void set_enabled_statistics_writers_mask(
+            uint32_t enabled_writers);
 };
 
 // auxiliary conversion functions

--- a/src/cpp/statistics/rtps/StatisticsBase.hpp
+++ b/src/cpp/statistics/rtps/StatisticsBase.hpp
@@ -19,9 +19,8 @@
 #ifndef _STATISTICS_RTPS_STATISTICSBASE_HPP_
 #define _STATISTICS_RTPS_STATISTICSBASE_HPP_
 
-#include <cstdint>
-
 #include <atomic>
+#include <cstdint>
 #include <mutex>
 #include <set>
 

--- a/src/cpp/statistics/rtps/StatisticsBase.hpp
+++ b/src/cpp/statistics/rtps/StatisticsBase.hpp
@@ -77,11 +77,11 @@ Function StatisticsListenersImpl::for_each_listener(
 {
     // Use a collection copy to prevent locking on traversal
     std::unique_lock<fastrtps::RecursiveTimedMutex> lock(get_statistics_mutex());
-    auto listeners = members_->listeners;
-    lock.unlock();
-
     if (members_)
     {
+        auto listeners = members_->listeners;
+        lock.unlock();
+
         for (auto& listener : listeners)
         {
             f(listener);

--- a/src/cpp/statistics/rtps/reader/StatisticsReaderImpl.cpp
+++ b/src/cpp/statistics/rtps/reader/StatisticsReaderImpl.cpp
@@ -20,6 +20,8 @@
 
 #include <fastdds/rtps/reader/RTPSReader.h>
 
+#include "../../types/types.h"
+
 using namespace eprosima::fastdds::statistics;
 
 using eprosima::fastrtps::RecursiveTimedMutex;
@@ -62,6 +64,11 @@ void StatisticsReaderImpl::on_data_notify(
         const fastrtps::rtps::GUID_t& writer_guid,
         const fastrtps::rtps::Time_t& source_timestamp)
 {
+    if (!are_statistics_writers_enabled(EventKind::HISTORY2HISTORY_LATENCY))
+    {
+        return;
+    }
+
     // Get current timestamp
     fastrtps::rtps::Time_t current_time;
     fastrtps::rtps::Time_t::now(current_time);
@@ -88,6 +95,11 @@ void StatisticsReaderImpl::on_data_notify(
 void StatisticsReaderImpl::on_acknack(
         int32_t count)
 {
+    if (!are_statistics_writers_enabled(EventKind::ACKNACK_COUNT))
+    {
+        return;
+    }
+
     EntityCount notification;
     notification.guid(to_statistics_type(get_guid()));
     notification.count(count);
@@ -107,6 +119,11 @@ void StatisticsReaderImpl::on_acknack(
 void StatisticsReaderImpl::on_nackfrag(
         int32_t count)
 {
+    if (!are_statistics_writers_enabled(EventKind::NACKFRAG_COUNT))
+    {
+        return;
+    }
+
     EntityCount notification;
     notification.guid(to_statistics_type(get_guid()));
     notification.count(count);
@@ -131,6 +148,10 @@ void StatisticsReaderImpl::on_subscribe_throughput(
 
     if (payload > 0 )
     {
+        if (!are_statistics_writers_enabled(EventKind::SUBSCRIPTION_THROUGHPUT))
+        {
+            return;
+        }
         // update state
         time_point<steady_clock> former_timepoint;
         auto& current_timepoint = get_members()->last_history_change_;

--- a/src/cpp/statistics/rtps/reader/StatisticsReaderImpl.cpp
+++ b/src/cpp/statistics/rtps/reader/StatisticsReaderImpl.cpp
@@ -19,8 +19,7 @@
 #include <statistics/rtps/StatisticsBase.hpp>
 
 #include <fastdds/rtps/reader/RTPSReader.h>
-
-#include "../../types/types.h"
+#include <statistics/types/types.h>
 
 using namespace eprosima::fastdds::statistics;
 

--- a/src/cpp/statistics/rtps/writer/StatisticsWriterImpl.cpp
+++ b/src/cpp/statistics/rtps/writer/StatisticsWriterImpl.cpp
@@ -20,6 +20,8 @@
 
 #include <fastdds/rtps/writer/RTPSWriter.h>
 
+#include "../../types/types.h"
+
 using namespace eprosima::fastdds::statistics;
 
 using eprosima::fastrtps::RecursiveTimedMutex;
@@ -64,6 +66,11 @@ void StatisticsWriterImpl::on_sample_datas(
         const fastrtps::rtps::SampleIdentity& sample_identity,
         size_t num_sent_submessages)
 {
+    if (!are_statistics_writers_enabled(EventKind::SAMPLE_DATAS))
+    {
+        return;
+    }
+
     SampleIdentityCount notification;
     notification.sample_id(to_statistics_type(sample_identity));
     notification.count(static_cast<uint64_t>(num_sent_submessages));
@@ -89,6 +96,11 @@ void StatisticsWriterImpl::on_data_generated(
 
 void StatisticsWriterImpl::on_data_sent()
 {
+    if (!are_statistics_writers_enabled(EventKind::DATA_COUNT))
+    {
+        return;
+    }
+
     EntityCount notification;
     notification.guid(to_statistics_type(get_guid()));
 
@@ -113,6 +125,11 @@ void StatisticsWriterImpl::on_data_sent()
 void StatisticsWriterImpl::on_heartbeat(
         uint32_t count)
 {
+    if (!are_statistics_writers_enabled(EventKind::HEARTBEAT_COUNT))
+    {
+        return;
+    }
+
     EntityCount notification;
     notification.guid(to_statistics_type(get_guid()));
     notification.count(count);
@@ -131,6 +148,11 @@ void StatisticsWriterImpl::on_heartbeat(
 
 void StatisticsWriterImpl::on_gap()
 {
+    if (!are_statistics_writers_enabled(EventKind::GAP_COUNT))
+    {
+        return;
+    }
+
     EntityCount notification;
     notification.guid(to_statistics_type(get_guid()));
 
@@ -155,6 +177,11 @@ void StatisticsWriterImpl::on_resent_data(
         uint32_t to_send)
 {
     if ( 0 == to_send )
+    {
+        return;
+    }
+
+    if (!are_statistics_writers_enabled(EventKind::RESENT_DATAS))
     {
         return;
     }
@@ -186,6 +213,11 @@ void StatisticsWriterImpl::on_publish_throughput(
 
     if (payload > 0 )
     {
+        if (!are_statistics_writers_enabled(EventKind::PUBLICATION_THROUGHPUT))
+        {
+            return;
+        }
+
         // update state
         time_point<steady_clock> former_timepoint;
         auto& current_timepoint = get_members()->last_history_change_;

--- a/src/cpp/statistics/rtps/writer/StatisticsWriterImpl.cpp
+++ b/src/cpp/statistics/rtps/writer/StatisticsWriterImpl.cpp
@@ -19,8 +19,7 @@
 #include <statistics/rtps/StatisticsBase.hpp>
 
 #include <fastdds/rtps/writer/RTPSWriter.h>
-
-#include "../../types/types.h"
+#include <statistics/types/types.h>
 
 using namespace eprosima::fastdds::statistics;
 

--- a/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.h
+++ b/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.h
@@ -104,6 +104,11 @@ public:
         return true;
     }
 
+    void set_enabled_statistics_writers_mask(
+            uint32_t /*enabled_writers*/)
+    {
+    }
+
 #endif // FASTDDS_STATISTICS
 
 

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -613,17 +613,17 @@ TEST_F(RTPSStatisticsTests, statistics_rpts_listener_callbacks)
     create_endpoints(length, RELIABLE);
 
     uint32_t enable_writers_mask =
-        EventKind::HISTORY2HISTORY_LATENCY |
-        EventKind::NETWORK_LATENCY |
-        EventKind::PUBLICATION_THROUGHPUT |
-        EventKind::SUBSCRIPTION_THROUGHPUT |
-        EventKind::RTPS_SENT |
-        EventKind::RTPS_LOST |
-        EventKind::RESENT_DATAS |
-        EventKind::HEARTBEAT_COUNT |
-        EventKind::ACKNACK_COUNT |
-        EventKind::DATA_COUNT |
-        EventKind::SAMPLE_DATAS;
+            EventKind::HISTORY2HISTORY_LATENCY |
+            EventKind::NETWORK_LATENCY |
+            EventKind::PUBLICATION_THROUGHPUT |
+            EventKind::SUBSCRIPTION_THROUGHPUT |
+            EventKind::RTPS_SENT |
+            EventKind::RTPS_LOST |
+            EventKind::RESENT_DATAS |
+            EventKind::HEARTBEAT_COUNT |
+            EventKind::ACKNACK_COUNT |
+            EventKind::DATA_COUNT |
+            EventKind::SAMPLE_DATAS;
 
     // participant specific callbacks
     auto participant_listener = make_shared<MockListener>();
@@ -775,11 +775,11 @@ TEST_F(RTPSStatisticsTests, statistics_rpts_listener_callbacks_fragmented)
         });
 
     uint32_t enable_writers_mask =
-        EventKind::HISTORY2HISTORY_LATENCY |
-        EventKind::HEARTBEAT_COUNT |
-        EventKind::ACKNACK_COUNT |
-        EventKind::NACKFRAG_COUNT |
-        EventKind::DATA_COUNT;
+            EventKind::HISTORY2HISTORY_LATENCY |
+            EventKind::HEARTBEAT_COUNT |
+            EventKind::ACKNACK_COUNT |
+            EventKind::NACKFRAG_COUNT |
+            EventKind::DATA_COUNT;
 
     // writer callbacks through participant listener
     auto participant_listener = make_shared<MockListener>();
@@ -824,6 +824,168 @@ TEST_F(RTPSStatisticsTests, statistics_rpts_listener_callbacks_fragmented)
 }
 
 /*
+ * This test checks the behaviour of RTPSParticipant, RTPSWriter and RTPSReader statistics module
+ * related APIs when their enabled statistics writers mask is set to 0.
+ * - RTPS_SENT callbacks are not performed
+ * - RTPS_LOST callbacks are not performed
+ * - NETWORK_LATENCY callbacks are not performed
+ * - HISTORY2HISTORY_LATENCY callbacks are not performed
+ * - DATA_COUNT callbacks are not performed for DATA submessages
+ * - RESENT_DATAS callbacks are not performed for DATA submessages demanded by the readers
+ * - ACKNACK_COUNT callbacks are not performed
+ * - HEARBEAT_COUNT callbacks are not performed
+ * - SAMPLE_DATAS callbacks are not performed
+ * - PUBLICATION_THROUGHPUT callbacks are not performed
+ * - SUBSCRIPTION_THROUGHPUT callbacks are not performed
+ */
+TEST_F(RTPSStatisticsTests, statistics_rpts_listener_callbacks_no_enabled_writers)
+{
+    using namespace ::testing;
+    using namespace fastrtps;
+    using namespace fastrtps::rtps;
+    using namespace std;
+
+    // make sure some messages are lost to assure the RESENT_DATAS callback
+    set_transport_filter(
+        DATA,
+        [](fastrtps::rtps::CDRMessage_t& msg)-> bool
+        {
+            static unsigned int samples_filtered = 0;
+            uint32_t old_pos = msg.pos;
+
+            // see RTPS DDS 9.4.5.3 Data Submessage
+            EntityId_t readerID, writerID;
+            SequenceNumber_t sn;
+
+            msg.pos += 2; // flags
+            msg.pos += 2; // octets to inline quos
+            CDRMessage::readEntityId(&msg, &readerID);
+            CDRMessage::readEntityId(&msg, &writerID);
+            CDRMessage::readSequenceNumber(&msg, &sn);
+
+            // restore buffer pos
+            msg.pos = old_pos;
+
+            // generate losses
+            if ( samples_filtered < 10 // only a few times (mind the interfaces)
+            && (writerID.value[3] & 0xC0) == 0      // only user endpoints
+            && (sn == SequenceNumber_t{0, 1}))     // only first sample
+            {
+                ++samples_filtered;
+                return true;
+            }
+
+            return false;
+        });
+
+    // create the testing endpoints
+    uint16_t length = 255;
+    create_endpoints(length, RELIABLE);
+
+    // participant specific callbacks
+    auto participant_listener = make_shared<MockListener>();
+    ASSERT_TRUE(participant_->add_statistics_listener(participant_listener,
+            EventKind::RTPS_SENT | EventKind::NETWORK_LATENCY | EventKind::RTPS_LOST));
+
+    // writer callbacks through participant listener
+    auto participant_writer_listener = make_shared<MockListener>();
+    ASSERT_TRUE(participant_->add_statistics_listener(participant_writer_listener,
+            EventKind::DATA_COUNT | EventKind::RESENT_DATAS |
+            EventKind::PUBLICATION_THROUGHPUT | EventKind::SAMPLE_DATAS));
+
+    // writer specific callbacks
+    auto writer_listener = make_shared<MockListener>();
+    ASSERT_TRUE(writer_->add_statistics_listener(writer_listener));
+
+    // reader callbacks through participant listener
+    auto participant_reader_listener = make_shared<MockListener>();
+    ASSERT_TRUE(participant_->add_statistics_listener(participant_reader_listener,
+            EventKind::ACKNACK_COUNT | EventKind::HISTORY2HISTORY_LATENCY |
+            EventKind::SUBSCRIPTION_THROUGHPUT));
+
+    // reader specific callbacks
+    auto reader_listener = make_shared<MockListener>();
+    ASSERT_TRUE(reader_->add_statistics_listener(reader_listener));
+
+    // we must not receive the RTPS_SENT, RTPS_LOST and NETWORK_LATENCY notifications
+    EXPECT_CALL(*participant_listener, on_rtps_sent)
+            .Times(0);
+    EXPECT_CALL(*participant_listener, on_rtps_lost)
+            .Times(0);
+    EXPECT_CALL(*participant_listener, on_network_latency)
+            .Times(0);
+
+    // Check callbacks on data exchange; we must not receive:
+    // + RTPSWriter: PUBLICATION_THROUGHPUT, RESENT_DATAS,
+    //               GAP_COUNT, DATA_COUNT, SAMPLE_DATAS & PHYSICAL_DATA
+    //   neither: NACKFRAG_COUNT
+    EXPECT_CALL(*writer_listener, on_heartbeat_count)
+            .Times(0);
+    EXPECT_CALL(*writer_listener, on_data_count)
+            .Times(0);
+    EXPECT_CALL(*writer_listener, on_resent_count)
+            .Times(0);
+    EXPECT_CALL(*writer_listener, on_sample_datas)
+            .Times(0);
+    EXPECT_CALL(*writer_listener, on_publisher_throughput)
+            .Times(0);
+
+    EXPECT_CALL(*participant_writer_listener, on_data_count)
+            .Times(0);
+    EXPECT_CALL(*participant_writer_listener, on_resent_count)
+            .Times(0);
+    EXPECT_CALL(*participant_writer_listener, on_sample_datas)
+            .Times(0);
+    EXPECT_CALL(*participant_writer_listener, on_publisher_throughput)
+            .Times(0);
+
+    // + RTPSReader: SUBSCRIPTION_THROUGHPUT,
+    //               SAMPLE_DATAS & PHYSICAL_DATA
+    //   neither: ACKNACK_COUNT
+    EXPECT_CALL(*reader_listener, on_acknack_count)
+            .Times(0);
+    EXPECT_CALL(*reader_listener, on_history_latency)
+            .Times(0);
+    EXPECT_CALL(*reader_listener, on_subscriber_throughput)
+            .Times(0);
+
+    EXPECT_CALL(*participant_reader_listener, on_acknack_count)
+            .Times(0);
+    EXPECT_CALL(*participant_reader_listener, on_history_latency)
+            .Times(0);
+    EXPECT_CALL(*participant_reader_listener, on_subscriber_throughput)
+            .Times(0);
+
+    // match writer and reader on a dummy topic
+    match_endpoints(false, "string", "statisticsSmallTopic");
+
+    // exchange data
+    write_small_sample(length);
+
+    // wait for reception
+    EXPECT_TRUE(reader_->wait_for_unread_cache(Duration_t(5, 0)));
+
+    // receive the sample
+    CacheChange_t* reader_change = nullptr;
+    ASSERT_TRUE(reader_->nextUntakenCache(&reader_change, nullptr));
+
+    // wait for acknowledgement
+    EXPECT_TRUE(writer_->wait_for_all_acked(Duration_t(5, 0)));
+
+    EXPECT_TRUE(writer_->remove_statistics_listener(writer_listener));
+    EXPECT_TRUE(reader_->remove_statistics_listener(reader_listener));
+
+    EXPECT_TRUE(participant_->remove_statistics_listener(participant_listener,
+            EventKind::RTPS_SENT | EventKind::NETWORK_LATENCY | EventKind::RTPS_LOST));
+    EXPECT_TRUE(participant_->remove_statistics_listener(participant_writer_listener,
+            EventKind::DATA_COUNT | EventKind::RESENT_DATAS |
+            EventKind::PUBLICATION_THROUGHPUT | EventKind::SAMPLE_DATAS));
+    EXPECT_TRUE(participant_->remove_statistics_listener(participant_reader_listener,
+            EventKind::ACKNACK_COUNT | EventKind::HISTORY2HISTORY_LATENCY |
+            EventKind::SUBSCRIPTION_THROUGHPUT));
+}
+
+/*
  * This test checks RTPSWriter GAP_COUNT statistics callback
  */
 TEST_F(RTPSStatisticsTests, statistics_rpts_listener_gap_callback)
@@ -834,14 +996,14 @@ TEST_F(RTPSStatisticsTests, statistics_rpts_listener_gap_callback)
     using namespace std;
 
     uint32_t enable_writers_mask =
-        EventKind::PUBLICATION_THROUGHPUT |
-        EventKind::RESENT_DATAS |
-        EventKind::HEARTBEAT_COUNT |
-        EventKind::ACKNACK_COUNT |
-        EventKind::NACKFRAG_COUNT |
-        EventKind::GAP_COUNT |
-        EventKind::DATA_COUNT |
-        EventKind::SAMPLE_DATAS;
+            EventKind::PUBLICATION_THROUGHPUT |
+            EventKind::RESENT_DATAS |
+            EventKind::HEARTBEAT_COUNT |
+            EventKind::ACKNACK_COUNT |
+            EventKind::NACKFRAG_COUNT |
+            EventKind::GAP_COUNT |
+            EventKind::DATA_COUNT |
+            EventKind::SAMPLE_DATAS;
 
     // create the listeners and set expectations
     auto participant_writer_listener = make_shared<MockListener>();
@@ -915,9 +1077,9 @@ TEST_F(RTPSStatisticsTests, statistics_rpts_listener_discovery_callbacks)
     using namespace std;
 
     uint32_t enable_writers_mask =
-        EventKind::PDP_PACKETS |
-        EventKind::EDP_PACKETS |
-        EventKind::DISCOVERED_ENTITY;
+            EventKind::PDP_PACKETS |
+            EventKind::EDP_PACKETS |
+            EventKind::DISCOVERED_ENTITY;
 
     // create the listener and set expectations
     auto participant_listener = make_shared<MockListener>();
@@ -1051,11 +1213,11 @@ TEST_F(RTPSStatisticsTests, statistics_rpts_avoid_empty_resent_callbacks)
     uint16_t length = 255;
     create_lazy_writer(length, RELIABLE, TRANSIENT_LOCAL);
     uint32_t enable_writers_mask =
-        EventKind::HEARTBEAT_COUNT |
-        EventKind::DATA_COUNT |
-        EventKind::SAMPLE_DATAS |
-        EventKind::PUBLICATION_THROUGHPUT |
-        EventKind::RESENT_DATAS;
+            EventKind::HEARTBEAT_COUNT |
+            EventKind::DATA_COUNT |
+            EventKind::SAMPLE_DATAS |
+            EventKind::PUBLICATION_THROUGHPUT |
+            EventKind::RESENT_DATAS;
     writer_->set_enabled_statistics_writers_mask(enable_writers_mask);
 
     // writer specific callbacks

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -917,7 +917,7 @@ TEST_F(RTPSStatisticsTests, statistics_rpts_listener_callbacks_no_enabled_writer
 
     // Check callbacks on data exchange; we must not receive:
     // + RTPSWriter: PUBLICATION_THROUGHPUT, RESENT_DATAS,
-    //               GAP_COUNT, DATA_COUNT, SAMPLE_DATAS & PHYSICAL_DATA
+    //               DATA_COUNT, SAMPLE_DATAS & PHYSICAL_DATA
     //   neither: NACKFRAG_COUNT
     EXPECT_CALL(*writer_listener, on_heartbeat_count)
             .Times(0);
@@ -1321,12 +1321,6 @@ TEST_F(RTPSStatisticsTests, statistics_rpts_unordered_datagrams)
     // create the listener and set expectations
     auto participant_listener = make_shared<MockListener>();
     ASSERT_TRUE(participant_->add_statistics_listener(participant_listener, EventKind::RTPS_LOST));
-    // uint32_t enable_writers_mask =
-    //     EventKind::HEARTBEAT_COUNT |
-    //     EventKind::DATA_COUNT |
-    //     EventKind::SAMPLE_DATAS |
-    //     EventKind::PUBLICATION_THROUGHPUT |
-    //     EventKind::RESENT_DATAS;
     participant_->set_enabled_statistics_writers_mask(EventKind::RTPS_LOST);
 
     std::vector<Entity2LocatorTraffic> lost_callback_data;

--- a/versions.md
+++ b/versions.md
@@ -2,7 +2,7 @@ Forthcoming
 -----------
 
 * Default memory management policy set to `PREALLOCATED_WITH_REALLOC_MEMORY_MODE` (behaviour change)
-* Statistics metric are only calculated/accumulated when their corresponding DataWriter is enabled (behaviour change)
+* Statistics metrics are only calculated/accumulated when their corresponding DataWriter is enabled (behaviour change)
 
 Version 2.8.0
 -------------

--- a/versions.md
+++ b/versions.md
@@ -1,7 +1,8 @@
 Forthcoming
 -----------
 
-* Default memory management policy set to `PREALLOCATED_WITH_REALLOC_MEMORY_MODE`
+* Default memory management policy set to `PREALLOCATED_WITH_REALLOC_MEMORY_MODE` (behaviour change)
+* Statistics metric are only calculated/accumulated when their corresponding DataWriter is enabled (behaviour change)
 
 Version 2.8.0
 -------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR prevents the calculation of any statistics measurements if the corresponding DataWriter is not enabled.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- *N/A*: New feature has been added to the `versions.md` file (if applicable).
- *N/A*: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
