### PR TITLE
[17961] Select correct listener for on_requested_deadline_missed

### DIFF
--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1402,7 +1402,7 @@ bool DataWriterImpl::deadline_missed()
     auto listener = get_listener_for(notify_status);
     if (nullptr != listener)
     {
-        listener_->on_offered_deadline_missed(user_datawriter_, deadline_missed_status_);
+        listener->on_offered_deadline_missed(user_datawriter_, deadline_missed_status_);
         deadline_missed_status_.total_count_change = 0;
     }
     user_datawriter_->get_statuscondition().get_impl()->set_status(notify_status, true);

--- a/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
@@ -360,7 +360,7 @@ TEST(DDSDataWriter, OfferedDeadlineMissedListener)
     std::atomic_bool deadline_called{false};
     std::unique_lock<std::mutex> lck(mtx);
 
-    WriterWrapper(cv, deadline_called);
+    WriterWrapper writer_w(cv, deadline_called);
 
     auto ret = cv.wait_for(lck, std::chrono::seconds(1), [&]()
                     {

--- a/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
+
 #include "BlackboxTests.hpp"
 
 #include "PubSubReader.hpp"
@@ -277,6 +279,94 @@ TEST_P(DDSDataWriter, WithTimestampOperations)
     }
 
     EXPECT_EQ(ReturnCode_t::RETCODE_OK, datareader.return_loan(datas, infos));
+}
+
+/**
+ * Regression test for EasyRedmine issue https://eprosima.easyredmine.com/issues/17961
+ *
+ * The test:
+ *     1. Creates a DomainParticipant with a listener which captures the offered_deadline_missed
+ *        events.
+ *     2. Creates a DataWriter with a 1 ms deadline period, without any listener and that never
+ *        publishes data.
+ *     3. Wait for the deadline callback to be triggered at least once within a second.
+ *     4. Checks that the callback was indeed triggered.
+ */
+
+TEST(DDSDataWriter, OfferedDeadlineMissedListener)
+{
+    using namespace eprosima::fastdds::dds;
+
+    class WriterWrapper : public DomainParticipantListener
+    {
+    public:
+
+        WriterWrapper(
+                std::condition_variable& cv,
+                std::atomic_bool& deadline_called)
+            : cv_(cv)
+            , deadline_called_(deadline_called)
+        {
+            StatusMask status_mask = StatusMask::none();
+            status_mask << StatusMask::offered_deadline_missed();
+            participant_ = DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT,
+                            this, status_mask);
+
+            type_support_.reset(new HelloWorldPubSubType());
+            type_support_.register_type(participant_, "DeadlineListenerTest");
+
+            topic_ = participant_->create_topic("deadline_listener_test", "DeadlineListenerTest", TOPIC_QOS_DEFAULT);
+
+            publisher_ = participant_->create_publisher(PUBLISHER_QOS_DEFAULT);
+
+            DataWriterQos dw_qos = DATAWRITER_QOS_DEFAULT;
+            dw_qos.deadline().period = Time_t(0, 1e+6);
+            datawriter_ = publisher_->create_datawriter(
+                topic_,
+                dw_qos);
+
+            // Apparently the time is not started until the first data is published
+            HelloWorld data;
+            datawriter_->write(&data);
+        }
+
+        virtual ~WriterWrapper()
+        {
+            participant_->delete_contained_entities();
+            DomainParticipantFactory::get_instance()->delete_participant(participant_);
+        }
+
+        void on_offered_deadline_missed(
+                DataWriter* /* writer */,
+                const OfferedDeadlineMissedStatus& /* status */) override
+        {
+            deadline_called_.store(true);
+            cv_.notify_one();
+        }
+
+    protected:
+
+        std::condition_variable& cv_;
+        std::atomic_bool& deadline_called_;
+        DomainParticipant* participant_;
+        TypeSupport type_support_;
+        Topic* topic_;
+        Publisher* publisher_;
+        DataWriter* datawriter_;
+    };
+
+    std::mutex mtx;
+    std::condition_variable cv;
+    std::atomic_bool deadline_called{false};
+    std::unique_lock<std::mutex> lck(mtx);
+
+    WriterWrapper(cv, deadline_called);
+
+    auto ret = cv.wait_for(lck, std::chrono::seconds(1), [&]()
+                    {
+                        return deadline_called.load();
+                    });
+    ASSERT_TRUE(ret);
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P

--- a/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
@@ -320,7 +320,7 @@ TEST(DDSDataWriter, OfferedDeadlineMissedListener)
             publisher_ = participant_->create_publisher(PUBLISHER_QOS_DEFAULT);
 
             DataWriterQos dw_qos = DATAWRITER_QOS_DEFAULT;
-            dw_qos.deadline().period = Time_t(0, 1e+6);
+            dw_qos.deadline().period = Time_t(0, 1000000);
             datawriter_ = publisher_->create_datawriter(
                 topic_,
                 dw_qos);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR fixes a SEGFAULT which occurred when doing the following sequence:

1. Creating a a DomainParticipant with a listener which captures the offered_deadline_missed events.
2. Creating a DataWriter without any listener that was not used to write data within the deadline period, thus triggering the offered deadline missed event.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.9.x 2.6.x 2.1.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
