### PR TITLE
[19256] Remove mutex from TimedEventImpl

### DIFF
--- a/src/cpp/rtps/resources/TimedEventImpl.h
+++ b/src/cpp/rtps/resources/TimedEventImpl.h
@@ -26,11 +26,7 @@
 #include <fastdds/rtps/resources/TimedEvent.h>
 
 #include <atomic>
-#include <thread>
-#include <memory>
 #include <functional>
-#include <mutex>
-#include <condition_variable>
 
 namespace eprosima {
 namespace fastrtps {
@@ -91,9 +87,8 @@ public:
      */
     double getIntervalMsec()
     {
-        std::unique_lock<std::mutex> lock(mutex_);
-        auto total_milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(interval_microsec_);
-        return static_cast<double>(total_milliseconds.count());
+        const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(interval_microsec_.load());
+        return static_cast<double>(ms.count());
     }
 
     /*!
@@ -102,10 +97,9 @@ public:
      */
     double getRemainingTimeMilliSec()
     {
-        std::unique_lock<std::mutex> lock(mutex_);
         return static_cast<double>(
             std::chrono::duration_cast<std::chrono::milliseconds>(
-                next_trigger_time_ - std::chrono::steady_clock::now()).
+                next_trigger_time_.load() - std::chrono::steady_clock::now()).
             count());
     }
 
@@ -115,7 +109,6 @@ public:
      */
     std::chrono::steady_clock::time_point next_trigger_time()
     {
-        std::unique_lock<std::mutex> lock(mutex_);
         return next_trigger_time_;
     }
 
@@ -154,19 +147,16 @@ public:
 private:
 
     //! Expiration time in microseconds of the event.
-    std::chrono::microseconds interval_microsec_;
+    std::atomic<std::chrono::microseconds> interval_microsec_;
 
     //! Next time this event should be triggered
-    std::chrono::steady_clock::time_point next_trigger_time_;
+    std::atomic<std::chrono::steady_clock::time_point> next_trigger_time_;
 
     //! User function to be called when this event is triggered
     Callback callback_;
 
     //! Current state of this event
     std::atomic<StateCode> state_;
-
-    //! Protects interval_microsec_ and next_trigger_time_
-    std::mutex mutex_;
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/resources/TimedEventImpl.h
+++ b/src/cpp/rtps/resources/TimedEventImpl.h
@@ -97,10 +97,9 @@ public:
      */
     double getRemainingTimeMilliSec()
     {
-        return static_cast<double>(
-            std::chrono::duration_cast<std::chrono::milliseconds>(
-                next_trigger_time_.load() - std::chrono::steady_clock::now()).
-            count());
+        const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+            next_trigger_time_.load() - std::chrono::steady_clock::now());
+        return static_cast<double>(ms.count());
     }
 
     /*!


### PR DESCRIPTION
Eliminates the overhead of mutex locking in a method in TimeEventImpl that is frequently called. 

## Description

While investigating scalability of discovery service on a large distributed system, hotspot analysis using Intel vtune showed that most time is spent with mutexes. Further analysis identifies a particular culprit whose removal increases the performance by 2x.

The following is from a machine with Haswell CPU running a SERVER participant. Evidently, 50% of the compute is spent locking and unlocking a mutex. The CPU consumption measured by top is of the order of 37%.

![hotspot](https://github.com/eProsima/Fast-DDS/assets/1699431/b1ae6236-61d0-491c-acc3-04d5f7320155)

The performance analysis with vtune allows the construction of a so-called flamegraph that makes it very easy to understand the caller-callee relationship. The graph makes it very clear that the vast majority of the mutex locks and unlocks can be attributed to the function `eProsima::fastrtps::rtps::event_compare`.

![flame_graph](https://github.com/eProsima/Fast-DDS/assets/1699431/1272880e-84ab-4c18-bc47-938586010d97)

Looking at the source code we can see that the mutex is locked and unlocked during a sort operation:

```
// src/cpp/rtps/resources/TimedEventImpl.h
std::chrono::steady_clock::time_point next_trigger_time()
{   
    std::unique_lock<std::mutex> lock(mutex_);
    return next_trigger_time_;
}

// src/cpp/rtps/resources/ResourceEvent.cpp
static bool event_compare(
        TimedEventImpl* lhs,
        TimedEventImpl* rhs)
{
    return lhs->next_trigger_time() < rhs->next_trigger_time();
}

void ResourceEvent::sort_timers()
{
    std::sort(active_timers_.begin(), active_timers_.end(), event_compare);
}
```

The mutex protects a couple of data members that can be wrapped in `std::atomic` instead. After eliminating the mutex, the flame graph becomes

![flame_graph_after](https://github.com/eProsima/Fast-DDS/assets/1699431/3617551f-4979-47b6-a5cb-4e90756faf91)

At least in our use case, we are able to see an improvement in how well the discovery service scales without the lock.

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.

@Mergifyio backport 2.11.x 2.10.x 2.6.x