### PR TITLE
[17515] Use standard value for PID_RELATED_SAMPLE_IDENTITY

### DIFF
--- a/include/fastdds/dds/core/policy/ParameterTypes.hpp
+++ b/include/fastdds/dds/core/policy/ParameterTypes.hpp
@@ -148,9 +148,15 @@ enum ParameterId_t : uint16_t
     /* From table 14 of DDS-SEC 1.1 */
     PID_DATA_TAGS                           = 0x1003,
 
+    /* From Remote Procedure Call over DDS, document "ptc/2016-03-19" V1.0 */
+    PID_SERVICE_INSTANCE_NAME               = 0x0080,
+    PID_RELATED_ENTITY_GUID                 = 0x0081,
+    PID_TOPIC_ALIASES                       = 0x0082,
+    PID_RELATED_SAMPLE_IDENTITY             = 0x0083,
+
     /* eProsima Fast DDS extensions */
     PID_PERSISTENCE_GUID                    = 0x8002,
-    PID_RELATED_SAMPLE_IDENTITY             = 0x800f,
+    PID_CUSTOM_RELATED_SAMPLE_IDENTITY      = 0x800f,
     PID_DISABLE_POSITIVE_ACKS               = 0x8005,
     PID_DATASHARING                         = 0x8006,
 };

--- a/src/cpp/fastdds/core/policy/ParameterList.cpp
+++ b/src/cpp/fastdds/core/policy/ParameterList.cpp
@@ -61,8 +61,8 @@ bool ParameterList::updateCacheChangeFromInlineQos(
                         break;
                     }
 
-                    case (PID_CUSTOM_RELATED_SAMPLE_IDENTITY):
-                    case (PID_RELATED_SAMPLE_IDENTITY):
+                    case PID_CUSTOM_RELATED_SAMPLE_IDENTITY:
+                    case PID_RELATED_SAMPLE_IDENTITY:
                     {
                         if (plength >= 24)
                         {

--- a/src/cpp/fastdds/core/policy/ParameterList.cpp
+++ b/src/cpp/fastdds/core/policy/ParameterList.cpp
@@ -61,7 +61,8 @@ bool ParameterList::updateCacheChangeFromInlineQos(
                         break;
                     }
 
-                    case PID_RELATED_SAMPLE_IDENTITY:
+                    case (PID_CUSTOM_RELATED_SAMPLE_IDENTITY):
+                    case (PID_RELATED_SAMPLE_IDENTITY):
                     {
                         if (plength >= 24)
                         {

--- a/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
@@ -178,7 +178,7 @@ public:
      * @param sample_id Sample id.
      * @return true if operation is successful, false if the operation would overflow the maximum size of the message.
      */
-    static bool custom_add_parameter_sample_identity(
+    static bool add_parameter_custom_related_sample_identity(
             fastrtps::rtps::CDRMessage_t* cdr_message,
             const fastrtps::rtps::SampleIdentity& sample_id)
     {

--- a/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
@@ -144,6 +144,13 @@ public:
         return true;
     }
 
+    /**
+     * This method fills the sample identity parameter to the cdr_message.
+     * The PID used is the standard PID_RELATED_SAMPLE_IDENTITY.
+     * @param cdr_message Message to be filled up.
+     * @param sample_id Sample id.
+     * @return true if operation is successful, false if the operation would overflow the maximum size of the message.
+     */
     static bool add_parameter_sample_identity(
             fastrtps::rtps::CDRMessage_t* cdr_message,
             const fastrtps::rtps::SampleIdentity& sample_id)
@@ -154,6 +161,33 @@ public:
         }
 
         fastrtps::rtps::CDRMessage::addUInt16(cdr_message, fastdds::dds::PID_RELATED_SAMPLE_IDENTITY);
+        fastrtps::rtps::CDRMessage::addUInt16(cdr_message, 24);
+        fastrtps::rtps::CDRMessage::addData(cdr_message,
+                sample_id.writer_guid().guidPrefix.value, fastrtps::rtps::GuidPrefix_t::size);
+        fastrtps::rtps::CDRMessage::addData(cdr_message,
+                sample_id.writer_guid().entityId.value, fastrtps::rtps::EntityId_t::size);
+        fastrtps::rtps::CDRMessage::addInt32(cdr_message, sample_id.sequence_number().high);
+        fastrtps::rtps::CDRMessage::addUInt32(cdr_message, sample_id.sequence_number().low);
+        return true;
+    }
+
+    /**
+     * This method fills the sample identity parameter to the cdr_message.
+     * The PID used is the legacy PID_RELATED_SAMPLE_IDENTITY: PID_CUSTOM_RELATED_SAMPLE_IDENTITY, due to backwards compatibility compliance.
+     * @param cdr_message Message to be filled up.
+     * @param sample_id Sample id.
+     * @return true if operation is successful, false if the operation would overflow the maximum size of the message.
+     */
+    static bool custom_add_parameter_sample_identity(
+            fastrtps::rtps::CDRMessage_t* cdr_message,
+            const fastrtps::rtps::SampleIdentity& sample_id)
+    {
+        if (cdr_message->pos + 28 > cdr_message->max_size)
+        {
+            return false;
+        }
+
+        fastrtps::rtps::CDRMessage::addUInt16(cdr_message, fastdds::dds::PID_CUSTOM_RELATED_SAMPLE_IDENTITY);
         fastrtps::rtps::CDRMessage::addUInt16(cdr_message, 24);
         fastrtps::rtps::CDRMessage::addData(cdr_message,
                 sample_id.writer_guid().guidPrefix.value, fastrtps::rtps::GuidPrefix_t::size);

--- a/src/cpp/rtps/history/CacheChangePool.cpp
+++ b/src/cpp/rtps/history/CacheChangePool.cpp
@@ -95,17 +95,19 @@ void CacheChangePool::return_cache_to_pool(
         CacheChange_t* ch)
 {
     ch->kind = ALIVE;
-    ch->sequenceNumber.high = 0;
-    ch->sequenceNumber.low = 0;
     ch->writerGUID = c_Guid_Unknown;
     ch->instanceHandle.clear();
-    ch->isRead = 0;
+    ch->sequenceNumber.high = 0;
+    ch->sequenceNumber.low = 0;
+    ch->inline_qos.pos = 0;
+    ch->inline_qos.length = 0;
+    ch->isRead = false;
     ch->sourceTimestamp.seconds(0);
     ch->sourceTimestamp.fraction(0);
     ch->writer_info.num_sent_submessages = 0;
+    ch->write_params.sample_identity(SampleIdentity::unknown());
+    ch->write_params.related_sample_identity(SampleIdentity::unknown());
     ch->setFragmentSize(0);
-    ch->inline_qos.pos = 0;
-    ch->inline_qos.length = 0;
     assert(free_caches_.end() == std::find(free_caches_.begin(), free_caches_.end(), ch));
     free_caches_.push_back(ch);
 }

--- a/src/cpp/rtps/history/WriterHistory.cpp
+++ b/src/cpp/rtps/history/WriterHistory.cpp
@@ -307,7 +307,7 @@ void WriterHistory::set_fragments(
     uint32_t inline_qos_size = change->inline_qos.length;
     if (change->write_params.related_sample_identity() != SampleIdentity::unknown())
     {
-        inline_qos_size += fastdds::dds::ParameterSerializer<Parameter_t>::PARAMETER_SAMPLE_IDENTITY_SIZE;
+        inline_qos_size += (2 * fastdds::dds::ParameterSerializer<Parameter_t>::PARAMETER_SAMPLE_IDENTITY_SIZE);
     }
     if (ChangeKind_t::ALIVE != change->kind && TopicKind_t::WITH_KEY == mp_writer->m_att.topicKind)
     {

--- a/src/cpp/rtps/messages/submessages/DataMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/DataMsg.hpp
@@ -125,7 +125,7 @@ struct DataMsgUtils
         {
             fastdds::dds::ParameterSerializer<Parameter_t>::add_parameter_sample_identity(msg,
                     change->write_params.related_sample_identity());
-            fastdds::dds::ParameterSerializer<Parameter_t>::custom_add_parameter_sample_identity(msg,
+            fastdds::dds::ParameterSerializer<Parameter_t>::add_parameter_custom_related_sample_identity(msg,
                     change->write_params.related_sample_identity());
         }
 

--- a/src/cpp/rtps/messages/submessages/DataMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/DataMsg.hpp
@@ -125,6 +125,8 @@ struct DataMsgUtils
         {
             fastdds::dds::ParameterSerializer<Parameter_t>::add_parameter_sample_identity(msg,
                     change->write_params.related_sample_identity());
+            fastdds::dds::ParameterSerializer<Parameter_t>::custom_add_parameter_sample_identity(msg,
+                    change->write_params.related_sample_identity());
         }
 
         if (WITH_KEY == topicKind && (expectsInlineQos || ALIVE != change->kind))

--- a/src/cpp/rtps/transport/test_UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.cpp
@@ -307,8 +307,8 @@ bool test_UDPv4Transport::packet_should_drop(
         return true;
     }
 
-    CDRMessage_t cdrMessage(send_buffer_size);
-    memcpy(cdrMessage.buffer, send_buffer, send_buffer_size);
+    CDRMessage_t cdrMessage(0);
+    cdrMessage.init(const_cast<octet*>(send_buffer), send_buffer_size);
     cdrMessage.length = send_buffer_size;
 
     if (cdrMessage.length < RTPSMESSAGE_HEADER_SIZE)

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -280,14 +280,14 @@ TEST(DDSBasic, MultithreadedReaderCreationDoesNotDeadlock)
 }
 
 /**
-* Read a parameterList from a CDRMessage.
-* Search for PID_CUSTOM_RELATED_SAMPLE_IDENTITY and PID_RELATED_SAMPLE_IDENTITY.
-* Overwrite PID_CUSTOM_RELATED_SAMPLE_IDENTITY to just leave the new one in msg.
-* @param[in] msg Reference to the message.
-* @param[out] exists_pid_related_sample_identity True if the parameter is inside msg.
-* @param[out] exists_pid_custom_related_sample_identity True if the parameter is inside msg.
-* @return true if parsing was correct, false otherwise.
-*/
+ * Read a parameterList from a CDRMessage.
+ * Search for PID_CUSTOM_RELATED_SAMPLE_IDENTITY and PID_RELATED_SAMPLE_IDENTITY.
+ * Overwrite PID_CUSTOM_RELATED_SAMPLE_IDENTITY to just leave the new one in msg.
+ * @param[in] msg Reference to the message.
+ * @param[out] exists_pid_related_sample_identity True if the parameter is inside msg.
+ * @param[out] exists_pid_custom_related_sample_identity True if the parameter is inside msg.
+ * @return true if parsing was correct, false otherwise.
+ */
 bool readParameterListfromCDRMsg(
         fastrtps::rtps::CDRMessage_t& msg,
         bool& exists_pid_related_sample_identity,
@@ -400,13 +400,16 @@ TEST(DDSBasic, PidRelatedSampleIdentity)
     bool exists_pid_custom_related_sample_identity = false;
     bool another_debug_bool_flag = false;
 
-    test_transport->drop_data_messages_filter_ = [&exists_pid_related_sample_identity, &exists_pid_custom_related_sample_identity, &another_debug_bool_flag]
-            (eprosima::fastrtps::rtps::CDRMessage_t& msg)-> bool
+    test_transport->drop_data_messages_filter_ =
+            [&exists_pid_related_sample_identity, &exists_pid_custom_related_sample_identity,
+                    &another_debug_bool_flag]
+                (eprosima::fastrtps::rtps::CDRMessage_t& msg)-> bool
             {
                 // Inside this filter, the two flags passed in register wether both PIDs are included in the msg to be sent.
                 // The legacy value is overwritten in order to sent a msg with only the standard PID_RELATED_SAMPLE_IDENTITY as valid parameter,
                 // so that the reader will only parse that one.
-                bool ret = readParameterListfromCDRMsg(msg, exists_pid_related_sample_identity, exists_pid_custom_related_sample_identity);
+                bool ret = readParameterListfromCDRMsg(msg, exists_pid_related_sample_identity,
+                                exists_pid_custom_related_sample_identity);
                 EXPECT_TRUE(ret);
                 return false;
             };
@@ -422,7 +425,7 @@ TEST(DDSBasic, PidRelatedSampleIdentity)
             .add_user_transport_to_pparams(test_transport)
             .init();
     ASSERT_TRUE(reliable_reader.isInitialized());
-    
+
     reliable_writer.wait_discovery();
     reliable_reader.wait_discovery();
 
@@ -448,9 +451,12 @@ TEST(DDSBasic, PidRelatedSampleIdentity)
     eprosima::fastdds::dds::SampleInfo info;
     eprosima::fastrtps::Duration_t timeout;
     timeout.seconds = 2;
-    while (!native_reader.wait_for_unread_message(timeout)) {};
+    while (!native_reader.wait_for_unread_message(timeout))
+    {
+    }
 
-    ASSERT_EQ(eprosima::fastrtps::types::ReturnCode_t::RETCODE_OK, native_reader.take_next_sample((void*)&read_data, &info));
+    ASSERT_EQ(eprosima::fastrtps::types::ReturnCode_t::RETCODE_OK,
+            native_reader.take_next_sample((void*)&read_data, &info));
 
     ASSERT_TRUE(exists_pid_related_sample_identity);
     ASSERT_TRUE(exists_pid_custom_related_sample_identity);

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -427,7 +427,7 @@ TEST(DDSBasic, PidRelatedSampleIdentity)
 
     DataWriter& native_writer = reliable_writer.get_native_writer();
 
-    void* data = nullptr;
+    HelloWorld data;
     // Send reply associating it with the client request.
     eprosima::fastrtps::rtps::WriteParams write_params;
     eprosima::fastrtps::rtps::SampleIdentity related_sample_identity_;
@@ -438,12 +438,12 @@ TEST(DDSBasic, PidRelatedSampleIdentity)
     write_params.related_sample_identity() = related_sample_identity_;
 
     // Publish the new value, deduce the instance handle
-    bool write_ret = native_writer.write(&data, write_params);
+    bool write_ret = native_writer.write((void*)&data, write_params);
     ASSERT_EQ(true, write_ret);
 
     DataReader& native_reader = reliable_reader.get_native_reader();
 
-    FixedSized read_data;
+    HelloWorld read_data;
     eprosima::fastdds::dds::SampleInfo info;
     eprosima::fastrtps::Duration_t timeout;
     timeout.seconds = 2;

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -33,10 +33,18 @@
 #include <fastdds/dds/topic/qos/TopicQos.hpp>
 #include <fastdds/dds/topic/Topic.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
+#include <fastrtps/transport/test_UDPv4TransportDescriptor.h>
 #include <fastrtps/types/TypesBase.h>
+#include <fastdds/core/policy/ParameterSerializer.hpp>
 
 #include "BlackboxTests.hpp"
+#include "../api/dds-pim/PubSubWriter.hpp"
+#include "../api/dds-pim/PubSubReader.hpp"
+//#include "PubSubReader.hpp"
+//#include "PubSubWriter.hpp"
 #include "../types/HelloWorldPubSubTypes.h"
+#include "../types/FixedSized.h"
+#include "../types/FixedSizedPubSubTypes.h"
 
 namespace eprosima {
 namespace fastdds {
@@ -269,6 +277,175 @@ TEST(DDSBasic, MultithreadedReaderCreationDoesNotDeadlock)
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, participant->delete_subscriber(subscriber));
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, participant->delete_topic(topic));
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, factory->delete_participant(participant));
+}
+
+/**
+* Read a parameterList from a CDRMessage
+* @param[in] msg Reference to the message.
+* @param[out] exists_pid_related_sample_identity True if the parameter is inside msg.
+* @param[out] exists_pid_custom_related_sample_identity True if the parameter is inside msg.
+* @return true if parsing was correct, false otherwise.
+*/
+bool readParameterListfromCDRMsg(
+        fastrtps::rtps::CDRMessage_t& msg,
+        bool& exists_pid_related_sample_identity,
+        bool& exists_pid_custom_related_sample_identity)
+{
+    uint32_t qos_size = 0;
+
+    auto parameter_process = [&](
+        fastrtps::rtps::CDRMessage_t* msg,
+        const ParameterId_t pid,
+        uint16_t plength)
+            {
+                switch (pid)
+                {
+                    case PID_CUSTOM_RELATED_SAMPLE_IDENTITY:
+                    {
+                        if (plength >= 24)
+                        {
+                            ParameterSampleIdentity_t p(pid, plength);
+                            if (!fastdds::dds::ParameterSerializer<ParameterSampleIdentity_t>::read_from_cdr_message(p,
+                                    msg, plength))
+                            {
+                                return false;
+                            }
+                            exists_pid_custom_related_sample_identity = true;
+                        }
+                        break;
+                    }
+                    case (PID_RELATED_SAMPLE_IDENTITY):
+                    {
+                        if (plength >= 24)
+                        {
+                            ParameterSampleIdentity_t p(pid, plength);
+                            if (!fastdds::dds::ParameterSerializer<ParameterSampleIdentity_t>::read_from_cdr_message(p,
+                                    msg, plength))
+                            {
+                                return false;
+                            }
+                            exists_pid_related_sample_identity = true;
+                        }
+                        break;
+                    }
+
+                    default:
+                        break;
+                }
+                return true;
+            };
+
+    uint32_t original_pos = msg.pos;
+    bool is_sentinel = false;
+    while (!is_sentinel)
+    {
+        msg.pos = original_pos + qos_size;
+
+        ParameterId_t pid{PID_SENTINEL};
+        uint16_t plength = 0;
+        bool valid = true;
+        valid &= fastrtps::rtps::CDRMessage::readUInt16(&msg, (uint16_t*)&pid);
+        valid &= fastrtps::rtps::CDRMessage::readUInt16(&msg, &plength);
+
+        if (pid == PID_SENTINEL)
+        {
+            // PID_SENTINEL is always considered of length 0
+            plength = 0;
+            is_sentinel = true;
+        }
+
+        qos_size += (4 + plength);
+
+        // Align to 4 byte boundary and prepare for next iteration
+        qos_size = (qos_size + 3) & ~3;
+
+        if (!valid || ((msg.pos + plength) > msg.length))
+        {
+            return false;
+        }
+        else if (!is_sentinel)
+        {
+            if (!parameter_process(&msg, pid, plength))
+            {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+/**
+ * This test checks that PID_RELATED_SAMPLE_IDENTITY and
+ * PID_CUSTOM_RELATED_SAMPLE_IDENTITY are being sent as parameter,
+ * and that the new PID_RELATED_SAMPLE_IDENTITY is being properly
+ * interpreted.
+ */
+TEST(DDSBasic, PidRelatedSampleIdentity)
+{
+    PubSubWriter<HelloWorldPubSubType> reliable_writer(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> reliable_reader(TEST_TOPIC_NAME);
+
+    // Test transport will be used in order to filter inlineQoS
+    auto test_transport = std::make_shared<eprosima::fastrtps::rtps::test_UDPv4TransportDescriptor>();
+    bool exists_pid_related_sample_identity = false;
+    bool exists_pid_custom_related_sample_identity = false;
+    bool another_debug_bool_flag = false;
+
+    test_transport->drop_data_messages_filter_ = [&exists_pid_related_sample_identity, &exists_pid_custom_related_sample_identity, &another_debug_bool_flag]
+            (eprosima::fastrtps::rtps::CDRMessage_t& msg)-> bool
+            {
+                bool ret = readParameterListfromCDRMsg(msg, exists_pid_related_sample_identity, exists_pid_custom_related_sample_identity);
+                EXPECT_TRUE(ret);
+                return false;
+            };
+
+    reliable_writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            .disable_builtin_transport()
+            .add_user_transport_to_pparams(test_transport)
+            .init();
+    ASSERT_TRUE(reliable_writer.isInitialized());
+
+    reliable_reader.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            .disable_builtin_transport()
+            .add_user_transport_to_pparams(test_transport)
+            .init();
+    ASSERT_TRUE(reliable_reader.isInitialized());
+    
+    reliable_writer.wait_discovery();
+    reliable_reader.wait_discovery();
+
+    DataWriter& native_writer = reliable_writer.get_native_writer();
+
+    void* data = nullptr;
+    // Send reply associating it with the client request.
+    eprosima::fastrtps::rtps::WriteParams write_params;
+    eprosima::fastrtps::rtps::SampleIdentity related_sample_identity_;
+    //related_sample_identity_.writer_guid(native_writer->guid());
+    eprosima::fastrtps::rtps::GUID_t unknown_guid;
+    related_sample_identity_.writer_guid(unknown_guid);
+    eprosima::fastrtps::rtps::SequenceNumber_t seq(51, 24);
+    related_sample_identity_.sequence_number(seq);
+    write_params.related_sample_identity() = related_sample_identity_;
+
+    // Publish the new value, deduce the instance handle
+    bool write_ret = native_writer.write(&data, write_params);
+    ASSERT_EQ(true, write_ret);
+
+    DataReader& native_reader = reliable_reader.get_native_reader();
+
+    FixedSized read_data;
+    eprosima::fastdds::dds::SampleInfo info;
+    eprosima::fastrtps::Duration_t timeout;
+    timeout.seconds = 2;
+    while (!native_reader.wait_for_unread_message(timeout)) {};
+
+    ASSERT_EQ(eprosima::fastrtps::types::ReturnCode_t::RETCODE_OK, native_reader.take_next_sample((void*)&read_data, &info));
+
+    ASSERT_TRUE(exists_pid_related_sample_identity);
+    ASSERT_TRUE(exists_pid_custom_related_sample_identity);
+
+    ASSERT_EQ(related_sample_identity_, info.related_sample_identity);
+
 }
 
 } // namespace dds


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

The value for PID_RELATED_SAMPLE_IDENTITY enum definition is changed to (`0x0083`) the one defined in the document `Remote Procedure Call over DDS`, document reference `ptc/2016-03-19`, V1.0.
The legacy value used is now defined under PID_CUSTOM_RELATED_SAMPLE_IDENTITY.
The definitions for the values `0x0080` to `0x0082` have been added as well.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.9.x 2.8.x 2.6.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [N/A] New feature has been added to the `versions.md` file (if applicable).
- [N/A] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [N/A] Applicable backports have been included in the description.


## Reviewer Checklist
- [ ] The PR has a milestone assigned.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
