### PR TITLE
[16880] Fix simple test scenarios

### DIFF
--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -453,16 +453,23 @@ bool PDPClient::create_ds_pdp_reliable_endpoints(
             mp_RTPSParticipant->createSenderResources(it.metatrafficMulticastLocatorList);
             mp_RTPSParticipant->createSenderResources(it.metatrafficUnicastLocatorList);
 
+#if HAVE_SECURITY
             if (!mp_RTPSParticipant->is_secure())
             {
                 match_pdp_writer_nts_(it);
                 match_pdp_reader_nts_(it);
             }
-            else if (mp_RTPSParticipant->is_secure() &&
-                    !mp_RTPSParticipant->security_attributes().is_discovery_protected)
+            else if (!should_protect_discovery())
             {
                 endpoints.reader.reader_->enableMessagesFromUnkownWriters(true);
             }
+#else
+            if (!secure)
+            {
+                match_pdp_writer_nts_(it);
+                match_pdp_reader_nts_(it);
+            }
+#endif // HAVE_SECURITY
         }
     }
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -364,7 +364,8 @@ bool PDPClient::create_ds_pdp_reliable_endpoints(
 
     RTPSReader* reader = nullptr;
 #if HAVE_SECURITY
-    EntityId_t reader_entity = is_discovery_protected ? c_EntityId_spdp_reliable_participant_secure_reader : c_EntityId_SPDPReader;
+    EntityId_t reader_entity =
+            is_discovery_protected ? c_EntityId_spdp_reliable_participant_secure_reader : c_EntityId_SPDPReader;
 #else
     EntityId_t reader_entity = c_EntityId_SPDPReader;
 #endif // if HAVE_SECURITY
@@ -424,7 +425,8 @@ bool PDPClient::create_ds_pdp_reliable_endpoints(
 
     RTPSWriter* wout = nullptr;
 #if HAVE_SECURITY
-    EntityId_t writer_entity = is_discovery_protected ? c_EntityId_spdp_reliable_participant_secure_writer : c_EntityId_SPDPWriter;
+    EntityId_t writer_entity =
+            is_discovery_protected ? c_EntityId_spdp_reliable_participant_secure_writer : c_EntityId_SPDPWriter;
 #else
     EntityId_t writer_entity = c_EntityId_SPDPWriter;
 #endif // if HAVE_SECURITY

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.h
@@ -218,7 +218,7 @@ private:
      */
     bool create_ds_pdp_reliable_endpoints(
             DiscoveryServerPDPEndpoints& endpoints,
-            bool secure);
+            bool is_discovery_protected);
 
     /**
      * Performs creation of DS best-effort PDP reader.

--- a/test/communication/CMakeLists.txt
+++ b/test/communication/CMakeLists.txt
@@ -144,7 +144,8 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/secure_simple_ds_server_no_discovery_
     ${CMAKE_CURRENT_BINARY_DIR}/secure_simple_ds_server_no_discovery_no_rtps_protection.xml COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/secure_simple_ds_server_no_discovery_protection.xml
     ${CMAKE_CURRENT_BINARY_DIR}/secure_simple_ds_server_no_discovery_protection.xml COPYONLY)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/secure_simple_ds_server_no_rtps_protection.xml    ${CMAKE_CURRENT_BINARY_DIR}/secure_simple_ds_server_no_rtps_protection.xml COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/secure_simple_ds_server_no_rtps_protection.xml
+    ${CMAKE_CURRENT_BINARY_DIR}/secure_simple_ds_server_no_rtps_protection.xml COPYONLY)
 
 if(SECURITY)
     configure_file(${PROJECT_SOURCE_DIR}/test/certs/maincacert.pem


### PR DESCRIPTION
…kelists spaces corrected

Signed-off-by: Mario Dominguez <mariodominguez@eprosima.com>

<!-- Provide a general summary of your changes in the Title above -->

<!-- 
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR intends to add the necessary fixes to get the 3 simple test scenarios working. 

When discovery is not protected, let pdp matching to be done later but accept messages from unknown, but trusted, reliable writers. When discovery is not protected, discoveryservers participantproxydata is not filled within `assignremoteEndpoints()` because discovering a participant happens before authentication, so security secrets are not known at that moment. On disposal, try again to find the correct participantproxydata.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line with the corresponding branches.
-->
<!-- @Mergifyio backport (branch/es) -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Fast DDS test suite has been run locally. <!-- Please provide the platform/architecture where the test suite has been run. In case that only some tests are run, please provide the list (unit test, blackbox Fast DDS PIM API, blackbox FastRTPS API, etc.) -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [ ] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
