### PR TITLE
[19375] Setting infraestructure for naming threads

### DIFF
--- a/include/fastdds/rtps/resources/ResourceEvent.h
+++ b/include/fastdds/rtps/resources/ResourceEvent.h
@@ -25,8 +25,9 @@
 #include <fastrtps/utils/TimedMutex.hpp>
 #include <fastrtps/utils/TimedConditionVariable.hpp>
 
-#include <thread>
 #include <atomic>
+#include <functional>
+#include <thread>
 #include <vector>
 
 namespace eprosima {
@@ -49,8 +50,12 @@ public:
 
     /*!
      * @brief Method to initialize the internal thread.
+     *
+     * @param[in]  configure_cb  Function to be called in the context of the started thread
+     *                           before calling the internal service routine.
      */
-    void init_thread();
+    void init_thread(
+            std::function<void()> configure_cb = {});
 
     void stop_thread();
 

--- a/src/cpp/fastdds/log/Log.cpp
+++ b/src/cpp/fastdds/log/Log.cpp
@@ -26,6 +26,7 @@
 #include <fastdds/dds/log/StdoutErrConsumer.hpp>
 #include <fastdds/dds/log/Colors.hpp>
 #include <utils/SystemInfo.hpp>
+#include <utils/threading.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -258,6 +259,8 @@ private:
 
     void run()
     {
+        set_name_to_current_thread("dds.log");
+
         std::unique_lock<std::mutex> guard(cv_mutex_);
 
         while (logging_)

--- a/src/cpp/rtps/DataSharing/DataSharingListener.cpp
+++ b/src/cpp/rtps/DataSharing/DataSharingListener.cpp
@@ -18,6 +18,7 @@
 
 #include <rtps/DataSharing/DataSharingListener.hpp>
 #include <fastdds/rtps/reader/RTPSReader.h>
+#include <utils/threading.hpp>
 
 #include <memory>
 #include <mutex>
@@ -49,6 +50,8 @@ DataSharingListener::~DataSharingListener()
 
 void DataSharingListener::run()
 {
+    set_name_to_current_thread("dds.dsha.%u", reader_->getGuid().entityId.to_uint32() & 0x0000FFFF);
+
     std::unique_lock<Segment::mutex> lock(notification_->notification_->notification_mutex, std::defer_lock);
     while (is_running_.load())
     {

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -54,6 +54,8 @@
 
 #include <rtps/builtin/discovery/database/backup/SharedBackupFunctions.hpp>
 
+#include <utils/threading.hpp>
+
 namespace eprosima {
 namespace fastdds {
 namespace rtps {
@@ -160,7 +162,11 @@ bool PDPServer::init(
     getRTPSParticipant()->enableReader(edp->publications_reader_.first);
 
     // Initialize server dedicated thread.
-    resource_event_thread_.init_thread();
+    uint32_t id_for_thread = static_cast<uint32_t>(getRTPSParticipant()->getRTPSParticipantAttributes().participantID);
+    resource_event_thread_.init_thread([id_for_thread]()
+            {
+                set_name_to_current_thread("dds.ds_ev.%u", id_for_thread);
+            });
 
     /*
         Given the fact that a participant is either a client or a server the

--- a/src/cpp/rtps/flowcontrol/FlowControllerFactory.cpp
+++ b/src/cpp/rtps/flowcontrol/FlowControllerFactory.cpp
@@ -25,26 +25,26 @@ void FlowControllerFactory::init(
                 pure_sync_flow_controller_name,
                 std::unique_ptr<FlowController>(
                     new FlowControllerImpl<FlowControllerPureSyncPublishMode,
-                    FlowControllerFifoSchedule>(participant_, nullptr))));
+                    FlowControllerFifoSchedule>(participant_, nullptr, 0))));
     // SyncFlowController -> used by rest of besteffort writers.
     flow_controllers_.insert(decltype(flow_controllers_)::value_type(
                 sync_flow_controller_name,
                 std::unique_ptr<FlowController>(
                     new FlowControllerImpl<FlowControllerSyncPublishMode,
-                    FlowControllerFifoSchedule>(participant_, nullptr))));
+                    FlowControllerFifoSchedule>(participant_, nullptr, async_controller_index_++))));
     // AsyncFlowController
     flow_controllers_.insert(decltype(flow_controllers_)::value_type(
                 async_flow_controller_name,
                 std::unique_ptr<FlowController>(
                     new FlowControllerImpl<FlowControllerAsyncPublishMode,
-                    FlowControllerFifoSchedule>(participant_, nullptr))));
+                    FlowControllerFifoSchedule>(participant_, nullptr, async_controller_index_++))));
 
 #ifdef FASTDDS_STATISTICS
     flow_controllers_.insert(decltype(flow_controllers_)::value_type(
                 async_statistics_flow_controller_name,
                 std::unique_ptr<FlowController>(
                     new FlowControllerImpl<FlowControllerAsyncPublishMode,
-                    FlowControllerFifoSchedule>(participant_, nullptr))));
+                    FlowControllerFifoSchedule>(participant_, nullptr, async_controller_index_++))));
 #endif // ifndef FASTDDS_STATISTICS
 }
 
@@ -67,7 +67,8 @@ void FlowControllerFactory::register_flow_controller (
                             flow_controller_descr.name,
                             std::unique_ptr<FlowController>(
                                 new FlowControllerImpl<FlowControllerLimitedAsyncPublishMode,
-                                FlowControllerFifoSchedule>(participant_, &flow_controller_descr))));
+                                FlowControllerFifoSchedule>(participant_,
+                                &flow_controller_descr, async_controller_index_++))));
                 break;
             case FlowControllerSchedulerPolicy::ROUND_ROBIN:
                 flow_controllers_.insert(decltype(flow_controllers_)::value_type(
@@ -75,7 +76,7 @@ void FlowControllerFactory::register_flow_controller (
                             std::unique_ptr<FlowController>(
                                 new FlowControllerImpl<FlowControllerLimitedAsyncPublishMode,
                                 FlowControllerRoundRobinSchedule>(participant_,
-                                &flow_controller_descr))));
+                                &flow_controller_descr, async_controller_index_++))));
                 break;
             case FlowControllerSchedulerPolicy::HIGH_PRIORITY:
                 flow_controllers_.insert(decltype(flow_controllers_)::value_type(
@@ -83,7 +84,7 @@ void FlowControllerFactory::register_flow_controller (
                             std::unique_ptr<FlowController>(
                                 new FlowControllerImpl<FlowControllerLimitedAsyncPublishMode,
                                 FlowControllerHighPrioritySchedule>(participant_,
-                                &flow_controller_descr))));
+                                &flow_controller_descr, async_controller_index_++))));
                 break;
             case FlowControllerSchedulerPolicy::PRIORITY_WITH_RESERVATION:
                 flow_controllers_.insert(decltype(flow_controllers_)::value_type(
@@ -91,7 +92,7 @@ void FlowControllerFactory::register_flow_controller (
                             std::unique_ptr<FlowController>(
                                 new FlowControllerImpl<FlowControllerLimitedAsyncPublishMode,
                                 FlowControllerPriorityWithReservationSchedule>(participant_,
-                                &flow_controller_descr))));
+                                &flow_controller_descr, async_controller_index_++))));
                 break;
             default:
                 assert(false);
@@ -106,7 +107,8 @@ void FlowControllerFactory::register_flow_controller (
                             flow_controller_descr.name,
                             std::unique_ptr<FlowController>(
                                 new FlowControllerImpl<FlowControllerAsyncPublishMode,
-                                FlowControllerFifoSchedule>(participant_, &flow_controller_descr))));
+                                FlowControllerFifoSchedule>(participant_,
+                                &flow_controller_descr, async_controller_index_++))));
                 break;
             case FlowControllerSchedulerPolicy::ROUND_ROBIN:
                 flow_controllers_.insert(decltype(flow_controllers_)::value_type(
@@ -114,7 +116,7 @@ void FlowControllerFactory::register_flow_controller (
                             std::unique_ptr<FlowController>(
                                 new FlowControllerImpl<FlowControllerAsyncPublishMode,
                                 FlowControllerRoundRobinSchedule>(participant_,
-                                &flow_controller_descr))));
+                                &flow_controller_descr, async_controller_index_++))));
                 break;
             case FlowControllerSchedulerPolicy::HIGH_PRIORITY:
                 flow_controllers_.insert(decltype(flow_controllers_)::value_type(
@@ -122,7 +124,7 @@ void FlowControllerFactory::register_flow_controller (
                             std::unique_ptr<FlowController>(
                                 new FlowControllerImpl<FlowControllerAsyncPublishMode,
                                 FlowControllerHighPrioritySchedule>(participant_,
-                                &flow_controller_descr))));
+                                &flow_controller_descr, async_controller_index_++))));
                 break;
             case FlowControllerSchedulerPolicy::PRIORITY_WITH_RESERVATION:
                 flow_controllers_.insert(decltype(flow_controllers_)::value_type(
@@ -130,7 +132,7 @@ void FlowControllerFactory::register_flow_controller (
                             std::unique_ptr<FlowController>(
                                 new FlowControllerImpl<FlowControllerAsyncPublishMode,
                                 FlowControllerPriorityWithReservationSchedule>(participant_,
-                                &flow_controller_descr))));
+                                &flow_controller_descr, async_controller_index_++))));
                 break;
             default:
                 assert(false);

--- a/src/cpp/rtps/flowcontrol/FlowControllerFactory.hpp
+++ b/src/cpp/rtps/flowcontrol/FlowControllerFactory.hpp
@@ -66,6 +66,9 @@ private:
     //! Stores the created flow controllers.
     std::map<std::string, std::unique_ptr<FlowController>> flow_controllers_;
 
+    //! Counter used for thread identification
+    uint32_t async_controller_index_ = 0;
+
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp
+++ b/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp
@@ -4,6 +4,8 @@
 #include "FlowController.hpp"
 #include <fastdds/rtps/common/Guid.h>
 #include <fastdds/rtps/writer/RTPSWriter.h>
+#include <rtps/participant/RTPSParticipantImpl.h>
+#include <utils/threading.hpp>
 
 #include <atomic>
 #include <cassert>
@@ -926,11 +928,19 @@ public:
 
     FlowControllerImpl(
             fastrtps::rtps::RTPSParticipantImpl* participant,
-            const FlowControllerDescriptor* descriptor
+            const FlowControllerDescriptor* descriptor,
+            uint32_t async_index
             )
         : participant_(participant)
         , async_mode(participant, descriptor)
+        , participant_id_(0)
+        , async_index_(async_index)
     {
+        if (nullptr != participant)
+        {
+            participant_id_ = static_cast<uint32_t>(participant->getRTPSParticipantAttributes().participantID);
+        }
+
         uint32_t limitation = get_max_payload();
 
         if (std::numeric_limits<uint32_t>::max() != limitation)
@@ -1257,6 +1267,8 @@ private:
      */
     void run()
     {
+        set_name_to_current_thread("dds.asyn.%u.%u", participant_id_, async_index_);
+
         while (async_mode.running)
         {
             // There are writers interested in removing a sample.
@@ -1399,6 +1411,9 @@ private:
 
     // async_mode must be destroyed before sched.
     publish_mode async_mode;
+
+    uint32_t participant_id_ = 0;
+    uint32_t async_index_ = 0;
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -61,6 +61,7 @@
 #include <rtps/participant/RTPSParticipantImpl.h>
 #include <rtps/persistence/PersistenceService.h>
 #include <statistics/rtps/GuidUtils.hpp>
+#include <utils/threading.hpp>
 
 namespace eprosima {
 namespace fastrtps {
@@ -239,7 +240,11 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     }
 
     mp_userParticipant->mp_impl = this;
-    mp_event_thr.init_thread();
+    uint32_t id_for_thread = static_cast<uint32_t>(m_att.participantID);
+    mp_event_thr.init_thread([id_for_thread]()
+            {
+                set_name_to_current_thread("dds.ev.%u", id_for_thread);
+            });
 
     if (!networkFactoryHasRegisteredTransports())
     {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -138,7 +138,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     , internal_metatraffic_locators_(false)
     , internal_default_locators_(false)
 #if HAVE_SECURITY
-    , m_security_manager(this)
+    , m_security_manager(this, *this)
 #endif // if HAVE_SECURITY
     , mp_participantListener(plisten)
     , mp_userParticipant(par)

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -63,6 +63,10 @@
 #include <statistics/rtps/GuidUtils.hpp>
 #include <utils/threading.hpp>
 
+#if HAVE_SECURITY
+#include <security/logging/LogTopic.h>
+#endif  // HAVE_SECURITY
+
 namespace eprosima {
 namespace fastrtps {
 namespace rtps {
@@ -2189,6 +2193,15 @@ bool RTPSParticipantImpl::is_security_enabled_for_reader(
     }
 
     return false;
+}
+
+security::Logging* RTPSParticipantImpl::create_builtin_logging_plugin()
+{
+    return new security::LogTopic([this]()
+                   {
+                       uint32_t participant_id = static_cast<uint32_t>(m_att.participantID);
+                       set_name_to_current_thread("dds.slog.%u", participant_id);
+                   });
 }
 
 #endif // if HAVE_SECURITY

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -402,6 +402,8 @@ public:
     bool is_security_enabled_for_reader(
             const ReaderAttributes& reader_attributes);
 
+    security::Logging* create_builtin_logging_plugin() override;
+
 #endif // if HAVE_SECURITY
 
     PDPSimple* pdpsimple();

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -59,6 +59,7 @@
 #include <fastdds/rtps/Endpoint.h>
 #include <fastdds/rtps/security/accesscontrol/ParticipantSecurityAttributes.h>
 #include <rtps/security/SecurityManager.h>
+#include <rtps/security/SecurityPluginFactory.h>
 #endif // if HAVE_SECURITY
 
 namespace eprosima {
@@ -106,6 +107,9 @@ class WLP;
  */
 class RTPSParticipantImpl
     : public fastdds::statistics::StatisticsParticipantImpl
+#if HAVE_SECURITY
+    , private security::SecurityPluginFactory
+#endif // if HAVE_SECURITY
 {
     /*
        Receiver Control block is a struct we use to encapsulate the resources that take part in message reception.

--- a/src/cpp/rtps/resources/ResourceEvent.cpp
+++ b/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -314,7 +314,10 @@ void ResourceEvent::init_thread(
 
     thread_ = std::thread([this, configure_cb]()
                     {
-                        if (configure_cb) configure_cb();
+                        if (configure_cb)
+                        {
+                            configure_cb();
+                        }
                         event_service();
                     });
 }

--- a/src/cpp/rtps/resources/ResourceEvent.cpp
+++ b/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -303,7 +303,8 @@ void ResourceEvent::do_timer_actions()
     }
 }
 
-void ResourceEvent::init_thread()
+void ResourceEvent::init_thread(
+        std::function<void()> configure_cb)
 {
     std::lock_guard<TimedMutex> lock(mutex_);
 
@@ -311,7 +312,11 @@ void ResourceEvent::init_thread()
     stop_.store(false);
     resize_collections();
 
-    thread_ = std::thread(&ResourceEvent::event_service, this);
+    thread_ = std::thread([this, configure_cb]()
+                    {
+                        if (configure_cb) configure_cb();
+                        event_service();
+                    });
 }
 
 } /* namespace rtps */

--- a/src/cpp/rtps/security/ISecurityPluginFactory.h
+++ b/src/cpp/rtps/security/ISecurityPluginFactory.h
@@ -1,0 +1,78 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*!
+ * @file ISecurityPluginFactory.h
+ */
+#ifndef _RTPS_SECURITY_ISECURITYPLUGINFACTORY_H_
+#define _RTPS_SECURITY_ISECURITYPLUGINFACTORY_H_
+
+#include <fastdds/rtps/security/authentication/Authentication.h>
+#include <fastdds/rtps/security/accesscontrol/AccessControl.h>
+#include <fastdds/rtps/security/cryptography/Cryptography.h>
+#include <fastdds/rtps/security/logging/Logging.h>
+#include <fastdds/rtps/attributes/PropertyPolicy.h>
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+namespace security {
+
+class ISecurityPluginFactory
+{
+public:
+
+    /*!
+     * @brief Create an Authentication plugin described in the PropertyPolicy.
+     * @param property_policy PropertyPolicy containing the definition of the Authentication
+     * plugin that has to be created.
+     * @param Pointer to the new Authentication plugin. In case of error nullptr will be returned.
+     */
+    virtual Authentication* create_authentication_plugin(
+            const PropertyPolicy& property_policy) = 0;
+
+    /*!
+     * @brief Create an AccessControl plugin described in the PropertyPolicy.
+     * @param property_policy PropertyPolicy containing the definition of the AccessControl
+     * plugin that has to be created.
+     * @param Pointer to the new AccessControl plugin. In case of error nullptr will be returned.
+     */
+    virtual AccessControl* create_access_control_plugin(
+            const PropertyPolicy& property_policy) = 0;
+
+    /*!
+     * @brief Create an Cryptographic plugin described in the PropertyPolicy.
+     * @param property_policy PropertyPolicy containing the definition of the Cryptographic
+     * plugin that has to be created.
+     * @param Pointer to the new Cryptographic plugin. In case of error nullptr will be returned.
+     */
+    virtual Cryptography* create_cryptography_plugin(
+            const PropertyPolicy& property_policy) = 0;
+
+    /**
+     * @brief Create a Logging plugin described in the PropertyPolicy.
+     * @param property_policy PropertyPolicy containing the definition of the Logging
+     * plugin that has to be created.
+     * @return Pointer to the new Logging plugin. In case of error nullptr will be returned.
+     */
+    virtual Logging* create_logging_plugin(
+            const PropertyPolicy& property_policy) = 0;
+};
+
+} //namespace security
+} //namespace rtps
+} //namespace fastrtps
+} //namespace eprosima
+
+#endif // _RTPS_SECURITY_SECURITYPLUGINFACTORY_H_

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -74,25 +74,13 @@ inline bool usleep_bool()
 }
 
 SecurityManager::SecurityManager(
-        RTPSParticipantImpl* participant)
+        RTPSParticipantImpl* participant,
+        ISecurityPluginFactory& plugin_factory)
     : participant_stateless_message_listener_(*this)
     , participant_volatile_message_secure_listener_(*this)
     , participant_(participant)
-    , participant_stateless_message_writer_(nullptr)
-    , participant_stateless_message_writer_history_(nullptr)
-    , participant_stateless_message_reader_(nullptr)
-    , participant_stateless_message_reader_history_(nullptr)
-    , participant_volatile_message_secure_writer_(nullptr)
-    , participant_volatile_message_secure_writer_history_(nullptr)
-    , participant_volatile_message_secure_reader_(nullptr)
-    , participant_volatile_message_secure_reader_history_(nullptr)
-    , logging_plugin_(nullptr)
-    , authentication_plugin_(nullptr)
-    , access_plugin_(nullptr)
-    , crypto_plugin_(nullptr)
+    , factory_(plugin_factory)
     , domain_id_(0)
-    , local_identity_handle_(nullptr)
-    , local_permissions_handle_(nullptr)
     , auth_last_sequence_number_(1)
     , crypto_last_sequence_number_(1)
     , temp_reader_proxies_({

--- a/src/cpp/rtps/security/SecurityManager.h
+++ b/src/cpp/rtps/security/SecurityManager.h
@@ -18,7 +18,7 @@
 #ifndef _RTPS_SECURITY_SECURITYMANAGER_H_
 #define _RTPS_SECURITY_SECURITYMANAGER_H_
 
-#include <rtps/security/SecurityPluginFactory.h>
+#include <rtps/security/ISecurityPluginFactory.h>
 
 #include <fastdds/rtps/attributes/HistoryAttributes.h>
 #include <fastdds/rtps/builtin/data/ParticipantProxyData.h>
@@ -75,7 +75,8 @@ public:
      * @param participant RTPSParticipantImpl* references the associated participant
      */
     SecurityManager(
-            RTPSParticipantImpl* participant);
+            RTPSParticipantImpl* participant,
+            ISecurityPluginFactory& plugin_factory);
 
     // @brief Destructor
     ~SecurityManager();
@@ -769,30 +770,27 @@ private:
             const ParticipantProxyData& participant_data,
             const SecurityException& exception) const;
 
-    RTPSParticipantImpl* participant_;
-    StatelessWriter* participant_stateless_message_writer_;
-    WriterHistory* participant_stateless_message_writer_history_;
-    StatelessReader* participant_stateless_message_reader_;
-    ReaderHistory* participant_stateless_message_reader_history_;
-    StatefulWriter* participant_volatile_message_secure_writer_;
-    WriterHistory* participant_volatile_message_secure_writer_history_;
-    StatefulReader* participant_volatile_message_secure_reader_;
-    ReaderHistory* participant_volatile_message_secure_reader_history_;
-    SecurityPluginFactory factory_;
+    RTPSParticipantImpl* participant_ = nullptr;
+    StatelessWriter* participant_stateless_message_writer_ = nullptr;
+    WriterHistory* participant_stateless_message_writer_history_ = nullptr;
+    StatelessReader* participant_stateless_message_reader_ = nullptr;
+    ReaderHistory* participant_stateless_message_reader_history_ = nullptr;
+    StatefulWriter* participant_volatile_message_secure_writer_ = nullptr;
+    WriterHistory* participant_volatile_message_secure_writer_history_ = nullptr;
+    StatefulReader* participant_volatile_message_secure_reader_ = nullptr;
+    ReaderHistory* participant_volatile_message_secure_reader_history_ = nullptr;
+    ISecurityPluginFactory& factory_;
 
-    Logging* logging_plugin_;
+    Logging* logging_plugin_ = nullptr;
+    Authentication* authentication_plugin_ = nullptr;
+    AccessControl* access_plugin_ = nullptr;
+    Cryptography* crypto_plugin_ = nullptr;
 
-    Authentication* authentication_plugin_;
+    uint32_t domain_id_ = 0;
 
-    AccessControl* access_plugin_;
+    IdentityHandle* local_identity_handle_ = nullptr;
 
-    Cryptography* crypto_plugin_;
-
-    uint32_t domain_id_;
-
-    IdentityHandle* local_identity_handle_;
-
-    PermissionsHandle* local_permissions_handle_;
+    PermissionsHandle* local_permissions_handle_ = nullptr;
 
     std::shared_ptr<ParticipantCryptoHandle> local_participant_crypto_handle_;
 

--- a/src/cpp/rtps/security/SecurityPluginFactory.cpp
+++ b/src/cpp/rtps/security/SecurityPluginFactory.cpp
@@ -25,15 +25,16 @@
 using namespace eprosima::fastrtps::rtps;
 using namespace eprosima::fastrtps::rtps::security;
 
-Authentication* SecurityPluginFactory::create_authentication_plugin(const PropertyPolicy& property_policy)
+Authentication* SecurityPluginFactory::create_authentication_plugin(
+        const PropertyPolicy& property_policy)
 {
     Authentication* plugin = nullptr;
     const std::string* auth_plugin_property = PropertyPolicyHelper::find_property(property_policy,
-            "dds.sec.auth.plugin");
+                    "dds.sec.auth.plugin");
 
-    if(auth_plugin_property != nullptr)
+    if (auth_plugin_property != nullptr)
     {
-        if(auth_plugin_property->compare("builtin.PKI-DH") == 0)
+        if (auth_plugin_property->compare("builtin.PKI-DH") == 0)
         {
             plugin = create_builtin_authentication_plugin();
         }
@@ -42,15 +43,16 @@ Authentication* SecurityPluginFactory::create_authentication_plugin(const Proper
     return plugin;
 }
 
-AccessControl* SecurityPluginFactory::create_access_control_plugin(const PropertyPolicy& property_policy)
+AccessControl* SecurityPluginFactory::create_access_control_plugin(
+        const PropertyPolicy& property_policy)
 {
     AccessControl* plugin = nullptr;
     const std::string* access_plugin_property = PropertyPolicyHelper::find_property(property_policy,
-            "dds.sec.access.plugin");
+                    "dds.sec.access.plugin");
 
-    if(access_plugin_property != nullptr)
+    if (access_plugin_property != nullptr)
     {
-        if(access_plugin_property->compare("builtin.Access-Permissions") == 0)
+        if (access_plugin_property->compare("builtin.Access-Permissions") == 0)
         {
             plugin = create_builtin_access_control_plugin();
         }
@@ -59,16 +61,17 @@ AccessControl* SecurityPluginFactory::create_access_control_plugin(const Propert
     return plugin;
 }
 
-Cryptography* SecurityPluginFactory::create_cryptography_plugin(const PropertyPolicy& property_policy)
+Cryptography* SecurityPluginFactory::create_cryptography_plugin(
+        const PropertyPolicy& property_policy)
 {
     Cryptography* plugin = nullptr;
     const std::string* crypto_plugin_property = PropertyPolicyHelper::find_property(property_policy,
-            "dds.sec.crypto.plugin");
+                    "dds.sec.crypto.plugin");
 
-    if(crypto_plugin_property != nullptr)
+    if (crypto_plugin_property != nullptr)
     {
         // Check it is builtin DDS:Auth:PKI-DH.
-        if(crypto_plugin_property->compare("builtin.AES-GCM-GMAC") == 0)
+        if (crypto_plugin_property->compare("builtin.AES-GCM-GMAC") == 0)
         {
             plugin = create_builtin_cryptography_plugin();
         }
@@ -77,15 +80,16 @@ Cryptography* SecurityPluginFactory::create_cryptography_plugin(const PropertyPo
     return plugin;
 }
 
-Logging* SecurityPluginFactory::create_logging_plugin(const PropertyPolicy& property_policy)
+Logging* SecurityPluginFactory::create_logging_plugin(
+        const PropertyPolicy& property_policy)
 {
     Logging* plugin = nullptr;
     const std::string* logging_plugin_property = PropertyPolicyHelper::find_property(property_policy,
                     "dds.sec.log.plugin");
 
-    if(logging_plugin_property != nullptr)
+    if (logging_plugin_property != nullptr)
     {
-        if(logging_plugin_property->compare("builtin.DDS_LogTopic") == 0)
+        if (logging_plugin_property->compare("builtin.DDS_LogTopic") == 0)
         {
             plugin = create_builtin_logging_plugin();
         }

--- a/src/cpp/rtps/security/SecurityPluginFactory.cpp
+++ b/src/cpp/rtps/security/SecurityPluginFactory.cpp
@@ -35,7 +35,7 @@ Authentication* SecurityPluginFactory::create_authentication_plugin(const Proper
     {
         if(auth_plugin_property->compare("builtin.PKI-DH") == 0)
         {
-            plugin = new PKIDH();
+            plugin = create_builtin_authentication_plugin();
         }
     }
 
@@ -52,7 +52,7 @@ AccessControl* SecurityPluginFactory::create_access_control_plugin(const Propert
     {
         if(access_plugin_property->compare("builtin.Access-Permissions") == 0)
         {
-            plugin = new Permissions();
+            plugin = create_builtin_access_control_plugin();
         }
     }
 
@@ -70,7 +70,7 @@ Cryptography* SecurityPluginFactory::create_cryptography_plugin(const PropertyPo
         // Check it is builtin DDS:Auth:PKI-DH.
         if(crypto_plugin_property->compare("builtin.AES-GCM-GMAC") == 0)
         {
-            plugin = new AESGCMGMAC();
+            plugin = create_builtin_cryptography_plugin();
         }
     }
 
@@ -87,9 +87,29 @@ Logging* SecurityPluginFactory::create_logging_plugin(const PropertyPolicy& prop
     {
         if(logging_plugin_property->compare("builtin.DDS_LogTopic") == 0)
         {
-            plugin = new LogTopic();
+            plugin = create_builtin_logging_plugin();
         }
     }
 
     return plugin;
+}
+
+Authentication* SecurityPluginFactory::create_builtin_authentication_plugin()
+{
+    return new PKIDH();
+}
+
+AccessControl* SecurityPluginFactory::create_builtin_access_control_plugin()
+{
+    return new Permissions();
+}
+
+Cryptography* SecurityPluginFactory::create_builtin_cryptography_plugin()
+{
+    return new AESGCMGMAC();
+}
+
+Logging* SecurityPluginFactory::create_builtin_logging_plugin()
+{
+    return new LogTopic();
 }

--- a/src/cpp/rtps/security/SecurityPluginFactory.h
+++ b/src/cpp/rtps/security/SecurityPluginFactory.h
@@ -46,6 +46,16 @@ public:
 
     Logging* create_logging_plugin(
             const PropertyPolicy& property_policy) override;
+
+protected:
+
+    virtual Authentication* create_builtin_authentication_plugin();
+
+    virtual AccessControl* create_builtin_access_control_plugin();
+
+    virtual Cryptography* create_builtin_cryptography_plugin();
+
+    virtual Logging* create_builtin_logging_plugin();
 };
 
 } //namespace security

--- a/src/cpp/rtps/security/SecurityPluginFactory.h
+++ b/src/cpp/rtps/security/SecurityPluginFactory.h
@@ -24,40 +24,28 @@
 #include <fastdds/rtps/security/logging/Logging.h>
 #include <fastdds/rtps/attributes/PropertyPolicy.h>
 
+#include <rtps/security/ISecurityPluginFactory.h>
+
 namespace eprosima {
 namespace fastrtps {
 namespace rtps {
 namespace security {
 
-class SecurityPluginFactory
+class SecurityPluginFactory : public ISecurityPluginFactory
 {
-    public:
+public:
 
-        /*!
-         * @brief Create an Authentication plugin  described in the PropertyPolicy.
-         * @param property_policy PropertyPolicy containing the definition of the Authentication
-         * plugin that has to be created.
-         * @param Pointer to the new Authentication plugin. In case of error nullptr will be returned.
-         */
-        Authentication* create_authentication_plugin(const PropertyPolicy& property_policy);
+    Authentication* create_authentication_plugin(
+            const PropertyPolicy& property_policy) override;
 
-        AccessControl* create_access_control_plugin(const PropertyPolicy& property_policy);
+    AccessControl* create_access_control_plugin(
+            const PropertyPolicy& property_policy) override;
 
-        /*!
-         * @brief Create an Cryptographic plugin  described in the PropertyPolicy.
-         * @param property_policy PropertyPolicy containing the definition of the Cryptographic
-         * plugin that has to be created.
-         * @param Pointer to the new Cryptographic plugin. In case of error nullptr will be returned.
-         */
-        Cryptography* create_cryptography_plugin(const PropertyPolicy& property_policy);
+    Cryptography* create_cryptography_plugin(
+            const PropertyPolicy& property_policy) override;
 
-        /**
-         * @brief Create a loggin plugin described in the PropertyPolicy.
-         * @param property_policy PropertyPolicy containing the definition of the Logging
-         * plugin that has to be created.
-         * @return Pointer to the new Logging plugin. In case of error nullptr will be returned.
-         */
-        Logging* create_logging_plugin(const PropertyPolicy& property_policy);
+    Logging* create_logging_plugin(
+            const PropertyPolicy& property_policy) override;
 };
 
 } //namespace security

--- a/src/cpp/rtps/transport/UDPChannelResource.cpp
+++ b/src/cpp/rtps/transport/UDPChannelResource.cpp
@@ -17,6 +17,7 @@
 #include <asio.hpp>
 #include <fastdds/rtps/messages/MessageReceiver.h>
 #include <rtps/transport/UDPTransportInterface.h>
+#include <utils/threading.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -53,6 +54,8 @@ UDPChannelResource::~UDPChannelResource()
 void UDPChannelResource::perform_listen_operation(
         Locator input_locator)
 {
+    set_name_to_current_thread("dds.udp.%u", input_locator.port);
+
     Locator remote_locator;
 
     while (alive())

--- a/src/cpp/rtps/transport/shared_mem/SharedMemChannelResource.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemChannelResource.hpp
@@ -22,6 +22,8 @@
 #include <rtps/transport/shared_mem/SharedMemTransport.h>
 #include <rtps/transport/ChannelResource.h>
 
+#include <utils/threading.hpp>
+
 namespace eprosima {
 namespace fastdds {
 namespace rtps {
@@ -123,6 +125,8 @@ private:
     void perform_listen_operation(
             Locator input_locator)
     {
+        set_name_to_current_thread("dds.shm.%u", input_locator.port);
+
         Locator remote_locator;
 
         while (alive())

--- a/src/cpp/rtps/transport/shared_mem/SharedMemChannelResource.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemChannelResource.hpp
@@ -51,7 +51,7 @@ public:
             auto packets_file_consumer = std::unique_ptr<SHMPacketFileConsumer>(
                 new SHMPacketFileConsumer(dump_file));
 
-            packet_logger_ = std::make_shared<PacketsLog<SHMPacketFileConsumer>>();
+            packet_logger_ = std::make_shared<PacketsLog<SHMPacketFileConsumer>>(locator.port);
             packet_logger_->RegisterConsumer(std::move(packets_file_consumer));
         }
 

--- a/src/cpp/rtps/transport/shared_mem/SharedMemLog.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemLog.hpp
@@ -199,6 +199,12 @@ class PacketsLog
 {
 public:
 
+    PacketsLog(
+            uint32_t thread_id)
+        : thread_id_(thread_id)
+    {
+    }
+
     ~PacketsLog()
     {
         Flush();
@@ -349,9 +355,11 @@ private:
     };
 
     Resources resources_;
+    uint32_t thread_id_;
 
     void run()
     {
+        set_name_to_current_thread("dds.shmd.%u", thread_id_);
         std::unique_lock<std::mutex> guard(resources_.cv_mutex);
 
         while (resources_.logging)

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
@@ -285,7 +285,7 @@ bool SharedMemTransport::init(
             auto packets_file_consumer = std::unique_ptr<SHMPacketFileConsumer>(
                 new SHMPacketFileConsumer(configuration_.rtps_dump_file()));
 
-            packet_logger_ = std::make_shared<PacketsLog<SHMPacketFileConsumer>>();
+            packet_logger_ = std::make_shared<PacketsLog<SHMPacketFileConsumer>>(0);
             packet_logger_->RegisterConsumer(std::move(packets_file_consumer));
         }
     }

--- a/src/cpp/security/logging/LogTopic.h
+++ b/src/cpp/security/logging/LogTopic.h
@@ -25,6 +25,7 @@
 
 #include <atomic>
 #include <fstream>
+#include <functional>
 #include <thread>
 
 namespace eprosima {
@@ -41,7 +42,8 @@ class LogTopic final : public Logging
 
 public:
 
-    LogTopic();
+    LogTopic(
+            std::function<void()> thread_init_cb = {});
     ~LogTopic();
 
 private:

--- a/src/cpp/utils/SystemInfo.cpp
+++ b/src/cpp/utils/SystemInfo.cpp
@@ -34,6 +34,7 @@
 
 #include <nlohmann/json.hpp>
 #include <fastrtps/types/TypesBase.h>
+#include <utils/threading.hpp>
 
 namespace eprosima {
 
@@ -274,3 +275,6 @@ std::string SystemInfo::get_timestamp(
 std::string SystemInfo::environment_file_;
 
 } // eprosima
+
+// threading.hpp implementations
+#include "threading/threading_empty.ipp"

--- a/src/cpp/utils/shared_memory/SharedMemWatchdog.hpp
+++ b/src/cpp/utils/shared_memory/SharedMemWatchdog.hpp
@@ -22,6 +22,8 @@
 #include <thread>
 #include <unordered_set>
 
+#include <utils/threading.hpp>
+
 namespace eprosima {
 namespace fastdds {
 namespace rtps {
@@ -121,6 +123,8 @@ private:
 
     void run()
     {
+        set_name_to_current_thread("dds.shm.wdog");
+
         while (!exit_thread_)
         {
             {

--- a/src/cpp/utils/threading.hpp
+++ b/src/cpp/utils/threading.hpp
@@ -1,0 +1,29 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef UTILS__THREADING_HPP_
+#define UTILS__THREADING_HPP_
+
+namespace eprosima {
+
+void set_name_to_current_thread(
+        const char* fmt,
+        uint32_t arg);
+
+void set_name_to_current_thread(
+        const char* name);
+
+} // eprosima
+
+#endif  // UTILS__THREADING_HPP_

--- a/src/cpp/utils/threading.hpp
+++ b/src/cpp/utils/threading.hpp
@@ -18,11 +18,16 @@
 namespace eprosima {
 
 void set_name_to_current_thread(
+        const char* name);
+
+void set_name_to_current_thread(
         const char* fmt,
         uint32_t arg);
 
 void set_name_to_current_thread(
-        const char* name);
+        const char* fmt,
+        uint32_t arg1,
+        uint32_t arg2);
 
 } // eprosima
 

--- a/src/cpp/utils/threading/threading_empty.ipp
+++ b/src/cpp/utils/threading/threading_empty.ipp
@@ -1,0 +1,28 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace eprosima {
+
+void set_name_to_current_thread(
+        const char* /* fmt */,
+        uint32_t /* arg */)
+{
+}
+
+void set_name_to_current_thread(
+        const char* /* name */)
+{
+}
+
+}  // namespace eprosima

--- a/src/cpp/utils/threading/threading_empty.ipp
+++ b/src/cpp/utils/threading/threading_empty.ipp
@@ -15,13 +15,20 @@
 namespace eprosima {
 
 void set_name_to_current_thread(
+        const char* /* name */)
+{
+}
+
+void set_name_to_current_thread(
         const char* /* fmt */,
         uint32_t /* arg */)
 {
 }
 
 void set_name_to_current_thread(
-        const char* /* name */)
+        const char* /* fmt */,
+        uint32_t /* arg1 */,
+        uint32_t /* arg2 */)
 {
 }
 

--- a/test/mock/rtps/SecurityPluginFactory/rtps/security/SecurityPluginFactory.h
+++ b/test/mock/rtps/SecurityPluginFactory/rtps/security/SecurityPluginFactory.h
@@ -33,41 +33,49 @@ namespace security {
 
 class SecurityPluginFactory : public ISecurityPluginFactory
 {
-    public:
+public:
 
-        Authentication* create_authentication_plugin(const PropertyPolicy& property_policy) override;
+    Authentication* create_authentication_plugin(
+            const PropertyPolicy& property_policy) override;
 
-        AccessControl* create_access_control_plugin(const PropertyPolicy& property_policy) override;
+    AccessControl* create_access_control_plugin(
+            const PropertyPolicy& property_policy) override;
 
-        Cryptography* create_cryptography_plugin(const PropertyPolicy& property_policy) override;
+    Cryptography* create_cryptography_plugin(
+            const PropertyPolicy& property_policy) override;
 
-        Logging* create_logging_plugin(const PropertyPolicy& property_policy) override;
+    Logging* create_logging_plugin(
+            const PropertyPolicy& property_policy) override;
 
-        static void set_auth_plugin(Authentication* plugin);
+    static void set_auth_plugin(
+            Authentication* plugin);
 
-        static void release_auth_plugin();
+    static void release_auth_plugin();
 
-        static void set_access_control_plugin(AccessControl* plugin);
+    static void set_access_control_plugin(
+            AccessControl* plugin);
 
-        static void release_access_control_plugin();
+    static void release_access_control_plugin();
 
-        static void set_crypto_plugin(Cryptography* plugin);
+    static void set_crypto_plugin(
+            Cryptography* plugin);
 
-        static void release_crypto_plugin();
+    static void release_crypto_plugin();
 
-        static void set_logging_plugin(Logging* plugin);
+    static void set_logging_plugin(
+            Logging* plugin);
 
-        static void release_logging_plugin();
+    static void release_logging_plugin();
 
-    private:
+private:
 
-        static Authentication* auth_plugin_;
+    static Authentication* auth_plugin_;
 
-        static AccessControl* access_plugin_;
+    static AccessControl* access_plugin_;
 
-        static Cryptography* crypto_plugin_;
+    static Cryptography* crypto_plugin_;
 
-        static Logging* logging_plugin_;
+    static Logging* logging_plugin_;
 };
 
 } //namespace security

--- a/test/mock/rtps/SecurityPluginFactory/rtps/security/SecurityPluginFactory.h
+++ b/test/mock/rtps/SecurityPluginFactory/rtps/security/SecurityPluginFactory.h
@@ -24,34 +24,24 @@
 #include <fastdds/rtps/security/logging/Logging.h>
 #include <fastrtps/rtps/attributes/PropertyPolicy.h>
 
+#include <rtps/security/ISecurityPluginFactory.h>
+
 namespace eprosima {
 namespace fastrtps {
 namespace rtps {
 namespace security {
 
-class SecurityPluginFactory
+class SecurityPluginFactory : public ISecurityPluginFactory
 {
     public:
 
-        /*!
-         * @brief Create an Authentication plugin  described in the PropertyPolicy.
-         * @param property_policy PropertyPolicy containing the definition of the Authentication
-         * plugin that has to be created.
-         * @param Pointer to the new Authentication plugin. In case of error nullptr will be returned.
-         */
-        Authentication* create_authentication_plugin(const PropertyPolicy& property_policy);
+        Authentication* create_authentication_plugin(const PropertyPolicy& property_policy) override;
 
-        AccessControl* create_access_control_plugin(const PropertyPolicy& property_policy);
+        AccessControl* create_access_control_plugin(const PropertyPolicy& property_policy) override;
 
-        /*!
-         * @brief Create an Cryptography plugin  described in the PropertyPolicy.
-         * @param property_policy PropertyPolicy containing the definition of the Cryptography
-         * plugin that has to be created.
-         * @param Pointer to the new Cryptography plugin. In case of error nullptr will be returned.
-         */
-        Cryptography* create_cryptography_plugin(const PropertyPolicy& property_policy);
+        Cryptography* create_cryptography_plugin(const PropertyPolicy& property_policy) override;
 
-        Logging* create_logging_plugin(const PropertyPolicy& property_policy);
+        Logging* create_logging_plugin(const PropertyPolicy& property_policy) override;
 
         static void set_auth_plugin(Authentication* plugin);
 

--- a/test/unittest/rtps/flowcontrol/FlowControllerPublishModesOnAsyncTests.cpp
+++ b/test/unittest/rtps/flowcontrol/FlowControllerPublishModesOnAsyncTests.cpp
@@ -7,7 +7,7 @@ TYPED_TEST(FlowControllerPublishModes, async_publish_mode)
 {
     FlowControllerDescriptor flow_controller_descr;
     FlowControllerImpl<FlowControllerAsyncPublishMode, TypeParam> async(nullptr,
-            &flow_controller_descr);
+            &flow_controller_descr, 0);
     async.init();
 
     // Instantiate writers.

--- a/test/unittest/rtps/flowcontrol/FlowControllerPublishModesOnLimitedAsyncTests.cpp
+++ b/test/unittest/rtps/flowcontrol/FlowControllerPublishModesOnLimitedAsyncTests.cpp
@@ -28,7 +28,7 @@ TYPED_TEST(FlowControllerPublishModes, limited_async_publish_mode)
     flow_controller_descr.max_bytes_per_period = 10200;
     flow_controller_descr.period_ms = 10;
     FlowControllerImpl<FlowControllerLimitedAsyncPublishModeMock, TypeParam> async(nullptr,
-            &flow_controller_descr);
+            &flow_controller_descr, 0);
     async.init();
 
     // Instantiate writers.

--- a/test/unittest/rtps/flowcontrol/FlowControllerPublishModesOnPureSyncTests.cpp
+++ b/test/unittest/rtps/flowcontrol/FlowControllerPublishModesOnPureSyncTests.cpp
@@ -7,7 +7,7 @@ TYPED_TEST(FlowControllerPublishModes, pure_sync_publish_mode)
 {
     FlowControllerDescriptor flow_controller_descr;
     FlowControllerImpl<FlowControllerPureSyncPublishMode, TypeParam> pure_sync(nullptr,
-            &flow_controller_descr);
+            &flow_controller_descr, 0);
     pure_sync.init();
 
     // Initialize callback to get info.

--- a/test/unittest/rtps/flowcontrol/FlowControllerPublishModesOnSyncTests.cpp
+++ b/test/unittest/rtps/flowcontrol/FlowControllerPublishModesOnSyncTests.cpp
@@ -7,7 +7,7 @@ TYPED_TEST(FlowControllerPublishModes, sync_publish_mode)
 {
     FlowControllerDescriptor flow_controller_descr;
     FlowControllerImpl<FlowControllerSyncPublishMode, TypeParam> sync(nullptr,
-            &flow_controller_descr);
+            &flow_controller_descr, 0);
     sync.init();
 
     // Instantiate writers.

--- a/test/unittest/rtps/flowcontrol/FlowControllerSchedulersTests.cpp
+++ b/test/unittest/rtps/flowcontrol/FlowControllerSchedulersTests.cpp
@@ -90,7 +90,7 @@ TEST_F(FlowControllerSchedulers, Fifo)
     flow_controller_descr.max_bytes_per_period = 10200;
     flow_controller_descr.period_ms = 10;
     FlowControllerImpl<FlowControllerLimitedAsyncPublishModeMock, FlowControllerFifoSchedule> async(nullptr,
-            &flow_controller_descr);
+            &flow_controller_descr, 0);
     async.init();
 
     // Instantiate writers.
@@ -691,7 +691,7 @@ TEST_F(FlowControllerSchedulers, RoundRobin)
     flow_controller_descr.max_bytes_per_period = 10200;
     flow_controller_descr.period_ms = 10;
     FlowControllerImpl<FlowControllerLimitedAsyncPublishModeMock, FlowControllerRoundRobinSchedule> async(nullptr,
-            &flow_controller_descr);
+            &flow_controller_descr, 0);
     async.init();
 
     // Instantiate writers.
@@ -1292,7 +1292,7 @@ TEST_F(FlowControllerSchedulers, HighPriority)
     flow_controller_descr.max_bytes_per_period = 10200;
     flow_controller_descr.period_ms = 10;
     FlowControllerImpl<FlowControllerLimitedAsyncPublishModeMock, FlowControllerHighPrioritySchedule> async(nullptr,
-            &flow_controller_descr);
+            &flow_controller_descr, 0);
     async.init();
 
     // Instantiate writers.
@@ -1916,7 +1916,7 @@ TEST_F(FlowControllerSchedulers, PriorityWithReservation)
     flow_controller_descr.period_ms = 10;
     FlowControllerImpl<FlowControllerLimitedAsyncPublishModeMock,
             FlowControllerPriorityWithReservationSchedule> async(nullptr,
-            &flow_controller_descr);
+            &flow_controller_descr, 0);
     async.init();
 
     // Instantiate writers.

--- a/test/unittest/rtps/security/SecurityTests.hpp
+++ b/test/unittest/rtps/security/SecurityTests.hpp
@@ -137,7 +137,7 @@ public:
         , stateless_reader_(nullptr)
         , volatile_writer_(nullptr)
         , volatile_reader_(nullptr)
-        , manager_(&participant_)
+        , manager_(&participant_, plugin_factory_)
         , participant_data_(c_default_RTPSParticipantAllocationAttributes)
         , default_cdr_message(RTPSMESSAGE_DEFAULT_SIZE)
     {
@@ -162,6 +162,7 @@ public:
     ::testing::NiceMock<StatefulWriter>* volatile_writer_;
     ::testing::NiceMock<StatefulReader>* volatile_reader_;
     PDP pdp_;
+    SecurityPluginFactory plugin_factory_;
     SecurityManager manager_;
 
     // handles

--- a/thirdparty/filewatch/FileWatch.hpp
+++ b/thirdparty/filewatch/FileWatch.hpp
@@ -23,6 +23,8 @@
 #ifndef FILEWATCHER_H
 #define FILEWATCHER_H
 
+#include <utils/threading.hpp>
+
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #define stat _stat
@@ -209,6 +211,7 @@ namespace filewatch {
 #endif // WIN32
             _callback_thread = std::move(std::thread([this]() {
                 try {
+                    eprosima::set_name_to_current_thread("dds.fwatch.cb");
                     callback_thread();
                 } catch (...) {
                     try {
@@ -219,6 +222,7 @@ namespace filewatch {
             }));
             _watch_thread = std::move(std::thread([this]() {
                 try {
+                    eprosima::set_name_to_current_thread("dds.fwatch");
                     monitor_directory();
                 } catch (...) {
                     try {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This is part of the thread configuration feature.

It adds some methods with an empty implementation to change the name of the current thread.

It also has all the required changes to provide the names as depicted on the internal design document.

A follow-up PR will provide implementations of the empty methods for the supported platforms.

As part of the changes needed to give name to the security logging thread, I refactored the SecurityManager to receive the SecurityPluginFactory by dependency injection.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.11.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- **N/A** Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [ ] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
