### PR TITLE
[16979] Moved boost at_exit registration to RTPSDomainImpl

### DIFF
--- a/src/cpp/rtps/RTPSDomainImpl.hpp
+++ b/src/cpp/rtps/RTPSDomainImpl.hpp
@@ -30,6 +30,8 @@
 
 #include <utils/SystemInfo.hpp>
 
+#include <utils/shared_memory/BoostAtExitRegistry.hpp>
+
 namespace eprosima {
 namespace fastrtps {
 namespace rtps {
@@ -218,6 +220,10 @@ private:
 
     void removeRTPSParticipant_nts(
             t_p_RTPSParticipant&);
+
+    std::shared_ptr<eprosima::detail::BoostAtExitRegistry> boost_singleton_handler_ { eprosima::detail::
+                                                                                              BoostAtExitRegistry::
+                                                                                              get_instance() };
 
     std::mutex m_mutex;
 

--- a/src/cpp/utils/shared_memory/RobustInterprocessCondition.hpp
+++ b/src/cpp/utils/shared_memory/RobustInterprocessCondition.hpp
@@ -35,7 +35,6 @@ public:
     RobustInterprocessCondition()
         : list_listening_(SemaphoreList::LIST_NULL, SemaphoreList::LIST_NULL)
         , list_free_(0, MAX_LISTENERS - 1)
-        , boost_singleton_handler_(eprosima::detail::BoostAtExitRegistry::get_instance())
     {
         init_sem_list();
     }
@@ -325,7 +324,6 @@ private:
     SemaphoreList list_listening_;
     SemaphoreList list_free_;
     bi::interprocess_mutex semaphore_lists_mutex_;
-    std::shared_ptr<eprosima::detail::BoostAtExitRegistry> boost_singleton_handler_;
 
     void init_sem_list()
     {

--- a/src/cpp/utils/shared_memory/SharedMemSegment.hpp
+++ b/src/cpp/utils/shared_memory/SharedMemSegment.hpp
@@ -85,7 +85,6 @@ public:
     explicit SharedSegmentBase(
             const std::string& name)
         : name_(name)
-        , boost_singleton_handler_(eprosima::detail::BoostAtExitRegistry::get_instance())
     {
     }
 
@@ -305,8 +304,6 @@ private:
     shared_mem_environment_initializer_;
 
     std::string name_;
-
-    std::shared_ptr<eprosima::detail::BoostAtExitRegistry> boost_singleton_handler_;
 
     static std::mutex& mtx_()
     {


### PR DESCRIPTION
Signed-off-by: Javier Santiago <javiersantiago@eprosima.com>

<!-- Provide a general summary of your changes in the Title above -->

#3185 introduced shared pointers to keep track of Boost objects usage and optimize destruction order. This had the side effect of preventing SHM communication with earlier versions of Fast DDS. This PR restores the compatibility.

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.9.x 2.8.x 2.7.x 2.6.x 2.1.x -->
@Mergifyio backport 2.9.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [NA] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [NA] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Check there are no typos in the Doxygen documentation. -->
- [NA] New feature has been added to the `versions.md` file (if applicable).
- [NA] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
