### PR TITLE
Added < and > operators to fixed_string.

### DIFF
--- a/include/fastrtps/utils/fixed_size_string.hpp
+++ b/include/fastrtps/utils/fixed_size_string.hpp
@@ -161,6 +161,18 @@ public:
         return strncmp(string_data, rhs.c_str(), MAX_CHARS) != 0;
     }
 
+    bool operator < (
+            const std::string& rhs) const noexcept
+    {
+        return 0 > compare(rhs);
+    }
+
+    bool operator > (
+            const std::string& rhs) const noexcept
+    {
+        return 0 < compare(rhs);
+    }
+
     operator const char* () const noexcept {
         return c_str();
     }

--- a/include/fastrtps/utils/fixed_size_string.hpp
+++ b/include/fastrtps/utils/fixed_size_string.hpp
@@ -161,6 +161,18 @@ public:
         return strncmp(string_data, rhs.c_str(), MAX_CHARS) != 0;
     }
 
+    template<size_t N>  bool operator < (
+            const fixed_string<N>& rhs) const noexcept
+    {
+        return 0 > compare(rhs);
+    }
+
+    template<size_t N>  bool operator > (
+            const fixed_string<N>& rhs) const noexcept
+    {
+        return 0 < compare(rhs);
+    }
+
     bool operator < (
             const std::string& rhs) const noexcept
     {

--- a/test/unittest/utils/FixedSizeStringTests.cpp
+++ b/test/unittest/utils/FixedSizeStringTests.cpp
@@ -222,6 +222,48 @@ TEST_F(FixedSizeStringTests, comparisons)
     ASSERT_GT(0, fixed_b.compare(fixed_large));
 }
 
+TEST_F(FixedSizeStringTests, less_than_operator_fixed_string)
+{
+    fixed_string<MAX_CHARS> fixed_string_short = "test string";
+    fixed_string<MAX_CHARS> fixed_string_long = "test string long";
+
+    ASSERT_FALSE(fixed_string_short < fixed_string_short);
+    ASSERT_FALSE(fixed_string_long < fixed_string_long);
+    ASSERT_TRUE(fixed_string_short < fixed_string_long);
+    ASSERT_FALSE(fixed_string_long < fixed_string_short);
+}
+
+TEST_F(FixedSizeStringTests, less_than_operator_std_string)
+{
+    fixed_string<MAX_CHARS> fixed_string_short = "test string";
+    std::string std_string_long = "test string long";
+    std::string std_string_short = "test";
+
+    ASSERT_TRUE(fixed_string_short < std_string_long);
+    ASSERT_FALSE(fixed_string_short < std_string_short);
+}
+
+TEST_F(FixedSizeStringTests, greater_than_operator_fixed_string)
+{
+    fixed_string<MAX_CHARS> fixed_string_short = "test string";
+    fixed_string<MAX_CHARS> fixed_string_long = "test string long";
+
+    ASSERT_FALSE(fixed_string_short > fixed_string_short);
+    ASSERT_FALSE(fixed_string_long > fixed_string_long);
+    ASSERT_FALSE(fixed_string_short > fixed_string_long);
+    ASSERT_TRUE(fixed_string_long > fixed_string_short);
+}
+
+TEST_F(FixedSizeStringTests, greater_than_operator_std_string)
+{
+    fixed_string<MAX_CHARS> fixed_string_short = "test string";
+    std::string std_string_long = "test string long";
+    std::string std_string_short = "test";
+
+    ASSERT_FALSE(fixed_string_short > std_string_long);
+    ASSERT_TRUE(fixed_string_short > std_string_short);
+}
+
 int main(
         int argc,
         char** argv)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
The< and > operators use the compare function.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.10.x 2.9.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- *N/A* Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.