### PR TITLE
[18763] Improve content filter expression parameters checks and verbosity.

### DIFF
--- a/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
@@ -21,7 +21,6 @@
 #define FASTDDS_CORE_POLICY__PARAMETERSERIALIZER_HPP_
 
 #include "ParameterList.hpp"
-#include "fastdds/dds/log/Log.hpp"
 
 #include <fastdds/rtps/builtin/data/ContentFilterProperty.hpp>
 #include <fastdds/rtps/common/CDRMessage_t.h>

--- a/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
@@ -21,6 +21,7 @@
 #define FASTDDS_CORE_POLICY__PARAMETERSERIALIZER_HPP_
 
 #include "ParameterList.hpp"
+#include "fastdds/dds/log/Log.hpp"
 
 #include <fastdds/rtps/builtin/data/ContentFilterProperty.hpp>
 #include <fastdds/rtps/common/CDRMessage_t.h>
@@ -869,7 +870,7 @@ public:
                 valid = fastrtps::rtps::CDRMessage::readUInt32(cdr_message, &num_parameters);
                 if (valid)
                 {
-                    valid = (num_parameters < 100) && (num_parameters < parameter.expression_parameters.max_size());
+                    valid = (num_parameters <= 100) && (num_parameters <= parameter.expression_parameters.max_size());
                 }
                 if (valid)
                 {

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -583,6 +583,21 @@ ContentFilteredTopic* DomainParticipantImpl::create_contentfilteredtopic(
         return nullptr;
     }
 
+    if (expression_parameters.size() > qos_.allocation().content_filter.expression_parameters.maximum)
+    {
+        EPROSIMA_LOG_ERROR(PARTICIPANT, "Number of expression parameters exceeds maximum allocation limit: "
+                << expression_parameters.size() << " > "
+                << qos_.allocation().content_filter.expression_parameters.maximum);
+        return nullptr;
+    }
+
+    if (expression_parameters.size() > 100)
+    {
+        EPROSIMA_LOG_ERROR(PARTICIPANT, "Number of expression parameters exceeds maximum protocol limit: "
+                << expression_parameters.size() << " > 100");
+        return nullptr;
+    }
+
     TopicProxy* topic_impl = dynamic_cast<TopicProxy*>(related_topic->get_impl());
     assert(nullptr != topic_impl);
     const TypeSupport& type = topic_impl->get_type();

--- a/src/cpp/fastdds/topic/ContentFilteredTopicImpl.cpp
+++ b/src/cpp/fastdds/topic/ContentFilteredTopicImpl.cpp
@@ -23,7 +23,7 @@
 #include <fastdds/core/policy/ParameterList.hpp>
 #include <fastdds/dds/core/policy/ParameterTypes.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
-#include <fastdds/domain/DomainParticipantImpl.hpp>
+#include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
 #include <fastdds/rtps/messages/CDRMessage.h>
 #include <fastdds/subscriber/DataReaderImpl.hpp>
 #include <fastdds/topic/ContentFilterUtils.hpp>

--- a/src/cpp/fastdds/topic/ContentFilteredTopicImpl.cpp
+++ b/src/cpp/fastdds/topic/ContentFilteredTopicImpl.cpp
@@ -20,14 +20,17 @@
 
 #include <algorithm>
 
-#include <fastdds/dds/core/policy/ParameterTypes.hpp>
-#include <fastrtps/utils/md5.h>
-
 #include <fastdds/core/policy/ParameterList.hpp>
+#include <fastdds/dds/core/policy/ParameterTypes.hpp>
+#include <fastdds/dds/domain/DomainParticipant.hpp>
+#include <fastdds/domain/DomainParticipantImpl.hpp>
 #include <fastdds/rtps/messages/CDRMessage.h>
 #include <fastdds/subscriber/DataReaderImpl.hpp>
 #include <fastdds/topic/ContentFilterUtils.hpp>
 #include <fastdds/topic/TopicProxy.hpp>
+
+#include <fastrtps/types/TypesBase.h>
+#include <fastrtps/utils/md5.h>
 
 namespace eprosima {
 namespace fastdds {
@@ -59,6 +62,16 @@ ReturnCode_t ContentFilteredTopicImpl::set_expression_parameters(
     TopicProxy* topic_impl = dynamic_cast<TopicProxy*>(related_topic->get_impl());
     assert(nullptr != topic_impl);
     const TypeSupport& type = topic_impl->get_type();
+
+    DomainParticipantQos pqos;
+    related_topic->get_participant()->get_qos(pqos);
+    if (new_expression_parameters.size() > pqos.allocation().content_filter.expression_parameters.maximum )
+    {
+        EPROSIMA_LOG_ERROR(CONTENT_FILTERED_TOPIC, "Number of expression parameters exceeds maximum allocation limit: "
+                << new_expression_parameters.size() << " > "
+                << pqos.allocation().content_filter.expression_parameters.maximum);
+        return ReturnCode_t::RETCODE_BAD_PARAMETER;
+    }
 
     LoanableSequence<const char*>::size_type n_params;
     n_params = static_cast<LoanableSequence<const char*>::size_type>(new_expression_parameters.size());

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -2169,14 +2169,46 @@ TEST(ParticipantTests, DeleteTopicInUse)
 // Check that the constraints on maximum expression parameter size are honored
 TEST(ParticipantTests, ExpressionParameterLimits)
 {
-    DomainParticipantQos pqos = PARTICIPANT_QOS_DEFAULT;
 
+    DomainParticipantQos pqos = PARTICIPANT_QOS_DEFAULT;
+    TypeSupport type(new TopicDataTypeMock());
+
+    // Testing QoS Default limit
+    DomainParticipant* participant_default_max_parameters =
+            DomainParticipantFactory::get_instance()->create_participant(0, pqos);
+    type.register_type(participant_default_max_parameters, "footype");
+
+    Topic* topic_default_max_parameters = participant_default_max_parameters->create_topic("footopic", "footype",
+                    TOPIC_QOS_DEFAULT);
+
+    std::vector<std::string> expression_parameters;
+    for (int i = 0; i < 101; i++)
+    {
+        expression_parameters.push_back("Parameter");
+    }
+
+    ContentFilteredTopic* content_filtered_topic_default_max_parameters =
+            participant_default_max_parameters->create_contentfilteredtopic("contentfilteredtopic",
+                    topic_default_max_parameters, "", expression_parameters);
+    ASSERT_EQ(content_filtered_topic_default_max_parameters, nullptr);
+
+    ContentFilteredTopic* content_filtered_topic_default_valid_parameters =
+            participant_default_max_parameters->create_contentfilteredtopic("contentfilteredtopic",
+                    topic_default_max_parameters, "", {"Parameter1", "Parameter2"});
+    ASSERT_NE(content_filtered_topic_default_valid_parameters, nullptr);
+
+    ASSERT_EQ(participant_default_max_parameters->delete_contentfilteredtopic(
+                content_filtered_topic_default_valid_parameters), ReturnCode_t::RETCODE_OK);
+    ASSERT_EQ(participant_default_max_parameters->delete_topic(topic_default_max_parameters), ReturnCode_t::RETCODE_OK);
+    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(
+                participant_default_max_parameters), ReturnCode_t::RETCODE_OK);
+
+    // Test user defined limits
     pqos.allocation().content_filter.expression_parameters.maximum = 1;
 
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(0, pqos);
 
-    TypeSupport type(new TopicDataTypeMock());
     type.register_type(participant, "footype");
 
     Topic* topic = participant->create_topic("footopic", "footype", TOPIC_QOS_DEFAULT);

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -2189,6 +2189,10 @@ TEST(ParticipantTests, ExpressionParameterLimits)
                     topic, "", {"Parameter1"});
     ASSERT_NE(content_filtered_topic, nullptr);
 
+    ASSERT_EQ(fastrtps::types::ReturnCode_t::RETCODE_BAD_PARAMETER, content_filtered_topic->set_expression_parameters(
+                {"Parameter1",
+                 "Parameter2"}));
+
     ASSERT_EQ(participant->delete_contentfilteredtopic(content_filtered_topic), ReturnCode_t::RETCODE_OK);
     ASSERT_EQ(participant->delete_topic(topic), ReturnCode_t::RETCODE_OK);
 

--- a/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
+++ b/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "fastdds/dds/log/Log.hpp"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -1195,6 +1196,67 @@ TEST(BuiltinDataSerializationTests, contentfilterproperty_interoperability)
     ASSERT_EQ("200", out.content_filter().expression_parameters[1].to_string());
     ASSERT_EQ("100", out.content_filter().expression_parameters[2].to_string());
     ASSERT_EQ("200", out.content_filter().expression_parameters[3].to_string());
+}
+
+/*!
+ * \test Test for deserialization of messages with the maximum size of expression parameters
+ */
+TEST(BuiltinDataSerializationTests, contentfilterproperty_max_parameter_check)
+{
+    // Empty value
+    {
+        ReaderProxyData out(max_unicast_locators, max_multicast_locators);
+
+        // Perform serialization
+        CDRMessage_t msg(5000);
+        EXPECT_TRUE(fastdds::dds::ParameterList::writeEncapsulationToCDRMsg(&msg));
+        const std::string content_filtered_topic_name("CFT_TEST");
+        const std::string related_topic_name("TEST");
+        const std::string filter_class_name("MyFilterClass");
+        const std::string filter_expression("This is a custom test filter expression");
+        std::vector<std::string> expression_parameters;
+        for (int i = 0; i < 100; ++i)
+        {
+            expression_parameters.push_back("Parameter");
+        }
+
+        // Manual serialization of a ContentFilterProperty.
+        {
+            uint32_t len = manual_content_filter_cdr_serialized_size(
+                content_filtered_topic_name,
+                related_topic_name,
+                filter_class_name,
+                filter_expression,
+                expression_parameters
+                );
+            EXPECT_TRUE(fastrtps::rtps::CDRMessage::addUInt16(&msg, fastdds::dds::PID_CONTENT_FILTER_PROPERTY));
+            EXPECT_TRUE(fastrtps::rtps::CDRMessage::addUInt16(&msg, static_cast<uint16_t>(len - 4)));
+            // content_filtered_topic_name
+            EXPECT_TRUE(fastrtps::rtps::CDRMessage::add_string(&msg, content_filtered_topic_name));
+            // related_topic_name
+            EXPECT_TRUE(fastrtps::rtps::CDRMessage::add_string(&msg, related_topic_name));
+            // filter_class_name
+            EXPECT_TRUE(fastrtps::rtps::CDRMessage::add_string(&msg, filter_class_name));
+            // filter_expression
+            EXPECT_TRUE(fastrtps::rtps::CDRMessage::add_string(&msg, filter_expression));
+            // expression_parameters
+            // sequence length
+            uint32_t num_params = static_cast<uint32_t>(expression_parameters.size());
+            EXPECT_EQ(num_params, 100);
+            EXPECT_TRUE(fastrtps::rtps::CDRMessage::addUInt32(&msg, num_params));
+            // Add all parameters
+            for (const std::string& param : expression_parameters)
+            {
+                EXPECT_TRUE(fastrtps::rtps::CDRMessage::add_string(&msg, param));
+            }
+        }
+        EXPECT_TRUE(fastdds::dds::ParameterSerializer<Parameter_t>::add_parameter_sentinel(&msg));
+
+        msg.pos = 0;
+        EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true));
+
+        ASSERT_EQ(100, out.content_filter().expression_parameters.size());
+    }
 }
 
 } // namespace rtps

--- a/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
+++ b/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
@@ -1242,7 +1242,7 @@ TEST(BuiltinDataSerializationTests, contentfilterproperty_max_parameter_check)
             // expression_parameters
             // sequence length
             uint32_t num_params = static_cast<uint32_t>(expression_parameters.size());
-            EXPECT_EQ(num_params, 100);
+            EXPECT_EQ(num_params, 100u);
             EXPECT_TRUE(fastrtps::rtps::CDRMessage::addUInt32(&msg, num_params));
             // Add all parameters
             for (const std::string& param : expression_parameters)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds an additional check to verify that the expression_parameters vector provided when creating a ContentFilteredTopic math with the limits established in the DomainParticipantQoS. It also fixes a wrong length comparison when deserializing that same vector.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.10.x 2.9.x 2.6.x -->

@Mergifyio backport 2.10.x 2.9.x 2.6.x

Related documentation PR: eProsima/Fast-DDS-Docs#510

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [NA] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [NA] New feature has been added to the `versions.md` file (if applicable).
- [NA] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
