### PR TITLE
[19870] PubSubAsReliable test fix 

### DIFF
--- a/include/fastdds/rtps/transport/test_UDPv4TransportDescriptor.h
+++ b/include/fastdds/rtps/transport/test_UDPv4TransportDescriptor.h
@@ -38,7 +38,7 @@ struct test_UDPv4TransportDescriptor : public SocketTransportDescriptor
 
     //! Test shim parameters
     //! Percentage of data messages being dropped
-    uint8_t dropDataMessagesPercentage;
+    mutable std::atomic<uint8_t> dropDataMessagesPercentage;
     //! Filtering function for dropping data messages
     filter drop_data_messages_filter_;
     //! Flag to enable dropping of discovery Participant DATA(P) messages
@@ -48,24 +48,24 @@ struct test_UDPv4TransportDescriptor : public SocketTransportDescriptor
     //! Flag to enable dropping of discovery Reader DATA(R) messages
     bool dropSubscriptionBuiltinTopicData;
     //! Percentage of data fragments being dropped
-    uint8_t dropDataFragMessagesPercentage;
+    mutable std::atomic<uint8_t> dropDataFragMessagesPercentage;
     //! Filtering function for dropping data fragments messages
     filter drop_data_frag_messages_filter_;
     //! Percentage of heartbeats being dropped
-    uint8_t dropHeartbeatMessagesPercentage;
+    mutable std::atomic<uint8_t> dropHeartbeatMessagesPercentage;
     //! Filtering function for dropping heartbeat messages
     filter drop_heartbeat_messages_filter_;
     //! Percentage of AckNacks being dropped
-    uint8_t dropAckNackMessagesPercentage;
+    mutable std::atomic<uint8_t> dropAckNackMessagesPercentage;
     //! Filtering function for dropping AckNacks
     filter drop_ack_nack_messages_filter_;
     //! Percentage of gap messages being dropped
-    uint8_t dropGapMessagesPercentage;
+    mutable std::atomic<uint8_t> dropGapMessagesPercentage;
     //! Filtering function for dropping gap messages
     filter drop_gap_messages_filter_;
 
     // General drop percentage (indiscriminate)
-    uint8_t percentageOfMessagesToDrop;
+    mutable std::atomic<uint8_t> percentageOfMessagesToDrop;
     // General filtering function for all kind of messages (indiscriminate)
     filter messages_filter_;
 

--- a/src/cpp/rtps/transport/test_UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.cpp
@@ -492,7 +492,7 @@ bool test_UDPv4Transport::log_drop(
 bool test_UDPv4Transport::should_be_dropped(
         PercentageData* percent)
 {
-    percent->accumulator += percent->percentage;
+    percent->accumulator += percent->percentage.load();
     if (percent->accumulator >= 100u)
     {
         percent->accumulator -= 100u;

--- a/src/cpp/rtps/transport/test_UDPv4Transport.h
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.h
@@ -73,13 +73,13 @@ private:
     struct PercentageData
     {
         PercentageData(
-                uint8_t percent)
+                std::atomic<uint8_t>& percent)
             : percentage(percent)
             , accumulator(0)
         {
         }
 
-        uint8_t percentage;
+        std::atomic<uint8_t>& percentage;
         uint8_t accumulator;
     };
 

--- a/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
@@ -992,6 +992,11 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepLastWithKeyUnorderedReception)
     writer.send(data);
     ASSERT_TRUE(data.empty());
 
+    reader.block_for_at_least(keys * depth * 0.1);
+
+    //! Avoid dropping determiniscally the same re-sent samples
+    testTransport->dropDataMessagesPercentage.store(10);
+
     reader.block_for_all();
     reader.stopReception();
 }

--- a/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
@@ -994,7 +994,7 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepLastWithKeyUnorderedReception)
 
     reader.block_for_at_least(static_cast<size_t>(keys * depth * 0.1));
 
-    //! Avoid dropping determiniscally the same re-sent samples
+    //! Avoid dropping deterministically the same re-sent samples
     testTransport->dropDataMessagesPercentage.store(10);
 
     reader.block_for_all();

--- a/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
@@ -992,7 +992,7 @@ TEST_P(PubSubHistory, PubSubAsReliableKeepLastWithKeyUnorderedReception)
     writer.send(data);
     ASSERT_TRUE(data.empty());
 
-    reader.block_for_at_least(keys * depth * 0.1);
+    reader.block_for_at_least(static_cast<size_t>(keys * depth * 0.1));
 
     //! Avoid dropping determiniscally the same re-sent samples
     testTransport->dropDataMessagesPercentage.store(10);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

The `PubSubHistory/PubSubHistory.PubSubAsReliableKeepLastWithKeyUnorderedReception` consistently fails if it is launched with `taskset -c 2 [command]` (which makes the test to run in one core). The reason is that the `drop data percentage` deterministically drop every 1 out of 5 DATA packages sent (User endpoints only, discovery traffic endpoints are not considered, so any change in the discovery settings results in no effect).

The changes let the `test_UDPTransportDescriptor` percentages to be dynamically updated, and proposes a fix for the test which consists in varying the drop percentage after having received some packets.

Note: The complete launch command is `taskset -c 2 ./BlackboxTests_DDS_PIM --gtest_filter=PubSubHistory/PubSubHistory.PubSubAsReliableKeepLastWithKeyUnorderedReception/Transport_PREALLOCATED`

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [X] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
