### PR TITLE
Fix: mac address overflow on windows

### DIFF
--- a/src/cpp/utils/IPFinder.cpp
+++ b/src/cpp/utils/IPFinder.cpp
@@ -265,7 +265,7 @@ bool IPFinder::getAllMACAddress(
         if (aa->OperStatus == 1) //is ENABLED
         {
             info_MAC mac;
-            memcpy(mac.address, aa->PhysicalAddress, std::min(6UL, aa->PhysicalAddressLength));
+            memcpy(mac.address, aa->PhysicalAddress, (std::min)(6UL, aa->PhysicalAddressLength));
 
             if (std::find(macs->begin(), macs->end(), mac) == macs->end())
             {

--- a/src/cpp/utils/IPFinder.cpp
+++ b/src/cpp/utils/IPFinder.cpp
@@ -265,7 +265,7 @@ bool IPFinder::getAllMACAddress(
         if (aa->OperStatus == 1) //is ENABLED
         {
             info_MAC mac;
-            memcpy(mac.address, aa->PhysicalAddress, aa->PhysicalAddressLength);
+            memcpy(mac.address, aa->PhysicalAddress, std::min(6UL, aa->PhysicalAddressLength));
 
             if (std::find(macs->begin(), macs->end(), mac) == macs->end())
             {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This pull request fixed #3982: Mac address overflow in `IPFinder::getAllMACAddress()` on Windows.

`IP_ADAPTER_ADDRESSES::PhysicalAddressLength` will get max up to 8 bytes, but we have only 6 bytes for mac address.

In some case, `GetAdaptersAddresses()` will report address with `PhysicalAddressLength=8`, e.g. "Microsoft Teredo Tunneling Adapter", which will cause crash at `DomainParticipantFactory::create_participant()`. All 8 bytes of `IP_ADAPTER_ADDRESSES::PhysicalAddress` here are `0` in this situation, so use minimal length 6 does not affect the result.

This bug fix could be backported to older versions.

This fix is valid for all versions since `v2.6.6` up to `master`, older versions not checked yet. It should be merged to all branches having `IPFinder::getAllMACAddress()`.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.11.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] ~~New feature has been added to the `versions.md` file (if applicable).~~
  - No new feature added.
- [ ] ~~New feature has been documented/Current behavior is correctly described in the documentation.~~ <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
  - No new feature added.
- [X] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
