### PR TITLE
WIP - [17005] Fix performance throughput tests: security low performance with large payloads

### DIFF
--- a/test/performance/throughput/xml/interprocess_reliable_shm.xml
+++ b/test/performance/throughput/xml/interprocess_reliable_shm.xml
@@ -9,6 +9,7 @@
             <transport_descriptor>
                 <transport_id>shm_transport</transport_id>
                 <type>SHM</type>
+                <segment_size>12582912</segment_size>
             </transport_descriptor>
             <transport_descriptor>
               <transport_id>udp_transport</transport_id>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

Throughput performance tests suffer low packets reception when using security with large payloads.
It seems to happen in Jammy distribution, and not in Focal.

## How to reproduce:

Running the throughput performance tests,

```colcon test --event-handlers console_direct+ --packages-select fastrtps --ctest-args -R performance.throughput.interprocess_best_effort_shm.data_loans.security```

for any of the following tests:

```
  performance.throughput.interprocess_best_effort_shm.data_loans.security
  performance.throughput.interprocess_best_effort_shm.security
  performance.throughput.interprocess_best_effort_udp.data_loans.security
  performance.throughput.interprocess_best_effort_udp.security
  performance.throughput.interprocess_reliable_udp.security
  performance.throughput.interprocess_reliable_shm.security
```

with the following payload/demands for the throughput tests (payload_demands.csv file `Fast-DDS_ws/src/fastrtps/test/performance/throughput/payload_demands.csv`):

```
4194304;100;1000
8388608;100;500
```

with the following recoveries (recoveries.csv file `Fast-DDS_ws/src/fastrtps/test/performance/throughput/recoveries.csv`):

```
0;10;100;
```

## Proposed fix:

* Fix for reliable and SHM: The addition of `<segment_size>12582912</segment_size>` configuration to the corresponding XML profile.


## WIP

* Fix for Best effort throughput tests.
* FIx for UDP throughput tests.


## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [N/A] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [N/A] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [N/A] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [N/A] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [N/A] New feature has been added to the `versions.md` file (if applicable).
- [N/A] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [N/A] Applicable backports have been included in the description.


## Reviewer Checklist
- [ ] The PR has a milestone assigned.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
