### PR TITLE
[19127] Revert parallel testing SemaphoreNode changes

### DIFF
--- a/src/cpp/utils/shared_memory/RobustInterprocessCondition.hpp
+++ b/src/cpp/utils/shared_memory/RobustInterprocessCondition.hpp
@@ -209,20 +209,7 @@ private:
 
     struct SemaphoreNode
     {
-        SemaphoreNode()
-        {
-        }
-
-        ~SemaphoreNode()
-        {
-            sem.bi::interprocess_semaphore::~interprocess_semaphore();
-        }
-
-        union
-        {
-            bi::interprocess_semaphore sem;
-        };
-        bool initialized = false;
+        bi::interprocess_semaphore sem {0};
         uint32_t next;
         uint32_t prev;
     };
@@ -356,11 +343,6 @@ private:
     inline uint32_t enqueue_listener()
     {
         auto sem_index = list_free_.pop(semaphores_pool_);
-        if (!semaphores_pool_[sem_index].initialized)
-        {
-            new (&semaphores_pool_[sem_index].sem) bi::interprocess_semaphore(0);
-            semaphores_pool_[sem_index].initialized = true;
-        }
         list_listening_.push(sem_index, semaphores_pool_);
         return sem_index;
     }

--- a/src/cpp/utils/shared_memory/RobustInterprocessCondition.hpp
+++ b/src/cpp/utils/shared_memory/RobustInterprocessCondition.hpp
@@ -207,9 +207,6 @@ public:
 
 private:
 
-    /*!
-     * @warning Changing this class means no communication with previous versions of SHM transport.
-     */
     struct SemaphoreNode
     {
         SemaphoreNode()
@@ -225,8 +222,9 @@ private:
         {
             bi::interprocess_semaphore sem;
         };
-        uint32_t next {SemaphoreList::LIST_NULL};
-        uint32_t prev {SemaphoreList::LIST_NULL};
+        bool initialized = false;
+        uint32_t next;
+        uint32_t prev;
     };
 
     static constexpr uint32_t MAX_LISTENERS = 512;
@@ -236,8 +234,8 @@ private:
     {
     private:
 
-        uint32_t head_ {LIST_NULL};
-        uint32_t tail_ {LIST_NULL};
+        uint32_t head_;
+        uint32_t tail_;
 
     public:
 
@@ -358,7 +356,11 @@ private:
     inline uint32_t enqueue_listener()
     {
         auto sem_index = list_free_.pop(semaphores_pool_);
-        new (&semaphores_pool_[sem_index].sem) bi::interprocess_semaphore(0);
+        if (!semaphores_pool_[sem_index].initialized)
+        {
+            new (&semaphores_pool_[sem_index].sem) bi::interprocess_semaphore(0);
+            semaphores_pool_[sem_index].initialized = true;
+        }
         list_listening_.push(sem_index, semaphores_pool_);
         return sem_index;
     }
@@ -367,7 +369,6 @@ private:
             uint32_t sem_index)
     {
         list_listening_.remove(sem_index, semaphores_pool_);
-        (&semaphores_pool_[sem_index])->~SemaphoreNode();
         list_free_.push(sem_index, semaphores_pool_);
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.10.x 2.9.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [NA] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [NA] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [NA] New feature has been added to the `versions.md` file (if applicable).
- [NA] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
