### PR TITLE
Fix failed tests when compiling with statistics enabled

### DIFF
--- a/src/cpp/rtps/transport/UDPTransportInterface.h
+++ b/src/cpp/rtps/transport/UDPTransportInterface.h
@@ -101,6 +101,7 @@ public:
     /**
      * Blocking Send through the specified channel. In both modes, using a localLocator of 0.0.0.0 will
      * send through all whitelisted interfaces provided the channel is open.
+     *
      * @param send_buffer Slice into the raw data to send.
      * @param send_buffer_size Size of the raw data. It will be used as a bounds check for the previous argument.
      * It must not exceed the send_buffer_size fed to this class during construction.
@@ -112,6 +113,8 @@ public:
      * @param only_multicast_purpose multicast network interface
      * @param whitelisted network interface included in the user whitelist
      * @param max_blocking_time_point maximum blocking time.
+     *
+     * @pre Open the output channel of each remote locator by invoking \ref OpenOutputChannel function.
      */
     virtual bool send(
             const fastrtps::rtps::octet* send_buffer,

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
@@ -989,14 +989,14 @@ public:
     }
 
     PubSubWriter& property_policy(
-            const eprosima::fastrtps::rtps::PropertyPolicy property_policy)
+            const eprosima::fastrtps::rtps::PropertyPolicy& property_policy)
     {
         participant_attr_.rtps.properties = property_policy;
         return *this;
     }
 
     PubSubWriter& entity_property_policy(
-            const eprosima::fastrtps::rtps::PropertyPolicy property_policy)
+            const eprosima::fastrtps::rtps::PropertyPolicy& property_policy)
     {
         publisher_attr_.properties = property_policy;
         return *this;

--- a/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
@@ -560,11 +560,11 @@ TEST_P(PubSubBasic, ReceivedPropertiesDataWithinSizeLimit)
     // Set statistics properties manually to ensure a fix size of participant properties
     PropertyPolicy property_policy;
     property_policy.properties().emplace_back(
-            eprosima::fastdds::dds::parameter_policy_physical_data_host, "test_host");
+        eprosima::fastdds::dds::parameter_policy_physical_data_host, "test_host");
     property_policy.properties().emplace_back(
-            eprosima::fastdds::dds::parameter_policy_physical_data_user, "test_user");
+        eprosima::fastdds::dds::parameter_policy_physical_data_user, "test_user");
     property_policy.properties().emplace_back(
-            eprosima::fastdds::dds::parameter_policy_physical_data_process, "test_process");
+        eprosima::fastdds::dds::parameter_policy_physical_data_process, "test_process");
 
     writer.static_discovery("file://PubSubWriter.xml")
             .unicastLocatorList(WriterUnicastLocators)

--- a/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
@@ -22,6 +22,7 @@
 #include "ReqRepAsReliableHelloWorldRequester.hpp"
 
 #include <fastdds/dds/log/Log.hpp>
+#include <fastdds/dds/core/policy/ParameterTypes.hpp>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 
 #include <gtest/gtest.h>
@@ -556,10 +557,22 @@ TEST_P(PubSubBasic, ReceivedPropertiesDataWithinSizeLimit)
     LocatorBuffer.port = static_cast<uint16_t>(MULTICAST_PORT_RANDOM_NUMBER);
     WriterMulticastLocators.push_back(LocatorBuffer);
 
-    writer.static_discovery("file://PubSubWriter.xml").
-            unicastLocatorList(WriterUnicastLocators).multicastLocatorList(WriterMulticastLocators).
-            setPublisherIDs(1,
-            2).setManualTopicName(std::string("BlackBox_StaticDiscovery_") + TOPIC_RANDOM_NUMBER).init();
+    // Set statistics properties manually to ensure a fix size of participant properties
+    PropertyPolicy property_policy;
+    property_policy.properties().emplace_back(
+            eprosima::fastdds::dds::parameter_policy_physical_data_host, "test_host");
+    property_policy.properties().emplace_back(
+            eprosima::fastdds::dds::parameter_policy_physical_data_user, "test_user");
+    property_policy.properties().emplace_back(
+            eprosima::fastdds::dds::parameter_policy_physical_data_process, "test_process");
+
+    writer.static_discovery("file://PubSubWriter.xml")
+            .unicastLocatorList(WriterUnicastLocators)
+            .multicastLocatorList(WriterMulticastLocators)
+            .setPublisherIDs(1, 2)
+            .setManualTopicName(std::string("BlackBox_StaticDiscovery_") + TOPIC_RANDOM_NUMBER)
+            .property_policy(property_policy)
+            .init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -573,12 +586,31 @@ TEST_P(PubSubBasic, ReceivedPropertiesDataWithinSizeLimit)
     LocatorBuffer.port = static_cast<uint16_t>(MULTICAST_PORT_RANDOM_NUMBER);
     ReaderMulticastLocators.push_back(LocatorBuffer);
 
-    //Expected properties have exactly size 92
-    reader.properties_max_size(92).
-            static_discovery("file://PubSubReader.xml").
-            unicastLocatorList(ReaderUnicastLocators).multicastLocatorList(ReaderMulticastLocators).
-            setSubscriberIDs(3,
-            4).setManualTopicName(std::string("BlackBox_StaticDiscovery_") + TOPIC_RANDOM_NUMBER).init();
+    // The calculation of exact maximum properties size has been done according to the following table
+    //
+    // | Type  | Value                               | Size | Alignment | Extra | Total |
+    // |-------|-------------------------------------|------|-----------|-------|-------|
+    // | key   | PARTICIPANT_TYPE                    |   17 |         3 |     4 |    24 |
+    // | value | SIMPLE                              |    7 |         1 |     4 |    12 |
+    // | key   | fastdds.physical_data.host          |   27 |         1 |     4 |    32 |
+    // | value | test_host                           |   10 |         2 |     4 |    16 |
+    // | key   | fastdds.physical_data.user          |   27 |         1 |     4 |    32 |
+    // | value | test_user                           |   10 |         2 |     4 |    16 |
+    // | key   | fastdds.physical_data.process       |   30 |         2 |     4 |    36 |
+    // | value | test_process                        |   13 |         3 |     4 |    20 |
+    // | key   | eProsimaEDPStatic_Writer_ALIVE_ID_1 |   36 |         0 |     4 |    40 |
+    // | value | 0.0.2.3                             |    8 |         0 |     4 |    12 |
+    //
+    // Total: 240 Bytes
+
+    reader.properties_max_size(240)
+            .static_discovery("file://PubSubReader.xml")
+            .unicastLocatorList(ReaderUnicastLocators)
+            .multicastLocatorList(ReaderMulticastLocators)
+            .setSubscriberIDs(3, 4)
+            .setManualTopicName(std::string("BlackBox_StaticDiscovery_") + TOPIC_RANDOM_NUMBER)
+            .property_policy(property_policy)
+            .init();
 
     ASSERT_TRUE(reader.isInitialized());
 

--- a/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
@@ -557,7 +557,7 @@ TEST_P(PubSubBasic, ReceivedPropertiesDataWithinSizeLimit)
     LocatorBuffer.port = static_cast<uint16_t>(MULTICAST_PORT_RANDOM_NUMBER);
     WriterMulticastLocators.push_back(LocatorBuffer);
 
-    // Set statistics properties manually to ensure a fix size of participant properties
+    // Set statistics properties manually to ensure a fixed size of participant properties
     PropertyPolicy property_policy;
     property_policy.properties().emplace_back(
         eprosima::fastdds::dds::parameter_policy_physical_data_host, "test_host");
@@ -586,7 +586,7 @@ TEST_P(PubSubBasic, ReceivedPropertiesDataWithinSizeLimit)
     LocatorBuffer.port = static_cast<uint16_t>(MULTICAST_PORT_RANDOM_NUMBER);
     ReaderMulticastLocators.push_back(LocatorBuffer);
 
-    // The calculation of exact maximum properties size has been done according to the following table
+    // The calculation of the exact maximum properties size has been done according to the following table
     //
     // | Type  | Value                               | Size | Alignment | Extra | Total |
     // |-------|-------------------------------------|------|-----------|-------|-------|

--- a/test/unittest/transport/UDPv4Tests.cpp
+++ b/test/unittest/transport/UDPv4Tests.cpp
@@ -311,13 +311,14 @@ TEST_F(UDPv4Tests, send_to_wrong_interface)
     ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, outputChannelLocator));
     ASSERT_FALSE(send_resource_list.empty());
 
+    Locator_t empty_locator;
+    EXPECT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, empty_locator));
+
     LocatorList_t locator_list;
-    locator_list.push_back(Locator_t());
+    locator_list.push_back(empty_locator);
     Locators locators_begin(locator_list.begin());
     Locators locators_end(locator_list.end());
 
-    //Sending through a different IP will NOT work, except 0.0.0.0
-    IPLocator::setIPv4(outputChannelLocator, 111, 111, 111, 111);
     std::vector<octet> message = { 'H', 'e', 'l', 'l', 'o' };
     ASSERT_FALSE(send_resource_list.at(0)->send(message.data(), (uint32_t)message.size(), &locators_begin,
             &locators_end,

--- a/test/unittest/transport/UDPv6Tests.cpp
+++ b/test/unittest/transport/UDPv6Tests.cpp
@@ -342,14 +342,15 @@ TEST_F(UDPv6Tests, send_to_wrong_interface)
     ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, outputChannelLocator));
     ASSERT_FALSE(send_resource_list.empty());
 
+    Locator_t empty_locator;
+    empty_locator.kind = LOCATOR_KIND_UDPv6;
+    EXPECT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, empty_locator));
+
     LocatorList_t locator_list;
-    Locator_t locator;
-    locator.kind = LOCATOR_KIND_UDPv6;
-    locator_list.push_back(locator);
+    locator_list.push_back(empty_locator);
     Locators locators_begin(locator_list.begin());
     Locators locators_end(locator_list.end());
 
-    //Sending through a different IP will NOT work, except 0.0.0.0
     IPLocator::setIPv6(outputChannelLocator, std::string("fe80::ffff:6f6f:6f6f"));
     std::vector<octet> message = { 'H', 'e', 'l', 'l', 'o' };
     ASSERT_FALSE(send_resource_list.at(0)->send(message.data(), (uint32_t)message.size(), &locators_begin,

--- a/test/unittest/transport/UDPv6Tests.cpp
+++ b/test/unittest/transport/UDPv6Tests.cpp
@@ -351,7 +351,6 @@ TEST_F(UDPv6Tests, send_to_wrong_interface)
     Locators locators_begin(locator_list.begin());
     Locators locators_end(locator_list.end());
 
-    IPLocator::setIPv6(outputChannelLocator, std::string("fe80::ffff:6f6f:6f6f"));
     std::vector<octet> message = { 'H', 'e', 'l', 'l', 'o' };
     ASSERT_FALSE(send_resource_list.at(0)->send(message.data(), (uint32_t)message.size(), &locators_begin,
             &locators_end,


### PR DESCRIPTION
This PR covers the fix of the following tests:

  - BlackboxTests_DDS_PIM.PubSubBasic.ReceivedPropertiesDataWithinSizeLimit.Transport (Failed)
  - BlackboxTests_DDS_PIM.PubSubBasic.ReceivedPropertiesDataWithinSizeLimit.Intraprocess (Failed)
  - BlackboxTests_DDS_PIM.PubSubBasic.ReceivedPropertiesDataWithinSizeLimit.Datasharing (Failed)
  - UDPv4Tests.send_to_wrong_interface (Subprocess aborted)
  - UDPv6Tests.send_to_wrong_interface (Subprocess aborted)

<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
