### PR TITLE
[16671] Fixed StatisticsSubmessageData unaligned access

### DIFF
--- a/include/fastdds/rtps/common/Time_t.h
+++ b/include/fastdds/rtps/common/Time_t.h
@@ -167,6 +167,11 @@ public:
     uint32_t fraction() const;
 
     /**
+     * Retrieve the fraction field by ref.
+     */
+    uint32_t& fraction();
+
+    /**
      * Sets fraction field and updates the nanoseconds.
      */
     void fraction(

--- a/src/cpp/rtps/common/Time_t.cpp
+++ b/src/cpp/rtps/common/Time_t.cpp
@@ -225,6 +225,11 @@ uint32_t Time_t::fraction() const
     return fraction_;
 }
 
+uint32_t& Time_t::fraction()
+{
+    return fraction_;
+}
+
 void Time_t::fraction(
         uint32_t frac)
 {

--- a/src/cpp/statistics/rtps/messages/RTPSStatisticsMessages.hpp
+++ b/src/cpp/statistics/rtps/messages/RTPSStatisticsMessages.hpp
@@ -199,9 +199,6 @@ inline void set_statistics_submessage_from_transport(
         Time_t ts;
         Time_t::now(ts);
 
-
-        auto fraction = ts.fraction();
-
         /*
          * This set of memcpy blocks is intended to prevent an undefined behavior caused when casting from an octet* to a StatisticsSubmessageData*
          * since these classes have different alignment.
@@ -210,7 +207,7 @@ inline void set_statistics_submessage_from_transport(
         memcpy((char*)current_pos + offsetof(StatisticsSubmessageData, destination), &destination, sizeof(destination));
         memcpy((char*)current_pos + offsetof(StatisticsSubmessageData, ts.seconds), &ts.seconds(),
                 sizeof(StatisticsSubmessageData::ts.seconds));
-        memcpy((char*)current_pos + offsetof(StatisticsSubmessageData, ts.fraction), &fraction,
+        memcpy((char*)current_pos + offsetof(StatisticsSubmessageData, ts.fraction), &ts.fraction(),
                 sizeof(StatisticsSubmessageData::ts.fraction));
         memcpy((char*)current_pos + offsetof(StatisticsSubmessageData, seq.sequence), &sequence.sequence,
                 sizeof(sequence.sequence));

--- a/src/cpp/statistics/rtps/messages/RTPSStatisticsMessages.hpp
+++ b/src/cpp/statistics/rtps/messages/RTPSStatisticsMessages.hpp
@@ -19,7 +19,9 @@
 #ifndef _STATISTICS_RTPS_MESSAGES_RTPSSTATISTICSMESSAGES_HPP_
 #define _STATISTICS_RTPS_MESSAGES_RTPSSTATISTICSMESSAGES_HPP_
 
+#include <cstddef>
 #include <cstdint>
+#include <cstring>
 
 #include <fastdds/rtps/common/CDRMessage_t.h>
 #include <fastdds/rtps/common/Types.h>
@@ -193,16 +195,29 @@ inline void set_statistics_submessage_from_transport(
         statistics_pos += RTPSMESSAGE_SUBMESSAGEHEADER_SIZE;
 
         // Set current timestamp and sequence
-        auto submessage = (StatisticsSubmessageData*)(&send_buffer[statistics_pos]);
+        auto current_pos = &send_buffer[statistics_pos];
         Time_t ts;
         Time_t::now(ts);
 
-        submessage->destination = destination;
-        submessage->ts.seconds = ts.seconds();
-        submessage->ts.fraction = ts.fraction();
-        submessage->seq.sequence = sequence.sequence;
-        submessage->seq.bytes = sequence.bytes;
-        submessage->seq.bytes_high = sequence.bytes_high;
+
+        auto fraction = ts.fraction();
+
+        /*
+         * This set of memcpy blocks is intended to prevent an undefined behavior caused when casting from an octet* to a StatisticsSubmessageData*
+         * since these classes have different alignment.
+         */
+
+        memcpy((char*)current_pos + offsetof(StatisticsSubmessageData, destination), &destination, sizeof(destination));
+        memcpy((char*)current_pos + offsetof(StatisticsSubmessageData, ts.seconds), &ts.seconds(),
+                sizeof(StatisticsSubmessageData::ts.seconds));
+        memcpy((char*)current_pos + offsetof(StatisticsSubmessageData, ts.fraction), &fraction,
+                sizeof(StatisticsSubmessageData::ts.fraction));
+        memcpy((char*)current_pos + offsetof(StatisticsSubmessageData, seq.sequence), &sequence.sequence,
+                sizeof(sequence.sequence));
+        memcpy((char*)current_pos + offsetof(StatisticsSubmessageData, seq.bytes), &sequence.bytes,
+                sizeof(sequence.bytes));
+        memcpy((char*)current_pos + offsetof(StatisticsSubmessageData, seq.bytes_high), &sequence.bytes_high,
+                sizeof(sequence.bytes_high));
     }
 #endif // FASTDDS_STATISTICS
 }


### PR DESCRIPTION
Signed-off-by: Javier Santiago <javiersantiago@eprosima.com>

<!-- Provide a general summary of your changes in the Title above -->

UBSan (Undefined Behavior Sanitizer) produced the following warning:

```
third-party/eprosima/Fast-DDS/Fast-DDS-2.9.0/src/cpp/statistics/rtps/messages/RTPSStatisticsMessages.hpp:200:21: runtime error: member access within misaligned address 0x7f81715df7d4 for type 'eprosima::fastdds::statistics::rtps::StatisticsSubmessageData', which requires 8 byte alignment
```

This is triggered by casting an octet* to a StatisticsSubmessageData* and accessing one of StatisticsSubmessageData members . Since both of them have different alignment that operation is undefined behavior.

The workaround for this issue is using memcpy and offsetof to copy directly to the octet buffer reconstructing the StatisticsSubmessageData manually.

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [NA] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [NA] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [NA] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [NA] New feature has been added to the `versions.md` file (if applicable).
- [NA] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
