### PR TITLE
[18966] Improved shm listener status update mechanism

### DIFF
--- a/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
@@ -286,9 +286,9 @@ public:
                         if (status.is_processing)
                         {
                             if ((last_checked_buffer.validity_id == status.descriptor.validity_id) &&
-                               (last_checked_buffer.source_segment_id == status.descriptor.source_segment_id) &&
-                               (last_checked_buffer.buffer_node_offset == status.descriptor.buffer_node_offset)) 
-                                
+                                    (last_checked_buffer.source_segment_id == status.descriptor.source_segment_id) &&
+                                    (last_checked_buffer.buffer_node_offset == status.descriptor.buffer_node_offset))
+
                             {
                                 return false;
                             }
@@ -308,7 +308,7 @@ public:
                                 {
                                     return false;
                                 }
-                            } 
+                            }
                         }
                         if (listeners_found == port_node->num_listeners)
                         {

--- a/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
@@ -461,7 +461,7 @@ public:
             node_->ref_counter.fetch_add(1);
 
             auto port_context = std::make_shared<Port::WatchTask::PortContext>();
-            *port_context = {port_segment_, node_, buffer_.get(), BufferDescriptor{}};
+            *port_context = {port_segment_, node_, buffer_.get(), { BufferDescriptor{} } };
             Port::WatchTask::get()->add_port(std::move(port_context));
         }
 

--- a/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
@@ -304,7 +304,7 @@ public:
                                 {
                                     status.last_verified_counter = status.counter;
                                 }
-                                else             // Counter is freeze => this listener is blocked!!!
+                                else             // Counter is frozen => this listener is blocked!!!
                                 {
                                     return false;
                                 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR improves the detection of ports that may have been left in an inconsistent state, adding checks to detect if a port owner has died, leaving the port in a perpetually processing state.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.10.x 2.9.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [NA] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [NA] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [NA] New feature has been added to the `versions.md` file (if applicable).
- [NA] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
