### PR TITLE
Fix heap-use-after-free on XMLElementParser.cpp

### DIFF
--- a/.github/workflows/sanitizer-tests.yaml
+++ b/.github/workflows/sanitizer-tests.yaml
@@ -27,6 +27,9 @@ jobs:
 
     runs-on: ubuntu-22.04
 
+    env:
+        FASTDDS_BRANCH: ${{ github.head_ref || github.event.inputs.fastdds_branch || 'master' }}
+
     steps:
       - uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
         with:
@@ -39,7 +42,7 @@ jobs:
       - uses: eProsima/eProsima-CI/ubuntu/get_file_from_repo@v0
         with:
           source_repository: eProsima/Fast-DDS
-          source_repository_branch: ${{ github.head_ref || github.event.inputs.fastdds_branch || 'master' }}
+          source_repository_branch: ${{ env.FASTDDS_BRANCH }}
           file_name: fastrtps.repos
           file_result: fastrtps.repos
 
@@ -48,6 +51,11 @@ jobs:
         with:
           vcs_repos_file: fastrtps.repos
           destination_workspace: src
+
+      - name: Checkout Fast DDS branch
+        run: |
+          cd ./src/fastrtps
+          git checkout ${{ env.FASTDDS_BRANCH }}
 
       - name: Install apt packages
         uses: ./src/fastrtps/.github/actions/install-apt-packages
@@ -100,6 +108,10 @@ jobs:
 
     runs-on: ubuntu-22.04
 
+    env:
+      FASTDDS_BRANCH: ${{ github.head_ref || github.event.inputs.fastdds_branch || 'master' }}
+      DEFAULT_DISCOVERY_SERVER_BRANCH: ${{ github.event.inputs.discovery_server_branch || 'master' }}
+
     steps:
       - uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
         with:
@@ -112,7 +124,7 @@ jobs:
       - uses: eProsima/eProsima-CI/ubuntu/get_file_from_repo@v0
         with:
           source_repository: eProsima/Fast-DDS
-          source_repository_branch: ${{ github.head_ref || github.event.inputs.fastdds_branch || 'master' }}
+          source_repository_branch: ${{ env.FASTDDS_BRANCH }}
           file_name: fastrtps.repos
           file_result: fastrtps.repos
 
@@ -122,14 +134,17 @@ jobs:
           vcs_repos_file: fastrtps.repos
           destination_workspace: src
 
+      - name: Checkout Fast DDS branch
+        run: |
+          cd ./src/fastrtps
+          git checkout ${{ env.FASTDDS_BRANCH }}
+
       - name: Sync eProsima/Discovery-Server repository
         uses: actions/checkout@v4
-        env:
-          DEFAULT_DISCOVERY_SERVER_BRANCH: 'master'
         with:
           path: src/discovery_server
           repository: eProsima/Discovery-Server
-          ref: ${{ github.event.inputs.discovery_server_branch || env.DEFAULT_DISCOVERY_SERVER_BRANCH }}
+          ref: ${{ env.DEFAULT_DISCOVERY_SERVER_BRANCH }}
 
       - name: Install apt packages
         uses: ./src/fastrtps/.github/actions/install-apt-packages

--- a/src/cpp/rtps/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLElementParser.cpp
@@ -84,15 +84,16 @@ static std::string process_environment(
         std::regex_search(ret_val, match, expression);
         if (!match.empty())
         {
+            std::string var_name = match[1];
             std::string value;
-            if (ReturnCode_t::RETCODE_OK == SystemInfo::get_env(match[1], value))
+            if (ReturnCode_t::RETCODE_OK == SystemInfo::get_env(var_name, value))
             {
                 ret_val = match.prefix().str() + value + match.suffix().str();
             }
             else
             {
                 ret_val = match.prefix().str() + match.suffix().str();
-                EPROSIMA_LOG_ERROR(XMLPARSER, "Could not find a value for environment variable " << match[1]);
+                EPROSIMA_LOG_ERROR(XMLPARSER, "Could not find a value for environment variable " << var_name);
             }
         }
     } while (!match.empty());


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This fixes an error on #3841 detected by the asan job, due to a submatch being used after modifying the original input string.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.11.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- **N/A** Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
