### PR TITLE
[19359] Fix DomainParticipant::register_remote_type return when negotiating type

### DIFF
--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -850,7 +850,7 @@ public:
             const fastrtps::types::TypeIdentifierSeq& in) const;
 
     /**
-     * Helps the user to solve all dependencies calling internally to the typelookup service and
+     * Helps the user to solve all dependencies calling internally to the type lookup service and
      * registers the resulting dynamic type.
      * The registration may be perform asynchronously, case in which the user will be notified
      * through the given callback, which receives the type_name as unique argument.
@@ -858,13 +858,13 @@ public:
      * @param type_information
      * @param type_name
      * @param callback
-     * @return ReturnCode_t::RETCODE_NOT_ENABLED if the DomainParticipant is not enabled.
-     * @return ReturnCode_t::RETCODE_OK If the given type_information is enough to build the type
-     *         without using the typelookup service (callback will not be called).
-     * @return ReturnCode_t::RETCODE_OK if the given type is already available (callback will not be
-     *         called).
-     * @return ReturnCode_t::RETCODE_TIMEOUT if type is not available yet (the callback will be
-     *         called if negotiation is success, and ignored in other case).
+     * @return RETCODE_OK If the given type_information is enough to build the type without using
+     *         the typelookup service (callback will not be called).
+     * @return RETCODE_OK if the given type is already available (callback will not be called).
+     * @return RETCODE_NO_DATA if type is not available yet (the callback will be called if
+     *         negotiation is success, and ignored in other case).
+     * @return RETCODE_NOT_ENABLED if the DomainParticipant is not enabled.
+     * @return RETCODE_PRECONDITION_NOT_MET if the DomainParticipant type lookup service is disabled.
      */
     RTPS_DllAPI ReturnCode_t register_remote_type(
             const fastrtps::types::TypeInformation& type_information,

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -850,19 +850,21 @@ public:
             const fastrtps::types::TypeIdentifierSeq& in) const;
 
     /**
-     * Helps the user to solve all dependencies calling internally to the typelookup service
-     * and registers the resulting dynamic type.
-     * The registration will be perform asynchronously and the user will be notified through the
-     * given callback, which receives the type_name as unique argument.
-     * If the type is already registered, the function will return true, but the callback will not be called.
-     * If the given type_information is enough to build the type without using the typelookup service,
-     * it will return true and the callback will be never called.
+     * Helps the user to solve all dependencies calling internally to the typelookup service and
+     * registers the resulting dynamic type.
+     * The registration may be perform asynchronously, case in which the user will be notified
+     * through the given callback, which receives the type_name as unique argument.
      *
      * @param type_information
      * @param type_name
      * @param callback
-     * @return true if type is already available (callback will not be called). false if type isn't available yet
-     * (the callback will be called if negotiation is success, and ignored in other case).
+     * @return ReturnCode_t::RETCODE_NOT_ENABLED if the DomainParticipant is not enabled.
+     * @return ReturnCode_t::RETCODE_OK If the given type_information is enough to build the type
+     *         without using the typelookup service (callback will not be called).
+     * @return ReturnCode_t::RETCODE_OK if the given type is already available (callback will not be
+     *         called).
+     * @return ReturnCode_t::RETCODE_TIMEOUT if type is not available yet (the callback will be
+     *         called if negotiation is success, and ignored in other case).
      */
     RTPS_DllAPI ReturnCode_t register_remote_type(
             const fastrtps::types::TypeInformation& type_information,

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1801,7 +1801,7 @@ ReturnCode_t DomainParticipantImpl::register_remote_type(
         // Move the filled vector to the map
         parent_requests_.emplace(std::make_pair(requestId, std::move(vector)));
 
-        return ReturnCode_t::RETCODE_OK;
+        return ReturnCode_t::RETCODE_NO_DATA;
     }
     return ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;
 }

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -489,6 +489,23 @@ public:
     fastrtps::rtps::SampleIdentity get_types(
             const fastrtps::types::TypeIdentifierSeq& in) const;
 
+    /**
+     * Helps the user to solve all dependencies calling internally to the typelookup service and
+     * registers the resulting dynamic type.
+     * The registration may be perform asynchronously, case in which the user will be notified
+     * through the given callback, which receives the type_name as unique argument.
+     *
+     * @param type_information
+     * @param type_name
+     * @param callback
+     * @return RETCODE_OK If the given type_information is enough to build the type without using
+     *         the typelookup service (callback will not be called).
+     * @return RETCODE_OK if the given type is already available (callback will not be called).
+     * @return RETCODE_NO_DATA if type is not available yet (the callback will be called if
+     *         negotiation is success, and ignored in other case).
+     * @return RETCODE_NOT_ENABLED if the DomainParticipant is not enabled.
+     * @return RETCODE_PRECONDITION_NOT_MET if the DomainParticipant type lookup service is disabled.
+     */
     ReturnCode_t register_remote_type(
             const fastrtps::types::TypeInformation& type_information,
             const std::string& type_name,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

According to the [documentation](https://fast-dds.docs.eprosima.com/en/latest/fastdds/api_reference/dds_pim/domain/domainparticipant.html"), register_remote_type returns true if type is already available to indicate its intention of not calling the callback.
However, the function returns RETCODE_OK regardless.
This PR fixes this by:

* Returning NO_DATA when using type lookup service
* Improving the API reference

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- *N/A*: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A*: New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
