### PR TITLE
[18155] Participant ignore local enpoints tests

### DIFF
--- a/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
@@ -595,6 +595,21 @@ public:
                 });
     }
 
+    template<class _Rep,
+            class _Period
+            >
+    size_t block_for_all(
+            const std::chrono::duration<_Rep, _Period>& max_wait)
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        cv_.wait_for(lock, max_wait, [this]() -> bool
+                {
+                    return number_samples_expected_ == current_received_count_;
+                });
+
+        return current_received_count_;
+    }
+
     void block(
             std::function<bool()> checker)
     {
@@ -615,6 +630,32 @@ public:
 
         ASSERT_GE(matched_readers_.size() + matched_writers_.size(), 2u);
         std::cout << "Discovery finished..." << std::endl;
+    }
+
+    void wait_discovery(
+            size_t matches,
+            std::chrono::seconds timeout = std::chrono::seconds::zero())
+    {
+        std::unique_lock<std::mutex> lock(mutexDiscovery_);
+
+        std::cout << "Waiting discovery for " << matches << " matches..." << std::endl;
+
+        if (timeout == std::chrono::seconds::zero())
+        {
+            cv_.wait(lock, [&]()
+                    {
+                        return matched_readers_.size() >= matches && matched_writers_.size() >= matches;
+                    });
+        }
+        else
+        {
+            cv_.wait_for(lock, timeout, [&]()
+                    {
+                        return matched_readers_.size() >= matches && matched_writers_.size() >= matches;
+                    });
+        }
+
+        std::cout << "Finished waiting for discovery" << std::endl;
     }
 
     void waitRemoval()

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -21,7 +21,6 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-
 #include <fastdds/core/policy/ParameterSerializer.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
@@ -43,8 +42,9 @@
 #include <fastrtps/types/TypesBase.h>
 
 #include "BlackboxTests.hpp"
-#include "../api/dds-pim/PubSubWriter.hpp"
 #include "../api/dds-pim/PubSubReader.hpp"
+#include "../api/dds-pim/PubSubWriter.hpp"
+#include "../api/dds-pim/PubSubWriterReader.hpp"
 #include "../types/FixedSized.h"
 #include "../types/FixedSizedPubSubTypes.h"
 #include "../types/HelloWorldPubSubTypes.h"
@@ -546,6 +546,102 @@ TEST(DDSBasic, IgnoreParticipant)
     factory->delete_participant(participant_listener);
     factory->delete_participant(participant_ign);
 
+}
+
+TEST(DDSBasic, participant_ignore_local_endpoints)
+{
+    class CustomLogConsumer : public LogConsumer
+    {
+    public:
+
+        void Consume(
+                const Log::Entry&) override
+        {
+            logs_consumed_++;
+            cv_.notify_all();
+        }
+
+        size_t wait_for_entries(
+                uint32_t amount,
+                const std::chrono::duration<double>& max_wait)
+        {
+            std::unique_lock<std::mutex> lock(mtx_);
+            cv_.wait_for(lock, max_wait, [this, amount]() -> bool
+                    {
+                        return logs_consumed_ > 0 && logs_consumed_.load() == amount;
+                    });
+            return logs_consumed_.load();
+        }
+
+    protected:
+
+        std::atomic<size_t> logs_consumed_{0u};
+        std::mutex mtx_;
+        std::condition_variable cv_;
+    };
+
+    struct Config
+    {
+        std::string test_id;
+        std::string property_value;
+        uint8_t log_errors;
+        uint8_t expected_matched_endpoints;
+        uint8_t sent_samples;
+        uint8_t expected_received_samples;
+    };
+
+    std::vector<Config> tests_configs = {
+        {"PART-IGNORE-LOCAL-TEST:01", "true", 0, 0, 5, 0},
+        {"PART-IGNORE-LOCAL-TEST:02", "false", 0, 1, 5, 5},
+        {"PART-IGNORE-LOCAL-TEST:03", "asdfg", 1, 1, 5, 5}
+    };
+
+    for (Config test_config : tests_configs)
+    {
+        std::cout << std::endl;
+        std::cout << "---------------------------------------" << std::endl;
+        std::cout << "Running test: " << test_config.test_id << std::endl;
+        std::cout << "---------------------------------------" << std::endl;
+
+        /* Set up */
+        Log::Reset();
+        Log::SetVerbosity(Log::Error);
+        CustomLogConsumer* log_consumer = new CustomLogConsumer();
+        std::unique_ptr<CustomLogConsumer> log_consumer_unique_ptr(log_consumer);
+        Log::RegisterConsumer(std::move(log_consumer_unique_ptr));
+
+        // Create the DomainParticipant with the appropriate value for the property
+        PubSubWriterReader<HelloWorldPubSubType> writer_reader(TEST_TOPIC_NAME);
+        eprosima::fastrtps::rtps::PropertyPolicy property_policy;
+        property_policy.properties().emplace_back("fastdds.ignore_local_endpoints", test_config.property_value);
+        writer_reader.property_policy(property_policy);
+
+        /* Procedure */
+        // Create the DataWriter & DataReader
+        writer_reader.init();
+        EXPECT_TRUE(writer_reader.isInitialized());
+
+        // Wait for discovery
+        writer_reader.wait_discovery(test_config.expected_matched_endpoints, std::chrono::seconds(1));
+        EXPECT_EQ(writer_reader.get_publication_matched(), test_config.expected_matched_endpoints);
+        EXPECT_EQ(writer_reader.get_subscription_matched(), test_config.expected_matched_endpoints);
+
+        // Send samples
+        auto samples = default_helloworld_data_generator(test_config.sent_samples);
+        writer_reader.startReception(samples);
+        writer_reader.send(samples);
+        EXPECT_TRUE(samples.empty());
+
+        // Wait for reception
+        EXPECT_EQ(writer_reader.block_for_all(std::chrono::seconds(1)), test_config.expected_received_samples);
+
+        // Wait for log entries
+        EXPECT_EQ(log_consumer->wait_for_entries(test_config.log_errors, std::chrono::seconds(
+                    1)), test_config.log_errors);
+
+        /* Tear-down */
+        Log::Reset();
+    }
 }
 
 } // namespace dds

--- a/test/blackbox/common/RTPSWithRegistrationReader.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationReader.hpp
@@ -121,8 +121,16 @@ public:
 
     RTPSWithRegistrationReader(
             const std::string& topic_name)
+        : RTPSWithRegistrationReader(topic_name, nullptr)
+    {
+    }
+
+    RTPSWithRegistrationReader(
+            const std::string& topic_name,
+            eprosima::fastrtps::rtps::RTPSParticipant* participant)
         : listener_(*this)
-        , participant_(nullptr)
+        , participant_(participant)
+        , destroy_participant_(nullptr == participant)
         , reader_(nullptr)
         , history_(nullptr)
         , initialized_(false)
@@ -139,29 +147,27 @@ public:
         reader_attr_.times.heartbeatResponseDelay.seconds = 0;
         //reader_attr_.times.heartbeatResponseDelay.nanosec = 100000000;
         reader_attr_.times.heartbeatResponseDelay.nanosec = 100000000;
+
+        participant_attr_.builtin.discovery_config.discoveryProtocol =
+                eprosima::fastrtps::rtps::DiscoveryProtocol::SIMPLE;
+        participant_attr_.builtin.use_WriterLivelinessProtocol = true;
     }
 
     virtual ~RTPSWithRegistrationReader()
     {
-        if (participant_ != nullptr)
-        {
-            eprosima::fastrtps::rtps::RTPSDomain::removeRTPSParticipant(participant_);
-        }
-        if (history_ != nullptr)
-        {
-            delete(history_);
-        }
+        destroy();
     }
 
     void init()
     {
         matched_ = 0;
 
-        eprosima::fastrtps::rtps::RTPSParticipantAttributes pattr;
-        pattr.builtin.discovery_config.discoveryProtocol = eprosima::fastrtps::rtps::DiscoveryProtocol::SIMPLE;
-        pattr.builtin.use_WriterLivelinessProtocol = true;
-        participant_ = eprosima::fastrtps::rtps::RTPSDomain::createParticipant((uint32_t)GET_PID() % 230, pattr);
-        ASSERT_NE(participant_, nullptr);
+        if (nullptr == participant_)
+        {
+            participant_ = eprosima::fastrtps::rtps::RTPSDomain::createParticipant(
+                static_cast<uint32_t>(GET_PID()) % 230, participant_attr_);
+            ASSERT_NE(participant_, nullptr);
+        }
 
         //Create readerhistory
         hattr_.payloadMaxSize = type_.m_typeSize;
@@ -205,11 +211,11 @@ public:
 
     void destroy()
     {
-        if (participant_ != nullptr)
+        if (destroy_participant_ && participant_ != nullptr)
         {
             eprosima::fastrtps::rtps::RTPSDomain::removeRTPSParticipant(participant_);
-            participant_ = nullptr;
         }
+        participant_ = nullptr;
 
         if (history_ != nullptr)
         {
@@ -333,21 +339,28 @@ public:
     void wait_discovery(
             std::chrono::seconds timeout = std::chrono::seconds::zero())
     {
-        std::unique_lock<std::mutex> lock(mutexDiscovery_);
+        wait_discovery(1, timeout);
+        ASSERT_NE(matched_, 0u);
+    }
 
-        if (matched_ == 0 && timeout == std::chrono::seconds::zero())
+    void wait_discovery(
+            size_t matches,
+            std::chrono::seconds timeout = std::chrono::seconds::zero())
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+
+        if (timeout == std::chrono::seconds::zero())
         {
-            cvDiscovery_.wait(lock, [this]() -> bool
+            cv_.wait(lock, [&]() -> bool
                     {
-                        return matched_ != 0;
+                        return matched_ >= matches;
                     });
-            EXPECT_NE(matched_, 0u);
         }
         else
         {
             cv_.wait_for(lock, timeout, [&]()
                     {
-                        return matched_ != 0;
+                        return matched_ >= matches;
                     });
         }
     }
@@ -602,6 +615,8 @@ private:
             const RTPSWithRegistrationReader&) = delete;
 
     eprosima::fastrtps::rtps::RTPSParticipant* participant_;
+    eprosima::fastrtps::rtps::RTPSParticipantAttributes participant_attr_;
+    bool destroy_participant_{false};
     eprosima::fastrtps::rtps::RTPSReader* reader_;
     eprosima::fastrtps::rtps::ReaderAttributes reader_attr_;
     eprosima::fastrtps::TopicAttributes topic_attr_;

--- a/test/blackbox/common/RTPSWithRegistrationReader.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationReader.hpp
@@ -339,8 +339,12 @@ public:
     void wait_discovery(
             std::chrono::seconds timeout = std::chrono::seconds::zero())
     {
+        bool post_assertion = (matched_ == 0 && timeout == std::chrono::seconds::zero()) ? true : false;
         wait_discovery(1, timeout);
-        ASSERT_NE(matched_, 0u);
+        if (post_assertion)
+        {
+            ASSERT_NE(matched_, 0u);
+        }
     }
 
     void wait_discovery(
@@ -351,14 +355,14 @@ public:
 
         if (timeout == std::chrono::seconds::zero())
         {
-            cv_.wait(lock, [&]() -> bool
+            cvDiscovery_.wait(lock, [&]() -> bool
                     {
                         return matched_ >= matches;
                     });
         }
         else
         {
-            cv_.wait_for(lock, timeout, [&]()
+            cvDiscovery_.wait_for(lock, timeout, [&]()
                     {
                         return matched_ >= matches;
                     });

--- a/test/blackbox/common/RTPSWithRegistrationWriter.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationWriter.hpp
@@ -109,8 +109,16 @@ public:
 
     RTPSWithRegistrationWriter(
             const std::string& topic_name)
+        : RTPSWithRegistrationWriter(topic_name, nullptr)
+    {
+    }
+
+    RTPSWithRegistrationWriter(
+            const std::string& topic_name,
+            eprosima::fastrtps::rtps::RTPSParticipant* participant)
         : listener_(*this)
-        , participant_(nullptr)
+        , participant_(participant)
+        , destroy_participant_(nullptr == participant)
         , writer_(nullptr)
         , history_(nullptr)
         , initialized_(false)
@@ -135,14 +143,7 @@ public:
 
     virtual ~RTPSWithRegistrationWriter()
     {
-        if (participant_ != nullptr)
-        {
-            eprosima::fastrtps::rtps::RTPSDomain::removeRTPSParticipant(participant_);
-        }
-        if (history_ != nullptr)
-        {
-            delete(history_);
-        }
+        destroy();
     }
 
     void init()
@@ -150,8 +151,11 @@ public:
         matched_ = 0;
 
         //Create participant
-        participant_ = eprosima::fastrtps::rtps::RTPSDomain::createParticipant(
-            (uint32_t)GET_PID() % 230, participant_attr_);
+        if (nullptr == participant_)
+        {
+            participant_ = eprosima::fastrtps::rtps::RTPSDomain::createParticipant(
+                static_cast<uint32_t>(GET_PID()) % 230, participant_attr_);
+        }
         ASSERT_NE(participant_, nullptr);
 
         //Create writerhistory
@@ -192,7 +196,7 @@ public:
 
     void destroy()
     {
-        if (participant_ != nullptr)
+        if (destroy_participant_ && participant_ != nullptr)
         {
             eprosima::fastrtps::rtps::RTPSDomain::removeRTPSParticipant(participant_);
         }
@@ -281,21 +285,28 @@ public:
     void wait_discovery(
             std::chrono::seconds timeout = std::chrono::seconds::zero())
     {
+        wait_discovery(1, timeout);
+        ASSERT_NE(matched_, 0u);
+    }
+
+    void wait_discovery(
+            size_t matches,
+            std::chrono::seconds timeout = std::chrono::seconds::zero())
+    {
         std::unique_lock<std::mutex> lock(mutex_);
 
-        if (matched_ == 0 && timeout == std::chrono::seconds::zero())
+        if (timeout == std::chrono::seconds::zero())
         {
-            cv_.wait(lock, [this]() -> bool
+            cv_.wait(lock, [&]() -> bool
                     {
-                        return matched_ != 0;
+                        return matched_ >= matches;
                     });
-            ASSERT_NE(matched_, 0u);
         }
         else
         {
             cv_.wait_for(lock, timeout, [&]()
                     {
-                        return matched_ != 0;
+                        return matched_ >= matches;
                     });
         }
     }
@@ -564,11 +575,12 @@ private:
             const RTPSWithRegistrationWriter&) = delete;
 
     eprosima::fastrtps::rtps::RTPSParticipant* participant_;
+    eprosima::fastrtps::rtps::RTPSParticipantAttributes participant_attr_;
+    bool destroy_participant_{false};
     eprosima::fastrtps::rtps::RTPSWriter* writer_;
     eprosima::fastrtps::rtps::WriterAttributes writer_attr_;
     eprosima::fastrtps::WriterQos writer_qos_;
     eprosima::fastrtps::TopicAttributes topic_attr_;
-    eprosima::fastrtps::rtps::RTPSParticipantAttributes participant_attr_;
     eprosima::fastrtps::rtps::WriterHistory* history_;
     eprosima::fastrtps::rtps::HistoryAttributes hattr_;
     bool initialized_;

--- a/test/blackbox/common/RTPSWithRegistrationWriter.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationWriter.hpp
@@ -285,8 +285,12 @@ public:
     void wait_discovery(
             std::chrono::seconds timeout = std::chrono::seconds::zero())
     {
+        bool post_assertion = (matched_ == 0 && timeout == std::chrono::seconds::zero()) ? true : false;
         wait_discovery(1, timeout);
-        ASSERT_NE(matched_, 0u);
+        if (post_assertion)
+        {
+            ASSERT_NE(matched_, 0u);
+        }
     }
 
     void wait_discovery(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR provides tests for the participant ignore local endpoints tests
The following changes are expected to fail:
* BlackboxTests_RTPS.RTPS.participant_ignore_local_endpoints
* BlackboxTests_DDS_PIM.DDSBasic.participant_ignore_local_endpoints

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.9.x 2.8.x 2.6.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A*: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- *N/A* Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- *N/A* Check CI results: changes do not issue any warning.
- *N/A* Check CI results: failing tests are unrelated with the changes.
