### PR TITLE
Adds logic for delayed reconciliation of unassociated readers and writers

### DIFF
--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
@@ -518,6 +518,20 @@ protected:
     std::vector<eprosima::fastrtps::rtps::GUID_t> get_readers_in_topic(
             const std::string& topic_name);
 
+    // Reconciles as-yet unassociated writers with their participants and matched readers
+    void reconcile_unassociated_writers();
+
+    // Reconciles writer information with its own participant and matched writers
+    bool reconcile_writer(
+            const eprosima::fastrtps::rtps::GUID_t& writer_guid);
+
+    // Reconciles as-yet unassociated readers with their participants and matched writers
+    void reconcile_unassociated_readers();
+
+    // Reconciles reader information with its own participant and matches remote writers
+    bool reconcile_reader(
+            const eprosima::fastrtps::rtps::GUID_t& reader_guid);
+
     ////////////////
     // Variables
 
@@ -541,6 +555,8 @@ protected:
     //  - stores the topic name (only matching criteria available)
     std::map<eprosima::fastrtps::rtps::GUID_t, DiscoveryEndpointInfo> readers_;
     std::map<eprosima::fastrtps::rtps::GUID_t, DiscoveryEndpointInfo> writers_;
+    std::vector<eprosima::fastrtps::rtps::GUID_t> unassociated_readers_;
+    std::vector<eprosima::fastrtps::rtps::GUID_t> unassociated_writers_;
 
     //! Collection of topics whose related endpoints have changed and require a match recalculation
     std::vector<std::string> dirty_topics_;

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryEndpointInfo.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryEndpointInfo.hpp
@@ -57,7 +57,7 @@ public:
     {
     }
 
-    const std::string topic()
+    const std::string topic() const
     {
         return topic_;
     }


### PR DESCRIPTION
(cherry picked from commit 4bb698e2a23fdc3a4d9907b49064492ffbdc8913)

## Description

For a description of the issue resolved here, see https://github.com/eProsima/Fast-DDS/issues/3544

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [ ] Applicable backports have been included in the description.


## Reviewer Checklist
- [ ] The PR has a milestone assigned.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
