### PR TITLE
[19071] Move and complete the Monitor Service High level API to statistics

### DIFF
--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -943,27 +943,6 @@ public:
      */
     bool has_active_entities();
 
-    /**
-     * Enables the monitor service in this DomainParticipant.
-     *
-     * @return RETCODE_OK if the monitor service could be correctly enabled.
-     * @return RETCODE_ERROR if the monitor service could not be enabled properly.
-     *
-     * @note Not supported yet. Currently returns RETCODE_UNSUPPORTED
-     */
-    RTPS_DllAPI ReturnCode_t enable_monitor_service() const;
-
-    /**
-     * Disables the monitor service in this DomainParticipant. Does nothing if the service was not enabled before.
-     *
-     * @return RETCODE_OK if the monitor service could be correctly disabled.
-     * @return RETCODE_NOT_ENABLED if the monitor service was not previously enabled.
-     * @return RETCODE_ERROR if the service could not be properly disabled.
-     *
-     * @note Not supported yet. Currently returns RETCODE_UNSUPPORTED
-     */
-    RTPS_DllAPI ReturnCode_t disable_monitor_service() const;
-
 protected:
 
     DomainParticipant(

--- a/include/fastdds/rtps/participant/RTPSParticipant.h
+++ b/include/fastdds/rtps/participant/RTPSParticipant.h
@@ -351,14 +351,14 @@ public:
      * Creates the monitor service in this RTPSParticipant with the provided interfaces.
      *
      * @param sq reference to the object implementing the StatusQueryable interface.
-     * It will usually be the DDS DoaminParticipant
+     * It will usually be the DDS DomainParticipant
      *
      * @return A const pointer to the listener (implemented within the RTPSParticipant)
      *
      * @note Not supported yet. Currently always returns nullptr
      */
     const fastdds::statistics::rtps::IStatusListener* create_monitor_service(
-            fastdds::statistics::rtps::IStatusQueryable& sq);
+            fastdds::statistics::rtps::IStatusQueryable& status_queryable);
 
     /**
      * Creates the monitor service in this RTPSParticipant with a simple default

--- a/include/fastdds/rtps/participant/RTPSParticipant.h
+++ b/include/fastdds/rtps/participant/RTPSParticipant.h
@@ -34,6 +34,20 @@
 namespace eprosima {
 
 namespace fastdds {
+
+#ifdef FASTDDS_STATISTICS
+
+namespace statistics {
+namespace rtps {
+
+class IStatusQueryable;
+class IStatusListener;
+
+} // namespace rtps
+} // namespace statistics
+
+#endif //FASTDDS_STATISTICS
+
 namespace dds {
 namespace builtin {
 
@@ -283,25 +297,6 @@ public:
     bool ignore_reader(
             const GUID_t& reader_guid);
 
-    /**
-     * Enables the monitor service in this RTPSParticipant.
-     *
-     * @return true if the monitor service could be correctly enabled.
-     *
-     * @note Not supported yet. Currently always returns false
-     */
-    bool enable_monitor_service() const;
-
-    /**
-     * Disables the monitor service in this RTPSParticipant. Does nothing if the service was not enabled before.
-     *
-     * @return true if the monitor service could be correctly disabled.
-     * @return false if the service could not be properly disabled or if the monitor service was not previously enabled.
-     *
-     * @note Not supported yet. Currently always returns false
-     */
-    bool disable_monitor_service() const;
-
 #if HAVE_SECURITY
 
     /**
@@ -351,6 +346,58 @@ public:
      */
     void set_enabled_statistics_writers_mask(
             uint32_t enabled_writers);
+
+    /**
+     * Creates the monitor service in this RTPSParticipant with the provided interfaces.
+     *
+     * @param sq reference to the object implementing the StatusQueryable interface.
+     * It will usually be the DDS DoaminParticipant
+     *
+     * @return A const pointer to the listener (implemented within the RTPSParticipant)
+     *
+     * @note Not supported yet. Currently always returns nullptr
+     */
+    const fastdds::statistics::rtps::IStatusListener* create_monitor_service(
+            fastdds::statistics::rtps::IStatusQueryable& sq);
+
+    /**
+     * Creates the monitor service in this RTPSParticipant with a simple default
+     * implementation of the IStatusQueryable.
+     *
+     * @return true if the monitor service could be correctly created.
+     *
+     * @note Not supported yet. Currently always returns false
+     */
+    bool create_monitor_service();
+
+    /**
+     * Returns whether the monitor service in created in this RTPSParticipant.
+     *
+     * @return true if the monitor service is created.
+     * @return false otherwise.
+     *
+     * @note Not supported yet. Currently always returns false
+     */
+    bool is_monitor_service_created() const;
+
+    /**
+     * Enables the monitor service in this RTPSParticipant.
+     *
+     * @return true if the monitor service could be correctly enabled.
+     *
+     * @note Not supported yet. Currently always returns false
+     */
+    bool enable_monitor_service() const;
+
+    /**
+     * Disables the monitor service in this RTPSParticipant. Does nothing if the service was not enabled before.
+     *
+     * @return true if the monitor service could be correctly disabled.
+     * @return false if the service could not be properly disabled or if the monitor service was not previously enabled.
+     *
+     * @note Not supported yet. Currently always returns false
+     */
+    bool disable_monitor_service() const;
 
 #endif // FASTDDS_STATISTICS
 

--- a/include/fastdds/statistics/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/statistics/dds/domain/DomainParticipant.hpp
@@ -104,6 +104,27 @@ public:
     RTPS_DllAPI static const DomainParticipant* narrow(
             const eprosima::fastdds::dds::DomainParticipant* domain_participant);
 
+    /**
+     * Enables the monitor service in the DomainParticipant.
+     *
+     * @return RETCODE_OK if the monitor service could be correctly enabled.
+     * @return RETCODE_ERROR if the monitor service could not be enabled properly.
+     *
+     * @note Not supported yet. Currently returns RETCODE_UNSUPPORTED
+     */
+    RTPS_DllAPI ReturnCode_t enable_monitor_service() const;
+
+    /**
+     * Disables the monitor service in this DomainParticipant. Does nothing if the service was not enabled before.
+     *
+     * @return RETCODE_OK if the monitor service could be correctly disabled.
+     * @return RETCODE_NOT_ENABLED if the monitor service was not previously enabled.
+     * @return RETCODE_ERROR if the service could not be properly disabled.
+     *
+     * @note Not supported yet. Currently returns RETCODE_UNSUPPORTED
+     */
+    RTPS_DllAPI ReturnCode_t disable_monitor_service() const;
+
 };
 
 } // namespace dds

--- a/include/fastdds/statistics/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/statistics/dds/domain/DomainParticipant.hpp
@@ -109,6 +109,7 @@ public:
      *
      * @return RETCODE_OK if the monitor service could be correctly enabled.
      * @return RETCODE_ERROR if the monitor service could not be enabled properly.
+     * @return RETCODE_UNSUPPORTED if FASTDDS_STATISTICS is not enabled.
      *
      * @note Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
@@ -120,6 +121,7 @@ public:
      * @return RETCODE_OK if the monitor service could be correctly disabled.
      * @return RETCODE_NOT_ENABLED if the monitor service was not previously enabled.
      * @return RETCODE_ERROR if the service could not be properly disabled.
+     * @return RETCODE_UNSUPPORTED if FASTDDS_STATISTICS is not enabled.
      *
      * @note Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */

--- a/src/cpp/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipant.cpp
@@ -507,4 +507,3 @@ bool DomainParticipant::has_active_entities()
 {
     return impl_->has_active_entities();
 }
-

--- a/src/cpp/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipant.cpp
@@ -508,12 +508,3 @@ bool DomainParticipant::has_active_entities()
     return impl_->has_active_entities();
 }
 
-ReturnCode_t DomainParticipant::enable_monitor_service() const
-{
-    return impl_->enable_monitor_service();
-}
-
-ReturnCode_t DomainParticipant::disable_monitor_service() const
-{
-    return impl_->disable_monitor_service();
-}

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -2139,16 +2139,6 @@ bool DomainParticipantImpl::has_active_entities()
     return false;
 }
 
-ReturnCode_t DomainParticipantImpl::enable_monitor_service() const
-{
-    return fastrtps::types::ReturnCode_t::RETCODE_UNSUPPORTED;
-}
-
-ReturnCode_t DomainParticipantImpl::disable_monitor_service() const
-{
-    return fastrtps::types::ReturnCode_t::RETCODE_UNSUPPORTED;
-}
-
 bool DomainParticipantImpl::set_qos(
         DomainParticipantQos& to,
         const DomainParticipantQos& from,

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -505,27 +505,6 @@ public:
     bool has_active_entities();
 
     /**
-     * Enables the monitor service in this DomainParticipant.
-     *
-     * @return RETCODE_OK if the monitor service could be correctly enabled.
-     * @return RETCODE_ERROR if the monitor service could not be enabled properly.
-     *
-     * @note Not supported yet. Currently returns RETCODE_UNSUPPORTED
-     */
-    ReturnCode_t enable_monitor_service() const;
-
-    /**
-     * Disables the monitor service in this DomainParticipant. Does nothing if the service was not enabled before.
-     *
-     * @return RETCODE_OK if the monitor service could be correctly disabled.
-     * @return RETCODE_NOT_ENABLED if the monitor service was not previously enabled.
-     * @return RETCODE_ERROR if the service could not be properly disabled.
-     *
-     * @note Not supported yet. Currently returns RETCODE_UNSUPPORTED
-     */
-    ReturnCode_t disable_monitor_service() const;
-
-    /**
      * Returns the most appropriate listener to handle the callback for the given status,
      * or nullptr if there is no appropriate listener.
      */

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -196,16 +196,6 @@ bool RTPSParticipant::ignore_reader(
     return false;
 }
 
-bool RTPSParticipant::enable_monitor_service() const
-{
-    return mp_impl->enable_monitor_service();
-}
-
-bool RTPSParticipant::disable_monitor_service() const
-{
-    return mp_impl->disable_monitor_service();
-}
-
 #if HAVE_SECURITY
 
 bool RTPSParticipant::is_security_enabled_for_writer(
@@ -242,6 +232,32 @@ void RTPSParticipant::set_enabled_statistics_writers_mask(
         uint32_t enabled_writers)
 {
     mp_impl->set_enabled_statistics_writers_mask(enabled_writers);
+}
+
+const fastdds::statistics::rtps::IStatusListener* RTPSParticipant::create_monitor_service(
+            fastdds::statistics::rtps::IStatusQueryable& sq)
+{
+    return mp_impl->create_monitor_service(sq);
+}
+
+bool RTPSParticipant::create_monitor_service()
+{
+    return mp_impl->create_monitor_service();
+}
+
+bool RTPSParticipant::is_monitor_service_created() const
+{
+    return mp_impl->is_monitor_service_created();
+}
+
+bool RTPSParticipant::enable_monitor_service() const
+{
+    return mp_impl->enable_monitor_service();
+}
+
+bool RTPSParticipant::disable_monitor_service() const
+{
+    return mp_impl->disable_monitor_service();
 }
 
 #endif // FASTDDS_STATISTICS

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -235,7 +235,7 @@ void RTPSParticipant::set_enabled_statistics_writers_mask(
 }
 
 const fastdds::statistics::rtps::IStatusListener* RTPSParticipant::create_monitor_service(
-            fastdds::statistics::rtps::IStatusQueryable& sq)
+        fastdds::statistics::rtps::IStatusQueryable& sq)
 {
     return mp_impl->create_monitor_service(sq);
 }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -2572,16 +2572,6 @@ bool RTPSParticipantImpl::ignore_reader(
     return false;
 }
 
-bool RTPSParticipantImpl::enable_monitor_service() const
-{
-    return false;
-}
-
-bool RTPSParticipantImpl::disable_monitor_service() const
-{
-    return false;
-}
-
 #ifdef FASTDDS_STATISTICS
 
 bool RTPSParticipantImpl::register_in_writer(
@@ -2689,6 +2679,32 @@ void RTPSParticipantImpl::set_enabled_statistics_writers_mask(
     {
         writer->set_enabled_statistics_writers_mask(enabled_writers);
     }
+}
+
+const fastdds::statistics::rtps::IStatusListener* RTPSParticipantImpl::create_monitor_service(
+            fastdds::statistics::rtps::IStatusQueryable& /*sq*/)
+{
+    return nullptr;
+}
+
+bool RTPSParticipantImpl::create_monitor_service()
+{
+    return false;
+}
+
+bool RTPSParticipantImpl::is_monitor_service_created() const
+{
+    return false;
+}
+
+bool RTPSParticipantImpl::enable_monitor_service() const
+{
+    return false;
+}
+
+bool RTPSParticipantImpl::disable_monitor_service() const
+{
+    return false;
 }
 
 #endif // FASTDDS_STATISTICS

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -2682,7 +2682,7 @@ void RTPSParticipantImpl::set_enabled_statistics_writers_mask(
 }
 
 const fastdds::statistics::rtps::IStatusListener* RTPSParticipantImpl::create_monitor_service(
-        fastdds::statistics::rtps::IStatusQueryable& /*sq*/)
+        fastdds::statistics::rtps::IStatusQueryable& /*status_queryable*/)
 {
     return nullptr;
 }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -2682,7 +2682,7 @@ void RTPSParticipantImpl::set_enabled_statistics_writers_mask(
 }
 
 const fastdds::statistics::rtps::IStatusListener* RTPSParticipantImpl::create_monitor_service(
-            fastdds::statistics::rtps::IStatusQueryable& /*sq*/)
+        fastdds::statistics::rtps::IStatusQueryable& /*sq*/)
 {
     return nullptr;
 }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -1133,14 +1133,14 @@ public:
      * Creates the monitor service in this RTPSParticipant with the provided interfaces.
      *
      * @param sq reference to the object implementing the StatusQueryable interface.
-     * It will usually be the DDS DoaminParticipant
+     * It will usually be the DDS DomainParticipant
      *
      * @return A const pointer to the listener (implemented within the RTPSParticipant)
      *
      * @note Not supported yet. Currently always returns nullptr
      */
     const fastdds::statistics::rtps::IStatusListener* create_monitor_service(
-            fastdds::statistics::rtps::IStatusQueryable& sq);
+            fastdds::statistics::rtps::IStatusQueryable& status_queryable);
 
     /**
      * Creates the monitor service in this RTPSParticipant with a simple default

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -64,6 +64,20 @@
 namespace eprosima {
 
 namespace fastdds {
+
+#ifdef FASTDDS_STATISTICS
+
+namespace statistics {
+namespace rtps {
+
+class IStatusQueryable;
+class IStatusListener;
+
+} // namespace rtps
+} // namespace statistics
+
+#endif //FASTDDS_STATISTICS
+
 namespace dds {
 namespace builtin {
 
@@ -1056,25 +1070,6 @@ public:
     bool ignore_reader(
             const GUID_t& reader_guid);
 
-    /**
-     * Enables the monitor service in this RTPSParticipant.
-     *
-     * @return true if the monitor service could be correctly enabled.
-     *
-     * @note Not supported yet. Currently always returns false
-     */
-    bool enable_monitor_service() const;
-
-    /**
-     * Disables the monitor service in this RTPSParticipant. Does nothing if the service was not enabled before.
-     *
-     * @return true if the monitor service could be correctly disabled.
-     * @return false if the service could not be properly disabled or if the monitor service was not previously enabled.
-     *
-     * @note Not supported yet. Currently always returns false
-     */
-    bool disable_monitor_service() const;
-
     template <EndpointKind_t kind, octet no_key, octet with_key>
     static bool preprocess_endpoint_attributes(
             const EntityId_t& entity_id,
@@ -1133,6 +1128,58 @@ public:
      */
     void set_enabled_statistics_writers_mask(
             uint32_t enabled_writers) override;
+
+    /**
+     * Creates the monitor service in this RTPSParticipant with the provided interfaces.
+     *
+     * @param sq reference to the object implementing the StatusQueryable interface.
+     * It will usually be the DDS DoaminParticipant
+     *
+     * @return A const pointer to the listener (implemented within the RTPSParticipant)
+     *
+     * @note Not supported yet. Currently always returns nullptr
+     */
+    const fastdds::statistics::rtps::IStatusListener* create_monitor_service(
+            fastdds::statistics::rtps::IStatusQueryable& sq);
+
+    /**
+     * Creates the monitor service in this RTPSParticipant with a simple default
+     * implementation of the IStatusQueryable.
+     *
+     * @return true if the monitor service could be correctly created.
+     *
+     * @note Not supported yet. Currently always returns false
+     */
+    bool create_monitor_service();
+
+    /**
+     * Returns whether the monitor service in created in this RTPSParticipant.
+     *
+     * @return true if the monitor service is created.
+     * @return false otherwise.
+     *
+     * @note Not supported yet. Currently always returns false
+     */
+    bool is_monitor_service_created() const;
+
+    /**
+     * Enables the monitor service in this RTPSParticipant.
+     *
+     * @return true if the monitor service could be correctly enabled.
+     *
+     * @note Not supported yet. Currently always returns false
+     */
+    bool enable_monitor_service() const;
+
+    /**
+     * Disables the monitor service in this RTPSParticipant. Does nothing if the service was not enabled before.
+     *
+     * @return true if the monitor service could be correctly disabled.
+     * @return false if the service could not be properly disabled or if the monitor service was not previously enabled.
+     *
+     * @note Not supported yet. Currently always returns false
+     */
+    bool disable_monitor_service() const;
 
 #endif // FASTDDS_STATISTICS
 

--- a/src/cpp/statistics/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipant.cpp
@@ -94,6 +94,24 @@ const DomainParticipant* DomainParticipant::narrow(
 #endif // FASTDDS_STATISTICS
 }
 
+ReturnCode_t DomainParticipant::enable_monitor_service() const
+{
+#ifdef FASTDDS_STATISTICS
+    return static_cast<DomainParticipantImpl*>(impl_)->enable_monitor_service();
+#else
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+#endif // FASTDDS_STATISTICS
+}
+
+ReturnCode_t DomainParticipant::disable_monitor_service() const
+{
+#ifdef FASTDDS_STATISTICS
+    return static_cast<DomainParticipantImpl*>(impl_)->disable_monitor_service();
+#else
+    return ReturnCode_t::RETCODE_UNSUPPORTED;
+#endif // FASTDDS_STATISTICS
+}
+
 } // dds
 } // statistics
 } // fastdds

--- a/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.cpp
@@ -283,6 +283,16 @@ ReturnCode_t DomainParticipantImpl::delete_contained_entities()
     return ret;
 }
 
+ReturnCode_t DomainParticipantImpl::enable_monitor_service() const
+{
+    return fastrtps::types::ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
+ReturnCode_t DomainParticipantImpl::disable_monitor_service() const
+{
+    return fastrtps::types::ReturnCode_t::RETCODE_UNSUPPORTED;
+}
+
 efd::PublisherImpl* DomainParticipantImpl::create_publisher_impl(
         const efd::PublisherQos& qos,
         efd::PublisherListener* listener)

--- a/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.hpp
@@ -127,6 +127,7 @@ public:
      *
      * @return RETCODE_OK if the monitor service could be correctly enabled.
      * @return RETCODE_ERROR if the monitor service could not be enabled properly.
+     * @return RETCODE_UNSUPPORTED if FASTDDS_STATISTICS is not enabled.
      *
      * @note Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
@@ -138,6 +139,7 @@ public:
      * @return RETCODE_OK if the monitor service could be correctly disabled.
      * @return RETCODE_NOT_ENABLED if the monitor service was not previously enabled.
      * @return RETCODE_ERROR if the service could not be properly disabled.
+     * @return RETCODE_UNSUPPORTED if FASTDDS_STATISTICS is not enabled.
      *
      * @note Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */

--- a/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipantImpl.hpp
@@ -122,6 +122,27 @@ public:
      */
     ReturnCode_t delete_contained_entities() override;
 
+    /**
+     * Enables the monitor service in this DomainParticipant.
+     *
+     * @return RETCODE_OK if the monitor service could be correctly enabled.
+     * @return RETCODE_ERROR if the monitor service could not be enabled properly.
+     *
+     * @note Not supported yet. Currently returns RETCODE_UNSUPPORTED
+     */
+    ReturnCode_t enable_monitor_service() const;
+
+    /**
+     * Disables the monitor service in this DomainParticipant. Does nothing if the service was not enabled before.
+     *
+     * @return RETCODE_OK if the monitor service could be correctly disabled.
+     * @return RETCODE_NOT_ENABLED if the monitor service was not previously enabled.
+     * @return RETCODE_ERROR if the service could not be properly disabled.
+     *
+     * @note Not supported yet. Currently returns RETCODE_UNSUPPORTED
+     */
+    ReturnCode_t disable_monitor_service() const;
+
 protected:
 
     /**


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR moves the Monitor Service high level api to the statistics DDS DomainParticipant API and in the RTPS layer under the `FASTDDS_STATISTICS` compilation macro . It also completes the RTPS API by including the last changes of the `update 2` on the design

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.9.x 2.8.x 2.6.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x]  New feature has been added to the `versions.md` file (if applicable).
- [x]  New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    Related documentation PR: eProsima/Fast-DDS-docs#506
- **N/A**  Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [N/A] Check CI results: failing tests are unrelated with the changes.
