### PR TITLE
[17148] Improve behavior when HAVE_STRICT_REALTIME is not set.

### DIFF
--- a/include/fastrtps/utils/TimedMutex.hpp
+++ b/include/fastrtps/utils/TimedMutex.hpp
@@ -77,7 +77,7 @@ public:
     bool try_lock_until(
             const std::chrono::time_point<Clock, Duration>& abs_time)
     {
-        std::chrono::nanoseconds nsecs = abs_time - std::chrono::steady_clock::now();
+        std::chrono::nanoseconds nsecs = abs_time - Clock::now();
 
         if (0 < nsecs.count())
         {
@@ -153,7 +153,7 @@ public:
     bool try_lock_until(
             const std::chrono::time_point<Clock, Duration>& abs_time)
     {
-        std::chrono::nanoseconds nsecs = abs_time - std::chrono::steady_clock::now();
+        std::chrono::nanoseconds nsecs = abs_time - Clock::now();
         if (0 < nsecs.count())
         {
             struct timespec max_wait = {
@@ -226,7 +226,7 @@ public:
     bool try_lock_until(
             const std::chrono::time_point<Clock, Duration>& abs_time)
     {
-        std::chrono::nanoseconds nsecs = abs_time - std::chrono::steady_clock::now();
+        std::chrono::nanoseconds nsecs = abs_time - Clock::now();
         struct timespec max_wait = {
             0, 0
         };
@@ -297,7 +297,7 @@ public:
     bool try_lock_until(
             const std::chrono::time_point<Clock, Duration>& abs_time)
     {
-        std::chrono::nanoseconds nsecs = abs_time - std::chrono::steady_clock::now();
+        std::chrono::nanoseconds nsecs = abs_time - Clock::now();
         struct timespec max_wait = {
             0, 0
         };

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -494,19 +494,18 @@ ReturnCode_t DataReaderImpl::read_or_take(
         return code;
     }
 
-    auto max_blocking_time = std::chrono::steady_clock::now() +
 #if HAVE_STRICT_REALTIME
+    auto max_blocking_time = std::chrono::steady_clock::now() +
             std::chrono::microseconds(::TimeConv::Time_t2MicroSecondsInt64(qos_.reliability().max_blocking_time));
-#else
-            std::chrono::hours(24);
-#endif // if HAVE_STRICT_REALTIME
-
     std::unique_lock<RecursiveTimedMutex> lock(reader_->getMutex(), std::defer_lock);
 
     if (!lock.try_lock_until(max_blocking_time))
     {
         return ReturnCode_t::RETCODE_TIMEOUT;
     }
+#else
+    std::lock_guard<RecursiveTimedMutex> _(reader_->getMutex());
+#endif // if HAVE_STRICT_REALTIME
 
     set_read_communication_status(false);
 
@@ -693,19 +692,19 @@ ReturnCode_t DataReaderImpl::read_or_take_next_sample(
         return ReturnCode_t::RETCODE_NO_DATA;
     }
 
-    auto max_blocking_time = std::chrono::steady_clock::now() +
 #if HAVE_STRICT_REALTIME
+    auto max_blocking_time = std::chrono::steady_clock::now() +
             std::chrono::microseconds(::TimeConv::Time_t2MicroSecondsInt64(qos_.reliability().max_blocking_time));
-#else
-            std::chrono::hours(24);
-#endif // if HAVE_STRICT_REALTIME
-
     std::unique_lock<RecursiveTimedMutex> lock(reader_->getMutex(), std::defer_lock);
 
     if (!lock.try_lock_until(max_blocking_time))
     {
         return ReturnCode_t::RETCODE_TIMEOUT;
     }
+
+#else
+    std::lock_guard<RecursiveTimedMutex> _(reader_->getMutex());
+#endif // if HAVE_STRICT_REALTIME
 
     set_read_communication_status(false);
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -276,9 +276,12 @@ public:
             std::chrono::steady_clock::time_point& max_blocking_time_point)
     {
         bool ret_code = false;
+#if HAVE_STRICT_REALTIME
         std::unique_lock<std::timed_mutex> lock(m_send_resources_mutex_, std::defer_lock);
-
         if (lock.try_lock_until(max_blocking_time_point))
+#else
+        std::unique_lock<std::timed_mutex> lock(m_send_resources_mutex_);
+#endif // if HAVE_STRICT_REALTIME
         {
             ret_code = true;
 

--- a/src/cpp/rtps/reader/RTPSReader.cpp
+++ b/src/cpp/rtps/reader/RTPSReader.cpp
@@ -343,9 +343,12 @@ bool RTPSReader::wait_for_unread_cache(
     auto time_out = std::chrono::steady_clock::now() + std::chrono::seconds(timeout.seconds) +
             std::chrono::nanoseconds(timeout.nanosec);
 
+#if HAVE_STRICT_REALTIME
     std::unique_lock<RecursiveTimedMutex> lock(mp_mutex, std::defer_lock);
-
     if (lock.try_lock_until(time_out))
+#else
+    std::unique_lock<RecursiveTimedMutex> lock(mp_mutex);
+#endif  // HAVE_STRICT_REALTIME
     {
         if (new_notification_cv_.wait_until(
                     lock, time_out,

--- a/src/cpp/rtps/resources/ResourceEvent.cpp
+++ b/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -139,9 +139,13 @@ void ResourceEvent::notify(
         TimedEventImpl* event,
         const std::chrono::steady_clock::time_point& timeout)
 {
+#if HAVE_STRICT_REALTIME
     std::unique_lock<TimedMutex> lock(mutex_, std::defer_lock);
-
     if (lock.try_lock_until(timeout))
+#else
+    static_cast<void>(timeout);
+    std::lock_guard<TimedMutex> _(mutex_);
+#endif  // HAVE_STRICT_REALTIME
     {
         if (register_timer_nts(event))
         {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR avoids using `try_lock_until` when `HAVE_STRICT_REALTIME` has not been set (in which case it was using a 24 hours timeout).

It also fixes a bug in the custom TimedMutex, which was always using `steady_clock::now` for calculating the required timeout.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.9.x 2.8.x 2.6.x 2.1.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
