### PR TITLE
Improve doxygen documentation for ResourceLimitsQos [16814]

### DIFF
--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -1727,21 +1727,21 @@ public:
      * @brief Specifies the maximum number of data-samples the DataWriter (or DataReader) can manage across all the
      * instances associated with it. Represents the maximum samples the middleware can store for any one DataWriter
      * (or DataReader). <br>
-     * By default, 5000.
+     * Value 0 means infinite resources. By default, 5000.
      *
      * @warning It is inconsistent if `max_samples < (max_instances * max_samples_per_instance)`.
      */
     int32_t max_samples;
     /**
      * @brief Represents the maximum number of instances DataWriter (or DataReader) can manage. <br>
-     * By default, 10.
+     * Value 0 means infinite resources. By default, 10.
      *
      * @warning It is inconsistent if `(max_instances * max_samples_per_instance) > max_samples`.
      */
     int32_t max_instances;
     /**
      * @brief Represents the maximum number of samples of any one instance a DataWriter(or DataReader) can manage. <br>
-     * By default, 400.
+     * Value 0 means infinite resources. By default, 400.
      *
      * @warning It is inconsistent if `(max_instances * max_samples_per_instance) > max_samples`.
      */


### PR DESCRIPTION
## Description

This PR specifies the meaning of value 0 in `ResourceLimitsQos` attributes.

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- *N/A* Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- *N/A* Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- *N/A* Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- *N/A* Applicable backports have been included in the description.


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
