### PR TITLE
Fix remote locators filtering when whitelist provided

### DIFF
--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -179,7 +179,7 @@ void BuiltinProtocols::filter_server_remote_locators(
         LocatorList_t allowed_locators;
         for (Locator_t& loc : rs.metatrafficUnicastLocatorList)
         {
-            if (nf.is_locator_allowed(loc))
+            if (!nf.is_local_locator(loc) || nf.is_locator_allowed(loc))
             {
                 allowed_locators.push_back(loc);
             }

--- a/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
@@ -1201,7 +1201,7 @@ void ReaderProxyData::set_remote_unicast_locators(
     remote_locators_.unicast.clear();
     for (const Locator_t& locator : locators)
     {
-        if (network.is_locator_allowed(locator))
+        if (!network.is_local_locator(locator) || network.is_locator_allowed(locator))
         {
             remote_locators_.add_unicast_locator(locator);
         }
@@ -1221,7 +1221,7 @@ void ReaderProxyData::set_multicast_locators(
     remote_locators_.multicast.clear();
     for (const Locator_t& locator : locators)
     {
-        if (network.is_locator_allowed(locator))
+        if (!network.is_local_locator(locator) || network.is_locator_allowed(locator))
         {
             remote_locators_.add_multicast_locator(locator);
         }
@@ -1244,7 +1244,7 @@ void ReaderProxyData::set_remote_locators(
 
     for (const Locator_t& locator : locators.unicast)
     {
-        if (network.is_locator_allowed(locator))
+        if (!network.is_local_locator(locator) || network.is_locator_allowed(locator))
         {
             remote_locators_.add_unicast_locator(locator);
         }
@@ -1254,7 +1254,7 @@ void ReaderProxyData::set_remote_locators(
     {
         for (const Locator_t& locator : locators.multicast)
         {
-            if (network.is_locator_allowed(locator))
+            if (!network.is_local_locator(locator) || network.is_locator_allowed(locator))
             {
                 remote_locators_.add_multicast_locator(locator);
             }

--- a/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.cpp
@@ -1172,7 +1172,7 @@ void WriterProxyData::set_remote_unicast_locators(
     remote_locators_.unicast.clear();
     for (const Locator_t& locator : locators)
     {
-        if (network.is_locator_allowed(locator))
+        if (!network.is_local_locator(locator) || network.is_locator_allowed(locator))
         {
             remote_locators_.add_unicast_locator(locator);
         }
@@ -1192,7 +1192,7 @@ void WriterProxyData::set_multicast_locators(
     remote_locators_.multicast.clear();
     for (const Locator_t& locator : locators)
     {
-        if (network.is_locator_allowed(locator))
+        if (!network.is_local_locator(locator) || network.is_locator_allowed(locator))
         {
             remote_locators_.add_multicast_locator(locator);
         }
@@ -1215,7 +1215,7 @@ void WriterProxyData::set_remote_locators(
 
     for (const Locator_t& locator : locators.unicast)
     {
-        if (network.is_locator_allowed(locator))
+        if (!network.is_local_locator(locator) || network.is_locator_allowed(locator))
         {
             remote_locators_.add_unicast_locator(locator);
         }
@@ -1225,7 +1225,7 @@ void WriterProxyData::set_remote_locators(
     {
         for (const Locator_t& locator : locators.multicast)
         {
-            if (network.is_locator_allowed(locator))
+            if (!network.is_local_locator(locator) || network.is_locator_allowed(locator))
             {
                 remote_locators_.add_multicast_locator(locator);
             }

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -347,7 +347,7 @@ bool PDPSimple::createPDPEndpoints()
             LocatorList_t fixed_locators;
             for (const Locator_t& loc : mp_builtin->m_initialPeersList)
             {
-                if (network.is_locator_allowed(loc))
+                if (!network.is_local_locator(loc) || network.is_locator_allowed(loc))
                 {
                     // Add initial peers locator without transformation as we don't know whether the
                     // remote transport will allow localhost


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
PR https://github.com/eProsima/Fast-DDS/pull/3733 introduced a regression in which remote locators were being wrongly discarded when a whitelist is provided. In particular, the PR replaced several calls to `transform_remote_locator` (which for a remote locator performs no transformation and always return true irrespective of whether a whitelist is provided) by `is_locator_allowed` (which discards remote locators when a whitelist is provided).
This PR fixes the issue by checking if a locator is remote before going through the `is_locator_allowed` filter (every place where `transform_remote_locator`->`is_locator_allowed` change was introduced).
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.11.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- **N/A** Applicable backports have been included in the description.


## Reviewer Checklist
- [ ] The PR has a milestone assigned.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
