### PR TITLE
Fix static variable data race access [17163]

### DIFF
--- a/include/fastdds/rtps/builtin/discovery/participant/PDP.h
+++ b/include/fastdds/rtps/builtin/discovery/participant/PDP.h
@@ -146,7 +146,7 @@ public:
      */
     virtual void announceParticipantState(
             bool new_change,
-            bool dispose = false) = 0;
+            bool dispose = false);
 
     //!Stop the RTPSParticipantAnnouncement (only used in tests).
     virtual void stopParticipantAnnouncement();

--- a/include/fastdds/rtps/builtin/discovery/participant/PDP.h
+++ b/include/fastdds/rtps/builtin/discovery/participant/PDP.h
@@ -138,8 +138,15 @@ public:
      */
     virtual void announceParticipantState(
             bool new_change,
-            bool dispose = false,
-            WriteParams& wparams = WriteParams::WRITE_PARAM_DEFAULT) = 0;
+            bool dispose,
+            WriteParams& wparams) = 0;
+
+    /**
+     * \c announceParticipantState method without optional output parameter \c wparams .
+     */
+    virtual void announceParticipantState(
+            bool new_change,
+            bool dispose = false) = 0;
 
     //!Stop the RTPSParticipantAnnouncement (only used in tests).
     virtual void stopParticipantAnnouncement();

--- a/include/fastdds/rtps/builtin/discovery/participant/PDPSimple.h
+++ b/include/fastdds/rtps/builtin/discovery/participant/PDPSimple.h
@@ -77,12 +77,19 @@ public:
      * Force the sending of our local DPD to all remote RTPSParticipants and multicast Locators.
      * @param new_change If true a new change (with new seqNum) is created and sent; if false the last change is re-sent
      * @param dispose Sets change kind to NOT_ALIVE_DISPOSED_UNREGISTERED
-     * @param wparams allows to identify the change
+     * @param[in, out] wparams  allows to identify the change
      */
     void announceParticipantState(
             bool new_change,
-            bool dispose = false,
-            WriteParams& wparams = WriteParams::WRITE_PARAM_DEFAULT) override;
+            bool dispose,
+            WriteParams& wparams) override;
+
+    /**
+     * \c announceParticipantState method without optional output parameter \c wparams .
+     */
+    void announceParticipantState(
+            bool new_change,
+            bool dispose = false) override;
 
     /**
      * This method assigns remote endpoints to the builtin endpoints defined in this protocol. It also calls

--- a/include/fastdds/rtps/common/WriteParams.h
+++ b/include/fastdds/rtps/common/WriteParams.h
@@ -178,6 +178,8 @@ public:
         return *this;
     }
 
+    static WriteParams WRITE_PARAM_DEFAULT;
+
     /**
      * Default value for methods receiving a WriteParams.
      *
@@ -185,8 +187,14 @@ public:
      * - sample_identity: Invalid SampleIdentity
      * - related_sample_identity: Invalid SampleIdentity
      * - source_timestamp: Invalid Time_t
+     *
+     * @note This should not return a reference to the static value if this value is meant to be
+     * read and written from different threads.
      */
-    static WriteParams WRITE_PARAM_DEFAULT;
+    static WriteParams write_params_default() noexcept
+    {
+        return WriteParams();
+    }
 
 private:
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -452,6 +452,14 @@ void PDP::announceParticipantState(
         RTPSWriter& writer,
         WriterHistory& history,
         bool new_change,
+        bool dispose /* = false */)
+{
+    WriteParams __wp = WriteParams::write_params_default();
+    announceParticipantState(new_change, dispose, __wp);
+}
+
+void PDP::announceParticipantState(
+        bool new_change,
         bool dispose,
         WriteParams& wparams)
 {

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -449,8 +449,6 @@ bool PDP::enable()
 }
 
 void PDP::announceParticipantState(
-        RTPSWriter& writer,
-        WriterHistory& history,
         bool new_change,
         bool dispose /* = false */)
 {
@@ -459,6 +457,8 @@ void PDP::announceParticipantState(
 }
 
 void PDP::announceParticipantState(
+        RTPSWriter& writer,
+        WriterHistory& history,
         bool new_change,
         bool dispose,
         WriteParams& wparams)

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.h
@@ -105,7 +105,12 @@ public:
      * @param new_change If true a new change (with new seqNum) is created and sent;
      * if false the last change is re-sent
      * @param dispose Sets change kind to NOT_ALIVE_DISPOSED_UNREGISTERED
-     * @param wparams allows to identify the change
+     * @param wparams allows to identify the change [unused]
+     *
+     * @warning this method uses the static variable reference as it does not use the parameter \c wparams
+     * and this avoids a creation of an object WriteParams.
+     * However, if in future versions this method uses this argument, it must change to the function
+     * \c write_params_default for thread safety reasons.
      */
     void announceParticipantState(
             bool new_change,

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
@@ -108,7 +108,12 @@ public:
      * Force the sending of our local PDP to all servers
      * @param new_change If true a new change (with new seqNum) is created and sent; if false the last change is re-sent
      * @param dispose Sets change kind to NOT_ALIVE_DISPOSED_UNREGISTERED
-     * @param wparams allows to identify the change
+     * @param wparams allows to identify the change [unused]
+     *
+     * @warning this method uses the static variable reference as it does not use the parameter \c wparams
+     * and this avoids a creation of an object WriteParams.
+     * However, if in future versions this method uses this argument, it must change to the function
+     * \c write_params_default for thread safety reasons.
      */
     void announceParticipantState(
             bool new_change,

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -225,6 +225,14 @@ bool PDPSimple::updateInfoMatchesEDP()
 
 void PDPSimple::announceParticipantState(
         bool new_change,
+        bool dispose /* = false */)
+{
+    WriteParams __wp = WriteParams::write_params_default();
+    announceParticipantState(new_change, dispose, __wp);
+}
+
+void PDPSimple::announceParticipantState(
+        bool new_change,
         bool dispose,
         WriteParams& wp)
 {


### PR DESCRIPTION
Signed-off-by: jparisu <javierparis@eprosima.com>

<!-- Provide a general summary of your changes in the Title above -->

There is a static (global) variable that is supposed to contain default values, but it does not.
This variable is sent to multiple functions by default by reference, where it is modified (it is not default anymore) without guards (TSAN issues).

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.9.x 2.8.x 2.7.x 2.6.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- N/A Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- N/A New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [ ] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
