### PR TITLE
Improve SHM resilience to crashing participants

### DIFF
--- a/src/cpp/rtps/DataSharing/DataSharingListener.cpp
+++ b/src/cpp/rtps/DataSharing/DataSharingListener.cpp
@@ -56,9 +56,9 @@ void DataSharingListener::run()
         {
             lock.lock();
             notification_->notification_->notification_cv.wait(lock, [&]
-                {
-                    return !is_running_.load() || notification_->notification_->new_data.load();
-                });
+                    {
+                        return !is_running_.load() || notification_->notification_->new_data.load();
+                    });
 
             lock.unlock();
         }

--- a/src/cpp/rtps/DataSharing/DataSharingListener.cpp
+++ b/src/cpp/rtps/DataSharing/DataSharingListener.cpp
@@ -52,13 +52,21 @@ void DataSharingListener::run()
     std::unique_lock<Segment::mutex> lock(notification_->notification_->notification_mutex, std::defer_lock);
     while (is_running_.load())
     {
-        lock.lock();
-        notification_->notification_->notification_cv.wait(lock, [&]
+        try
+        {
+            lock.lock();
+            notification_->notification_->notification_cv.wait(lock, [&]
                 {
                     return !is_running_.load() || notification_->notification_->new_data.load();
                 });
 
-        lock.unlock();
+            lock.unlock();
+        }
+        catch (const boost::interprocess::interprocess_exception& /*e*/)
+        {
+            // Timeout when locking
+            continue;
+        }
 
         if (!is_running_.load())
         {

--- a/src/cpp/rtps/DataSharing/DataSharingNotification.hpp
+++ b/src/cpp/rtps/DataSharing/DataSharingNotification.hpp
@@ -53,10 +53,17 @@ public:
      */
     inline void notify()
     {
-        std::unique_lock<Segment::mutex> lock(notification_->notification_mutex);
-        notification_->new_data.store(true);
-        lock.unlock();
-        notification_->notification_cv.notify_all();
+        try
+        {
+            std::unique_lock<Segment::mutex> lock(notification_->notification_mutex);
+            notification_->new_data.store(true);
+            lock.unlock();
+            notification_->notification_cv.notify_all();
+        }
+        catch (const boost::interprocess::interprocess_exception& /*e*/)
+        {
+            // Timeout when locking
+        }
     }
 
     /**

--- a/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
@@ -718,7 +718,9 @@ public:
                         throw std::runtime_error("");
                     }
 
+                    // Read and pop descriptor
                     SharedMemGlobal::BufferDescriptor buffer_descriptor = head_cell->data();
+                    global_port_->pop(*global_listener_, was_cell_freed);
 
                     auto segment = shared_mem_manager_->find_segment(buffer_descriptor.source_segment_id);
                     auto buffer_node =
@@ -729,9 +731,6 @@ public:
                     buffer_ref = std::make_shared<SharedMemBuffer>(segment, buffer_descriptor.source_segment_id,
                                     buffer_node,
                                     buffer_descriptor.validity_id);
-
-                    // If the cell has been read by all listeners
-                    global_port_->pop(*global_listener_, was_cell_freed);
 
                     if (buffer_ref)
                     {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This, along with #3753, highly improves the situation described in ros2/rmw_fastrtps#699.
I'm still not sure whether it is completely fixed, but the changes here fix two obvious bugs.

1. When a participant crashes just after pushing a descriptor into the listening port of another participant, the descriptor should be popped from the port even if it points to a non-existent / corrupted segment. Otherwise the listener enters in an infinite loop.
2. Some mutex locks could throw an unhandled timeout exception, making participant crashes more probable.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
    - I consider the testcase in ros2/rmw_fastrtps#699 good enough, but difficult to automate
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
