### PR TITLE
[19089] Fix HelloWorld DataSharing example idl

### DIFF
--- a/examples/cpp/dds/HelloWorldExampleDataSharing/HelloWorld.cxx
+++ b/examples/cpp/dds/HelloWorldExampleDataSharing/HelloWorld.cxx
@@ -126,7 +126,7 @@ uint32_t& HelloWorld::index()
  * @param _message New value to be copied in member message
  */
 void HelloWorld::message(
-        const std::string& _message)
+        const eprosima::fastcdr::fixed_string<20>& _message)
 {
     m_message = _message;
 }
@@ -136,7 +136,7 @@ void HelloWorld::message(
  * @param _message New value to be moved in member message
  */
 void HelloWorld::message(
-        std::string&& _message)
+        eprosima::fastcdr::fixed_string<20>&& _message)
 {
     m_message = std::move(_message);
 }
@@ -145,7 +145,7 @@ void HelloWorld::message(
  * @brief This function returns a constant reference to member message
  * @return Constant reference to member message
  */
-const std::string& HelloWorld::message() const
+const eprosima::fastcdr::fixed_string<20>& HelloWorld::message() const
 {
     return m_message;
 }
@@ -154,7 +154,7 @@ const std::string& HelloWorld::message() const
  * @brief This function returns a reference to member message
  * @return Reference to member message
  */
-std::string& HelloWorld::message()
+eprosima::fastcdr::fixed_string<20>& HelloWorld::message()
 {
     return m_message;
 }

--- a/examples/cpp/dds/HelloWorldExampleDataSharing/HelloWorld.h
+++ b/examples/cpp/dds/HelloWorldExampleDataSharing/HelloWorld.h
@@ -152,32 +152,31 @@ public:
      * @param _message New value to be copied in member message
      */
     eProsima_user_DllExport void message(
-            const std::string& _message);
+            const eprosima::fastcdr::fixed_string<20>& _message);
 
     /*!
      * @brief This function moves the value in member message
      * @param _message New value to be moved in member message
      */
     eProsima_user_DllExport void message(
-            std::string&& _message);
+            eprosima::fastcdr::fixed_string<20>&& _message);
 
     /*!
      * @brief This function returns a constant reference to member message
      * @return Constant reference to member message
      */
-    eProsima_user_DllExport const std::string& message() const;
+    eProsima_user_DllExport const eprosima::fastcdr::fixed_string<20>& message() const;
 
     /*!
      * @brief This function returns a reference to member message
      * @return Reference to member message
      */
-    eProsima_user_DllExport std::string& message();
+    eProsima_user_DllExport eprosima::fastcdr::fixed_string<20>& message();
 
 private:
 
     uint32_t m_index{0};
-    std::string m_message;
-
+    eprosima::fastcdr::fixed_string<20> m_message;
 };
 
 #endif // _FAST_DDS_GENERATED_HELLOWORLD_H_

--- a/examples/cpp/dds/HelloWorldExampleDataSharing/HelloWorld.idl
+++ b/examples/cpp/dds/HelloWorldExampleDataSharing/HelloWorld.idl
@@ -1,5 +1,5 @@
 struct HelloWorld
 {
 	unsigned long index;
-	string message;
+	string<20> message;
 };

--- a/examples/cpp/dds/HelloWorldExampleDataSharing/HelloWorldCdrAux.hpp
+++ b/examples/cpp/dds/HelloWorldExampleDataSharing/HelloWorldCdrAux.hpp
@@ -24,7 +24,7 @@
 
 #include "HelloWorld.h"
 
-constexpr uint32_t HelloWorld_max_cdr_typesize {268UL};
+constexpr uint32_t HelloWorld_max_cdr_typesize {33UL};
 constexpr uint32_t HelloWorld_max_key_cdr_typesize {0UL};
 
 

--- a/examples/cpp/dds/HelloWorldExampleDataSharing/HelloWorldPubSubTypes.h
+++ b/examples/cpp/dds/HelloWorldExampleDataSharing/HelloWorldPubSubTypes.h
@@ -91,7 +91,7 @@ public:
 #ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
     eProsima_user_DllExport inline bool is_bounded() const override
     {
-        return false;
+        return true;
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
@@ -103,7 +103,7 @@ public:
     }
 
     eProsima_user_DllExport inline bool is_plain(
-        eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
     {
         static_cast<void>(data_representation);
         return false;

--- a/examples/cpp/dds/HelloWorldExampleDataSharing/HelloWorldPubSubTypes.h
+++ b/examples/cpp/dds/HelloWorldExampleDataSharing/HelloWorldPubSubTypes.h
@@ -103,7 +103,7 @@ public:
     }
 
     eProsima_user_DllExport inline bool is_plain(
-            eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
+        eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
     {
         static_cast<void>(data_representation);
         return false;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
One of the Data-sharing constraints is that the types must be bounded. In the Data-sharing helloworld example, it is forced to use datasharing but the IDL types do not use bounded strings. 
This Pull Request updates IDL to use bounded string, and regenerates the types with the bounded string.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.11.x 2.10.x 2.6.x 

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
Fixes #3710 

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- **N/A** Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [ ] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
