### PR TITLE
[19354] Add XML parser bit_bound bounds check

### DIFF
--- a/src/cpp/rtps/xmlparser/XMLDynamicParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLDynamicParser.cpp
@@ -616,12 +616,12 @@ XMLP_ret XMLParser::parseXMLBitmaskDynamicType(
     const char* anno_bit_bound = p_root->Attribute(BIT_BOUND);
     if (anno_bit_bound != nullptr)
     {
-        bit_bound = static_cast<uint16_t>(std::atoi(anno_bit_bound));
-    }
-
-    if (bit_bound < 1 || bit_bound > 64)
-    {
-        return XMLP_ret::XML_ERROR;
+        auto input_bit_bound = std::atoi(anno_bit_bound);
+        if (input_bit_bound < 1 || input_bit_bound > 64)
+        {
+            return XMLP_ret::XML_ERROR;
+        }
+        bit_bound = static_cast<uint16_t>(input_bit_bound);
     }
 
     const char* name = p_root->Attribute(NAME);

--- a/src/cpp/rtps/xmlparser/XMLDynamicParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLDynamicParser.cpp
@@ -619,6 +619,11 @@ XMLP_ret XMLParser::parseXMLBitmaskDynamicType(
         bit_bound = static_cast<uint16_t>(std::atoi(anno_bit_bound));
     }
 
+    if (bit_bound < 1 || bit_bound > 64)
+    {
+        return XMLP_ret::XML_ERROR;
+    }
+
     const char* name = p_root->Attribute(NAME);
     if (nullptr == name)
     {

--- a/src/cpp/rtps/xmlparser/XMLDynamicParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLDynamicParser.cpp
@@ -625,7 +625,7 @@ XMLP_ret XMLParser::parseXMLBitmaskDynamicType(
     }
 
     const char* name = p_root->Attribute(NAME);
-    if (nullptr == name)
+    if (nullptr == name || name[0] == '\0')
     {
         return XMLP_ret::XML_ERROR;
     }

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -61,6 +61,7 @@ TEST_F(XMLParserTests, regressions)
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/14456_profile_bin.xml", root));
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/15344_profile_bin.xml", root));
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/18395_profile_bin.xml", root));
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/19354_profile_bin.xml", root));
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/simple_participant_profiles_nok.xml", root));
     EXPECT_EQ(XMLP_ret::XML_OK, XMLParser::loadXML("regressions/simple_participant_profiles_ok.xml", root));
 }

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -62,6 +62,7 @@ TEST_F(XMLParserTests, regressions)
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/15344_profile_bin.xml", root));
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/18395_profile_bin.xml", root));
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/19354_profile_bin.xml", root));
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/19354_2_profile_bin.xml", root));
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/simple_participant_profiles_nok.xml", root));
     EXPECT_EQ(XMLP_ret::XML_OK, XMLParser::loadXML("regressions/simple_participant_profiles_ok.xml", root));
 }

--- a/test/unittest/xmlparser/regressions/19354_2_profile_bin.xml
+++ b/test/unittest/xmlparser/regressions/19354_2_profile_bin.xml
@@ -1,0 +1,1 @@
+<types><type><bitmask bit_bound="2" name=""/></type></types>

--- a/test/unittest/xmlparser/regressions/19354_profile_bin.xml
+++ b/test/unittest/xmlparser/regressions/19354_profile_bin.xml
@@ -1,1 +1,1 @@
-<types><type><bitmask bit_bound="-2"name=""/></type></types>
+<types><type><bitmask bit_bound="-2" name=""/></type></types>

--- a/test/unittest/xmlparser/regressions/19354_profile_bin.xml
+++ b/test/unittest/xmlparser/regressions/19354_profile_bin.xml
@@ -1,0 +1,1 @@
+<types><type><bitmask bit_bound="-2"name=""/></type></types>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Bit mask's bit bound attribute can be set to values out of expected bounds (0 < bit_bound < 65) through XML configuration. This PR add a check in XML parser to avoid it.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A**  New feature has been added to the `versions.md` file (if applicable).
- **N/A**  New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
