### PR TITLE
[18910] Temporal fix for 3361 Regression test types and regeneration with Fast DDS Gen 2.5.1

### DIFF
--- a/test/blackbox/types/TestIncludeRegression3361PubSubTypes.h
+++ b/test/blackbox/types/TestIncludeRegression3361PubSubTypes.h
@@ -1,0 +1,3 @@
+/*Temporal workaround for TestRegression3361PubSubTypes.h
+ * that mistakenly expects this file
+ */

--- a/test/blackbox/types/TestIncludeRegression3361TypeObject.cxx
+++ b/test/blackbox/types/TestIncludeRegression3361TypeObject.cxx
@@ -26,6 +26,7 @@ namespace { char dummy; }
 
 #include "TestIncludeRegression3361.h"
 #include "TestIncludeRegression3361TypeObject.h"
+#include <mutex>
 #include <utility>
 #include <sstream>
 #include <fastrtps/rtps/common/SerializedPayload.h>
@@ -40,13 +41,17 @@ using namespace eprosima::fastrtps::rtps;
 
 void registerTestIncludeRegression3361Types()
 {
-    TypeObjectFactory *factory = TypeObjectFactory::get_instance();
-    factory->add_type_object("TestModule::MACHINEID", TestModule::GetMACHINEIDIdentifier(true),
-            TestModule::GetMACHINEIDObject(true));
-    factory->add_type_object("TestModule::MACHINEID", TestModule::GetMACHINEIDIdentifier(false),
-            TestModule::GetMACHINEIDObject(false));
+    static std::once_flag once_flag;
+    std::call_once(once_flag, []()
+            {
+                TypeObjectFactory *factory = TypeObjectFactory::get_instance();
+                factory->add_type_object("TestModule::MACHINEID", TestModule::GetMACHINEIDIdentifier(true),
+                        TestModule::GetMACHINEIDObject(true));
+                factory->add_type_object("TestModule::MACHINEID", TestModule::GetMACHINEIDIdentifier(false),
+                        TestModule::GetMACHINEIDObject(false));
 
 
+            });
 }
 
 namespace TestModule {

--- a/test/blackbox/types/TestIncludeRegression3361TypeObject.h
+++ b/test/blackbox/types/TestIncludeRegression3361TypeObject.h
@@ -31,10 +31,10 @@
 #define eProsima_user_DllExport __declspec( dllexport )
 #else
 #define eProsima_user_DllExport
-#endif // if defined(EPROSIMA_USER_DLL_EXPORT)
+#endif
 #else
 #define eProsima_user_DllExport
-#endif // if defined(_WIN32)
+#endif
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)
@@ -45,7 +45,7 @@
 #endif // TestIncludeRegression3361_SOURCE
 #else
 #define TestIncludeRegression3361_DllAPI
-#endif // if defined(EPROSIMA_USER_DLL_EXPORT)
+#endif
 #else
 #define TestIncludeRegression3361_DllAPI
 #endif // _WIN32
@@ -55,12 +55,10 @@ using namespace eprosima::fastrtps::types;
 eProsima_user_DllExport void registerTestIncludeRegression3361Types();
 
 namespace TestModule {
-eProsima_user_DllExport const TypeIdentifier* GetMACHINEIDIdentifier(
-        bool complete = false);
-eProsima_user_DllExport const TypeObject* GetMACHINEIDObject(
-        bool complete = false);
-eProsima_user_DllExport const TypeObject* GetMinimalMACHINEIDObject();
-eProsima_user_DllExport const TypeObject* GetCompleteMACHINEIDObject();
+    eProsima_user_DllExport const TypeIdentifier* GetMACHINEIDIdentifier(bool complete = false);
+    eProsima_user_DllExport const TypeObject* GetMACHINEIDObject(bool complete = false);
+    eProsima_user_DllExport const TypeObject* GetMinimalMACHINEIDObject();
+    eProsima_user_DllExport const TypeObject* GetCompleteMACHINEIDObject();
 
 } // namespace TestModule
 

--- a/test/blackbox/types/TestRegression3361.cxx
+++ b/test/blackbox/types/TestRegression3361.cxx
@@ -27,6 +27,7 @@ char dummy;
 #endif  // _WIN32
 
 #include "TestRegression3361.h"
+#include "TestRegression3361TypeObject.h"
 #include <fastcdr/Cdr.h>
 
 #include <fastcdr/exceptions/BadParamException.h>
@@ -44,6 +45,8 @@ TestRegression3361::TestRegression3361()
     // TestModule::MACHINEID m_uuid
     m_uuid ="";
 
+    // Just to register all known types
+    registerTestRegression3361Types();
 }
 
 TestRegression3361::~TestRegression3361()

--- a/test/blackbox/types/TestRegression3361PubSubTypes.h
+++ b/test/blackbox/types/TestRegression3361PubSubTypes.h
@@ -28,6 +28,8 @@
 
 #include "TestRegression3361.h"
 
+#include "TestIncludeRegression3361PubSubTypes.h"
+
 #if !defined(GEN_API_VER) || (GEN_API_VER != 1)
 #error \
     Generated TestRegression3361 is not compatible with current installed Fast DDS. Please, regenerate it with fastddsgen.

--- a/test/blackbox/types/TestRegression3361TypeObject.cxx
+++ b/test/blackbox/types/TestRegression3361TypeObject.cxx
@@ -26,6 +26,7 @@ namespace { char dummy; }
 
 #include "TestRegression3361.h"
 #include "TestRegression3361TypeObject.h"
+#include <mutex>
 #include <utility>
 #include <sstream>
 #include <fastrtps/rtps/common/SerializedPayload.h>
@@ -40,18 +41,22 @@ using namespace eprosima::fastrtps::rtps;
 
 void registerTestRegression3361Types()
 {
-    TypeObjectFactory *factory = TypeObjectFactory::get_instance();
-    factory->add_type_object("TestModule::MACHINEID", TestModule::GetMACHINEIDIdentifier(true),
-            TestModule::GetMACHINEIDObject(true));
-    factory->add_type_object("TestModule::MACHINEID", TestModule::GetMACHINEIDIdentifier(false),
-            TestModule::GetMACHINEIDObject(false));
+    static std::once_flag once_flag;
+    std::call_once(once_flag, []()
+            {
+                TypeObjectFactory *factory = TypeObjectFactory::get_instance();
+                factory->add_type_object("TestModule::MACHINEID", TestModule::GetMACHINEIDIdentifier(true),
+                        TestModule::GetMACHINEIDObject(true));
+                factory->add_type_object("TestModule::MACHINEID", TestModule::GetMACHINEIDIdentifier(false),
+                        TestModule::GetMACHINEIDObject(false));
 
 
-    factory->add_type_object("TestRegression3361", GetTestRegression3361Identifier(true),
-    GetTestRegression3361Object(true));
-    factory->add_type_object("TestRegression3361", GetTestRegression3361Identifier(false),
-    GetTestRegression3361Object(false));
+                factory->add_type_object("TestRegression3361", GetTestRegression3361Identifier(true),
+                GetTestRegression3361Object(true));
+                factory->add_type_object("TestRegression3361", GetTestRegression3361Identifier(false),
+                GetTestRegression3361Object(false));
 
+            });
 }
 
 const TypeIdentifier* GetTestRegression3361Identifier(bool complete)

--- a/test/blackbox/types/TestRegression3361TypeObject.h
+++ b/test/blackbox/types/TestRegression3361TypeObject.h
@@ -32,10 +32,10 @@
 #define eProsima_user_DllExport __declspec( dllexport )
 #else
 #define eProsima_user_DllExport
-#endif // if defined(EPROSIMA_USER_DLL_EXPORT)
+#endif
 #else
 #define eProsima_user_DllExport
-#endif // if defined(_WIN32)
+#endif
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)
@@ -46,7 +46,7 @@
 #endif // TestRegression3361_SOURCE
 #else
 #define TestRegression3361_DllAPI
-#endif // if defined(EPROSIMA_USER_DLL_EXPORT)
+#endif
 #else
 #define TestRegression3361_DllAPI
 #endif // _WIN32
@@ -55,10 +55,8 @@ using namespace eprosima::fastrtps::types;
 
 eProsima_user_DllExport void registerTestRegression3361Types();
 
-eProsima_user_DllExport const TypeIdentifier* GetTestRegression3361Identifier(
-        bool complete = false);
-eProsima_user_DllExport const TypeObject* GetTestRegression3361Object(
-        bool complete = false);
+eProsima_user_DllExport const TypeIdentifier* GetTestRegression3361Identifier(bool complete = false);
+eProsima_user_DllExport const TypeObject* GetTestRegression3361Object(bool complete = false);
 eProsima_user_DllExport const TypeObject* GetMinimalTestRegression3361Object();
 eProsima_user_DllExport const TypeObject* GetCompleteTestRegression3361Object();
 

--- a/utils/scripts/update_generated_code_from_idl.sh
+++ b/utils/scripts/update_generated_code_from_idl.sh
@@ -6,6 +6,7 @@ files_to_exclude=(
 
 files_needing_typeobject=(
     './examples/cpp/dds/ContentFilteredTopicExample/HelloWorld.idl'
+    './test/blackbox/types/TestRegression3361.idl'
     './test/unittest/dynamic_types/idl/Basic.idl'
     './test/unittest/dynamic_types/idl/new_features_4_2.idl'
     './test/unittest/dynamic_types/idl/Test.idl'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
This PR regenerates the `TestRegression3361...` types with Fast DDS Gen `2.5.1` with the `-typeobject` arg and proposes a temporal fix for a mistaken `#include` in one of the generated files.

Another solution would be ignoring the `TestRegression3361.idl` temporarily by appending it to the `files_to_exclude()` 
 `update_generated_code_from_idl.sh` automation script array. Opening it as a draft for the moment. 

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.10.x 2.9.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [ ] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [ ] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [ ] Applicable backports have been included in the description.


## Reviewer Checklist
- [ ] The PR has a milestone assigned.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
