### PR TITLE
[18002] Internal refactor on port handling

### DIFF
--- a/src/cpp/rtps/network/NetworkFactory.cpp
+++ b/src/cpp/rtps/network/NetworkFactory.cpp
@@ -460,30 +460,27 @@ bool NetworkFactory::configureInitialPeerLocator(
 }
 
 bool NetworkFactory::getDefaultUnicastLocators(
-        uint32_t domain_id,
         LocatorList_t& locators,
-        const RTPSParticipantAttributes& m_att) const
+        uint32_t port) const
 {
     bool result = false;
     for (auto& transport : mRegisteredTransports)
     {
-        result |= transport->getDefaultUnicastLocators(locators, calculate_well_known_port(domain_id, m_att, false));
+        result |= transport->getDefaultUnicastLocators(locators, port);
     }
     return result;
 }
 
 bool NetworkFactory::fill_default_locator_port(
-        uint32_t domain_id,
         Locator_t& locator,
-        const RTPSParticipantAttributes& m_att,
-        bool is_multicast) const
+        uint32_t port) const
 {
     bool result = false;
     for (auto& transport : mRegisteredTransports)
     {
         if (transport->IsLocatorSupported(locator))
         {
-            result |= transport->fillUnicastLocator(locator, calculate_well_known_port(domain_id, m_att, is_multicast));
+            result |= transport->fillUnicastLocator(locator, port);
         }
     }
     return result;

--- a/src/cpp/rtps/network/NetworkFactory.h
+++ b/src/cpp/rtps/network/NetworkFactory.h
@@ -283,18 +283,15 @@ public:
      * Add locators to the default unicast configuration.
      * */
     bool getDefaultUnicastLocators(
-            uint32_t domain_id,
             LocatorList_t& locators,
-            const RTPSParticipantAttributes& m_att) const;
+            uint32_t port) const;
 
     /**
      * Fill the locator with the default unicast configuration.
      * */
     bool fill_default_locator_port(
-            uint32_t domain_id,
             Locator_t& locator,
-            const RTPSParticipantAttributes& m_att,
-            bool is_multicast) const;
+            uint32_t port) const;
 
     /**
      * Shutdown method to close the connections of the transports.
@@ -323,6 +320,14 @@ public:
      */
     std::vector<fastdds::rtps::TransportNetmaskFilterInfo> netmask_filter_info() const;
 
+    /**
+     * Calculate well-known ports.
+     */
+    uint16_t calculate_well_known_port(
+            uint32_t domain_id,
+            const RTPSParticipantAttributes& att,
+            bool is_multicast) const;
+
 private:
 
     std::vector<std::unique_ptr<fastdds::rtps::TransportInterface>> mRegisteredTransports;
@@ -339,14 +344,6 @@ private:
 
     // Mask using transport kinds to indicate whether the transports allows localhost
     NetworkConfigSet_t network_configuration_;
-
-    /**
-     * Calculate well-known ports.
-     */
-    uint16_t calculate_well_known_port(
-            uint32_t domain_id,
-            const RTPSParticipantAttributes& att,
-            bool is_multicast) const;
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -560,10 +560,10 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         m_att.defaultMulticastLocatorList.clear();
     }
 
-    createReceiverResources(m_att.builtin.metatrafficMulticastLocatorList, true, false, true);
+    createReceiverResources(m_att.builtin.metatrafficMulticastLocatorList, false, false, true);
     createReceiverResources(m_att.builtin.metatrafficUnicastLocatorList, true, false, true);
     createReceiverResources(m_att.defaultUnicastLocatorList, true, false, true);
-    createReceiverResources(m_att.defaultMulticastLocatorList, true, false, true);
+    createReceiverResources(m_att.defaultMulticastLocatorList, false, false, true);
 
     {
         using namespace fastdds::rtps::network::external_locators;

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -469,23 +469,6 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     setup_initial_peers();
     setup_output_traffic();
 
-    // Initial peers
-    if (m_att.builtin.initialPeersList.empty())
-    {
-        m_att.builtin.initialPeersList = m_att.builtin.metatrafficMulticastLocatorList;
-    }
-    else
-    {
-        LocatorList_t initial_peers;
-        initial_peers.swap(m_att.builtin.initialPeersList);
-
-        std::for_each(initial_peers.begin(), initial_peers.end(),
-                [&](Locator_t& locator)
-                {
-                    m_network_Factory.configureInitialPeerLocator(domain_id_, locator, m_att);
-                });
-    }
-
     // Creation of user locator and receiver resources
     //If no default locators are defined we define some.
     /* The reasoning here is the following.
@@ -685,6 +668,22 @@ void RTPSParticipantImpl::setup_user_traffic()
 
 void RTPSParticipantImpl::setup_initial_peers()
 {
+    // Initial peers
+    if (m_att.builtin.initialPeersList.empty())
+    {
+        m_att.builtin.initialPeersList = m_att.builtin.metatrafficMulticastLocatorList;
+    }
+    else
+    {
+        LocatorList_t initial_peers;
+        initial_peers.swap(m_att.builtin.initialPeersList);
+
+        std::for_each(initial_peers.begin(), initial_peers.end(),
+                [&](Locator_t& locator)
+                {
+                    m_network_Factory.configureInitialPeerLocator(domain_id_, locator, m_att);
+                });
+    }
 }
 
 void RTPSParticipantImpl::setup_output_traffic()

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -600,17 +600,20 @@ void RTPSParticipantImpl::setup_user_traffic()
     else
     {
         // Locator with port 0, calculate port.
+        uint32_t unicast_port = metatraffic_unicast_port_ + m_att.port.offsetd3 - m_att.port.offsetd1;
         std::for_each(m_att.defaultUnicastLocatorList.begin(), m_att.defaultUnicastLocatorList.end(),
                 [&](Locator_t& loc)
                 {
-                    m_network_Factory.fill_default_locator_port(domain_id_, loc, m_att, false);
+                    m_network_Factory.fill_default_locator_port(loc, unicast_port);
                 });
         m_network_Factory.NormalizeLocators(m_att.defaultUnicastLocatorList);
 
+        // Locator with port 0, calculate port.
+        uint32_t multicast_port = m_network_Factory.calculate_well_known_port(domain_id_, m_att, true);
         std::for_each(m_att.defaultMulticastLocatorList.begin(), m_att.defaultMulticastLocatorList.end(),
                 [&](Locator_t& loc)
                 {
-                    m_network_Factory.fill_default_locator_port(domain_id_, loc, m_att, true);
+                    m_network_Factory.fill_default_locator_port(loc, multicast_port);
                 });
     }
 
@@ -2246,13 +2249,15 @@ void RTPSParticipantImpl::normalize_endpoint_locators(
         EndpointAttributes& endpoint_att)
 {
     // Locators with port 0, calculate port.
+    uint32_t unicast_port = metatraffic_unicast_port_ + m_att.port.offsetd3 - m_att.port.offsetd1;
     for (Locator_t& loc : endpoint_att.unicastLocatorList)
     {
-        m_network_Factory.fill_default_locator_port(domain_id_, loc, m_att, false);
+        m_network_Factory.fill_default_locator_port(loc, unicast_port);
     }
+    uint32_t multicast_port = m_network_Factory.calculate_well_known_port(domain_id_, m_att, true);
     for (Locator_t& loc : endpoint_att.multicastLocatorList)
     {
-        m_network_Factory.fill_default_locator_port(domain_id_, loc, m_att, true);
+        m_network_Factory.fill_default_locator_port(loc, multicast_port);
     }
 
     // Normalize unicast locators
@@ -2810,7 +2815,8 @@ void RTPSParticipantImpl::get_default_metatraffic_locators()
 
 void RTPSParticipantImpl::get_default_unicast_locators()
 {
-    m_network_Factory.getDefaultUnicastLocators(domain_id_, m_att.defaultUnicastLocatorList, m_att);
+    uint32_t unicast_port = metatraffic_unicast_port_ + m_att.port.offsetd3 - m_att.port.offsetd1;
+    m_network_Factory.getDefaultUnicastLocators(m_att.defaultUnicastLocatorList, unicast_port);
     m_network_Factory.NormalizeLocators(m_att.defaultUnicastLocatorList);
 }
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -453,6 +453,17 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         return;
     }
 
+#if HAVE_SECURITY
+    // Start security
+    if (!m_security_manager.init(
+                security_attributes_,
+                m_att.properties))
+    {
+        // Participant will be deleted, no need to allocate buffers or create builtin endpoints
+        return;
+    }
+#endif // if HAVE_SECURITY
+
     /* If metatrafficMulticastLocatorList is empty, add mandatory default Locators
        Else -> Take them */
 
@@ -541,17 +552,6 @@ RTPSParticipantImpl::RTPSParticipantImpl(
                     m_network_Factory.fill_default_locator_port(domain_id_, loc, m_att, true);
                 });
     }
-
-#if HAVE_SECURITY
-    // Start security
-    if (!m_security_manager.init(
-                security_attributes_,
-                m_att.properties))
-    {
-        // Participant will be deleted, no need to allocate buffers or create builtin endpoints
-        return;
-    }
-#endif // if HAVE_SECURITY
 
     if (is_intraprocess_only())
     {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -524,8 +524,7 @@ void RTPSParticipantImpl::setup_meta_traffic()
 
     // Creation of metatraffic locator and receiver resources
     uint32_t metatraffic_multicast_port = m_att.port.getMulticastPort(domain_id_);
-    uint32_t metatraffic_unicast_port = m_att.port.getUnicastPort(domain_id_,
-                    static_cast<uint32_t>(m_att.participantID));
+    metatraffic_unicast_port_ = m_att.port.getUnicastPort(domain_id_, static_cast<uint32_t>(m_att.participantID));
     uint32_t meta_multicast_port_for_check = metatraffic_multicast_port;
 
     /* INSERT DEFAULT MANDATORY MULTICAST LOCATORS HERE */
@@ -551,7 +550,7 @@ void RTPSParticipantImpl::setup_meta_traffic()
         std::for_each(m_att.builtin.metatrafficUnicastLocatorList.begin(),
                 m_att.builtin.metatrafficUnicastLocatorList.end(), [&](Locator_t& locator)
                 {
-                    m_network_Factory.fillMetatrafficUnicastLocator(locator, metatraffic_unicast_port);
+                    m_network_Factory.fillMetatrafficUnicastLocator(locator, metatraffic_unicast_port_);
                 });
         m_network_Factory.NormalizeLocators(m_att.builtin.metatrafficUnicastLocatorList);
     }
@@ -2799,15 +2798,13 @@ void RTPSParticipantImpl::environment_file_has_changed()
 void RTPSParticipantImpl::get_default_metatraffic_locators()
 {
     uint32_t metatraffic_multicast_port = m_att.port.getMulticastPort(domain_id_);
-    uint32_t metatraffic_unicast_port = m_att.port.getUnicastPort(domain_id_,
-                    static_cast<uint32_t>(m_att.participantID));
 
     m_network_Factory.getDefaultMetatrafficMulticastLocators(m_att.builtin.metatrafficMulticastLocatorList,
             metatraffic_multicast_port);
     m_network_Factory.NormalizeLocators(m_att.builtin.metatrafficMulticastLocatorList);
 
     m_network_Factory.getDefaultMetatrafficUnicastLocators(m_att.builtin.metatrafficUnicastLocatorList,
-            metatraffic_unicast_port);
+            metatraffic_unicast_port_);
     m_network_Factory.NormalizeLocators(m_att.builtin.metatrafficUnicastLocatorList);
 }
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -237,7 +237,12 @@ Locator_t& RTPSParticipantImpl::applyLocatorAdaptRule(
 {
     // This is a completely made up rule
     // It is transport responsibility to interpret this new port.
-    loc.port += m_att.port.participantIDGain;
+    uint16_t delta = m_att.port.participantIDGain;
+    if (metatraffic_unicast_port_ == loc.port)
+    {
+        metatraffic_unicast_port_ += delta;
+    }
+    loc.port += delta;
     return loc;
 }
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -464,6 +464,11 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     }
 #endif // if HAVE_SECURITY
 
+    setup_meta_traffic();
+    setup_user_traffic();
+    setup_initial_peers();
+    setup_output_traffic();
+
     /* If metatrafficMulticastLocatorList is empty, add mandatory default Locators
        Else -> Take them */
 
@@ -661,6 +666,22 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         RTPSParticipant* par,
         RTPSParticipantListener* plisten)
     : RTPSParticipantImpl(domain_id, PParam, guidP, c_GuidPrefix_Unknown, par, plisten)
+{
+}
+
+void RTPSParticipantImpl::setup_meta_traffic()
+{
+}
+
+void RTPSParticipantImpl::setup_user_traffic()
+{
+}
+
+void RTPSParticipantImpl::setup_initial_peers()
+{
+}
+
+void RTPSParticipantImpl::setup_output_traffic()
 {
 }
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -560,13 +560,13 @@ void RTPSParticipantImpl::setup_meta_traffic()
         m_network_Factory.NormalizeLocators(m_att.builtin.metatrafficUnicastLocatorList);
     }
 
-    createReceiverResources(m_att.builtin.metatrafficMulticastLocatorList, false, false, true);
-    createReceiverResources(m_att.builtin.metatrafficUnicastLocatorList, true, false, true);
-
     if (is_intraprocess_only())
     {
         m_att.builtin.metatrafficUnicastLocatorList.clear();
     }
+
+    createReceiverResources(m_att.builtin.metatrafficMulticastLocatorList, false, false, true);
+    createReceiverResources(m_att.builtin.metatrafficUnicastLocatorList, true, false, true);
 
     // Check metatraffic multicast port
     if (0 < m_att.builtin.metatrafficMulticastLocatorList.size() &&

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -565,8 +565,8 @@ void RTPSParticipantImpl::setup_meta_traffic()
         m_att.builtin.metatrafficUnicastLocatorList.clear();
     }
 
-    createReceiverResources(m_att.builtin.metatrafficMulticastLocatorList, false, false, true);
     createReceiverResources(m_att.builtin.metatrafficUnicastLocatorList, true, false, true);
+    createReceiverResources(m_att.builtin.metatrafficMulticastLocatorList, false, false, true);
 
     // Check metatraffic multicast port
     if (0 < m_att.builtin.metatrafficMulticastLocatorList.size() &&

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1849,7 +1849,8 @@ bool RTPSParticipantImpl::createAndAssociateReceiverswithEndpoint(
             }
 
             // Try creating receiver resources
-            if (createReceiverResources(attributes.unicastLocatorList, false, true, false))
+            LocatorList_t aux_locator_list = attributes.unicastLocatorList;
+            if (createReceiverResources(aux_locator_list, false, true, false))
             {
                 break;
             }
@@ -1966,8 +1967,11 @@ bool RTPSParticipantImpl::createReceiverResources(
         bool RegisterReceiver,
         bool log_when_creation_fails)
 {
+    auto input_list = Locator_list;
+    Locator_list.clear();
+
     std::vector<std::shared_ptr<ReceiverResource>> newItemsBuffer;
-    bool ret_val = Locator_list.empty();
+    bool ret_val = input_list.empty();
 
 #if HAVE_SECURITY
     // An auxilary buffer is needed in the ReceiverResource to to decrypt the message,
@@ -1978,7 +1982,7 @@ bool RTPSParticipantImpl::createReceiverResources(
     uint32_t max_receiver_buffer_size = (std::numeric_limits<uint32_t>::max)();
 #endif // if HAVE_SECURITY
 
-    for (auto it_loc = Locator_list.begin(); it_loc != Locator_list.end(); ++it_loc)
+    for (auto it_loc = input_list.begin(); it_loc != input_list.end(); ++it_loc)
     {
         Locator_t loc = *it_loc;
         bool ret = m_network_Factory.BuildReceiverResources(loc, newItemsBuffer, max_receiver_buffer_size);
@@ -1995,7 +1999,7 @@ bool RTPSParticipantImpl::createReceiverResources(
 
         if (ret)
         {
-            *it_loc = loc;
+            Locator_list.push_back(loc);
         }
         else if (log_when_creation_fails)
         {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -622,6 +622,11 @@ private:
     //! Protect ignored entities collection concurrent access
     mutable shared_mutex ignored_mtx_;
 
+    void setup_meta_traffic();
+    void setup_user_traffic();
+    void setup_initial_peers();
+    void setup_output_traffic();
+
     RTPSParticipantImpl& operator =(
             const RTPSParticipantImpl&) = delete;
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -550,6 +550,8 @@ private:
     uint32_t domain_id_;
     //!Attributes of the RTPSParticipant
     RTPSParticipantAttributes m_att;
+    //! Metatraffic unicast port used by default on this participant
+    uint32_t metatraffic_unicast_port_ = 0;
     //!Guid of the RTPSParticipant.
     GUID_t m_guid;
     //! String containing the RTPSParticipant Guid.

--- a/test/blackbox/common/BlackboxTestsTransportSHM.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportSHM.cpp
@@ -120,11 +120,15 @@ TEST(SHM, SamePortUnicastMulticast)
     LocatorList reader_locators;
     participant.get_native_reader().get_listening_locators(reader_locators);
 
-    ASSERT_EQ(reader_locators.size(), 2u);
+    ASSERT_LE(reader_locators.size(), 2u);
     auto it = reader_locators.begin();
-    auto first_port = it->port;
-    ++it;
-    auto second_port = it->port;
+    uint32_t first_port = it->port;
+    uint32_t second_port = 0;
+    if (reader_locators.size() == 2)
+    {
+        ++it;
+        second_port = it->port;
+    }
     EXPECT_NE(first_port, second_port);
     EXPECT_TRUE(first_port == global_port || second_port == global_port);
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR refactors the constructor of RTPSParticipantImpl, and changes the calculation of the ports used when set to 0 on the input locators.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
