### PR TITLE
Improve target loading [16416]

### DIFF
--- a/cmake/packaging/Config.cmake.in
+++ b/cmake/packaging/Config.cmake.in
@@ -28,18 +28,60 @@ find_package(TinyXML2 QUIET)
 @FASTRTPS_INSTALLER_DEPS_ANCILLARY@
 @FASTRTPS_PACKAGE_UNIX_OPT_DEPS@
 
-if(FASTDDS_STATIC)
-    @FASTRTPS_INSTALLER_OPT_DEPS@
-    @FASTRTPS_PACKAGE_WIN32_OPT_DEPS@
-    include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-static-targets.cmake)
-else()
-    include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-dynamic-targets.cmake OPTIONAL RESULT_VARIABLE DYNAMIC_TARGET_FILE)
-    # fallback to static linking if dynamic target is missing
-    if( NOT DYNAMIC_TARGET_FILE )
-        @FASTRTPS_INSTALLER_OPT_DEPS@
-        @FASTRTPS_PACKAGE_WIN32_OPT_DEPS@
-        include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-static-targets.cmake)
-    endif()
-endif()
+set(fastrtps_known_comps static shared)
+set(fastrtps_comp_static NO)
+set(fastrtps_comp_shared NO)
+foreach (fastrtps_comp IN LISTS ${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS)
+    if (fastrtps_comp IN_LIST fastrtps_known_comps)
+        set(fastrtps_comp_${fastrtps_comp} YES)
+    else ()
+        set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE
+            "fastrtps does not recognize component `${fastrtps_comp}`.")
+        set(${CMAKE_FIND_PACKAGE_NAME}_FOUND FALSE)
+        return()
+    endif ()
+endforeach ()
+
+if (fastrtps_comp_static AND fastrtps_comp_shared)
+    set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE
+        "fastrtps `static` and `shared` components are mutually exclusive.")
+    set(${CMAKE_FIND_PACKAGE_NAME}_FOUND FALSE)
+    return()
+endif ()
+
+set(fastrtps_static_targets "${CMAKE_CURRENT_LIST_DIR}/fastrtps-static-targets.cmake")
+set(fastrtps_shared_targets "${CMAKE_CURRENT_LIST_DIR}/fastrtps-shared-targets.cmake")
+
+macro(fastrtps_load_targets type)
+    if (NOT EXISTS "${fastrtps_${type}_targets}")
+        set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE
+            "fastrtps `${type}` libraries were requested but not found.")
+        set(${CMAKE_FIND_PACKAGE_NAME}_FOUND FALSE)
+        return()
+    endif ()
+    include("${fastrtps_${type}_targets}")
+endmacro()
+
+if (fastrtps_comp_static)
+    fastrtps_load_targets(static)
+elseif (fastrtps_comp_shared)
+    fastrtps_load_targets(shared)
+elseif (DEFINED fastrtps_SHARED_LIBS AND fastrtps_SHARED_LIBS)
+    fastrtps_load_targets(shared)
+elseif (DEFINED fastrtps_SHARED_LIBS AND NOT fastrtps_SHARED_LIBS)
+    fastrtps_load_targets(static)
+elseif (BUILD_SHARED_LIBS)
+    if (EXISTS "${fastrtps_shared_targets}")
+        fastrtps_load_targets(shared)
+    else ()
+        fastrtps_load_targets(static)
+    endif ()
+else ()
+    if (EXISTS "${fastrtps_static_targets}")
+        fastrtps_load_targets(static)
+    else ()
+        fastrtps_load_targets(shared)
+    endif ()
+endif ()
 
 @INCLUDE_FASTDDS_TARGETS@

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -611,23 +611,21 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/fastdds/statistics
 
 # Install libraries
 
-# Generate different target names depending on linking
-get_target_property(TARGET_TYPE ${PROJECT_NAME} TYPE)
-if(TARGET_TYPE STREQUAL "SHARED_LIBRARY")
-    set(FASTDDS_LINKING dynamic)
-else()
-    set(FASTDDS_LINKING static)
-endif()
-
 install(TARGETS ${PROJECT_NAME} eProsima_atomic
-    EXPORT ${PROJECT_NAME}-${FASTDDS_LINKING}-targets
+    EXPORT ${PROJECT_NAME}-targets
     COMPONENT libraries
     RUNTIME DESTINATION "${BIN_INSTALL_DIR}${MSVCARCH_DIR_EXTENSION}"
     LIBRARY DESTINATION "${LIB_INSTALL_DIR}${MSVCARCH_DIR_EXTENSION}"
     ARCHIVE DESTINATION "${LIB_INSTALL_DIR}${MSVCARCH_DIR_EXTENSION}"
     )
 
-export(TARGETS ${PROJECT_NAME} eProsima_atomic FILE ${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-${FASTDDS_LINKING}-targets.cmake)
+# Generate different target names depending on linking
+get_target_property(TARGET_TYPE ${PROJECT_NAME} TYPE)
+if(TARGET_TYPE STREQUAL "SHARED_LIBRARY")
+    set(FASTDDS_LINKING shared)
+else()
+    set(FASTDDS_LINKING static)
+endif()
 
 if(INSTALLER_PLATFORM)
     set(INSTALL_DESTINATION_PATH ${DATA_INSTALL_DIR}/${PROJECT_NAME}-${INSTALLER_PLATFORM}/cmake)
@@ -635,8 +633,9 @@ else()
     set(INSTALL_DESTINATION_PATH ${DATA_INSTALL_DIR}/${PROJECT_NAME}/cmake${MSVCARCH_DIR_EXTENSION_EXT})
 endif()
 
-install(EXPORT ${PROJECT_NAME}-${FASTDDS_LINKING}-targets
+install(EXPORT ${PROJECT_NAME}-targets
     DESTINATION ${INSTALL_DESTINATION_PATH}
+    FILE ${PROJECT_NAME}-${FASTDDS_LINKING}-targets.cmake
     COMPONENT cmake
     )
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

Improve loading `fastrtps` through its cmake config file. This PR includes these features:

1. Select library type using `find_package()` components.
    ```cmake
    find_package(fastrtps shared) # Load shared library
    find_package(fastrtps static) # Load static library
    ```
2. Select library type using variable `fastrtps_SHARED_LIBS`
    ```cmake
    fastrtps_SHARED_LIBS=ON # Load shared library
    ffastrtps_SHARED_LIBS=OFF # Load static library
    ```
3. Select library type using the variable `BUILD_SHARED_LIBS`
    ```cmake
    BUILD_SHARED_LIBS=ON # Load shared library
    BUILD_SHARED_LIBS=OFF # Load static library
    ```
4. If non-previous scenarios were used, the static library tried to be loaded and if it fails, dynamic library is loaded.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- *N/A* Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- *N/A* Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
