### PR TITLE
Fix performance tests - Overflow in lost samples

### DIFF
--- a/test/performance/throughput/ThroughputPublisher.cpp
+++ b/test/performance/throughput/ThroughputPublisher.cpp
@@ -826,9 +826,11 @@ bool ThroughputPublisher::test(
                 result.publisher.totaltime_us =
                         std::chrono::duration<double, std::micro>(t_end_ - t_start_) - clock_overhead;
 
-                if (samples < command_sample.m_receivedsamples) command_sample.m_receivedsamples = samples;
+                if (samples < command_sample.m_receivedsamples)
+                {
+                    command_sample.m_receivedsamples = samples;
+                }
                 result.subscriber.recv_samples = command_sample.m_receivedsamples;
-                assert(samples >= command_sample.m_receivedsamples);
                 result.subscriber.lost_samples = samples - (uint32_t)command_sample.m_receivedsamples;
                 result.subscriber.totaltime_us =
                         std::chrono::microseconds(command_sample.m_totaltime)

--- a/test/performance/throughput/ThroughputPublisher.cpp
+++ b/test/performance/throughput/ThroughputPublisher.cpp
@@ -826,6 +826,7 @@ bool ThroughputPublisher::test(
                 result.publisher.totaltime_us =
                         std::chrono::duration<double, std::micro>(t_end_ - t_start_) - clock_overhead;
 
+                if (samples < command_sample.m_receivedsamples) command_sample.m_receivedsamples = samples;
                 result.subscriber.recv_samples = command_sample.m_receivedsamples;
                 assert(samples >= command_sample.m_receivedsamples);
                 result.subscriber.lost_samples = samples - (uint32_t)command_sample.m_receivedsamples;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Samples lost numbers occasionally suffer overflow.

## How to reproduce:

Run colcon test for any of the following tests:
- interprocess_reliable_shm
- interprocess_reliable_shm.security

For payloads;demand:
- 16;100
- 8388608;100

And recoveries:
- 0;10;100;

## Fix performed

- Fix received samples count whenever the number is bigger that sent samples.

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [N/A] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [N/A] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [N/A] New feature has been added to the `versions.md` file (if applicable).
- [N/A] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
<!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [N/A] Applicable backports have been included in the description.


## Reviewer Checklist
- [ ] The PR has a milestone assigned.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
