### PR TITLE
[19913] Make `test_UDPv4TransportDescriptor` non-copyable and non-moveable

### DIFF
--- a/include/fastdds/rtps/transport/test_UDPv4TransportDescriptor.h
+++ b/include/fastdds/rtps/transport/test_UDPv4TransportDescriptor.h
@@ -99,11 +99,11 @@ struct test_UDPv4TransportDescriptor : public SocketTransportDescriptor
 
     //! Move constructor
     RTPS_DllAPI test_UDPv4TransportDescriptor(
-            test_UDPv4TransportDescriptor&& t) = default;
+            test_UDPv4TransportDescriptor&& t) = delete;
 
     //! Move assignment
     RTPS_DllAPI test_UDPv4TransportDescriptor& operator =(
-            test_UDPv4TransportDescriptor&& t) = default;
+            test_UDPv4TransportDescriptor&& t) = delete;
 
     //! Comparison operator
     // Filters are not included

--- a/include/fastdds/rtps/transport/test_UDPv4TransportDescriptor.h
+++ b/include/fastdds/rtps/transport/test_UDPv4TransportDescriptor.h
@@ -91,11 +91,19 @@ struct test_UDPv4TransportDescriptor : public SocketTransportDescriptor
 
     //! Copy constructor
     RTPS_DllAPI test_UDPv4TransportDescriptor(
-            const test_UDPv4TransportDescriptor& t) = default;
+            const test_UDPv4TransportDescriptor& t) = delete;
 
     //! Copy assignment
     RTPS_DllAPI test_UDPv4TransportDescriptor& operator =(
-            const test_UDPv4TransportDescriptor& t) = default;
+            const test_UDPv4TransportDescriptor& t) = delete;
+
+    //! Move constructor
+    RTPS_DllAPI test_UDPv4TransportDescriptor(
+            test_UDPv4TransportDescriptor&& t) = default;
+
+    //! Move assignment
+    RTPS_DllAPI test_UDPv4TransportDescriptor& operator =(
+            test_UDPv4TransportDescriptor&& t) = default;
 
     //! Comparison operator
     // Filters are not included


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
PR #3994 was merged with warnings in Mac. This PR fixes those warnings by deleting the copy/move constructor/assignment from `test_UDPv4TransportDescriptor`.

**Note:** Since backports of #3994 have not yet been merged, it would be a good idea to cherry pick the only commit in this PR to those backports.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.11.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- **NO** Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
    - Though changes are not API compatible, the transport descriptor is only used for testing purposes, and it is always constructed with `std::make_shared`, so nothing should break
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.
    - See note, above. Backports will be done manually


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
