### PR TITLE
[19642] Use STL implementation of Timed/RecursiveTimedMutex when MSVC >= 19.36

### DIFF
--- a/include/fastrtps/utils/TimedMutex.hpp
+++ b/include/fastrtps/utils/TimedMutex.hpp
@@ -31,7 +31,7 @@
 extern int clock_gettime(
         int,
         struct timespec* tv);
-#endif
+#endif // if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 193632528
 
 #elif _GTHREAD_USE_MUTEX_TIMEDLOCK
 #include <mutex>
@@ -194,7 +194,7 @@ private:
 
     _Mtx_t mutex_;
 };
-#endif
+#endif // if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 193632528
 
 #elif _GTHREAD_USE_MUTEX_TIMEDLOCK || !defined(__unix__)
 using TimedMutex = std::timed_mutex;

--- a/include/fastrtps/utils/TimedMutex.hpp
+++ b/include/fastrtps/utils/TimedMutex.hpp
@@ -23,10 +23,16 @@
 #include <iostream>
 
 #if defined(_WIN32)
+
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 193632528
+#include <mutex>
+#else
 #include <thread>
 extern int clock_gettime(
         int,
         struct timespec* tv);
+#endif
+
 #elif _GTHREAD_USE_MUTEX_TIMEDLOCK
 #include <mutex>
 #else
@@ -38,14 +44,12 @@ namespace fastrtps {
 
 #if defined(_WIN32)
 
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 193632528
+using TimedMutex = std::timed_mutex;
+using RecursiveTimedMutex = std::recursive_timed_mutex;
+#else
 class TimedMutex
 {
-    // On MSVC 19.36.32528.95 `xtime` was changed into `_timespec64`.
-    // See https://github.com/eProsima/Fast-DDS/issues/3451
-    // See https://github.com/microsoft/STL/pull/3594
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 193632528
-    using xtime = _timespec64;
-#endif  // _MSC_FULL_VER check
 
 public:
 
@@ -190,6 +194,8 @@ private:
 
     _Mtx_t mutex_;
 };
+#endif
+
 #elif _GTHREAD_USE_MUTEX_TIMEDLOCK || !defined(__unix__)
 using TimedMutex = std::timed_mutex;
 using RecursiveTimedMutex = std::recursive_timed_mutex;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR changes to the the STL implementation the Timed/RecursiveTimedMutex in MSVC >= 19.36.

_Note: Tested compilation against 19.37.32824.0_

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
Fixes #3783 
Fixes #3829

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
 **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
**N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
**N/A**  New feature has been added to the `versions.md` file (if applicable).
**N/A**  New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [X] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
