### PR TITLE
[19590] Change history remove change return statement

### DIFF
--- a/include/fastdds/rtps/history/History.h
+++ b/include/fastdds/rtps/history/History.h
@@ -322,6 +322,10 @@ protected:
     RTPS_DllAPI virtual void do_release_cache(
             CacheChange_t* ch) = 0;
 
+    //! Remove history iterator constness
+    History::iterator remove_iterator_constness(
+            const_iterator c_it);
+
 };
 
 } // namespace rtps

--- a/include/fastdds/rtps/history/History.h
+++ b/include/fastdds/rtps/history/History.h
@@ -322,7 +322,15 @@ protected:
     RTPS_DllAPI virtual void do_release_cache(
             CacheChange_t* ch) = 0;
 
-    //! Remove history iterator constness
+    /**
+     * @brief Removes the constness of a const_iterator to obtain a regular iterator.
+     *
+     * This function takes a const_iterator as input and returns a regular iterator by removing the constness.
+     *
+     * @param c_it The const_iterator to remove constness from.
+     *
+     * @return An iterator with the same position as the input const_iterator.
+     */
     History::iterator remove_iterator_constness(
             const_iterator c_it);
 

--- a/src/cpp/rtps/history/History.cpp
+++ b/src/cpp/rtps/history/History.cpp
@@ -264,7 +264,7 @@ History::iterator History::remove_iterator_constness(
         const_iterator c_it)
 {
     History::iterator it = changesBegin();
-    std::advance(it, std::distance<const_iterator>(it, c_it));
+    std::advance(it, std::distance<const_iterator>(m_changes.cbegin(), c_it));
     return it;
 }
 

--- a/src/cpp/rtps/history/History.cpp
+++ b/src/cpp/rtps/history/History.cpp
@@ -131,6 +131,7 @@ bool History::remove_change(
         return false;
     }
 
+    // Dummy change just used to compare original change with change returned from remove_change_nts function
     CacheChange_t dummy_change;
     dummy_change.writerGUID = (*it)->writerGUID;
     dummy_change.sequenceNumber = (*it)->sequenceNumber;
@@ -262,7 +263,7 @@ bool History::get_earliest_change(
 History::iterator History::remove_iterator_constness(
         const_iterator c_it)
 {
-    History::iterator it;
+    History::iterator it = changesBegin();
     std::advance(it, std::distance<const_iterator>(it, c_it));
     return it;
 }

--- a/src/cpp/rtps/history/History.cpp
+++ b/src/cpp/rtps/history/History.cpp
@@ -74,7 +74,7 @@ History::iterator History::remove_change_nts(
 {
     if (nullptr == mp_mutex)
     {
-        return changesEnd();
+        return remove_iterator_constness(removal);
     }
 
     if (removal == changesEnd())
@@ -124,16 +124,29 @@ bool History::remove_change(
 #endif // if HAVE_STRICT_REALTIME
 
     const_iterator it = find_change_nts(ch);
-    const_iterator end_it = changesEnd();
 
-    if (it == end_it)
+    if (it == changesEnd())
     {
         EPROSIMA_LOG_INFO(RTPS_WRITER_HISTORY, "Trying to remove a change not in history");
         return false;
     }
 
-    // remove using the virtual method
-    return end_it != remove_change_nts(it, max_blocking_time);
+    CacheChange_t dummy_change;
+    dummy_change.writerGUID = (*it)->writerGUID;
+    dummy_change.sequenceNumber = (*it)->sequenceNumber;
+
+    // Remove using the virtual method
+    History::iterator history_it = remove_change_nts(it, max_blocking_time);
+
+    // If remove_change_nts returns a valid iterator (not end()) and this is the same iterator means that it
+    // could not remove it so this function should fail
+    if (history_it != changesEnd() && matches_change(&dummy_change, *history_it))
+    {
+        EPROSIMA_LOG_INFO(RTPS_WRITER_HISTORY, "Failed to remove a change from history");
+        return false;
+    }
+
+    return true;
 }
 
 bool History::remove_all_changes()
@@ -244,6 +257,14 @@ bool History::get_earliest_change(
 
     *change = m_changes.front();
     return true;
+}
+
+History::iterator History::remove_iterator_constness(
+        const_iterator c_it)
+{
+    History::iterator it;
+    std::advance(it, std::distance<const_iterator>(it, c_it));
+    return it;
 }
 
 } // namespace rtps

--- a/src/cpp/rtps/history/ReaderHistory.cpp
+++ b/src/cpp/rtps/history/ReaderHistory.cpp
@@ -131,14 +131,14 @@ History::iterator ReaderHistory::remove_change_nts(
         const_iterator removal,
         bool release)
 {
-    if ( mp_reader == nullptr || mp_mutex == nullptr)
+    if (mp_reader == nullptr || mp_mutex == nullptr)
     {
         EPROSIMA_LOG_ERROR(RTPS_WRITER_HISTORY,
                 "You need to create a Writer with this History before removing any changes");
-        return changesEnd();
+        return remove_iterator_constness(removal);
     }
 
-    if ( removal == changesEnd())
+    if (removal == changesEnd())
     {
         EPROSIMA_LOG_INFO(RTPS_WRITER_HISTORY, "Trying to remove without a proper CacheChange_t referenced");
         return changesEnd();

--- a/src/cpp/rtps/history/WriterHistory.cpp
+++ b/src/cpp/rtps/history/WriterHistory.cpp
@@ -188,7 +188,7 @@ History::iterator WriterHistory::remove_change_nts(
         return remove_iterator_constness(removal);
     }
 
-    if ( removal == changesEnd())
+    if (removal == changesEnd())
     {
         EPROSIMA_LOG_INFO(RTPS_WRITER_HISTORY, "Trying to remove without a proper CacheChange_t referenced");
         return changesEnd();
@@ -212,7 +212,9 @@ History::iterator WriterHistory::remove_change_nts(
         return ret_val;
     }
 
-    return changesEnd();
+    EPROSIMA_LOG_INFO(RTPS_WRITER_HISTORY,
+            "Failed to inform the writer that a change is going to be removed by the history");
+    return remove_iterator_constness(removal);
 }
 
 bool WriterHistory::remove_change_g(

--- a/src/cpp/rtps/history/WriterHistory.cpp
+++ b/src/cpp/rtps/history/WriterHistory.cpp
@@ -185,7 +185,7 @@ History::iterator WriterHistory::remove_change_nts(
     {
         EPROSIMA_LOG_ERROR(RTPS_WRITER_HISTORY,
                 "You need to create a Writer with this History before removing any changes");
-        return changesEnd();
+        return remove_iterator_constness(removal);
     }
 
     if ( removal == changesEnd())

--- a/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
@@ -1058,6 +1058,7 @@ TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1Data300Kb)
 {
     PubSubReader<Data1mbPubSubType> reader(TEST_TOPIC_NAME);
     PubSubWriter<Data1mbPubSubType> writer(TEST_TOPIC_NAME);
+    auto transport = std::make_shared<UDPv4TransportDescriptor>();
 
     auto data = default_data300kb_data_generator();
     auto reader_data = data;
@@ -1066,6 +1067,7 @@ TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1Data300Kb)
             .history_depth(static_cast<int32_t>(data.size()))
             .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
             .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
+            .disable_builtin_transport().add_user_transport_to_pparams(transport)
             .mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(writer.isInitialized());
@@ -1080,6 +1082,7 @@ TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1Data300Kb)
             .history_depth(1)
             .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
             .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
+            .disable_builtin_transport().add_user_transport_to_pparams(transport)
             .mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(reader.isInitialized());

--- a/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
+++ b/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
@@ -147,6 +147,11 @@ public:
         return m_changes.cend();
     }
 
+    iterator changesEnd()
+    {
+        return m_changes.end();
+    }
+
     virtual iterator remove_change_nts(
             const_iterator removal,
             bool release = true)
@@ -175,6 +180,22 @@ public:
     {
         static_cast<void>(writer_guid);
         static_cast<void>(ownership_strength);
+    }
+
+    bool matches_change(
+            const CacheChange_t* inner_change,
+            CacheChange_t* outer_change)
+    {
+        return inner_change->sequenceNumber == outer_change->sequenceNumber &&
+               inner_change->writerGUID == outer_change->writerGUID;
+    }
+
+    iterator remove_iterator_constness(
+            const_iterator c_it)
+    {
+        iterator it = m_changes.begin();
+        std::advance(it, std::distance<const_iterator>(it, c_it));
+        return it;
     }
 
     HistoryAttributes m_att;

--- a/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
+++ b/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
@@ -194,7 +194,7 @@ public:
             const_iterator c_it)
     {
         iterator it = m_changes.begin();
-        std::advance(it, std::distance<const_iterator>(it, c_it));
+        std::advance(it, std::distance<const_iterator>(m_changes.cbegin(), c_it));
         return it;
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

`History::remove_change` return statement was based on the fact that `remove_change_nts` return a `History::iterator` different than `end` iteration. However, `remove_change_nts` was also calling `erase` method and this will return the iterator pointing to the next element of the collection or `end` if that was the last element. Therefore, `remove_change_nts` could return `end` iterator and still be the expected result. 

This PR updates two main functions:

- `remove_change_nts`. This function will return the same iterator in case it could not remove the change.
- `History::remove_change`. This function will check if the change pointed by the iterator returned by `remove_change_nts` is the expected one (next iterator in the History colection) or not (same iterator).

This PR also expects to solve the following issue rising in Windows platforms testing any Fast DDS dependent software compiled in Debug mode.

```
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.35.32215\include\vector(192) : Assertion failed: vector iterators incompatible
```

This can be tested using any of the following tests in Fast DDS (only in Windows platforms and Debug cmake build type):

```
The following tests FAILED:
         88 - BlackboxTests_DDS_PIM.DDSBasic.MultithreadedPublisherCreation (Exit code 0xc0000409)
         89 - BlackboxTests_DDS_PIM.DDSBasic.MultithreadedReaderCreationDoesNotDeadlock (Exit code 0xc0000409)
         90 - BlackboxTests_DDS_PIM.DDSBasic.PidRelatedSampleIdentity (Exit code 0xc0000409)
         91 - BlackboxTests_DDS_PIM.DDSBasic.IgnoreParticipant (Exit code 0xc0000409)
         92 - BlackboxTests_DDS_PIM.DDSBasic.participant_ignore_local_endpoints (Exit code 0xc0000409)
         94 - BlackboxTests_DDS_PIM.DDSBasic.endpoint_custom_payload_pools (Exit code 0xc0000409)
```

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.11.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- *N/A* Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- *N/A* Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- *N/A* Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
