### PR TITLE
[16166] Fixing deadlock in WLP

### DIFF
--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -866,12 +866,13 @@ bool WLP::automatic_liveliness_assertion()
 
 bool WLP::participant_liveliness_assertion()
 {
-    std::lock_guard<std::recursive_mutex> guard(*mp_builtinProtocols->mp_PDP->getMutex());
+    std::unique_lock<std::recursive_mutex> lock(*mp_builtinProtocols->mp_PDP->getMutex());
 
     if (0 < manual_by_participant_writers_.size())
     {
         if (pub_liveliness_manager_->is_any_alive(MANUAL_BY_PARTICIPANT_LIVELINESS_QOS))
         {
+            lock.unlock();
             return send_liveliness_message(manual_by_participant_instance_handle_);
         }
     }

--- a/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
@@ -757,6 +757,53 @@ public:
         return *this;
     }
 
+    PubSubWriterReader& pub_liveliness_kind(
+            const eprosima::fastrtps::LivelinessQosPolicyKind kind)
+    {
+        datawriter_qos_.liveliness().kind = kind;
+        return *this;
+    }
+
+    PubSubWriterReader& sub_liveliness_kind(
+            const eprosima::fastrtps::LivelinessQosPolicyKind kind)
+    {
+        datareader_qos_.liveliness().kind = kind;
+        return *this;
+    }
+
+    PubSubWriterReader& pub_liveliness_announcement_period(
+            const eprosima::fastrtps::Duration_t announcement_period)
+    {
+        datawriter_qos_.liveliness().announcement_period = announcement_period;
+        return *this;
+    }
+
+    PubSubWriterReader& sub_liveliness_announcement_period(
+            const eprosima::fastrtps::Duration_t announcement_period)
+    {
+        datareader_qos_.liveliness().announcement_period = announcement_period;
+        return *this;
+    }
+
+    PubSubWriterReader& pub_liveliness_lease_duration(
+            const eprosima::fastrtps::Duration_t lease_duration)
+    {
+        datawriter_qos_.liveliness().lease_duration = lease_duration;
+        return *this;
+    }
+
+    PubSubWriterReader& sub_liveliness_lease_duration(
+            const eprosima::fastrtps::Duration_t lease_duration)
+    {
+        datareader_qos_.liveliness().lease_duration = lease_duration;
+        return *this;
+    }
+
+    void assert_liveliness()
+    {
+        datawriter_->assert_liveliness();
+    }
+
     size_t get_num_discovered_participants() const
     {
         return participant_listener_.get_num_discovered_participants();

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriterReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriterReader.hpp
@@ -657,6 +657,53 @@ public:
         return *this;
     }
 
+    PubSubWriterReader& pub_liveliness_kind(
+            const eprosima::fastrtps::LivelinessQosPolicyKind kind)
+    {
+        publisher_attr_.qos.m_liveliness.kind = kind;
+        return *this;
+    }
+
+    PubSubWriterReader& sub_liveliness_kind(
+            const eprosima::fastrtps::LivelinessQosPolicyKind kind)
+    {
+        subscriber_attr_.qos.m_liveliness.kind = kind;
+        return *this;
+    }
+
+    PubSubWriterReader& pub_liveliness_announcement_period(
+            const eprosima::fastrtps::Duration_t announcement_period)
+    {
+        publisher_attr_.qos.m_liveliness.announcement_period = announcement_period;
+        return *this;
+    }
+
+    PubSubWriterReader& sub_liveliness_announcement_period(
+            const eprosima::fastrtps::Duration_t announcement_period)
+    {
+        subscriber_attr_.qos.m_liveliness.announcement_period = announcement_period;
+        return *this;
+    }
+
+    PubSubWriterReader& pub_liveliness_lease_duration(
+            const eprosima::fastrtps::Duration_t lease_duration)
+    {
+        publisher_attr_.qos.m_liveliness.lease_duration = lease_duration;
+        return *this;
+    }
+
+    PubSubWriterReader& sub_liveliness_lease_duration(
+            const eprosima::fastrtps::Duration_t lease_duration)
+    {
+        subscriber_attr_.qos.m_liveliness.lease_duration = lease_duration;
+        return *this;
+    }
+
+    void assert_liveliness()
+    {
+        publisher_->assert_liveliness();
+    }
+
     size_t get_num_discovered_participants() const
     {
         return participant_listener_.get_num_discovered_participants();

--- a/test/blackbox/common/BlackboxTestsLivelinessQos.cpp
+++ b/test/blackbox/common/BlackboxTestsLivelinessQos.cpp
@@ -1914,22 +1914,22 @@ TEST(LivelinessTests, Detect_Deadlock_ManualByParticipant_Intraprocess)
     unsigned int announcement_period_ms = 1;
 
     participantA.pub_liveliness_kind(MANUAL_BY_PARTICIPANT_LIVELINESS_QOS)
-                .sub_liveliness_kind(MANUAL_BY_PARTICIPANT_LIVELINESS_QOS)
-                .pub_liveliness_announcement_period(announcement_period_ms * 1e-3)
-                .sub_liveliness_announcement_period(announcement_period_ms * 1e-3)
-                .pub_liveliness_lease_duration(lease_duration_ms * 1e-3)
-                .sub_liveliness_lease_duration(lease_duration_ms * 1e-3)
-//              .disable_builtin_transport()
-                .init();
+            .sub_liveliness_kind(MANUAL_BY_PARTICIPANT_LIVELINESS_QOS)
+            .pub_liveliness_announcement_period(announcement_period_ms * 1e-3)
+            .sub_liveliness_announcement_period(announcement_period_ms * 1e-3)
+            .pub_liveliness_lease_duration(lease_duration_ms * 1e-3)
+            .sub_liveliness_lease_duration(lease_duration_ms * 1e-3)
+    //              .disable_builtin_transport()
+            .init();
 
     participantB.pub_liveliness_kind(MANUAL_BY_PARTICIPANT_LIVELINESS_QOS)
-                .sub_liveliness_kind(MANUAL_BY_PARTICIPANT_LIVELINESS_QOS)
-                .pub_liveliness_announcement_period(announcement_period_ms * 1e-3)
-                .sub_liveliness_announcement_period(announcement_period_ms * 1e-3)
-                .pub_liveliness_lease_duration(lease_duration_ms * 1e-3)
-                .sub_liveliness_lease_duration(lease_duration_ms * 1e-3)
-//              .disable_builtin_transport()
-                .init();
+            .sub_liveliness_kind(MANUAL_BY_PARTICIPANT_LIVELINESS_QOS)
+            .pub_liveliness_announcement_period(announcement_period_ms * 1e-3)
+            .sub_liveliness_announcement_period(announcement_period_ms * 1e-3)
+            .pub_liveliness_lease_duration(lease_duration_ms * 1e-3)
+            .sub_liveliness_lease_duration(lease_duration_ms * 1e-3)
+    //              .disable_builtin_transport()
+            .init();
 
     ASSERT_TRUE(participantA.isInitialized());
     ASSERT_TRUE(participantB.isInitialized());

--- a/test/blackbox/common/BlackboxTestsLivelinessQos.cpp
+++ b/test/blackbox/common/BlackboxTestsLivelinessQos.cpp
@@ -14,8 +14,11 @@
 
 #include "BlackboxTests.hpp"
 
+#include <thread>
+
 #include "PubSubReader.hpp"
 #include "PubSubWriter.hpp"
+#include "PubSubWriterReader.hpp"
 #include "PubSubParticipant.hpp"
 #include "ReqRepAsReliableHelloWorldRequester.hpp"
 #include "ReqRepAsReliableHelloWorldReplier.hpp"
@@ -1889,6 +1892,60 @@ TEST_P(LivelinessQos, AssertLivelinessParticipant)
     // Only the two MANUAL_BY_PARTICIPANT publishers will have lost liveliness, as the
     // MANUAL_BY_TOPIC one was never asserted
     EXPECT_EQ(publishers.pub_times_liveliness_lost(), 2u);
+}
+
+//! Tests associated with an ABBA deadlock discovered between PDP mutexes on two different participants.
+//! The deadlock scenario involved:
+//! + Intraprocess
+//! + WLP assertions due to MANUAL_BY_PARTICIPANT set up
+//! + Both participants' event thread trigger the liveliness assertion simultaneously
+TEST(LivelinessTests, Detect_Deadlock_ManualByParticipant_Intraprocess)
+{
+    // Set up intraprocess
+    LibrarySettingsAttributes library_settings;
+    library_settings.intraprocess_delivery = IntraprocessDeliveryType::INTRAPROCESS_FULL;
+    xmlparser::XMLProfileManager::library_settings(library_settings);
+
+    // Create two participants
+    PubSubWriterReader<HelloWorldPubSubType> participantA(TEST_TOPIC_NAME), participantB(TEST_TOPIC_NAME);
+
+    // Set up MANUAL_BY_PARTICIPANT liveliness and make it fast
+    unsigned int lease_duration_ms = 1000;
+    unsigned int announcement_period_ms = 1;
+
+    participantA.pub_liveliness_kind(MANUAL_BY_PARTICIPANT_LIVELINESS_QOS)
+                .sub_liveliness_kind(MANUAL_BY_PARTICIPANT_LIVELINESS_QOS)
+                .pub_liveliness_announcement_period(announcement_period_ms * 1e-3)
+                .sub_liveliness_announcement_period(announcement_period_ms * 1e-3)
+                .pub_liveliness_lease_duration(lease_duration_ms * 1e-3)
+                .sub_liveliness_lease_duration(lease_duration_ms * 1e-3)
+//              .disable_builtin_transport()
+                .init();
+
+    participantB.pub_liveliness_kind(MANUAL_BY_PARTICIPANT_LIVELINESS_QOS)
+                .sub_liveliness_kind(MANUAL_BY_PARTICIPANT_LIVELINESS_QOS)
+                .pub_liveliness_announcement_period(announcement_period_ms * 1e-3)
+                .sub_liveliness_announcement_period(announcement_period_ms * 1e-3)
+                .pub_liveliness_lease_duration(lease_duration_ms * 1e-3)
+                .sub_liveliness_lease_duration(lease_duration_ms * 1e-3)
+//              .disable_builtin_transport()
+                .init();
+
+    ASSERT_TRUE(participantA.isInitialized());
+    ASSERT_TRUE(participantB.isInitialized());
+
+    // Wait for discovery.
+    participantA.wait_discovery();
+    participantB.wait_discovery();
+
+    // The DataWriter is alive
+    participantA.assert_liveliness();
+    participantB.assert_liveliness();
+
+    // Wait a second expecting a deadlock
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    // Test failure is due to timeout
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P

--- a/test/blackbox/common/BlackboxTestsLivelinessQos.cpp
+++ b/test/blackbox/common/BlackboxTestsLivelinessQos.cpp
@@ -1919,7 +1919,6 @@ TEST(LivelinessTests, Detect_Deadlock_ManualByParticipant_Intraprocess)
             .sub_liveliness_announcement_period(announcement_period_ms * 1e-3)
             .pub_liveliness_lease_duration(lease_duration_ms * 1e-3)
             .sub_liveliness_lease_duration(lease_duration_ms * 1e-3)
-    //              .disable_builtin_transport()
             .init();
 
     participantB.pub_liveliness_kind(MANUAL_BY_PARTICIPANT_LIVELINESS_QOS)
@@ -1928,7 +1927,6 @@ TEST(LivelinessTests, Detect_Deadlock_ManualByParticipant_Intraprocess)
             .sub_liveliness_announcement_period(announcement_period_ms * 1e-3)
             .pub_liveliness_lease_duration(lease_duration_ms * 1e-3)
             .sub_liveliness_lease_duration(lease_duration_ms * 1e-3)
-    //              .disable_builtin_transport()
             .init();
 
     ASSERT_TRUE(participantA.isInitialized());


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

There is a classic ABBA lock between the two participants' PDP mutexes due to the intraprocess scenario.

The threads deadlock are the participants' event threads (in this trace 49 and 42). The event that triggers the deadlock
is WLP announcement.

The deadlock in the main thread takes place on participants' writer destruction. The writer's destructor must unregister
it's timers and that can only take place once the writer's participant event thread is idle (been deadlock never gets
idle).

A new test able to reproduce this situation was introduced.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
