### PR TITLE
Distinguished names comparator [18789]

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -295,6 +295,7 @@ set(${PROJECT_NAME}_security_source_files
     rtps/builtin/discovery/participant/DS/PDPSecurityInitiatorListener.cpp
     security/authentication/PKIDH.cpp
     security/accesscontrol/Permissions.cpp
+    security/accesscontrol/DistinguishedName.cpp
     security/cryptography/AESGCMGMAC.cpp
     security/cryptography/AESGCMGMAC_KeyExchange.cpp
     security/cryptography/AESGCMGMAC_KeyFactory.cpp

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -357,7 +357,11 @@ bool SecurityManager::init(
                 }
             }
 
-            throw exception;
+            // NOTE: This makes Participant creation fails, in some occasions without any info of what happened.
+            // However, it has been decided to leave it this way.
+            // For future developers struggling with security debugging issues, remember that the exception variable
+            // at this point has relevant information.
+            throw false;
         }
         else
         {

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -343,9 +343,21 @@ bool SecurityManager::init(
                     // Should be activated here, to enable encription buffer on created entities
                     throw true;
                 }
+                else
+                {
+                    if (access_plugin_ != nullptr && local_permissions_handle_ == nullptr)
+                    {
+                        EPROSIMA_LOG_ERROR(SECURITY, "Participant is not allowed with its own permissions file.");
+                    }
+
+                    if (crypto_plugin_ != nullptr && local_participant_crypto_handle_ == nullptr)
+                    {
+                        EPROSIMA_LOG_ERROR(SECURITY, "Participant cryptography could not be configured.");
+                    }
+                }
             }
 
-            throw false;
+            throw exception;
         }
         else
         {

--- a/src/cpp/security/accesscontrol/DistinguishedName.cpp
+++ b/src/cpp/security/accesscontrol/DistinguishedName.cpp
@@ -28,7 +28,7 @@ namespace fastrtps {
 namespace rtps {
 namespace security {
 
-namespace details {
+namespace detail {
 
 Attribute::Attribute(
         const DistinguishedName& name)
@@ -216,12 +216,16 @@ Attribute Attribute::cut(
     return res;
 }
 
+std::ostream& operator<<(std::ostream& os, const Attribute& att)
+{
+    os.write(att.value, att.length);
+    return os;
+}
+
 bool DistinguishedNameSpecialized::compare(
         const DistinguishedName& name1,
         const DistinguishedName& name2) noexcept
 {
-    DistinguishedNameSpecialized dns1(name1);
-    DistinguishedNameSpecialized dns2(name2);
     return DistinguishedNameSpecialized(name1) == DistinguishedNameSpecialized(name2);
 }
 
@@ -374,13 +378,13 @@ bool DistinguishedNameSpecialized::operator ==(
     return true;
 }
 
-} //namespace details
+} //namespace detail
 
 bool rfc2253_string_compare(
         const DistinguishedName& name1,
         const DistinguishedName& name2)
 {
-    return details::DistinguishedNameSpecialized::compare(name1, name2);
+    return detail::DistinguishedNameSpecialized::compare(name1, name2);
 }
 
 } //namespace security

--- a/src/cpp/security/accesscontrol/DistinguishedName.cpp
+++ b/src/cpp/security/accesscontrol/DistinguishedName.cpp
@@ -239,19 +239,19 @@ DistinguishedNameSpecialized::DistinguishedNameSpecialized(
 
     switch (res)
     {
-        case ErrorCase::max_value:
+        case ErrorCase::MAX_VALUE:
             EPROSIMA_LOG_ERROR(
                 SECURITY,
                 "DistinguishedName " << name << " have more type-values attributes than allowed.");
             break;
 
-        case ErrorCase::empty:
+        case ErrorCase::EMPTY:
             EPROSIMA_LOG_ERROR(
                 SECURITY,
                 "DistinguishedName " << name << " has an empty field.");
             break;
 
-        case ErrorCase::no_type_value_format:
+        case ErrorCase::NO_TYPE_VALUE_FORMAT:
             EPROSIMA_LOG_ERROR(
                 SECURITY,
                 "DistinguishedName " << name << " has incorrect format.");
@@ -270,13 +270,13 @@ DistinguishedNameSpecialized::ErrorCase DistinguishedNameSpecialized::find_and_a
     // If input has finished, stop
     if (!rest.is_set())
     {
-        return ErrorCase::empty;
+        return ErrorCase::EMPTY;
     }
 
     // If this object is already full, failure (no exception to follow fast policy)
     if (size() >= MAX_VALUES_)
     {
-        return ErrorCase::max_value;
+        return ErrorCase::MAX_VALUE;
     }
 
     //////////////////////////////////////////
@@ -289,7 +289,7 @@ DistinguishedNameSpecialized::ErrorCase DistinguishedNameSpecialized::find_and_a
     index = rest.find('=', found);
     if (!found)
     {
-        return ErrorCase::no_type_value_format;
+        return ErrorCase::NO_TYPE_VALUE_FORMAT;
     }
     Attribute type = Attribute::cut(rest, 0, index);
     rest.cut(index + 1);
@@ -301,7 +301,7 @@ DistinguishedNameSpecialized::ErrorCase DistinguishedNameSpecialized::find_and_a
     {
         // Last element found, add it and finish
         add_type_values(type, rest);
-        return ErrorCase::ok;
+        return ErrorCase::OK;
     }
 
     // If it is not the last one, continue

--- a/src/cpp/security/accesscontrol/DistinguishedName.cpp
+++ b/src/cpp/security/accesscontrol/DistinguishedName.cpp
@@ -216,7 +216,9 @@ Attribute Attribute::cut(
     return res;
 }
 
-std::ostream& operator<<(std::ostream& os, const Attribute& att)
+std::ostream& operator <<(
+        std::ostream& os,
+        const Attribute& att)
 {
     os.write(att.value, att.length);
     return os;

--- a/src/cpp/security/accesscontrol/DistinguishedName.cpp
+++ b/src/cpp/security/accesscontrol/DistinguishedName.cpp
@@ -1,0 +1,368 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*!
+ * @file DistinguishedName.cpp
+ */
+
+#include <array>
+#include <cstring>
+
+#include <fastrtps/log/Log.h>
+
+#include <security/accesscontrol/DistinguishedName.h>
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+namespace security {
+
+namespace details {
+
+Attribute::Attribute(const DistinguishedName& name)
+    : value(name.c_str())
+    , length(name.size())
+{
+    // Do nothing
+}
+
+Attribute::Attribute(const char* name)
+    : value(name)
+{
+    size_t i = 0;
+    while (name[i] != 0)
+    {
+        ++i;
+    }
+    length = i;
+}
+
+bool Attribute::is_set() const noexcept
+{
+    return length > 0;
+}
+
+size_t Attribute::cut(size_t ini, size_t fin /*= 0*/) noexcept
+{
+    // If cut greater than actual size, return empty string
+    if (ini >= length || fin > length)
+    {
+        return clear();
+    }
+
+    // If fin is 0, cut to the end
+    if (fin == 0)
+    {
+        value += ini;
+        length -= ini;
+        return ini;
+    }
+
+    // If fin is lower or equal ini, empty string
+    if (fin <= ini)
+    {
+        return clear();
+    }
+
+    // Otherwise cut it
+    value += ini;
+    size_t aux = length;
+    length = fin - ini;
+    return aux - length;
+}
+
+size_t Attribute::trim_blank_spaces()
+{
+    size_t i = 0;
+    while (i < length && value[i] == ' ')
+    {
+        i++;
+    }
+    return cut(i);
+}
+
+size_t Attribute::trim_back_blank_spaces()
+{
+    size_t i = length;
+    // NOTE: using -1 because size_t cannot be lower than 0, so comparison i >= 0 make no sense
+    while (i > 0 && value[i-1] == ' ')
+    {
+        i--;
+    }
+    return cut(0, i);
+}
+
+size_t Attribute::clear() noexcept
+{
+    value = nullptr;
+    size_t aux = length;
+    length = 0;
+    return aux;
+}
+
+size_t Attribute::find(char c) const noexcept
+{
+    size_t i = 0;
+    bool in_quotes = false;
+    while (i < length)
+    {
+        if (!in_quotes && value[i] == c)
+        {
+            return i;
+        }
+
+        if (value[i] == '"')
+        {
+            in_quotes = !in_quotes;
+        }
+
+        else if (value[i] == '\\')
+        {
+            i++;
+        }
+
+        i++;
+    }
+    return i;
+}
+
+size_t Attribute::find(char c, bool& result) const noexcept
+{
+    auto res = find(c);
+    result = found(res);
+    return res;
+}
+
+bool Attribute::found(const size_t& find_result) const noexcept
+{
+    return find_result < length;
+}
+
+bool Attribute::operator==(const Attribute& other) const noexcept
+{
+    // Compare char to char
+    // scaped chars with \ must be taken into account, and " must be ignored
+    size_t index_this = 0;
+    size_t index_other = 0;
+    while (true)
+    {
+        while (
+            index_this < this->length
+            && (this->value[index_this] == '\\' || this->value[index_this] == '"'))
+        {
+            index_this++;
+        }
+
+        while (
+            index_other < other.length
+            && (other.value[index_other] == '\\' || other.value[index_other] == '"'))
+        {
+            index_other++;
+        }
+
+        if (index_this == this->length && index_other == other.length)
+        {
+            return true;
+        }
+
+        if (
+            !(index_this < this->length)
+            || !(index_other < other.length)
+            || (this->value[index_this] != other.value[index_other]))
+        {
+            return false;
+        }
+        else
+        {
+            index_this++;
+            index_other++;
+        }
+    }
+}
+
+bool Attribute::operator!=(const Attribute& other) const noexcept
+{
+    return !operator==(other);
+}
+
+Attribute Attribute::cut(const Attribute& att, size_t ini, size_t fin /*= 0*/) noexcept
+{
+    Attribute res {att};
+    res.cut(ini, fin);
+    return res;
+}
+
+bool DistinguishedNameSpecialized::compare(const DistinguishedName& name1, const DistinguishedName& name2) noexcept
+{
+    DistinguishedNameSpecialized dns1(name1);
+    DistinguishedNameSpecialized dns2(name2);
+    return DistinguishedNameSpecialized(name1) == DistinguishedNameSpecialized(name2);
+}
+
+DistinguishedNameSpecialized::DistinguishedNameSpecialized(const DistinguishedName& name) noexcept
+{
+    // Create it by recursive function
+    auto res = find_and_add_type_values(name);
+
+    switch (res)
+    {
+    case ErrorCase::max_value:
+        EPROSIMA_LOG_ERROR(
+            SECURITY,
+            "DistinguishedName " << name << " have more type-values attributes than allowed.");
+        break;
+
+    case ErrorCase::empty:
+        EPROSIMA_LOG_ERROR(
+            SECURITY,
+            "DistinguishedName " << name << " has an empty field.");
+        break;
+
+    case ErrorCase::no_type_value_format:
+        EPROSIMA_LOG_ERROR(
+            SECURITY,
+            "DistinguishedName " << name << " has incorrect format.");
+        break;
+
+    default:
+        break;
+    }
+}
+
+DistinguishedNameSpecialized::ErrorCase DistinguishedNameSpecialized::find_and_add_type_values(const Attribute& input) noexcept
+{
+    Attribute rest = input;
+    rest.trim_blank_spaces();
+    // If input has finished, stop
+    if (!rest.is_set())
+    {
+        return ErrorCase::empty;
+    }
+
+    // If this object is already full, failure (no exception to follow fast policy)
+    if (size() >= MAX_VALUES_)
+    {
+        return ErrorCase::max_value;
+    }
+
+    //////////////////////////////////////////
+    // Variables
+    bool found = false;
+    size_t index = 0;
+
+    //////////////////////////////////////////
+    // Find first =
+    index = rest.find('=', found);
+    if (!found)
+    {
+        return ErrorCase::no_type_value_format;
+    }
+    Attribute type = Attribute::cut(rest, 0, index);
+    rest.cut(index+1);
+
+    //////////////////////////////////////////
+    // Find first ,
+    index = rest.find(',', found);
+    if (!found)
+    {
+        // Last element found, add it and finish
+        add_type_values(type, rest);
+        return ErrorCase::ok;
+    }
+
+    // If it is not the last one, continue
+    Attribute value = Attribute::cut(rest, 0, index);
+    rest.cut(index+1);
+
+    // Add values
+    add_type_values(type, value);
+
+    //////////////////////////////////////////
+    // Keep adding values
+    return find_and_add_type_values(rest);
+}
+
+void DistinguishedNameSpecialized::add_type_values(const Attribute& type, const Attribute& value) noexcept
+{
+    // NOTE: storing values before trimming them avoids one copy
+
+    //////////////////////////////////////////
+    // Store new values
+    types_[size_] = type;
+    values_[size_] = value;
+
+    //////////////////////////////////////////
+    // Trim blank spaces
+    types_[size_].trim_blank_spaces();
+    types_[size_].trim_back_blank_spaces();
+    values_[size_].trim_blank_spaces();
+    values_[size_].trim_back_blank_spaces();
+
+    size_++;
+}
+
+size_t DistinguishedNameSpecialized::size() const noexcept
+{
+    return size_;
+}
+
+DistinguishedNameSpecialized::Value DistinguishedNameSpecialized::get_attribute(const Type& type) const noexcept
+{
+    for (size_t i = 0; i < size_; ++i)
+    {
+        if (!types_[i].is_set())
+        {
+            // Finish if no more types
+            break;
+        }
+        else if (types_[i] == type)
+        {
+            return values_[i];
+        }
+    }
+    return Value();
+}
+
+bool DistinguishedNameSpecialized::operator==(const DistinguishedNameSpecialized& other) const noexcept
+{
+    if (this->size() != other.size())
+    {
+        return false;
+    }
+
+    for (size_t i = 0; i < size_; ++i)
+    {
+        if (other.get_attribute(this->types_[i]) != this->values_[i])
+        {
+            return false;
+        }
+    }
+
+    // If same size and all keys in A are in B, all keys in B are in A
+    return true;
+}
+
+} //namespace details
+
+bool rfc2253_string_compare(
+        const DistinguishedName& name1,
+        const DistinguishedName& name2)
+{
+    return details::DistinguishedNameSpecialized::compare(name1, name2);
+}
+
+} //namespace security
+} //namespace rtps
+} //namespace fastrtps
+} //namespace eprosima

--- a/src/cpp/security/accesscontrol/DistinguishedName.cpp
+++ b/src/cpp/security/accesscontrol/DistinguishedName.cpp
@@ -30,14 +30,16 @@ namespace security {
 
 namespace details {
 
-Attribute::Attribute(const DistinguishedName& name)
+Attribute::Attribute(
+        const DistinguishedName& name)
     : value(name.c_str())
     , length(name.size())
 {
     // Do nothing
 }
 
-Attribute::Attribute(const char* name)
+Attribute::Attribute(
+        const char* name)
     : value(name)
 {
     size_t i = 0;
@@ -53,7 +55,9 @@ bool Attribute::is_set() const noexcept
     return length > 0;
 }
 
-size_t Attribute::cut(size_t ini, size_t fin /*= 0*/) noexcept
+size_t Attribute::cut(
+        size_t ini,
+        size_t fin /*= 0*/) noexcept
 {
     // If cut greater than actual size, return empty string
     if (ini >= length || fin > length)
@@ -96,7 +100,7 @@ size_t Attribute::trim_back_blank_spaces()
 {
     size_t i = length;
     // NOTE: using -1 because size_t cannot be lower than 0, so comparison i >= 0 make no sense
-    while (i > 0 && value[i-1] == ' ')
+    while (i > 0 && value[i - 1] == ' ')
     {
         i--;
     }
@@ -111,7 +115,8 @@ size_t Attribute::clear() noexcept
     return aux;
 }
 
-size_t Attribute::find(char c) const noexcept
+size_t Attribute::find(
+        char c) const noexcept
 {
     size_t i = 0;
     bool in_quotes = false;
@@ -137,19 +142,23 @@ size_t Attribute::find(char c) const noexcept
     return i;
 }
 
-size_t Attribute::find(char c, bool& result) const noexcept
+size_t Attribute::find(
+        char c,
+        bool& result) const noexcept
 {
     auto res = find(c);
     result = found(res);
     return res;
 }
 
-bool Attribute::found(const size_t& find_result) const noexcept
+bool Attribute::found(
+        const size_t& find_result) const noexcept
 {
     return find_result < length;
 }
 
-bool Attribute::operator==(const Attribute& other) const noexcept
+bool Attribute::operator ==(
+        const Attribute& other) const noexcept
 {
     // Compare char to char
     // scaped chars with \ must be taken into account, and " must be ignored
@@ -191,56 +200,64 @@ bool Attribute::operator==(const Attribute& other) const noexcept
     }
 }
 
-bool Attribute::operator!=(const Attribute& other) const noexcept
+bool Attribute::operator !=(
+        const Attribute& other) const noexcept
 {
-    return !operator==(other);
+    return !operator ==(other);
 }
 
-Attribute Attribute::cut(const Attribute& att, size_t ini, size_t fin /*= 0*/) noexcept
+Attribute Attribute::cut(
+        const Attribute& att,
+        size_t ini,
+        size_t fin /*= 0*/) noexcept
 {
     Attribute res {att};
     res.cut(ini, fin);
     return res;
 }
 
-bool DistinguishedNameSpecialized::compare(const DistinguishedName& name1, const DistinguishedName& name2) noexcept
+bool DistinguishedNameSpecialized::compare(
+        const DistinguishedName& name1,
+        const DistinguishedName& name2) noexcept
 {
     DistinguishedNameSpecialized dns1(name1);
     DistinguishedNameSpecialized dns2(name2);
     return DistinguishedNameSpecialized(name1) == DistinguishedNameSpecialized(name2);
 }
 
-DistinguishedNameSpecialized::DistinguishedNameSpecialized(const DistinguishedName& name) noexcept
+DistinguishedNameSpecialized::DistinguishedNameSpecialized(
+        const DistinguishedName& name) noexcept
 {
     // Create it by recursive function
     auto res = find_and_add_type_values(name);
 
     switch (res)
     {
-    case ErrorCase::max_value:
-        EPROSIMA_LOG_ERROR(
-            SECURITY,
-            "DistinguishedName " << name << " have more type-values attributes than allowed.");
-        break;
+        case ErrorCase::max_value:
+            EPROSIMA_LOG_ERROR(
+                SECURITY,
+                "DistinguishedName " << name << " have more type-values attributes than allowed.");
+            break;
 
-    case ErrorCase::empty:
-        EPROSIMA_LOG_ERROR(
-            SECURITY,
-            "DistinguishedName " << name << " has an empty field.");
-        break;
+        case ErrorCase::empty:
+            EPROSIMA_LOG_ERROR(
+                SECURITY,
+                "DistinguishedName " << name << " has an empty field.");
+            break;
 
-    case ErrorCase::no_type_value_format:
-        EPROSIMA_LOG_ERROR(
-            SECURITY,
-            "DistinguishedName " << name << " has incorrect format.");
-        break;
+        case ErrorCase::no_type_value_format:
+            EPROSIMA_LOG_ERROR(
+                SECURITY,
+                "DistinguishedName " << name << " has incorrect format.");
+            break;
 
-    default:
-        break;
+        default:
+            break;
     }
 }
 
-DistinguishedNameSpecialized::ErrorCase DistinguishedNameSpecialized::find_and_add_type_values(const Attribute& input) noexcept
+DistinguishedNameSpecialized::ErrorCase DistinguishedNameSpecialized::find_and_add_type_values(
+        const Attribute& input) noexcept
 {
     Attribute rest = input;
     rest.trim_blank_spaces();
@@ -269,7 +286,7 @@ DistinguishedNameSpecialized::ErrorCase DistinguishedNameSpecialized::find_and_a
         return ErrorCase::no_type_value_format;
     }
     Attribute type = Attribute::cut(rest, 0, index);
-    rest.cut(index+1);
+    rest.cut(index + 1);
 
     //////////////////////////////////////////
     // Find first ,
@@ -283,7 +300,7 @@ DistinguishedNameSpecialized::ErrorCase DistinguishedNameSpecialized::find_and_a
 
     // If it is not the last one, continue
     Attribute value = Attribute::cut(rest, 0, index);
-    rest.cut(index+1);
+    rest.cut(index + 1);
 
     // Add values
     add_type_values(type, value);
@@ -293,7 +310,9 @@ DistinguishedNameSpecialized::ErrorCase DistinguishedNameSpecialized::find_and_a
     return find_and_add_type_values(rest);
 }
 
-void DistinguishedNameSpecialized::add_type_values(const Attribute& type, const Attribute& value) noexcept
+void DistinguishedNameSpecialized::add_type_values(
+        const Attribute& type,
+        const Attribute& value) noexcept
 {
     // NOTE: storing values before trimming them avoids one copy
 
@@ -317,7 +336,8 @@ size_t DistinguishedNameSpecialized::size() const noexcept
     return size_;
 }
 
-DistinguishedNameSpecialized::Value DistinguishedNameSpecialized::get_attribute(const Type& type) const noexcept
+DistinguishedNameSpecialized::Value DistinguishedNameSpecialized::get_attribute(
+        const Type& type) const noexcept
 {
     for (size_t i = 0; i < size_; ++i)
     {
@@ -334,7 +354,8 @@ DistinguishedNameSpecialized::Value DistinguishedNameSpecialized::get_attribute(
     return Value();
 }
 
-bool DistinguishedNameSpecialized::operator==(const DistinguishedNameSpecialized& other) const noexcept
+bool DistinguishedNameSpecialized::operator ==(
+        const DistinguishedNameSpecialized& other) const noexcept
 {
     if (this->size() != other.size())
     {

--- a/src/cpp/security/accesscontrol/DistinguishedName.h
+++ b/src/cpp/security/accesscontrol/DistinguishedName.h
@@ -1,0 +1,179 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*!
+ * @file DistinguishedName.h
+ */
+
+#ifndef _SECURITY_ACCESSCONTROL_DISTINGUISHEDNAME_H_
+#define _SECURITY_ACCESSCONTROL_DISTINGUISHEDNAME_H_
+
+#include <string>
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+namespace security {
+
+/*
+ * RFC 1779: https://datatracker.ietf.org/doc/html/rfc1779 specifies how to represent DistinguishedNames
+ * in string format (obsolete in favor of rfc2253).
+ *
+ * RFC 2253: https://datatracker.ietf.org/doc/html/rfc2253 specifies how to represent DistinguishedNames
+ * in string UTF-8 format.
+ *
+ * ASN.1 representation of DistinguishedNames
+ * DistinguishedName ::= RDNSequence
+ * RDNSequence ::= SEQUENCE OF RelativeDistinguishedName
+ * RelativeDistinguishedName ::= SET SIZE (1..MAX) OF
+ * AttributeTypeAndValue
+ * AttributeTypeAndValue ::= SEQUENCE {
+ * type  AttributeType,
+ * value AttributeValue }
+ *
+ * Each RDN in a RDNSequence is separated by ','.
+ * Each AttributeTypeAndValue in a RDN is separated by '+'.
+ * Attribute and Value are separated by '='.
+ *
+ */
+
+/**
+ * @brief class that represents a Distinguished Name
+ *
+ * @note so far this implementation works only as a string
+ * @todo make this a real class with real methods that correctly implement RFC 2253:
+ */
+using DistinguishedName = std::string;
+
+/**
+ * @brief This function compares 2 strings representing DistinguishedNames.
+ *
+ * Follow RFC 2253: https://datatracker.ietf.org/doc/html/rfc2253
+ * The idea here is that comparing 2 DistinguishedNames is not as trivial as comparing 2 strings,
+ * nor comparing its values splitting the string.
+ * The comparison must be a complex function that takes into account many specific details.
+ *
+ * So far, Fast DDS gives 2 strings (in some format that we assume is the correct one) and this compares
+ * whether the two strings refer to the same DistinguishedName.
+ * It would be better (and easier) to store DistinguishedName in a specialized function instead of in a string,
+ * and thus this comparison would be much easier and efficient.
+ * But this will be left for future improvements.
+ *
+ * @warning this function does not correctly fulfilled all requirements of RFC 2253.
+ * Requirements that are not fulfilled:
+ * - multi-attribute
+ * - types accept oid
+ * - assumes that input is a well formed DistinguishedName following rfc2253
+ * @todo make this function complete (probably better by implementing DistinguishedName class).
+ *
+ * @param name1 first DistinguishedName in string format
+ * @param name2 second DistinguishedName in string format
+ *
+ * @return true if both first strings represent the same DistinguishedName.
+ * @return false otherwise
+ */
+bool rfc2253_string_compare(
+        const DistinguishedName& name1,
+        const DistinguishedName& name2);
+
+
+namespace details {
+
+struct Attribute
+{
+    Attribute() = default;
+
+    Attribute(const DistinguishedName& name);
+
+    Attribute(const char* name);
+
+    bool is_set() const noexcept;
+
+    size_t cut(size_t ini, size_t fin = 0) noexcept;
+
+    size_t trim_blank_spaces();
+
+    size_t trim_back_blank_spaces();
+
+    size_t clear() noexcept;
+
+    size_t find(char c) const noexcept;
+
+    size_t find(char c, bool& result) const noexcept;
+
+    bool found(const size_t& find_result) const noexcept;
+
+    bool operator==(const Attribute& other) const noexcept;
+
+    bool operator!=(const Attribute& other) const noexcept;
+
+    static Attribute cut(const Attribute& att, size_t ini, size_t fin = 0) noexcept;
+
+    const char* value {nullptr};
+    size_t length {0};
+};
+
+/**
+ * @brief This class is only used to compare 2 DistinguishedName.
+ *
+ * @warning be aware that this class does not store any memory, so using for something different than
+ * comparison may lead to seg faults.
+ */
+class DistinguishedNameSpecialized
+{
+public:
+
+    static bool compare(const DistinguishedName& name1, const DistinguishedName& name2) noexcept;
+
+    enum class ErrorCase
+    {
+        ok,
+        empty,
+        max_value,
+        no_type_value_format,
+    };
+
+    using Type = Attribute;
+    using Value = Attribute;
+
+    DistinguishedNameSpecialized(const DistinguishedName& name) noexcept;
+
+    ErrorCase find_and_add_type_values(const Attribute& input) noexcept;
+
+    void add_type_values(const Attribute& type, const Attribute& value) noexcept;
+
+    size_t size() const noexcept;
+
+    Value get_attribute(const Type& type) const noexcept;
+
+    bool operator==(const DistinguishedNameSpecialized& other) const noexcept;
+
+protected:
+
+    static constexpr size_t MAX_VALUES_ = 20;
+
+    std::array<Attribute, MAX_VALUES_> types_ {};
+    std::array<Attribute, MAX_VALUES_> values_ {};
+    bool ok_ {false};
+    size_t size_ {0};
+};
+
+} //namespace details
+
+} //namespace security
+} //namespace rtps
+} //namespace fastrtps
+} //namespace eprosima
+
+#endif // _SECURITY_ACCESSCONTROL_DISTINGUISHEDNAME_H_

--- a/src/cpp/security/accesscontrol/DistinguishedName.h
+++ b/src/cpp/security/accesscontrol/DistinguishedName.h
@@ -36,9 +36,12 @@ namespace security {
  *
  * ASN.1 representation of DistinguishedNames
  * DistinguishedName ::= RDNSequence
+ *
  * RDNSequence ::= SEQUENCE OF RelativeDistinguishedName
+ *
  * RelativeDistinguishedName ::= SET SIZE (1..MAX) OF
  * AttributeTypeAndValue
+ *
  * AttributeTypeAndValue ::= SEQUENCE {
  * type  AttributeType,
  * value AttributeValue }
@@ -63,7 +66,7 @@ using DistinguishedName = std::string;
  * Follow RFC 2253: https://datatracker.ietf.org/doc/html/rfc2253
  * The idea here is that comparing 2 DistinguishedNames is not as trivial as comparing 2 strings,
  * nor comparing its values splitting the string.
- * The comparison must be a complex function that takes into account many specific details.
+ * The comparison must be a complex function that takes into account many specific detail.
  *
  * So far, Fast DDS gives 2 strings (in some format that we assume is the correct one) and this compares
  * whether the two strings refer to the same DistinguishedName.
@@ -74,7 +77,7 @@ using DistinguishedName = std::string;
  * @warning this function does not correctly fulfilled all requirements of RFC 2253.
  * Requirements that are not fulfilled:
  * - multi-attribute
- * - types accept oid
+ * - types accept void
  * - assumes that input is a well formed DistinguishedName following rfc2253
  * @todo make this function complete (probably better by implementing DistinguishedName class).
  *
@@ -89,8 +92,17 @@ bool rfc2253_string_compare(
         const DistinguishedName& name2);
 
 
-namespace details {
+namespace detail {
 
+/**
+ * @brief Struct that stores a const char* and a size, referencing a string without dynamic allocation.
+ *
+ * This struct is only an auxiliary class to implement \c rfc2253_string_compare .
+ * This class is not meant to be used outside this function.
+ *
+ * The necessity of this class is due to comparing two key-value format strings without allocate heap memory.
+ * Thus, it implements string formatter functions only using char ptr and size.
+ */
 struct Attribute
 {
     Attribute() = default;
@@ -137,6 +149,9 @@ struct Attribute
     const char* value {nullptr};
     size_t length {0};
 };
+
+//! To string method for Attribute
+std::ostream& operator<<(std::ostream& os, const Attribute& att);
 
 /**
  * @brief This class is only used to compare 2 DistinguishedName.
@@ -191,7 +206,7 @@ protected:
     size_t size_ {0};
 };
 
-} //namespace details
+} //namespace detail
 
 } //namespace security
 } //namespace rtps

--- a/src/cpp/security/accesscontrol/DistinguishedName.h
+++ b/src/cpp/security/accesscontrol/DistinguishedName.h
@@ -19,6 +19,7 @@
 #ifndef _SECURITY_ACCESSCONTROL_DISTINGUISHEDNAME_H_
 #define _SECURITY_ACCESSCONTROL_DISTINGUISHEDNAME_H_
 
+#include <array>
 #include <string>
 
 namespace eprosima {

--- a/src/cpp/security/accesscontrol/DistinguishedName.h
+++ b/src/cpp/security/accesscontrol/DistinguishedName.h
@@ -100,8 +100,9 @@ namespace detail {
  * This struct is only an auxiliary class to implement \c rfc2253_string_compare .
  * This class is not meant to be used outside this function.
  *
- * The necessity of this class is due to comparing two key-value format strings without allocate heap memory.
- * Thus, it implements string formatter functions only using char ptr and size.
+ * The necessity of this class arises from the need to compare two key-value format strings without
+ * allocating heap memory.
+ * Thus, it implements string formatter functions (cut, trim, find) only using char ptr and size.
  */
 struct Attribute
 {
@@ -169,10 +170,10 @@ public:
 
     enum class ErrorCase
     {
-        ok,
-        empty,
-        max_value,
-        no_type_value_format,
+        OK,
+        EMPTY,
+        MAX_VALUE,
+        NO_TYPE_VALUE_FORMAT,
     };
 
     using Type = Attribute;

--- a/src/cpp/security/accesscontrol/DistinguishedName.h
+++ b/src/cpp/security/accesscontrol/DistinguishedName.h
@@ -95,13 +95,17 @@ struct Attribute
 {
     Attribute() = default;
 
-    Attribute(const DistinguishedName& name);
+    Attribute(
+            const DistinguishedName& name);
 
-    Attribute(const char* name);
+    Attribute(
+            const char* name);
 
     bool is_set() const noexcept;
 
-    size_t cut(size_t ini, size_t fin = 0) noexcept;
+    size_t cut(
+            size_t ini,
+            size_t fin = 0) noexcept;
 
     size_t trim_blank_spaces();
 
@@ -109,17 +113,26 @@ struct Attribute
 
     size_t clear() noexcept;
 
-    size_t find(char c) const noexcept;
+    size_t find(
+            char c) const noexcept;
 
-    size_t find(char c, bool& result) const noexcept;
+    size_t find(
+            char c,
+            bool& result) const noexcept;
 
-    bool found(const size_t& find_result) const noexcept;
+    bool found(
+            const size_t& find_result) const noexcept;
 
-    bool operator==(const Attribute& other) const noexcept;
+    bool operator ==(
+            const Attribute& other) const noexcept;
 
-    bool operator!=(const Attribute& other) const noexcept;
+    bool operator !=(
+            const Attribute& other) const noexcept;
 
-    static Attribute cut(const Attribute& att, size_t ini, size_t fin = 0) noexcept;
+    static Attribute cut(
+            const Attribute& att,
+            size_t ini,
+            size_t fin = 0) noexcept;
 
     const char* value {nullptr};
     size_t length {0};
@@ -135,7 +148,9 @@ class DistinguishedNameSpecialized
 {
 public:
 
-    static bool compare(const DistinguishedName& name1, const DistinguishedName& name2) noexcept;
+    static bool compare(
+            const DistinguishedName& name1,
+            const DistinguishedName& name2) noexcept;
 
     enum class ErrorCase
     {
@@ -148,17 +163,23 @@ public:
     using Type = Attribute;
     using Value = Attribute;
 
-    DistinguishedNameSpecialized(const DistinguishedName& name) noexcept;
+    DistinguishedNameSpecialized(
+            const DistinguishedName& name) noexcept;
 
-    ErrorCase find_and_add_type_values(const Attribute& input) noexcept;
+    ErrorCase find_and_add_type_values(
+            const Attribute& input) noexcept;
 
-    void add_type_values(const Attribute& type, const Attribute& value) noexcept;
+    void add_type_values(
+            const Attribute& type,
+            const Attribute& value) noexcept;
 
     size_t size() const noexcept;
 
-    Value get_attribute(const Type& type) const noexcept;
+    Value get_attribute(
+            const Type& type) const noexcept;
 
-    bool operator==(const DistinguishedNameSpecialized& other) const noexcept;
+    bool operator ==(
+            const DistinguishedNameSpecialized& other) const noexcept;
 
 protected:
 

--- a/src/cpp/security/accesscontrol/DistinguishedName.h
+++ b/src/cpp/security/accesscontrol/DistinguishedName.h
@@ -152,7 +152,9 @@ struct Attribute
 };
 
 //! To string method for Attribute
-std::ostream& operator<<(std::ostream& os, const Attribute& att);
+std::ostream& operator <<(
+        std::ostream& os,
+        const Attribute& att);
 
 /**
  * @brief This class is only used to compare 2 DistinguishedName.

--- a/src/cpp/security/accesscontrol/Permissions.cpp
+++ b/src/cpp/security/accesscontrol/Permissions.cpp
@@ -44,6 +44,7 @@
 #include <openssl/obj_mac.h>
 
 #include <security/artifact_providers/FileProvider.hpp>
+#include <security/accesscontrol/DistinguishedName.h>
 
 #include <cassert>
 #include <fstream>
@@ -273,76 +274,6 @@ static bool get_signature_algorithm(
     }
 
     return returnedValue;
-}
-
-static bool rfc2253_string_compare(
-        const std::string& str1,
-        const std::string& str2)
-{
-    bool returned_value = true;
-
-    size_t str1_mark_low = 0, str1_mark_high = 0, str2_mark_low = 0, str2_mark_high = 0;
-
-    str1_mark_high = str1.find_first_of(',');
-    if (str1_mark_high == std::string::npos)
-    {
-        str1_mark_high = str1.length();
-    }
-    str2_mark_high = str2.find_first_of(',');
-    if (str2_mark_high == std::string::npos)
-    {
-        str2_mark_high = str2.length();
-    }
-
-    while (str1_mark_low < str1_mark_high && str2_mark_low < str2_mark_high)
-    {
-        // Trim
-        size_t str1_trim_high = str1_mark_high - 1, str2_trim_high = str2_mark_high - 1;
-
-        while (str1.at(str1_mark_low) == ' ' && (str1_mark_low + 1) != str1_trim_high)
-        {
-            ++str1_mark_low;
-        }
-        while (str2.at(str2_mark_low) == ' ' && (str2_mark_low + 1) != str2_trim_high)
-        {
-            ++str2_mark_low;
-        }
-        while (str1.at(str1_trim_high) == ' ' && (str1_trim_high - 1) != str1_mark_low)
-        {
-            --str1_trim_high;
-        }
-        while (str2.at(str2_trim_high) == ' ' && (str2_trim_high - 1) != str2_mark_low)
-        {
-            --str2_trim_high;
-        }
-
-        if (str1.compare(str1_mark_low, str1_trim_high - str1_mark_low + 1, str2,
-                str2_mark_low, str2_trim_high - str2_mark_low + 1) != 0)
-        {
-            returned_value = false;
-            break;
-        }
-
-        str1_mark_low = str1_mark_high + 1;
-        str2_mark_low = str2_mark_high + 1;
-        str1_mark_high = str1.find_first_of(',', str1_mark_low);
-        if (str1_mark_high == std::string::npos)
-        {
-            str1_mark_high = str1.length();
-        }
-        str2_mark_high = str2.find_first_of(',', str2_mark_low);
-        if (str2_mark_high == std::string::npos)
-        {
-            str2_mark_high = str2.length();
-        }
-    }
-
-    if (str1_mark_low < str1_mark_high || str2_mark_low < str2_mark_high)
-    {
-        returned_value = false;
-    }
-
-    return returned_value;
 }
 
 // Auxiliary functions

--- a/test/unittest/dds/publisher/CMakeLists.txt
+++ b/test/unittest/dds/publisher/CMakeLists.txt
@@ -259,6 +259,7 @@ set(DATAWRITERTESTS_SOURCE DataWriterTests.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/security/artifact_providers/Pkcs11Provider.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/security/authentication/PKIDH.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/security/accesscontrol/Permissions.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/security/accesscontrol/DistinguishedName.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/security/cryptography/AESGCMGMAC.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/security/cryptography/AESGCMGMAC_KeyExchange.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/security/cryptography/AESGCMGMAC_KeyFactory.cpp

--- a/test/unittest/security/accesscontrol/CMakeLists.txt
+++ b/test/unittest/security/accesscontrol/CMakeLists.txt
@@ -58,6 +58,7 @@ add_executable(AccessControlTests ${COMMON_SOURCES_ACCESS_CONTROL_TEST_SOURCE}
     ${PROJECT_SOURCE_DIR}/src/cpp/security/accesscontrol/CommonParser.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/security/accesscontrol/GovernanceParser.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/security/accesscontrol/Permissions.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/security/accesscontrol/DistinguishedName.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/security/accesscontrol/PermissionsParser.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/security/artifact_providers/FileProvider.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/security/artifact_providers/Pkcs11Provider.cpp
@@ -114,3 +115,55 @@ add_gtest(AccessControlTests
 if(ANDROID)
     set_property(TARGET AccessControlTests PROPERTY CROSSCOMPILING_EMULATOR "adb;shell;cd;${CMAKE_CURRENT_BINARY_DIR};&&")
 endif()
+
+####################################################################################################
+####################################################################################################
+# DistinguishedNameTests
+set(
+    DISTINGUISHEDNAME_TEST_NAME
+    "DistinguishedNameTests"
+)
+
+add_executable(
+    ${DISTINGUISHEDNAME_TEST_NAME}
+
+    # Log related files
+    ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/utils/SystemInfo.cpp
+
+    # src files
+    ${PROJECT_SOURCE_DIR}/src/cpp/security/accesscontrol/DistinguishedName.cpp
+
+    # test files
+    ${CMAKE_CURRENT_SOURCE_DIR}/DistinguishedNameTests.cpp
+)
+
+target_compile_definitions(
+    ${DISTINGUISHEDNAME_TEST_NAME}
+    PRIVATE
+        FASTRTPS_NO_LIB
+        $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+        $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+)
+
+target_include_directories(
+    ${DISTINGUISHEDNAME_TEST_NAME}
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_BINARY_DIR}/include
+        ${PROJECT_SOURCE_DIR}/src/cpp
+)
+
+target_link_libraries(
+    ${DISTINGUISHEDNAME_TEST_NAME}
+    GTest::gtest
+)
+
+add_gtest(
+    ${DISTINGUISHEDNAME_TEST_NAME}
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/DistinguishedNameTests.cpp
+)

--- a/test/unittest/security/accesscontrol/DistinguishedNameTests.cpp
+++ b/test/unittest/security/accesscontrol/DistinguishedNameTests.cpp
@@ -1,0 +1,294 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <list>
+
+#include <security/accesscontrol/DistinguishedName.h>
+
+using namespace eprosima::fastrtps::rtps::security;
+
+namespace test{
+
+/*
+ * This struct join multiple DistinguishedNames in string format that refer to the same entity.
+ * This entity is different for the different sets.
+ *
+ * Each of the sets is though to check a specific functionality of the compare function.
+ */
+static const std::vector<std::vector<DistinguishedName>> DIFFERENT_DISTINGUISHED_NAMES =
+{
+    // ROS2 case (check trim spaces)
+    {
+        "CN=/pub",
+        "CN = /pub",
+        "CN= /pub",
+        "CN =/pub",
+        "  CN  =  /pub  ",
+    },
+
+    // Documentation case (check different order)
+    {
+        "emailAddress=example@eprosima.com, CN=DomainParticipantName, O=eProsima, ST=MA, C=ES",
+        "C=ES, ST=MA, O=eProsima, CN=DomainParticipantName, emailAddress=example@eprosima.com",
+    },
+
+    // RFC 2253 example (check scaped comma)
+    {
+        "CN=L. Eagle,O=Sue\\, Grabbit and Runn,C=GB",
+        "CN=L. Eagle,O=\"Sue, Grabbit and Runn\",C=GB",
+    },
+
+    // Some other values to verify negative compare works
+    {
+        "CN=/o_pub",
+        "CN=\"/o_pub\"",
+    },
+
+    {
+        "CN=/pub,O=ROS",
+        "CN=/pub, O=ROS",
+    },
+};
+
+} // namespace test
+
+/*
+ * Test rfc2253_string_compare function by giving known equal values.
+ */
+TEST(DistinguishedNameTests, rfc2253_string_compare_positive)
+{
+    // For each collection of equals
+    for (const auto& equal_collection : test::DIFFERENT_DISTINGUISHED_NAMES)
+    {
+        // For each name
+        for (const auto& name_to_compare : equal_collection)
+        {
+            // For each equal name
+            for (const auto& other_equal_name : equal_collection)
+            {
+                // std::cout << "COMPARING: " << name_to_compare << " and " << other_equal_name << std::endl;
+                ASSERT_TRUE(rfc2253_string_compare(name_to_compare, other_equal_name))
+                    << name_to_compare << " != " << other_equal_name;
+
+                ASSERT_TRUE(rfc2253_string_compare(other_equal_name, name_to_compare))
+                    << " inverse: " << other_equal_name << " != " << name_to_compare;
+            }
+        }
+    }
+}
+
+/*
+ * Test rfc2253_string_compare function by giving known not equal values.
+ */
+TEST(DistinguishedNameTests, rfc2253_string_compare_negative)
+{
+    // For each collection of equals
+    for (size_t i = 0; i < test::DIFFERENT_DISTINGUISHED_NAMES.size(); i++)
+    {
+        auto& collection_to_compare = test::DIFFERENT_DISTINGUISHED_NAMES[i];
+
+        // For each name
+        for (const auto& name_to_compare : collection_to_compare)
+        {
+            // For each different collection of equals
+            for (size_t j = 0; j < test::DIFFERENT_DISTINGUISHED_NAMES.size(); j++)
+            {
+                if (i == j)
+                {
+                    continue;
+                }
+
+                auto& other_collection_to_compare = test::DIFFERENT_DISTINGUISHED_NAMES[j];
+
+                // For each not equal name
+                for (const auto& other_name_to_compare : other_collection_to_compare)
+                {
+                    // std::cout << "COMPARING: " << name_to_compare << " and " << other_name_to_compare << std::endl;
+                    ASSERT_FALSE(rfc2253_string_compare(name_to_compare, other_name_to_compare))
+                        << name_to_compare << " == " << other_name_to_compare;
+
+                }
+            }
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// details functions
+
+/*
+ * Test Attribute operator==
+ */
+TEST(DistinguishedNameTests, attribute_compare)
+{
+    // Positive cases
+    {
+        // Same string
+        {
+            const char* cc1 = "Hello";
+            details::Attribute att1(cc1);
+            details::Attribute att2(cc1);
+            ASSERT_EQ(att1, att2)
+                << att1.value << " != " << att2.value;
+        }
+
+        // With spaces
+        {
+            const char* cc1 = " He  llo   ";
+            const char* cc2 = " He  llo   ";
+            details::Attribute att1(cc1);
+            details::Attribute att2(cc2);
+            ASSERT_EQ(att1, att2)
+                << att1.value << " != " << att2.value;
+        }
+
+        // With scaped chars
+        {
+            const char* cc1 = "Hello,";
+            const char* cc2 = "Hello\\,";
+            details::Attribute att1(cc1);
+            details::Attribute att2(cc2);
+            ASSERT_EQ(att1, att2)
+                << att1.value << " != " << att2.value;
+        }
+
+        // With quotes chars
+        {
+            const char* cc1 = "\"Hello\"";
+            const char* cc2 = "Hello";
+            details::Attribute att1(cc1);
+            details::Attribute att2(cc2);
+            ASSERT_EQ(att1, att2)
+                << att1.value << " != " << att2.value;
+        }
+    }
+
+    // Negative cases
+    {
+        {
+            const char* cc1 = "/pub";
+            const char* cc2 = "/sub";
+            details::Attribute att1(cc1);
+            details::Attribute att2(cc2);
+            ASSERT_NE(att1, att2)
+                << att1.value << " == " << att2.value;
+        }
+
+        {
+            const char* cc1 = "/pub";
+            const char* cc2 = " /pub";
+            details::Attribute att1(cc1);
+            details::Attribute att2(cc2);
+            ASSERT_NE(att1, att2)
+                << att1.value << " == " << att2.value;
+        }
+
+        {
+            const char* cc1 = "Hello\\.";
+            const char* cc2 = "Hello\\,";
+            details::Attribute att1(cc1);
+            details::Attribute att2(cc2);
+            ASSERT_NE(att1, att2)
+                << att1.value << " == " << att2.value;
+        }
+    }
+}
+
+/*
+ * Test Attribute trim_blank_spaces function
+ */
+TEST(DistinguishedNameTests, trim_blank_spaces)
+{
+    // No spaces
+    {
+        const char* cc1 = "Hello";
+        const char* cc2 = "Hello";
+        details::Attribute att1(cc1);
+        att1.trim_blank_spaces();
+        details::Attribute att2(cc2);
+        ASSERT_EQ(att1, att2)
+            << att1.value << " != " << att2.value;
+    }
+
+    // One space
+    {
+        const char* cc1 = " Hello";
+        const char* cc2 = "Hello";
+        details::Attribute att1(cc1);
+        att1.trim_blank_spaces();
+        details::Attribute att2(cc2);
+        ASSERT_EQ(att1, att2)
+            << att1.value << " != " << att2.value;
+    }
+
+    // Multiple spaces
+    {
+        const char* cc1 = "   Hello";
+        const char* cc2 = "Hello";
+        details::Attribute att1(cc1);
+        att1.trim_blank_spaces();
+        details::Attribute att2(cc2);
+        ASSERT_EQ(att1, att2)
+            << att1.value << " != " << att2.value;
+    }
+}
+
+/*
+ * Test Attribute trim_back_blank_spaces function
+ */
+TEST(DistinguishedNameTests, trim_back_blank_spaces)
+{
+    // No spaces
+    {
+        const char* cc1 = "Hello";
+        const char* cc2 = "Hello";
+        details::Attribute att1(cc1);
+        att1.trim_back_blank_spaces();
+        details::Attribute att2(cc2);
+        ASSERT_EQ(att1, att2)
+            << att1.value << " != " << att2.value;
+    }
+
+    // One space
+    {
+        const char* cc1 = "Hello ";
+        const char* cc2 = "Hello";
+        details::Attribute att1(cc1);
+        att1.trim_back_blank_spaces();
+        details::Attribute att2(cc2);
+        ASSERT_EQ(att1, att2)
+            << att1.value << " != " << att2.value;
+    }
+
+    // Multiple spaces
+    {
+        const char* cc1 = "Hello   ";
+        const char* cc2 = "Hello";
+        details::Attribute att1(cc1);
+        att1.trim_back_blank_spaces();
+        details::Attribute att2(cc2);
+        ASSERT_EQ(att1, att2)
+            << att1.value << " != " << att2.value;
+    }
+}
+
+int main(
+        int argc,
+        char** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/unittest/security/accesscontrol/DistinguishedNameTests.cpp
+++ b/test/unittest/security/accesscontrol/DistinguishedNameTests.cpp
@@ -139,8 +139,8 @@ TEST(DistinguishedNameTests, attribute_compare)
         // Same string
         {
             const char* cc1 = "Hello";
-            details::Attribute att1(cc1);
-            details::Attribute att2(cc1);
+            detail::Attribute att1(cc1);
+            detail::Attribute att2(cc1);
             ASSERT_EQ(att1, att2)
                 << att1.value << " != " << att2.value;
         }
@@ -149,8 +149,8 @@ TEST(DistinguishedNameTests, attribute_compare)
         {
             const char* cc1 = " He  llo   ";
             const char* cc2 = " He  llo   ";
-            details::Attribute att1(cc1);
-            details::Attribute att2(cc2);
+            detail::Attribute att1(cc1);
+            detail::Attribute att2(cc2);
             ASSERT_EQ(att1, att2)
                 << att1.value << " != " << att2.value;
         }
@@ -159,8 +159,8 @@ TEST(DistinguishedNameTests, attribute_compare)
         {
             const char* cc1 = "Hello,";
             const char* cc2 = "Hello\\,";
-            details::Attribute att1(cc1);
-            details::Attribute att2(cc2);
+            detail::Attribute att1(cc1);
+            detail::Attribute att2(cc2);
             ASSERT_EQ(att1, att2)
                 << att1.value << " != " << att2.value;
         }
@@ -169,8 +169,8 @@ TEST(DistinguishedNameTests, attribute_compare)
         {
             const char* cc1 = "\"Hello\"";
             const char* cc2 = "Hello";
-            details::Attribute att1(cc1);
-            details::Attribute att2(cc2);
+            detail::Attribute att1(cc1);
+            detail::Attribute att2(cc2);
             ASSERT_EQ(att1, att2)
                 << att1.value << " != " << att2.value;
         }
@@ -181,8 +181,8 @@ TEST(DistinguishedNameTests, attribute_compare)
         {
             const char* cc1 = "/pub";
             const char* cc2 = "/sub";
-            details::Attribute att1(cc1);
-            details::Attribute att2(cc2);
+            detail::Attribute att1(cc1);
+            detail::Attribute att2(cc2);
             ASSERT_NE(att1, att2)
                 << att1.value << " == " << att2.value;
         }
@@ -190,8 +190,8 @@ TEST(DistinguishedNameTests, attribute_compare)
         {
             const char* cc1 = "/pub";
             const char* cc2 = " /pub";
-            details::Attribute att1(cc1);
-            details::Attribute att2(cc2);
+            detail::Attribute att1(cc1);
+            detail::Attribute att2(cc2);
             ASSERT_NE(att1, att2)
                 << att1.value << " == " << att2.value;
         }
@@ -199,8 +199,8 @@ TEST(DistinguishedNameTests, attribute_compare)
         {
             const char* cc1 = "Hello\\.";
             const char* cc2 = "Hello\\,";
-            details::Attribute att1(cc1);
-            details::Attribute att2(cc2);
+            detail::Attribute att1(cc1);
+            detail::Attribute att2(cc2);
             ASSERT_NE(att1, att2)
                 << att1.value << " == " << att2.value;
         }
@@ -216,9 +216,9 @@ TEST(DistinguishedNameTests, trim_blank_spaces)
     {
         const char* cc1 = "Hello";
         const char* cc2 = "Hello";
-        details::Attribute att1(cc1);
+        detail::Attribute att1(cc1);
         att1.trim_blank_spaces();
-        details::Attribute att2(cc2);
+        detail::Attribute att2(cc2);
         ASSERT_EQ(att1, att2)
             << att1.value << " != " << att2.value;
     }
@@ -227,9 +227,9 @@ TEST(DistinguishedNameTests, trim_blank_spaces)
     {
         const char* cc1 = " Hello";
         const char* cc2 = "Hello";
-        details::Attribute att1(cc1);
+        detail::Attribute att1(cc1);
         att1.trim_blank_spaces();
-        details::Attribute att2(cc2);
+        detail::Attribute att2(cc2);
         ASSERT_EQ(att1, att2)
             << att1.value << " != " << att2.value;
     }
@@ -238,9 +238,9 @@ TEST(DistinguishedNameTests, trim_blank_spaces)
     {
         const char* cc1 = "   Hello";
         const char* cc2 = "Hello";
-        details::Attribute att1(cc1);
+        detail::Attribute att1(cc1);
         att1.trim_blank_spaces();
-        details::Attribute att2(cc2);
+        detail::Attribute att2(cc2);
         ASSERT_EQ(att1, att2)
             << att1.value << " != " << att2.value;
     }
@@ -255,9 +255,9 @@ TEST(DistinguishedNameTests, trim_back_blank_spaces)
     {
         const char* cc1 = "Hello";
         const char* cc2 = "Hello";
-        details::Attribute att1(cc1);
+        detail::Attribute att1(cc1);
         att1.trim_back_blank_spaces();
-        details::Attribute att2(cc2);
+        detail::Attribute att2(cc2);
         ASSERT_EQ(att1, att2)
             << att1.value << " != " << att2.value;
     }
@@ -266,9 +266,9 @@ TEST(DistinguishedNameTests, trim_back_blank_spaces)
     {
         const char* cc1 = "Hello ";
         const char* cc2 = "Hello";
-        details::Attribute att1(cc1);
+        detail::Attribute att1(cc1);
         att1.trim_back_blank_spaces();
-        details::Attribute att2(cc2);
+        detail::Attribute att2(cc2);
         ASSERT_EQ(att1, att2)
             << att1.value << " != " << att2.value;
     }
@@ -277,9 +277,9 @@ TEST(DistinguishedNameTests, trim_back_blank_spaces)
     {
         const char* cc1 = "Hello   ";
         const char* cc2 = "Hello";
-        details::Attribute att1(cc1);
+        detail::Attribute att1(cc1);
         att1.trim_back_blank_spaces();
-        details::Attribute att2(cc2);
+        detail::Attribute att2(cc2);
         ASSERT_EQ(att1, att2)
             << att1.value << " != " << att2.value;
     }

--- a/test/unittest/security/accesscontrol/DistinguishedNameTests.cpp
+++ b/test/unittest/security/accesscontrol/DistinguishedNameTests.cpp
@@ -20,7 +20,7 @@
 
 using namespace eprosima::fastrtps::rtps::security;
 
-namespace test{
+namespace test {
 
 /*
  * This struct join multiple DistinguishedNames in string format that refer to the same entity.

--- a/test/unittest/statistics/dds/CMakeLists.txt
+++ b/test/unittest/statistics/dds/CMakeLists.txt
@@ -309,6 +309,7 @@ if (SQLITE3_SUPPORT AND FASTDDS_STATISTICS AND NOT QNX)
             ${PROJECT_SOURCE_DIR}/src/cpp/security/artifact_providers/Pkcs11Provider.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/security/authentication/PKIDH.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/security/accesscontrol/Permissions.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/security/accesscontrol/DistinguishedName.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/security/cryptography/AESGCMGMAC.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/security/cryptography/AESGCMGMAC_KeyExchange.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/security/cryptography/AESGCMGMAC_KeyFactory.cpp


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
Reimplement Distinguished names comparator function `rfc2253_string_compare`.

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
There was an incorrect behavior in the comparison of Distinguished Names in security accesscontrol module.
Main problem is that RFC 2253 was not correctly followed, and some Distinguished Names that should be accepted were not (mainly because disorder of value-types attributes was not contemplated).

This PR have the following features in respective commits:
1. Extend a function that made security fail without log information (35cd6225ae72188100bc04edf9cc06e674053776)
2. Implement new `rfc2253_string_compare` function (c80227739b7842dbc7428da9e73b338881989cb7)
3. Add tests for such function (270c155eca0fdbb2c003a1ea5d8be459d79cfccf)

> **NOTE**: The implementation of this function is highly non trivial as many concerns must be taken into account, as all RFC 2253 details and zero-allocation policy.

> **NOTE**: This implementation is not complete, but at least extender than before. A future refactor must be done to handle Distinguished Names appropriately.

### Documentation

- https://github.com/eProsima/Fast-DDS-docs/pull/499


<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.10.x 2.9.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [ ] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [N/A] New feature has been added to the `versions.md` file (if applicable).
- [N/A] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [ ] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [ ] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
