### PR TITLE
[19315] Allow participant profiles with no rtps tag

### DIFF
--- a/src/cpp/rtps/xmlparser/XMLParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLParser.cpp
@@ -1774,7 +1774,7 @@ XMLP_ret XMLParser::fillDataNode(
     tinyxml2::XMLElement* p_element;
     tinyxml2::XMLElement* p_aux0 = nullptr;
     const char* name = nullptr;
-    std::unordered_map<std::string, bool> tags_present;
+    std::set<std::string> tags_present;
 
     /*
      * The only allowed elements are <domainId> and <rtps>
@@ -1784,12 +1784,12 @@ XMLP_ret XMLParser::fillDataNode(
     for (p_element = p_profile->FirstChildElement(); p_element != nullptr; p_element = p_element->NextSiblingElement())
     {
         name = p_element->Name();
-        if (tags_present[name])
+        if (tags_present.count(name) != 0)
         {
-            EPROSIMA_LOG_ERROR(XMLPARSER, "Duplicated element found in 'participant'. Name: " << name);
+            EPROSIMA_LOG_ERROR(XMLPARSER, "Duplicated element found in 'participant'. Tag: " << name);
             return XMLP_ret::XML_ERROR;
         }
-        tags_present[name] = true;
+        tags_present.emplace(name);
 
         if (strcmp(p_element->Name(), DOMAIN_ID) == 0)
         {
@@ -1822,13 +1822,13 @@ XMLP_ret XMLParser::fillDataNode(
     {
         name = p_aux0->Name();
 
-        if (tags_present[name])
+        if (tags_present.count(name) != 0)
         {
             EPROSIMA_LOG_ERROR(XMLPARSER,
                     "Duplicated element found in 'rtpsParticipantAttributesType'. Name: " << name);
             return XMLP_ret::XML_ERROR;
         }
-        tags_present[name] = true;
+        tags_present.emplace(name);
 
         if (strcmp(name, ALLOCATION) == 0)
         {

--- a/src/cpp/rtps/xmlparser/XMLParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLParser.cpp
@@ -1825,7 +1825,7 @@ XMLP_ret XMLParser::fillDataNode(
         if (tags_present.count(name) != 0)
         {
             EPROSIMA_LOG_ERROR(XMLPARSER,
-                    "Duplicated element found in 'rtpsParticipantAttributesType'. Name: " << name);
+                    "Duplicated element found in 'rtpsParticipantAttributesType'. Tag: " << name);
             return XMLP_ret::XML_ERROR;
         }
         tags_present.emplace(name);

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -61,6 +61,8 @@ TEST_F(XMLParserTests, regressions)
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/14456_profile_bin.xml", root));
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/15344_profile_bin.xml", root));
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/18395_profile_bin.xml", root));
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/simple_participant_profiles_nok.xml", root));
+    EXPECT_EQ(XMLP_ret::XML_OK, XMLParser::loadXML("regressions/simple_participant_profiles_ok.xml", root));
 }
 
 TEST_F(XMLParserTests, NoFile)
@@ -1611,10 +1613,9 @@ TEST_F(XMLParserTests, parseLogConfig)
 /*
  * This test checks the return of the negative cases of the fillDataNode given a ParticipantAttributes DataNode
  * 1. Check passing a nullptr as if the XMLElement was wrongly parsed above
- * 2. Check missing required rtps tag
- * 3. Check missing DomainId value in tag
- * 4. Check bad values for all attributes
- * 5. Check a non existant attribute tag
+ * 2. Check missing DomainId value in tag
+ * 3. Check bad values for all attributes
+ * 4. Check a non existant attribute tag
  */
 TEST_F(XMLParserTests, fillDataNodeParticipantNegativeClauses)
 {
@@ -1635,12 +1636,6 @@ TEST_F(XMLParserTests, fillDataNodeParticipantNegativeClauses)
                 </participant>\
                 ";
         char xml[500];
-
-        // Misssing rtps tag
-        sprintf(xml, xml_p, "<domainId>0</domainId>");
-        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
-        titleElement = xml_doc.RootElement();
-        EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(titleElement, *participant_node));
 
         // Misssing DomainId Value
         sprintf(xml, xml_p, "<domainId></domainId><rtps></rtps>");
@@ -1759,6 +1754,7 @@ TEST_F(XMLParserTests, parseXMLProfilesRoot)
     // <topic>, <requester>, <replier>, <types>, and <log> are read as xml child elements of the <profiles>
     // root element.
     std::vector<std::string> elements_ok {
+        "participant",
         "publisher",
         "data_writer",
         "subscriber",
@@ -1776,7 +1772,6 @@ TEST_F(XMLParserTests, parseXMLProfilesRoot)
 
     std::vector<std::string> elements_error {
         "library_settings",
-        "participant",
         "requester",
         "replier"
     };

--- a/test/unittest/xmlparser/regressions/simple_participant_profiles_nok.xml
+++ b/test/unittest/xmlparser/regressions/simple_participant_profiles_nok.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dds xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles">
+    <profiles>
+        <participant profile_name="duplicated_domainid_participant">
+            <domainId>1</domainId>
+            <domainId>2</domainId>
+        </participant>
+
+        <participant profile_name="duplicated_rtps_participant">
+            <rtps></rtps>
+            <rtps></rtps>
+        </participant>
+    </profiles>
+</dds>

--- a/test/unittest/xmlparser/regressions/simple_participant_profiles_ok.xml
+++ b/test/unittest/xmlparser/regressions/simple_participant_profiles_ok.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dds xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles">
+    <profiles>
+        <participant profile_name="empty_participant">
+        </participant>
+
+        <participant profile_name="only_rtps_participant">
+            <rtps></rtps>
+        </participant>
+
+        <participant profile_name="only_domainid_participant">
+            <domainId>1</domainId>
+        </participant>
+
+        <participant profile_name="complete_participant">
+            <domainId>1</domainId>
+            <rtps></rtps>
+        </participant>
+    </profiles>
+</dds>

--- a/test/unittest/xmlparser/regressions/simple_participant_profiles_ok.xml
+++ b/test/unittest/xmlparser/regressions/simple_participant_profiles_ok.xml
@@ -8,6 +8,10 @@
             <rtps></rtps>
         </participant>
 
+        <participant profile_name="only_rtps_participant">
+            <rtps/>
+        </participant>
+
         <participant profile_name="only_domainid_participant">
             <domainId>1</domainId>
         </participant>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

According to the XSD schema, an XML configuration file can include an empty DomainParticipant profile, meaning without any `domainId` or `rtps` tags.

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<dds xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles">
    <profiles>
        <participant profile_name="empty_participant">
        </participant>
    </profiles>
</dds>
```

However, the XMLParser was expecting a minimum occurrences of 1 for the `rtps` tag, so the above XML passes the validation, but fails to load.

This PR fixes that inconsistency by allowing an empty participant profile.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A*: New feature has been added to the `versions.md` file (if applicable).
- *N/A*: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
