### PR TITLE
[18074] Unit tests for the Monitor Service main class

### DIFF
--- a/test/unittest/statistics/rtps/CMakeLists.txt
+++ b/test/unittest/statistics/rtps/CMakeLists.txt
@@ -39,9 +39,36 @@ target_include_directories(RTPSStatisticsTests PRIVATE
 
 target_link_libraries(RTPSStatisticsTests fastrtps fastcdr GTest::gtest GTest::gmock)
 add_gtest(RTPSStatisticsTests SOURCES ${STATISTICS_RTPS_TESTS_SOURCE})
+
+set(STATISTICS_RTPS_MONITORSERVICETESTS_SOURCE
+    MonitorServiceTests.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/statistics/types/monitorservice_types.cxx
+    )
+
+add_executable(MonitorServiceTests ${STATISTICS_RTPS_MONITORSERVICETESTS_SOURCE})
+
+target_compile_definitions(MonitorServiceTests PRIVATE FASTRTPS_NO_LIB
+    BOOST_ASIO_STANDALONE
+    ASIO_STANDALONE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNAL_DEBUG> # Internal debug activated.
+    )
+
+target_include_directories(MonitorServiceTests PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_BINARY_DIR}/include
+    ${PROJECT_SOURCE_DIR}/src/cpp
+    ${Asio_INCLUDE_DIR}
+    )
+
+target_link_libraries(MonitorServiceTests fastrtps fastcdr GTest::gtest GTest::gmock)
+add_gtest(MonitorServiceTests SOURCES ${STATISTICS_RTPS_MONITORSERVICETESTS_SOURCE})
+
 if(QNX)
     target_link_libraries(RTPSStatisticsTests socket)
+    target_link_libraries(MonitorServiceTests socket)
 endif()
 if(ANDROID)
     set_property(TARGET RTPSStatisticsTests PROPERTY CROSSCOMPILING_EMULATOR "adb;shell;cd;${CMAKE_CURRENT_BINARY_DIR};&&")
+    set_property(TARGET MonitorServiceTests PROPERTY CROSSCOMPILING_EMULATOR "adb;shell;cd;${CMAKE_CURRENT_BINARY_DIR};&&")
 endif()

--- a/test/unittest/statistics/rtps/CMakeLists.txt
+++ b/test/unittest/statistics/rtps/CMakeLists.txt
@@ -42,7 +42,10 @@ add_gtest(RTPSStatisticsTests SOURCES ${STATISTICS_RTPS_TESTS_SOURCE})
 
 set(STATISTICS_RTPS_MONITORSERVICETESTS_SOURCE
     MonitorServiceTests.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/statistics/rtps/monitor-service/MonitorService.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/statistics/rtps/monitor-service/MonitorServiceListener.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/statistics/types/monitorservice_types.cxx
+    ${PROJECT_SOURCE_DIR}/src/cpp/statistics/types/types.cxx
     )
 
 add_executable(MonitorServiceTests ${STATISTICS_RTPS_MONITORSERVICETESTS_SOURCE})

--- a/test/unittest/statistics/rtps/MonitorServiceTests.cpp
+++ b/test/unittest/statistics/rtps/MonitorServiceTests.cpp
@@ -1,0 +1,224 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <fastdds/dds/log/Log.hpp>
+#include <fastdds/statistics/rtps/monitor_service/Interfaces.hpp>
+
+#include <statistics/rtps/monitor-service/MonitorService.hpp>
+#include <statistics/rtps/monitor-service/MonitorServiceListener.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace statistics {
+namespace rtps {
+
+struct MockStatusQueryable : public IStatusQueryable
+{
+    MOCK_METHOD2(get_incompatible_qos_status, bool (
+                const fastrtps::rtps::GUID_t& guid,
+                dds::IncompatibleQosStatus& status));
+
+    MOCK_METHOD2(get_inconsistent_topic_status, bool(
+                const fastrtps::rtps::GUID_t& guid,
+                dds::InconsistentTopicStatus& status));
+
+    MOCK_METHOD2(get_liveliness_lost_status, bool(
+                const fastrtps::rtps::GUID_t& guid,
+                dds::LivelinessLostStatus& status));
+
+    MOCK_METHOD2(get_liveliness_changed_status, bool(
+                const fastrtps::rtps::GUID_t& guid,
+                dds::LivelinessChangedStatus& status));
+
+    MOCK_METHOD2(get_deadline_missed_status, bool(
+                const fastrtps::rtps::GUID_t& guid,
+                dds::DeadlineMissedStatus& status));
+
+    MOCK_METHOD2(get_sample_lost_status, bool(
+                const fastrtps::rtps::GUID_t& guid,
+                dds::SampleLostStatus& status));
+
+};
+
+struct MockConnectionsQueryable : public IConnectionsQueryable
+{
+    MOCK_METHOD1(get_entity_connections, ConnectionList(
+                const fastrtps::rtps::GUID_t& guid));
+};
+
+struct MockProxyQueryable : public IProxyQueryable
+{
+
+    MOCK_METHOD1(get_all_local_proxies, bool(
+                std::vector<fastrtps::rtps::GUID_t>& guids));
+
+    MOCK_METHOD2(get_serialized_proxy, bool(
+                const fastrtps::rtps::GUID_t& guid,
+                fastrtps::rtps::CDRMessage_t* msg));
+};
+
+
+class MonitorServiceTests : public ::testing::Test
+{
+
+public:
+
+    MonitorServiceTests()
+        : monitor_srv_(
+            fastrtps::rtps::GUID_t(),
+            &mock_proxy_q_,
+            &mock_conns_q_,
+            mock_status_q_)
+        , listener_(&monitor_srv_)
+        , n_local_entities(5)
+    {
+
+    }
+
+    void SetUp() override
+    {
+        mock_guids.reserve(n_local_entities);
+
+        ON_CALL(mock_proxy_q_, get_all_local_proxies(::testing::_)).WillByDefault(testing::Invoke(
+                    [this](std::vector<fastrtps::rtps::GUID_t>& guids)
+                    {
+                        guids.reserve(n_local_entities);
+                        mock_guids.reserve(n_local_entities);
+
+                        for (size_t i = 1; i <= n_local_entities; i++)
+                        {
+                            fastrtps::rtps::GUID_t guid;
+                            guid.entityId.value[3] = i;
+                            guids.push_back(guid);
+                            mock_guids.push_back(guid);
+                        }
+                        return true;
+                    }));
+    }
+
+    void TearDown() override
+    {
+
+    }
+
+protected:
+
+    MockConnectionsQueryable mock_conns_q_;
+    MockStatusQueryable mock_status_q_;
+    MockProxyQueryable mock_proxy_q_;
+
+    MonitorService monitor_srv_;
+    MonitorServiceListener listener_;
+    size_t n_local_entities;
+    std::vector<fastrtps::rtps::GUID_t> mock_guids;
+};
+
+TEST_F(MonitorServiceTests, enabling_monitor_service_routine)
+{
+    //! At the startup, the service should collect the already existing
+    //! local entities
+    EXPECT_CALL(mock_proxy_q_, get_all_local_proxies(::testing::_)).Times(1);
+    EXPECT_CALL(mock_proxy_q_, get_serialized_proxy(::testing::_, ::testing::_)).Times(n_local_entities);
+    EXPECT_CALL(mock_conns_q_, get_entity_connections(::testing::_)).Times(n_local_entities);
+
+    //! Enable the service
+    ASSERT_FALSE(monitor_srv_.disable_monitor_service());
+    ASSERT_TRUE(monitor_srv_.enable_monitor_service());
+
+    //! Verify expectations
+    std::this_thread::sleep_for(std::chrono::seconds(3));
+    ::testing::Mock::VerifyAndClearExpectations(&mock_conns_q_);
+    ::testing::Mock::VerifyAndClearExpectations(&mock_proxy_q_);
+
+}
+
+TEST_F(MonitorServiceTests, multiple_proxy_and_connection_updates)
+{
+    //! Enable the service
+    ASSERT_FALSE(monitor_srv_.disable_monitor_service());
+    ASSERT_TRUE(monitor_srv_.enable_monitor_service());
+
+    std::this_thread::sleep_for(std::chrono::seconds(3));
+
+    //! Expect the getters for each status that is going to be updated
+    EXPECT_CALL(mock_proxy_q_, get_serialized_proxy(::testing::_, ::testing::_)).
+            Times(n_local_entities);
+    EXPECT_CALL(mock_conns_q_, get_entity_connections(::testing::_)).
+            Times(n_local_entities);
+
+    //! Trigger statuses updates for each entity
+    for (auto& entity : mock_guids)
+    {
+        listener_.on_local_entity_change(entity, true);
+        listener_.on_local_entity_connections_change(entity);
+    }
+
+    //! Verify expectations
+    std::this_thread::sleep_for(std::chrono::seconds(5));
+    ::testing::Mock::VerifyAndClearExpectations(&mock_status_q_);
+}
+
+TEST_F(MonitorServiceTests, multiple_dds_status_updates)
+{
+    //! Enable the service
+    ASSERT_FALSE(monitor_srv_.disable_monitor_service());
+    ASSERT_TRUE(monitor_srv_.enable_monitor_service());
+
+    //! Expect the getters for each status that is going to be updated
+    EXPECT_CALL(mock_status_q_, get_incompatible_qos_status(::testing::_, ::testing::_)).
+            Times(n_local_entities);
+    EXPECT_CALL(mock_status_q_, get_liveliness_lost_status(::testing::_, ::testing::_)).
+            Times(n_local_entities);
+    EXPECT_CALL(mock_status_q_, get_liveliness_changed_status(::testing::_, ::testing::_)).
+            Times(n_local_entities);
+    EXPECT_CALL(mock_status_q_, get_deadline_missed_status(::testing::_, ::testing::_)).
+            Times(n_local_entities);
+    EXPECT_CALL(mock_status_q_, get_sample_lost_status(::testing::_, ::testing::_)).
+            Times(n_local_entities);
+
+    //! Trigger statuses updates for each entity
+    for (auto& entity : mock_guids)
+    {
+        listener_.on_local_entity_status_change(entity, statistics::INCOMPATIBLE_QOS);
+        listener_.on_local_entity_status_change(entity, statistics::LIVELINESS_CHANGED);
+        listener_.on_local_entity_status_change(entity, statistics::LIVELINESS_LOST);
+        listener_.on_local_entity_status_change(entity, statistics::DEADLINE_MISSED);
+        listener_.on_local_entity_status_change(entity, statistics::SAMPLE_LOST);
+    }
+
+    //! Verify expectations
+    std::this_thread::sleep_for(std::chrono::seconds(5));
+    ::testing::Mock::VerifyAndClearExpectations(&mock_status_q_);
+}
+
+} // namespace rtps
+} // namespace statistics
+} // namespace fastdds
+} // namespace eprosima
+
+int main(
+        int argc,
+        char** argv)
+{
+    eprosima::fastdds::dds::Log::SetVerbosity(eprosima::fastdds::dds::Log::Error);
+
+    testing::InitGoogleTest(&argc, argv);
+    int ret = RUN_ALL_TESTS();
+
+    eprosima::fastdds::dds::Log::Flush();
+    return ret;
+}

--- a/test/unittest/statistics/rtps/MonitorServiceTests.cpp
+++ b/test/unittest/statistics/rtps/MonitorServiceTests.cpp
@@ -142,8 +142,8 @@ TEST_F(MonitorServiceTests, enabling_monitor_service_routine)
 
     //! Verify expectations
     std::this_thread::sleep_for(std::chrono::seconds(3));
-    ::testing::Mock::VerifyAndClearExpectations(&mock_conns_q_);
-    ::testing::Mock::VerifyAndClearExpectations(&mock_proxy_q_);
+    ASSERT_TRUE(::testing::Mock::VerifyAndClearExpectations(&mock_conns_q_));
+    ASSERT_TRUE(::testing::Mock::VerifyAndClearExpectations(&mock_proxy_q_));
 
 }
 
@@ -172,7 +172,8 @@ TEST_F(MonitorServiceTests, multiple_proxy_and_connection_updates)
 
     //! Verify expectations
     std::this_thread::sleep_for(std::chrono::seconds(5));
-    ::testing::Mock::VerifyAndClearExpectations(&mock_status_q_);
+    ASSERT_TRUE(::testing::Mock::VerifyAndClearExpectations(&mock_proxy_q_));
+    ASSERT_TRUE(::testing::Mock::VerifyAndClearExpectations(&mock_conns_q_));
 }
 
 TEST_F(MonitorServiceTests, multiple_dds_status_updates)
@@ -206,7 +207,7 @@ TEST_F(MonitorServiceTests, multiple_dds_status_updates)
 
     //! Verify expectations
     std::this_thread::sleep_for(std::chrono::seconds(5));
-    ::testing::Mock::VerifyAndClearExpectations(&mock_status_q_);
+    ASSERT_TRUE(::testing::Mock::VerifyAndClearExpectations(&mock_status_q_));
 }
 
 TEST_F(MonitorServiceTests, entity_removal_correctly_performs)
@@ -252,7 +253,9 @@ TEST_F(MonitorServiceTests, entity_removal_correctly_performs)
 
     //! Verify expectations
     std::this_thread::sleep_for(std::chrono::seconds(3));
-    ::testing::Mock::VerifyAndClearExpectations(&mock_status_q_);
+    ASSERT_TRUE(::testing::Mock::VerifyAndClearExpectations(&mock_status_q_));
+    ASSERT_TRUE(::testing::Mock::VerifyAndClearExpectations(&mock_proxy_q_));
+    ASSERT_TRUE(::testing::Mock::VerifyAndClearExpectations(&mock_conns_q_));
 }
 
 } // namespace rtps

--- a/test/unittest/statistics/rtps/MonitorServiceTests.cpp
+++ b/test/unittest/statistics/rtps/MonitorServiceTests.cpp
@@ -99,7 +99,7 @@ public:
                         guids.reserve(n_local_entities);
                         mock_guids.reserve(n_local_entities);
 
-                        for (size_t i = 1; i <= n_local_entities; i++)
+                        for (size_t i = 1; i <= static_cast<size_t>(n_local_entities); i++)
                         {
                             fastrtps::rtps::GUID_t guid;
                             guid.entityId.value[3] = i;
@@ -123,7 +123,7 @@ protected:
 
     MonitorService monitor_srv_;
     MonitorServiceListener listener_;
-    size_t n_local_entities;
+    int n_local_entities;
     std::vector<fastrtps::rtps::GUID_t> mock_guids;
 };
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR introduces the unittests for the MonitorService class. A series of triggers are fired on the listener so that the Monitor service performs the corresponding calls (timed) to the query interfaces is asserted.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.10.x 2.9.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- **N/A** Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
