### PR TITLE
[13608] Dynamic memory topic payload pool properly handle Zero sized payloads

### DIFF
--- a/include/fastdds/rtps/history/IPayloadPool.h
+++ b/include/fastdds/rtps/history/IPayloadPool.h
@@ -49,7 +49,6 @@ public:
      * In both cases, the received @c size will be for the whole serialized payload.
      *
      * @param [in]     size          Number of bytes required for the serialized payload.
-     *                               Should be greater than 0.
      * @param [in,out] cache_change  Cache change to assign the payload to
      *
      * @returns whether the operation succeeded or not

--- a/src/cpp/rtps/history/TopicPayloadPool.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPool.hpp
@@ -139,9 +139,17 @@ protected:
         explicit PayloadNode(
                 uint32_t size)
         {
-            assert(size > 0);
+            if (!size)
+            {
+                //! At least, we need this to allocate space for a NodeInfo.
+                //! In order to be able to place-construct later
+                buffer = (octet*)calloc(sizeof(NodeInfo), sizeof(octet));
+            }
+            else
+            {
+                buffer = (octet*)calloc(size + sizeof(NodeInfo) - 1, sizeof(octet));
+            }
 
-            buffer = (octet*)calloc(size + sizeof(NodeInfo) - 1, sizeof(octet));
             if (buffer == nullptr)
             {
                 throw std::bad_alloc();

--- a/src/cpp/rtps/history/TopicPayloadPool_impl/Dynamic.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPool_impl/Dynamic.hpp
@@ -33,7 +33,7 @@ public:
             uint32_t size,
             CacheChange_t& cache_change) override
     {
-        return (size > 0u) && do_get_payload(size, cache_change, true);
+        return do_get_payload(size, cache_change, true);
     }
 
     bool release_payload(

--- a/src/cpp/rtps/history/TopicPayloadPool_impl/DynamicReusable.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPool_impl/DynamicReusable.hpp
@@ -31,7 +31,7 @@ class DynamicReusableTopicPayloadPool : public TopicPayloadPool
             uint32_t size,
             CacheChange_t& cache_change) override
     {
-        return (size > 0u) && do_get_payload(size, cache_change, true);
+        return do_get_payload(size, cache_change, true);
     }
 
 protected:

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -449,6 +449,19 @@ public:
         return initialized_;
     }
 
+    bool delete_datareader()
+    {
+        ReturnCode_t ret(ReturnCode_t::RETCODE_ERROR);
+
+        if (subscriber_ && datareader_)
+        {
+            ret = subscriber_->delete_datareader(datareader_);
+            datareader_ = nullptr;
+        }
+
+        return (ReturnCode_t::RETCODE_OK == ret);
+    }
+
     virtual void destroy()
     {
         if (participant_ != nullptr)
@@ -948,6 +961,13 @@ public:
     PubSubReader& disable_builtin_transport()
     {
         participant_qos_.transport().use_builtin_transports = false;
+        return *this;
+    }
+
+    PubSubReader& set_wire_protocol_qos(
+            const eprosima::fastdds::dds::WireProtocolConfigQos& qos)
+    {
+        participant_qos_.wire_protocol() = qos;
         return *this;
     }
 

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -645,6 +645,35 @@ public:
         std::cout << "Writer removal finished..." << std::endl;
     }
 
+    bool wait_reader_undiscovery(
+            std::chrono::seconds timeout,
+            unsigned int matched = 0)
+    {
+        bool ret_value = true;
+        std::unique_lock<std::mutex> lock(mutexDiscovery_);
+
+        std::cout << "Writer is waiting removal..." << std::endl;
+
+        if (!cv_.wait_for(lock, timeout, [&]()
+                {
+                    return matched_ == matched;
+                }))
+        {
+            ret_value = false;
+        }
+
+        if (ret_value)
+        {
+            std::cout << "Writer removal finished successfully..." << std::endl;
+        }
+        else
+        {
+            std::cout << "Writer removal finished unsuccessfully..." << std::endl;
+        }
+
+        return ret_value;
+    }
+
     void wait_liveliness_lost(
             unsigned int times = 1)
     {
@@ -920,6 +949,13 @@ public:
     PubSubWriter& disable_builtin_transport()
     {
         participant_qos_.transport().use_builtin_transports = false;
+        return *this;
+    }
+
+    PubSubWriter& set_wire_protocol_qos(
+            const eprosima::fastdds::dds::WireProtocolConfigQos& qos)
+    {
+        participant_qos_.wire_protocol() = qos;
         return *this;
     }
 

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -656,7 +656,7 @@ public:
 
         if (!cv_.wait_for(lock, timeout, [&]()
                 {
-                    return matched_ == matched;
+                    return matched_ <= matched;
                 }))
         {
             ret_value = false;

--- a/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
@@ -667,6 +667,41 @@ TEST(DDSDiscovery, DDSDiscoveryDoesNotDropUDPLocator)
 }
 
 /**
+ * This is a regression test for #1929
+ * Checks that the disposal of an matched Endpoint is correctly received
+ * by a remote participant when DYNAMIC_REUSABLE memory mode is used
+ */
+TEST(DDSDiscovery, WriterAndReaderMatchUsingDynamicReusableMemoryMode)
+{
+    using namespace eprosima::fastdds::dds;
+    using namespace eprosima::fastrtps::rtps;
+
+    WireProtocolConfigQos qos;
+
+    qos.builtin.readerHistoryMemoryPolicy = eprosima::fastrtps::rtps::DYNAMIC_REUSABLE_MEMORY_MODE;
+
+    PubSubWriter<HelloWorldPubSubType> writer("test");
+    PubSubReader<HelloWorldPubSubType> reader("test");
+
+    writer.set_wire_protocol_qos(qos).init();
+    ASSERT_TRUE(writer.isInitialized());
+
+    reader.set_wire_protocol_qos(qos).init();
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    ASSERT_TRUE(reader.is_matched());
+    ASSERT_TRUE(writer.is_matched());
+
+    reader.delete_datareader();
+
+    ASSERT_TRUE(writer.wait_reader_undiscovery(std::chrono::seconds(3)));
+
+}
+
+/**
  * This test checks the missing file case of DomainParticipantFactory->check_xml_static_discovery
  * method and checks it returns RETCODE_ERROR
  */


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
As a regression of #1929, this PR introduces a couple of unit tests, the regression BB test and proposes a fix for accepting zero sized payload allocations in the topic pool. 

In particular, this is interesting to properly add to the history the disposals of any endpoints in a remote Participant configured with DYNAMIC_*_MEMORY modes, as the payload size in that case is 0. Otherwise, the disposal CacheChanges are always discarded by remote participants and are not added to the history.

*Note: this PR should not be merged until 2.11 freeze is finished*

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.11.x 2.10.x 2.9.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
Fixes #1929

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [X] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
