### PR TITLE
Fix segfault when creating two participant with same fixed id [18051]

### DIFF
--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -195,7 +195,7 @@ DomainParticipant* DomainParticipantFactory::create_participant(
     }
     else
     {
-        delete_participant(dom_part);
+        delete dom_part_impl;
         return nullptr;
     }
 

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -166,29 +166,37 @@ DomainParticipant* DomainParticipantFactory::create_participant(
             new eprosima::fastdds::statistics::dds::DomainParticipantImpl(dom_part, did, pqos, listen);
 #endif // FASTDDS_STATISTICS
 
+    if (fastrtps::rtps::GUID_t::unknown() != dom_part_impl->guid())
     {
-        std::lock_guard<std::mutex> guard(mtx_participants_);
-        using VectorIt = std::map<DomainId_t, std::vector<DomainParticipantImpl*>>::iterator;
-        VectorIt vector_it = participants_.find(did);
-
-        if (vector_it == participants_.end())
         {
-            // Insert the vector
-            std::vector<DomainParticipantImpl*> new_vector;
-            auto pair_it = participants_.insert(std::make_pair(did, std::move(new_vector)));
-            vector_it = pair_it.first;
+            std::lock_guard<std::mutex> guard(mtx_participants_);
+            using VectorIt = std::map<DomainId_t, std::vector<DomainParticipantImpl*>>::iterator;
+            VectorIt vector_it = participants_.find(did);
+
+            if (vector_it == participants_.end())
+            {
+                // Insert the vector
+                std::vector<DomainParticipantImpl*> new_vector;
+                auto pair_it = participants_.insert(std::make_pair(did, std::move(new_vector)));
+                vector_it = pair_it.first;
+            }
+
+            vector_it->second.push_back(dom_part_impl);
         }
 
-        vector_it->second.push_back(dom_part_impl);
+        if (factory_qos_.entity_factory().autoenable_created_entities)
+        {
+            if (ReturnCode_t::RETCODE_OK != dom_part->enable())
+            {
+                delete_participant(dom_part);
+                return nullptr;
+            }
+        }
     }
-
-    if (factory_qos_.entity_factory().autoenable_created_entities)
+    else
     {
-        if (ReturnCode_t::RETCODE_OK != dom_part->enable())
-        {
-            delete_participant(dom_part);
-            return nullptr;
-        }
+        delete_participant(dom_part);
+        return nullptr;
     }
 
     return dom_part;

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -127,7 +127,10 @@ DomainParticipantImpl::DomainParticipantImpl(
 
     // Pre calculate participant id and generated guid
     participant_id_ = qos_.wire_protocol().participant_id;
-    eprosima::fastrtps::rtps::RTPSDomainImpl::create_participant_guid(participant_id_, guid_);
+    if (!eprosima::fastrtps::rtps::RTPSDomainImpl::create_participant_guid(participant_id_, guid_))
+    {
+        EPROSIMA_LOG_ERROR(DOMAIN_PARTICIPANT, "Error generating GUID for participant");
+    }
 
     /* Fill physical data properties if they are found and empty */
     std::string* property_value = fastrtps::rtps::PropertyPolicyHelper::find_property(
@@ -254,6 +257,12 @@ ReturnCode_t DomainParticipantImpl::enable()
 {
     // Should not have been previously enabled
     assert(get_rtps_participant() == nullptr);
+
+    // Preconditions
+    if (guid_ == GUID_t::unknown())
+    {
+        return ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;
+    }
 
     fastrtps::rtps::RTPSParticipantAttributes rtps_attr;
     utils::set_attributes_from_qos(rtps_attr, qos_);

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -257,12 +257,8 @@ ReturnCode_t DomainParticipantImpl::enable()
 {
     // Should not have been previously enabled
     assert(get_rtps_participant() == nullptr);
-
-    // Preconditions
-    if (guid_ == GUID_t::unknown())
-    {
-        return ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;
-    }
+    // Should not have failed assigning the GUID
+    assert (guid_ != GUID_t::unknown());
 
     fastrtps::rtps::RTPSParticipantAttributes rtps_attr;
     utils::set_attributes_from_qos(rtps_attr, qos_);

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -661,7 +661,7 @@ bool RTPSDomainImpl::create_participant_guid(
         int32_t& participant_id,
         GUID_t& guid)
 {
-    bool ret_value = reserve_participant_id(participant_id);
+    bool ret_value = get_instance()->reserve_participant_id(participant_id);
 
     if (ret_value)
     {

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -636,19 +636,40 @@ uint32_t RTPSDomainImpl::get_id_for_prefix(
     return ret;
 }
 
-void RTPSDomainImpl::create_participant_guid(
+bool RTPSDomainImpl::reserve_participant_id(
+        int32_t& participant_id)
+{
+    auto instance = get_instance();
+    std::lock_guard<std::mutex> guard(instance->m_mutex);
+    if (participant_id < 0)
+    {
+        participant_id = instance->getNewId();
+    }
+    else
+    {
+        if (instance->m_RTPSParticipantIDs[participant_id].reserved == true)
+        {
+            return false;
+        }
+        instance->m_RTPSParticipantIDs[participant_id].reserved = true;
+    }
+
+    return true;
+}
+
+bool RTPSDomainImpl::create_participant_guid(
         int32_t& participant_id,
         GUID_t& guid)
 {
-    if (participant_id < 0)
+    bool ret_value = reserve_participant_id(participant_id);
+
+    if (ret_value)
     {
-        auto instance = get_instance();
-        std::lock_guard<std::mutex> guard(instance->m_mutex);
-        participant_id = instance->getNewId();
+        guid_prefix_create(participant_id, guid.guidPrefix);
+        guid.entityId = c_EntityId_RTPSParticipant;
     }
 
-    guid_prefix_create(participant_id, guid.guidPrefix);
-    guid.entityId = c_EntityId_RTPSParticipant;
+    return ret_value;
 }
 
 RTPSParticipantImpl* RTPSDomainImpl::find_local_participant(

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -639,19 +639,18 @@ uint32_t RTPSDomainImpl::get_id_for_prefix(
 bool RTPSDomainImpl::reserve_participant_id(
         int32_t& participant_id)
 {
-    auto instance = get_instance();
-    std::lock_guard<std::mutex> guard(instance->m_mutex);
+    std::lock_guard<std::mutex> guard(m_mutex);
     if (participant_id < 0)
     {
-        participant_id = instance->getNewId();
+        participant_id = getNewId();
     }
     else
     {
-        if (instance->m_RTPSParticipantIDs[participant_id].reserved == true)
+        if (m_RTPSParticipantIDs[participant_id].reserved == true)
         {
             return false;
         }
-        instance->m_RTPSParticipantIDs[participant_id].reserved = true;
+        m_RTPSParticipantIDs[participant_id].reserved = true;
     }
 
     return true;

--- a/src/cpp/rtps/RTPSDomainImpl.hpp
+++ b/src/cpp/rtps/RTPSDomainImpl.hpp
@@ -221,7 +221,7 @@ private:
     /**
      * Reserves a participant id.
      * @param [in, out] participant_id   Participant identifier for reservation.
-     *                                   When negative, it will be modified to the first non-existent participant id.
+     *                                   When negative, it will be modified to the first non-reserved participant id.
      *
      * @return True value if reservation was possible. False in other case.
      */

--- a/src/cpp/rtps/RTPSDomainImpl.hpp
+++ b/src/cpp/rtps/RTPSDomainImpl.hpp
@@ -225,7 +225,7 @@ private:
      *
      * @return True value if reservation was possible. False in other case.
      */
-    static bool reserve_participant_id(
+    bool reserve_participant_id(
             int32_t& participant_id);
 
     uint32_t get_id_for_prefix(

--- a/src/cpp/rtps/RTPSDomainImpl.hpp
+++ b/src/cpp/rtps/RTPSDomainImpl.hpp
@@ -149,8 +149,10 @@ public:
      * @param [in, out] participant_id   Participant identifier for which to generate the GUID.
      *                                   When negative, it will be modified to the first non-existent participant id.
      * @param [out]     guid             GUID corresponding to participant_id
+     *
+     * @return True value if guid was created. False in other case.
      */
-    static void create_participant_guid(
+    static bool create_participant_guid(
             int32_t& participant_id,
             GUID_t& guid);
 
@@ -215,6 +217,16 @@ private:
     bool prepare_participant_id(
             int32_t input_id,
             uint32_t& participant_id);
+
+    /**
+     * Reserves a participant id.
+     * @param [in, out] participant_id   Participant identifier for reservation.
+     *                                   When negative, it will be modified to the first non-existent participant id.
+     *
+     * @return True value if reservation was possible. False in other case.
+     */
+    static bool reserve_participant_id(
+            int32_t& participant_id);
 
     uint32_t get_id_for_prefix(
             uint32_t participant_id);

--- a/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
+++ b/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
@@ -355,9 +355,9 @@ public:
     }
 
     MOCK_METHOD5(create_contentfilteredtopic, ContentFilteredTopic * (
-                const std::string & name,
+                const std::string& name,
                 Topic * related_topic,
-                const std::string & filter_expression,
+                const std::string& filter_expression,
                 const std::vector<std::string>& expression_parameters,
                 const char* filter_class_name));
 
@@ -378,7 +378,7 @@ public:
                 const char* filter_class_name));
 
     MOCK_METHOD1(ignore_participant, bool (
-                const fastrtps::rtps::InstanceHandle_t & handle));
+                const fastrtps::rtps::InstanceHandle_t& handle));
 
 
     TopicDescription* lookup_topicdescription(

--- a/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
+++ b/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
@@ -85,6 +85,7 @@ protected:
     {
         participant_->impl_ = this;
 
+        guid_.guidPrefix.value[11] = 1;
         eprosima::fastrtps::TopicAttributes top_attr;
         eprosima::fastrtps::xmlparser::XMLProfileManager::getDefaultTopicAttributes(top_attr);
         default_topic_qos_.history() = top_attr.historyQos;
@@ -354,9 +355,9 @@ public:
     }
 
     MOCK_METHOD5(create_contentfilteredtopic, ContentFilteredTopic * (
-                const std::string& name,
+                const std::string & name,
                 Topic * related_topic,
-                const std::string& filter_expression,
+                const std::string & filter_expression,
                 const std::vector<std::string>& expression_parameters,
                 const char* filter_class_name));
 
@@ -377,7 +378,7 @@ public:
                 const char* filter_class_name));
 
     MOCK_METHOD1(ignore_participant, bool (
-                const fastrtps::rtps::InstanceHandle_t& handle));
+                const fastrtps::rtps::InstanceHandle_t & handle));
 
 
     TopicDescription* lookup_topicdescription(

--- a/test/mock/rtps/RTPSDomainImpl/rtps/RTPSDomainImpl.hpp
+++ b/test/mock/rtps/RTPSDomainImpl/rtps/RTPSDomainImpl.hpp
@@ -63,8 +63,9 @@ public:
 
     static bool create_participant_guid(
             int32_t& /*participant_id*/,
-            GUID_t& /*guid*/)
+            GUID_t& guid)
     {
+        guid.guidPrefix.value[11] = 1;
         return true;
     }
 

--- a/test/mock/rtps/RTPSDomainImpl/rtps/RTPSDomainImpl.hpp
+++ b/test/mock/rtps/RTPSDomainImpl/rtps/RTPSDomainImpl.hpp
@@ -61,10 +61,11 @@ public:
         return nullptr;
     }
 
-    static void create_participant_guid(
+    static bool create_participant_guid(
             int32_t& /*participant_id*/,
             GUID_t& /*guid*/)
     {
+        return true;
     }
 
     /**

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -3728,22 +3728,24 @@ TEST(ParticipantTests, UnsupportedMethods)
 /*
  * Regression test for redmine issue #18050.
  *
- * This tests tries to create two participant with the same fixed id.
+ * This test tries to create two participants with the same fixed id.
  */
 TEST(ParticipantTests, TwoParticipantWithSameFixedId)
 {
     DomainParticipantQos participant_qos;
     participant_qos.wire_protocol().participant_id = 1;
 
-    // Create the participant
+    // Create the first participant
     DomainParticipant* participant1 =
             DomainParticipantFactory::get_instance()->create_participant(0, participant_qos);
     ASSERT_NE(participant1, nullptr);
 
+    // Creating a second participant with the same fixed id should fail
     DomainParticipant* participant2 =
             DomainParticipantFactory::get_instance()->create_participant(0, participant_qos);
     ASSERT_EQ(participant2, nullptr);
 
+    // Destroy the first participant
     ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant1), ReturnCode_t::RETCODE_OK);
 }
 

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -3769,17 +3769,12 @@ TEST(ParticipantTests, TwoParticipantWithSameFixedId)
         // Creating a second participant with the same fixed id should fail
         DomainParticipant* participant2 =
                 DomainParticipantFactory::get_instance()->create_participant(0, participant_qos);
-        ASSERT_NE(participant2, nullptr);
+        ASSERT_EQ(participant2, nullptr);
 
         ASSERT_EQ(ReturnCode_t::RETCODE_OK, participant1->enable());
 
-        ASSERT_EQ(ReturnCode_t::RETCODE_PRECONDITION_NOT_MET, participant2->enable());
-
         // Destroy the first participant
         ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant1), ReturnCode_t::RETCODE_OK);
-
-        // Destroy the second participant
-        ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant2), ReturnCode_t::RETCODE_OK);
 
         factory_qos.entity_factory().autoenable_created_entities = true;
         ASSERT_EQ(ReturnCode_t::RETCODE_OK, DomainParticipantFactory::get_instance()->set_qos(factory_qos));

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -3725,6 +3725,28 @@ TEST(ParticipantTests, UnsupportedMethods)
     ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), ReturnCode_t::RETCODE_OK);
 }
 
+/*
+ * Regression test for redmine issue #18050.
+ *
+ * This tests tries to create two participant with the same fixed id.
+ */
+TEST(ParticipantTests, TwoParticipantWithSameFixedId)
+{
+    DomainParticipantQos participant_qos;
+    participant_qos.wire_protocol().participant_id = 1;
+
+    // Create the participant
+    DomainParticipant* participant1 =
+            DomainParticipantFactory::get_instance()->create_participant(0, participant_qos);
+    ASSERT_NE(participant1, nullptr);
+
+    DomainParticipant* participant2 =
+            DomainParticipantFactory::get_instance()->create_participant(0, participant_qos);
+    ASSERT_EQ(participant2, nullptr);
+
+    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant1), ReturnCode_t::RETCODE_OK);
+}
+
 } // namespace dds
 } // namespace fastdds
 } // namespace eprosima

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -3732,21 +3732,58 @@ TEST(ParticipantTests, UnsupportedMethods)
  */
 TEST(ParticipantTests, TwoParticipantWithSameFixedId)
 {
-    DomainParticipantQos participant_qos;
-    participant_qos.wire_protocol().participant_id = 1;
+    // Test participants enabled from beginning
+    {
+        DomainParticipantQos participant_qos;
+        participant_qos.wire_protocol().participant_id = 1;
 
-    // Create the first participant
-    DomainParticipant* participant1 =
-            DomainParticipantFactory::get_instance()->create_participant(0, participant_qos);
-    ASSERT_NE(participant1, nullptr);
+        // Create the first participant
+        DomainParticipant* participant1 =
+                DomainParticipantFactory::get_instance()->create_participant(0, participant_qos);
+        ASSERT_NE(participant1, nullptr);
 
-    // Creating a second participant with the same fixed id should fail
-    DomainParticipant* participant2 =
-            DomainParticipantFactory::get_instance()->create_participant(0, participant_qos);
-    ASSERT_EQ(participant2, nullptr);
+        // Creating a second participant with the same fixed id should fail
+        DomainParticipant* participant2 =
+                DomainParticipantFactory::get_instance()->create_participant(0, participant_qos);
+        ASSERT_EQ(participant2, nullptr);
 
-    // Destroy the first participant
-    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant1), ReturnCode_t::RETCODE_OK);
+        // Destroy the first participant
+        ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant1), ReturnCode_t::RETCODE_OK);
+    }
+
+    // Test participants disabled from beginning
+    {
+        DomainParticipantFactoryQos factory_qos;
+        ASSERT_EQ(ReturnCode_t::RETCODE_OK, DomainParticipantFactory::get_instance()->get_qos(factory_qos));
+        factory_qos.entity_factory().autoenable_created_entities = false;
+        ASSERT_EQ(ReturnCode_t::RETCODE_OK, DomainParticipantFactory::get_instance()->set_qos(factory_qos));
+
+        DomainParticipantQos participant_qos;
+        participant_qos.wire_protocol().participant_id = 1;
+
+        // Create the first participant
+        DomainParticipant* participant1 =
+                DomainParticipantFactory::get_instance()->create_participant(0, participant_qos);
+        ASSERT_NE(participant1, nullptr);
+
+        // Creating a second participant with the same fixed id should fail
+        DomainParticipant* participant2 =
+                DomainParticipantFactory::get_instance()->create_participant(0, participant_qos);
+        ASSERT_NE(participant2, nullptr);
+
+        ASSERT_EQ(ReturnCode_t::RETCODE_OK, participant1->enable());
+
+        ASSERT_EQ(ReturnCode_t::RETCODE_PRECONDITION_NOT_MET, participant2->enable());
+
+        // Destroy the first participant
+        ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant1), ReturnCode_t::RETCODE_OK);
+
+        // Destroy the second participant
+        ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant2), ReturnCode_t::RETCODE_OK);
+
+        factory_qos.entity_factory().autoenable_created_entities = true;
+        ASSERT_EQ(ReturnCode_t::RETCODE_OK, DomainParticipantFactory::get_instance()->set_qos(factory_qos));
+    }
 }
 
 } // namespace dds


### PR DESCRIPTION
"<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

Second participant creation fails, but when its `DomainParticipantImpl` will be removed from the factory, the code remove the one of the first participant. This is because they share the same GUID.
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.9.x 2.8.x 2.6.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- *N/A* Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
"
