### PR TITLE
[18725] Added documentation version fallback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -502,12 +502,23 @@ if(BUILD_DOCUMENTATION)
 
         file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/readthedocs_custom_template.cmake [=[
 
-            file(DOWNLOAD "https://fast-dds.docs.eprosima.com/_/downloads/en/v${PROJECT_VERSION}/htmlzip/" "./eprosima-fast-rtps.zip")
+            file(DOWNLOAD "https://fast-dds.docs.eprosima.com/_/downloads/en/v${PROJECT_VERSION}/htmlzip/" "./eprosima-fast-rtps.zip"
+                 STATUS DOWNLOAD_STATUS)
+            list(GET DOWNLOAD_STATUS 0 DOWNLOAD_RC)
+            
+            if (DOWNLOAD_RC)
+                message(STATUS "Unable to download documentation for version ${PROJECT_VERSION}. Falling back to master")
+                file(DOWNLOAD "https://fast-dds.docs.eprosima.com/_/downloads/en/master/htmlzip/" "./eprosima-fast-rtps.zip")
+            endif()
             # TODO: when windows ci CMake version surpasses 17 favor file() instead of UNZIP as in the next line
             # file(ARCHIVE_EXTRACT INPUT "./eprosima-fast-rtps.zip" DESTINATION  "${PROJECT_BINARY_DIR}/doc/")
             execute_process(COMMAND "${UNZIP_EXE}" "./eprosima-fast-rtps.zip" -d "${PROJECT_BINARY_DIR}/doc/")
             file(REMOVE_RECURSE "${PROJECT_BINARY_DIR}/doc/manual")
-            file(RENAME "${PROJECT_BINARY_DIR}/doc/eprosima-fast-rtps-v${PROJECT_VERSION}" "${PROJECT_BINARY_DIR}/doc/manual")
+            if (DOWNLOAD_RC)
+                file(RENAME "${PROJECT_BINARY_DIR}/doc/eprosima-fast-rtps-master" "${PROJECT_BINARY_DIR}/doc/manual")
+            else()
+                file(RENAME "${PROJECT_BINARY_DIR}/doc/eprosima-fast-rtps-v${PROJECT_VERSION}" "${PROJECT_BINARY_DIR}/doc/manual")
+            endif()
             file(REMOVE  "./eprosima-fast-rtps.zip")
 
             ]=])

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -504,18 +504,22 @@ if(BUILD_DOCUMENTATION)
 
             file(DOWNLOAD "https://fast-dds.docs.eprosima.com/_/downloads/en/v${PROJECT_VERSION}/htmlzip/" "./eprosima-fast-rtps.zip"
                  STATUS DOWNLOAD_STATUS)
+
+            # As stated in CMake's documentation: https://cmake.org/cmake/help/latest/command/file.html#transfer
+            # STATUS will return a list with two elements: the numeric status and the message returned.
+            # A 0 numeric error means no error in the operation 
             list(GET DOWNLOAD_STATUS 0 DOWNLOAD_RC)
             
             if (DOWNLOAD_RC)
-                message(STATUS "Unable to download documentation for version ${PROJECT_VERSION}. Falling back to master")
-                file(DOWNLOAD "https://fast-dds.docs.eprosima.com/_/downloads/en/master/htmlzip/" "./eprosima-fast-rtps.zip")
+                message(STATUS "Unable to download documentation for version ${PROJECT_VERSION}. Falling back to latest.")
+                file(DOWNLOAD "https://fast-dds.docs.eprosima.com/_/downloads/en/latest/htmlzip/" "./eprosima-fast-rtps.zip")
             endif()
             # TODO: when windows ci CMake version surpasses 17 favor file() instead of UNZIP as in the next line
             # file(ARCHIVE_EXTRACT INPUT "./eprosima-fast-rtps.zip" DESTINATION  "${PROJECT_BINARY_DIR}/doc/")
             execute_process(COMMAND "${UNZIP_EXE}" "./eprosima-fast-rtps.zip" -d "${PROJECT_BINARY_DIR}/doc/")
             file(REMOVE_RECURSE "${PROJECT_BINARY_DIR}/doc/manual")
             if (DOWNLOAD_RC)
-                file(RENAME "${PROJECT_BINARY_DIR}/doc/eprosima-fast-rtps-master" "${PROJECT_BINARY_DIR}/doc/manual")
+                file(RENAME "${PROJECT_BINARY_DIR}/doc/eprosima-fast-rtps-latest" "${PROJECT_BINARY_DIR}/doc/manual")
             else()
                 file(RENAME "${PROJECT_BINARY_DIR}/doc/eprosima-fast-rtps-v${PROJECT_VERSION}" "${PROJECT_BINARY_DIR}/doc/manual")
             endif()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Currently, documentation builds fail if the current version of Fast DDS does not have a matching tag in ReadTheDocs. This complicated the process of generating testing. 

This PR adds a mechanism to get the current `master` branch from ReadTheDocs should the current version download fail. 

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.10.x 2.9.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [NA] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [NA] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [NA] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [NA] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [NA] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [NA] New feature has been added to the `versions.md` file (if applicable).
- [NA] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [NA] Applicable backports have been included in the description.


## Reviewer Checklist
- [ ] The PR has a milestone assigned.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
