### PR TITLE
[17873] DomainParticipant::ignore_participant implementation

### DIFF
--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -426,9 +426,7 @@ public:
      * @note This action is not reversible.
      *
      * @param handle Identifier of the remote participant to ignore
-     * @return RETURN_OK code if everything correct, error code otherwise
-     *
-     * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
+     * @return RETURN_OK code if everything correct, RETCODE_BAD_PARAMENTER otherwise
      *
      */
     RTPS_DllAPI ReturnCode_t ignore_participant(

--- a/include/fastdds/dds/domain/DomainParticipantListener.hpp
+++ b/include/fastdds/dds/domain/DomainParticipantListener.hpp
@@ -74,8 +74,8 @@ public:
             DomainParticipant* participant,
             fastrtps::rtps::ParticipantDiscoveryInfo&& info)
     {
-        static_cast<void>(participant);
-        static_cast<void>(info);
+        bool dummy_ignore = false;
+        on_participant_discovery(participant, std::move(info), dummy_ignore);
     }
 
     /*!

--- a/include/fastdds/dds/domain/DomainParticipantListener.hpp
+++ b/include/fastdds/dds/domain/DomainParticipantListener.hpp
@@ -74,8 +74,8 @@ public:
             DomainParticipant* participant,
             fastrtps::rtps::ParticipantDiscoveryInfo&& info)
     {
-        bool dummy_ignore = false;
-        on_participant_discovery(participant, std::move(info), dummy_ignore);
+        static_cast<void>(participant);
+        static_cast<void>(info);
     }
 
     /*!
@@ -91,9 +91,8 @@ public:
             fastrtps::rtps::ParticipantDiscoveryInfo&& info,
             bool& should_be_ignored)
     {
-        static_cast<void>(participant);
-        static_cast<void>(info);
-        static_cast<void>(should_be_ignored);
+        on_participant_discovery(participant, std::move(info));
+        should_be_ignored = false;
     }
 
 #if HAVE_SECURITY

--- a/include/fastdds/rtps/messages/MessageReceiver.h
+++ b/include/fastdds/rtps/messages/MessageReceiver.h
@@ -157,7 +157,7 @@ private:
      * -Return an error if the message is malformed.
      * @param[in,out] msg Pointer to the message
      * @param[in] smh Pointer to the submessage header
-     * @param[in, out] WriterID Writer EntityID (only for DATA messages)
+     * @param[out] WriterID Writer EntityID (only for DATA messages)
      * @return True if correct, false otherwise
      */
 

--- a/include/fastdds/rtps/messages/MessageReceiver.h
+++ b/include/fastdds/rtps/messages/MessageReceiver.h
@@ -157,6 +157,7 @@ private:
      * -Return an error if the message is malformed.
      * @param[in,out] msg Pointer to the message
      * @param[in] smh Pointer to the submessage header
+     * @param[in, out] WriterID Writer EntityID (only for DATA messages)
      * @return True if correct, false otherwise
      */
 
@@ -165,11 +166,13 @@ private:
      *
      * @param msg
      * @param smh
+     * @param writerID
      * @return
      */
     bool proc_Submsg_Data(
             CDRMessage_t* msg,
-            SubmessageHeader_t* smh) const;
+            SubmessageHeader_t* smh,
+            EntityId_t& writerID) const;
     bool proc_Submsg_DataFrag(
             CDRMessage_t* msg,
             SubmessageHeader_t* smh) const;

--- a/include/fastdds/rtps/participant/RTPSParticipantListener.h
+++ b/include/fastdds/rtps/participant/RTPSParticipantListener.h
@@ -78,9 +78,8 @@ public:
             ParticipantDiscoveryInfo&& info,
             bool& should_be_ignored)
     {
-        static_cast<void>(participant);
-        static_cast<void>(info);
-        static_cast<void>(should_be_ignored);
+        onParticipantDiscovery(participant, std::move(info));
+        should_be_ignored = false;
     }
 
 #if HAVE_SECURITY

--- a/src/cpp/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipant.cpp
@@ -271,8 +271,7 @@ const Subscriber* DomainParticipant::get_builtin_subscriber() const
 ReturnCode_t DomainParticipant::ignore_participant(
         const InstanceHandle_t& handle)
 {
-    static_cast<void> (handle);
-    return ReturnCode_t::RETCODE_UNSUPPORTED;
+    return impl_->ignore_participant(handle);
 }
 
 ReturnCode_t DomainParticipant::ignore_topic(

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -835,7 +835,7 @@ ReturnCode_t DomainParticipantImpl::ignore_participant(
 {
     return (nullptr == rtps_participant_) ? ReturnCode_t::RETCODE_NOT_ENABLED :
            rtps_participant_->ignore_participant(iHandle2GUID(handle).guidPrefix) ? ReturnCode_t::RETCODE_OK :
-           ReturnCode_t::RETCODE_ERROR;
+           ReturnCode_t::RETCODE_BAD_PARAMETER;
 }
 
 /* TODO

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -20,6 +20,7 @@
 #include "fastdds/rtps/common/Guid.h"
 #include "fastdds/rtps/common/GuidPrefix_t.hpp"
 #include <chrono>
+#include <fastrtps/types/TypesBase.h>
 #include <string>
 
 #include <asio.hpp>
@@ -829,10 +830,12 @@ PublisherImpl* DomainParticipantImpl::create_publisher_impl(
    }
  */
 
-bool DomainParticipantImpl::ignore_participant(
+ReturnCode_t DomainParticipantImpl::ignore_participant(
         const InstanceHandle_t& handle)
 {
-    return rtps_participant_->ignore_participant(iHandle2GUID(handle).guidPrefix);
+    return (nullptr == rtps_participant_) ? ReturnCode_t::RETCODE_NOT_ENABLED :
+           rtps_participant_->ignore_participant(iHandle2GUID(handle).guidPrefix) ? ReturnCode_t::RETCODE_OK :
+           ReturnCode_t::RETCODE_ERROR;
 }
 
 /* TODO

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -17,6 +17,8 @@
  *
  */
 
+#include "fastdds/rtps/common/Guid.h"
+#include "fastdds/rtps/common/GuidPrefix_t.hpp"
 #include <chrono>
 #include <string>
 
@@ -830,9 +832,7 @@ PublisherImpl* DomainParticipantImpl::create_publisher_impl(
 bool DomainParticipantImpl::ignore_participant(
         const InstanceHandle_t& handle)
 {
-    static_cast<void>(handle);
-    EPROSIMA_LOG_ERROR(PARTICIPANT, "Not implemented.");
-    return false;
+    return rtps_participant_->ignore_participant(iHandle2GUID(handle).guidPrefix);
 }
 
 /* TODO
@@ -1528,12 +1528,14 @@ ReturnCode_t DomainParticipantImpl::unregister_type(
 
 void DomainParticipantImpl::MyRTPSParticipantListener::onParticipantDiscovery(
         RTPSParticipant*,
-        ParticipantDiscoveryInfo&& info)
+        ParticipantDiscoveryInfo&& info,
+        bool& should_be_ignored)
 {
     Sentry sentinel(this);
     if (sentinel)
     {
-        participant_->listener_->on_participant_discovery(participant_->participant_, std::move(info));
+        participant_->listener_->on_participant_discovery(participant_->participant_, std::move(info),
+                should_be_ignored);
     }
 }
 

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -332,9 +332,12 @@ public:
      * @brief Locally ignore a remote domain participant.
      *
      * @param[in] handle Identifier of the remote participant to ignore.
-     * @return true if correctly ignored. False otherwise.
+     * @return RETCODE_NOT_ENABLED if the participant is not enabled.
+     *         RETCODE_ERROR if unable to ignore.
+     *         RETCODE_OK if successful.
+     *
      */
-    bool ignore_participant(
+    ReturnCode_t ignore_participant(
             const InstanceHandle_t& handle);
 
     /* TODO

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -658,7 +658,8 @@ protected:
 
         void onParticipantDiscovery(
                 fastrtps::rtps::RTPSParticipant* participant,
-                fastrtps::rtps::ParticipantDiscoveryInfo&& info) override;
+                fastrtps::rtps::ParticipantDiscoveryInfo&& info,
+                bool& should_be_ignored) override;
 
 #if HAVE_SECURITY
         void onParticipantAuthentication(

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1060,13 +1060,8 @@ bool PDP::remove_remote_participant(
             std::lock_guard<std::mutex> lock(callback_mtx_);
             ParticipantDiscoveryInfo info(*pdata);
             info.status = reason;
-            bool should_ignore;
             listener->onParticipantDiscovery(mp_RTPSParticipant->getUserRTPSParticipant(), std::move(
-                        info), should_ignore);
-            if (should_ignore && !mp_RTPSParticipant->is_participant_ignored(pdata->m_guid.guidPrefix))
-            {
-                mp_RTPSParticipant->ignore_participant(pdata->m_guid.guidPrefix);
-            }
+                        info));
         }
 
         this->mp_mutex->lock();

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1060,7 +1060,13 @@ bool PDP::remove_remote_participant(
             std::lock_guard<std::mutex> lock(callback_mtx_);
             ParticipantDiscoveryInfo info(*pdata);
             info.status = reason;
-            listener->onParticipantDiscovery(mp_RTPSParticipant->getUserRTPSParticipant(), std::move(info));
+            bool should_ignore;
+            listener->onParticipantDiscovery(mp_RTPSParticipant->getUserRTPSParticipant(), std::move(
+                        info), should_ignore);
+            if (should_ignore && !mp_RTPSParticipant->is_participant_ignored(pdata->m_guid.guidPrefix))
+            {
+                mp_RTPSParticipant->ignore_participant(pdata->m_guid.guidPrefix);
+            }
         }
 
         this->mp_mutex->lock();

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1060,8 +1060,9 @@ bool PDP::remove_remote_participant(
             std::lock_guard<std::mutex> lock(callback_mtx_);
             ParticipantDiscoveryInfo info(*pdata);
             info.status = reason;
+            bool should_be_ignored = false;
             listener->onParticipantDiscovery(mp_RTPSParticipant->getUserRTPSParticipant(), std::move(
-                        info));
+                        info), should_be_ignored);
         }
 
         this->mp_mutex->lock();

--- a/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
@@ -152,7 +152,7 @@ void PDPListener::onNewCacheChangeAdded(
                     RTPSParticipantListener* listener = parent_pdp_->getRTPSParticipant()->getListener();
                     if (listener != nullptr)
                     {
-                        bool should_be_ignored;
+                        bool should_be_ignored = false;
                         {
                             std::lock_guard<std::mutex> cb_lock(parent_pdp_->callback_mtx_);
                             ParticipantDiscoveryInfo info(*pdata);
@@ -167,8 +167,6 @@ void PDPListener::onNewCacheChangeAdded(
                         if (should_be_ignored)
                         {
                             parent_pdp_->getRTPSParticipant()->ignore_participant(guid.guidPrefix);
-                            parent_pdp_->remove_remote_participant(guid,
-                                    ParticipantDiscoveryInfo::DISCOVERY_STATUS::IGNORED_PARTICIPANT);
                         }
 
                     }
@@ -207,7 +205,7 @@ void PDPListener::onNewCacheChangeAdded(
                 RTPSParticipantListener* listener = parent_pdp_->getRTPSParticipant()->getListener();
                 if (listener != nullptr)
                 {
-                    bool should_be_ignored;
+                    bool should_be_ignored = false;
 
                     {
                         std::lock_guard<std::mutex> cb_lock(parent_pdp_->callback_mtx_);
@@ -222,8 +220,6 @@ void PDPListener::onNewCacheChangeAdded(
                     if (should_be_ignored)
                     {
                         parent_pdp_->getRTPSParticipant()->ignore_participant(temp_participant_data_.m_guid.guidPrefix);
-                        parent_pdp_->remove_remote_participant(guid,
-                                ParticipantDiscoveryInfo::DISCOVERY_STATUS::IGNORED_PARTICIPANT);
                     }
                 }
             }

--- a/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
@@ -109,6 +109,11 @@ void PDPListener::onNewCacheChangeAdded(
             change->instanceHandle = temp_participant_data_.m_key;
             guid = temp_participant_data_.m_guid;
 
+            if (parent_pdp_->getRTPSParticipant()->is_participant_ignored(guid.guidPrefix))
+            {
+                return;
+            }
+
             // Filter locators
             const auto& pattr = parent_pdp_->getRTPSParticipant()->getAttributes();
             fastdds::rtps::ExternalLocatorsProcessor::filter_remote_locators(temp_participant_data_,
@@ -147,13 +152,25 @@ void PDPListener::onNewCacheChangeAdded(
                     RTPSParticipantListener* listener = parent_pdp_->getRTPSParticipant()->getListener();
                     if (listener != nullptr)
                     {
-                        std::lock_guard<std::mutex> cb_lock(parent_pdp_->callback_mtx_);
-                        ParticipantDiscoveryInfo info(*pdata);
-                        info.status = status;
+                        bool should_be_ignored;
+                        {
+                            std::lock_guard<std::mutex> cb_lock(parent_pdp_->callback_mtx_);
+                            ParticipantDiscoveryInfo info(*pdata);
+                            info.status = status;
 
-                        listener->onParticipantDiscovery(
-                            parent_pdp_->getRTPSParticipant()->getUserRTPSParticipant(),
-                            std::move(info));
+
+                            listener->onParticipantDiscovery(
+                                parent_pdp_->getRTPSParticipant()->getUserRTPSParticipant(),
+                                std::move(info),
+                                should_be_ignored);
+                        }
+                        if (should_be_ignored)
+                        {
+                            parent_pdp_->getRTPSParticipant()->ignore_participant(guid.guidPrefix);
+                            parent_pdp_->remove_remote_participant(guid,
+                                    ParticipantDiscoveryInfo::DISCOVERY_STATUS::IGNORED_PARTICIPANT);
+                        }
+
                     }
 
                     // Assigning remote endpoints implies sending a DATA(p) to all matched and fixed readers, since
@@ -190,13 +207,24 @@ void PDPListener::onNewCacheChangeAdded(
                 RTPSParticipantListener* listener = parent_pdp_->getRTPSParticipant()->getListener();
                 if (listener != nullptr)
                 {
-                    std::lock_guard<std::mutex> cb_lock(parent_pdp_->callback_mtx_);
-                    ParticipantDiscoveryInfo info(*pdata);
-                    info.status = status;
+                    bool should_be_ignored;
 
-                    listener->onParticipantDiscovery(
-                        parent_pdp_->getRTPSParticipant()->getUserRTPSParticipant(),
-                        std::move(info));
+                    {
+                        std::lock_guard<std::mutex> cb_lock(parent_pdp_->callback_mtx_);
+                        ParticipantDiscoveryInfo info(*pdata);
+                        info.status = status;
+
+                        listener->onParticipantDiscovery(
+                            parent_pdp_->getRTPSParticipant()->getUserRTPSParticipant(),
+                            std::move(info),
+                            should_be_ignored);
+                    }
+                    if (should_be_ignored)
+                    {
+                        parent_pdp_->getRTPSParticipant()->ignore_participant(temp_participant_data_.m_guid.guidPrefix);
+                        parent_pdp_->remove_remote_participant(guid,
+                                ParticipantDiscoveryInfo::DISCOVERY_STATUS::IGNORED_PARTICIPANT);
+                    }
                 }
             }
 

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -17,6 +17,7 @@
  *
  */
 
+#include <fastdds/rtps/common/Guid.h>
 #include <fastdds/rtps/messages/MessageReceiver.h>
 
 #include <cassert>
@@ -334,6 +335,8 @@ void MessageReceiver::processCDRMsg(
     int decode_ret = 0;
 #endif // if HAVE_SECURITY && !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
 
+    bool ignore_submessages;
+
     {
         std::lock_guard<eprosima::shared_mutex> guard(mtx_);
 
@@ -349,12 +352,11 @@ void MessageReceiver::processCDRMsg(
             return;
         }
 
-        if (participant_->is_participant_ignored(source_guid_prefix_))
+        ignore_submessages = participant_->is_participant_ignored(source_guid_prefix_);
+        if (!ignore_submessages)
         {
-            return;
+            notify_network_statistics(source_locator, reception_locator, msg);
         }
-
-        notify_network_statistics(source_locator, reception_locator, msg);
 
 #if HAVE_SECURITY && !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
         decode_ret = security.decode_rtps_message(*msg, *auxiliary_buffer, source_guid_prefix_);
@@ -379,6 +381,8 @@ void MessageReceiver::processCDRMsg(
     // Each submessage processing method choses the lock kind required
     bool valid;
     SubmessageHeader_t submsgh; //Current submessage header
+
+    bool ignore_current_submessage;
 
     while (msg->pos < msg->length)// end of the message
     {
@@ -407,124 +411,137 @@ void MessageReceiver::processCDRMsg(
         valid = true;
         uint32_t next_msg_pos = submessage->pos;
         next_msg_pos += (submsgh.submessageLength + 3u) & ~3u;
-        switch (submsgh.submessageId)
-        {
-            case DATA:
-            {
-                if (dest_guid_prefix_ != participantGuidPrefix)
-                {
-                    EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "Data Submsg ignored, DST is another RTPSParticipant");
-                }
-                else
-                {
-                    EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "Data Submsg received, processing.");
-                    valid = proc_Submsg_Data(submessage, &submsgh);
-                }
-                break;
-            }
-            case DATA_FRAG:
-                if (dest_guid_prefix_ != participantGuidPrefix)
-                {
-                    EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "DataFrag Submsg ignored, DST is another RTPSParticipant");
-                }
-                else
-                {
-                    EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "DataFrag Submsg received, processing.");
-                    valid = proc_Submsg_DataFrag(submessage, &submsgh);
-                }
-                break;
-            case GAP:
-            {
-                if (dest_guid_prefix_ != participantGuidPrefix)
-                {
-                    EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "Gap Submsg ignored, DST is another RTPSParticipant...");
-                }
-                else
-                {
-                    EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "Gap Submsg received, processing...");
-                    valid = proc_Submsg_Gap(submessage, &submsgh);
-                }
-                break;
-            }
-            case ACKNACK:
-            {
-                if (dest_guid_prefix_ != participantGuidPrefix)
-                {
-                    EPROSIMA_LOG_INFO(RTPS_MSG_IN,
-                            IDSTRING "Acknack Submsg ignored, DST is another RTPSParticipant...");
-                }
-                else
-                {
-                    EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "Acknack Submsg received, processing...");
-                    valid = proc_Submsg_Acknack(submessage, &submsgh);
-                }
-                break;
-            }
-            case NACK_FRAG:
-            {
-                if (dest_guid_prefix_ != participantGuidPrefix)
-                {
-                    EPROSIMA_LOG_INFO(RTPS_MSG_IN,
-                            IDSTRING "NackFrag Submsg ignored, DST is another RTPSParticipant...");
-                }
-                else
-                {
-                    EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "NackFrag Submsg received, processing...");
-                    valid = proc_Submsg_NackFrag(submessage, &submsgh);
-                }
-                break;
-            }
-            case HEARTBEAT:
-            {
-                if (dest_guid_prefix_ != participantGuidPrefix)
-                {
-                    EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "HB Submsg ignored, DST is another RTPSParticipant...");
-                }
-                else
-                {
-                    EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "Heartbeat Submsg received, processing...");
-                    valid = proc_Submsg_Heartbeat(submessage, &submsgh);
-                }
-                break;
-            }
-            case HEARTBEAT_FRAG:
-            {
-                if (dest_guid_prefix_ != participantGuidPrefix)
-                {
-                    EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "HBFrag Submsg ignored, DST is another RTPSParticipant...");
-                }
-                else
-                {
-                    EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "HeartbeatFrag Submsg received, processing...");
-                    valid = proc_Submsg_HeartbeatFrag(submessage, &submsgh);
-                }
-                break;
-            }
-            case PAD:
-                EPROSIMA_LOG_WARNING(RTPS_MSG_IN, IDSTRING "PAD messages not yet implemented, ignoring");
-                break;
-            case INFO_DST:
-                EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "InfoDST message received, processing...");
-                valid = proc_Submsg_InfoDST(submessage, &submsgh);
-                break;
-            case INFO_SRC:
-                EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "InfoSRC message received, processing...");
-                valid = proc_Submsg_InfoSRC(submessage, &submsgh);
-                break;
-            case INFO_TS:
-            {
-                EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "InfoTS Submsg received, processing...");
-                valid = proc_Submsg_InfoTS(submessage, &submsgh);
-                break;
-            }
-            case INFO_REPLY:
-                break;
-            case INFO_REPLY_IP4:
-                break;
-            default:
-                break;
-        }
 
+        // We ignore submessage if the source participant is to be ignored, unless the submessage king is INFO_SRC
+        // which triggers a reevaluation of the flag.
+        ignore_current_submessage = ignore_submessages &&
+                submsgh.submessageId != INFO_SRC;
+
+        if (!ignore_current_submessage)
+        {
+
+            switch (submsgh.submessageId)
+            {
+                case DATA:
+                {
+                    if (dest_guid_prefix_ != participantGuidPrefix)
+                    {
+                        EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "Data Submsg ignored, DST is another RTPSParticipant");
+                    }
+                    else
+                    {
+                        EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "Data Submsg received, processing.");
+                        valid = proc_Submsg_Data(submessage, &submsgh);
+                    }
+                    break;
+                }
+                case DATA_FRAG:
+                    if (dest_guid_prefix_ != participantGuidPrefix)
+                    {
+                        EPROSIMA_LOG_INFO(RTPS_MSG_IN,
+                                IDSTRING "DataFrag Submsg ignored, DST is another RTPSParticipant");
+                    }
+                    else
+                    {
+                        EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "DataFrag Submsg received, processing.");
+                        valid = proc_Submsg_DataFrag(submessage, &submsgh);
+                    }
+                    break;
+                case GAP:
+                {
+                    if (dest_guid_prefix_ != participantGuidPrefix)
+                    {
+                        EPROSIMA_LOG_INFO(RTPS_MSG_IN,
+                                IDSTRING "Gap Submsg ignored, DST is another RTPSParticipant...");
+                    }
+                    else
+                    {
+                        EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "Gap Submsg received, processing...");
+                        valid = proc_Submsg_Gap(submessage, &submsgh);
+                    }
+                    break;
+                }
+                case ACKNACK:
+                {
+                    if (dest_guid_prefix_ != participantGuidPrefix)
+                    {
+                        EPROSIMA_LOG_INFO(RTPS_MSG_IN,
+                                IDSTRING "Acknack Submsg ignored, DST is another RTPSParticipant...");
+                    }
+                    else
+                    {
+                        EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "Acknack Submsg received, processing...");
+                        valid = proc_Submsg_Acknack(submessage, &submsgh);
+                    }
+                    break;
+                }
+                case NACK_FRAG:
+                {
+                    if (dest_guid_prefix_ != participantGuidPrefix)
+                    {
+                        EPROSIMA_LOG_INFO(RTPS_MSG_IN,
+                                IDSTRING "NackFrag Submsg ignored, DST is another RTPSParticipant...");
+                    }
+                    else
+                    {
+                        EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "NackFrag Submsg received, processing...");
+                        valid = proc_Submsg_NackFrag(submessage, &submsgh);
+                    }
+                    break;
+                }
+                case HEARTBEAT:
+                {
+                    if (dest_guid_prefix_ != participantGuidPrefix)
+                    {
+                        EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "HB Submsg ignored, DST is another RTPSParticipant...");
+                    }
+                    else
+                    {
+                        EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "Heartbeat Submsg received, processing...");
+                        valid = proc_Submsg_Heartbeat(submessage, &submsgh);
+                    }
+                    break;
+                }
+                case HEARTBEAT_FRAG:
+                {
+                    if (dest_guid_prefix_ != participantGuidPrefix)
+                    {
+                        EPROSIMA_LOG_INFO(RTPS_MSG_IN,
+                                IDSTRING "HBFrag Submsg ignored, DST is another RTPSParticipant...");
+                    }
+                    else
+                    {
+                        EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "HeartbeatFrag Submsg received, processing...");
+                        valid = proc_Submsg_HeartbeatFrag(submessage, &submsgh);
+                    }
+                    break;
+                }
+                case PAD:
+                    EPROSIMA_LOG_WARNING(RTPS_MSG_IN, IDSTRING "PAD messages not yet implemented, ignoring");
+                    break;
+                case INFO_DST:
+                    EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "InfoDST message received, processing...");
+                    valid = proc_Submsg_InfoDST(submessage, &submsgh);
+                    break;
+                case INFO_SRC:
+                    EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "InfoSRC message received, processing...");
+                    valid = proc_Submsg_InfoSRC(submessage, &submsgh);
+                    ignore_submessages = participant_->is_participant_ignored(source_guid_prefix_);
+                    break;
+                case INFO_TS:
+                {
+                    EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING "InfoTS Submsg received, processing...");
+                    valid = proc_Submsg_InfoTS(submessage, &submsgh);
+                    break;
+                }
+                case INFO_REPLY:
+                    break;
+                case INFO_REPLY_IP4:
+                    break;
+                default:
+                    break;
+            }
+        }
         if (!valid || submsgh.is_last)
         {
             break;

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -349,6 +349,11 @@ void MessageReceiver::processCDRMsg(
             return;
         }
 
+        if (participant_->is_participant_ignored(source_guid_prefix_))
+        {
+            return;
+        }
+
         notify_network_statistics(source_locator, reception_locator, msg);
 
 #if HAVE_SECURITY && !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -179,9 +179,9 @@ void RTPSParticipant::enable()
 }
 
 bool RTPSParticipant::ignore_participant(
-        const GuidPrefix_t& /*participant_guid*/)
+        const GuidPrefix_t& participant_guid)
 {
-    return false;
+    return mp_impl->ignore_participant(participant_guid);
 }
 
 bool RTPSParticipant::ignore_writer(

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -2537,8 +2537,10 @@ bool RTPSParticipantImpl::ignore_participant(
     if (!is_participant_ignored(participant_guid))
     {
         {
-            std::unique_lock<shared_mutex> _(ignored_mtx_);
-            ignored_participants_.insert(participant_guid);
+            {
+                std::unique_lock<shared_mutex> _(ignored_mtx_);
+                ignored_participants_.insert(participant_guid);
+            }
             pdp()->remove_remote_participant(GUID_t(participant_guid, c_EntityId_RTPSParticipant),
                     ParticipantDiscoveryInfo::DISCOVERY_STATUS::IGNORED_PARTICIPANT);
         }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -17,10 +17,6 @@
  *
  */
 
-#include "fastdds/rtps/builtin/discovery/participant/PDP.h"
-#include "fastdds/rtps/common/EntityId_t.hpp"
-#include "fastdds/rtps/participant/ParticipantDiscoveryInfo.h"
-#include <rtps/participant/RTPSParticipantImpl.h>
 
 #include <algorithm>
 #include <functional>
@@ -32,11 +28,14 @@
 #include <fastdds/rtps/attributes/ServerAttributes.h>
 #include <fastdds/rtps/builtin/BuiltinProtocols.h>
 #include <fastdds/rtps/builtin/discovery/endpoint/EDP.h>
+#include <fastdds/rtps/builtin/discovery/participant/PDP.h>
 #include <fastdds/rtps/builtin/discovery/participant/PDPSimple.h>
 #include <fastdds/rtps/builtin/data/ParticipantProxyData.h>
 #include <fastdds/rtps/builtin/liveliness/WLP.h>
+#include <fastdds/rtps/common/EntityId_t.hpp>
 #include <fastdds/rtps/history/WriterHistory.h>
 #include <fastdds/rtps/messages/MessageReceiver.h>
+#include <fastdds/rtps/participant/ParticipantDiscoveryInfo.h>
 #include <fastdds/rtps/participant/RTPSParticipant.h>
 #include <fastdds/rtps/reader/StatelessReader.h>
 #include <fastdds/rtps/reader/StatefulReader.h>
@@ -60,6 +59,7 @@
 #include <rtps/builtin/discovery/participant/PDPClient.h>
 #include <rtps/history/BasicPayloadPool.hpp>
 #include <rtps/network/ExternalLocatorsProcessor.hpp>
+#include <rtps/participant/RTPSParticipantImpl.h>
 #include <rtps/persistence/PersistenceService.h>
 #include <statistics/rtps/GuidUtils.hpp>
 
@@ -2539,6 +2539,8 @@ bool RTPSParticipantImpl::ignore_participant(
         {
             std::unique_lock<shared_mutex> _(ignored_mtx_);
             ignored_participants_.insert(participant_guid);
+            pdp()->remove_remote_participant(GUID_t(participant_guid, c_EntityId_RTPSParticipant),
+                    ParticipantDiscoveryInfo::DISCOVERY_STATUS::IGNORED_PARTICIPANT);
         }
         return true;
     }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -2534,6 +2534,19 @@ bool RTPSParticipantImpl::is_reader_ignored(
 bool RTPSParticipantImpl::ignore_participant(
         const GuidPrefix_t& participant_guid)
 {
+    {
+        shared_lock<eprosima::shared_mutex> _(mp_builtinProtocols->getDiscoveryMutex());
+
+        for (auto server_it = m_att.builtin.discovery_config.m_DiscoveryServers.begin();
+                server_it != m_att.builtin.discovery_config.m_DiscoveryServers.end(); server_it++)
+        {
+            if (server_it->guidPrefix == participant_guid)
+            {
+                EPROSIMA_LOG_WARNING(RTPS_PARTICIPANT, "Cannot ignore one of this participant Discovery Servers");
+                return false;
+            }
+        }
+    }
     if (!is_participant_ignored(participant_guid))
     {
         {

--- a/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
+++ b/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
@@ -16,6 +16,7 @@
 #define _FASTDDS_PARTICIPANTIMPL_HPP_
 
 #include <atomic>
+#include <fastdds/rtps/common/InstanceHandle.h>
 #include <map>
 #include <mutex>
 #include <string>
@@ -374,6 +375,10 @@ public:
 
     MOCK_METHOD1(find_content_filter_factory, IContentFilterFactory * (
                 const char* filter_class_name));
+
+    MOCK_METHOD1(ignore_participant, bool (
+                const fastrtps::rtps::InstanceHandle_t& handle));
+
 
     TopicDescription* lookup_topicdescription(
             const std::string& topic_name) const

--- a/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.h
+++ b/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.h
@@ -169,6 +169,9 @@ public:
                 const TopicAttributes& topicAtt,
                 const ReaderQos& rqos));
 
+    MOCK_METHOD1(ignore_participant, bool(
+                const GuidPrefix_t& participant_guid));
+
     MOCK_METHOD4(updateReader, bool(
                 RTPSReader * Reader,
                 const TopicAttributes& topicAtt,

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -3668,7 +3668,6 @@ TEST(ParticipantTests, ContentFilterInterfaces)
  *  create_multitopic
  *  delete_multitopic
  *  get_builtin_subscriber
- *  ignore_participant
  *  ignore_topic
  *  ignore_publication
  *  ignore_subscription
@@ -3705,7 +3704,6 @@ TEST(ParticipantTests, UnsupportedMethods)
 
     ASSERT_EQ(participant->get_builtin_subscriber(), nullptr);
 
-    ASSERT_EQ(participant->ignore_participant(InstanceHandle_t()), ReturnCode_t::RETCODE_UNSUPPORTED);
     ASSERT_EQ(participant->ignore_topic(InstanceHandle_t()), ReturnCode_t::RETCODE_UNSUPPORTED);
     ASSERT_EQ(participant->ignore_publication(InstanceHandle_t()), ReturnCode_t::RETCODE_UNSUPPORTED);
     ASSERT_EQ(participant->ignore_subscription(InstanceHandle_t()), ReturnCode_t::RETCODE_UNSUPPORTED);

--- a/versions.md
+++ b/versions.md
@@ -1,6 +1,8 @@
 Forthcoming
 -----------
 
+* Added `ignore_participant` implementation.
+
 Version 2.10.0
 --------------
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR provides the implementation and test for the ignore_participant API call.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.9.x 2.8.x 2.6.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - Related documentation PR: eProsima/Fast-DDS-docs#475
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
