### PR TITLE
[16363] Ensure samples are not removed from reader history on participant drop

### DIFF
--- a/include/fastrtps/subscriber/SubscriberHistory.h
+++ b/include/fastrtps/subscriber/SubscriberHistory.h
@@ -158,6 +158,19 @@ public:
             iterator& it);
 
     /**
+     * Called when a writer is unmatched from the reader holding this history.
+     *
+     * This method will remove all the changes on the history that came from the writer being unmatched and which have
+     * not yet been notified to the user.
+     *
+     * @param writer_guid        GUID of the writer being unmatched.
+     * @param last_notified_seq  Last sequence number from the specified writer that was notified to the user.
+     */
+    void writer_unmatched(
+            const rtps::GUID_t& writer_guid,
+            const rtps::SequenceNumber_t& last_notified_seq) override;
+
+    /**
      * @brief A method to set the next deadline for the given instance
      * @param handle The handle to the instance
      * @param next_deadline_us The time point when the deadline will occur

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -535,6 +535,18 @@ bool SubscriberHistory::find_key(
     return false;
 }
 
+void SubscriberHistory::writer_unmatched(
+        const GUID_t& writer_guid,
+        const SequenceNumber_t& last_notified_seq)
+{
+    // Remove all future changes from the unmatched writer
+    remove_changes_with_pred(
+        [&writer_guid, &last_notified_seq](CacheChange_t* ch)
+        {
+            return (writer_guid == ch->writerGUID) && (last_notified_seq < ch->sequenceNumber);
+        });
+}
+
 bool SubscriberHistory::remove_change_sub(
         CacheChange_t* change)
 {

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -561,11 +561,11 @@ TEST(Discovery, EndpointRediscoveryWithTransientLocalData_2)
     reader.add_user_transport_to_pparams(testTransport);
 
     reader
-        .lease_duration({ 2, 0 }, { 1, 0 })
-        .history_depth(10)
-        .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
-        .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
-        .init();
+            .lease_duration({ 2, 0 }, { 1, 0 })
+            .history_depth(10)
+            .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+            .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
+            .init();
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -573,11 +573,11 @@ TEST(Discovery, EndpointRediscoveryWithTransientLocalData_2)
     writer.add_user_transport_to_pparams(testTransport);
 
     writer
-        .lease_duration({ 2, 0 }, { 1, 0 })
-        .history_depth(10)
-        .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
-        .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
-        .init();
+            .lease_duration({ 2, 0 }, { 1, 0 })
+            .history_depth(10)
+            .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+            .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
+            .init();
 
     ASSERT_TRUE(writer.isInitialized());
 

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -542,6 +542,73 @@ TEST(Discovery, EndpointRediscoveryWithTransientLocalData)
     std::this_thread::sleep_for(std::chrono::seconds(1));
 }
 
+// Regression for bug #12127
+TEST(Discovery, EndpointRediscoveryWithTransientLocalData_2)
+{
+    // Both writer and reader will be RELIABLE, TRANSIENT_LOCAL, KEEP_LAST 10
+    // Partcipant lease duration will be small on both
+    // Writer will send 2 samples, but the reader will not take them
+    // Then the cable will be unplugged and we wait for participant drop
+    // The writer will then send another 8 samples
+    // The cable is plugged again, and the reader expects the reception of all (10) samples
+
+    PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+
+    auto testTransport = std::make_shared<test_UDPv4TransportDescriptor>();
+
+    reader.disable_builtin_transport();
+    reader.add_user_transport_to_pparams(testTransport);
+
+    reader
+        .lease_duration({ 2, 0 }, { 1, 0 })
+        .history_depth(10)
+        .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+        .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
+        .init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer.disable_builtin_transport();
+    writer.add_user_transport_to_pparams(testTransport);
+
+    writer
+        .lease_duration({ 2, 0 }, { 1, 0 })
+        .history_depth(10)
+        .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+        .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
+        .init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    auto data = default_helloworld_data_generator(10);
+    reader.startReception(data);
+
+    for (int i = 0; i < 2; ++i)
+    {
+        HelloWorld& item = data.front();
+        default_send_print(item);
+        writer.send_sample(item);
+        data.pop_front();
+    }
+
+    test_UDPv4Transport::test_UDPv4Transport_ShutdownAllNetwork = true;
+
+    reader.wait_participant_undiscovery();
+    writer.wait_participant_undiscovery();
+    writer.send(data);
+
+    test_UDPv4Transport::test_UDPv4Transport_ShutdownAllNetwork = false;
+
+    reader.block_for_all();
+
+    EXPECT_TRUE(writer.waitForAllAcked(std::chrono::seconds(1)));
+}
+
 /*!
  * @test Checks that although DATA(p) are not received, but other kind of RTPS submessages, it keeps the participant
  * liveliness from the remote participant.

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -552,7 +552,7 @@ TEST(Discovery, EndpointRediscoveryWithTransientLocalData_2)
     // The writer will then send another 8 samples
     // The cable is plugged again, and the reader expects the reception of all (10) samples
 
-    PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME, false);
     PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
 
     auto testTransport = std::make_shared<test_UDPv4TransportDescriptor>();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds a regression test to check that samples are not removed from reader history on participant drop, and fixes old PubSub API SubscriberHistory behavior.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
@Mergifyio backport 2.7.x 2.6.x 2.1.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
    - Only the new test has been checked.
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
