### PR TITLE
[16737] Fix StatelessWriter ACK check

### DIFF
--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -377,7 +377,7 @@ bool StatelessWriter::change_removed_by_history(
     }
 
     const uint64_t sequence_number = change->sequenceNumber.to64long();
-    if (sequence_number < last_sequence_number_sent_)
+    if (sequence_number <= last_sequence_number_sent_)
     {
         unsent_changes_cond_.notify_all();
     }

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -377,7 +377,7 @@ bool StatelessWriter::change_removed_by_history(
     }
 
     const uint64_t sequence_number = change->sequenceNumber.to64long();
-    if (sequence_number > last_sequence_number_sent_)
+    if (sequence_number < last_sequence_number_sent_)
     {
         unsent_changes_cond_.notify_all();
     }
@@ -389,7 +389,7 @@ bool StatelessWriter::is_acked_by_all(
         const CacheChange_t* change) const
 {
     std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
-    return change->sequenceNumber.to64long() >= last_sequence_number_sent_;
+    return change->sequenceNumber.to64long() <= last_sequence_number_sent_;
 }
 
 bool StatelessWriter::try_remove_change(
@@ -407,7 +407,7 @@ bool StatelessWriter::wait_for_acknowledgement(
     uint64_t sequence_number = seq.to64long();
     auto change_is_acknowledged = [this, sequence_number]()
             {
-                return sequence_number >= last_sequence_number_sent_;
+                return sequence_number <= last_sequence_number_sent_;
             };
     return unsent_changes_cond_.wait_until(lock, max_blocking_time_point, change_is_acknowledged);
 }

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -404,15 +404,18 @@ bool StatelessWriter::wait_for_acknowledgement(
         const std::chrono::steady_clock::time_point& max_blocking_time_point,
         std::unique_lock<RecursiveTimedMutex>& lock)
 {
-    auto change_is_acknowledged = [this, seq]()
+    uint64_t seq_long_64 = seq.to64long();
+    auto change_is_acknowledged = [this, seq, seq_long_64]()
             {
                 bool ret = false;
-                if (seq.to64long() <= last_sequence_number_sent_)
+                if (seq_long_64 <= last_sequence_number_sent_)
                 {
+                    // Stop waiting if the sequence number has been sent
                     ret = true;
                 }
                 else
                 {
+                    // If the sequence number has not been sent, stop waiting if it is not present in the history
                     CacheChange_t* change = nullptr;
                     ret = !mp_history->get_change(seq, m_guid, &change);
                 }


### PR DESCRIPTION
Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>

<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

`StatelessWriter::is_acked_by_all` checks that the sample has been delivered but instead of checking that the sequence number is lower than the last sent, the contrary is checked. This PR fixes this and other places where this same issue is happening.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->

@Mergifyio backport 2.9.x 2.8.x 2.7.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
**N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
**N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
**N/A** Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
**N/A** New feature has been added to the `versions.md` file (if applicable).
**N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
