### PR TITLE
Public RTPS API: RTPSWriter::has_been_delivered()

### DIFF
--- a/include/fastdds/rtps/writer/RTPSWriter.h
+++ b/include/fastdds/rtps/writer/RTPSWriter.h
@@ -201,7 +201,7 @@ public:
      * @return true if delivered. False otherwise.
      */
     RTPS_DllAPI virtual bool has_been_delivered(
-                const CacheChange_t* change) const
+            const CacheChange_t* change) const
     {
         static_cast<void>(change);
         return false;

--- a/include/fastdds/rtps/writer/RTPSWriter.h
+++ b/include/fastdds/rtps/writer/RTPSWriter.h
@@ -195,6 +195,19 @@ public:
     RTPS_DllAPI virtual const fastdds::rtps::IReaderDataFilter* reader_data_filter() const = 0;
 
     /**
+     * @brief Check if a specific change has been delivered to the transport layer at least once.
+     *
+     * @param change Pointer to the CacheChange to check.
+     * @return true if delivered. False otherwise.
+     */
+    RTPS_DllAPI virtual bool has_been_delivered(
+                const CacheChange_t* change) const
+    {
+        static_cast<void>(change);
+        return false;
+    }
+
+    /**
      * Check if a specific change has been acknowledged by all Readers.
      * Is only useful in reliable Writer. In BE Writers returns false when pending to be sent.
      * @return True if acknowledged by all.

--- a/versions.md
+++ b/versions.md
@@ -2,6 +2,7 @@ Forthcoming
 -----------
 
 * Added non-standard DataWriterListener callback `on_unacknowledged_sample_removed` (API extension on DDS layer).
+* Added `RTPSWriter::has_been_delivered` virtual method (ABI break on RTPS layer).
 
 Version 2.9.0
 -------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds the empty implementation for the `RTPSWriter::has_been_delivered` public virtual method required for the implementation of the new `DataWriterListener::on_unacknowledged_sample_removed`.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
**N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
**N/A** Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
**ABI break** Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
**N/A** Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
**N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
**N/A** Applicable backports have been included in the description.


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
