### PR TITLE
[17492] Platform implementations for set_name_to_current_thread

### DIFF
--- a/src/cpp/utils/SystemInfo.cpp
+++ b/src/cpp/utils/SystemInfo.cpp
@@ -277,7 +277,9 @@ std::string SystemInfo::environment_file_;
 } // eprosima
 
 // threading.hpp implementations
-#if defined(_POSIX_SOURCE)
+#ifdef _WIN32
+#include "threading/threading_win32.ipp"
+#elif defined(_POSIX_SOURCE) || defined(__QNXNTO__)
 #include "threading/threading_pthread.ipp"
 #else
 #include "threading/threading_empty.ipp"

--- a/src/cpp/utils/SystemInfo.cpp
+++ b/src/cpp/utils/SystemInfo.cpp
@@ -277,4 +277,8 @@ std::string SystemInfo::environment_file_;
 } // eprosima
 
 // threading.hpp implementations
+#if defined(_POSIX_SOURCE)
+#include "threading/threading_pthread.ipp"
+#else
 #include "threading/threading_empty.ipp"
+#endif // Platform selection

--- a/src/cpp/utils/SystemInfo.cpp
+++ b/src/cpp/utils/SystemInfo.cpp
@@ -281,7 +281,7 @@ std::string SystemInfo::environment_file_;
 #include "threading/threading_win32.ipp"
 #elif defined(__APPLE__)
 #include "threading/threading_osx.ipp"
-#elif defined(_POSIX_SOURCE) || defined(__QNXNTO__)
+#elif defined(_POSIX_SOURCE) || defined(__QNXNTO__) || defined(__ANDROID__)
 #include "threading/threading_pthread.ipp"
 #else
 #include "threading/threading_empty.ipp"

--- a/src/cpp/utils/SystemInfo.cpp
+++ b/src/cpp/utils/SystemInfo.cpp
@@ -279,6 +279,8 @@ std::string SystemInfo::environment_file_;
 // threading.hpp implementations
 #ifdef _WIN32
 #include "threading/threading_win32.ipp"
+#elif defined(__APPLE__)
+#include "threading/threading_osx.ipp"
 #elif defined(_POSIX_SOURCE) || defined(__QNXNTO__)
 #include "threading/threading_pthread.ipp"
 #else

--- a/src/cpp/utils/threading.hpp
+++ b/src/cpp/utils/threading.hpp
@@ -21,10 +21,8 @@ namespace eprosima {
  * @brief Give a name to the thread calling this function.
  *
  * @param[in]  name  A null-terminated string with the name to give to the calling thread.
- *                   Please note that the implementation may use as the format argument of
- *                   a `snprintf` like function, in order to accomodate the restrictions of
- *                   the OS. Those restrictions may truncate the final thread name if there
- *                   is a limit on the length of the name of a thread.
+ *                   The implementation for certain platforms may truncate the final thread
+ *                   name if there is a limit on the length of the name of a thread.
  */
 void set_name_to_current_thread(
         const char* name);

--- a/src/cpp/utils/threading.hpp
+++ b/src/cpp/utils/threading.hpp
@@ -17,13 +17,41 @@
 
 namespace eprosima {
 
+/**
+ * @brief Give a name to the thread calling this function.
+ *
+ * @param[in]  name  A null-terminated string with the name to give to the calling thread.
+ *                   Please note that the implementation may use as the format argument of
+ *                   a `snprintf` like function, in order to accomodate the restrictions of
+ *                   the OS. Those restrictions may truncate the final thread name if there
+ *                   is a limit on the length of the name of a thread.
+ */
 void set_name_to_current_thread(
         const char* name);
 
+/**
+ * @brief Give a name to the thread calling this function.
+ *
+ * @param[in]  fmt   A null-terminated string to be used as the format argument of
+ *                   a `snprintf` like function, in order to accomodate the restrictions of
+ *                   the OS. Those restrictions may truncate the final thread name if there
+ *                   is a limit on the length of the name of a thread.
+ * @param[in]  arg   Single variadic argument passed to the formatting function.
+ */
 void set_name_to_current_thread(
         const char* fmt,
         uint32_t arg);
 
+/**
+ * @brief Give a name to the thread calling this function.
+ *
+ * @param[in]  fmt   A null-terminated string to be used as the format argument of
+ *                   a `snprintf` like function, in order to accomodate the restrictions of
+ *                   the OS. Those restrictions may truncate the final thread name if there
+ *                   is a limit on the length of the name of a thread.
+ * @param[in]  arg1  First variadic argument passed to the formatting function.
+ * @param[in]  arg2  Second variadic argument passed to the formatting function.
+ */
 void set_name_to_current_thread(
         const char* fmt,
         uint32_t arg1,

--- a/src/cpp/utils/threading/threading_osx.ipp
+++ b/src/cpp/utils/threading/threading_osx.ipp
@@ -30,7 +30,7 @@ static void set_name_to_current_thread_impl(
 void set_name_to_current_thread(
         const char* name)
 {
-    set_name_to_current_thread_impl(name);
+    set_name_to_current_thread_impl("%s", name);
 }
 
 void set_name_to_current_thread(

--- a/src/cpp/utils/threading/threading_osx.ipp
+++ b/src/cpp/utils/threading/threading_osx.ipp
@@ -1,0 +1,51 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <pthread.h>
+#include <string.h>
+#include <stdio.h>
+
+namespace eprosima {
+
+template<typename... Args>
+static void set_name_to_current_thread_impl(
+    const char* fmt, Args... args)
+{
+    char thread_name[16]{};
+    snprintf(thread_name, 16, fmt, args...);
+    pthread_setname_np(thread_name);
+}
+
+void set_name_to_current_thread(
+        const char* name)
+{
+    set_name_to_current_thread_impl(name);
+}
+
+void set_name_to_current_thread(
+        const char* fmt,
+        uint32_t arg)
+{
+    set_name_to_current_thread_impl(fmt, arg);
+}
+
+void set_name_to_current_thread(
+        const char* fmt,
+        uint32_t arg1,
+        uint32_t arg2)
+{
+    set_name_to_current_thread_impl(fmt, arg1, arg2);
+}
+
+}  // namespace eprosima

--- a/src/cpp/utils/threading/threading_pthread.ipp
+++ b/src/cpp/utils/threading/threading_pthread.ipp
@@ -31,7 +31,7 @@ static void set_name_to_current_thread_impl(
 void set_name_to_current_thread(
         const char* name)
 {
-    set_name_to_current_thread_impl(name);
+    set_name_to_current_thread_impl("%s", name);
 }
 
 void set_name_to_current_thread(

--- a/src/cpp/utils/threading/threading_pthread.ipp
+++ b/src/cpp/utils/threading/threading_pthread.ipp
@@ -1,0 +1,52 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <pthread.h>
+#include <string.h>
+#include <stdio.h>
+
+namespace eprosima {
+
+template<typename... Args>
+static void set_name_to_current_thread_impl(
+    const char* fmt, Args... args)
+{
+    char thread_name[16]{};
+    snprintf(thread_name, 16, fmt, args...);
+    auto id = pthread_self();
+    pthread_setname_np(id, thread_name);
+}
+
+void set_name_to_current_thread(
+        const char* name)
+{
+    set_name_to_current_thread_impl(name);
+}
+
+void set_name_to_current_thread(
+        const char* fmt,
+        uint32_t arg)
+{
+    set_name_to_current_thread_impl(fmt, arg);
+}
+
+void set_name_to_current_thread(
+        const char* fmt,
+        uint32_t arg1,
+        uint32_t arg2)
+{
+    set_name_to_current_thread_impl(fmt, arg1, arg2);
+}
+
+}  // namespace eprosima

--- a/src/cpp/utils/threading/threading_win32.ipp
+++ b/src/cpp/utils/threading/threading_win32.ipp
@@ -1,0 +1,56 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sstream>
+#include <string>
+#include <processthreadsapi.h>
+
+namespace eprosima {
+
+template<typename... Args>
+static void set_name_to_current_thread_impl(
+    const char* fmt, Args... args)
+{
+    char thread_name[16]{};
+    snprintf(thread_name, 16, fmt, args...);
+
+    std::wstringstream stream;
+    stream << thread_name;
+    std::wstring w_thread_name = stream.str();
+
+    SetThreadDescription(GetCurrentThread(), w_thread_name.c_str());
+}
+
+void set_name_to_current_thread(
+        const char* name)
+{
+    set_name_to_current_thread_impl(name);
+}
+
+void set_name_to_current_thread(
+        const char* fmt,
+        uint32_t arg)
+{
+    set_name_to_current_thread_impl(fmt, arg);
+}
+
+void set_name_to_current_thread(
+        const char* fmt,
+        uint32_t arg1,
+        uint32_t arg2)
+{
+    set_name_to_current_thread_impl(fmt, arg1, arg2);
+}
+
+}  // namespace eprosima

--- a/src/cpp/utils/threading/threading_win32.ipp
+++ b/src/cpp/utils/threading/threading_win32.ipp
@@ -35,7 +35,7 @@ static void set_name_to_current_thread_impl(
 void set_name_to_current_thread(
         const char* name)
 {
-    set_name_to_current_thread_impl(name);
+    set_name_to_current_thread_impl("%s", name);
 }
 
 void set_name_to_current_thread(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This provides implementation of the methods for setting the thread name added in #3821 

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.11.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- **N/A** Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
