### PR TITLE
Pick smallest available participant ID for new paricipants

### DIFF
--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -605,8 +605,10 @@ uint32_t RTPSDomainImpl::getNewId()
     // Choosing the smallest value ensures peers using unicast discovery will
     // find this participant as long as the total number of participants has
     // not exceeded the number of peers they will look for.
-    for (uint32_t i = 0; i <= m_maxRTPSParticipantID; ++i) {
-        if (m_RTPSParticipantIDs.find(i) == m_RTPSParticipantIDs.end()) {
+    for (uint32_t i = 0; i <= m_maxRTPSParticipantID; ++i)
+    {
+        if (m_RTPSParticipantIDs.find(i) == m_RTPSParticipantIDs.end())
+        {
             return i;
         }
     }

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -605,16 +605,17 @@ uint32_t RTPSDomainImpl::getNewId()
     // Choosing the smallest value ensures peers using unicast discovery will
     // find this participant as long as the total number of participants has
     // not exceeded the number of peers they will look for.
-    uint32_t i = 0;
-    for (; i <= m_RTPSParticipantIDs.size(); ++i)
+    for (uint32_t i = 0; i < m_RTPSParticipantIDs.size(); ++i)
     {
         if (m_RTPSParticipantIDs.find(i) == m_RTPSParticipantIDs.end())
         {
             return i;
         }
     }
-    // Couldn't find any free space in the set of IDs; return one larger.
-    return i + 1;
+    // Couldn't find any free space in the set of IDs.
+    // The exisiting IDs must be continuous starting from zero, so the next
+    // available ID must be the size of the set of IDs.
+    return m_RTPSParticipantIDs.size();
 }
 
 void RTPSDomainImpl::create_participant_guid(

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -153,26 +153,9 @@ RTPSParticipant* RTPSDomainImpl::createParticipant(
     }
 
     uint32_t ID;
+    if (!instance->prepare_participant_id(PParam.participantID, ID))
     {
-        std::lock_guard<std::mutex> guard(instance->m_mutex);
-
-        if (PParam.participantID < 0)
-        {
-            ID = instance->getNewId();
-            while (instance->m_RTPSParticipantIDs.insert(ID).second == false)
-            {
-                ID = instance->getNewId();
-            }
-        }
-        else
-        {
-            ID = PParam.participantID;
-            if (instance->m_RTPSParticipantIDs.insert(ID).second == false)
-            {
-                EPROSIMA_LOG_ERROR(RTPS_PARTICIPANT, "RTPSParticipant with the same ID already exists");
-                return nullptr;
-            }
-        }
+        return nullptr;
     }
 
     if (!PParam.defaultUnicastLocatorList.isValid())
@@ -259,6 +242,8 @@ RTPSParticipant* RTPSDomainImpl::createParticipant(
     {
         std::lock_guard<std::mutex> guard(instance->m_mutex);
         instance->m_RTPSParticipants.push_back(t_p_RTPSParticipant(p, pimpl));
+        instance->m_RTPSParticipantIDs[ID].used = true;
+        instance->m_RTPSParticipantIDs[ID].reserved = true;
     }
 
     // Check the environment file in case it was modified during participant creation leading to a missed callback.
@@ -291,7 +276,9 @@ bool RTPSDomainImpl::removeRTPSParticipant(
             {
                 RTPSDomainImpl::t_p_RTPSParticipant participant = *it;
                 instance->m_RTPSParticipants.erase(it);
-                instance->m_RTPSParticipantIDs.erase(participant.second->getRTPSParticipantID());
+                uint32_t participant_id = participant.second->getRTPSParticipantID();
+                instance->m_RTPSParticipantIDs[participant_id].used = false;
+                instance->m_RTPSParticipantIDs[participant_id].reserved = false;
                 lock.unlock();
                 instance->removeRTPSParticipant_nts(participant);
                 return true;
@@ -605,17 +592,34 @@ uint32_t RTPSDomainImpl::getNewId()
     // Choosing the smallest value ensures peers using unicast discovery will
     // find this participant as long as the total number of participants has
     // not exceeded the number of peers they will look for.
-    for (uint32_t i = 0; i < m_RTPSParticipantIDs.size(); ++i)
+    uint32_t i = 0;
+    while (m_RTPSParticipantIDs[i].reserved || m_RTPSParticipantIDs[i].used)
     {
-        if (m_RTPSParticipantIDs.find(i) == m_RTPSParticipantIDs.end())
+        ++i;
+    }
+    m_RTPSParticipantIDs[i].reserved = true;
+    return i;
+}
+
+bool RTPSDomainImpl::prepare_participant_id(
+        int32_t input_id,
+        uint32_t& participant_id)
+{
+    std::lock_guard<std::mutex> guard(m_mutex);
+    if (input_id < 0)
+    {
+        participant_id = getNewId();
+    }
+    else
+    {
+        participant_id = input_id;
+        if (m_RTPSParticipantIDs[participant_id].used == true)
         {
-            return i;
+            EPROSIMA_LOG_ERROR(RTPS_PARTICIPANT, "RTPSParticipant with the same ID already exists");
+            return false;
         }
     }
-    // Couldn't find any free space in the set of IDs.
-    // The exisiting IDs must be continuous starting from zero, so the next
-    // available ID must be the size of the set of IDs.
-    return static_cast<uint32_t>(m_RTPSParticipantIDs.size());
+    return true;
 }
 
 uint32_t RTPSDomainImpl::get_id_for_prefix(
@@ -625,8 +629,8 @@ uint32_t RTPSDomainImpl::get_id_for_prefix(
     if (ret < 0x10000)
     {
         std::lock_guard<std::mutex> guard(m_mutex);
-        ret |= prefix_id_offset_;
-        prefix_id_offset_ += 0x10000;
+        ret |= m_RTPSParticipantIDs[participant_id].counter;
+        m_RTPSParticipantIDs[participant_id].counter += 0x10000;
     }
 
     return ret;
@@ -640,10 +644,7 @@ void RTPSDomainImpl::create_participant_guid(
     {
         auto instance = get_instance();
         std::lock_guard<std::mutex> guard(instance->m_mutex);
-        do
-        {
-            participant_id = instance->getNewId();
-        } while (instance->m_RTPSParticipantIDs.find(participant_id) != instance->m_RTPSParticipantIDs.end());
+        participant_id = instance->getNewId();
     }
 
     guid_prefix_create(participant_id, guid.guidPrefix);

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -599,6 +599,18 @@ RTPSParticipant* RTPSDomainImpl::clientServerEnvironmentCreationOverride(
 
 uint32_t RTPSDomainImpl::getNewId()
 {
+    // Get the smallest available participant ID.
+    // Settings like maxInitialPeersRange control how many participants a peer
+    // will look for on this host.
+    // Choosing the smallest value ensures peers using unicast discovery will
+    // find this participant as long as the total number of participants has
+    // not exceeded the number of peers they will look for.
+    for (uint32_t i = 0; i <= m_maxRTPSParticipantID; ++i) {
+        if (m_RTPSParticipantIDs.find(i) == m_RTPSParticipantIDs.end()) {
+            return i;
+        }
+    }
+    // Couldn't find any free space in the set of IDs; return one larger.
     return m_maxRTPSParticipantID++;
 }
 

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -615,7 +615,7 @@ uint32_t RTPSDomainImpl::getNewId()
     // Couldn't find any free space in the set of IDs.
     // The exisiting IDs must be continuous starting from zero, so the next
     // available ID must be the size of the set of IDs.
-    return m_RTPSParticipantIDs.size();
+    return static_cast<uint32_t>(m_RTPSParticipantIDs.size());
 }
 
 void RTPSDomainImpl::create_participant_guid(

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -190,7 +190,7 @@ RTPSParticipant* RTPSDomainImpl::createParticipant(
 
     // Generate a new GuidPrefix_t
     GuidPrefix_t guidP;
-    guid_prefix_create(ID, guidP);
+    guid_prefix_create(instance->get_id_for_prefix(ID), guidP);
     if (!PParam.builtin.metatraffic_external_unicast_locators.empty())
     {
         fastdds::rtps::LocatorList locators;
@@ -616,6 +616,20 @@ uint32_t RTPSDomainImpl::getNewId()
     // The exisiting IDs must be continuous starting from zero, so the next
     // available ID must be the size of the set of IDs.
     return static_cast<uint32_t>(m_RTPSParticipantIDs.size());
+}
+
+uint32_t RTPSDomainImpl::get_id_for_prefix(
+        uint32_t participant_id)
+{
+    uint32_t ret = participant_id;
+    if (ret < 0x10000)
+    {
+        std::lock_guard<std::mutex> guard(m_mutex);
+        ret |= prefix_id_offset_;
+        prefix_id_offset_ += 0x10000;
+    }
+
+    return ret;
 }
 
 void RTPSDomainImpl::create_participant_guid(

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -605,7 +605,8 @@ uint32_t RTPSDomainImpl::getNewId()
     // Choosing the smallest value ensures peers using unicast discovery will
     // find this participant as long as the total number of participants has
     // not exceeded the number of peers they will look for.
-    for (uint32_t i = 0; i <= m_maxRTPSParticipantID; ++i)
+    uint32_t i = 0;
+    for (; i <= m_RTPSParticipantIDs.size(); ++i)
     {
         if (m_RTPSParticipantIDs.find(i) == m_RTPSParticipantIDs.end())
         {
@@ -613,7 +614,7 @@ uint32_t RTPSDomainImpl::getNewId()
         }
     }
     // Couldn't find any free space in the set of IDs; return one larger.
-    return m_maxRTPSParticipantID++;
+    return i + 1;
 }
 
 void RTPSDomainImpl::create_participant_guid(

--- a/src/cpp/rtps/RTPSDomainImpl.hpp
+++ b/src/cpp/rtps/RTPSDomainImpl.hpp
@@ -105,16 +105,6 @@ public:
             RTPSParticipant* p);
 
     /**
-     * Set the maximum RTPSParticipantID.
-     * @param maxRTPSParticipantId ID.
-     */
-    static inline void setMaxRTPSParticipantId(
-            uint32_t maxRTPSParticipantId)
-    {
-        get_instance()->m_maxRTPSParticipantID = maxRTPSParticipantId;
-    }
-
-    /**
      * Creates a RTPSParticipant as default server or client if ROS_MASTER_URI environment variable is set.
      * @param domain_id DDS domain associated
      * @param enabled True if the RTPSParticipant should be enabled on creation. False if it will be enabled later with RTPSParticipant::enable()
@@ -229,8 +219,6 @@ private:
                                                                                               get_instance() };
 
     std::mutex m_mutex;
-
-    std::atomic<uint32_t> m_maxRTPSParticipantID;
 
     std::vector<t_p_RTPSParticipant> m_RTPSParticipants;
 

--- a/src/cpp/rtps/RTPSDomainImpl.hpp
+++ b/src/cpp/rtps/RTPSDomainImpl.hpp
@@ -214,6 +214,9 @@ private:
 
     /**
      * @brief Get Id to create a RTPSParticipant.
+     *
+     * This function assumes m_mutex is already locked by the caller.
+     *
      * @return Different ID for each call.
      */
     uint32_t getNewId();

--- a/src/cpp/rtps/RTPSDomainImpl.hpp
+++ b/src/cpp/rtps/RTPSDomainImpl.hpp
@@ -211,6 +211,9 @@ private:
      */
     uint32_t getNewId();
 
+    uint32_t get_id_for_prefix(
+            uint32_t participant_id);
+
     void removeRTPSParticipant_nts(
             t_p_RTPSParticipant&);
 
@@ -225,6 +228,8 @@ private:
     std::set<uint32_t> m_RTPSParticipantIDs;
 
     FileWatchHandle file_watch_handle_;
+
+    uint32_t prefix_id_offset_ = 0;
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/RTPSDomainImpl.hpp
+++ b/src/cpp/rtps/RTPSDomainImpl.hpp
@@ -19,6 +19,7 @@
 #include <chrono>
 #include <memory>
 #include <thread>
+#include <unordered_map>
 
 #if defined(_WIN32) || defined(__unix__)
 #include <FileWatch.hpp>
@@ -211,6 +212,10 @@ private:
      */
     uint32_t getNewId();
 
+    bool prepare_participant_id(
+            int32_t input_id,
+            uint32_t& participant_id);
+
     uint32_t get_id_for_prefix(
             uint32_t participant_id);
 
@@ -225,11 +230,16 @@ private:
 
     std::vector<t_p_RTPSParticipant> m_RTPSParticipants;
 
-    std::set<uint32_t> m_RTPSParticipantIDs;
+    struct ParticipantIDState
+    {
+        uint32_t counter = 0;
+        bool reserved = false;
+        bool used = false;
+    };
+
+    std::unordered_map<uint32_t, ParticipantIDState> m_RTPSParticipantIDs;
 
     FileWatchHandle file_watch_handle_;
-
-    uint32_t prefix_id_offset_ = 0;
 };
 
 } // namespace rtps


### PR DESCRIPTION
Picks the smallest available participant ID.

## Description
This picks the smallest available participant ID when creating new participants.
This is necessary for the out of box discovery improvements in ROS 2: https://github.com/ros2/rmw_fastrtps/pull/653

The issue with picking one greater than the maximum participant ID  is that it's possible for the ID to increase well beyond the number of alive participants. For example, Participant A is created with 0, and B is created with 1. A is destroyed, and C is created. C takes ID 2 even though 0 is available and there are only two participants. When using unicast discovery this can cause participants to no longer be discoverable after the maximum ID climbs past `maxInititialPeersRange`. This is currently causing the `test_launch_ros` tests to fail with the change to unicast discovery by default.

Assuming the change looks ok, would it be possible to backport this to the 2.10 branch (assuming that's the branch that will be used for ROS Iron)?

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- *N/A* Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
