### PR TITLE
[19247] Improve performance on intraprocess + data-sharing

### DIFF
--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -196,7 +196,7 @@ bool StatefulReader::matched_writer_add(
 
         listener = mp_listener;
         bool is_same_process = RTPSDomainImpl::should_intraprocess_between(m_guid, wdata.guid());
-        bool is_datasharing = !is_same_process && is_datasharing_compatible_with(wdata);
+        bool is_datasharing = is_datasharing_compatible_with(wdata);
 
         for (WriterProxy* it : matched_writers_)
         {

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -43,18 +43,12 @@
 
 using namespace eprosima::fastrtps::rtps;
 
-static void send_ack_if_datasharing(
+static void send_datasharing_ack(
         StatefulReader* reader,
         ReaderHistory* history,
         WriterProxy* writer,
         const SequenceNumber_t& sequence_number)
 {
-    // If not datasharing, we are done
-    if (!writer || !writer->is_datasharing_writer() || writer->is_on_same_process())
-    {
-        return;
-    }
-
     // This may not be the change read with highest SN,
     // need to find largest SN to ACK
     for (std::vector<CacheChange_t*>::iterator it = history->changesBegin(); it != history->changesEnd(); ++it)
@@ -78,6 +72,19 @@ static void send_ack_if_datasharing(
     // Must ACK all in the writer
     SequenceNumberSet_t sns(writer->available_changes_max() + 1);
     reader->send_acknack(writer, sns, writer, false);
+}
+
+static inline void send_ack_if_datasharing(
+        StatefulReader* reader,
+        ReaderHistory* history,
+        WriterProxy* writer,
+        const SequenceNumber_t& sequence_number)
+{
+    // Shall be datasharing, and not on same process
+    if (writer && writer->is_datasharing_writer() && !writer->is_on_same_process())
+    {
+        send_datasharing_ack(reader, history, writer, sequence_number);
+    }
 }
 
 StatefulReader::~StatefulReader()

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -50,7 +50,7 @@ static void send_ack_if_datasharing(
         const SequenceNumber_t& sequence_number)
 {
     // If not datasharing, we are done
-    if (!writer || !writer->is_datasharing_writer())
+    if (!writer || !writer->is_datasharing_writer() || writer->is_on_same_process())
     {
         return;
     }

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -123,7 +123,7 @@ bool StatelessReader::matched_writer_add(
         }
 
         bool is_same_process = RTPSDomainImpl::should_intraprocess_between(m_guid, wdata.guid());
-        bool is_datasharing = !is_same_process && is_datasharing_compatible_with(wdata);
+        bool is_datasharing = is_datasharing_compatible_with(wdata);
 
         RemoteWriterInfo_t info;
         info.guid = wdata.guid();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR enables datasharing processing on readers which are directly notified by a datasharing writer in the same process.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
    - Some of the existing datasharing blackbox tests have been updated to run both with intraprocess on and off, so we can check for TSan report on possible deadlocks.
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
