### PR TITLE
Fix compilation on old compilers [16901]

### DIFF
--- a/src/cpp/rtps/transport/ChainingTransport.cpp
+++ b/src/cpp/rtps/transport/ChainingTransport.cpp
@@ -36,7 +36,7 @@ bool ChainingTransport::OpenInputChannel(
     if (iterator == receiver_resources_.end())
     {
         ChainingReceiverResource* receiver_resource = new ChainingReceiverResource(*this, receiver_interface);
-        receiver_resources_.emplace(loc, receiver_resource);
+        receiver_resources_.emplace(loc, ChainingReceiverResourceReferenceType(receiver_resource));
         return low_level_transport_->OpenInputChannel(loc, receiver_resource, max_message_size);
     }
 


### PR DESCRIPTION
## Description

This PR fixes compilation error in Ubuntu Xenial which uses old compiler gcc 5.4.

@mergifyio backport 2.9.x 2.8.x 2.6.x

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- *N/A* Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
