### PR TITLE
[18259] Calling old `on_participant_discovery` overload

### DIFF
--- a/include/fastdds/dds/domain/DomainParticipantListener.hpp
+++ b/include/fastdds/dds/domain/DomainParticipantListener.hpp
@@ -91,7 +91,8 @@ public:
             fastrtps::rtps::ParticipantDiscoveryInfo&& info,
             bool& should_be_ignored)
     {
-        on_participant_discovery(participant, std::move(info));
+        static_cast<void>(participant);
+        static_cast<void>(info);
         should_be_ignored = false;
     }
 

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1554,11 +1554,16 @@ void DomainParticipantImpl::MyRTPSParticipantListener::onParticipantDiscovery(
         ParticipantDiscoveryInfo&& info,
         bool& should_be_ignored)
 {
+    should_be_ignored = false;
     Sentry sentinel(this);
     if (sentinel)
     {
         participant_->listener_->on_participant_discovery(participant_->participant_, std::move(info),
                 should_be_ignored);
+        if (!should_be_ignored)
+        {
+            participant_->listener_->on_participant_discovery(participant_->participant_, std::move(info));
+        }
     }
 }
 

--- a/versions.md
+++ b/versions.md
@@ -6,6 +6,7 @@ Forthcoming
   Please, use `BUILD_SHARED_LIBS=OFF` instead.
 * Fixed exported symbols on ContentFilteredTopic (ABI break)
 * Deprecated the DDS:Crypto:AES-GCM-GMAC plugin configuration through the DomainParticipant PropertyPolicyQos (security vulnerability).
+* `DomainParticipantListener::on_participant_discovery` changed behavior (fix API break in 2.10.0).
 
 Version 2.10.1
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This should fix #3460 by calling the old overload whenever the new one does not ignore the participant.

Please note that a test that mixes two versions of the product would be difficult to implement, so this fix should be manually checked.

The black-box tests currently use the old overload of the listener, so passing them is enough to check that the old overload is called when the new one has not been overridden.

No need to backport since it only affects 2.10.1.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.9.x 2.6.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    Related documentation PR: eProsima/Fast-DDS-docs#511
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
