### PR TITLE
[19869] SHM transport: ignore non-existing segment on pop

### DIFF
--- a/src/cpp/rtps/transport/shared_mem/SharedMemChannelResource.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemChannelResource.hpp
@@ -109,7 +109,7 @@ public:
         }
         catch (const std::exception& e)
         {
-            EPROSIMA_LOG_WARNING(RTPS_MSG_IN, e.what());
+            EPROSIMA_LOG_WARNING(RTPS_TRANSPORT_SHM, e.what());
         }
     }
 
@@ -150,7 +150,7 @@ private:
             }
             else if (alive())
             {
-                EPROSIMA_LOG_WARNING(RTPS_MSG_IN, "Received Message, but no receiver attached");
+                EPROSIMA_LOG_WARNING(RTPS_TRANSPORT_SHM, "Received Message, but no receiver attached");
             }
 
             // Forces message release before waiting for the next
@@ -184,8 +184,9 @@ protected:
         catch (const std::exception& error)
         {
             (void)error;
-            EPROSIMA_LOG_WARNING(RTPS_MSG_OUT, "Error receiving data: " << error.what() << " - " << message_receiver()
-                                                                        << " (" << this << ")");
+            EPROSIMA_LOG_WARNING(RTPS_TRANSPORT_SHM,
+                    "Error receiving data: " << error.what() << " - " << message_receiver()
+                                             << " (" << this << ")");
             return nullptr;
         }
     }

--- a/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
@@ -736,6 +736,11 @@ public:
                     global_port_->pop(*global_listener_, was_cell_freed);
 
                     auto segment = shared_mem_manager_->find_segment(buffer_descriptor.source_segment_id);
+                    if (!segment)
+                    {
+                        // Descriptor points to non-existing segment: discard
+                        continue;
+                    }
                     auto buffer_node =
                             static_cast<BufferNode*>(segment->get_address_from_offset(buffer_descriptor.
                                     buffer_node_offset));
@@ -1305,7 +1310,14 @@ private:
         else // Is a new segment
         {
             auto segment_name = global_segment_.domain_name() + "_" + id.to_string();
-            segment = std::make_shared<SharedMemSegment>(boost::interprocess::open_only, segment_name);
+            try
+            {
+                segment = std::make_shared<SharedMemSegment>(boost::interprocess::open_only, segment_name);
+            }
+            catch (std::exception&)
+            {
+                return segment;
+            }
             auto segment_wrapper = std::make_shared<SegmentWrapper>(shared_from_this(), segment, id, segment_name);
 
             ids_segments_[id.get()] = segment_wrapper;

--- a/test/blackbox/common/BlackboxTestsTransportSHM.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportSHM.cpp
@@ -19,7 +19,11 @@
 #include "PubSubReader.hpp"
 #include "PubSubWriter.hpp"
 
+#include "./mock/BlackboxMockConsumer.h"
+
 #include <gtest/gtest.h>
+
+#include <fastdds/dds/log/Log.hpp>
 
 #include <rtps/transport/shared_mem/test_SharedMemTransportDescriptor.h>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
@@ -68,6 +72,78 @@ TEST(SHM, TransportPubSub)
 
     // Check that reader receives the unmatched.
     reader.wait_participant_undiscovery();
+}
+
+// Regression test for redmine #19500
+TEST(SHM, IgnoreNonExistentSegment)
+{
+    using namespace eprosima::fastdds::dds;
+
+    // Set up log
+    BlackboxMockConsumer* helper_consumer = new BlackboxMockConsumer();
+    Log::ClearConsumers();  // Remove default consumers
+    Log::RegisterConsumer(std::unique_ptr<LogConsumer>(helper_consumer)); // Registering a consumer transfer ownership
+    // Filter specific message
+    Log::SetVerbosity(eprosima::fastdds::dds::Log::Kind::Warning);
+    Log::SetCategoryFilter(std::regex("RTPS_TRANSPORT_SHM"));
+    Log::SetErrorStringFilter(std::regex("Error receiving data.*"));
+
+    PubSubReader<Data1mbPubSubType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<Data1mbPubSubType> writer(TEST_TOPIC_NAME);
+
+    writer
+            .asynchronously(eprosima::fastrtps::SYNCHRONOUS_PUBLISH_MODE)
+            .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+            .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
+            .history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS)
+            .disable_builtin_transport()
+            .add_user_transport_to_pparams(std::make_shared<SharedMemTransportDescriptor>())
+            .init();
+    ASSERT_TRUE(writer.isInitialized());
+
+    reader
+            .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+            .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
+            .history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS)
+            .disable_builtin_transport()
+            .add_user_transport_to_pparams(std::make_shared<SharedMemTransportDescriptor>())
+            .init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    reader.wait_discovery();
+
+    // Create and quickly destroy several participants
+    std::thread other_participant_thread([]()
+            {
+                constexpr size_t num_parts = 2;
+                for (size_t i = 0; i < num_parts; ++i)
+                {
+                    PubSubWriter<Data1mbPubSubType> late_writer(TEST_TOPIC_NAME);
+                    late_writer
+                            .asynchronously(eprosima::fastrtps::SYNCHRONOUS_PUBLISH_MODE)
+                            .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+                            .disable_builtin_transport()
+                            .add_user_transport_to_pparams(std::make_shared<SharedMemTransportDescriptor>())
+                            .init();
+                    ASSERT_TRUE(late_writer.isInitialized());
+                }
+            });
+
+    // Destroy the writer participant.
+    writer.destroy();
+
+    // Check that reader receives the unmatched.
+    reader.wait_participant_undiscovery();
+
+    other_participant_thread.join();
+
+    // Check logs
+    Log::Flush();
+    EXPECT_EQ(helper_consumer->ConsumedEntries().size(), 0);
+
+    // Clean-up
+    Log::Reset();  // This calls to ClearConsumers, which deletes the registered consumer
 }
 
 TEST(SHM, Test300KFragmentation)

--- a/test/blackbox/common/BlackboxTestsTransportSHM.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportSHM.cpp
@@ -119,9 +119,9 @@ TEST(SHM, IgnoreNonExistentSegment)
     {
         threads.push_back(std::thread([]()
                 {
-                        constexpr size_t num_parts = 10;
-                        for (size_t i = 0; i < num_parts; ++i)
-                        {
+                    constexpr size_t num_parts = 10;
+                    for (size_t i = 0; i < num_parts; ++i)
+                    {
                         PubSubWriter<Data1mbPubSubType> late_writer(TEST_TOPIC_NAME);
                         late_writer
                                 .asynchronously(eprosima::fastrtps::SYNCHRONOUS_PUBLISH_MODE)
@@ -130,7 +130,7 @@ TEST(SHM, IgnoreNonExistentSegment)
                                 .add_user_transport_to_pparams(std::make_shared<SharedMemTransportDescriptor>())
                                 .init();
                         ASSERT_TRUE(late_writer.isInitialized());
-                        }
+                    }
                 }));
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR avoids an ` Error receiving data: No such file or directory` warning when processing a descriptor for which the segment does not exist anymore.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.11.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [ ] Applicable backports have been included in the description.
    -  Not sure if we can backport this completely, since I have changed the category of some warnings, which can be considered a behavior change


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
