### PR TITLE
Fix deadlock on TLS closure [16288]

### DIFF
--- a/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
@@ -225,20 +225,15 @@ size_t TCPChannelResourceSecure::send(
                 {
                     if (socket->lowest_layer().is_open())
                     {
-                        asio::async_write(*socket, buffers,
-                        [&, socket](const std::error_code& error, const size_t& bytes_transferred)
+                        size_t bytes_transferred = asio::write(*socket, buffers, ec);
+                        if (!ec)
                         {
-                            ec = error;
-
-                            if (!error)
-                            {
-                                write_bytes_promise.set_value(bytes_transferred);
-                            }
-                            else
-                            {
-                                write_bytes_promise.set_value(0);
-                            }
-                        });
+                            write_bytes_promise.set_value(bytes_transferred);
+                        }
+                        else
+                        {
+                            write_bytes_promise.set_value(0);
+                        }
                     }
                     else
                     {

--- a/src/cpp/rtps/transport/tcp/RTCPMessageManager.cpp
+++ b/src/cpp/rtps/transport/tcp/RTCPMessageManager.cpp
@@ -93,7 +93,8 @@ size_t RTCPMessageManager::sendMessage(
     size_t send = channel->send(nullptr, 0, msg.buffer, msg.length, ec);
     if (send != msg.length || ec)
     {
-        EPROSIMA_LOG_WARNING(RTCP, "Bad sent size..." << send << " bytes of " << msg.length << " bytes: " << ec.message());
+        EPROSIMA_LOG_WARNING(RTCP,
+                "Bad sent size..." << send << " bytes of " << msg.length << " bytes: " << ec.message());
         send = 0;
     }
 

--- a/src/cpp/rtps/transport/tcp/RTCPMessageManager.cpp
+++ b/src/cpp/rtps/transport/tcp/RTCPMessageManager.cpp
@@ -93,7 +93,7 @@ size_t RTCPMessageManager::sendMessage(
     size_t send = channel->send(nullptr, 0, msg.buffer, msg.length, ec);
     if (send != msg.length || ec)
     {
-        EPROSIMA_LOG_INFO(RTCP, "Bad sent size..." << send << " bytes of " << msg.length << " bytes: " << ec.message());
+        EPROSIMA_LOG_WARNING(RTCP, "Bad sent size..." << send << " bytes of " << msg.length << " bytes: " << ec.message());
         send = 0;
     }
 

--- a/test/blackbox/common/BlackboxTestsTransportTCP.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportTCP.cpp
@@ -416,6 +416,61 @@ TEST_P(TransportTCP, TCP_TLS)
     ASSERT_TRUE(replier.is_matched());
 }
 
+// Test successful removal of client after previously matched server is removed
+TEST_P(TransportTCP, TCP_TLS_client_disconnect_after_server)
+{
+    TCPReqRepHelloWorldRequester* requester = new TCPReqRepHelloWorldRequester();
+    TCPReqRepHelloWorldReplier* replier = new TCPReqRepHelloWorldReplier();
+
+    requester->init(0, 0, global_port, 5, certs_path);
+
+    ASSERT_TRUE(requester->isInitialized());
+
+    replier->init(4, 0, global_port, 5, certs_path);
+
+    ASSERT_TRUE(replier->isInitialized());
+
+    // Wait for discovery.
+    requester->wait_discovery();
+    replier->wait_discovery();
+
+    ASSERT_TRUE(requester->is_matched());
+    ASSERT_TRUE(replier->is_matched());
+
+    // Completely remove server prior to deleting client
+    delete replier;
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    delete requester;
+}
+
+// Test successful removal of server after previously matched client is removed
+// Issue -> https://eprosima.easyredmine.com/issues/16288
+TEST_P(TransportTCP, TCP_TLS_server_disconnect_after_client)
+{
+    TCPReqRepHelloWorldReplier* replier = new TCPReqRepHelloWorldReplier();
+    TCPReqRepHelloWorldRequester* requester = new TCPReqRepHelloWorldRequester();
+
+    requester->init(0, 0, global_port, 5, certs_path);
+
+    ASSERT_TRUE(requester->isInitialized());
+
+    replier->init(4, 0, global_port, 5, certs_path);
+
+    ASSERT_TRUE(replier->isInitialized());
+
+    // Wait for discovery.
+    requester->wait_discovery();
+    replier->wait_discovery();
+
+    ASSERT_TRUE(requester->is_matched());
+    ASSERT_TRUE(replier->is_matched());
+
+    // Completely remove client prior to deleting server
+    delete requester;
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    delete replier;
+}
+
 void tls_init()
 {
     certs_path = std::getenv("CERTS_PATH");


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Sporadically, the Blackbox TCP_TLS tests stops on an ABBA deadlock. perform_listen_operation is called while another thread is processing a send operation on a TCP Transport.

After further analysis, the root of the problem seems to be the occasional miss of callback execution in `asio::async_write`. As a consequence, a waited-for promise is never set, hence getting stuck at the future get with several locked mutexes required in other threads.  This event seems not to be random; it could only be observed after the communication channel is closed/broken (ec=broken_pipe).

Proposed solution:
After testing several versions of asio library and looking for related issues without success, `asio::async_write` is replaced for its synchronous counterpart. Note that there should be no difference in Fast-DDS behavior, as `TCPChannelResourceSecure::send` behaves as a synchronous function even when `asio::async_write` is being used.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
