### PR TITLE
[18151] Participant ignore local endpoints

### DIFF
--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
@@ -233,7 +233,10 @@ bool EDP::newLocalReaderProxyData(
     }
 
     //PAIRING
-    pairing_reader_proxy_with_any_local_writer(participant_guid, reader_data);
+    if (this->mp_PDP->getRTPSParticipant()->should_match_local_endpoints())
+    {
+        pairing_reader_proxy_with_any_local_writer(participant_guid, reader_data);
+    }
     pairingReader(reader, participant_guid, *reader_data);
     //DO SOME PROCESSING DEPENDING ON THE IMPLEMENTATION (SIMPLE OR STATIC)
     processLocalReaderProxyData(reader, reader_data);
@@ -365,7 +368,10 @@ bool EDP::newLocalWriterProxyData(
     }
 
     //PAIRING
-    pairing_writer_proxy_with_any_local_reader(participant_guid, writer_data);
+    if (this->mp_PDP->getRTPSParticipant()->should_match_local_endpoints())
+    {
+        pairing_writer_proxy_with_any_local_reader(participant_guid, writer_data);
+    }
     pairingWriter(writer, participant_guid, *writer_data);
     //DO SOME PROCESSING DEPENDING ON THE IMPLEMENTATION (SIMPLE OR STATIC)
     processLocalWriterProxyData(writer, writer_data);
@@ -469,7 +475,10 @@ bool EDP::updatedLocalReader(
     if (reader_data != nullptr)
     {
         processLocalReaderProxyData(reader, reader_data);
-        pairing_reader_proxy_with_any_local_writer(participant_guid, reader_data);
+        if (this->mp_PDP->getRTPSParticipant()->should_match_local_endpoints())
+        {
+            pairing_reader_proxy_with_any_local_writer(participant_guid, reader_data);
+        }
         pairingReader(reader, participant_guid, *reader_data);
         return true;
     }
@@ -551,7 +560,10 @@ bool EDP::updatedLocalWriter(
     if (writer_data != nullptr)
     {
         processLocalWriterProxyData(writer, writer_data);
-        pairing_writer_proxy_with_any_local_reader(participant_guid, writer_data);
+        if (this->mp_PDP->getRTPSParticipant()->should_match_local_endpoints())
+        {
+            pairing_writer_proxy_with_any_local_reader(participant_guid, writer_data);
+        }
         pairingWriter(writer, participant_guid, *writer_data);
         return true;
     }
@@ -1065,8 +1077,13 @@ bool EDP::pairingReader(
     EPROSIMA_LOG_INFO(RTPS_EDP, rdata.guid() << " in topic: \"" << rdata.topicName() << "\"");
     std::lock_guard<std::recursive_mutex> pguard(*mp_PDP->getMutex());
 
-    for (ResourceLimitedVector<ParticipantProxyData*>::const_iterator pit = mp_PDP->ParticipantProxiesBegin();
-            pit != mp_PDP->ParticipantProxiesEnd(); ++pit)
+    ResourceLimitedVector<ParticipantProxyData*>::const_iterator pit = mp_PDP->ParticipantProxiesBegin();
+    if (!this->mp_PDP->getRTPSParticipant()->should_match_local_endpoints())
+    {
+        pit++;
+    }
+
+    for (; pit != mp_PDP->ParticipantProxiesEnd(); ++pit)
     {
         for (auto& pair : *(*pit)->m_writers)
         {
@@ -1152,8 +1169,13 @@ bool EDP::pairingWriter(
     EPROSIMA_LOG_INFO(RTPS_EDP, W->getGuid() << " in topic: \"" << wdata.topicName() << "\"");
     std::lock_guard<std::recursive_mutex> pguard(*mp_PDP->getMutex());
 
-    for (ResourceLimitedVector<ParticipantProxyData*>::const_iterator pit = mp_PDP->ParticipantProxiesBegin();
-            pit != mp_PDP->ParticipantProxiesEnd(); ++pit)
+    ResourceLimitedVector<ParticipantProxyData*>::const_iterator pit = mp_PDP->ParticipantProxiesBegin();
+    if (!this->mp_PDP->getRTPSParticipant()->should_match_local_endpoints())
+    {
+        pit++;
+    }
+
+    for (; pit != mp_PDP->ParticipantProxiesEnd(); ++pit)
     {
         for (auto& pair : *(*pit)->m_readers)
         {
@@ -1223,7 +1245,6 @@ bool EDP::pairingWriter(
                         const PublicationMatchedStatus& pub_info =
                                 update_publication_matched_status(reader_guid, writer_guid, -1);
                         W->getListener()->onWriterMatched(W, pub_info);
-
 
                     }
                 }
@@ -1483,7 +1504,6 @@ bool EDP::pairing_writer_proxy_with_any_local_reader(
                                 info.status = MATCHED_MATCHING;
                                 info.remoteEndpointGuid = writer_guid;
                                 r.getListener()->onReaderMatched(&r, info);
-
 
                                 const SubscriptionMatchedStatus& sub_info =
                                 update_subscription_matched_status(readerGUID, writer_guid, 1);

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -734,6 +734,11 @@ private:
      */
     void get_default_unicast_locators();
 
+    bool match_local_endpoints_ = true;
+
+    bool should_match_local_endpoints(
+            const RTPSParticipantAttributes& att);
+
 public:
 
     const RTPSParticipantAttributes& getRTPSParticipantAttributes() const
@@ -1111,6 +1116,11 @@ public:
             uint32_t enabled_writers) override;
 
 #endif // FASTDDS_STATISTICS
+
+    bool should_match_local_endpoints()
+    {
+        return match_local_endpoints_;
+    }
 
 };
 } // namespace rtps

--- a/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
@@ -595,6 +595,21 @@ public:
                 });
     }
 
+    template<class _Rep,
+            class _Period
+            >
+    size_t block_for_all(
+            const std::chrono::duration<_Rep, _Period>& max_wait)
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        cv_.wait_for(lock, max_wait, [this]() -> bool
+                {
+                    return number_samples_expected_ == current_received_count_;
+                });
+
+        return current_received_count_;
+    }
+
     void block(
             std::function<bool()> checker)
     {
@@ -615,6 +630,32 @@ public:
 
         ASSERT_GE(matched_readers_.size() + matched_writers_.size(), 2u);
         std::cout << "Discovery finished..." << std::endl;
+    }
+
+    void wait_discovery(
+            size_t matches,
+            std::chrono::seconds timeout = std::chrono::seconds::zero())
+    {
+        std::unique_lock<std::mutex> lock(mutexDiscovery_);
+
+        std::cout << "Waiting discovery for " << matches << " matches..." << std::endl;
+
+        if (timeout == std::chrono::seconds::zero())
+        {
+            cv_.wait(lock, [&]()
+                    {
+                        return matched_readers_.size() >= matches && matched_writers_.size() >= matches;
+                    });
+        }
+        else
+        {
+            cv_.wait_for(lock, timeout, [&]()
+                    {
+                        return matched_readers_.size() >= matches && matched_writers_.size() >= matches;
+                    });
+        }
+
+        std::cout << "Finished waiting for discovery" << std::endl;
     }
 
     void waitRemoval()

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -21,7 +21,6 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-
 #include <fastdds/core/policy/ParameterSerializer.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
@@ -43,8 +42,9 @@
 #include <fastrtps/types/TypesBase.h>
 
 #include "BlackboxTests.hpp"
-#include "../api/dds-pim/PubSubWriter.hpp"
 #include "../api/dds-pim/PubSubReader.hpp"
+#include "../api/dds-pim/PubSubWriter.hpp"
+#include "../api/dds-pim/PubSubWriterReader.hpp"
 #include "../types/FixedSized.h"
 #include "../types/FixedSizedPubSubTypes.h"
 #include "../types/HelloWorldPubSubTypes.h"
@@ -546,6 +546,154 @@ TEST(DDSBasic, IgnoreParticipant)
     factory->delete_participant(participant_listener);
     factory->delete_participant(participant_ign);
 
+}
+
+/**
+ * @test This test checks the ignore local endpoints feature on the RTPS layer when writer and
+ *       reader are under the same participant. Corresponds with tests:
+ *          * PART-IGNORE-LOCAL-TEST:01
+ *          * PART-IGNORE-LOCAL-TEST:02
+ *          * PART-IGNORE-LOCAL-TEST:03
+ */
+TEST(DDSBasic, participant_ignore_local_endpoints)
+{
+    class CustomLogConsumer : public LogConsumer
+    {
+    public:
+
+        void Consume(
+                const Log::Entry&) override
+        {
+            logs_consumed_++;
+            cv_.notify_all();
+        }
+
+        size_t wait_for_entries(
+                uint32_t amount,
+                const std::chrono::duration<double>& max_wait)
+        {
+            std::unique_lock<std::mutex> lock(mtx_);
+            cv_.wait_for(lock, max_wait, [this, amount]() -> bool
+                    {
+                        return logs_consumed_ > 0 && logs_consumed_.load() == amount;
+                    });
+            return logs_consumed_.load();
+        }
+
+    protected:
+
+        std::atomic<size_t> logs_consumed_{0u};
+        std::mutex mtx_;
+        std::condition_variable cv_;
+    };
+
+    struct Config
+    {
+        std::string test_id;
+        std::string property_value;
+        uint8_t log_errors;
+        uint8_t expected_matched_endpoints;
+        uint8_t sent_samples;
+        uint8_t expected_received_samples;
+    };
+
+    std::vector<Config> tests_configs = {
+        {"PART-IGNORE-LOCAL-TEST:01", "true", 0, 0, 5, 0},
+        {"PART-IGNORE-LOCAL-TEST:02", "false", 0, 1, 5, 5},
+        {"PART-IGNORE-LOCAL-TEST:03", "asdfg", 1, 1, 5, 5}
+    };
+
+    for (Config test_config : tests_configs)
+    {
+        std::cout << std::endl;
+        std::cout << "---------------------------------------" << std::endl;
+        std::cout << "Running test: " << test_config.test_id << std::endl;
+        std::cout << "---------------------------------------" << std::endl;
+
+        /* Set up */
+        Log::Reset();
+        Log::SetVerbosity(Log::Error);
+        CustomLogConsumer* log_consumer = new CustomLogConsumer();
+        std::unique_ptr<CustomLogConsumer> log_consumer_unique_ptr(log_consumer);
+        Log::RegisterConsumer(std::move(log_consumer_unique_ptr));
+
+        // Create the DomainParticipant with the appropriate value for the property
+        PubSubWriterReader<HelloWorldPubSubType> writer_reader(TEST_TOPIC_NAME);
+        eprosima::fastrtps::rtps::PropertyPolicy property_policy;
+        property_policy.properties().emplace_back("fastdds.ignore_local_endpoints", test_config.property_value);
+        writer_reader.property_policy(property_policy);
+
+        /* Procedure */
+        // Create the DataWriter & DataReader
+        writer_reader.init();
+        EXPECT_TRUE(writer_reader.isInitialized());
+
+        // Wait for discovery
+        writer_reader.wait_discovery(test_config.expected_matched_endpoints, std::chrono::seconds(1));
+        EXPECT_EQ(writer_reader.get_publication_matched(), test_config.expected_matched_endpoints);
+        EXPECT_EQ(writer_reader.get_subscription_matched(), test_config.expected_matched_endpoints);
+
+        // Send samples
+        auto samples = default_helloworld_data_generator(test_config.sent_samples);
+        writer_reader.startReception(samples);
+        writer_reader.send(samples);
+        EXPECT_TRUE(samples.empty());
+
+        // Wait for reception
+        EXPECT_EQ(writer_reader.block_for_all(std::chrono::seconds(1)), test_config.expected_received_samples);
+
+        // Wait for log entries
+        EXPECT_EQ(log_consumer->wait_for_entries(test_config.log_errors, std::chrono::seconds(
+                    1)), test_config.log_errors);
+
+        /* Tear-down */
+        Log::Reset();
+    }
+}
+
+/**
+ * @test This test checks the ignore local endpoints feature on the RTPS layer when writer and
+ *       reader are under the different participant. Corresponds with test:
+ *          * PART-IGNORE-LOCAL-TEST:07
+ */
+TEST(DDSBasic, participant_ignore_local_endpoints_two_participants)
+{
+    std::cout << std::endl;
+    std::cout << "---------------------------------------" << std::endl;
+    std::cout << "Running test: PART-IGNORE-LOCAL-TEST:07" << std::endl;
+    std::cout << "---------------------------------------" << std::endl;
+
+    /* Set up */
+
+    // Create the DomainParticipants with the appropriate value for the property
+    eprosima::fastrtps::rtps::PropertyPolicy property_policy;
+    property_policy.properties().emplace_back("fastdds.ignore_local_endpoints", "true");
+    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+    writer.property_policy(property_policy);
+    reader.property_policy(property_policy);
+
+    /* Procedure */
+    // Create the DataWriter & DataReader
+    writer.init();
+    EXPECT_TRUE(writer.isInitialized());
+    reader.init();
+    EXPECT_TRUE(reader.isInitialized());
+
+    // Wait for discovery
+    writer.wait_discovery(std::chrono::seconds(1));
+    reader.wait_discovery(std::chrono::seconds(1));
+    EXPECT_EQ(writer.get_matched(), 1);
+    EXPECT_EQ(reader.get_matched(), 1);
+
+    // Send samples
+    auto samples = default_helloworld_data_generator(5);
+    reader.startReception(samples);
+    writer.send(samples);
+    EXPECT_TRUE(samples.empty());
+
+    // Wait for reception
+    EXPECT_EQ(reader.block_for_all(std::chrono::seconds(1)), 5);
 }
 
 } // namespace dds

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -683,8 +683,8 @@ TEST(DDSBasic, participant_ignore_local_endpoints_two_participants)
     // Wait for discovery
     writer.wait_discovery(std::chrono::seconds(1));
     reader.wait_discovery(std::chrono::seconds(1));
-    EXPECT_EQ(writer.get_matched(), 1);
-    EXPECT_EQ(reader.get_matched(), 1);
+    EXPECT_EQ(writer.get_matched(), 1u);
+    EXPECT_EQ(reader.get_matched(), 1u);
 
     // Send samples
     auto samples = default_helloworld_data_generator(5);

--- a/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
@@ -27,6 +27,7 @@
 #include <fastdds/rtps/participant/RTPSParticipant.h>
 #include <fastdds/rtps/RTPSDomain.h>
 #include <fastdds/rtps/transport/test_UDPv4TransportDescriptor.h>
+#include <fastrtps/log/Log.h>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 
 #include "RTPSAsSocketReader.hpp"
@@ -756,7 +757,6 @@ TEST(RTPS, RemoveDisabledParticipant)
     ASSERT_TRUE(RTPSDomain::removeRTPSParticipant(rtps_participant));
 }
 
-
 /**
  * This test checks a race condition on initializing a writer's flow controller when creating
  * several RTPSWriters in parallel: https://eprosima.easyredmine.com/issues/15905
@@ -894,7 +894,6 @@ TEST(RTPS, RTPSCorrectGAPProcessing)
     ASSERT_NO_FATAL_FAILURE(native_reader.processGapMsg(writer.guid(), {0, 0}, seq_set));
 }
 
-
 class CustomReaderDataFilter : public eprosima::fastdds::rtps::IReaderDataFilter
 {
 public:
@@ -1010,6 +1009,176 @@ TEST(RTPS, best_effort_has_been_fully_delivered)
 TEST(RTPS, reliable_has_been_fully_delivered)
 {
     has_been_fully_delivered_test(ReliabilityKind_t::RELIABLE);
+}
+
+/**
+ * @test This test checks the ignore local endpoints feature on the RTPS layer when writer and
+ *       reader are under the same participant. Corresponds with tests:
+ *          * PART-IGNORE-LOCAL-TEST:04
+ *          * PART-IGNORE-LOCAL-TEST:05
+ *          * PART-IGNORE-LOCAL-TEST:06
+ */
+TEST(RTPS, participant_ignore_local_endpoints)
+{
+    class CustomLogConsumer : public LogConsumer
+    {
+    public:
+
+        void Consume(
+                const Log::Entry&) override
+        {
+            logs_consumed_++;
+            cv_.notify_all();
+        }
+
+        size_t wait_for_entries(
+                uint32_t amount,
+                const std::chrono::duration<double>& max_wait)
+        {
+            std::unique_lock<std::mutex> lock(mtx_);
+            cv_.wait_for(lock, max_wait, [this, amount]() -> bool
+                    {
+                        return logs_consumed_ > 0 && logs_consumed_.load() == amount;
+                    });
+            return logs_consumed_.load();
+        }
+
+    protected:
+
+        std::atomic<size_t> logs_consumed_{0u};
+        std::mutex mtx_;
+        std::condition_variable cv_;
+    };
+
+    struct Config
+    {
+        std::string test_id;
+        std::string property_value;
+        uint8_t log_errors;
+        uint8_t expected_matched_endpoints;
+        uint8_t sent_samples;
+        uint8_t expected_received_samples;
+    };
+
+    std::vector<Config> tests_configs = {
+        {"PART-IGNORE-LOCAL-TEST:04", "true", 0, 0, 5, 0},
+        {"PART-IGNORE-LOCAL-TEST:05", "false", 0, 1, 5, 5},
+        {"PART-IGNORE-LOCAL-TEST:06", "asdfg", 1, 1, 5, 5}
+    };
+
+    for (Config test_config : tests_configs)
+    {
+        std::cout << std::endl;
+        std::cout << "---------------------------------------" << std::endl;
+        std::cout << "Running test: " << test_config.test_id << std::endl;
+        std::cout << "---------------------------------------" << std::endl;
+
+        /* Set up */
+        Log::Reset();
+        Log::SetVerbosity(Log::Error);
+        CustomLogConsumer* log_consumer = new CustomLogConsumer();
+        std::unique_ptr<CustomLogConsumer> log_consumer_unique_ptr(log_consumer);
+        Log::RegisterConsumer(std::move(log_consumer_unique_ptr));
+
+        // Create the RTPSParticipant with the appropriate value for the property
+        eprosima::fastrtps::rtps::RTPSParticipantAttributes patt;
+        patt.properties.properties().emplace_back("fastdds.ignore_local_endpoints", test_config.property_value);
+        eprosima::fastrtps::rtps::RTPSParticipant* participant =
+                eprosima::fastrtps::rtps::RTPSDomain::createParticipant(static_cast<uint32_t>(GET_PID()) % 230, patt);
+        ASSERT_NE(participant, nullptr);
+
+        /* Procedure */
+        // Create the RTPSWriter
+        RTPSWithRegistrationWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME, participant);
+        writer.init();
+        EXPECT_TRUE(writer.isInitialized());
+
+        // Create the RTPSReader
+        RTPSWithRegistrationReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME, participant);
+        reader.init();
+        EXPECT_TRUE(reader.isInitialized());
+
+        // Wait for discovery
+        writer.wait_discovery(test_config.expected_matched_endpoints, std::chrono::seconds(1));
+        reader.wait_discovery(test_config.expected_matched_endpoints, std::chrono::seconds(1));
+        EXPECT_EQ(writer.get_matched(), test_config.expected_matched_endpoints);
+        EXPECT_EQ(reader.get_matched(), test_config.expected_matched_endpoints);
+
+        // Send samples
+        auto samples = default_helloworld_data_generator(test_config.sent_samples);
+        reader.expected_data(samples);
+        reader.startReception(samples.size());
+        writer.send(samples);
+        EXPECT_TRUE(samples.empty());
+
+        // Wait for reception
+        reader.block_for_all(std::chrono::seconds(1));
+        EXPECT_EQ(reader.getReceivedCount(), test_config.expected_received_samples);
+
+        // Wait for log entries
+        EXPECT_EQ(log_consumer->wait_for_entries(test_config.log_errors, std::chrono::seconds(
+                    1)), test_config.log_errors);
+
+        /* Tear-down */
+        eprosima::fastrtps::rtps::RTPSDomain::removeRTPSParticipant(participant);
+        Log::Reset();
+    }
+}
+
+/**
+ * @test This test checks the ignore local endpoints feature on the RTPS layer when writer and
+ *       reader are under the different participant. Corresponds with test:
+ *          * PART-IGNORE-LOCAL-TEST:08
+ */
+TEST(RTPS, participant_ignore_local_endpoints_two_participants)
+{
+    std::cout << std::endl;
+    std::cout << "---------------------------------------" << std::endl;
+    std::cout << "Running test: PART-IGNORE-LOCAL-TEST:08" << std::endl;
+    std::cout << "---------------------------------------" << std::endl;
+
+    /* Set up */
+    // Create the RTPSParticipants with the appropriate value for the property
+    eprosima::fastrtps::rtps::RTPSParticipantAttributes patt;
+    patt.properties.properties().emplace_back("fastdds.ignore_local_endpoints", "true");
+    eprosima::fastrtps::rtps::RTPSParticipant* participant_writer =
+            eprosima::fastrtps::rtps::RTPSDomain::createParticipant(static_cast<uint32_t>(GET_PID()) % 230, patt);
+    ASSERT_NE(participant_writer, nullptr);
+    eprosima::fastrtps::rtps::RTPSParticipant* participant_reader =
+            eprosima::fastrtps::rtps::RTPSDomain::createParticipant(static_cast<uint32_t>(GET_PID()) % 230, patt);
+    ASSERT_NE(participant_reader, nullptr);
+
+    /* Procedure */
+    // Create the RTPSWriter
+    RTPSWithRegistrationWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME, participant_writer);
+    writer.init();
+    EXPECT_TRUE(writer.isInitialized());
+
+    // Create the RTPSReader
+    RTPSWithRegistrationReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME, participant_reader);
+    reader.init();
+    EXPECT_TRUE(reader.isInitialized());
+
+    // Wait for discovery
+    writer.wait_discovery(1, std::chrono::seconds(1));
+    reader.wait_discovery(1, std::chrono::seconds(1));
+    EXPECT_EQ(writer.get_matched(), 1);
+    EXPECT_EQ(reader.get_matched(), 1);
+
+    // Send samples
+    auto samples = default_helloworld_data_generator(5);
+    reader.expected_data(samples);
+    reader.startReception(samples.size());
+    writer.send(samples);
+    EXPECT_TRUE(samples.empty());
+
+    // Wait for reception
+    reader.block_for_all(std::chrono::seconds(1));
+    EXPECT_EQ(reader.getReceivedCount(), 5);
+
+    /* Tear-down */
+    eprosima::fastrtps::rtps::RTPSDomain::removeRTPSParticipant(participant_writer);
+    eprosima::fastrtps::rtps::RTPSDomain::removeRTPSParticipant(participant_reader);
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P

--- a/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
@@ -1162,8 +1162,8 @@ TEST(RTPS, participant_ignore_local_endpoints_two_participants)
     // Wait for discovery
     writer.wait_discovery(1, std::chrono::seconds(1));
     reader.wait_discovery(1, std::chrono::seconds(1));
-    EXPECT_EQ(writer.get_matched(), 1);
-    EXPECT_EQ(reader.get_matched(), 1);
+    EXPECT_EQ(writer.get_matched(), 1u);
+    EXPECT_EQ(reader.get_matched(), 1u);
 
     // Send samples
     auto samples = default_helloworld_data_generator(5);
@@ -1174,7 +1174,7 @@ TEST(RTPS, participant_ignore_local_endpoints_two_participants)
 
     // Wait for reception
     reader.block_for_all(std::chrono::seconds(1));
-    EXPECT_EQ(reader.getReceivedCount(), 5);
+    EXPECT_EQ(reader.getReceivedCount(), 5u);
 
     /* Tear-down */
     eprosima::fastrtps::rtps::RTPSDomain::removeRTPSParticipant(participant_writer);

--- a/test/mock/rtps/PDP/fastdds/rtps/builtin/discovery/participant/PDP.h
+++ b/test/mock/rtps/PDP/fastdds/rtps/builtin/discovery/participant/PDP.h
@@ -86,6 +86,8 @@ public:
 
     MOCK_METHOD0(ParticipantProxiesEnd, ResourceLimitedVector<ParticipantProxyData*>::const_iterator());
 
+    MOCK_METHOD(RTPSParticipantImpl*, getRTPSParticipant, (), (const));
+
     ProxyPool<ReaderProxyData>& get_temporary_reader_proxies_pool()
     {
         return temp_proxy_readers;
@@ -104,7 +106,6 @@ public:
     ProxyPool<ReaderProxyData> temp_proxy_readers = {{4, 1}};
     ProxyPool<WriterProxyData> temp_proxy_writers = {{4, 1}};
 };
-
 
 } //namespace rtps
 } //namespace fastrtps

--- a/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
+++ b/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
@@ -308,6 +308,8 @@ public:
         return f;
     }
 
+    MOCK_METHOD(bool, should_match_local_endpoints, ());
+
 private:
 
     MockParticipantListener listener_;

--- a/versions.md
+++ b/versions.md
@@ -1,6 +1,8 @@
 Forthcoming
 -----------
 
+* Added Participant ignore local endpoints feature.
+
 Version 2.10.1
 --------------
 
@@ -17,7 +19,7 @@ Version 2.10.0
 * Added ignore RTPS entity API in RTPSParticipant (ABI break on RTPS layer).
 * Overload `PDP::removeWriterProxyData` and `PDP::removeReaderProxyData` (ABI break on RTPS layer).
 * Overload RTPS discovery callbacks in RTPSParticipantListener (ABI break on RTPS layer).
-* Overload DDS discovery callbacks in DomainParticipantListener (ABI break on DDS layer). 
+* Overload DDS discovery callbacks in DomainParticipantListener (ABI break on DDS layer).
 * Added on_incompatible_type to RTPS listeners (ABI break on RTPS layer).
 * Added support for QNX 7.1 build.
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds functionality for instructing a DomainParticipant/RTPSParticipant to not match their compatible local endpoints.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.9.x 2.6.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    * Related documentation PR: eProsima/Fast-DDS-docs#485
- *N/A* Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
