### PR TITLE
Fix tests with Log: wait for Log background thread initialization on the first queued entry [16948]

### DIFF
--- a/src/cpp/fastdds/log/Log.cpp
+++ b/src/cpp/fastdds/log/Log.cpp
@@ -212,7 +212,10 @@ struct LogResources
             // pessimization
             cv_.notify_all();
             // wait till the thread is initialized
-            cv_.wait(guard, [&]{ return current_loop_; });
+            cv_.wait(guard, [&]
+                    {
+                        return current_loop_;
+                    });
         }
     }
 

--- a/src/cpp/fastdds/log/Log.cpp
+++ b/src/cpp/fastdds/log/Log.cpp
@@ -209,8 +209,11 @@ struct LogResources
         {
             std::unique_lock<std::mutex> guard(cv_mutex_);
             work_ = true;
+            // pessimization
+            cv_.notify_all();
+            // wait till the thread is initialized
+            cv_.wait(guard, [&]{ return current_loop_; });
         }
-        cv_.notify_all();
     }
 
     //! Stops the logging_ thread. It will re-launch on the next call to QueueLog.
@@ -269,14 +272,16 @@ private:
                 logs_.Swap();
                 while (!logs_.Empty())
                 {
-                    std::unique_lock<std::mutex> configGuard(config_mutex_);
-
                     Log::Entry& entry = logs_.Front();
-                    if (preprocess(entry))
                     {
-                        for (auto& consumer : consumers_)
+                        std::unique_lock<std::mutex> configGuard(config_mutex_);
+
+                        if (preprocess(entry))
                         {
-                            consumer->Consume(entry);
+                            for (auto& consumer : consumers_)
+                            {
+                                consumer->Consume(entry);
+                            }
                         }
                     }
                     // This Pop() is also a barrier for Log::Flush wait condition


### PR DESCRIPTION
Signed-off-by: Irene Bandera <irenebandera@eprosima.com>

<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
https://github.com/eProsima/Fast-DDS/tree/bug/logError

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.10.x 2.9.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- **N/A** Check CI results: failing tests are unrelated with the changes.
