### PR TITLE
[16440] Set enabled statistics writers mask on new endpoints

### DIFF
--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -787,6 +787,8 @@ bool RTPSParticipantImpl::create_writer(
                         register_in_writer(listener->get_shared_ptr(), guid);
                     }
                 });
+
+        SWriter->set_enabled_statistics_writers_mask(StatisticsParticipantImpl::get_enabled_statistics_writers_mask());
     }
 
 #endif // FASTDDS_STATISTICS
@@ -926,6 +928,8 @@ bool RTPSParticipantImpl::create_reader(
                         register_in_reader(listener->get_shared_ptr(), guid);
                     }
                 });
+
+        SReader->set_enabled_statistics_writers_mask(StatisticsParticipantImpl::get_enabled_statistics_writers_mask());
     }
 
 #endif // FASTDDS_STATISTICS

--- a/src/cpp/statistics/rtps/StatisticsBase.cpp
+++ b/src/cpp/statistics/rtps/StatisticsBase.cpp
@@ -138,7 +138,8 @@ bool StatisticsListenersImpl::are_statistics_writers_enabled(
     std::unique_lock<fastrtps::RecursiveTimedMutex> lock(get_statistics_mutex());
     if (members_)
     {
-        return (members_->enabled_writers_mask & checked_enabled_writers);
+        // Casting a number other than 1 to bool is not guaranteed to yield true
+        return (0 != (members_->enabled_writers_mask & checked_enabled_writers));
     }
     return false;
 }
@@ -354,6 +355,11 @@ void StatisticsParticipantImpl::set_enabled_statistics_writers_mask(
         uint32_t enabled_writers)
 {
     enabled_writers_mask_.store(enabled_writers);
+}
+
+uint32_t StatisticsParticipantImpl::get_enabled_statistics_writers_mask()
+{
+    return enabled_writers_mask_.load();
 }
 
 void StatisticsParticipantImpl::on_network_statistics(

--- a/src/cpp/statistics/rtps/StatisticsBase.hpp
+++ b/src/cpp/statistics/rtps/StatisticsBase.hpp
@@ -450,6 +450,13 @@ public:
      */
     virtual void set_enabled_statistics_writers_mask(
             uint32_t enabled_writers);
+
+    /**
+     * @brief Get the enabled statistics writers mask
+     *
+     * @return The mask of enabled writers
+     */
+    virtual uint32_t get_enabled_statistics_writers_mask();
 };
 
 // auxiliary conversion functions


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR fixes a behaviour in which endpoints created after setting the enabled_writers_mask where not receiving such mask and so they were not publishing statistical data.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- *N/A*: New feature has been added to the `versions.md` file (if applicable).
- *N/A*: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
