### PR TITLE
[17514] Fixed ASAN detected leaks

### DIFF
--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -2933,6 +2933,7 @@ TEST(DDSStatus, keyed_best_effort_on_unack_sample_removed)
         EXPECT_EQ(instance, (index % 2) == 0 ? handle_even : handle_odd);
         index++;
     }
+    delete dummy_data;
 }
 
 // Auxiliary method to initialize Reliable DataWriter configuring sample drops in the transport
@@ -3061,6 +3062,7 @@ TEST(DDSStatus, keyed_reliable_on_unack_sample_removed)
     {
         EXPECT_EQ(instance, handle);
     }
+    delete dummy_data;
 }
 
 class CustomDataWriterListener : public eprosima::fastdds::dds::DataWriterListener
@@ -3255,6 +3257,7 @@ TEST(DDSStatus, keyed_reliable_positive_acks_disabled_on_unack_sample_removed)
     EXPECT_EQ(reader.getReceivedCount(), 10u);
     EXPECT_EQ(listener.times_unack_sample_removed(), 8u);
     EXPECT_EQ(listener.notified_writer(), &(writer_1.get_native_writer()));
+    delete dummy_data;
 }
 
 /*!


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

This PR aims to fix multiple memory leaks detected by the ASAN workflow on some tests.

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.9.x 2.8.x 2.6.x 2.1.x -->

@Mergifyio backport 2.9.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [NA] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [NA] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [NA] New feature has been added to the `versions.md` file (if applicable).
- [NA] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
