### PR TITLE
[18004] Added length checks to prevent nullptr memcpy calls

### DIFF
--- a/include/fastdds/rtps/messages/CDRMessage.hpp
+++ b/include/fastdds/rtps/messages/CDRMessage.hpp
@@ -92,7 +92,10 @@ inline bool CDRMessage::readData(
     {
         return false;
     }
-    memcpy(o, &msg->buffer[msg->pos], length);
+    if (length > 0)
+    {
+        memcpy(o, &msg->buffer[msg->pos], length);
+    }
     msg->pos += length;
     return true;
 }
@@ -468,8 +471,10 @@ inline bool CDRMessage::addData(
     {
         return false;
     }
-
-    memcpy(&msg->buffer[msg->pos], data, length);
+    if (length > 0)
+    {
+        memcpy(&msg->buffer[msg->pos], data, length);
+    }
     msg->pos += length;
     msg->length += length;
     return true;

--- a/include/fastdds/rtps/messages/CDRMessage.hpp
+++ b/include/fastdds/rtps/messages/CDRMessage.hpp
@@ -88,6 +88,10 @@ inline bool CDRMessage::readData(
         octet* o,
         uint32_t length)
 {
+    if (msg == nullptr || o == nullptr)
+    {
+        return false;
+    }
     if (msg->pos + length > msg->length)
     {
         return false;
@@ -95,8 +99,8 @@ inline bool CDRMessage::readData(
     if (length > 0)
     {
         memcpy(o, &msg->buffer[msg->pos], length);
+        msg->pos += length;
     }
-    msg->pos += length;
     return true;
 }
 
@@ -467,6 +471,10 @@ inline bool CDRMessage::addData(
         const octet* data,
         const uint32_t length)
 {
+    if (msg == nullptr || data == nullptr)
+    {
+        return false;
+    }
     if (msg->pos + length > msg->max_size)
     {
         return false;
@@ -474,9 +482,9 @@ inline bool CDRMessage::addData(
     if (length > 0)
     {
         memcpy(&msg->buffer[msg->pos], data, length);
+        msg->pos += length;
+        msg->length += length;
     }
-    msg->pos += length;
-    msg->length += length;
     return true;
 }
 

--- a/include/fastdds/rtps/messages/CDRMessage.hpp
+++ b/include/fastdds/rtps/messages/CDRMessage.hpp
@@ -88,7 +88,7 @@ inline bool CDRMessage::readData(
         octet* o,
         uint32_t length)
 {
-    if (msg == nullptr || o == nullptr)
+    if (msg == nullptr)
     {
         return false;
     }
@@ -98,6 +98,10 @@ inline bool CDRMessage::readData(
     }
     if (length > 0)
     {
+        if (o == nullptr)
+        {
+            return false;
+        }
         memcpy(o, &msg->buffer[msg->pos], length);
         msg->pos += length;
     }
@@ -471,7 +475,7 @@ inline bool CDRMessage::addData(
         const octet* data,
         const uint32_t length)
 {
-    if (msg == nullptr || data == nullptr)
+    if (msg == nullptr)
     {
         return false;
     }
@@ -481,6 +485,10 @@ inline bool CDRMessage::addData(
     }
     if (length > 0)
     {
+        if (data == nullptr)
+        {
+            return false;
+        }
         memcpy(&msg->buffer[msg->pos], data, length);
         msg->pos += length;
         msg->length += length;

--- a/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
+++ b/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "fastdds/rtps/messages/CDRMessage.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -1298,6 +1299,23 @@ TEST(BuiltinDataSerializationTests, contentfilterproperty_max_parameter_check)
         msg_fault.pos = 0;
         // Deserialization of messages with more than 100 parameters should fail
         ASSERT_FALSE(out.readFromCDRMessage(&msg_fault, network, true));
+    }
+}
+
+TEST(BuiltinDataSerializationTests, null_checks)
+{
+    {
+        // Test deserialization sanity checks
+        uint32_t msg_size = 100;
+        CDRMessage_t msg(msg_size);
+
+        ASSERT_FALSE(CDRMessage::addData(nullptr, (octet*) &msg, msg_size));
+        ASSERT_FALSE(CDRMessage::addData(&msg, nullptr, msg_size));
+
+        // Test deserialization sanity checks
+
+        ASSERT_FALSE(CDRMessage::readData(nullptr, (octet*) &msg, msg_size));
+        ASSERT_FALSE(CDRMessage::readData(&msg, nullptr, msg_size));
     }
 }
 

--- a/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
+++ b/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
@@ -1311,11 +1311,13 @@ TEST(BuiltinDataSerializationTests, null_checks)
 
         ASSERT_FALSE(CDRMessage::addData(nullptr, (octet*) &msg, msg_size));
         ASSERT_FALSE(CDRMessage::addData(&msg, nullptr, msg_size));
+        ASSERT_TRUE(CDRMessage::addData(&msg, nullptr, 0));
 
         // Test deserialization sanity checks
 
         ASSERT_FALSE(CDRMessage::readData(nullptr, (octet*) &msg, msg_size));
         ASSERT_FALSE(CDRMessage::readData(&msg, nullptr, msg_size));
+        ASSERT_TRUE(CDRMessage::readData(&msg, nullptr, 0));
     }
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

UBSan (Undefined behavior sanitizer) reports nullptr memcpy calls when memcpy arguments should be guaranteed as not null. Checks have been added to prevent this.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.9.x 2.8.x 2.6.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [ ] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
