### PR TITLE
Fix load profiles TSAN issue [17162]

### DIFF
--- a/include/fastdds/dds/domain/DomainParticipantFactory.hpp
+++ b/include/fastdds/dds/domain/DomainParticipantFactory.hpp
@@ -314,6 +314,13 @@ protected:
     std::shared_ptr<fastrtps::rtps::RTPSDomainImpl> rtps_domain_;
 
     std::shared_ptr<detail::LogResources> log_resources_;
+
+    /**
+     * This mutex guards the access to load the profiles.
+     * Is used to lock every thread that is trying to load the profiles, so only the first one loads it and
+     * until it is not finished the rest of them does not leave function \c load_profiles .
+     */
+    mutable std::mutex default_xml_profiles_loaded_mtx_;
 };
 
 }  // namespace dds

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -1884,3 +1884,28 @@ TEST(Discovery, MulticastInitialPeer)
     writer.wait_discovery();
     reader.wait_discovery();
 }
+
+//! Regression test for redmine issue 10674
+TEST(Discovery, MultipleXMLProfileLoad)
+{
+    auto participant_creation_reader = []()
+            {
+                PubSubReader<HelloWorldPubSubType> participant(TEST_TOPIC_NAME);
+                participant.init();
+                participant.wait_discovery();
+            };
+
+    auto participant_creation_writer = []()
+            {
+                PubSubWriter<HelloWorldPubSubType> participant(TEST_TOPIC_NAME);
+                participant.init();
+                participant.wait_discovery();
+            };
+
+    // Start thread creating second participant
+    std::thread thr_reader(participant_creation_reader);
+    std::thread thr_writer(participant_creation_writer);
+
+    thr_reader.join();
+    thr_writer.join();
+}

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -1910,8 +1910,11 @@ TEST(Discovery, MultipleXMLProfileLoad)
                 std::unique_lock<std::mutex> lock(cv_mtx);
                 cv.wait(
                     lock,
-                    [&](){ return n_discoveries >= 2; }
-                );
+                    [&]()
+                    {
+                        return n_discoveries >= 2;
+                    }
+                    );
             };
 
     auto participant_creation_writer = [&]()
@@ -1930,8 +1933,11 @@ TEST(Discovery, MultipleXMLProfileLoad)
                 std::unique_lock<std::mutex> lock(cv_mtx);
                 cv.wait(
                     lock,
-                    [&](){ return n_discoveries >= 2; }
-                );
+                    [&]()
+                    {
+                        return n_discoveries >= 2;
+                    }
+                    );
             };
 
     // Start thread creating second participant


### PR DESCRIPTION
Signed-off-by: jparisu <javierparis@eprosima.com>

<!-- Provide a general summary of your changes in the Title above -->

load_profiles() method is called in a singleton without guards, and this could lead to multiple threads loading files at the same time.
TSAN fails in most tests for this (every time a DomainParticipant is created).

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.9.x 2.8.x 2.7.x 2.6.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- N/A Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- ¿? Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- N/A New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [ ] Applicable backports have been included in the description.


## Reviewer Checklist
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
