### PR TITLE
[19546] Use FASTRTPS_NO_LIB on unittest root folder

### DIFF
--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_compile_definitions(FASTRTPS_NO_LIB)
+
 add_subdirectory(rtps/common)
 add_subdirectory(rtps/DataSharing)
 add_subdirectory(rtps/builtin)

--- a/test/unittest/dds/collections/CMakeLists.txt
+++ b/test/unittest/dds/collections/CMakeLists.txt
@@ -25,7 +25,7 @@ set(LOANABLE_SEQUENCE_TESTS_SOURCE
     LoanableSequenceTests.cpp)
 
 add_executable(LoanableSequenceTests ${LOANABLE_SEQUENCE_TESTS_SOURCE})
-target_compile_definitions(LoanableSequenceTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(LoanableSequenceTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )

--- a/test/unittest/dds/core/condition/CMakeLists.txt
+++ b/test/unittest/dds/core/condition/CMakeLists.txt
@@ -37,7 +37,7 @@ set(CONDITION_TESTS_SOURCE
     ConditionTests.cpp)
 
 add_executable(ConditionTests ${CONDITION_TESTS_SOURCE})
-target_compile_definitions(ConditionTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(ConditionTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -57,7 +57,7 @@ set(CONDITION_NOTIFIER_TESTS_SOURCE
     ConditionNotifierTests.cpp)
 
 add_executable(ConditionNotifierTests ${CONDITION_NOTIFIER_TESTS_SOURCE})
-target_compile_definitions(ConditionNotifierTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(ConditionNotifierTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -81,7 +81,7 @@ set(STATUS_CONDITION_IMPL_TESTS_SOURCE
     StatusConditionImplTests.cpp)
 
 add_executable(StatusConditionImplTests ${STATUS_CONDITION_IMPL_TESTS_SOURCE})
-target_compile_definitions(StatusConditionImplTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(StatusConditionImplTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -104,7 +104,7 @@ set(WAITSET_IMPL_TESTS_SOURCE
     WaitSetImplTests.cpp)
 
 add_executable(WaitSetImplTests ${WAITSET_IMPL_TESTS_SOURCE})
-target_compile_definitions(WaitSetImplTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(WaitSetImplTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )

--- a/test/unittest/dds/core/entity/CMakeLists.txt
+++ b/test/unittest/dds/core/entity/CMakeLists.txt
@@ -41,7 +41,7 @@ if(ANDROID)
 endif()
 
 add_executable(EntityTests ${ENTITY_TESTS_SOURCE})
-target_compile_definitions(EntityTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(EntityTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )

--- a/test/unittest/dds/participant/CMakeLists.txt
+++ b/test/unittest/dds/participant/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 
 
 add_executable(ParticipantTests ${PARTICIPANTTESTS_SOURCE})
-target_compile_definitions(ParticipantTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(ParticipantTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )

--- a/test/unittest/dds/publisher/CMakeLists.txt
+++ b/test/unittest/dds/publisher/CMakeLists.txt
@@ -312,7 +312,7 @@ if(ANDROID)
 endif()
 
 add_executable(PublisherTests ${PUBLISHERTESTS_SOURCE})
-target_compile_definitions(PublisherTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(PublisherTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -330,7 +330,7 @@ endif()
 add_gtest(PublisherTests SOURCES ${PUBLISHERTESTS_SOURCE})
 
 add_executable(DataWriterTests ${DATAWRITERTESTS_SOURCE})
-target_compile_definitions(DataWriterTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(DataWriterTests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     ASIO_DISABLE_VISIBILITY

--- a/test/unittest/dds/status/CMakeLists.txt
+++ b/test/unittest/dds/status/CMakeLists.txt
@@ -143,7 +143,7 @@ if(ANDROID)
 endif()
 
 add_executable(ListenerTests ${LISTENERTESTS_SOURCE})
-target_compile_definitions(ListenerTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(ListenerTests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     ASIO_DISABLE_VISIBILITY

--- a/test/unittest/dds/subscriber/CMakeLists.txt
+++ b/test/unittest/dds/subscriber/CMakeLists.txt
@@ -56,7 +56,7 @@ if(ANDROID)
 endif()
 
 add_executable(SubscriberTests ${SUBSCRIBERTESTS_SOURCE})
-target_compile_definitions(SubscriberTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(SubscriberTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -70,7 +70,7 @@ target_link_libraries(SubscriberTests fastrtps fastcdr foonathan_memory
 add_gtest(SubscriberTests SOURCES ${SUBSCRIBERTESTS_SOURCE})
 
 add_executable(DataReaderTests ${DATAREADERTESTS_SOURCE})
-target_compile_definitions(DataReaderTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(DataReaderTests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     ASIO_DISABLE_VISIBILITY
@@ -88,7 +88,7 @@ target_link_libraries(DataReaderTests fastrtps fastcdr foonathan_memory
 add_gtest(DataReaderTests SOURCES ${DATAREADERTESTS_SOURCE})
 
 add_executable(DataReaderInstanceTests ${DATAREADERINSTANCETESTS_SOURCE})
-target_compile_definitions(DataReaderInstanceTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(DataReaderInstanceTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -102,7 +102,7 @@ target_link_libraries(DataReaderInstanceTests foonathan_memory
 add_gtest(DataReaderInstanceTests SOURCES ${DATAREADERINSTANCETESTS_SOURCE})
 
 add_executable(DataReaderHistoryTests ${DATAREADERHISTORYTESTS_SOURCE})
-target_compile_definitions(DataReaderHistoryTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(DataReaderHistoryTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     $<$<BOOL:${MSVC}>:NOMINMAX> # avoid conflic with std::min & std::max in visual studio

--- a/test/unittest/dds/topic/CMakeLists.txt
+++ b/test/unittest/dds/topic/CMakeLists.txt
@@ -23,7 +23,7 @@ if(WIN32)
 endif()
 
 add_executable(TopicTests ${TOPICTESTS_SOURCE})
-target_compile_definitions(TopicTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(TopicTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )

--- a/test/unittest/dds/topic/DDSSQLFilter/CMakeLists.txt
+++ b/test/unittest/dds/topic/DDSSQLFilter/CMakeLists.txt
@@ -38,7 +38,7 @@ add_executable(DDSSQLFilterTests
     ${DDSSQLFILTER_SOURCES}
     ${DDSSQLFILTER_LIB_SOURCES}
     )
-target_compile_definitions(DDSSQLFilterTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(DDSSQLFilterTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )

--- a/test/unittest/dynamic_types/CMakeLists.txt
+++ b/test/unittest/dynamic_types/CMakeLists.txt
@@ -107,7 +107,7 @@ set(DYNAMIC_TYPES_4_2_TEST_SOURCE
 include_directories(mock/)
 
 add_executable(DynamicTypesTests ${DYNAMIC_TYPES_TEST_SOURCE})
-target_compile_definitions(DynamicTypesTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(DynamicTypesTests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
@@ -140,7 +140,7 @@ add_gtest(DynamicTypesTests SOURCES ${DYNAMIC_TYPES_TEST_SOURCE})
 
 
 add_executable(DynamicComplexTypesTests ${DYNAMIC_COMPLEX_TYPES_TEST_SOURCE})
-target_compile_definitions(DynamicComplexTypesTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(DynamicComplexTypesTests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
@@ -164,7 +164,7 @@ add_gtest(DynamicComplexTypesTests SOURCES ${DYNAMIC_COMPLEX_TYPES_TEST_SOURCE})
 
 
 add_executable(DynamicTypes_4_2_Tests ${DYNAMIC_TYPES_4_2_TEST_SOURCE})
-target_compile_definitions(DynamicTypes_4_2_Tests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(DynamicTypes_4_2_Tests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>

--- a/test/unittest/logging/CMakeLists.txt
+++ b/test/unittest/logging/CMakeLists.txt
@@ -36,7 +36,7 @@ set(LOGTESTS_SOURCE
 include_directories(mock/)
 
 add_executable(LogTests ${LOGTESTS_SOURCE})
-target_compile_definitions(LogTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(LogTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     HAVE_LOG_NO_INFO=0 FASTDDS_ENFORCE_LOG_INFO # logInfo is used in some tests
@@ -71,7 +71,7 @@ if(TINYXML2_INCLUDE_DIR)
 endif(TINYXML2_INCLUDE_DIR)
 
 add_executable(LogFileTests ${LOGFILETESTS_SOURCE})
-target_compile_definitions(LogFileTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(LogFileTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )

--- a/test/unittest/logging/log_macros/CMakeLists.txt
+++ b/test/unittest/logging/log_macros/CMakeLists.txt
@@ -32,7 +32,7 @@ set(LOGMACROS_SOURCE
     ${LOGMACROS_ALL_TEST_SOURCE})
 
 add_executable(LogMacrosAllActiveTests ${LOGMACROS_SOURCE})
-target_compile_definitions(LogMacrosAllActiveTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(LogMacrosAllActiveTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -53,7 +53,7 @@ set(LOGMACROS_SOURCE
     ${LOGMACROS_NOINFO_TEST_SOURCE})
 
 add_executable(LogMacrosNoInfoTests ${LOGMACROS_SOURCE})
-target_compile_definitions(LogMacrosNoInfoTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(LogMacrosNoInfoTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -74,7 +74,7 @@ set(LOGMACROS_SOURCE
     ${LOGMACROS_NOWARNING_TEST_SOURCE})
 
 add_executable(LogMacrosNoWarningTests ${LOGMACROS_SOURCE})
-target_compile_definitions(LogMacrosNoWarningTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(LogMacrosNoWarningTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -95,7 +95,7 @@ set(LOGMACROS_SOURCE
     ${LOGMACROS_NOERROR_TEST_SOURCE})
 
 add_executable(LogMacrosNoErrorTests ${LOGMACROS_SOURCE})
-target_compile_definitions(LogMacrosNoErrorTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(LogMacrosNoErrorTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -116,7 +116,7 @@ set(LOGMACROS_SOURCE
     ${LOGMACROS_DEFAULT_TEST_SOURCE})
 
 add_executable(LogMacrosDefaultTests ${LOGMACROS_SOURCE})
-target_compile_definitions(LogMacrosDefaultTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(LogMacrosDefaultTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -139,7 +139,7 @@ set(LOGMACROS_SOURCE
     ${LOGMACROS_INTERNALDEBUG_TEST_SOURCE})
 
 add_executable(LogMacrosInternalDebugOffTests ${LOGMACROS_SOURCE})
-target_compile_definitions(LogMacrosInternalDebugOffTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(LogMacrosInternalDebugOffTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -159,7 +159,7 @@ set(LOGMACROS_SOURCE
     ${LOGMACROS_ALL_TEST_SOURCE})
 
 add_executable(OldLogMacrosTests ${LOGMACROS_SOURCE})
-target_compile_definitions(OldLogMacrosTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(OldLogMacrosTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -180,7 +180,7 @@ set(LOGMACROS_SOURCE
     ${LOGMACROS_ALL_TEST_SOURCE})
 
 add_executable(OldLogMacrosDisableTests ${LOGMACROS_SOURCE})
-target_compile_definitions(OldLogMacrosDisableTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(OldLogMacrosDisableTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )

--- a/test/unittest/rtps/DataSharing/CMakeLists.txt
+++ b/test/unittest/rtps/DataSharing/CMakeLists.txt
@@ -21,7 +21,7 @@ if(WIN32)
 endif()
 
 add_executable(SHMSegmentTests ${SHMSEGMENTTESTS_SOURCE})
-target_compile_definitions(SHMSegmentTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(SHMSegmentTests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>

--- a/test/unittest/rtps/builtin/CMakeLists.txt
+++ b/test/unittest/rtps/builtin/CMakeLists.txt
@@ -75,7 +75,7 @@ endif()
 
 
 add_executable(BuiltinDataSerializationTests ${BUILTIN_DATA_SERIALIZATION_TESTS_SOURCE})
-target_compile_definitions(BuiltinDataSerializationTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(BuiltinDataSerializationTests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>

--- a/test/unittest/rtps/common/CMakeLists.txt
+++ b/test/unittest/rtps/common/CMakeLists.txt
@@ -49,7 +49,7 @@ set(TIMETESTS_SOURCE TimeTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp)
 
 add_executable(CacheChangeTests ${CACHECHANGETESTS_SOURCE})
-target_compile_definitions(CacheChangeTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(CacheChangeTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -59,7 +59,7 @@ target_link_libraries(CacheChangeTests GTest::gtest)
 add_gtest(CacheChangeTests SOURCES ${CACHECHANGETESTS_SOURCE})
 
 add_executable(GuidUtilsTests ${GUID_UTILS_TESTS_SOURCE})
-target_compile_definitions(GuidUtilsTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(GuidUtilsTests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
@@ -80,7 +80,7 @@ endif()
 add_gtest(GuidUtilsTests SOURCES ${GUID_UTILS_TESTS_SOURCE})
 
 add_executable(SequenceNumberTests ${SEQUENCENUMBERTESTS_SOURCE})
-target_compile_definitions(SequenceNumberTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(SequenceNumberTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -90,7 +90,7 @@ target_link_libraries(SequenceNumberTests GTest::gtest)
 add_gtest(SequenceNumberTests SOURCES ${SEQUENCENUMBERTESTS_SOURCE})
 
 add_executable(PortParametersTests ${PORTPARAMETERSTESTS_SOURCE})
-target_compile_definitions(PortParametersTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(PortParametersTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -107,7 +107,7 @@ add_gtest(PortParametersTests SOURCES ${PORTPARAMETERSTESTS_SOURCE} LABELS "NoMe
 set(GUIDPREFIXTESTS_SOURCE GuidPrefixTests.cpp)
 
 add_executable(GuidPrefixTests ${GUIDPREFIXTESTS_SOURCE})
-target_compile_definitions(GuidPrefixTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(GuidPrefixTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -124,7 +124,7 @@ add_gtest(GuidPrefixTests SOURCES ${GUIDPREFIXTESTS_SOURCE} LABELS "NoMemoryChec
 set(ENTITYIDTESTS_SOURCE EntityIdTests.cpp)
 
 add_executable(EntityIdTests ${ENTITYIDTESTS_SOURCE})
-target_compile_definitions(EntityIdTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(EntityIdTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -141,7 +141,7 @@ add_gtest(EntityIdTests SOURCES ${ENTITYIDTESTS_SOURCE} LABELS "NoMemoryCheck")
 set(GUIDTESTS_SOURCE GuidTests.cpp)
 
 add_executable(GuidTests ${GUIDTESTS_SOURCE})
-target_compile_definitions(GuidTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(GuidTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -166,7 +166,7 @@ endif()
 #############
 
 add_executable(TimeTests ${TIMETESTS_SOURCE})
-target_compile_definitions(TimeTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(TimeTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )

--- a/test/unittest/rtps/discovery/CMakeLists.txt
+++ b/test/unittest/rtps/discovery/CMakeLists.txt
@@ -57,7 +57,7 @@ if(WIN32)
 endif()
 
 add_executable(EdpTests ${EDPTESTS_SOURCE})
-target_compile_definitions(EdpTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(EdpTests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>

--- a/test/unittest/rtps/flowcontrol/CMakeLists.txt
+++ b/test/unittest/rtps/flowcontrol/CMakeLists.txt
@@ -35,7 +35,7 @@ set(FLOWCONTROLLERFACTORYTESTS_SOURCE
     )
 
 add_executable(FlowControllerFactoryTests ${FLOWCONTROLLERFACTORYTESTS_SOURCE})
-target_compile_definitions(FlowControllerFactoryTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(FlowControllerFactoryTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -63,7 +63,7 @@ set(FLOWCONTROLLERPUBLISHMODESTESTS_SOURCE
     )
 
 add_executable(FlowControllerPublishModesTests ${FLOWCONTROLLERPUBLISHMODESTESTS_SOURCE})
-target_compile_definitions(FlowControllerPublishModesTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(FlowControllerPublishModesTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -87,7 +87,7 @@ set(FLOWCONTROLLERSCHEDULERSTESTS_SOURCE
     )
 
 add_executable(FlowControllerSchedulersTests ${FLOWCONTROLLERSCHEDULERSTESTS_SOURCE})
-target_compile_definitions(FlowControllerSchedulersTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(FlowControllerSchedulersTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )

--- a/test/unittest/rtps/history/CMakeLists.txt
+++ b/test/unittest/rtps/history/CMakeLists.txt
@@ -65,7 +65,7 @@ if(ANDROID)
 endif()
 
 add_executable(ReaderHistoryTests ${READERHISTORYTESTS_SOURCE})
-target_compile_definitions(ReaderHistoryTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(ReaderHistoryTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -82,7 +82,7 @@ target_link_libraries(ReaderHistoryTests
 add_gtest(ReaderHistoryTests SOURCES ${READERHISTORYTESTS_SOURCE})
 
 add_executable(BasicPoolsTests ${BASICPOOLSTESTS_SOURCE})
-target_compile_definitions(BasicPoolsTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(BasicPoolsTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -95,7 +95,7 @@ target_link_libraries(BasicPoolsTests
 add_gtest(BasicPoolsTests SOURCES ${BASICPOOLSTESTS_SOURCE})
 
 add_executable(CacheChangePoolTests ${CACHECHANGEPOOLTESTS_SOURCE})
-target_compile_definitions(CacheChangePoolTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(CacheChangePoolTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -108,7 +108,7 @@ target_link_libraries(CacheChangePoolTests
 add_gtest(CacheChangePoolTests SOURCES ${CACHECHANGEPOOLTESTS_SOURCE})
 
 add_executable(TopicPayloadPoolTests ${TOPICPAYLOADPOOLTESTS_SOURCE})
-target_compile_definitions(TopicPayloadPoolTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(TopicPayloadPoolTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )

--- a/test/unittest/rtps/network/CMakeLists.txt
+++ b/test/unittest/rtps/network/CMakeLists.txt
@@ -79,7 +79,7 @@ endif()
 include_directories(mock/)
 
 add_executable(NetworkFactoryTests ${NETWORKFACTORYTESTS_SOURCE})
-target_compile_definitions(NetworkFactoryTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(NetworkFactoryTests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
@@ -146,7 +146,7 @@ add_executable(ExternalLocatorsProcessorTests
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/OStreamConsumer.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
     )
-target_compile_definitions(ExternalLocatorsProcessorTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(ExternalLocatorsProcessorTests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>

--- a/test/unittest/rtps/persistence/CMakeLists.txt
+++ b/test/unittest/rtps/persistence/CMakeLists.txt
@@ -32,7 +32,7 @@ if(SQLITE3_SUPPORT)
         )
 
     add_executable(PersistenceTests ${PERSISTENCETESTS_SOURCE})
-    target_compile_definitions(PersistenceTests PRIVATE FASTRTPS_NO_LIB
+    target_compile_definitions(PersistenceTests PRIVATE
         $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
         $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
         )

--- a/test/unittest/rtps/reader/CMakeLists.txt
+++ b/test/unittest/rtps/reader/CMakeLists.txt
@@ -31,7 +31,7 @@ if(WIN32)
 endif()
 
 add_executable(WriterProxyTests ${WRITERPROXYTESTS_SOURCE})
-target_compile_definitions(WriterProxyTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(WriterProxyTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -83,7 +83,7 @@ if(WIN32)
 endif()
 
 add_executable(WriterProxyStopTest ${WRITERPROXYSTOPTEST_SOURCE})
-target_compile_definitions(WriterProxyStopTest PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(WriterProxyStopTest PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -130,7 +130,7 @@ if(WIN32)
 endif()
 
 add_executable(WriterProxyAcknackTests ${WRITERPROXYACKNACKTESTS_SOURCE})
-target_compile_definitions(WriterProxyAcknackTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(WriterProxyAcknackTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )

--- a/test/unittest/rtps/resources/timedevent/CMakeLists.txt
+++ b/test/unittest/rtps/resources/timedevent/CMakeLists.txt
@@ -38,7 +38,7 @@ if(ANDROID)
 endif()
 
 add_executable(TimedEventTests ${TIMEDEVENTTESTS_SOURCE})
-target_compile_definitions(TimedEventTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(TimedEventTests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>

--- a/test/unittest/rtps/security/CMakeLists.txt
+++ b/test/unittest/rtps/security/CMakeLists.txt
@@ -57,7 +57,7 @@ if(WIN32)
     set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/SecurityInitializationTests.cpp PROPERTIES COMPILE_OPTIONS /bigobj)
 endif()
 
-target_compile_definitions(SecurityAuthentication PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(SecurityAuthentication PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>

--- a/test/unittest/rtps/writer/CMakeLists.txt
+++ b/test/unittest/rtps/writer/CMakeLists.txt
@@ -31,7 +31,7 @@ if(WIN32)
 endif()
 
 add_executable(ReaderProxyTests ${WRITERPROXYTESTS_SOURCE})
-target_compile_definitions(ReaderProxyTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(ReaderProxyTests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
@@ -75,7 +75,7 @@ set(LIVELINESSMANAGERTESTS_SOURCE LivelinessManagerTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/utils/SystemInfo.cpp)
 
 add_executable(LivelinessManagerTests ${LIVELINESSMANAGERTESTS_SOURCE})
-target_compile_definitions(LivelinessManagerTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(LivelinessManagerTests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>

--- a/test/unittest/security/accesscontrol/CMakeLists.txt
+++ b/test/unittest/security/accesscontrol/CMakeLists.txt
@@ -70,7 +70,7 @@ add_executable(AccessControlTests ${COMMON_SOURCES_ACCESS_CONTROL_TEST_SOURCE}
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/publisher/qos/WriterQos.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/AccessControlTests.cpp)
 
-target_compile_definitions(AccessControlTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(AccessControlTests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
@@ -144,7 +144,6 @@ add_executable(
 target_compile_definitions(
     ${DISTINGUISHEDNAME_TEST_NAME}
     PRIVATE
-        FASTRTPS_NO_LIB
         $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
         $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
 )

--- a/test/unittest/security/authentication/CMakeLists.txt
+++ b/test/unittest/security/authentication/CMakeLists.txt
@@ -51,7 +51,7 @@ add_executable(BuiltinPKIDH ${COMMON_SOURCES_AUTH_PLUGIN_TEST_SOURCE}
     ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPLocator.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/utils/SystemInfo.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/BuiltinPKIDHTests.cpp)
-target_compile_definitions(BuiltinPKIDH PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(BuiltinPKIDH PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>

--- a/test/unittest/security/cryptography/CMakeLists.txt
+++ b/test/unittest/security/cryptography/CMakeLists.txt
@@ -40,7 +40,7 @@ add_executable(BuiltinAESGCMGMAC ${COMMON_SOURCES_CRYPTO_PLUGIN_TEST_SOURCE}
     ${PROJECT_SOURCE_DIR}/src/cpp/security/accesscontrol/AccessPermissionsHandle.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/builtinAESGCMGMACTests.cpp)
 
-target_compile_definitions(BuiltinAESGCMGMAC PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(BuiltinAESGCMGMAC PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )

--- a/test/unittest/security/logging/CMakeLists.txt
+++ b/test/unittest/security/logging/CMakeLists.txt
@@ -34,7 +34,7 @@ add_executable(BuiltinLogging ${COMMON_SOURCES_LOGGING_PLUGIN_TEST_SOURCE}
     ${PROJECT_SOURCE_DIR}/src/cpp/security/logging/LogTopic.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/BuiltinLogTopicTests.cpp)
 
-target_compile_definitions(BuiltinLogging PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(BuiltinLogging PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )

--- a/test/unittest/statistics/dds/CMakeLists.txt
+++ b/test/unittest/statistics/dds/CMakeLists.txt
@@ -29,7 +29,7 @@ set(STATISTICS_DOMAINPARTICIPANT_TESTS_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/statistics/types/types.cxx)
 
 add_executable(StatisticsDomainParticipantTests ${STATISTICS_DOMAINPARTICIPANT_TESTS_SOURCE})
-target_compile_definitions(StatisticsDomainParticipantTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(StatisticsDomainParticipantTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNAL_DEBUG> # Internal debug activated.
     )
@@ -53,7 +53,7 @@ if(TINYXML2_SOURCE_DIR)
 endif()
 
 add_executable(StatisticsQosTests ${STATISTICS_QOS_TESTS_SOURCE})
-target_compile_definitions(StatisticsQosTests PRIVATE FASTRTPS_NO_LIB BOOST_ASIO_STANDALONE ASIO_STANDALONE
+target_compile_definitions(StatisticsQosTests PRIVATE BOOST_ASIO_STANDALONE ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNAL_DEBUG> # Internal debug activated.
     )
@@ -75,7 +75,7 @@ if (FASTDDS_STATISTICS)
         ${PROJECT_SOURCE_DIR}/src/cpp/utils/md5.cpp
         ${TINYXML2_SOURCES}
         ${DOMAINPARTICIPANTSTATISTICSLISTENER_TESTS_SOURCE})
-    target_compile_definitions(DomainParticipantStatisticsListenerTests PRIVATE FASTRTPS_NO_LIB
+    target_compile_definitions(DomainParticipantStatisticsListenerTests PRIVATE
         $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
         $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNAL_DEBUG> # Internal debug activated.
         )
@@ -333,7 +333,7 @@ if (SQLITE3_SUPPORT AND FASTDDS_STATISTICS AND NOT QNX)
     endif()
 
     add_executable(StatisticsDomainParticipantMockTests ${STATISTICS_DOMAINPARTICIPANT_MOCK_TESTS_SOURCE})
-    target_compile_definitions(StatisticsDomainParticipantMockTests PRIVATE FASTRTPS_NO_LIB
+    target_compile_definitions(StatisticsDomainParticipantMockTests PRIVATE
         BOOST_ASIO_STANDALONE
         ASIO_STANDALONE
         SQLITE_WIN32_GETVERSIONEX=0

--- a/test/unittest/statistics/rtps/CMakeLists.txt
+++ b/test/unittest/statistics/rtps/CMakeLists.txt
@@ -23,7 +23,7 @@ set(STATISTICS_RTPS_TESTS_SOURCE
 
 add_executable(RTPSStatisticsTests ${STATISTICS_RTPS_TESTS_SOURCE})
 
-target_compile_definitions(RTPSStatisticsTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(RTPSStatisticsTests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>

--- a/test/unittest/transport/CMakeLists.txt
+++ b/test/unittest/transport/CMakeLists.txt
@@ -245,7 +245,7 @@ endif()
 include_directories(mock/)
 
 add_executable(UDPv4Tests ${UDPV4TESTS_SOURCE})
-target_compile_definitions(UDPv4Tests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(UDPv4Tests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
@@ -273,7 +273,7 @@ option(DISABLE_UDPV6_TESTS "Disable UDPv6 tests because fails in some systems" O
 
 if(NOT DISABLE_UDPV6_TESTS)
     add_executable(UDPv6Tests ${UDPV6TESTS_SOURCE})
-    target_compile_definitions(UDPv6Tests PRIVATE FASTRTPS_NO_LIB
+    target_compile_definitions(UDPv6Tests PRIVATE
         BOOST_ASIO_STANDALONE
         ASIO_STANDALONE
         $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
@@ -297,7 +297,7 @@ if(NOT DISABLE_UDPV6_TESTS)
     set(TRANSPORT_XFAIL_LIST ${TRANSPORT_XFAIL_LIST} XFAIL_UDP6)
 
     add_executable(TCPv6Tests ${TCPV6TESTS_SOURCE})
-    target_compile_definitions(TCPv6Tests PRIVATE FASTRTPS_NO_LIB
+    target_compile_definitions(TCPv6Tests PRIVATE
         BOOST_ASIO_STANDALONE
         ASIO_STANDALONE
         $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
@@ -328,7 +328,7 @@ if(NOT DISABLE_UDPV6_TESTS)
 endif()
 
 add_executable(test_UDPv4Tests ${TEST_UDPV4TESTS_SOURCE})
-target_compile_definitions(test_UDPv4Tests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(test_UDPv4Tests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
@@ -357,7 +357,7 @@ add_gtest(test_UDPv4Tests SOURCES ${TEST_UDPV4TESTS_SOURCE})
 set(TRANSPORT_XFAIL_LIST ${TRANSPORT_XFAIL_LIST} XFAIL_TEST_UDP4)
 
 add_executable(TCPv4Tests ${TCPV4TESTS_SOURCE})
-target_compile_definitions(TCPv4Tests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(TCPv4Tests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
@@ -389,7 +389,7 @@ set(TRANSPORT_XFAIL_LIST ${TRANSPORT_XFAIL_LIST} XFAIL_TCP4)
 if(IS_THIRDPARTY_BOOST_OK)
     add_executable(SharedMemTests ${SHAREDMEMTESTS_SOURCE})
 
-    target_compile_definitions(SharedMemTests PRIVATE FASTRTPS_NO_LIB
+    target_compile_definitions(SharedMemTests PRIVATE
         BOOST_ASIO_STANDALONE
         ASIO_STANDALONE
         $<$<BOOL:${WIN32}>:_ENABLE_ATOMIC_ALIGNMENT_FIX>

--- a/test/unittest/utils/CMakeLists.txt
+++ b/test/unittest/utils/CMakeLists.txt
@@ -53,7 +53,7 @@ set(SYSTEMINFOTESTS_SOURCE
 include_directories(mock/)
 
 add_executable(StringMatchingTests ${STRINGMATCHINGTESTS_SOURCE})
-target_compile_definitions(StringMatchingTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(StringMatchingTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -69,7 +69,7 @@ add_gtest(StringMatchingTests SOURCES ${STRINGMATCHINGTESTS_SOURCE})
 
 
 add_executable(FixedSizeStringTests ${FIXEDSIZESTRINGTESTS_SOURCE})
-target_compile_definitions(FixedSizeStringTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(FixedSizeStringTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -80,7 +80,7 @@ add_gtest(FixedSizeStringTests SOURCES ${FIXEDSIZESTRINGTESTS_SOURCE})
 
 
 add_executable(BitmapRangeTests ${BITMAPRANGETESTS_SOURCE})
-target_compile_definitions(BitmapRangeTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(BitmapRangeTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -91,7 +91,7 @@ add_gtest(BitmapRangeTests SOURCES ${BITMAPRANGETESTS_SOURCE})
 
 
 add_executable(ResourceLimitedVectorTests ${RESOURCELIMITEDVECTORTESTS_SOURCE})
-target_compile_definitions(ResourceLimitedVectorTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(ResourceLimitedVectorTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -101,7 +101,7 @@ target_link_libraries(ResourceLimitedVectorTests GTest::gtest ${MOCKS})
 add_gtest(ResourceLimitedVectorTests SOURCES ${RESOURCELIMITEDVECTORTESTS_SOURCE})
 
 add_executable(LocatorTests ${LOCATORTESTS_SOURCE})
-target_compile_definitions(LocatorTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(LocatorTests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
@@ -129,14 +129,12 @@ if(NOT(EPROSIMA_BUILD))
 endif()
 
 add_executable(FixedSizeQueueTests ${FIXEDSIZEQUEUETESTS_SOURCE})
-target_compile_definitions(FixedSizeQueueTests PRIVATE FASTRTPS_NO_LIB)
 target_include_directories(FixedSizeQueueTests PRIVATE
     ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/cpp ${PROJECT_BINARY_DIR}/include)
 target_link_libraries(FixedSizeQueueTests GTest::gtest ${MOCKS})
 add_gtest(FixedSizeQueueTests SOURCES ${FIXEDSIZEQUEUETESTS_SOURCE})
 
 add_executable(SystemInfoTests ${SYSTEMINFOTESTS_SOURCE})
-target_compile_definitions(SystemInfoTests PRIVATE FASTRTPS_NO_LIB)
 target_include_directories(SystemInfoTests PRIVATE
     ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/cpp ${PROJECT_BINARY_DIR}/include)
 target_link_libraries(SystemInfoTests GTest::gtest)

--- a/test/unittest/xmlparser/CMakeLists.txt
+++ b/test/unittest/xmlparser/CMakeLists.txt
@@ -134,7 +134,7 @@ if(TINYXML2_INCLUDE_DIR)
 endif(TINYXML2_INCLUDE_DIR)
 
 add_executable(XMLProfileParserTests ${XMLPROFILEPARSER_SOURCE})
-target_compile_definitions(XMLProfileParserTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(XMLProfileParserTests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
@@ -233,7 +233,7 @@ if(ANDROID)
 endif()
 
 add_executable(XMLParserTests ${XMLPARSER_SOURCE})
-target_compile_definitions(XMLParserTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(XMLParserTests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
@@ -281,7 +281,7 @@ if(ANDROID)
 endif()
 
 add_executable(XMLTreeTests ${XMLTREE_SOURCE})
-target_compile_definitions(XMLTreeTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(XMLTreeTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
@@ -366,7 +366,7 @@ if(ANDROID)
 endif()
 
 add_executable(XMLEndpointParserTests ${XMLENDPOINTPARSERTESTS_SOURCE})
-target_compile_definitions(XMLEndpointParserTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(XMLEndpointParserTests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     )

--- a/test/unittest/xtypes/CMakeLists.txt
+++ b/test/unittest/xtypes/CMakeLists.txt
@@ -72,7 +72,7 @@ endif()
 include_directories(mock/)
 
 add_executable(XTypesTests ${XTYPES_TEST_SOURCE})
-target_compile_definitions(XTypesTests PRIVATE FASTRTPS_NO_LIB
+target_compile_definitions(XTypesTests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Unit tests that use public headers exporting DLL symbols require FASTRTPS_NO_LIB to be defined in order to avoid the auto-link of the library, which might be counter-intuitive.

This PR adds that definition to the build flags on the CMakeLists.txt of the root `test/unittest` folder and removes it from the CMakeLists.txt of the individual tests.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- **N/A** The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- **N/A** Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
