### PR TITLE
[16328] Set FASTDDS_STATISTICS CMake option to ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,7 +349,7 @@ endif()
 ###############################################################################
 # Fast DDS statistics tool default setup
 ###############################################################################
-option(FASTDDS_STATISTICS "Enable Fast DDS Statistics Module" OFF)
+option(FASTDDS_STATISTICS "Enable Fast DDS Statistics Module" ON)
 
 ###############################################################################
 # Compile library.

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1680,7 +1680,7 @@ bool RTPSParticipantImpl::createReceiverResources(
             while (!ret && (tries < m_att.builtin.mutation_tries))
             {
                 tries++;
-                *it_loc = applyLocatorAdaptRule(*it_loc);
+                applyLocatorAdaptRule(*it_loc);
                 ret = m_network_Factory.BuildReceiverResources(*it_loc, newItemsBuffer, max_receiver_buffer_size);
             }
         }

--- a/src/cpp/statistics/rtps/StatisticsBase.cpp
+++ b/src/cpp/statistics/rtps/StatisticsBase.cpp
@@ -27,9 +27,6 @@
 #include <fastrtps/qos/ParameterTypes.h>
 #include <rtps/participant/RTPSParticipantImpl.h>
 
-using namespace eprosima::fastdds::statistics;
-using eprosima::fastrtps::rtps::RTPSParticipantImpl;
-
 namespace eprosima {
 namespace fastdds {
 namespace statistics {
@@ -89,10 +86,6 @@ detail::SampleIdentity_s to_statistics_type(
 {
     return *reinterpret_cast<detail::SampleIdentity_s*>(&sample_id);
 }
-
-} // statistics
-} // fastdds
-} // eprosima
 
 StatisticsAncillary* StatisticsListenersImpl::get_aux_members() const
 {
@@ -644,3 +637,7 @@ void StatisticsParticipantImpl::on_edp_packet(
                 listener->on_statistics_data(data);
             });
 }
+
+} // statistics
+} // fastdds
+} // eprosima

--- a/src/cpp/statistics/rtps/reader/StatisticsReaderImpl.cpp
+++ b/src/cpp/statistics/rtps/reader/StatisticsReaderImpl.cpp
@@ -21,11 +21,13 @@
 #include <fastdds/rtps/reader/RTPSReader.h>
 #include <statistics/types/types.h>
 
-using namespace eprosima::fastdds::statistics;
-
 using eprosima::fastrtps::RecursiveTimedMutex;
 using eprosima::fastrtps::rtps::RTPSReader;
 using eprosima::fastrtps::rtps::GUID_t;
+
+namespace eprosima {
+namespace fastdds {
+namespace statistics {
 
 StatisticsReaderImpl::StatisticsReaderImpl()
 {
@@ -176,3 +178,7 @@ void StatisticsReaderImpl::on_subscribe_throughput(
                 });
     }
 }
+
+}  // namespace statistics
+}  // namespace fastdds
+}  // namespace eprosima

--- a/src/cpp/statistics/rtps/writer/StatisticsWriterImpl.cpp
+++ b/src/cpp/statistics/rtps/writer/StatisticsWriterImpl.cpp
@@ -21,11 +21,13 @@
 #include <fastdds/rtps/writer/RTPSWriter.h>
 #include <statistics/types/types.h>
 
-using namespace eprosima::fastdds::statistics;
-
 using eprosima::fastrtps::RecursiveTimedMutex;
 using eprosima::fastrtps::rtps::RTPSWriter;
 using eprosima::fastrtps::rtps::GUID_t;
+
+namespace eprosima {
+namespace fastdds {
+namespace statistics {
 
 StatisticsWriterImpl::StatisticsWriterImpl()
 {
@@ -241,3 +243,7 @@ void StatisticsWriterImpl::on_publish_throughput(
                 });
     }
 }
+
+}  // namespace statistics
+}  // namespace fastdds
+}  // namespace eprosima

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -313,6 +313,7 @@ public:
 
         if (participant_ != nullptr)
         {
+            participant_qos_ = participant_->get_qos();
             type_.reset(new type_support());
             participant_->register_type(type_);
             return true;

--- a/test/unittest/statistics/dds/StatisticsQosTests.cpp
+++ b/test/unittest/statistics/dds/StatisticsQosTests.cpp
@@ -33,7 +33,6 @@
 
 #ifdef FASTDDS_STATISTICS
 #include <statistics/fastdds/domain/DomainParticipantImpl.hpp>
-#include <statistics/fastdds/publisher/PublisherImpl.hpp>
 #endif // ifdef FASTDDS_STATISTICS
 
 namespace eprosima {

--- a/versions.md
+++ b/versions.md
@@ -5,6 +5,7 @@ Forthcoming
 * Statistics metrics are only calculated/accumulated when their corresponding DataWriter is enabled (behaviour change)
 * Added new log macros `EPROSIMA_LOG_INFO`, `EPROSIMA_LOG_WARNING` and `EPROSIMA_LOG_ERROR`, and change all old macros `logInfo`, `logWarning`, and `logError` in the project.
 * Added `ENABLE_OLD_LOG_MACROS` CMake option to support disabling the compilation of old log macros `logInfo`, `logWarning`, and `logError`.
+* FASTDDS_STATISTICS build option set to ON by default
 
 Version 2.8.0
 -------------


### PR DESCRIPTION
Signed-off-by: Mikel Rico <mikelrico@eprosima.com>

<!-- Provide a general summary of your changes in the Title above -->

Set FASTDDS_STATISTICS CMake option to ON


<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [N/A] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [N/A] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [N/A] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [N/A] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [N/A] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [N/A] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [N/A] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [N/A] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
Related documentation PR: [eProsima/Fast-DDS-docs# (PR) ](https://github.com/eProsima/Fast-DDS-docs/pull/430)


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
