### PR TITLE
[17976] Correctly assign multicast port to multicast initial peers

### DIFF
--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -648,12 +648,21 @@ bool UDPTransportInterface::configureInitialPeerLocator(
 {
     if (locator.port == 0)
     {
-        for (uint32_t i = 0; i < configuration()->maxInitialPeersRange; ++i)
+        if (IPLocator::isMulticast(locator))
         {
             Locator auxloc(locator);
-            auxloc.port = port_params.getUnicastPort(domainId, i);
-
+            auxloc.port = port_params.getMulticastPort(domainId);
             list.push_back(auxloc);
+        }
+        else
+        {
+            for (uint32_t i = 0; i < configuration()->maxInitialPeersRange; ++i)
+            {
+                Locator auxloc(locator);
+                auxloc.port = port_params.getUnicastPort(domainId, i);
+
+                list.push_back(auxloc);
+            }
         }
     }
     else

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -1861,3 +1861,26 @@ TEST(Discovery, RemoteBuiltinEndpointHonoring)
     ASSERT_EQ(num_writer_heartbeat, 3u);
     ASSERT_EQ(num_writer_acknack, 3u);
 }
+
+//! Regression test for redmine issue 10674
+TEST(Discovery, MulticastInitialPeer)
+{
+    PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+
+    eprosima::fastdds::rtps::LocatorList peers;
+    eprosima::fastdds::rtps::Locator loc{};
+    loc.kind = LOCATOR_KIND_UDPv4;
+    IPLocator::setIPv4(loc, "239.255.0.1");
+    peers.push_back(loc);
+
+    reader.participant_id(100).initial_peers(peers).init();
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer.participant_id(101).initial_peers(peers).init();
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Wait for discovery (times out before the fix).
+    writer.wait_discovery();
+    reader.wait_discovery();
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR fixes a wrong behavior where a multicast address on an initial peer locator is being incorrectly treated as unicast.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.9.x 2.6.x 2.1.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
