### PR TITLE
[19769] Add tests for reconnection with same GUID

### DIFF
--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -1401,6 +1401,13 @@ public:
         return *this;
     }
 
+    PubSubWriter& guid_prefix(
+            const eprosima::fastrtps::rtps::GuidPrefix_t& prefix)
+    {
+        participant_qos_.wire_protocol().prefix = prefix;
+        return *this;
+    }
+
     PubSubWriter& participant_id(
             int32_t participantId)
     {

--- a/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
@@ -1298,8 +1298,6 @@ public:
         return matched_;
     }
 
-private:
-
     const eprosima::fastrtps::rtps::GUID_t& participant_guid() const
     {
         return participant_guid_;

--- a/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
@@ -1145,6 +1145,13 @@ public:
         return *this;
     }
 
+    PubSubReader& guid_prefix(
+            const eprosima::fastrtps::rtps::GuidPrefix_t& prefix)
+    {
+        participant_attr_.rtps.prefix = prefix;
+        return *this;
+    }
+
     PubSubReader& participant_id(
             int32_t participantId)
     {

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
@@ -1150,6 +1150,13 @@ public:
         return *this;
     }
 
+    PubSubWriter& guid_prefix(
+            const eprosima::fastrtps::rtps::GuidPrefix_t& prefix)
+    {
+        participant_attr_.rtps.prefix = prefix;
+        return *this;
+    }
+
     PubSubWriter& participant_id(
             int32_t participantId)
     {

--- a/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
@@ -824,6 +824,25 @@ TEST_P(PubSubBasic, ReliableVolatileTwoWritersConsecutives)
     }
 }
 
+TEST_P(PubSubBasic, ReliableVolatileTwoWritersConsecutivesSameGuid)
+{
+    PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+
+    reader.history_depth(10).reliability(RELIABLE_RELIABILITY_QOS).init();
+    EXPECT_TRUE(reader.isInitialized());
+
+    auto reader_prefix = reader.participant_guid().guidPrefix;
+    auto writer_prefix = reader_prefix;
+    writer_prefix.value[11] = 0xFF;
+
+    for (int i = 0; i < 2; ++i)
+    {
+        PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+        writer.history_depth(10).durability_kind(VOLATILE_DURABILITY_QOS).guid_prefix(writer_prefix);
+        two_consecutive_writers(reader, writer, true);
+    }
+}
+
 TEST_P(PubSubBasic, ReliableTransientLocalTwoWritersConsecutives)
 {
     PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -517,6 +517,87 @@ TEST_P(Security, BuiltinAuthenticationPlugin_second_participant_creation_loop)
     EXPECT_EQ(0u, n_logs);
 }
 
+TEST_P(Security, BuiltinAuthenticationPlugin_ensure_same_guid_reconnection)
+{
+    constexpr size_t n_loops = 10;
+
+    using Log = eprosima::fastdds::dds::Log;
+    using LogConsumer = eprosima::fastdds::dds::LogConsumer;
+
+    // A LogConsumer that just counts the number of entries consumed
+    struct TestConsumer : public LogConsumer
+    {
+        TestConsumer(
+                std::atomic_size_t& n_logs_ref)
+            : n_logs_(n_logs_ref)
+        {
+        }
+
+        void Consume(
+                const Log::Entry&) override
+        {
+            ++n_logs_;
+        }
+
+    private:
+
+        std::atomic_size_t& n_logs_;
+    };
+
+    // Counter for log entries
+    std::atomic<size_t>n_logs{};
+
+    // Prepare Log module to check that no SECURITY errors are produced
+    Log::SetCategoryFilter(std::regex("SECURITY"));
+    Log::SetVerbosity(Log::Kind::Error);
+    Log::ClearConsumers();
+    Log::RegisterConsumer(std::unique_ptr<LogConsumer>(new TestConsumer(n_logs)));
+
+    // Prepare participant properties
+    PropertyPolicy property_policy;
+    property_policy.properties().emplace_back(Property("dds.sec.auth.plugin", "builtin.PKI-DH"));
+    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
+            "file://" + std::string(certs_path) + "/maincacert.pem"));
+    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
+            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
+    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
+            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+
+    // Create the participant being checked
+    PubSubWriter<HelloWorldPubSubType> main_participant("HelloWorldTopic");
+    main_participant.property_policy(property_policy).init();
+    EXPECT_TRUE(main_participant.isInitialized());
+
+    eprosima::fastrtps::rtps::GuidPrefix_t guid_prefix;
+    memset(guid_prefix.value, 0xBB, sizeof(guid_prefix.value));
+
+    // Perform a loop in which we create another participant, and destroy it just after it has been discovered.
+    // This is the best reproducer of the issue, as authentication messages should be sent when a remote participant
+    // is discovered.
+    for (size_t n = 1; n <= n_loops; ++n)
+    {
+        std::cout << "Iteration " << n << std::endl;
+
+        // Wait for undiscovery so we can wait for discovery below
+        EXPECT_TRUE(main_participant.wait_participant_undiscovery());
+
+        // Create another participant with authentication enabled and custom GUID
+        PubSubReader<HelloWorldPubSubType> other_participant("HelloWorldTopic");
+        other_participant.property_policy(property_policy).guid_prefix(guid_prefix).init();
+        EXPECT_TRUE(other_participant.isInitialized());
+
+        // Wait for mutual discovery and authentication
+        main_participant.wait_discovery();
+        other_participant.wait_discovery();
+
+        // The created participant gets out of scope here, and is destroyed
+    }
+
+    // No SECURITY error logs should have been produced
+    Log::Flush();
+    EXPECT_EQ(0u, n_logs);
+}
+
 TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_rtps_ok)
 {
     PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds two blackbox tests to check that a participant with a fixed GUID prefix is re-discovered when it is re-created, both with and without security.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
