### PR TITLE
Fine-tune DomainParticipant's blocking set_listener

### DIFF
--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -582,11 +582,11 @@ protected:
                 : listener_(listener)
                 , on_guard_(false)
             {
+                std::lock_guard<std::mutex> _(listener_->participant_->mtx_gs_);
                 if (listener_ != nullptr && listener_->participant_ != nullptr &&
                         listener_->participant_->listener_ != nullptr &&
                         listener_->participant_->participant_ != nullptr)
                 {
-                    std::lock_guard<std::mutex> _(listener_->participant_->mtx_gs_);
                     if (listener_->callback_counter_ >= 0)
                     {
                         ++listener_->callback_counter_;
@@ -599,12 +599,12 @@ protected:
             {
                 if (on_guard_)
                 {
-                    assert(
-                        listener_ != nullptr && listener_->participant_ != nullptr && listener_->participant_->listener_ != nullptr &&
-                        listener_->participant_->participant_ != nullptr);
                     bool notify = false;
                     {
                         std::lock_guard<std::mutex> lock(listener_->participant_->mtx_gs_);
+                        assert(
+                            listener_ != nullptr && listener_->participant_ != nullptr && listener_->participant_->listener_ != nullptr &&
+                            listener_->participant_->participant_ != nullptr);
                         --listener_->callback_counter_;
                         notify = !listener_->callback_counter_;
                     }

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -111,8 +111,15 @@ public:
             DomainParticipantListener* listener,
             const std::chrono::seconds timeout = std::chrono::seconds::max())
     {
+        auto time_out = std::chrono::time_point<std::chrono::system_clock>::max();
+        if (timeout < std::chrono::seconds::max())
+        {
+            auto now = std::chrono::system_clock::now();
+            time_out = now + timeout;
+        }
+
         std::unique_lock<std::mutex> lock(mtx_gs_);
-        if (!cv_gs_.wait_for(lock, timeout, [this]
+        if (!cv_gs_.wait_until(lock, time_out, [this]
                 {
                     // Proceed if no callbacks are being executed
                     return !(rtps_listener_.callback_counter_ > 0);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR fixes a corner case missed in #3089, where a data race might occur when a listener is being set while a `MyRTPSParticipantListener::Sentry` is being created (where the value of this listener was being checked without protection).
Additionally, an overflow issue affecting the timeout in `set_listener` is also addressed.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
