### PR TITLE
[16739] Operative SecureDS-SecureDS 

### DIFF
--- a/include/fastdds/rtps/builtin/discovery/endpoint/EDPSimple.h
+++ b/include/fastdds/rtps/builtin/discovery/endpoint/EDPSimple.h
@@ -223,6 +223,23 @@ protected:
             t_p_StatefulWriter& writer,
             key_list& demises);
 
+    /**
+     * Get a pointer pair of the corresponding writer builtin endpoint for the entity_id
+     * @param [in] entity_id The entity_id to obtain the pair from.
+     * @return A pair of nullptrs if operation was unsuccessful
+     */
+    t_p_StatefulWriter get_builtin_writer_history_pair_by_entity(
+            const EntityId_t& entity_id);
+
+    /**
+     * Get a pointer pair of the corresponding reader builtin endpoint for the entity_id.
+     * If a builtin writer Entity is passed, the equivalent reader entity builtin is returned.
+     * @param [in] entity_id The entity_id to obtain the pair from.
+     * @return A pair of nullptrs if operation was unsuccessful
+     */
+    t_p_StatefulReader get_builtin_reader_history_pair_by_entity(
+            const EntityId_t& entity_id);
+
     std::shared_ptr<ITopicPayloadPool> pub_writer_payload_pool_;
     std::shared_ptr<ITopicPayloadPool> pub_reader_payload_pool_;
     std::shared_ptr<ITopicPayloadPool> sub_writer_payload_pool_;

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -69,6 +69,23 @@ void DiscoveryDataBase::add_server(
     servers_.insert(server);
 }
 
+void DiscoveryDataBase::remove_related_alive_from_history_nts(
+        fastrtps::rtps::WriterHistory* writer_history,
+        const fastrtps::rtps::GuidPrefix_t& entity_guid_prefix)
+{
+    // Iterate over changes in writer_history
+    for (auto chit = writer_history->changesBegin(); chit != writer_history->changesEnd();)
+    {
+        // Remove all DATA whose original sender was entity_guid_prefix from writer_history
+        if (entity_guid_prefix == guid_from_change(*chit).guidPrefix)
+        {
+            chit = writer_history->remove_change(chit, false);
+            continue;
+        }
+        chit++;
+    }
+}
+
 std::vector<fastrtps::rtps::CacheChange_t*> DiscoveryDataBase::clear()
 {
     // Cannot clear an enabled database, since there could be inconsistencies after the process

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include <fastrtps/utils/fixed_size_string.hpp>
+#include <fastdds/rtps/history/WriterHistory.h>
 #include <fastdds/rtps/writer/ReaderProxy.h>
 #include <fastdds/rtps/common/CacheChange.h>
 #include <fastrtps/utils/DBQueue.h>
@@ -346,6 +347,11 @@ public:
     //! Add a server to the list of remote servers
     void add_server(
             fastrtps::rtps::GuidPrefix_t server);
+
+    // Removes all the changes whose original sender was entity_guid_prefix from writer_history
+    void remove_related_alive_from_history_nts(
+            fastrtps::rtps::WriterHistory* writer_history,
+            const fastrtps::rtps::GuidPrefix_t& entity_guid_prefix);
 
 protected:
 

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
@@ -482,25 +482,31 @@ bool EDPServer::process_and_release_change(
 
     auto builtin_to_remove_from = get_builtin_writer_history_pair_by_entity(change->writerGUID.entityId);
 
-    pdp->remove_change_from_writer_history(
-        builtin_to_remove_from.first,
-        builtin_to_remove_from.second,
-        change,
-        false);
-
-    if (is_remote_participant)
+    if (nullptr != builtin_to_remove_from.first && nullptr != builtin_to_remove_from.second)
     {
-        auto builtin_to_release = get_builtin_reader_history_pair_by_entity(change->writerGUID.entityId);
+        pdp->remove_change_from_writer_history(
+            builtin_to_remove_from.first,
+            builtin_to_remove_from.second,
+            change,
+            false);
 
-        builtin_to_release.first->releaseCache(change);
-        ret_val = true;
-    }
-    else
-    {
-        auto builtin_to_release = builtin_to_remove_from;
+        if (is_remote_participant)
+        {
+            auto builtin_to_release = get_builtin_reader_history_pair_by_entity(change->writerGUID.entityId);
 
-        builtin_to_release.first->release_change(change);
-        ret_val = true;
+            if (nullptr != builtin_to_release.first)
+            {
+                builtin_to_release.first->releaseCache(change);
+                ret_val = true;
+            }
+        }
+        else
+        {
+            auto builtin_to_release = builtin_to_remove_from;
+
+            builtin_to_release.first->release_change(change);
+            ret_val = true;
+        }
     }
 
     return ret_val;

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
@@ -435,6 +435,77 @@ bool EDPServer::processLocalReaderProxyData(
     return false;
 }
 
+bool EDPServer::process_disposal(
+        fastrtps::rtps::CacheChange_t* disposal_change,
+        fastdds::rtps::ddb::DiscoveryDataBase& discovery_db,
+        fastrtps::rtps::GuidPrefix_t& change_guid_prefix)
+{
+    bool ret_val = false;
+    eprosima::fastrtps::rtps::WriteParams wp = disposal_change->write_params;
+
+    // DATA(Uw) or DATA(Ur) cases
+    if (discovery_db.is_writer(disposal_change) || discovery_db.is_reader(disposal_change))
+    {
+        EPROSIMA_LOG_INFO(RTPS_PDP_SERVER_DISPOSAL, "Disposal is: " <<
+                (discovery_db.is_writer(
+                    disposal_change) ? "writer" : "reader") << " handle: " << disposal_change->instanceHandle);
+
+        auto builtin_pair = get_builtin_writer_history_pair_by_entity(disposal_change->writerGUID.entityId);
+
+        if (nullptr != builtin_pair.first && nullptr != builtin_pair.second)
+        {
+            // Lock EDP writer
+            std::unique_lock<fastrtps::RecursiveTimedMutex> lock(builtin_pair.first->getMutex());
+
+            // Remove all DATA(w/r) with the same sample identity as the DATA(Uw/Ur) from EDP PUBs/Subs writer's history
+            discovery_db.remove_related_alive_from_history_nts(builtin_pair.second, change_guid_prefix);
+
+            disposal_change->writerGUID.entityId = builtin_pair.first->getGuid().entityId;
+
+            if (builtin_pair.second->add_change(disposal_change, wp))
+            {
+                ret_val = true;
+            }
+        }
+    }
+
+    return ret_val;
+}
+
+bool EDPServer::process_and_release_change(
+        fastrtps::rtps::CacheChange_t* change,
+        const bool& is_remote_participant)
+{
+    bool ret_val = false;
+
+    auto pdp = get_pdp();
+
+    auto builtin_to_remove_from = get_builtin_writer_history_pair_by_entity(change->writerGUID.entityId);
+
+    pdp->remove_change_from_writer_history(
+        builtin_to_remove_from.first,
+        builtin_to_remove_from.second,
+        change,
+        false);
+
+    if (is_remote_participant)
+    {
+        auto builtin_to_release = get_builtin_reader_history_pair_by_entity(change->writerGUID.entityId);
+
+        builtin_to_release.first->releaseCache(change);
+        ret_val = true;
+    }
+    else
+    {
+        auto builtin_to_release = builtin_to_remove_from;
+
+        builtin_to_release.first->release_change(change);
+        ret_val = true;
+    }
+
+    return ret_val;
+}
+
 } /* namespace rtps */
 } /* namespace fastdds */
 } /* namespace eprosima */

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
@@ -438,7 +438,8 @@ bool EDPServer::processLocalReaderProxyData(
 bool EDPServer::process_disposal(
         fastrtps::rtps::CacheChange_t* disposal_change,
         fastdds::rtps::ddb::DiscoveryDataBase& discovery_db,
-        fastrtps::rtps::GuidPrefix_t& change_guid_prefix)
+        fastrtps::rtps::GuidPrefix_t& change_guid_prefix,
+        bool should_publish_disposal)
 {
     bool ret_val = false;
     eprosima::fastrtps::rtps::WriteParams wp = disposal_change->write_params;
@@ -460,12 +461,13 @@ bool EDPServer::process_disposal(
             // Remove all DATA(w/r) with the same sample identity as the DATA(Uw/Ur) from EDP PUBs/Subs writer's history
             discovery_db.remove_related_alive_from_history_nts(builtin_pair.second, change_guid_prefix);
 
-            disposal_change->writerGUID.entityId = builtin_pair.first->getGuid().entityId;
-
-            if (builtin_pair.second->add_change(disposal_change, wp))
+            if (should_publish_disposal)
             {
-                ret_val = true;
+                disposal_change->writerGUID.entityId = builtin_pair.first->getGuid().entityId;
+                builtin_pair.second->add_change(disposal_change, wp);
             }
+
+            ret_val = true;
         }
     }
 

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
@@ -474,7 +474,7 @@ bool EDPServer::process_disposal(
 
 bool EDPServer::process_and_release_change(
         fastrtps::rtps::CacheChange_t* change,
-        const bool& is_remote_participant)
+        bool release_from_reader)
 {
     bool ret_val = false;
 
@@ -490,7 +490,7 @@ bool EDPServer::process_and_release_change(
             change,
             false);
 
-        if (is_remote_participant)
+        if (release_from_reader)
         {
             auto builtin_to_release = get_builtin_reader_history_pair_by_entity(change->writerGUID.entityId);
 

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.hpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.hpp
@@ -127,7 +127,7 @@ public:
      */
     bool process_and_release_change(
             fastrtps::rtps::CacheChange_t* change,
-            bool release_from_reader = false);
+            bool release_from_reader);
 
 private:
 

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.hpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.hpp
@@ -115,7 +115,8 @@ public:
     bool process_disposal(
             fastrtps::rtps::CacheChange_t* disposal_change,
             fastdds::rtps::ddb::DiscoveryDataBase& discovery_db,
-            fastrtps::rtps::GuidPrefix_t& change_guid_prefix);
+            fastrtps::rtps::GuidPrefix_t& change_guid_prefix,
+            bool should_publish_disposal);
 
     /**
      * This method removes all changes from the correct data writer history (change->witerGUID.enitity)

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.hpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.hpp
@@ -104,6 +104,30 @@ public:
     bool removeLocalWriter(
             fastrtps::rtps::RTPSWriter* W) override;
 
+    /**
+     * This method removes all changes from the correct data writer history with the same identity as the one in the disposal_change
+     * and adds it to the corresponding builtin EDP endpoint for forwarding it to interested remotes.
+     * @param change Pointer to the CacheChange_t.
+     * @param discovery_db Reference to the discovery DB.
+     * @param change_guid_prefix The identity of the participant from which the change came.
+     * @return True if successful.
+     */
+    bool process_disposal(
+            fastrtps::rtps::CacheChange_t* disposal_change,
+            fastdds::rtps::ddb::DiscoveryDataBase& discovery_db,
+            fastrtps::rtps::GuidPrefix_t& change_guid_prefix);
+
+    /**
+     * This method removes all changes from the correct data writer history (change->witerGUID.enitity)
+     * and releases the change from the correct history dependeing whether the change is from
+     * this participant or remote
+     * @param change Pointer to the CacheChange_t.
+     * @return True if successful.
+     */
+    bool process_and_release_change(
+            fastrtps::rtps::CacheChange_t* change,
+            const bool& is_remote_participant = false);
+
 private:
 
     /**

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.hpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.hpp
@@ -126,7 +126,7 @@ public:
      */
     bool process_and_release_change(
             fastrtps::rtps::CacheChange_t* change,
-            const bool& is_remote_participant = false);
+            bool release_from_reader = false);
 
 private:
 

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners.cpp
@@ -68,7 +68,7 @@ void EDPServerPUBListener::onNewCacheChangeAdded(
 
     // Get writer's GUID and EDP publications' reader history
     GUID_t auxGUID = iHandle2GUID(change->instanceHandle);
-    ReaderHistory* reader_history = sedp_->publications_reader_.second;
+    ReaderHistory* reader_history = reader->getHistory();
 
     // Related_sample_identity could be lost in message delivered, so we set as sample_identity
     // An empty related_sample_identity could lead into an empty sample_identity when resending this msg
@@ -194,7 +194,7 @@ void EDPServerSUBListener::onNewCacheChangeAdded(
 
     // Get readers's GUID and EDP subscriptions' reader history
     GUID_t auxGUID = iHandle2GUID(change->instanceHandle);
-    ReaderHistory* reader_history = sedp_->subscriptions_reader_.second;
+    ReaderHistory* reader_history = reader->getHistory();
 
     // String to store the topic of the reader
     std::string topic_name = "";

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -298,6 +298,71 @@ void EDPSimple::processPersistentData(
     // We don't need to awake the server thread because we are in it
 }
 
+EDPSimple::t_p_StatefulWriter EDPSimple::get_builtin_writer_history_pair_by_entity(
+        const EntityId_t& entity_id)
+{
+    t_p_StatefulWriter ret{nullptr, nullptr};
+
+    if (entity_id == c_EntityId_SEDPPubWriter)
+    {
+        ret = publications_writer_;
+
+    }
+    else if (entity_id == c_EntityId_SEDPSubWriter)
+    {
+        ret = subscriptions_writer_;
+    }
+#if HAVE_SECURITY
+    else if (entity_id == sedp_builtin_publications_secure_writer)
+    {
+        ret = publications_secure_writer_;
+    }
+    else if (entity_id == sedp_builtin_subscriptions_secure_writer)
+    {
+        ret = subscriptions_secure_writer_;
+    }
+#endif // HAVE_SECURITY
+    else
+    {
+        EPROSIMA_LOG_ERROR(RTPS_EDP, "Could not find the requested writer builtin endpoint");
+    }
+
+    return ret;
+}
+
+EDPSimple::t_p_StatefulReader EDPSimple::get_builtin_reader_history_pair_by_entity(
+        const EntityId_t& entity_id)
+{
+    t_p_StatefulReader ret{nullptr, nullptr};
+
+    if (entity_id == c_EntityId_SEDPPubReader || entity_id == c_EntityId_SEDPPubWriter)
+    {
+        ret = publications_reader_;
+    }
+    else if (entity_id == c_EntityId_SEDPSubReader || entity_id == c_EntityId_SEDPSubWriter)
+    {
+        ret = subscriptions_reader_;
+    }
+#if HAVE_SECURITY
+    else if (entity_id == sedp_builtin_publications_secure_reader ||
+            entity_id == sedp_builtin_publications_secure_writer)
+    {
+        ret = publications_secure_reader_;
+    }
+    else if (entity_id == sedp_builtin_subscriptions_secure_reader ||
+            entity_id == sedp_builtin_subscriptions_secure_writer)
+    {
+        ret = subscriptions_secure_reader_;
+    }
+#endif // HAVE_SECURITY
+    else
+    {
+        EPROSIMA_LOG_ERROR(RTPS_EDP, "Could not find the requested reader builtin endpoint");
+    }
+
+    return ret;
+}
+
 void EDPSimple::set_builtin_reader_history_attributes(
         HistoryAttributes& attributes)
 {

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -752,7 +752,8 @@ void PDPClient::announceParticipantState(
                         {
                             //locators.push_back(svr.metatrafficMulticastLocatorList);
                             locators.push_back(svr.metatrafficUnicastLocatorList);
-                            remote_readers.emplace_back(svr.proxy->m_guid.guidPrefix, endpoints->reader.reader_->getGuid().entityId);
+                            remote_readers.emplace_back(svr.proxy->m_guid.guidPrefix,
+                                    endpoints->reader.reader_->getGuid().entityId);
                         }
                     }
                 }

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -758,7 +758,10 @@ void PDPClient::announceParticipantState(
                     }
                 }
 
-                direct_send(getRTPSParticipant(), locators, remote_readers, *change, *endpoints->writer.writer_);
+                if (!remote_readers.empty())
+                {
+                    direct_send(getRTPSParticipant(), locators, remote_readers, *change, *endpoints->writer.writer_);
+                }
             }
 
             // free change

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -1399,7 +1399,10 @@ void PDPServer::process_changes_release_(
             }
             else
             {
-                if (!edp->process_and_release_change(ch))
+                bool ret = (discovery_db_.is_writer(ch) || discovery_db_.is_reader(ch)) &&
+                        !edp->process_and_release_change(ch, true);
+
+                if (!ret)
                 {
                     EPROSIMA_LOG_ERROR(RTPS_PDP_SERVER, "Wrong DATA received to remove from this participant: "
                             << ch->instanceHandle);
@@ -1424,8 +1427,10 @@ void PDPServer::process_changes_release_(
             }
             else
             {
-                if ((discovery_db_.is_writer(ch) || discovery_db_.is_reader(ch)) &&
-                        !edp->process_and_release_change(ch, true))
+                bool ret = (discovery_db_.is_writer(ch) || discovery_db_.is_reader(ch)) &&
+                        !edp->process_and_release_change(ch, true);
+
+                if (!ret)
                 {
                     EPROSIMA_LOG_ERROR(RTPS_PDP_SERVER, "Wrong DATA received to remove from this participant: "
                             << ch->instanceHandle);

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -1351,9 +1351,12 @@ bool PDPServer::process_disposals()
         }
         // Check whether disposals contains a DATA(Up) from the same participant as the DATA(Uw) or DATA(Ur).
         // If it does, then there is no need of adding the DATA(Uw) or DATA(Ur).
-        else if (!announcement_from_same_participant_in_disposals(disposals, change_guid_prefix))
+        else
         {
-            if (!edp->process_disposal(change, discovery_db_, change_guid_prefix))
+            // Check whether disposals contains a DATA(Up) from the same participant as the DATA(Uw/r).
+            // If it does, then there is no need of adding the DATA(Uw/r).
+            bool should_publish_disposal = !announcement_from_same_participant_in_disposals(disposals, change_guid_prefix);
+            if (!edp->process_disposal(change, discovery_db_, change_guid_prefix, should_publish_disposal))
             {
                 EPROSIMA_LOG_ERROR(RTPS_PDP_SERVER_DISPOSAL,
                         "Wrong DATA received from disposals " << change->instanceHandle);
@@ -1400,7 +1403,7 @@ void PDPServer::process_changes_release_(
             else
             {
                 bool ret = (discovery_db_.is_writer(ch) || discovery_db_.is_reader(ch)) &&
-                        !edp->process_and_release_change(ch, true);
+                        !edp->process_and_release_change(ch);
 
                 if (!ret)
                 {

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -1321,8 +1321,6 @@ bool PDPServer::process_disposals()
 
     auto endpoints = static_cast<fastdds::rtps::DiscoveryServerPDPEndpoints*>(builtin_endpoints_.get());
     EDPServer* edp = static_cast<EDPServer*>(mp_EDP);
-    fastrtps::rtps::WriterHistory* pubs_history = edp->publications_writer_.second;
-    fastrtps::rtps::WriterHistory* subs_history = edp->subscriptions_writer_.second;
 
     // Get list of disposals from database
     std::vector<fastrtps::rtps::CacheChange_t*> disposals = discovery_db_.changes_to_dispose();
@@ -1345,51 +1343,21 @@ bool PDPServer::process_disposals()
             std::unique_lock<fastrtps::RecursiveTimedMutex> lock(endpoints->writer.writer_->getMutex());
 
             // Remove all DATA(p) with the same sample identity as the DATA(Up) from PDP writer's history.
-            remove_related_alive_from_history_nts(endpoints->writer.history_.get(), change_guid_prefix);
+            discovery_db_.remove_related_alive_from_history_nts(endpoints->writer.history_.get(), change_guid_prefix);
 
             // Add DATA(Up) to PDP writer's history
             eprosima::fastrtps::rtps::WriteParams wp = change->write_params;
             endpoints->writer.history_->add_change(change, wp);
         }
-        // DATA(Uw) case
-        else if (discovery_db_.is_writer(change))
+        // Check whether disposals contains a DATA(Up) from the same participant as the DATA(Uw) or DATA(Ur).
+        // If it does, then there is no need of adding the DATA(Uw) or DATA(Ur).
+        else if (!announcement_from_same_participant_in_disposals(disposals, change_guid_prefix))
         {
-            // Lock EDP publications writer
-            std::unique_lock<fastrtps::RecursiveTimedMutex> lock(edp->publications_writer_.first->getMutex());
-
-            // Remove all DATA(w) with the same sample identity as the DATA(Uw) from EDP publications writer's history
-            remove_related_alive_from_history_nts(pubs_history, change_guid_prefix);
-
-            // Check whether disposals contains a DATA(Up) from the same participant as the DATA(Uw).
-            // If it does, then there is no need of adding the DATA(Uw).
-            if (!announcement_from_same_participant_in_disposals(disposals, change_guid_prefix))
+            if (!edp->process_disposal(change, discovery_db_, change_guid_prefix))
             {
-                // Add DATA(Uw) to EDP publications writer's history.
-                eprosima::fastrtps::rtps::WriteParams wp = change->write_params;
-                pubs_history->add_change(change, wp);
+                EPROSIMA_LOG_ERROR(RTPS_PDP_SERVER_DISPOSAL,
+                        "Wrong DATA received from disposals " << change->instanceHandle);
             }
-        }
-        // DATA(Ur) case
-        else if (discovery_db_.is_reader(change))
-        {
-            // Lock EDP subscriptions writer
-            std::unique_lock<fastrtps::RecursiveTimedMutex> lock(edp->subscriptions_writer_.first->getMutex());
-
-            // Remove all DATA(r) with the same sample identity as the DATA(Ur) from EDP subscriptions writer's history
-            remove_related_alive_from_history_nts(subs_history, change_guid_prefix);
-
-            // Check whether disposals contains a DATA(Up) from the same participant as the DATA(Ur).
-            // If it does, then there is no need of adding the DATA(Ur).
-            if (!announcement_from_same_participant_in_disposals(disposals, change_guid_prefix))
-            {
-                // Add DATA(Ur) to EDP subscriptions writer's history.
-                eprosima::fastrtps::rtps::WriteParams wp = change->write_params;
-                subs_history->add_change(change, wp);
-            }
-        }
-        else
-        {
-            EPROSIMA_LOG_ERROR(RTPS_PDP_SERVER, "Wrong DATA received from disposals " << change->instanceHandle);
         }
     }
     // Clear database disposals list
@@ -1429,34 +1397,13 @@ void PDPServer::process_changes_release_(
                     endpoints->writer.writer_->release_change(ch);
                 }
             }
-            else if (discovery_db_.is_writer(ch))
-            {
-                // The change must return to the pool even if not present in the history
-                // Normally Data(Uw) will not be in history except in Own Server destruction
-                if (!remove_change_from_writer_history(
-                            edp->publications_writer_.first,
-                            edp->publications_writer_.second,
-                            ch))
-                {
-                    edp->publications_writer_.first->release_change(ch);
-                }
-            }
-            else if (discovery_db_.is_reader(ch))
-            {
-                // The change must return to the pool even if not present in the history
-                // Normally Data(Ur) will not be in history except in Own Server destruction
-                if (!remove_change_from_writer_history(
-                            edp->subscriptions_writer_.first,
-                            edp->subscriptions_writer_.second,
-                            ch))
-                {
-                    edp->subscriptions_writer_.first->release_change(ch);
-                }
-            }
             else
             {
-                EPROSIMA_LOG_ERROR(RTPS_PDP_SERVER, "Wrong DATA received to remove from this participant: "
-                        << ch->instanceHandle);
+                if (!edp->process_and_release_change(ch))
+                {
+                    EPROSIMA_LOG_ERROR(RTPS_PDP_SERVER, "Wrong DATA received to remove from this participant: "
+                            << ch->instanceHandle);
+                }
             }
         }
         // The change is not from this participant. In that case, the change comes from a reader pool (PDP, EDP
@@ -1475,46 +1422,16 @@ void PDPServer::process_changes_release_(
                     false);
                 endpoints->reader.reader_->releaseCache(ch);
             }
-            else if (discovery_db_.is_writer(ch))
-            {
-                remove_change_from_writer_history(
-                    edp->publications_writer_.first,
-                    edp->publications_writer_.second,
-                    ch,
-                    false);
-                edp->publications_reader_.first->releaseCache(ch);
-            }
-            else if (discovery_db_.is_reader(ch))
-            {
-                remove_change_from_writer_history(
-                    edp->subscriptions_writer_.first,
-                    edp->subscriptions_writer_.second,
-                    ch,
-                    false);
-                edp->subscriptions_reader_.first->releaseCache(ch);
-            }
             else
             {
-                EPROSIMA_LOG_ERROR(PDPServer, "Wrong DATA received to remove");
+                if ((discovery_db_.is_writer(ch) || discovery_db_.is_reader(ch)) &&
+                        !edp->process_and_release_change(ch, true))
+                {
+                    EPROSIMA_LOG_ERROR(RTPS_PDP_SERVER, "Wrong DATA received to remove from this participant: "
+                            << ch->instanceHandle);
+                }
             }
         }
-    }
-}
-
-void PDPServer::remove_related_alive_from_history_nts(
-        fastrtps::rtps::WriterHistory* writer_history,
-        const fastrtps::rtps::GuidPrefix_t& entity_guid_prefix)
-{
-    // Iterate over changes in writer_history
-    for (auto chit = writer_history->changesBegin(); chit != writer_history->changesEnd();)
-    {
-        // Remove all DATA whose original sender was entity_guid_prefix from writer_history
-        if (entity_guid_prefix == discovery_db_.guid_from_change(*chit).guidPrefix)
-        {
-            chit = writer_history->remove_change(chit, false);
-            continue;
-        }
-        chit++;
     }
 }
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -1405,7 +1405,7 @@ void PDPServer::process_changes_release_(
             {
                 bool ret = (discovery_db_.is_writer(ch) || discovery_db_.is_reader(ch));
 
-                if (!ret || !edp->process_and_release_change(ch,false))
+                if (!ret || !edp->process_and_release_change(ch, false))
                 {
                     EPROSIMA_LOG_ERROR(RTPS_PDP_SERVER, "Wrong DATA received to remove from this participant: "
                             << ch->instanceHandle);

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -1355,7 +1355,8 @@ bool PDPServer::process_disposals()
         {
             // Check whether disposals contains a DATA(Up) from the same participant as the DATA(Uw/r).
             // If it does, then there is no need of adding the DATA(Uw/r).
-            bool should_publish_disposal = !announcement_from_same_participant_in_disposals(disposals, change_guid_prefix);
+            bool should_publish_disposal = !announcement_from_same_participant_in_disposals(disposals,
+                            change_guid_prefix);
             if (!edp->process_disposal(change, discovery_db_, change_guid_prefix, should_publish_disposal))
             {
                 EPROSIMA_LOG_ERROR(RTPS_PDP_SERVER_DISPOSAL,

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -1405,7 +1405,7 @@ void PDPServer::process_changes_release_(
             {
                 bool ret = (discovery_db_.is_writer(ch) || discovery_db_.is_reader(ch));
 
-                if (!ret || (ret && !edp->process_and_release_change(ch)))
+                if (!ret || !edp->process_and_release_change(ch,false))
                 {
                     EPROSIMA_LOG_ERROR(RTPS_PDP_SERVER, "Wrong DATA received to remove from this participant: "
                             << ch->instanceHandle);
@@ -1432,7 +1432,7 @@ void PDPServer::process_changes_release_(
             {
                 bool ret = (discovery_db_.is_writer(ch) || discovery_db_.is_reader(ch));
 
-                if (!ret || (ret && !edp->process_and_release_change(ch, true)))
+                if (!ret || !edp->process_and_release_change(ch, true))
                 {
                     EPROSIMA_LOG_ERROR(RTPS_PDP_SERVER, "Wrong DATA received to remove from this participant: "
                             << ch->instanceHandle);

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -1432,7 +1432,7 @@ void PDPServer::process_changes_release_(
             {
                 bool ret = (discovery_db_.is_writer(ch) || discovery_db_.is_reader(ch));
 
-                if (!ret || (ret && !edp->process_and_release_change(ch)))
+                if (!ret || (ret && !edp->process_and_release_change(ch, true)))
                 {
                     EPROSIMA_LOG_ERROR(RTPS_PDP_SERVER, "Wrong DATA received to remove from this participant: "
                             << ch->instanceHandle);

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -1706,7 +1706,6 @@ void PDPServer::ping_remote_servers()
             if (server_it != ack_pending_servers.end())
             {
                 // get the info to send to this already known locators
-                remote_readers.push_back(GUID_t(server.guidPrefix, c_EntityId_SPDPReader));
                 locators.push_back(server.metatrafficUnicastLocatorList);
             }
         }

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -1024,13 +1024,16 @@ void PDPServer::announceParticipantState(
         std::vector<GuidPrefix_t> direct_clients_and_servers = discovery_db_.direct_clients_and_servers();
         for (GuidPrefix_t participant_prefix: direct_clients_and_servers)
         {
-            // Add remote reader
-            GUID_t remote_guid(participant_prefix, c_EntityId_SPDPReader);
-            remote_readers.push_back(remote_guid);
-
+            // Add corresponding remote reader and locator
+            remote_readers.emplace_back(participant_prefix, endpoints->reader.reader_->getGuid().entityId);
             locators.push_back(discovery_db_.participant_metatraffic_locators(participant_prefix));
         }
-        send_announcement(change, remote_readers, locators, dispose);
+
+        //! Send announcement only if we have someone to inform
+        if (!remote_readers.empty())
+        {
+            send_announcement(change, remote_readers, locators, dispose);
+        }
     }
 }
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -1402,10 +1402,9 @@ void PDPServer::process_changes_release_(
             }
             else
             {
-                bool ret = (discovery_db_.is_writer(ch) || discovery_db_.is_reader(ch)) &&
-                        !edp->process_and_release_change(ch);
+                bool ret = (discovery_db_.is_writer(ch) || discovery_db_.is_reader(ch));
 
-                if (!ret)
+                if (!ret || (ret && !edp->process_and_release_change(ch)))
                 {
                     EPROSIMA_LOG_ERROR(RTPS_PDP_SERVER, "Wrong DATA received to remove from this participant: "
                             << ch->instanceHandle);
@@ -1430,10 +1429,9 @@ void PDPServer::process_changes_release_(
             }
             else
             {
-                bool ret = (discovery_db_.is_writer(ch) || discovery_db_.is_reader(ch)) &&
-                        !edp->process_and_release_change(ch, true);
+                bool ret = (discovery_db_.is_writer(ch) || discovery_db_.is_reader(ch));
 
-                if (!ret)
+                if (!ret || (ret && !edp->process_and_release_change(ch)))
                 {
                     EPROSIMA_LOG_ERROR(RTPS_PDP_SERVER, "Wrong DATA received to remove from this participant: "
                             << ch->instanceHandle);

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
@@ -233,12 +233,6 @@ protected:
             fastrtps::rtps::CacheChange_t* change,
             bool release_change = true);
 
-
-    // Remove from writer_history all the changes whose original sender was entity_guid_prefix
-    void remove_related_alive_from_history_nts(
-            fastrtps::rtps::WriterHistory* writer_history,
-            const fastrtps::rtps::GuidPrefix_t& entity_guid_prefix);
-
     bool announcement_from_same_participant_in_disposals(
             const std::vector<fastrtps::rtps::CacheChange_t*>& disposals,
             const fastrtps::rtps::GuidPrefix_t& participant);

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -3155,6 +3155,8 @@ bool SecurityManager::discovered_reader(
 
                 remote_reader_pending_discovery_messages_.push_back(std::make_tuple(remote_reader_data,
                         remote_participant_key, writer_guid));
+
+                returned_value = true;
             }
         }
         else
@@ -3504,6 +3506,8 @@ bool SecurityManager::discovered_writer(
 
                 remote_writer_pending_discovery_messages_.push_back(std::make_tuple(remote_writer_data,
                         remote_participant_key, reader_guid));
+
+                returned_value = true;
             }
         }
         else


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR intends to add necessary fixes to have a successful Secure DIscovery Server - Secure DIscovery Server interaction. Punctual changes on PDP Clients are also considered.
The example scenario in which fixes have been tested has been:
SimpleSecurePublisher - SDS1 - SDS2 - SImpleSecureSubscriber

Update 18/01/2022:
- In `EDPServer::process_and_release_change`, I still leave the call to `remove_change_from_writer_history()` (from PDPServer) since PDPServer makes use of it when checking if the change comes from a participant.

- I applied the shortcut to accept a writer entity id on `get_builtin_reader_history_pair_by_entity()`.

- Tested case Pub-DS1-DS2-Sub With and Without security.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
**N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- **N/A** Applicable backports have been included in the description.


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
