### PR TITLE
[18765] Use unrestricted permissions when creating shared memory segments

### DIFF
--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -2101,7 +2101,7 @@ void DomainParticipantImpl::on_child_requests_finished(
         {
             // Or a top-level request?
             // auto cb_it = register_callbacks_.find(parent);
-            if (pending_requests_it->second.size() < 2)
+            if (parent_requests_.end() != pending_requests_it && pending_requests_it->second.size() < 2)
             {
                 parent_requests_.erase(pending_requests_it);
             }


### PR DESCRIPTION
Use unrestricted permissions when creating mutexes, locks and shared memory segments to allow applications started by different users to communicate.