### PR TITLE
Fix the clang build for clang 14.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,6 @@ else()
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-psabi")
         set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-builtins")
         set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl")
     endif()
 


### PR DESCRIPTION
clang 14 does not understand -Wno-deprecated-builtins, which causes problems trying to compile Fast-DDS on Ubuntu 22.04

This has been causing ROS 2 CI to fail for a few days now: https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/1669/

<!-- Provide a general summary of your changes in the Title above -->

## Description

Remove the unsupported `-Wno-deprecated-builtins` flag.

It may be the case that we want to port this to other branches as well; I leave it up to the maintainers to decide.


## Contributor Checklist
- [x] Commit messages follow the project guidelines.
- [x] The code follows the style guidelines of this project.
- [N/A] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [N/A] Any new/modified methods have been properly documented using Doxygen.
- [N/A] Changes are ABI compatible.
- [N/A] Changes are API compatible.
- [N/A] New feature has been added to the `versions.md` file (if applicable).
- [N/A ] New feature has been documented/Current behavior is correctly described in the documentation.
- [X] Applicable backports have been included in the description.

## Reviewer Checklist
- [ ] The PR has a milestone assigned.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.