### PR TITLE
[16315] Doxygen documentation: add deprecation notice to ThroughputControllerDescriptor

### DIFF
--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -2701,7 +2701,11 @@ public:
     //! Port Parameters
     fastrtps::rtps::PortParameters port;
 
-    //! Throughput controller parameters. Leave default for uncontrolled flow.
+    /**
+     * @brief Throughput controller parameters. Leave default for uncontrolled flow.
+     *
+     * @deprecated Use flow_controllers() on DomainParticipantQoS
+     */
     fastrtps::rtps::ThroughputControllerDescriptor throughput_controller;
 
     /**

--- a/include/fastdds/dds/publisher/qos/DataWriterQos.hpp
+++ b/include/fastdds/dds/publisher/qos/DataWriterQos.hpp
@@ -775,6 +775,7 @@ public:
      * Getter for ThroughputControllerDescriptor
      *
      * @return ThroughputControllerDescriptor reference
+     * @deprecated Use flow_controllers() on DomainParticipantQoS
      */
     RTPS_DllAPI fastrtps::rtps::ThroughputControllerDescriptor& throughput_controller()
     {
@@ -785,6 +786,7 @@ public:
      * Getter for ThroughputControllerDescriptor
      *
      * @return ThroughputControllerDescriptor reference
+     * @deprecated Use flow_controllers() on DomainParticipantQoS
      */
     RTPS_DllAPI const fastrtps::rtps::ThroughputControllerDescriptor& throughput_controller() const
     {
@@ -795,6 +797,7 @@ public:
      * Setter for ThroughputControllerDescriptor
      *
      * @param throughput_controller new value for the ThroughputControllerDescriptor
+     * @deprecated Use flow_controllers() on DomainParticipantQoS
      */
     RTPS_DllAPI void throughput_controller(
             const fastrtps::rtps::ThroughputControllerDescriptor& throughput_controller)

--- a/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h
+++ b/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h
@@ -536,7 +536,11 @@ public:
     //! Participant ID
     int32_t participantID;
 
-    //! Throughput controller parameters. Leave default for uncontrolled flow.
+    /**
+     * @brief Throughput controller parameters. Leave default for uncontrolled flow.
+     *
+     * @deprecated Use flow_controllers on RTPSParticipantAttributes
+     */
     ThroughputControllerDescriptor throughputController;
 
     //! User defined transports to use alongside or in place of builtins.

--- a/include/fastdds/rtps/attributes/WriterAttributes.h
+++ b/include/fastdds/rtps/attributes/WriterAttributes.h
@@ -123,7 +123,11 @@ public:
     //!Indicates if the Writer is synchronous or asynchronous
     RTPSWriterPublishMode mode;
 
-    // Throughput controller, always the last one to apply
+    /**
+     * @brief Throughput controller, always the last one to apply
+     *
+     * @deprecated Use flow_controllers on RTPSParticipantAttributes
+     */
     ThroughputControllerDescriptor throughputController;
 
     //! Disable the sending of heartbeat piggybacks.

--- a/include/fastdds/rtps/flowcontrol/ThroughputControllerDescriptor.h
+++ b/include/fastdds/rtps/flowcontrol/ThroughputControllerDescriptor.h
@@ -18,9 +18,9 @@
 #include <fastrtps/fastrtps_dll.h>
 #include <cstdint>
 
-namespace eprosima{
-namespace fastrtps{
-namespace rtps{
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
 
 /**
  * Descriptor for a Throughput Controller, containing all constructor information
@@ -36,13 +36,17 @@ struct ThroughputControllerDescriptor
     uint32_t periodMillisecs;
 
     RTPS_DllAPI ThroughputControllerDescriptor();
-    RTPS_DllAPI ThroughputControllerDescriptor(uint32_t size, uint32_t time);
+    RTPS_DllAPI ThroughputControllerDescriptor(
+            uint32_t size,
+            uint32_t time);
 
-    bool operator==(const ThroughputControllerDescriptor& b) const
+    bool operator ==(
+            const ThroughputControllerDescriptor& b) const
     {
         return (this->bytesPerPeriod == b.bytesPerPeriod) &&
                (this->periodMillisecs == b.periodMillisecs);
     }
+
 };
 
 } // namespace rtps

--- a/include/fastdds/rtps/flowcontrol/ThroughputControllerDescriptor.h
+++ b/include/fastdds/rtps/flowcontrol/ThroughputControllerDescriptor.h
@@ -26,6 +26,7 @@ namespace rtps{
  * Descriptor for a Throughput Controller, containing all constructor information
  * for it.
  * @ingroup NETWORK_MODULE
+ * @deprecated Use FlowControllerDescriptor
  */
 struct ThroughputControllerDescriptor
 {


### PR DESCRIPTION
Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>

<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Since Fast DDS v2.4.0, flow controllers have substituted the previous throughput controllers.
This PR fixes the Doxygen documentation so the methods and structures superseded are shown as deprecated.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
**N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
**N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
**N/A** Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
**N/A** New feature has been added to the `versions.md` file (if applicable).
**N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
