### PR TITLE
[18674] Fixes on XML schema

### DIFF
--- a/resources/xsd/fastRTPS_profiles.xsd
+++ b/resources/xsd/fastRTPS_profiles.xsd
@@ -1127,7 +1127,6 @@
         ├ lifespan                    [0~1],
         ├ liveliness                  [0~1],
         ├ ownership                   [0~1],
-        ├ ownershipStrength           [0~1],
         ├ partition                   [0~1],
         ├ presentation                [0~1] NOT SUPPORTED YET: COMMENTED,
         ├ reliability                 [0~1],
@@ -1148,7 +1147,6 @@
             <xs:element name="lifespan" type="lifespanQosPolicyType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="liveliness" type="livelinessQosPolicyType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="ownership" type="ownershipQosPolicyType" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="ownershipStrength" type="ownershipStrengthQosPolicyType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="partition" type="partitionQosPolicyType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="presentation" type="presentationQosPolicyType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="reliability" type="reliabilityQosPolicyType" minOccurs="0" maxOccurs="1"/>

--- a/resources/xsd/fastRTPS_profiles.xsd
+++ b/resources/xsd/fastRTPS_profiles.xsd
@@ -1120,7 +1120,7 @@
         ├ destination_order           [0~1] NOT SUPPORTED YET: COMMENTED,
         ├ disablePositiveAcks         [0~1],
         ├ durability                  [0~1],
-        ├ durability_service          [0~1] NOT SUPPORTED YET: COMMENTED,
+        ├ durabilityService           [0~1] NOT SUPPORTED YET: COMMENTED,
         ├ entity_factory              [0~1] NOT SUPPORTED YET: COMMENTED,
         ├ groupData                   [0~1],
         ├ latencyBudget               [0~1],
@@ -1131,16 +1131,17 @@
         ├ partition                   [0~1],
         ├ presentation                [0~1] NOT SUPPORTED YET: COMMENTED,
         ├ reliability                 [0~1],
+        ├ timeBasedFilter             [0~1],
         ├ topicData                   [0~1],
         └ userData                    [0~1] -->
     <xs:complexType name="dataReaderQosPoliciesType">
         <xs:all>
             <xs:element name="data_sharing" type="dataSharingQosPolicyType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="deadline" type="deadlineQosPolicyType" minOccurs="0" maxOccurs="1"/>
-            <!-- <xs:element name="destination_order" type="destinationOrderQosPolicyType" minOccurs="0" maxOccurs="1"/> -->
+            <xs:element name="destination_order" type="destinationOrderQosPolicyType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="disablePositiveAcks" type="disablePositiveAcksQosPolicyType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="durability" type="durabilityQosPolicyType" minOccurs="0" maxOccurs="1"/>
-            <!-- <xs:element name="durability_service" type="durabilityServiceQosPolicyType" minOccurs="0" maxOccurs="1"/> -->
+            <xs:element name="durabilityService" type="durabilityServiceQosPolicyType" minOccurs="0" maxOccurs="1"/>
             <!-- <xs:element name="entity_factory" type="entityFactoryQoSPolicyType" minOccurs="0" maxOccurs="1"/> -->
             <xs:element name="groupData" type="octectVectorQosPolicyType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="latencyBudget" type="latencyBudgetQosPolicyType" minOccurs="0" maxOccurs="1"/>
@@ -1149,8 +1150,9 @@
             <xs:element name="ownership" type="ownershipQosPolicyType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="ownershipStrength" type="ownershipStrengthQosPolicyType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="partition" type="partitionQosPolicyType" minOccurs="0" maxOccurs="1"/>
-            <!-- <xs:element name="presentation" type="presentationQosPolicyType" minOccurs="0" maxOccurs="1"/> -->
+            <xs:element name="presentation" type="presentationQosPolicyType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="reliability" type="reliabilityQosPolicyType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="timeBasedFilter" type="timeBasedFilterQosPolicyType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="topicData" type="octectVectorQosPolicyType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="userData" type="octectVectorQosPolicyType" minOccurs="0" maxOccurs="1"/>
         </xs:all>

--- a/test/system/tools/xmlvalidation/all_profile.xml
+++ b/test/system/tools/xmlvalidation/all_profile.xml
@@ -644,16 +644,12 @@
                     <kind>EXCLUSIVE</kind>
                 </ownership>
 
-                <ownershipStrength>
-                    <value>50</value>
-                </ownershipStrength>
-
                 <latencyBudget>
                     <duration>
                         <sec>1</sec>
                     </duration>
                 </latencyBudget>
-                
+
                 <disablePositiveAcks>
                     <enabled>true</enabled>
                     <duration>

--- a/test/system/tools/xmlvalidation/dataReader_profile.xml
+++ b/test/system/tools/xmlvalidation/dataReader_profile.xml
@@ -60,10 +60,6 @@
                     <kind>EXCLUSIVE</kind>
                 </ownership>
 
-                <ownershipStrength>
-                    <value>50</value>
-                </ownershipStrength>
-
                 <latencyBudget>
                     <duration>
                         <sec>1</sec>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Recent change in the endpoint QoS XML schema (#3492) was not considered while merging new XML schema supported tags (#3399).
This hotfix would include the new definition in both endpoint QoS XML schema. 

It also removes ownership strength from DataReadeQoS

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.10.x 

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    Related documentation PR: eProsima/Fast-DDS-docs#495
- [x] Applicable backports have been included in the description.
   Backport 2.10.x


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
