### PR TITLE
[16608] Fix total_unread_ consistent with reader's history upon get_first_untaken_info()

### DIFF
--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
@@ -353,21 +353,12 @@ bool DataReaderHistory::get_first_untaken_info(
 {
     std::lock_guard<RecursiveTimedMutex> lock(*getMutex());
 
-    CacheChange_t* change = nullptr;
-    WriterProxy* wp = nullptr;
-    if (mp_reader->nextUntakenCache(&change, &wp))
+    if (!data_available_instances_.empty())
     {
-        auto it = data_available_instances_.find(change->instanceHandle);
-        assert(it != data_available_instances_.end());
+        auto it = data_available_instances_.begin();
         auto& instance_changes = it->second->cache_changes;
-        auto item =
-                std::find_if(instance_changes.cbegin(), instance_changes.cend(),
-                        [change](const DataReaderCacheChange& v)
-                        {
-                            return v == change;
-                        });
+        auto item = instance_changes.cbegin();
         ReadTakeCommand::generate_info(info, *(it->second), *item);
-        mp_reader->change_read_by_user(change, wp, false);
         return true;
     }
 

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -1692,10 +1692,8 @@ private:
 
         if (!take_ && !read_)
         {
-            std::unique_lock<std::mutex> lock(mutex_);
-
             current_unread_count_ = datareader->get_unread_count();
-            std::cout << "Total unread count " << datareader->get_unread_count() << std::endl;
+            std::cout << "Total unread count " << current_unread_count_ << std::endl;
             cv_.notify_one();
             return;
         }

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -278,7 +278,8 @@ public:
     PubSubReader(
             const std::string& topic_name,
             bool take = true,
-            bool statistics = false)
+            bool statistics = false,
+            bool read = true)
         : participant_listener_(*this)
         , listener_(*this)
         , participant_(nullptr)
@@ -293,10 +294,12 @@ public:
         , receiving_(false)
         , current_processed_count_(0)
         , number_samples_expected_(0)
+        , current_unread_count_(0)
         , discovery_result_(false)
         , onDiscovery_(nullptr)
         , onEndpointDiscovery_(nullptr)
         , take_(take)
+        , read_(read)
         , statistics_(statistics)
 #if HAVE_SECURITY
         , authorized_(0)
@@ -548,6 +551,16 @@ public:
                     return current_processed_count_ >= at_least;
                 });
         return current_processed_count_;
+    }
+
+    size_t block_for_unread_count_of(
+            size_t n_unread)
+    {
+        block([this, n_unread]() -> bool
+                {
+                    return current_unread_count_ >= n_unread;
+                });
+        return current_unread_count_;
     }
 
     void block(
@@ -1677,6 +1690,16 @@ private:
         type data;
         eprosima::fastdds::dds::SampleInfo info;
 
+        if (!take_ && !read_)
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+
+            current_unread_count_ = datareader->get_unread_count();
+            std::cout << "Total unread count " << datareader->get_unread_count() << std::endl;
+            cv_.notify_one();
+            return;
+        }
+
         ReturnCode_t success = take_ ?
                 datareader->take_next_sample((void*)&data, &info) :
                 datareader->read_next_sample((void*)&data, &info);
@@ -1845,6 +1868,7 @@ protected:
     std::map<LastSeqInfo, eprosima::fastrtps::rtps::SequenceNumber_t> last_seq;
     std::atomic<size_t> current_processed_count_;
     std::atomic<size_t> number_samples_expected_;
+    std::atomic<size_t> current_unread_count_;
     bool discovery_result_;
 
     std::string xml_file_ = "";
@@ -1854,8 +1878,11 @@ protected:
     std::function<bool(const eprosima::fastrtps::rtps::ParticipantDiscoveryInfo& info)> onDiscovery_;
     std::function<bool(const eprosima::fastrtps::rtps::WriterDiscoveryInfo& info)> onEndpointDiscovery_;
 
-    //! True to take data from history. False to read
+    //! True to take data from history. On False, read_ is checked.
     bool take_;
+
+    //! True to read data from history. False, do nothing on data reception.
+    bool read_;
 
     //! True if the class is called from the statistics blackbox (specific topic name and domain id).
     bool statistics_;

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -507,6 +507,7 @@ public:
     bool send_sample(
             type& msg)
     {
+        default_send_print(msg);
         return datawriter_->write((void*)&msg);
     }
 

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -15,6 +15,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <thread>
+#include <future>
 
 #include <gtest/gtest.h>
 
@@ -37,6 +38,8 @@
 
 #include "BlackboxTests.hpp"
 #include "../types/HelloWorldPubSubTypes.h"
+#include "PubSubReader.hpp"
+#include "PubSubWriter.hpp"
 
 namespace eprosima {
 namespace fastdds {
@@ -269,6 +272,101 @@ TEST(DDSBasic, MultithreadedReaderCreationDoesNotDeadlock)
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, participant->delete_subscriber(subscriber));
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, participant->delete_topic(topic));
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, factory->delete_participant(participant));
+}
+
+// Regression test of Refs #16608, Github # . Checks that total_unread_ variable is consistent with
+// unread changes in reader's history after performing a get_first_untaken_info() on a change with no writer matched.
+TEST(DDSBasic, ConsistentTotalUnreadAfterGetFirstUntakenInfo)
+{
+    //! Spawn a couple of participants writer/reader
+    std::string topic_name = "HelloWorldTopic";
+    auto pubsub_writer = std::make_shared<PubSubWriter<HelloWorldPubSubType>>(topic_name);
+    //! Create a reader that does nothing when new data is available. Neither take nor read it.
+    auto pubsub_reader = std::make_shared<PubSubReader<HelloWorldPubSubType>>(topic_name, false, false, false);
+
+    // Initialization of all the participants
+    std::cout << "Initializing PubSubs for topic " << topic_name << std::endl;
+
+    auto udp_transport = std::make_shared<UDPv4TransportDescriptor>();
+
+    //! Participant Writer configuration and qos
+    pubsub_writer->disable_builtin_transport().add_user_transport_to_pparams(udp_transport);
+    pubsub_writer->reliability(eprosima::fastdds::dds::ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS);
+    pubsub_writer->durability_kind(eprosima::fastdds::dds::DurabilityQosPolicyKind::TRANSIENT_LOCAL_DURABILITY_QOS);
+    pubsub_writer->history_kind(eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_ALL_HISTORY_QOS);
+    pubsub_writer->init();
+    ASSERT_EQ(pubsub_writer->isInitialized(), true);
+
+    //! Participant Reader configuration and qos
+    pubsub_reader->disable_builtin_transport().add_user_transport_to_pparams(udp_transport);
+    pubsub_reader->reliability(eprosima::fastdds::dds::ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS);
+    pubsub_reader->durability_kind(eprosima::fastdds::dds::DurabilityQosPolicyKind::TRANSIENT_LOCAL_DURABILITY_QOS);
+    pubsub_reader->history_kind(eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_ALL_HISTORY_QOS);
+    pubsub_reader->init();
+    ASSERT_EQ(pubsub_reader->isInitialized(), true);
+
+    // Wait for discovery.
+    pubsub_reader->wait_discovery();
+    pubsub_writer->wait_discovery();
+
+    auto data = default_helloworld_data_generator();
+
+    pubsub_reader->startReception(data);
+
+    std::mutex mtx;
+    bool should_stop(false);
+    auto ret = std::async(std::launch::async, [&pubsub_writer, &data, &should_stop, &mtx]
+                    {
+                        for (auto sample : data)
+                        {
+                            std::unique_lock<std::mutex>  lock(mtx);
+                            if (!should_stop)
+                            {
+                                lock.unlock();
+                                pubsub_writer->send_sample(sample);
+                                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                            }
+                            else
+                            {
+                                break;
+                            }
+                        }
+                        //! drop publisher
+                        pubsub_writer->removePublisher();
+                        //! give some time to unmatch
+                        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+                    }
+                    );
+
+    pubsub_reader->block_for_unread_count_of(3);
+
+    {
+        std::unique_lock<std::mutex> lock(mtx);
+        should_stop = true;
+    }
+
+    //! wait for async task to finish
+    ret.get();
+
+    ASSERT_EQ(false, pubsub_reader->is_matched());
+
+    DataReader& reader = pubsub_reader->get_native_reader();
+    SampleInfo info;
+
+    //! Try reading the first untaken info.
+    //! Checks whether total_unread_ is consistent with
+    //! the number of unread changes in history
+    //! This API call should NOT modify the history
+    reader.get_first_untaken_info(&info);
+
+    HelloWorld msg;
+    SampleInfo sinfo;
+
+    //! Try getting a sample
+    auto result = reader.take_next_sample((void*)&msg, &sinfo);
+
+    //! Assert last operation
+    ASSERT_EQ(result, ReturnCode_t::RETCODE_OK) << "Reader's unread count is: " << reader.get_unread_count();
 }
 
 } // namespace dds

--- a/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
@@ -163,6 +163,13 @@ TEST_P(DDSDataReader, LivelinessChangedStatusGet)
 // unread changes in reader's history after performing a get_first_untaken_info() on a change with no writer matched.
 TEST_P(DDSDataReader, ConsistentTotalUnreadAfterGetFirstUntakenInfo)
 {
+    if (enable_datasharing)
+    {
+        //! TODO: Datasharing changes the behavior of this test. Changes are
+        //! instantly removed on removePublisher() call and on the PUBListener callback
+        GTEST_SKIP() << "Data-sharing removes the changes instantly changing the behavior of this test. Skipping";
+    }
+
     //! Spawn a couple of participants writer/reader
     auto pubsub_writer = std::make_shared<PubSubWriter<HelloWorldPubSubType>>(TEST_TOPIC_NAME);
     //! Create a reader that does nothing when new data is available. Neither take nor read it.

--- a/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
@@ -159,6 +159,91 @@ TEST_P(DDSDataReader, LivelinessChangedStatusGet)
 
 }
 
+// Regression test of Refs #16608, Github #3203. Checks that total_unread_ variable is consistent with
+// unread changes in reader's history after performing a get_first_untaken_info() on a change with no writer matched.
+TEST_P(DDSDataReader, ConsistentTotalUnreadAfterGetFirstUntakenInfo)
+{
+    //! Spawn a couple of participants writer/reader
+    auto pubsub_writer = std::make_shared<PubSubWriter<HelloWorldPubSubType>>(TEST_TOPIC_NAME);
+    //! Create a reader that does nothing when new data is available. Neither take nor read it.
+    auto pubsub_reader = std::make_shared<PubSubReader<HelloWorldPubSubType>>(TEST_TOPIC_NAME, false, false, false);
+
+    // Initialization of all the participants
+    std::cout << "Initializing PubSubs for topic " << TEST_TOPIC_NAME << std::endl;
+
+    //! Participant Writer configuration and qos
+    pubsub_writer->reliability(eprosima::fastdds::dds::ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS);
+    pubsub_writer->durability_kind(eprosima::fastdds::dds::DurabilityQosPolicyKind::TRANSIENT_LOCAL_DURABILITY_QOS);
+    pubsub_writer->history_kind(eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_ALL_HISTORY_QOS);
+    pubsub_writer->init();
+    ASSERT_EQ(pubsub_writer->isInitialized(), true);
+
+    //! Participant Reader configuration and qos
+    pubsub_reader->reliability(eprosima::fastdds::dds::ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS);
+    pubsub_reader->durability_kind(eprosima::fastdds::dds::DurabilityQosPolicyKind::TRANSIENT_LOCAL_DURABILITY_QOS);
+    pubsub_reader->history_kind(eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_ALL_HISTORY_QOS);
+    pubsub_reader->init();
+    ASSERT_EQ(pubsub_reader->isInitialized(), true);
+
+    // Wait for discovery.
+    pubsub_reader->wait_discovery();
+    pubsub_writer->wait_discovery();
+
+    auto data = default_helloworld_data_generator();
+
+    pubsub_reader->startReception(data);
+
+    std::mutex mtx;
+    bool should_stop(false);
+    auto ret = std::async(std::launch::async, [&pubsub_writer, &data, &should_stop, &mtx]
+                    {
+                        for (auto sample : data)
+                        {
+                            std::unique_lock<std::mutex>  lock(mtx);
+                            if (!should_stop)
+                            {
+                                lock.unlock();
+                                pubsub_writer->send_sample(sample);
+                                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                            }
+                            else
+                            {
+                                break;
+                            }
+                        }
+                        //! drop publisher
+                        pubsub_writer->removePublisher();
+                    }
+                    );
+
+    pubsub_reader->block_for_unread_count_of(3);
+
+    {
+        std::unique_lock<std::mutex> lock(mtx);
+        should_stop = true;
+    }
+
+    pubsub_reader->wait_writer_undiscovery();
+
+    eprosima::fastdds::dds::DataReader& reader = pubsub_reader->get_native_reader();
+    eprosima::fastdds::dds::SampleInfo info;
+
+    //! Try reading the first untaken info.
+    //! Checks whether total_unread_ is consistent with
+    //! the number of unread changes in history
+    //! This API call should NOT modify the history
+    reader.get_first_untaken_info(&info);
+
+    HelloWorld msg;
+    eprosima::fastdds::dds::SampleInfo sinfo;
+
+    //! Try getting a sample
+    auto result = reader.take_next_sample((void*)&msg, &sinfo);
+
+    //! Assert last operation
+    ASSERT_EQ(result, ReturnCode_t::RETCODE_OK) << "Reader's unread count is: " << reader.get_unread_count();
+}
+
 #ifdef INSTANTIATE_TEST_SUITE_P
 #define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_SUITE_P(x, y, z, w)
 #else


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
`mp_reader->nextUntakenCache()` in `get_first_untaken_info()` is removing the change (`it->remove_change()`) if `matched_writer_lookup()` returns false. This, in turn calls `change_removed_by_history()` but `get_last_notified()` returns always false in that case because no writerGUID is found, hence a sequence number of 0.0 is returned. 

This situation causes that `total_unread_` is not decremented despite removing the change, so the history size and `total_unread_` variable are inconsistent and the issue arises. 

When user calls `take_next_sample()`,  `Ret::NO_DATA` is returned despite `reader->get_unread_count()` is different from 0.

## Proposed solution
`get_first_untaken_info()` should be a read-only API and `mp_reader->nextUntakenCache()` should not be called from inside because it modifies the history in certain cases.


<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
@Mergifyio backport 2.8.x 2.7.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [X] Applicable backports have been included in the description.


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
