### PR TITLE
Fix asymmetric whitelist matching [19035]

### DIFF
--- a/include/fastdds/dds/core/policy/ParameterTypes.hpp
+++ b/include/fastdds/dds/core/policy/ParameterTypes.hpp
@@ -159,6 +159,7 @@ enum ParameterId_t : uint16_t
     PID_CUSTOM_RELATED_SAMPLE_IDENTITY      = 0x800f,
     PID_DISABLE_POSITIVE_ACKS               = 0x8005,
     PID_DATASHARING                         = 0x8006,
+    PID_NETWORK_CONFIGURATION_SET           = 0x8007,
 };
 
 /*!
@@ -886,6 +887,41 @@ public:
 
 #define PARAMETER_BUILTINENDPOINTSET_LENGTH 4
 
+/**
+ * @ingroup PARAMETER_MODULE
+ */
+class ParameterNetworkConfigSet_t : public Parameter_t
+{
+public:
+
+    //!Network Config Set <br> By default, 0.
+    fastrtps::rtps::NetworkConfigSet_t netconfigSet;
+
+    /**
+     * @brief Constructor without parameters
+     */
+    ParameterNetworkConfigSet_t()
+        : netconfigSet(0)
+    {
+    }
+
+    /**
+     * Constructor using a parameter PID and the parameter length
+     *
+     * @param pid Pid of the parameter
+     * @param in_length Its associated length
+     */
+    ParameterNetworkConfigSet_t(
+            ParameterId_t pid,
+            uint16_t in_length)
+        : Parameter_t(pid, in_length)
+        , netconfigSet(0)
+    {
+    }
+
+};
+
+#define PARAMETER_NETWORKCONFIGSET_LENGTH 4
 
 /**
  * @ingroup PARAMETER_MODULE

--- a/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h
+++ b/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h
@@ -26,6 +26,7 @@
 #include <fastdds/rtps/common/Locator.h>
 #include <fastdds/rtps/common/PortParameters.h>
 #include <fastdds/rtps/common/Time_t.h>
+#include <fastdds/rtps/common/Types.h>
 #include <fastdds/rtps/flowcontrol/FlowControllerDescriptor.hpp>
 #include <fastdds/rtps/flowcontrol/ThroughputControllerDescriptor.h>
 #include <fastdds/rtps/resources/ResourceManagement.h>

--- a/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h
+++ b/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h
@@ -381,6 +381,9 @@ public:
     //! TypeLookup Service settings
     TypeLookupSettings typelookup_config;
 
+    //! Network Configuration
+    NetworkConfigSet_t network_configuration;
+
     //! Metatraffic Unicast Locator List
     LocatorList_t metatrafficUnicastLocatorList;
 
@@ -424,6 +427,7 @@ public:
                (this->use_WriterLivelinessProtocol == b.use_WriterLivelinessProtocol) &&
                (typelookup_config.use_client == b.typelookup_config.use_client) &&
                (typelookup_config.use_server == b.typelookup_config.use_server) &&
+               (this->network_configuration == b.network_configuration) &&
                (this->metatrafficUnicastLocatorList == b.metatrafficUnicastLocatorList) &&
                (this->metatrafficMulticastLocatorList == b.metatrafficMulticastLocatorList) &&
                (this->metatraffic_external_unicast_locators == b.metatraffic_external_unicast_locators) &&

--- a/include/fastdds/rtps/builtin/BuiltinProtocols.h
+++ b/include/fastdds/rtps/builtin/BuiltinProtocols.h
@@ -102,11 +102,10 @@ public:
             LocatorList_t& loclist);
 
     /**
-     * Traverses the list of discover servers translating from remote to local locators
-     * if possible
-     * @param nf NetworkFactory used to make the translation
+     * Traverses the list of discover servers filtering out unsupported or not allowed remote locators
+     * @param nf NetworkFactory used to make the filtering
      */
-    void transform_server_remote_locators(
+    void filter_server_remote_locators(
             NetworkFactory& nf);
 
     //!BuiltinAttributes of the builtin protocols.

--- a/include/fastdds/rtps/builtin/data/NetworkConfiguration.hpp
+++ b/include/fastdds/rtps/builtin/data/NetworkConfiguration.hpp
@@ -1,0 +1,24 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file NetworkConfiguration.hpp
+ */
+
+#ifndef FASTDDS_RTPS_BUILTIN_DATA__NETWORKCONFIGURATION_HPP
+#define FASTDDS_RTPS_BUILTIN_DATA__NETWORKCONFIGURATION_HPP
+
+#define DISC_NETWORK_CONFIGURATION_LISTENING_LOCALHOST_ALL                         (0x0000000F)
+
+#endif // FASTDDS_RTPS_BUILTIN_DATA__NETWORKCONFIGURATION_HPP

--- a/include/fastdds/rtps/builtin/data/ParticipantProxyData.h
+++ b/include/fastdds/rtps/builtin/data/ParticipantProxyData.h
@@ -81,6 +81,8 @@ public:
     bool m_expectsInlineQos;
     //!Available builtin endpoints
     BuiltinEndpointSet_t m_availableBuiltinEndpoints;
+    //!Network configuration
+    NetworkConfigSet_t m_networkConfiguration;
     //!Metatraffic locators
     RemoteLocatorList metatraffic_locators;
     //!Default locators

--- a/include/fastdds/rtps/builtin/data/ReaderProxyData.h
+++ b/include/fastdds/rtps/builtin/data/ReaderProxyData.h
@@ -91,6 +91,28 @@ public:
         return m_guid;
     }
 
+    RTPS_DllAPI void networkConfiguration(
+            const NetworkConfigSet_t& networkConfiguration)
+    {
+        m_networkConfiguration = networkConfiguration;
+    }
+
+    RTPS_DllAPI void networkConfiguration(
+            NetworkConfigSet_t&& networkConfiguration)
+    {
+        m_networkConfiguration = std::move(networkConfiguration);
+    }
+
+    RTPS_DllAPI const NetworkConfigSet_t& networkConfiguration() const
+    {
+        return m_networkConfiguration;
+    }
+
+    RTPS_DllAPI NetworkConfigSet_t& networkConfiguration()
+    {
+        return m_networkConfiguration;
+    }
+
     RTPS_DllAPI bool has_locators() const
     {
         return !remote_locators_.unicast.empty() || !remote_locators_.multicast.empty();
@@ -459,6 +481,8 @@ private:
 
     //!GUID
     GUID_t m_guid;
+    //!Network configuration
+    NetworkConfigSet_t m_networkConfiguration;
     //!Holds locator information
     RemoteLocatorList remote_locators_;
     //!GUID_t of the Reader converted to InstanceHandle_t

--- a/include/fastdds/rtps/builtin/data/WriterProxyData.h
+++ b/include/fastdds/rtps/builtin/data/WriterProxyData.h
@@ -87,6 +87,28 @@ public:
         return m_guid;
     }
 
+    RTPS_DllAPI void networkConfiguration(
+            const NetworkConfigSet_t& networkConfiguration)
+    {
+        m_networkConfiguration = networkConfiguration;
+    }
+
+    RTPS_DllAPI void networkConfiguration(
+            NetworkConfigSet_t&& networkConfiguration)
+    {
+        m_networkConfiguration = std::move(networkConfiguration);
+    }
+
+    RTPS_DllAPI const NetworkConfigSet_t& networkConfiguration() const
+    {
+        return m_networkConfiguration;
+    }
+
+    RTPS_DllAPI NetworkConfigSet_t& networkConfiguration()
+    {
+        return m_networkConfiguration;
+    }
+
     RTPS_DllAPI void persistence_guid(
             const GUID_t& guid)
     {
@@ -439,6 +461,9 @@ private:
 
     //!GUID
     GUID_t m_guid;
+
+    //!Network configuration
+    NetworkConfigSet_t m_networkConfiguration;
 
     //!Holds locator information
     RemoteLocatorList remote_locators_;

--- a/include/fastdds/rtps/common/Types.h
+++ b/include/fastdds/rtps/common/Types.h
@@ -88,6 +88,7 @@ using octet = unsigned char;
 //typedef unsigned short ushort;
 using SubmessageFlag = unsigned char;
 using BuiltinEndpointSet_t = uint32_t;
+using NetworkConfigSet_t = uint32_t;
 using Count_t = uint32_t;
 
 #define BIT0 0x01u

--- a/include/fastdds/rtps/transport/ChainingTransport.h
+++ b/include/fastdds/rtps/transport/ChainingTransport.h
@@ -161,6 +161,15 @@ public:
     }
 
     /*!
+     * Call the low-level transport `is_localhost_allowed()`.
+     * Must report whether localhost locator is allowed
+     */
+    RTPS_DllAPI bool is_localhost_allowed() const override
+    {
+        return low_level_transport_->is_localhost_allowed();
+    }
+
+    /*!
      * Call the low-level transport `is_locator_allowed()`.
      * Must report whether the given locator is allowed by this transport.
      */
@@ -287,6 +296,18 @@ public:
             fastrtps::rtps::Locator_t& result_locator) const override
     {
         return low_level_transport_->transform_remote_locator(remote_locator, result_locator);
+    }
+
+    //! Call the low-level transport `transform_remote_locator()`.
+    //! Transforms a remote locator into a locator optimized for local communications,
+    //! if allowed by both local and remote transports.
+    RTPS_DllAPI bool transform_remote_locator(
+            const fastrtps::rtps::Locator_t& remote_locator,
+            fastrtps::rtps::Locator_t& result_locator,
+            bool allowed_remote_localhost,
+            bool allowed_local_localhost) const override
+    {
+        return low_level_transport_->transform_remote_locator(remote_locator, result_locator, allowed_remote_localhost, allowed_local_localhost);
     }
 
     /**

--- a/include/fastdds/rtps/transport/ChainingTransport.h
+++ b/include/fastdds/rtps/transport/ChainingTransport.h
@@ -359,7 +359,8 @@ public:
             bool allowed_remote_localhost,
             bool allowed_local_localhost) const override
     {
-        return low_level_transport_->transform_remote_locator(remote_locator, result_locator, allowed_remote_localhost, allowed_local_localhost);
+        return low_level_transport_->transform_remote_locator(remote_locator, result_locator, allowed_remote_localhost,
+                       allowed_local_localhost);
     }
 
     /*!

--- a/include/fastdds/rtps/transport/ChainingTransport.h
+++ b/include/fastdds/rtps/transport/ChainingTransport.h
@@ -170,16 +170,6 @@ public:
     }
 
     /*!
-     * Call the low-level transport `is_locator_allowed()`.
-     * Must report whether the given locator is allowed by this transport.
-     */
-    RTPS_DllAPI bool is_locator_allowed(
-            const fastrtps::rtps::Locator_t& locator) const override
-    {
-        return low_level_transport_->is_locator_allowed(locator);
-    }
-
-    /*!
      * Call the low-level transport `DoInputLocatorsMatch()`.
      * Must report whether two locators map to the same internal channel.
      */
@@ -298,18 +288,6 @@ public:
         return low_level_transport_->transform_remote_locator(remote_locator, result_locator);
     }
 
-    //! Call the low-level transport `transform_remote_locator()`.
-    //! Transforms a remote locator into a locator optimized for local communications,
-    //! if allowed by both local and remote transports.
-    RTPS_DllAPI bool transform_remote_locator(
-            const fastrtps::rtps::Locator_t& remote_locator,
-            fastrtps::rtps::Locator_t& result_locator,
-            bool allowed_remote_localhost,
-            bool allowed_local_localhost) const override
-    {
-        return low_level_transport_->transform_remote_locator(remote_locator, result_locator, allowed_remote_localhost, allowed_local_localhost);
-    }
-
     /**
      * Call the low-level transport `max_recv_buffer_size()`.
      * @return The maximum datagram size for reception supported by the transport
@@ -370,6 +348,28 @@ public:
     RTPS_DllAPI void update_network_interfaces() override
     {
         low_level_transport_->update_network_interfaces();
+    }
+
+    //! Call the low-level transport `transform_remote_locator()`.
+    //! Transforms a remote locator into a locator optimized for local communications,
+    //! if allowed by both local and remote transports.
+    RTPS_DllAPI bool transform_remote_locator(
+            const fastrtps::rtps::Locator_t& remote_locator,
+            fastrtps::rtps::Locator_t& result_locator,
+            bool allowed_remote_localhost,
+            bool allowed_local_localhost) const override
+    {
+        return low_level_transport_->transform_remote_locator(remote_locator, result_locator, allowed_remote_localhost, allowed_local_localhost);
+    }
+
+    /*!
+     * Call the low-level transport `is_locator_allowed()`.
+     * Must report whether the given locator is allowed by this transport.
+     */
+    RTPS_DllAPI bool is_locator_allowed(
+            const fastrtps::rtps::Locator_t& locator) const override
+    {
+        return low_level_transport_->is_locator_allowed(locator);
     }
 
 protected:

--- a/include/fastdds/rtps/transport/TransportInterface.h
+++ b/include/fastdds/rtps/transport/TransportInterface.h
@@ -22,9 +22,9 @@
 #include <fastdds/rtps/common/Locator.h>
 #include <fastdds/rtps/common/LocatorSelector.hpp>
 #include <fastdds/rtps/common/PortParameters.h>
+#include <fastdds/rtps/transport/SenderResource.h>
 #include <fastdds/rtps/transport/TransportDescriptorInterface.h>
 #include <fastdds/rtps/transport/TransportReceiverInterface.h>
-#include <fastdds/rtps/transport/SenderResource.h>
 
 namespace eprosima {
 namespace fastdds {
@@ -129,6 +129,30 @@ public:
         return false;
     }
 
+    /**
+     * Transforms a remote locator into a locator optimized for local communications.
+     *
+     * If the remote locator corresponds to one of the local interfaces, it is converted
+     * to the corresponding local address if allowed by both local and remote transports.
+     *
+     * @param [in]  remote_locator Locator to be converted.
+     * @param [out] result_locator Converted locator.
+     * @param [in]  allowed_remote_localhost Whether localhost is allowed (and hence used) in the remote transport.
+     * @param [in]  allowed_local_localhost Whether localhost is allowed locally (by this or other transport).
+     *
+     * @return false if the input locator is not supported/allowed by this transport, true otherwise.
+     */
+    virtual bool transform_remote_locator(
+            const Locator& remote_locator,
+            Locator& result_locator,
+            bool allowed_remote_localhost,
+            bool allowed_local_localhost) const
+    {
+        (void)allowed_remote_localhost;
+        (void)allowed_local_localhost;
+        return transform_remote_locator(remote_locator, result_locator);
+    }
+
     //! Must open the channel that maps to/from the given locator. This method must allocate, reserve and mark
     //! any resources that are needed for said channel.
     virtual bool OpenOutputChannel(
@@ -176,6 +200,9 @@ public:
     //! Must report whether the given locator is from the local host
     virtual bool is_local_locator(
             const Locator& locator) const = 0;
+
+    //! Must report whether localhost locator is allowed
+    virtual bool is_localhost_allowed() const = 0;
 
     //! Return the transport configuration (Transport Descriptor)
     virtual TransportDescriptorInterface* get_configuration() = 0;

--- a/include/fastdds/rtps/transport/TransportInterface.h
+++ b/include/fastdds/rtps/transport/TransportInterface.h
@@ -129,30 +129,6 @@ public:
         return false;
     }
 
-    /**
-     * Transforms a remote locator into a locator optimized for local communications.
-     *
-     * If the remote locator corresponds to one of the local interfaces, it is converted
-     * to the corresponding local address if allowed by both local and remote transports.
-     *
-     * @param [in]  remote_locator Locator to be converted.
-     * @param [out] result_locator Converted locator.
-     * @param [in]  allowed_remote_localhost Whether localhost is allowed (and hence used) in the remote transport.
-     * @param [in]  allowed_local_localhost Whether localhost is allowed locally (by this or other transport).
-     *
-     * @return false if the input locator is not supported/allowed by this transport, true otherwise.
-     */
-    virtual bool transform_remote_locator(
-            const Locator& remote_locator,
-            Locator& result_locator,
-            bool allowed_remote_localhost,
-            bool allowed_local_localhost) const
-    {
-        (void)allowed_remote_localhost;
-        (void)allowed_local_localhost;
-        return transform_remote_locator(remote_locator, result_locator);
-    }
-
     //! Must open the channel that maps to/from the given locator. This method must allocate, reserve and mark
     //! any resources that are needed for said channel.
     virtual bool OpenOutputChannel(
@@ -200,9 +176,6 @@ public:
     //! Must report whether the given locator is from the local host
     virtual bool is_local_locator(
             const Locator& locator) const = 0;
-
-    //! Must report whether localhost locator is allowed
-    virtual bool is_localhost_allowed() const = 0;
 
     //! Return the transport configuration (Transport Descriptor)
     virtual TransportDescriptorInterface* get_configuration() = 0;
@@ -271,6 +244,36 @@ public:
     int32_t kind() const
     {
         return transport_kind_;
+    }
+
+    /**
+     * Transforms a remote locator into a locator optimized for local communications.
+     *
+     * If the remote locator corresponds to one of the local interfaces, it is converted
+     * to the corresponding local address if allowed by both local and remote transports.
+     *
+     * @param [in]  remote_locator Locator to be converted.
+     * @param [out] result_locator Converted locator.
+     * @param [in]  allowed_remote_localhost Whether localhost is allowed (and hence used) in the remote transport.
+     * @param [in]  allowed_local_localhost Whether localhost is allowed locally (by this or other transport).
+     *
+     * @return false if the input locator is not supported/allowed by this transport, true otherwise.
+     */
+    virtual bool transform_remote_locator(
+            const Locator& remote_locator,
+            Locator& result_locator,
+            bool allowed_remote_localhost,
+            bool allowed_local_localhost) const
+    {
+        static_cast<void>(allowed_remote_localhost);
+        static_cast<void>(allowed_local_localhost);
+        return transform_remote_locator(remote_locator, result_locator);
+    }
+
+    //! Must report whether localhost locator is allowed
+    virtual bool is_localhost_allowed() const
+    {
+        return true;
     }
 
 protected:

--- a/include/fastrtps/qos/ParameterTypes.h
+++ b/include/fastrtps/qos/ParameterTypes.h
@@ -30,7 +30,7 @@
 #if HAVE_SECURITY
 #include <fastdds/rtps/security/accesscontrol/ParticipantSecurityAttributes.h>
 #include <fastdds/rtps/security/accesscontrol/EndpointSecurityAttributes.h>
-#endif
+#endif // if HAVE_SECURITY
 
 #include <string>
 #include <vector>
@@ -61,10 +61,10 @@ using ParameterSampleIdentity_t = fastdds::dds::ParameterSampleIdentity_t;
 using ParameterToken_t = fastdds::dds::ParameterToken_t;
 using ParameterParticipantSecurityInfo_t = fastdds::dds::ParameterParticipantSecurityInfo_t;
 using ParameterEndpointSecurityInfo_t = fastdds::dds::ParameterEndpointSecurityInfo_t;
-#endif
+#endif // if HAVE_SECURITY
 
 } //end of namespace
 } //end of namespace eprosima
 
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif /* PARAMETERTYPES_H_ */

--- a/include/fastrtps/qos/ParameterTypes.h
+++ b/include/fastrtps/qos/ParameterTypes.h
@@ -54,6 +54,7 @@ using ParameterCount_t = fastdds::dds::ParameterCount_t;
 using ParameterEntityId_t = fastdds::dds::ParameterEntityId_t;
 using ParameterTime_t = fastdds::dds::ParameterTime_t;
 using ParameterBuiltinEndpointSet_t = fastdds::dds::ParameterBuiltinEndpointSet_t;
+using ParameterNetworkConfigSet_t = fastdds::dds::ParameterNetworkConfigSet_t;
 using ParameterPropertyList_t = fastdds::dds::ParameterPropertyList_t;
 using ParameterSampleIdentity_t = fastdds::dds::ParameterSampleIdentity_t;
 #if HAVE_SECURITY

--- a/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
@@ -613,6 +613,28 @@ inline bool ParameterSerializer<ParameterBuiltinEndpointSet_t>::read_content_fro
 }
 
 template<>
+inline bool ParameterSerializer<ParameterNetworkConfigSet_t>::add_content_to_cdr_message(
+        const ParameterNetworkConfigSet_t& parameter,
+        fastrtps::rtps::CDRMessage_t* cdr_message)
+{
+    return fastrtps::rtps::CDRMessage::addUInt32(cdr_message, parameter.netconfigSet);
+}
+
+template<>
+inline bool ParameterSerializer<ParameterNetworkConfigSet_t>::read_content_from_cdr_message(
+        ParameterNetworkConfigSet_t& parameter,
+        fastrtps::rtps::CDRMessage_t* cdr_message,
+        const uint16_t parameter_length)
+{
+    if (parameter_length != PARAMETER_NETWORKCONFIGSET_LENGTH)
+    {
+        return false;
+    }
+    parameter.length = parameter_length;
+    return fastrtps::rtps::CDRMessage::readUInt32(cdr_message, &parameter.netconfigSet);
+}
+
+template<>
 inline uint32_t ParameterSerializer<ParameterPropertyList_t>::cdr_serialized_size(
         const ParameterPropertyList_t& parameter)
 {

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -2240,6 +2240,8 @@ bool DomainParticipantImpl::can_qos_be_updated(
                 from.wire_protocol().builtin.typelookup_config.use_client) ||
                 !(to.wire_protocol().builtin.typelookup_config.use_server ==
                 from.wire_protocol().builtin.typelookup_config.use_server) ||
+                !(to.wire_protocol().builtin.network_configuration ==
+                from.wire_protocol().builtin.network_configuration) ||
                 !(to.wire_protocol().builtin.metatrafficUnicastLocatorList ==
                 from.wire_protocol().builtin.metatrafficUnicastLocatorList) ||
                 !(to.wire_protocol().builtin.metatrafficMulticastLocatorList ==

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -183,6 +183,10 @@ void BuiltinProtocols::filter_server_remote_locators(
             {
                 allowed_locators.push_back(loc);
             }
+            else
+            {
+                EPROSIMA_LOG_WARNING(RTPS_PDP, "Ignoring remote server locator " << loc << " : not allowed.");
+            }
         }
         rs.metatrafficUnicastLocatorList.swap(allowed_locators);
     }

--- a/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
@@ -1122,7 +1122,6 @@ bool ReaderProxyData::is_update_allowed(
 void ReaderProxyData::update(
         ReaderProxyData* rdata)
 {
-    // m_networkConfiguration = rdata->m_networkConfiguration; // TODO: update?
     remote_locators_ = rdata->remote_locators_;
     m_qos.setQos(rdata->m_qos, false);
     m_isAlive = rdata->m_isAlive;

--- a/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.cpp
@@ -39,10 +39,11 @@ WriterProxyData::WriterProxyData(
 #if HAVE_SECURITY
     : security_attributes_(0)
     , plugin_security_attributes_(0)
-    , remote_locators_(max_unicast_locators, max_multicast_locators)
+    , m_networkConfiguration(0)
 #else
-    : remote_locators_(max_unicast_locators, max_multicast_locators)
+    : m_networkConfiguration(0)
 #endif // if HAVE_SECURITY
+    , remote_locators_(max_unicast_locators, max_multicast_locators)
     , m_userDefinedId(0)
     , m_typeMaxSerialized(0)
     , m_topicKind(NO_KEY)
@@ -73,6 +74,7 @@ WriterProxyData::WriterProxyData(
 #else
     : m_guid(writerInfo.m_guid)
 #endif // if HAVE_SECURITY
+    , m_networkConfiguration(writerInfo.m_networkConfiguration)
     , remote_locators_(writerInfo.remote_locators_)
     , m_key(writerInfo.m_key)
     , m_RTPSParticipantKey(writerInfo.m_RTPSParticipantKey)
@@ -122,6 +124,7 @@ WriterProxyData& WriterProxyData::operator =(
     plugin_security_attributes_ = writerInfo.plugin_security_attributes_;
 #endif // if HAVE_SECURITY
     m_guid = writerInfo.m_guid;
+    m_networkConfiguration = writerInfo.m_networkConfiguration;
     remote_locators_ = writerInfo.remote_locators_;
     m_key = writerInfo.m_key;
     m_RTPSParticipantKey = writerInfo.m_RTPSParticipantKey;
@@ -171,6 +174,9 @@ uint32_t WriterProxyData::get_serialized_size(
         bool include_encapsulation) const
 {
     uint32_t ret_val = include_encapsulation ? 4 : 0;
+
+    // PID_NETWORK_CONFIGURATION_SET
+    ret_val += 4 + PARAMETER_NETWORKCONFIGSET_LENGTH;
 
     // PID_UNICAST_LOCATOR
     ret_val += static_cast<uint32_t>((4 + PARAMETER_LOCATOR_LENGTH) * remote_locators_.unicast.size());
@@ -326,6 +332,15 @@ bool WriterProxyData::writeToCDRMessage(
     if (write_encapsulation)
     {
         if (!ParameterList::writeEncapsulationToCDRMsg(msg))
+        {
+            return false;
+        }
+    }
+
+    {
+        ParameterNetworkConfigSet_t p(fastdds::dds::PID_NETWORK_CONFIGURATION_SET, PARAMETER_NETWORKCONFIGSET_LENGTH);
+        p.netconfigSet = m_networkConfiguration;
+        if (!fastdds::dds::ParameterSerializer<ParameterNetworkConfigSet_t>::add_to_cdr_message(p, msg))
         {
             return false;
         }
@@ -825,6 +840,18 @@ bool WriterProxyData::readFromCDRMessage(
                         persistence_guid_ = p.guid;
                         break;
                     }
+                    case fastdds::dds::PID_NETWORK_CONFIGURATION_SET:
+                    {
+                        ParameterNetworkConfigSet_t p(pid, plength);
+                        if (!fastdds::dds::ParameterSerializer<ParameterNetworkConfigSet_t>::read_from_cdr_message(p,
+                                msg, plength))
+                        {
+                            return false;
+                        }
+
+                        m_networkConfiguration = p.netconfigSet;
+                        break;
+                    }
                     case fastdds::dds::PID_UNICAST_LOCATOR:
                     {
                         ParameterLocator_t p(pid, plength);
@@ -835,7 +862,7 @@ bool WriterProxyData::readFromCDRMessage(
                         }
 
                         Locator_t temp_locator;
-                        if (network.transform_remote_locator(p.locator, temp_locator))
+                        if (network.transform_remote_locator(p.locator, temp_locator, m_networkConfiguration))
                         {
                             ProxyDataFilters::filter_locators(
                                 is_shm_transport_available,
@@ -855,7 +882,7 @@ bool WriterProxyData::readFromCDRMessage(
                         }
 
                         Locator_t temp_locator;
-                        if (network.transform_remote_locator(p.locator, temp_locator))
+                        if (network.transform_remote_locator(p.locator, temp_locator, m_networkConfiguration))
                         {
                             ProxyDataFilters::filter_locators(
                                 is_shm_transport_available,
@@ -1019,6 +1046,7 @@ void WriterProxyData::clear()
     plugin_security_attributes_ = 0UL;
 #endif // if HAVE_SECURITY
     m_guid = c_Guid_Unknown;
+    m_networkConfiguration = 0;
     remote_locators_.unicast.clear();
     remote_locators_.multicast.clear();
     m_key = InstanceHandle_t();
@@ -1051,6 +1079,7 @@ void WriterProxyData::copy(
         WriterProxyData* wdata)
 {
     m_guid = wdata->m_guid;
+    m_networkConfiguration = wdata->m_networkConfiguration;
     remote_locators_ = wdata->remote_locators_;
     m_key = wdata->m_key;
     m_RTPSParticipantKey = wdata->m_RTPSParticipantKey;
@@ -1115,6 +1144,7 @@ bool WriterProxyData::is_update_allowed(
 void WriterProxyData::update(
         WriterProxyData* wdata)
 {
+    // m_networkConfiguration = wdata->m_networkConfiguration; // TODO: update?
     remote_locators_ = wdata->remote_locators_;
     m_qos.setQos(wdata->m_qos, false);
 }
@@ -1139,13 +1169,12 @@ void WriterProxyData::set_remote_unicast_locators(
         const LocatorList_t& locators,
         const NetworkFactory& network)
 {
-    Locator_t local_locator;
     remote_locators_.unicast.clear();
     for (const Locator_t& locator : locators)
     {
-        if (network.transform_remote_locator(locator, local_locator))
+        if (network.is_locator_allowed(locator))
         {
-            remote_locators_.add_unicast_locator(local_locator);
+            remote_locators_.add_unicast_locator(locator);
         }
     }
 }
@@ -1160,11 +1189,10 @@ void WriterProxyData::set_multicast_locators(
         const LocatorList_t& locators,
         const NetworkFactory& network)
 {
-    Locator_t local_locator;
     remote_locators_.multicast.clear();
     for (const Locator_t& locator : locators)
     {
-        if (network.transform_remote_locator(locator, local_locator))
+        if (network.is_locator_allowed(locator))
         {
             remote_locators_.add_multicast_locator(locator);
         }
@@ -1182,15 +1210,14 @@ void WriterProxyData::set_remote_locators(
         const NetworkFactory& network,
         bool use_multicast_locators)
 {
-    Locator_t local_locator;
     remote_locators_.unicast.clear();
     remote_locators_.multicast.clear();
 
     for (const Locator_t& locator : locators.unicast)
     {
-        if (network.transform_remote_locator(locator, local_locator))
+        if (network.is_locator_allowed(locator))
         {
-            remote_locators_.add_unicast_locator(local_locator);
+            remote_locators_.add_unicast_locator(locator);
         }
     }
 
@@ -1198,7 +1225,7 @@ void WriterProxyData::set_remote_locators(
     {
         for (const Locator_t& locator : locators.multicast)
         {
-            if (network.transform_remote_locator(locator, local_locator))
+            if (network.is_locator_allowed(locator))
             {
                 remote_locators_.add_multicast_locator(locator);
             }

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -283,6 +283,12 @@ void PDP::initializeParticipantProxyData(
     }
 #endif // if HAVE_SECURITY
 
+    // TODO: sort code blocks?
+    if (announce_locators)
+    {
+        participant_data->m_networkConfiguration = attributes.builtin.network_configuration;
+    }
+
     if (announce_locators)
     {
         for (const Locator_t& loc : attributes.defaultUnicastLocatorList)
@@ -839,6 +845,9 @@ ReaderProxyData* PDP::addReaderProxyData(
                 reader_proxies_pool_.pop_back();
             }
 
+            // Copy network configuration from participant to reader proxy
+            ret_val->networkConfiguration(pit->m_networkConfiguration);
+
             // Add to ParticipantProxyData
             (*pit->m_readers)[reader_guid.entityId] = ret_val;
 
@@ -933,6 +942,9 @@ WriterProxyData* PDP::addWriterProxyData(
                 ret_val = writer_proxies_pool_.back();
                 writer_proxies_pool_.pop_back();
             }
+
+            // Copy network configuration from participant to writer proxy
+            ret_val->networkConfiguration(pit->m_networkConfiguration);
 
             // Add to ParticipantProxyData
             (*pit->m_writers)[writer_guid.entityId] = ret_val;

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -283,14 +283,10 @@ void PDP::initializeParticipantProxyData(
     }
 #endif // if HAVE_SECURITY
 
-    // TODO: sort code blocks?
     if (announce_locators)
     {
         participant_data->m_networkConfiguration = attributes.builtin.network_configuration;
-    }
 
-    if (announce_locators)
-    {
         for (const Locator_t& loc : attributes.defaultUnicastLocatorList)
         {
             participant_data->default_locators.add_unicast_locator(loc);

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -350,12 +350,11 @@ bool PDPSimple::createPDPEndpoints()
         {
             const NetworkFactory& network = mp_RTPSParticipant->network_factory();
             LocatorList_t fixed_locators;
-            Locator_t local_locator;
             for (const Locator_t& loc : mp_builtin->m_initialPeersList)
             {
-                if (network.transform_remote_locator(loc, local_locator))
+                if (network.is_locator_allowed(loc))
                 {
-                    fixed_locators.push_back(local_locator);
+                    fixed_locators.push_back(loc);
                 }
             }
             endpoints->writer.writer_->set_fixed_locators(fixed_locators);

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -374,10 +374,11 @@ bool PDPSimple::createPDPEndpoints()
                      *   3. Checking that the network configuration allows for localhost locators
                      */
                     Locator_t local_locator;
-                    network.transform_remote_locator(loc, local_locator, DISC_NETWORK_CONFIGURATION_LISTENING_LOCALHOST_ALL);
+                    network.transform_remote_locator(loc, local_locator,
+                            DISC_NETWORK_CONFIGURATION_LISTENING_LOCALHOST_ALL);
                     if (loc != local_locator
-                        && (loc.kind == LOCATOR_KIND_TCPv4 || loc.kind == LOCATOR_KIND_TCPv6)
-                        && network.is_locator_allowed(local_locator))
+                            && (loc.kind == LOCATOR_KIND_TCPv4 || loc.kind == LOCATOR_KIND_TCPv6)
+                            && network.is_locator_allowed(local_locator))
                     {
                         fixed_locators.push_back(local_locator);
                     }

--- a/src/cpp/rtps/network/NetworkFactory.cpp
+++ b/src/cpp/rtps/network/NetworkFactory.cpp
@@ -196,7 +196,8 @@ bool NetworkFactory::transform_remote_locator(
 {
     for (auto& transport : mRegisteredTransports)
     {
-        if (transport->transform_remote_locator(remote_locator, result_locator, remote_network_config & remote_locator.kind, network_configuration_ & remote_locator.kind))
+        if (transport->transform_remote_locator(remote_locator, result_locator,
+                remote_network_config & remote_locator.kind, network_configuration_ & remote_locator.kind))
         {
             return true;
         }

--- a/src/cpp/rtps/network/NetworkFactory.cpp
+++ b/src/cpp/rtps/network/NetworkFactory.cpp
@@ -38,6 +38,7 @@ NetworkFactory::NetworkFactory(
         const RTPSParticipantAttributes& PParam)
     : maxMessageSizeBetweenTransports_(std::numeric_limits<uint32_t>::max())
     , minSendBufferSize_(std::numeric_limits<uint32_t>::max())
+    , network_configuration_(0)
 {
     const std::string* enforce_metatraffic = nullptr;
     enforce_metatraffic = PropertyPolicyHelper::find_property(PParam.properties, "fastdds.shm.enforce_metatraffic");
@@ -126,6 +127,9 @@ bool NetworkFactory::RegisterTransport(
 
     if (transport)
     {
+        int32_t kind = transport->kind();
+        bool is_localhost_allowed = transport->is_localhost_allowed();
+
         if (transport->init(properties))
         {
             minSendBufferSize = transport->get_configuration()->min_send_buffer_size();
@@ -143,6 +147,11 @@ bool NetworkFactory::RegisterTransport(
             if (minSendBufferSize < minSendBufferSize_)
             {
                 minSendBufferSize_ = minSendBufferSize;
+            }
+
+            if (is_localhost_allowed)
+            {
+                network_configuration_ |= kind;
             }
         }
     }
@@ -182,11 +191,26 @@ void NetworkFactory::NormalizeLocators(
 
 bool NetworkFactory::transform_remote_locator(
         const Locator_t& remote_locator,
-        Locator_t& result_locator) const
+        Locator_t& result_locator,
+        const NetworkConfigSet_t& remote_network_config) const
 {
     for (auto& transport : mRegisteredTransports)
     {
-        if (transport->transform_remote_locator(remote_locator, result_locator))
+        if (transport->transform_remote_locator(remote_locator, result_locator, remote_network_config & remote_locator.kind, network_configuration_ & remote_locator.kind))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool NetworkFactory::is_locator_allowed(
+        const Locator_t& locator) const
+{
+    for (auto& transport : mRegisteredTransports)
+    {
+        if (transport->is_locator_allowed(locator))
         {
             return true;
         }

--- a/src/cpp/rtps/network/NetworkFactory.h
+++ b/src/cpp/rtps/network/NetworkFactory.h
@@ -103,6 +103,7 @@ public:
      *
      * @param [in]  remote_locator Locator to be converted.
      * @param [out] result_locator Converted locator.
+     * @param [in]  remote_network_config Remote network configuration.
      *
      * @return false if the input locator is not supported/allowed by any of the registered transports,
      *         true otherwise.

--- a/src/cpp/rtps/network/NetworkFactory.h
+++ b/src/cpp/rtps/network/NetworkFactory.h
@@ -99,7 +99,7 @@ public:
      * Transform a remote locator into a locator optimized for local communications.
      *
      * If the remote locator corresponds to one of the local interfaces, it is converted
-     * to the corresponding local address.
+     * to the corresponding local address if allowed by both local and remote transports.
      *
      * @param [in]  remote_locator Locator to be converted.
      * @param [out] result_locator Converted locator.
@@ -109,7 +109,19 @@ public:
      */
     bool transform_remote_locator(
             const Locator_t& remote_locator,
-            Locator_t& result_locator) const;
+            Locator_t& result_locator,
+            const NetworkConfigSet_t& remote_network_config) const;
+
+    /**
+     * Must report whether the given locator is allowed by at least one of the registered transports.
+     *
+     * @param [in]  locator Locator to check if allowed.
+     *
+     * @return false if the input locator is not supported/allowed by any of the registered transports,
+     *         true otherwise.
+     */
+    bool is_locator_allowed(
+            const Locator_t& locator) const;
 
     /**
      * Perform the locator selection algorithm.
@@ -136,6 +148,11 @@ public:
     uint32_t get_min_send_buffer_size()
     {
         return minSendBufferSize_;
+    }
+
+    NetworkConfigSet_t network_configuration() const
+    {
+        return network_configuration_;
     }
 
     /**
@@ -230,6 +247,9 @@ private:
 
     // Whether multicast metatraffic on SHM transport should always be used
     bool enforce_shm_multicast_metatraffic_ = false;
+
+    // Mask using transport kinds to indicate whether the transports allows localhost
+    NetworkConfigSet_t network_configuration_;
 
     /**
      * Calculate well-known ports.

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -417,6 +417,10 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     }
 #endif // if HAVE_SECURITY
 
+    // Copy NetworkFactory network_configuration to participant attributes prior to proxy creation
+    // NOTE: all transports already registered before
+    m_att.builtin.network_configuration = m_network_Factory.network_configuration();
+
     mp_builtinProtocols = new BuiltinProtocols();
 
     // Initialize builtin protocols

--- a/src/cpp/rtps/transport/TCPAcceptor.cpp
+++ b/src/cpp/rtps/transport/TCPAcceptor.cpp
@@ -38,12 +38,12 @@ TCPAcceptor::TCPAcceptor(
         asio::io_service& io_service,
         const std::string& interface,
         const Locator& locator)
-    : acceptor_(io_service, asio::ip::tcp::endpoint(asio::ip::address_v4::from_string(interface),
+    : acceptor_(io_service, asio::ip::tcp::endpoint(asio::ip::address::from_string(interface),
             IPLocator::getPhysicalPort(locator)))
     , locator_(locator)
     , io_service_(&io_service)
 {
-    endpoint_ = asio::ip::tcp::endpoint(asio::ip::address_v4::from_string(interface),
+    endpoint_ = asio::ip::tcp::endpoint(asio::ip::address::from_string(interface),
                     IPLocator::getPhysicalPort(locator_));
 }
 

--- a/src/cpp/rtps/transport/TCPAcceptorBasic.cpp
+++ b/src/cpp/rtps/transport/TCPAcceptorBasic.cpp
@@ -40,7 +40,7 @@ TCPAcceptorBasic::TCPAcceptorBasic(
     : TCPAcceptor(io_service, interface, locator)
     , socket_(*io_service_)
 {
-    endpoint_ = asio::ip::tcp::endpoint(asio::ip::address_v4::from_string(interface),
+    endpoint_ = asio::ip::tcp::endpoint(asio::ip::address::from_string(interface),
                     IPLocator::getPhysicalPort(locator_));
 }
 

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
@@ -68,21 +68,9 @@ void TCPChannelResourceBasic::connect(
         {
             ip::tcp::resolver resolver(service_);
 
-            std::string unscoped_locator = IPLocator::ip_to_string(locator_);
-            std::string scoped_locator = unscoped_locator;
-            auto scoped_interfaces = parent_->get_binding_interfaces_list();
-            for (auto& scoped_interface : scoped_interfaces)
-            {
-                std::string unscoped_interface = scoped_interface.substr(0, scoped_interface.find('%'));
-                if (unscoped_locator == unscoped_interface)
-                {
-                    scoped_locator = scoped_interface;
-                    break;
-                }
-            }
-
             auto endpoints = resolver.resolve({
-                            IPLocator::hasWan(locator_) ? IPLocator::toWanstring(locator_) : scoped_locator,
+                            IPLocator::hasWan(locator_) ? IPLocator::toWanstring(locator_) : IPLocator::ip_to_string(
+                                locator_),
                             std::to_string(IPLocator::getPhysicalPort(locator_))});
 
             socket_ = std::make_shared<asio::ip::tcp::socket>(service_);

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -1304,9 +1304,10 @@ void TCPTransportInterface::SocketAccepted(
             channel->thread(std::thread(&TCPTransportInterface::perform_listen_operation, this,
                     channel_weak_ptr, rtcp_manager_weak_ptr));
 
-            EPROSIMA_LOG_INFO(RTCP, "Accepted connection (local: " << IPLocator::to_string(locator)
-                                                                    << ", remote: " << channel->remote_endpoint().address()
-                                                                    << ":" << channel->remote_endpoint().port() << ")");
+            EPROSIMA_LOG_INFO(RTCP, "Accepted connection (local: "
+                    << IPLocator::to_string(locator) << ", remote: "
+                    << channel->remote_endpoint().address() << ":"
+                    << channel->remote_endpoint().port() << ")");
         }
         else
         {

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -516,7 +516,7 @@ bool TCPTransportInterface::transform_remote_locator(
 
         // If we get here, the locator is a local unicast address
 
-        // Attempt conversion to localhost if remote transport listening on it
+        // Attempt conversion to localhost if remote transport listening on it allows it
         if (allowed_remote_localhost)
         {
             Locator loopbackLocator;
@@ -1304,13 +1304,13 @@ void TCPTransportInterface::SocketAccepted(
             channel->thread(std::thread(&TCPTransportInterface::perform_listen_operation, this,
                     channel_weak_ptr, rtcp_manager_weak_ptr));
 
-            EPROSIMA_LOG_INFO(RTCP, " Accepted connection (local: " << IPLocator::to_string(locator)
+            EPROSIMA_LOG_INFO(RTCP, "Accepted connection (local: " << IPLocator::to_string(locator)
                                                                     << ", remote: " << channel->remote_endpoint().address()
                                                                     << ":" << channel->remote_endpoint().port() << ")");
         }
         else
         {
-            EPROSIMA_LOG_INFO(RTCP, " Accepting connection (" << error.message() << ")");
+            EPROSIMA_LOG_INFO(RTCP, "Accepting connection (" << error.message() << ")");
             std::this_thread::sleep_for(std::chrono::milliseconds(200)); // Wait a little to accept again.
         }
 

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -524,6 +524,7 @@ bool TCPTransportInterface::transform_remote_locator(
             if (is_locator_allowed(loopbackLocator))
             {
                 // Locator localhost is in the whitelist, so use localhost instead of remote_locator
+                fill_local_ip(result_locator);
                 IPLocator::setPhysicalPort(result_locator, IPLocator::getPhysicalPort(remote_locator));
                 IPLocator::setLogicalPort(result_locator, IPLocator::getLogicalPort(remote_locator));
                 return true;

--- a/src/cpp/rtps/transport/TCPTransportInterface.h
+++ b/src/cpp/rtps/transport/TCPTransportInterface.h
@@ -293,16 +293,20 @@ public:
      * Transforms a remote locator into a locator optimized for local communications.
      *
      * If the remote locator corresponds to one of the local interfaces, it is converted
-     * to the corresponding local address.
+     * to the corresponding local address if allowed by both local and remote transports.
      *
      * @param [in]  remote_locator Locator to be converted.
      * @param [out] result_locator Converted locator.
+     * @param [in]  allowed_remote_localhost Whether localhost is allowed (and hence used) in the remote transport.
+     * @param [in]  allowed_local_localhost Whether localhost is allowed locally (by this or other transport).
      *
      * @return false if the input locator is not supported/allowed by this transport, true otherwise.
      */
     bool transform_remote_locator(
             const Locator& remote_locator,
-            Locator& result_locator) const override;
+            Locator& result_locator,
+            bool allowed_remote_localhost,
+            bool allowed_local_localhost) const override;
 
     /**
      * Blocking Receive from the specified channel.
@@ -428,6 +432,8 @@ public:
     void keep_alive();
 
     void update_network_interfaces() override;
+
+    bool is_localhost_allowed() const override;
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/transport/TCPv6Transport.cpp
+++ b/src/cpp/rtps/transport/TCPv6Transport.cpp
@@ -224,22 +224,39 @@ bool TCPv6Transport::is_interface_allowed(
         return true;
     }
 
-    return find(interface_whitelist_.begin(), interface_whitelist_.end(), ip) != interface_whitelist_.end();
+    for (auto& whitelist : interface_whitelist_)
+    {
+        if (compare_ips(whitelist.to_string(), ip.to_string()))
+        {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 LocatorList TCPv6Transport::NormalizeLocator(
         const Locator& locator)
 {
     LocatorList list;
-
     if (IPLocator::isAny(locator))
     {
         std::vector<IPFinder::info_IP> locNames;
         get_ipv6s(locNames);
         for (const auto& infoIP : locNames)
         {
+            if (is_interface_allowed(infoIP.name))
+            {
+                Locator newloc(locator);
+                IPLocator::setIPv6(newloc, infoIP.locator);
+                list.push_back(newloc);
+            }
+        }
+
+        if (list.empty())
+        {
             Locator newloc(locator);
-            IPLocator::setIPv6(newloc, infoIP.locator);
+            IPLocator::setIPv6(newloc, "::1");
             list.push_back(newloc);
         }
     }
@@ -347,6 +364,22 @@ void TCPv6Transport::endpoint_to_locator(
     IPLocator::setPhysicalPort(locator, endpoint.port());
     auto ipBytes = endpoint.address().to_v6().to_bytes();
     IPLocator::setIPv6(locator, ipBytes.data());
+}
+
+bool TCPv6Transport::compare_ips(
+            const std::string& ip1,
+            const std::string& ip2) const
+{
+    // string::find returns string::npos if the character is not found
+    // If the second parameter is string::npos value, it indicates to take all characters until the end of the string
+    std::string substr1 = ip1.substr(0, ip1.find('%'));
+    std::string substr2 = ip2.substr(0, ip2.find('%'));
+
+    if (substr1.compare(substr2) == 0)
+    {
+        return true;
+    }
+    return false;
 }
 
 } // namespace rtps

--- a/src/cpp/rtps/transport/TCPv6Transport.cpp
+++ b/src/cpp/rtps/transport/TCPv6Transport.cpp
@@ -367,8 +367,8 @@ void TCPv6Transport::endpoint_to_locator(
 }
 
 bool TCPv6Transport::compare_ips(
-            const std::string& ip1,
-            const std::string& ip2) const
+        const std::string& ip1,
+        const std::string& ip2) const
 {
     // string::find returns string::npos if the character is not found
     // If the second parameter is string::npos value, it indicates to take all characters until the end of the string

--- a/src/cpp/rtps/transport/TCPv6Transport.h
+++ b/src/cpp/rtps/transport/TCPv6Transport.h
@@ -121,6 +121,11 @@ protected:
             const asio::ip::tcp::endpoint& endpoint,
             Locator& locator) const override;
 
+    //! Checks if the IP addresses are the same without taking into account the IPv6 scope
+    bool compare_ips(
+            const std::string& ip1,
+            const std::string& ip2) const;
+
 public:
 
     RTPS_DllAPI TCPv6Transport(

--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -389,31 +389,44 @@ Locator UDPTransportInterface::RemoteToMainLocal(
 
 bool UDPTransportInterface::transform_remote_locator(
         const Locator& remote_locator,
-        Locator& result_locator) const
+        Locator& result_locator,
+        bool allowed_remote_localhost,
+        bool allowed_local_localhost) const
 {
     if (IsLocatorSupported(remote_locator))
     {
         result_locator = remote_locator;
         if (!is_local_locator(result_locator))
         {
-            // is_local_locator will return false for multicast addresses as well as
-            // remote unicast ones.
+            // is_local_locator will return false for multicast addresses as well as remote unicast ones.
             return true;
         }
 
         // If we get here, the locator is a local unicast address
-        if (!is_locator_allowed(result_locator))
+
+        // Attempt conversion to localhost if remote transport listening on it
+        if (allowed_remote_localhost)
         {
-            return false;
+            Locator loopbackLocator;
+            fill_local_ip(loopbackLocator);
+            if (is_locator_allowed(loopbackLocator))
+            {
+                // Locator localhost is in the whitelist, so use localhost instead of remote_locator
+                fill_local_ip(result_locator);
+                return true;
+            }
+            else if (allowed_local_localhost)
+            {
+                // Abort transformation if localhost not allowed by this transport, but it is by other local transport
+                // and the remote one.
+                return false;
+            }
         }
 
-        // The locator is in the whitelist (or the whitelist is empty)
-        Locator loopbackLocator;
-        fill_local_ip(loopbackLocator);
-        if (is_locator_allowed(loopbackLocator))
+        if (!is_locator_allowed(result_locator))
         {
-            // Loopback locator
-            fill_local_ip(result_locator);
+            // Neither original remote locator nor localhost allowed: abort.
+            return false;
         }
 
         return true;
@@ -717,6 +730,13 @@ void UDPTransportInterface::get_unknown_network_interfaces(
 void UDPTransportInterface::update_network_interfaces()
 {
     rescan_interfaces_.store(true);
+}
+
+bool UDPTransportInterface::is_localhost_allowed() const
+{
+    Locator local_locator;
+    fill_local_ip(local_locator);
+    return is_locator_allowed(local_locator);
 }
 
 } // namespace rtps

--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -404,7 +404,7 @@ bool UDPTransportInterface::transform_remote_locator(
 
         // If we get here, the locator is a local unicast address
 
-        // Attempt conversion to localhost if remote transport listening on it
+        // Attempt conversion to localhost if remote transport listening on it allows it
         if (allowed_remote_localhost)
         {
             Locator loopbackLocator;

--- a/src/cpp/rtps/transport/UDPTransportInterface.h
+++ b/src/cpp/rtps/transport/UDPTransportInterface.h
@@ -87,16 +87,20 @@ public:
      * Transforms a remote locator into a locator optimized for local communications.
      *
      * If the remote locator corresponds to one of the local interfaces, it is converted
-     * to the corresponding local address.
+     * to the corresponding local address if allowed by both local and remote transports.
      *
      * @param [in]  remote_locator Locator to be converted.
      * @param [out] result_locator Converted locator.
+     * @param [in]  allowed_remote_localhost Whether localhost is allowed (and hence used) in the remote transport.
+     * @param [in]  allowed_local_localhost Whether localhost is allowed locally (by this or other transport).
      *
      * @return false if the input locator is not supported/allowed by this transport, true otherwise.
      */
     bool transform_remote_locator(
             const Locator& remote_locator,
-            Locator& result_locator) const override;
+            Locator& result_locator,
+            bool allowed_remote_localhost,
+            bool allowed_local_localhost) const override;
 
     /**
      * Blocking Send through the specified channel. In both modes, using a localLocator of 0.0.0.0 will
@@ -166,6 +170,8 @@ public:
     }
 
     void update_network_interfaces() override;
+
+    bool is_localhost_allowed() const override;
 
 protected:
 

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
@@ -176,6 +176,11 @@ bool SharedMemTransport::is_local_locator(
     return true;
 }
 
+bool SharedMemTransport::is_localhost_allowed() const
+{
+    return true;
+}
+
 void SharedMemTransport::delete_input_channel(
         SharedMemChannelResource* channel)
 {
@@ -392,7 +397,9 @@ Locator SharedMemTransport::RemoteToMainLocal(
 
 bool SharedMemTransport::transform_remote_locator(
         const Locator& remote_locator,
-        Locator& result_locator) const
+        Locator& result_locator,
+        bool,
+        bool) const
 {
     if (IsLocatorSupported(remote_locator))
     {

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransport.h
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransport.h
@@ -98,22 +98,28 @@ public:
      * Transforms a remote locator into a locator optimized for local communications.
      *
      * If the remote locator corresponds to one of the local interfaces, it is converted
-     * to the corresponding local address.
+     * to the corresponding local address if allowed by both local and remote transports.
      *
      * @param [in]  remote_locator Locator to be converted.
      * @param [out] result_locator Converted locator.
+     * @param [in]  allowed_remote_localhost Whether localhost is allowed (and hence used) in the remote transport.
+     * @param [in]  allowed_local_localhost Whether localhost is allowed locally (by this or other transport).
      *
      * @return false if the input locator is not supported/allowed by this transport, true otherwise.
      */
     bool transform_remote_locator(
             const Locator& remote_locator,
-            Locator& result_locator) const override;
+            Locator& result_locator,
+            bool allowed_remote_localhost,
+            bool allowed_local_localhost) const override;
 
     LocatorList NormalizeLocator(
             const Locator& locator) override;
 
     bool is_local_locator(
             const Locator& locator) const override;
+
+    bool is_localhost_allowed() const override;
 
     TransportDescriptorInterface* get_configuration() override
     {

--- a/test/blackbox/common/BlackboxTestsNetworkConf.cpp
+++ b/test/blackbox/common/BlackboxTestsNetworkConf.cpp
@@ -46,6 +46,10 @@ public:
         }
         else
         {
+#ifdef __APPLE__
+            // TODO: fix IPv6 issues related with zone ID
+            GTEST_SKIP() << "UDPv6 tests are disabled in Mac";
+#endif // ifdef __APPLE__
             descriptor_ = std::make_shared<UDPv6TransportDescriptor>();
         }
     }

--- a/test/blackbox/common/BlackboxTestsNetworkConf.cpp
+++ b/test/blackbox/common/BlackboxTestsNetworkConf.cpp
@@ -290,8 +290,8 @@ TEST_P(NetworkConfig, PubSubInterfaceWhitelistUnicast)
     reader.block_for_all();
 }
 
-// Regression test to check in UDP (v4) that setting the interface whitelist in one of the endpoints (writer),
-//  but not in the other, connection is established anyways
+// Regression test for redmine issue #18854 to check in UDP (v4) that setting the interface whitelist in one
+//  of the endpoints (writer), but not in the other, connection is established anyways
 TEST(NetworkConfig, PubSubInterfaceWhitelistPubSide)
 {
     PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
@@ -327,10 +327,23 @@ TEST(NetworkConfig, PubSubInterfaceWhitelistPubSide)
     // Check that endpoints have discovered each other
     ASSERT_EQ(reader.get_matched(), 1u);
     ASSERT_EQ(writer.get_matched(), 1u);
+
+    // Because its volatile the durability
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    auto data = default_helloworld_data_generator();
+    reader.startReception(data);
+    writer.send(data);
+
+    // Check that the sample data has been sent and received successfully
+    ASSERT_TRUE(data.empty());
+    reader.block_for_all();
 }
 
-// Regression test to check in UDP (v4) that setting the interface whitelist in one of the endpoints (reader),
-//  but not in the other, connection is established anyways
+// Regression test for redmine issue #18854 to check in UDP (v4) that setting the interface whitelist in one
+//  of the endpoints (reader), but not in the other, connection is established anyways
 TEST(NetworkConfig, PubSubInterfaceWhitelistSubSide)
 {
     PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
@@ -366,6 +379,19 @@ TEST(NetworkConfig, PubSubInterfaceWhitelistSubSide)
     // Check that endpoints have discovered each other
     ASSERT_EQ(reader.get_matched(), 1u);
     ASSERT_EQ(writer.get_matched(), 1u);
+
+    // Because its volatile the durability
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    auto data = default_helloworld_data_generator();
+    reader.startReception(data);
+    writer.send(data);
+
+    // Check that the sample data has been sent and received successfully
+    ASSERT_TRUE(data.empty());
+    reader.block_for_all();
 }
 
 TEST_P(NetworkConfig, SubGetListeningLocators)

--- a/test/blackbox/common/BlackboxTestsNetworkConf.cpp
+++ b/test/blackbox/common/BlackboxTestsNetworkConf.cpp
@@ -325,8 +325,8 @@ TEST(NetworkConfig, PubSubInterfaceWhitelistPubSide)
     reader.wait_discovery(std::chrono::seconds(5));
 
     // Check that endpoints have discovered each other
-    ASSERT_EQ(reader.get_matched(), 1);
-    ASSERT_EQ(writer.get_matched(), 1);
+    ASSERT_EQ(reader.get_matched(), 1u);
+    ASSERT_EQ(writer.get_matched(), 1u);
 }
 
 // Regression test to check in UDP (v4) that setting the interface whitelist in one of the endpoints (reader),
@@ -364,8 +364,8 @@ TEST(NetworkConfig, PubSubInterfaceWhitelistSubSide)
     reader.wait_discovery(std::chrono::seconds(5));
 
     // Check that endpoints have discovered each other
-    ASSERT_EQ(reader.get_matched(), 1);
-    ASSERT_EQ(writer.get_matched(), 1);
+    ASSERT_EQ(reader.get_matched(), 1u);
+    ASSERT_EQ(writer.get_matched(), 1u);
 }
 
 TEST_P(NetworkConfig, SubGetListeningLocators)

--- a/test/blackbox/common/BlackboxTestsTransportTCP.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportTCP.cpp
@@ -43,6 +43,10 @@ public:
         use_ipv6 = std::get<1>(GetParam());
         if (use_ipv6)
         {
+#ifdef __APPLE__
+            // TODO: fix IPv6 issues related with zone ID
+            GTEST_SKIP() << "TCPv6 tests are disabled in Mac";
+#endif // ifdef __APPLE__
             test_transport_ = std::make_shared<TCPv6TransportDescriptor>();
         }
         else

--- a/test/blackbox/common/BlackboxTestsTransportUDP.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportUDP.cpp
@@ -46,6 +46,10 @@ public:
         }
         else
         {
+#ifdef __APPLE__
+            // TODO: fix IPv6 issues related with zone ID
+            GTEST_SKIP() << "UDPv6 tests are disabled in Mac";
+#endif // ifdef __APPLE__
             test_transport_ = std::make_shared<UDPv6TransportDescriptor>();
         }
     }

--- a/test/mock/rtps/NetworkFactory/rtps/network/NetworkFactory.h
+++ b/test/mock/rtps/NetworkFactory/rtps/network/NetworkFactory.h
@@ -48,15 +48,28 @@ public:
 
     bool transform_remote_locator(
             const Locator_t& remote_locator,
-            Locator_t& result_locator) const
+            Locator_t& result_locator,
+            const NetworkConfigSet_t&) const
     {
         result_locator = remote_locator;
+        return true;
+    }
+
+    bool is_locator_allowed(
+            const Locator_t&) const
+    {
         return true;
     }
 
     uint32_t get_min_send_buffer_size()
     {
         return 65536;
+    }
+
+    bool is_local_locator(
+            const Locator_t&) const
+    {
+        return true;
     }
 
 };

--- a/test/unittest/rtps/network/mock/MockTransport.h
+++ b/test/unittest/rtps/network/mock/MockTransport.h
@@ -112,6 +112,11 @@ public:
         return false;
     }
 
+    bool is_localhost_allowed() const override
+    {
+        return false;
+    }
+
     TransportDescriptorInterface* get_configuration() override
     {
         return nullptr;
@@ -181,6 +186,15 @@ public:
     bool transform_remote_locator(
             const fastrtps::rtps::Locator_t&,
             fastrtps::rtps::Locator_t&) const override
+    {
+        return true;
+    }
+
+    bool transform_remote_locator(
+            const fastrtps::rtps::Locator_t&,
+            fastrtps::rtps::Locator_t&,
+            bool,
+            bool) const override
     {
         return true;
     }

--- a/test/unittest/transport/SharedMemTests.cpp
+++ b/test/unittest/transport/SharedMemTests.cpp
@@ -785,8 +785,10 @@ TEST_F(SHMTransportTests, transform_remote_locator_returns_input_locator)
 
     // Then
     Locator_t otherLocator;
-    ASSERT_TRUE(transportUnderTest.transform_remote_locator(remote_locator, otherLocator));
+    ASSERT_TRUE(transportUnderTest.transform_remote_locator(remote_locator, otherLocator, false, false));
     ASSERT_EQ(otherLocator, remote_locator);
+    // NOTE: transform_remote_locator only checks for kind compatibility in SharedMemTransport, no transformation is
+    // performed and hence \c  allowed_remote_localhost and \c allowed_local_localhost args are irrelevant.
 }
 
 TEST_F(SHMTransportTests, all_shared_mem_locators_are_local)

--- a/test/unittest/transport/SharedMemTests.cpp
+++ b/test/unittest/transport/SharedMemTests.cpp
@@ -788,7 +788,7 @@ TEST_F(SHMTransportTests, transform_remote_locator_returns_input_locator)
     ASSERT_TRUE(transportUnderTest.transform_remote_locator(remote_locator, otherLocator, false, false));
     ASSERT_EQ(otherLocator, remote_locator);
     // NOTE: transform_remote_locator only checks for kind compatibility in SharedMemTransport, no transformation is
-    // performed and hence \c  allowed_remote_localhost and \c allowed_local_localhost args are irrelevant.
+    // performed and hence \c allowed_remote_localhost and \c allowed_local_localhost args are irrelevant.
 }
 
 TEST_F(SHMTransportTests, all_shared_mem_locators_are_local)

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -56,6 +56,14 @@ class TCPv6Tests : public ::testing::Test
 {
 public:
 
+    void SetUp() override
+    {
+#ifdef __APPLE__
+        // TODO: fix IPv6 issues related with zone ID
+        GTEST_SKIP() << "TCPv6 tests are disabled in Mac";
+#endif // ifdef __APPLE__
+    }
+
     TCPv6Tests()
     {
         HELPER_SetDescriptorDefaults();

--- a/test/unittest/transport/UDPv6Tests.cpp
+++ b/test/unittest/transport/UDPv6Tests.cpp
@@ -58,6 +58,14 @@ class UDPv6Tests : public ::testing::Test
 {
 public:
 
+    void SetUp() override
+    {
+#ifdef __APPLE__
+        // TODO: fix IPv6 issues related with zone ID
+        GTEST_SKIP() << "UDPv6 tests are disabled in Mac";
+#endif // ifdef __APPLE__
+    }
+
     UDPv6Tests()
     {
         HELPER_SetDescriptorDefaults();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Matching two local participants through UDP/TCP transport currently fails when only one of them sets an interface whitelist. In particular, the problematic cases are only including the loopback interface (**A**), or including all except the loopback interface (**B**).

The reason for this is that Fast DDS internally performs an optimization consisting in transforming a local locator to localhost (``NetworkFactory::transform_remote_locators``) whenever possible. This way, communication is performed through the loopback interface, which is allegedly more robust to changes in the environment.
However, the only input for determining whether this transformation should be performed is each transport's **own** interface whitelist. This implies that in some cases the transformation will be wrongly performed as the remote transport may not be listening on localhost (**B**).
Another issue with this transformation method is that it boths attempts conversion to localhost as well as filters locators based on one's interface whitelist. This explains why **A** arises, as the received remote (local) locator gets filtered out for being different than localhost.

This PR attempts to fix the issue by sending in discovery a new network configuration parameter, which for the moment only includes whether a participant is listening on localhost (depending on its whitelist). Four (plus 28 unused) different bits encoding this information are sent, each for a different transport kind (UDPv4, UDPv6, TCPv4 and TCPv6). 
An extended ``NetworkFactory::transform_remote_locators`` is added leveraging this information, so conversion to localhost is only performed when both remote and local participants allow for it.

**Behaviour changes:**
- Transformation to localhost is no longer attempted in Initial Peers and Discovery Server. This is because the remote's participant network configuration is only shared through discovery, and hence in these two cases it is not available.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
