### PR TITLE
[19263 ] User configuration for SHM metatraffic

### DIFF
--- a/src/cpp/rtps/network/NetworkFactory.cpp
+++ b/src/cpp/rtps/network/NetworkFactory.cpp
@@ -39,29 +39,29 @@ NetworkFactory::NetworkFactory(
     : maxMessageSizeBetweenTransports_(std::numeric_limits<uint32_t>::max())
     , minSendBufferSize_(std::numeric_limits<uint32_t>::max())
 {
-    const std::string* allow_metatraffic = nullptr;
-    allow_metatraffic = PropertyPolicyHelper::find_property(PParam.properties, "fastdds.shm.enforce_metatraffic");
-    if (allow_metatraffic)
+    const std::string* enforce_metatraffic = nullptr;
+    enforce_metatraffic = PropertyPolicyHelper::find_property(PParam.properties, "fastdds.shm.enforce_metatraffic");
+    if (enforce_metatraffic)
     {
-        if (*allow_metatraffic == "unicast")
+        if (*enforce_metatraffic == "unicast")
         {
             enforce_shm_unicast_metatraffic_ = true;
             enforce_shm_multicast_metatraffic_ = false;
         }
-        else if (*allow_metatraffic == "all")
+        else if (*enforce_metatraffic == "all")
         {
             enforce_shm_unicast_metatraffic_ = true;
             enforce_shm_multicast_metatraffic_ = true;
         }
-        else if (*allow_metatraffic == "none")
+        else if (*enforce_metatraffic == "none")
         {
             enforce_shm_unicast_metatraffic_ = false;
             enforce_shm_multicast_metatraffic_ = false;
         }
         else
         {
-            EPROSIMA_LOG_WARNING(RTPS_NETWORK, "Unrecognized value '" << *allow_metatraffic << "'" <<
-                    " for 'fastdds.shm.allow_metatraffic'. Using default value: 'none'");
+            EPROSIMA_LOG_WARNING(RTPS_NETWORK, "Unrecognized value '" << *enforce_metatraffic << "'" <<
+                    " for 'fastdds.shm.enforce_metatraffic'. Using default value: 'none'");
         }
     }
 }

--- a/src/cpp/rtps/network/NetworkFactory.cpp
+++ b/src/cpp/rtps/network/NetworkFactory.cpp
@@ -40,23 +40,23 @@ NetworkFactory::NetworkFactory(
     , minSendBufferSize_(std::numeric_limits<uint32_t>::max())
 {
     const std::string* allow_metatraffic = nullptr;
-    allow_metatraffic = PropertyPolicyHelper::find_property(PParam.properties, "fastdds.shm.allow_metatraffic");
+    allow_metatraffic = PropertyPolicyHelper::find_property(PParam.properties, "fastdds.shm.enforce_metatraffic");
     if (allow_metatraffic)
     {
         if (*allow_metatraffic == "unicast")
         {
-            allow_shm_unicast_metatraffic_ = true;
-            allow_shm_multicast_metatraffic_ = false;
+            enforce_shm_unicast_metatraffic_ = true;
+            enforce_shm_multicast_metatraffic_ = false;
         }
         else if (*allow_metatraffic == "all")
         {
-            allow_shm_unicast_metatraffic_ = true;
-            allow_shm_multicast_metatraffic_ = true;
+            enforce_shm_unicast_metatraffic_ = true;
+            enforce_shm_multicast_metatraffic_ = true;
         }
         else if (*allow_metatraffic == "none")
         {
-            allow_shm_unicast_metatraffic_ = false;
-            allow_shm_multicast_metatraffic_ = false;
+            enforce_shm_unicast_metatraffic_ = false;
+            enforce_shm_multicast_metatraffic_ = false;
         }
         else
         {
@@ -274,7 +274,7 @@ bool NetworkFactory::getDefaultMetatrafficMulticastLocators(
     {
         // For better fault-tolerance reasons, SHM metatraffic is avoided if it is already provided
         // by another transport
-        if (allow_shm_multicast_metatraffic_ || transport->kind() != LOCATOR_KIND_SHM)
+        if (enforce_shm_multicast_metatraffic_ || transport->kind() != LOCATOR_KIND_SHM)
         {
             result |= transport->getDefaultMetatrafficMulticastLocators(locators, metatraffic_multicast_port);
         }
@@ -319,7 +319,7 @@ bool NetworkFactory::getDefaultMetatrafficUnicastLocators(
     {
         // For better fault-tolerance reasons, SHM metatraffic is avoided if it is already provided
         // by another transport
-        if (allow_shm_unicast_metatraffic_ || transport->kind() != LOCATOR_KIND_SHM)
+        if (enforce_shm_unicast_metatraffic_ || transport->kind() != LOCATOR_KIND_SHM)
         {
             result |= transport->getDefaultMetatrafficUnicastLocators(locators, metatraffic_unicast_port);
         }

--- a/src/cpp/rtps/network/NetworkFactory.cpp
+++ b/src/cpp/rtps/network/NetworkFactory.cpp
@@ -34,7 +34,8 @@ namespace rtps {
 
 using SendResourceList = fastdds::rtps::SendResourceList;
 
-NetworkFactory::NetworkFactory()
+NetworkFactory::NetworkFactory(
+        const RTPSParticipantAttributes& PParam)
     : maxMessageSizeBetweenTransports_(std::numeric_limits<uint32_t>::max())
     , minSendBufferSize_(std::numeric_limits<uint32_t>::max())
 {

--- a/src/cpp/rtps/network/NetworkFactory.cpp
+++ b/src/cpp/rtps/network/NetworkFactory.cpp
@@ -246,7 +246,7 @@ bool NetworkFactory::getDefaultMetatrafficMulticastLocators(
 
     for (auto& transport : mRegisteredTransports)
     {
-        // For better fault-tolerance reasons, SHM multicast metatraffic is avoided if it is already provided
+        // For better fault-tolerance reasons, SHM metatraffic is avoided if it is already provided
         // by another transport
         if (transport->kind() != LOCATOR_KIND_SHM)
         {
@@ -286,10 +286,28 @@ bool NetworkFactory::getDefaultMetatrafficUnicastLocators(
         uint32_t metatraffic_unicast_port) const
 {
     bool result = false;
+
+    TransportInterface* shm_transport = nullptr;
+
     for (auto& transport : mRegisteredTransports)
     {
-        result |= transport->getDefaultMetatrafficUnicastLocators(locators, metatraffic_unicast_port);
+        // For better fault-tolerance reasons, SHM metatraffic is avoided if it is already provided
+        // by another transport
+        if (transport->kind() != LOCATOR_KIND_SHM)
+        {
+            result |= transport->getDefaultMetatrafficUnicastLocators(locators, metatraffic_unicast_port);
+        }
+        else
+        {
+            shm_transport = transport.get();
+        }
     }
+
+    if (locators.size() == 0 && shm_transport)
+    {
+        result |= shm_transport->getDefaultMetatrafficUnicastLocators(locators, metatraffic_unicast_port);
+    }
+
     return result;
 }
 

--- a/src/cpp/rtps/network/NetworkFactory.cpp
+++ b/src/cpp/rtps/network/NetworkFactory.cpp
@@ -39,6 +39,31 @@ NetworkFactory::NetworkFactory(
     : maxMessageSizeBetweenTransports_(std::numeric_limits<uint32_t>::max())
     , minSendBufferSize_(std::numeric_limits<uint32_t>::max())
 {
+    const std::string* allow_metatraffic = nullptr;
+    allow_metatraffic = PropertyPolicyHelper::find_property(PParam.properties, "fastdds.shm.allow_metatraffic");
+    if (allow_metatraffic)
+    {
+        if (*allow_metatraffic == "unicast")
+        {
+            allow_shm_unicast_metatraffic_ = true;
+            allow_shm_multicast_metatraffic_ = false;
+        }
+        else if (*allow_metatraffic == "all")
+        {
+            allow_shm_unicast_metatraffic_ = true;
+            allow_shm_multicast_metatraffic_ = true;
+        }
+        else if (*allow_metatraffic == "none")
+        {
+            allow_shm_unicast_metatraffic_ = false;
+            allow_shm_multicast_metatraffic_ = false;
+        }
+        else
+        {
+            EPROSIMA_LOG_WARNING(RTPS_NETWORK, "Unrecognized value '" << *allow_metatraffic << "'" <<
+                    " for 'fastdds.shm.allow_metatraffic'. Using default value: 'none'");
+        }
+    }
 }
 
 bool NetworkFactory::build_send_resources(

--- a/src/cpp/rtps/network/NetworkFactory.cpp
+++ b/src/cpp/rtps/network/NetworkFactory.cpp
@@ -248,7 +248,7 @@ bool NetworkFactory::getDefaultMetatrafficMulticastLocators(
     {
         // For better fault-tolerance reasons, SHM metatraffic is avoided if it is already provided
         // by another transport
-        if (transport->kind() != LOCATOR_KIND_SHM)
+        if (allow_shm_multicast_metatraffic_ || transport->kind() != LOCATOR_KIND_SHM)
         {
             result |= transport->getDefaultMetatrafficMulticastLocators(locators, metatraffic_multicast_port);
         }
@@ -293,7 +293,7 @@ bool NetworkFactory::getDefaultMetatrafficUnicastLocators(
     {
         // For better fault-tolerance reasons, SHM metatraffic is avoided if it is already provided
         // by another transport
-        if (transport->kind() != LOCATOR_KIND_SHM)
+        if (allow_shm_unicast_metatraffic_ || transport->kind() != LOCATOR_KIND_SHM)
         {
             result |= transport->getDefaultMetatrafficUnicastLocators(locators, metatraffic_unicast_port);
         }

--- a/src/cpp/rtps/network/NetworkFactory.h
+++ b/src/cpp/rtps/network/NetworkFactory.h
@@ -225,11 +225,11 @@ private:
 
     uint32_t minSendBufferSize_;
 
-    // Whether unicast metatraffic on SHM transport is allowed
-    bool allow_shm_unicast_metatraffic_ = false;
+    // Whether unicast metatraffic on SHM transport should always be used
+    bool enforce_shm_unicast_metatraffic_ = false;
 
-    // Whether multicast metatraffic on SHM transport is allowed
-    bool allow_shm_multicast_metatraffic_ = false;
+    // Whether multicast metatraffic on SHM transport should always be used
+    bool enforce_shm_multicast_metatraffic_ = false;
 
     /**
      * Calculate well-known ports.

--- a/src/cpp/rtps/network/NetworkFactory.h
+++ b/src/cpp/rtps/network/NetworkFactory.h
@@ -43,7 +43,8 @@ class NetworkFactory
 {
 public:
 
-    NetworkFactory();
+    NetworkFactory(
+            const RTPSParticipantAttributes& PParam);
 
     /**
      * Allow registration of a transport statically, by specifying the transport type and

--- a/src/cpp/rtps/network/NetworkFactory.h
+++ b/src/cpp/rtps/network/NetworkFactory.h
@@ -224,6 +224,12 @@ private:
 
     uint32_t minSendBufferSize_;
 
+    // Whether unicast metatraffic on SHM transport is allowed
+    bool allow_shm_unicast_metatraffic_ = false;
+
+    // Whether multicast metatraffic on SHM transport is allowed
+    bool allow_shm_multicast_metatraffic_ = false;
+
     /**
      * Calculate well-known ports.
      */

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -130,7 +130,6 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     , m_att(PParam)
     , m_guid(guidP, c_EntityId_RTPSParticipant)
     , mp_builtinProtocols(nullptr)
-    , mp_ResourceSemaphore(new Semaphore(0))
     , IdCounter(0)
     , m_network_Factory(PParam)
     , type_check_fn_(nullptr)
@@ -513,7 +512,6 @@ RTPSParticipantImpl::~RTPSParticipantImpl()
     }
     m_receiverResourcelist.clear();
 
-    delete mp_ResourceSemaphore;
     delete mp_userParticipant;
     mp_userParticipant = nullptr;
     send_resource_list_.clear();
@@ -2033,22 +2031,6 @@ bool RTPSParticipantImpl::newRemoteEndpointDiscovered(
     }
 
     return false;
-}
-
-void RTPSParticipantImpl::ResourceSemaphorePost()
-{
-    if (mp_ResourceSemaphore != nullptr)
-    {
-        mp_ResourceSemaphore->post();
-    }
-}
-
-void RTPSParticipantImpl::ResourceSemaphoreWait()
-{
-    if (mp_ResourceSemaphore != nullptr)
-    {
-        mp_ResourceSemaphore->wait();
-    }
 }
 
 void RTPSParticipantImpl::assert_remote_participant_liveliness(

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -132,6 +132,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     , mp_builtinProtocols(nullptr)
     , mp_ResourceSemaphore(new Semaphore(0))
     , IdCounter(0)
+    , m_network_Factory(PParam)
     , type_check_fn_(nullptr)
     , client_override_(false)
     , internal_metatraffic_locators_(false)

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -240,12 +240,6 @@ public:
         return (uint32_t)m_att.participantID;
     }
 
-    //!Post to the resource semaphore
-    void ResourceSemaphorePost();
-
-    //!Wait for the resource semaphore
-    void ResourceSemaphoreWait();
-
     //!Get Pointer to the Event Resource.
     ResourceEvent& getEventResource()
     {
@@ -529,8 +523,6 @@ private:
     ResourceEvent mp_event_thr;
     //! BuiltinProtocols of this RTPSParticipant
     BuiltinProtocols* mp_builtinProtocols;
-    //!Semaphore to wait for the listen thread creation.
-    Semaphore* mp_ResourceSemaphore;
     //!Id counter to correctly assign the ids to writers and readers.
     std::atomic<uint32_t> IdCounter;
     //! Mutex to safely access endpoints collections

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -1326,6 +1326,13 @@ public:
         return *this;
     }
 
+    PubSubReader& max_multicast_locators_number(
+            size_t max_multicast_locators)
+    {
+        participant_qos_.allocation().locators.max_multicast_locators = max_multicast_locators;
+        return *this;
+    }
+
     PubSubReader& lease_duration(
             eprosima::fastrtps::Duration_t lease_duration,
             eprosima::fastrtps::Duration_t announce_period)

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -1270,6 +1270,13 @@ public:
         return *this;
     }
 
+    PubSubReader& avoid_builtin_multicast(
+            bool value)
+    {
+        participant_qos_.wire_protocol().builtin.avoid_builtin_multicast = value;
+        return *this;
+    }
+
     PubSubReader& property_policy(
             const eprosima::fastrtps::rtps::PropertyPolicy& property_policy)
     {

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -1319,6 +1319,13 @@ public:
         return *this;
     }
 
+    PubSubWriter& max_multicast_locators_number(
+            size_t max_multicast_locators)
+    {
+        participant_qos_.allocation().locators.max_multicast_locators = max_multicast_locators;
+        return *this;
+    }
+
     PubSubWriter& lease_duration(
             eprosima::fastrtps::Duration_t lease_duration,
             eprosima::fastrtps::Duration_t announce_period)

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -1215,6 +1215,13 @@ public:
         return *this;
     }
 
+    PubSubWriter& avoid_builtin_multicast(
+            bool value)
+    {
+        participant_qos_.wire_protocol().builtin.avoid_builtin_multicast = value;
+        return *this;
+    }
+
     PubSubWriter& property_policy(
             const eprosima::fastrtps::rtps::PropertyPolicy& property_policy)
     {

--- a/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
@@ -1026,6 +1026,13 @@ public:
         return *this;
     }
 
+    PubSubReader& avoid_builtin_multicast(
+            bool value)
+    {
+        participant_attr_.rtps.builtin.avoid_builtin_multicast = value;
+        return *this;
+    }
+
     PubSubReader& property_policy(
             const eprosima::fastrtps::rtps::PropertyPolicy property_policy)
     {

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
@@ -995,6 +995,13 @@ public:
         return *this;
     }
 
+    PubSubWriter& avoid_builtin_multicast(
+            bool value)
+    {
+        participant_attr_.rtps.builtin.avoid_builtin_multicast = value;
+        return *this;
+    }
+
     PubSubWriter& property_policy(
             const eprosima::fastrtps::rtps::PropertyPolicy& property_policy)
     {

--- a/test/blackbox/common/DDSBlackboxTestsTransportSHMUDP.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsTransportSHMUDP.cpp
@@ -15,6 +15,7 @@
 #include "BlackboxTests.hpp"
 #include "mock/BlackboxMockConsumer.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <memory>
@@ -250,7 +251,7 @@ TEST(SHMUDP, SHM_metatraffic_wrong_config)
     Log::SetCategoryFilter(std::regex("RTPS_NETWORK"));
     Log::SetErrorStringFilter(std::regex(".*__WRONG_VALUE__.*"));
 
-    // Perfrorm test
+    // Perform test
     shm_metatraffic_test(TEST_TOPIC_NAME, "__WRONG_VALUE__", false, false);
 
     /* Check logs */

--- a/test/blackbox/common/DDSBlackboxTestsTransportSHMUDP.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsTransportSHMUDP.cpp
@@ -213,6 +213,7 @@ static void shm_metatraffic_test(
                 return true;
             };
     reader.setOnDiscoveryFunction(discovery_checker);
+    reader.max_multicast_locators_number(2);
     reader.init();
     ASSERT_TRUE(reader.isInitialized());
 
@@ -221,7 +222,7 @@ static void shm_metatraffic_test(
     p.name("fastdds.shm.enforce_metatraffic");
     p.value(value);
     properties.properties().push_back(p);
-    writer.property_policy(properties);
+    writer.property_policy(properties).avoid_builtin_multicast(false).max_multicast_locators_number(2);
     writer.init();
     ASSERT_TRUE(writer.isInitialized());
 

--- a/test/unittest/rtps/network/CMakeLists.txt
+++ b/test/unittest/rtps/network/CMakeLists.txt
@@ -22,6 +22,10 @@ set(NETWORKFACTORYTESTS_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
 
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/PropertyPolicy.cpp
+
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/flowcontrol/ThroughputControllerDescriptor.cpp
+
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/UDPChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/UDPTransportInterface.cpp

--- a/test/unittest/rtps/network/NetworkFactoryTests.cpp
+++ b/test/unittest/rtps/network/NetworkFactoryTests.cpp
@@ -24,7 +24,6 @@
 #include <fastrtps/utils/collections/ResourceLimitedVector.hpp>
 #include <fastrtps/utils/IPLocator.h>
 
-
 #include <MockTransport.h>
 #include <rtps/network/NetworkFactory.h>
 

--- a/test/unittest/rtps/network/NetworkFactoryTests.cpp
+++ b/test/unittest/rtps/network/NetworkFactoryTests.cpp
@@ -16,12 +16,14 @@
 
 #include <gtest/gtest.h>
 
+#include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
 #include <fastrtps/transport/TCPv4TransportDescriptor.h>
 #include <fastrtps/transport/TCPv6TransportDescriptor.h>
 #include <fastrtps/transport/UDPv4TransportDescriptor.h>
 #include <fastrtps/transport/UDPv6TransportDescriptor.h>
 #include <fastrtps/utils/collections/ResourceLimitedVector.hpp>
 #include <fastrtps/utils/IPLocator.h>
+
 
 #include <MockTransport.h>
 #include <rtps/network/NetworkFactory.h>
@@ -34,7 +36,8 @@ class NetworkTests : public ::testing::Test
 {
 public:
 
-    NetworkFactory networkFactoryUnderTest;
+    RTPSParticipantAttributes pattr{};
+    NetworkFactory networkFactoryUnderTest{pattr};
     void HELPER_RegisterTransportWithKindAndChannels(
             int kind,
             unsigned int channels);
@@ -648,7 +651,7 @@ TEST_F(NetworkTests, LocatorShrink)
     std::vector<ShrinkLocatorCase_t> test_cases;
     fill_blackbox_locators_test_cases(test_cases);
 
-    NetworkFactory f;
+    NetworkFactory f{pattr};
     UDPv4TransportDescriptor udpv4;
     f.RegisterTransport(&udpv4);
     // TODO: Register more transports

--- a/test/unittest/transport/CMakeLists.txt
+++ b/test/unittest/transport/CMakeLists.txt
@@ -53,6 +53,8 @@ set(UDPV4TESTS_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/PropertyPolicy.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/flowcontrol/ThroughputControllerDescriptor.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/UDPv4Transport.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/UDPTransportInterface.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
@@ -70,7 +72,9 @@ set(UDPV6TESTS_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/PropertyPolicy.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/flowcontrol/ThroughputControllerDescriptor.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/NetworkFactory.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/UDPChannelResource.cpp
@@ -91,7 +95,9 @@ set(TCPV4TESTS_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/PropertyPolicy.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/flowcontrol/ThroughputControllerDescriptor.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/messages/RTPSMessageCreator.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/NetworkFactory.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -179,6 +185,8 @@ set(TEST_UDPV4TESTS_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/policy/ParameterList.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPFinder.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPLocator.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/PropertyPolicy.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/flowcontrol/ThroughputControllerDescriptor.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/test_UDPv4Transport.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/UDPChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -198,7 +206,9 @@ set(SHAREDMEMTESTS_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/PropertyPolicy.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/flowcontrol/ThroughputControllerDescriptor.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/NetworkFactory.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/shared_mem/SharedMemTransportDescriptor.cpp

--- a/test/unittest/transport/CMakeLists.txt
+++ b/test/unittest/transport/CMakeLists.txt
@@ -133,7 +133,9 @@ set(TCPV6TESTS_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/PropertyPolicy.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/flowcontrol/ThroughputControllerDescriptor.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/messages/RTPSMessageCreator.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/NetworkFactory.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/ResourceEvent.cpp

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 
 #include <fastdds/dds/log/Log.hpp>
+#include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
 #include <fastrtps/transport/TCPv6TransportDescriptor.h>
 #include <fastrtps/utils/IPLocator.h>
 #include <fastrtps/utils/Semaphore.h>
@@ -151,7 +152,8 @@ TEST_F(TCPv6Tests, opening_and_closing_input_channel)
     multicastFilterLocator.port = g_default_port; // arbitrary
     IPLocator::setIPv6(multicastFilterLocator, 0xff31, 0, 0, 0, 0, 0, 0x8000, 0x1234);
 
-    NetworkFactory factory;
+    RTPSParticipantAttributes p_attr{};
+    NetworkFactory factory{p_attr};
     factory.RegisterTransport<TCPv6Transport, TCPv6TransportDescriptor>(descriptor);
     std::vector<std::shared_ptr<ReceiverResource>> receivers;
     factory.BuildReceiverResources(multicastFilterLocator, receivers, 0x8FFF);

--- a/versions.md
+++ b/versions.md
@@ -1,6 +1,8 @@
 Forthcoming
 -----------
 
+* Added participant property to configure SHM transport metatraffic behavior.
+
 Version 2.11.0
 --------------
 

--- a/versions.md
+++ b/versions.md
@@ -2,6 +2,7 @@ Forthcoming
 -----------
 
 * Added participant property to configure SHM transport metatraffic behavior.
+  No metatraffic over SHM transport by default.
 
 Version 2.11.0
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This is a rework of #3641.

In order to improve resilience when a participant dies unexpectedly, forcing discovery to use UDP by default.
The behavior can be configured using a new property `fastdds.shm.enforce_metatraffic`, which can take values `none` (default), `unicast` (default behavior before this PR), or `all` (would allow communication with a SHM only participant)

This PR changes the default behavior, but since it improves Fast DDS stability, and it has no ABI breaks, we will backport it to the supported branches.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    Related documentation PR: eProsima/Fast-DDS-docs#535
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
