### PR TITLE
[17832] Initial acknack backoff

### DIFF
--- a/src/cpp/rtps/reader/WriterProxy.cpp
+++ b/src/cpp/rtps/reader/WriterProxy.cpp
@@ -515,6 +515,9 @@ bool WriterProxy::perform_initial_ack_nack()
             if (0 == last_heartbeat_count_)
             {
                 reader_->send_acknack(this, sns, this, false);
+                auto time_ms = initial_acknack_->getIntervalMilliSec();
+                initial_acknack_->update_interval_millisec(time_ms * 2);
+                initial_acknack_->restart_timer();
                 ret_value = true;
             }
         }

--- a/src/cpp/rtps/reader/WriterProxy.cpp
+++ b/src/cpp/rtps/reader/WriterProxy.cpp
@@ -515,10 +515,13 @@ bool WriterProxy::perform_initial_ack_nack()
             if (0 == last_heartbeat_count_)
             {
                 reader_->send_acknack(this, sns, this, false);
-                auto time_ms = initial_acknack_->getIntervalMilliSec();
-                initial_acknack_->update_interval_millisec(time_ms * 2);
-                initial_acknack_->restart_timer();
-                ret_value = true;
+                double time_ms = initial_acknack_->getIntervalMilliSec();
+                constexpr double max_ms = 60 * 60 * 1000; // Limit to 1 hour
+                if (time_ms < max_ms)
+                {
+                    initial_acknack_->update_interval_millisec(time_ms * 2);
+                    ret_value = true;
+                }
             }
         }
     }

--- a/test/mock/rtps/TimedEvent/fastdds/rtps/resources/TimedEvent.h
+++ b/test/mock/rtps/TimedEvent/fastdds/rtps/resources/TimedEvent.h
@@ -44,6 +44,8 @@ public:
     MOCK_METHOD0(recreate_timer, void());
     MOCK_METHOD1(update_interval, bool(const Duration_t&));
     MOCK_METHOD1(update_interval_millisec, bool(double));
+    MOCK_METHOD0(getIntervalMilliSec, double());
+
 };
 
 } // namespace rtps

--- a/test/unittest/rtps/reader/CMakeLists.txt
+++ b/test/unittest/rtps/reader/CMakeLists.txt
@@ -109,3 +109,52 @@ add_gtest(WriterProxyStopTest SOURCES ${WRITERPROXYSTOPTEST_SOURCE})
 if(ANDROID)
     set_property(TARGET WriterProxyStopTest PROPERTY CROSSCOMPILING_EMULATOR "adb;shell;cd;${CMAKE_CURRENT_BINARY_DIR};&&")
 endif()
+
+###########################################################################
+# WriterProxyAcknackTests
+###########################################################################
+set(WRITERPROXYACKNACKTESTS_SOURCE WriterProxyAcknackTests.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/publisher/qos/WriterQos.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEvent.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEventImpl.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/utils/SystemInfo.cpp
+    )
+
+if(WIN32)
+    add_definitions(-D_WIN32_WINNT=0x0601)
+endif()
+
+add_executable(WriterProxyAcknackTests ${WRITERPROXYACKNACKTESTS_SOURCE})
+target_compile_definitions(WriterProxyAcknackTests PRIVATE FASTRTPS_NO_LIB
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
+target_include_directories(WriterProxyAcknackTests PRIVATE
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/Endpoint
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/ExternalLocatorsProcessor
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/RTPSReader
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/RTPSWriter
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/RTPSParticipantImpl
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/RTPSDomainImpl
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/StatefulReader
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/WriterProxyData
+    ${PROJECT_SOURCE_DIR}/test/mock/dds/QosPolicies
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/ResourceEvent
+    ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
+    ${PROJECT_SOURCE_DIR}/src/cpp
+    )
+target_link_libraries(WriterProxyAcknackTests foonathan_memory
+    GTest::gmock
+    ${CMAKE_DL_LIBS})
+add_gtest(WriterProxyAcknackTests SOURCES ${WRITERPROXYACKNACKTESTS_SOURCE})
+
+if(ANDROID)
+    set_property(TARGET WriterProxyAcknackTests PROPERTY CROSSCOMPILING_EMULATOR "adb;shell;cd;${CMAKE_CURRENT_BINARY_DIR};&&")
+endif()
+

--- a/test/unittest/rtps/reader/WriterProxyAcknackTests.cpp
+++ b/test/unittest/rtps/reader/WriterProxyAcknackTests.cpp
@@ -106,7 +106,7 @@ TEST(WriterProxyAcknackTests, AcknackBackoff)
 
     // Simulate initial acknack and check that the current acknack timer is increased from the default
     SequenceNumberSet_t t1(SequenceNumber_t(0, 0));
-    EXPECT_CALL(readerMock, simp_send_acknack(t1)).Times(1u);
+    EXPECT_CALL(readerMock, simp_send_acknack(t1)).Times(2u);
     EXPECT_EQ ( wproxy.initial_acknack_->getIntervalMilliSec(),
             readerMock.getTimes().initialAcknackDelay.to_ns() / 1000000);
     wproxy.perform_initial_ack_nack();

--- a/test/unittest/rtps/reader/WriterProxyAcknackTests.cpp
+++ b/test/unittest/rtps/reader/WriterProxyAcknackTests.cpp
@@ -116,6 +116,27 @@ TEST(WriterProxyAcknackTests, AcknackBackoff)
     EXPECT_EQ ( wproxy.initial_acknack_->getIntervalMilliSec(),
             readerMock.getTimes().initialAcknackDelay.to_ns() * 4 / 1000000);
 
+    // Simulate heartbeat reception and check if the delay cannot be updated again
+    bool assert_liveliness = false;
+    uint32_t heartbeat_count = 1;
+    int32_t current_sample_lost = 0;
+
+    wproxy.process_heartbeat(
+        heartbeat_count,
+        SequenceNumber_t(0, 1),
+        SequenceNumber_t(0, 1),
+        false,
+        false,
+        false,
+        assert_liveliness,
+        current_sample_lost);
+
+    EXPECT_EQ ( wproxy.initial_acknack_->getIntervalMilliSec(),
+            readerMock.getTimes().initialAcknackDelay.to_ns() * 4 / 1000000);
+    wproxy.perform_initial_ack_nack();
+    EXPECT_EQ ( wproxy.initial_acknack_->getIntervalMilliSec(),
+            readerMock.getTimes().initialAcknackDelay.to_ns() * 4 / 1000000);
+
 }
 
 } // namespace rtps

--- a/test/unittest/rtps/reader/WriterProxyAcknackTests.cpp
+++ b/test/unittest/rtps/reader/WriterProxyAcknackTests.cpp
@@ -1,0 +1,131 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <thread>
+
+#define TEST_FRIENDS \
+    FRIEND_TEST(WriterProxyAcknackTests, AcknackBackoff);
+
+#include <rtps/reader/WriterProxy.h>
+#include <rtps/participant/RTPSParticipantImpl.h>
+#include <fastrtps/rtps/reader/RTPSReader.h>
+#include <fastrtps/rtps/reader/StatefulReader.h>
+#include <fastrtps/rtps/builtin/data/WriterProxyData.h>
+#include <fastrtps/rtps/resources/TimedEvent.h>
+
+#include <rtps/reader/WriterProxy.cpp>
+// Make SequenceNumberSet_t compatible with GMock macros
+
+namespace testing {
+namespace internal {
+using namespace eprosima::fastrtps::rtps;
+
+template<>
+bool AnyEq::operator ()(
+        const SequenceNumberSet_t& a,
+        const SequenceNumberSet_t& b) const
+{
+    // remember that using SequenceNumberSet_t = BitmapRange<SequenceNumber_t, SequenceNumberDiff, 256>;
+    // see test\unittest\utils\BitmapRangeTests.cpp method TestResult::Check
+
+    if (a.empty() && b.empty())
+    {
+        return true;
+    }
+
+    if (a.base() == b.base())
+    {
+        uint32_t num_bits[2];
+        uint32_t num_longs[2];
+        SequenceNumberSet_t::bitmap_type bitmap[2];
+
+        a.bitmap_get(num_bits[0], bitmap[0], num_longs[0]);
+        b.bitmap_get(num_bits[1], bitmap[1], num_longs[1]);
+
+        if (num_bits[0] != num_bits[1] || num_longs[0] != num_longs[1])
+        {
+            return false;
+        }
+        return std::equal(bitmap[0].cbegin(), bitmap[0].cbegin() + num_longs[0], bitmap[1].cbegin());
+    }
+    else
+    {
+        bool equal = true;
+
+        a.for_each([&b, &equal](const SequenceNumber_t& e)
+                {
+                    equal &= b.is_set(e);
+                });
+
+        if (!equal)
+        {
+            return false;
+        }
+
+        b.for_each([&a, &equal](const SequenceNumber_t& e)
+                {
+                    equal &= a.is_set(e);
+                });
+
+        return equal;
+    }
+}
+
+} // namespace internal
+} // namespace testing
+
+
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+
+TEST(WriterProxyAcknackTests, AcknackBackoff)
+{
+    WriterProxyData wattr( 4u, 1u );
+    StatefulReader readerMock; // avoid annoying uninteresting call warnings
+
+    // Testing the Timed events are properly configured
+    EXPECT_CALL(readerMock, getEventResource()).Times(1u);
+    WriterProxy wproxy(&readerMock, RemoteLocatorsAllocationAttributes(), ResourceLimitedContainerConfig());
+    wproxy.start(wattr, SequenceNumber_t());
+
+    // Simulate initial acknack and check that the current acknack timer is increased from the default
+    SequenceNumberSet_t t1(SequenceNumber_t(0, 0));
+    EXPECT_CALL(readerMock, simp_send_acknack(t1)).Times(1u);
+    EXPECT_EQ ( wproxy.initial_acknack_->getIntervalMilliSec(),
+            readerMock.getTimes().initialAcknackDelay.to_ns() / 1000000);
+    wproxy.perform_initial_ack_nack();
+    EXPECT_EQ ( wproxy.initial_acknack_->getIntervalMilliSec(),
+            readerMock.getTimes().initialAcknackDelay.to_ns() * 2 / 1000000);
+    wproxy.perform_initial_ack_nack();
+    EXPECT_EQ ( wproxy.initial_acknack_->getIntervalMilliSec(),
+            readerMock.getTimes().initialAcknackDelay.to_ns() * 4 / 1000000);
+
+}
+
+} // namespace rtps
+} // namespace fastrtps
+} // namespace eprosima
+
+int main(
+        int argc,
+        char** argv)
+{
+    testing::InitGoogleMock(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/unittest/rtps/reader/WriterProxyTests.cpp
+++ b/test/unittest/rtps/reader/WriterProxyTests.cpp
@@ -109,7 +109,7 @@ TEST(WriterProxyTests, MissingChangesUpdate)
     WriterProxy wproxy(&readerMock, RemoteLocatorsAllocationAttributes(), ResourceLimitedContainerConfig());
     EXPECT_CALL(*wproxy.initial_acknack_, update_interval(readerMock.getTimes().initialAcknackDelay)).Times(1u);
     EXPECT_CALL(*wproxy.heartbeat_response_, update_interval(readerMock.getTimes().heartbeatResponseDelay)).Times(1u);
-    EXPECT_CALL(*wproxy.initial_acknack_, restart_timer()).Times(1u);
+    EXPECT_CALL(*wproxy.initial_acknack_, restart_timer()).Times(2u);
     wproxy.start(wattr, SequenceNumber_t());
 
     // 1. Simulate initial acknack

--- a/test/unittest/rtps/reader/WriterProxyTests.cpp
+++ b/test/unittest/rtps/reader/WriterProxyTests.cpp
@@ -109,7 +109,7 @@ TEST(WriterProxyTests, MissingChangesUpdate)
     WriterProxy wproxy(&readerMock, RemoteLocatorsAllocationAttributes(), ResourceLimitedContainerConfig());
     EXPECT_CALL(*wproxy.initial_acknack_, update_interval(readerMock.getTimes().initialAcknackDelay)).Times(1u);
     EXPECT_CALL(*wproxy.heartbeat_response_, update_interval(readerMock.getTimes().heartbeatResponseDelay)).Times(1u);
-    EXPECT_CALL(*wproxy.initial_acknack_, restart_timer()).Times(2u);
+    EXPECT_CALL(*wproxy.initial_acknack_, restart_timer()).Times(1u);
     wproxy.start(wattr, SequenceNumber_t());
 
     // 1. Simulate initial acknack


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR introduces an exponential backoff for the periodic sending of the initial acknack. 

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.9.x 2.8.x 2.6.x 2.1.x -->

@Mergifyio backport 2.9.x 2.8.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
