### PR TITLE
[18966] Refactor of regenerate_port.

### DIFF
--- a/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
@@ -784,10 +784,9 @@ public:
 
         void regenerate_port()
         {
-            auto new_port = shared_mem_manager_->regenerate_port(global_port_, global_port_->open_mode());
-
-            auto new_listener = new_port->create_listener();
-
+            auto new_port = global_port_;
+            shared_mem_manager_->regenerate_port(new_port, new_port->open_mode());
+            auto new_listener = std::make_shared<Listener>(shared_mem_manager_, new_port);
             *this = std::move(*new_listener);
         }
 
@@ -931,9 +930,7 @@ public:
         void regenerate_port()
         {
             recover_blocked_processing();
-            auto new_port = shared_mem_manager_->regenerate_port(global_port_, open_mode_);
-
-            *this = std::move(*new_port);
+            shared_mem_manager_->regenerate_port(global_port_, open_mode_);
         }
 
         SharedMemManager* shared_mem_manager_;
@@ -1017,11 +1014,11 @@ public:
 
 private:
 
-    std::shared_ptr<Port> regenerate_port(
-            std::shared_ptr<SharedMemGlobal::Port> port,
+    void regenerate_port(
+            std::shared_ptr<SharedMemGlobal::Port>& port,
             SharedMemGlobal::Port::OpenMode open_mode)
     {
-        return std::make_shared<Port>(this, global_segment_.regenerate_port(port, open_mode), open_mode);
+        port = global_segment_.regenerate_port(port, open_mode);
     }
 
     /**


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Small refactor to the way SHM ports are regenerated preventing extra shared pointers from being created.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.10.x 2.9.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [NA] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [NA] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [NA] New feature has been added to the `versions.md` file (if applicable).
- [NA] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
