### PR TITLE
[18395] Fix XMLParser null-derefence in parseLogConfig

### DIFF
--- a/src/cpp/rtps/xmlparser/XMLParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLParser.cpp
@@ -1390,23 +1390,28 @@ XMLP_ret XMLParser::parseLogConfig(
         tinyxml2::XMLElement* p_root)
 {
     /*
-       <xs:element name="log">
-       <xs:complexType>
-        <xs:boolean name="use_default"/>
-        <xs:sequence>
-          <xs:element maxOccurs="consumer">
-            <xs:complexType>
-              <xs:element name="class" type="string" minOccurs="1" maxOccurs="1"/>
-              <xs:sequence>
-                <xs:element name="propertyType"/>
-              </xs:sequence>
-            </xs:complexType>
-        </xs:sequence>
-       </xs:complexType>
-       </xs:element>
+        <xs:element name="log" type="logType"/>
+        <xs:complexType name="logType">
+            <xs:sequence minOccurs="1" maxOccurs="unbounded">
+                <xs:choice minOccurs="1">
+                    <xs:element name="use_default" type="booleanCaps" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="consumer" type="logConsumerType" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:choice>
+            </xs:sequence>
+        </xs:complexType>
+     */
+
+    /*
+     * TODO(eduponz): Uphold XSD validation in parsing
+     *   Even though the XSD above enforces the log tag to have at least one consumer,
+     *   the parsing allows for an empty log tag (e.g. `<log></log>`).
+     *   This inconsistency is kept to keep a backwards compatible behaviour.
+     *   In fact, test XMLParserTests.parseXMLNoRoot even checks that an empty log tag
+     *   is valid.
      */
 
     XMLP_ret ret = XMLP_ret::XML_OK;
+
     tinyxml2::XMLElement* p_aux0 = p_root->FirstChildElement(LOG);
     if (p_aux0 == nullptr)
     {
@@ -1414,31 +1419,37 @@ XMLP_ret XMLParser::parseLogConfig(
     }
 
     tinyxml2::XMLElement* p_element = p_aux0->FirstChildElement();
-    const char* tag = nullptr;
-    while (nullptr != p_element)
+
+    while (ret == XMLP_ret::XML_OK && nullptr != p_element)
     {
-        if (nullptr != (tag = p_element->Value()))
+        const char* tag = p_element->Value();
+        if (nullptr != tag)
         {
             if (strcmp(tag, USE_DEFAULT) == 0)
             {
-                bool use_default = true;
-                std::string auxBool = p_element->GetText();
-                if (std::strcmp(auxBool.c_str(), "FALSE") == 0)
+                if (nullptr == p_element->GetText())
                 {
-                    use_default = false;
+                    EPROSIMA_LOG_ERROR(XMLPARSER, "Cannot get text from tag: '" << tag << "'");
+                    ret = XMLP_ret::XML_ERROR;
                 }
-                if (!use_default)
+
+                if (ret == XMLP_ret::XML_OK)
                 {
-                    eprosima::fastdds::dds::Log::ClearConsumers();
+                    bool use_default = true;
+                    std::string auxBool = p_element->GetText();
+                    if (std::strcmp(auxBool.c_str(), "FALSE") == 0)
+                    {
+                        use_default = false;
+                    }
+                    if (!use_default)
+                    {
+                        eprosima::fastdds::dds::Log::ClearConsumers();
+                    }
                 }
             }
             else if (strcmp(tag, CONSUMER) == 0)
             {
                 ret = parseXMLConsumer(*p_element);
-                if (ret == XMLP_ret::XML_ERROR)
-                {
-                    return ret;
-                }
             }
             else
             {
@@ -1446,8 +1457,13 @@ XMLP_ret XMLParser::parseLogConfig(
                 ret = XMLP_ret::XML_ERROR;
             }
         }
-        p_element = p_element->NextSiblingElement(CONSUMER);
+
+        if (ret == XMLP_ret::XML_OK)
+        {
+            p_element = p_element->NextSiblingElement(CONSUMER);
+        }
     }
+
     return ret;
 }
 

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -60,6 +60,7 @@ TEST_F(XMLParserTests, regressions)
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/13513_profile_bin.xml", root));
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/14456_profile_bin.xml", root));
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/15344_profile_bin.xml", root));
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/18395_profile_bin.xml", root));
 }
 
 TEST_F(XMLParserTests, NoFile)

--- a/test/unittest/xmlparser/regressions/18395_profile_bin.xml
+++ b/test/unittest/xmlparser/regressions/18395_profile_bin.xml
@@ -1,0 +1,2 @@
+v�< log>suu/</use_default/>use_de�ta-g/>��< /log>��ypes/������
+</ds>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Fixes a `nullptr` access when attempting to get the text of no initialized `use_default` tag within a `log` tag in an XML configuration file, e.g.:

```xml
<log>
    </use_default/>
</log>
```

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A*: New feature has been added to the `versions.md` file (if applicable).
- *N/A*: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
