### PR TITLE
[19967] Define a super client by environment variable 

### DIFF
--- a/include/fastdds/dds/log/Log.hpp
+++ b/include/fastdds/dds/log/Log.hpp
@@ -255,7 +255,7 @@ protected:
         Log::QueueLog(fastdds_log_ss_tmp__.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, Log::Kind::Error); \
     } while (0)
 
-#elif (_INTERNALDEBUG)
+#elif (__INTERNALDEBUG || _INTERNALDEBUG)
 
 #define EPROSIMA_LOG_ERROR_IMPL_(cat, msg)                          \
     do {                                                        \
@@ -289,7 +289,7 @@ protected:
         }                                                                                                           \
     } while (0)
 
-#elif (_INTERNALDEBUG)
+#elif (__INTERNALDEBUG || _INTERNALDEBUG)
 
 #define EPROSIMA_LOG_WARNING_IMPL_(cat, msg)                        \
     do {                                                        \
@@ -328,7 +328,7 @@ protected:
         }                                                                                               \
     } while (0)
 
-#elif (_INTERNALDEBUG)
+#elif (__INTERNALDEBUG || _INTERNALDEBUG)
 
 #define EPROSIMA_LOG_INFO_IMPL_(cat, msg)                       \
     do {                                                    \

--- a/include/fastdds/dds/log/Log.hpp
+++ b/include/fastdds/dds/log/Log.hpp
@@ -255,7 +255,7 @@ protected:
         Log::QueueLog(fastdds_log_ss_tmp__.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, Log::Kind::Error); \
     } while (0)
 
-#elif (__INTERNALDEBUG || _INTERNALDEBUG)
+#elif (_INTERNALDEBUG)
 
 #define EPROSIMA_LOG_ERROR_IMPL_(cat, msg)                          \
     do {                                                        \
@@ -289,7 +289,7 @@ protected:
         }                                                                                                           \
     } while (0)
 
-#elif (__INTERNALDEBUG || _INTERNALDEBUG)
+#elif (_INTERNALDEBUG)
 
 #define EPROSIMA_LOG_WARNING_IMPL_(cat, msg)                        \
     do {                                                        \
@@ -328,7 +328,7 @@ protected:
         }                                                                                               \
     } while (0)
 
-#elif (__INTERNALDEBUG || _INTERNALDEBUG)
+#elif (_INTERNALDEBUG)
 
 #define EPROSIMA_LOG_INFO_IMPL_(cat, msg)                       \
     do {                                                    \

--- a/include/fastdds/rtps/attributes/ServerAttributes.h
+++ b/include/fastdds/rtps/attributes/ServerAttributes.h
@@ -178,6 +178,8 @@ const char* const DEFAULT_ROS2_SERVER_GUIDPREFIX = "44.53.00.5f.45.50.52.4f.53.4
  */
 const char* const DEFAULT_ROS2_MASTER_URI = "ROS_DISCOVERY_SERVER";
 
+const char* const ROS_SUPER_CLIENT = "ROS_SUPER_CLIENT";
+
 /**
  * Retrieves a semicolon-separated list of locators from a string, and
  * populates a RemoteServerList_t mapping list position to default guid.
@@ -211,6 +213,8 @@ RTPS_DllAPI bool load_environment_server_info(
  */
 RTPS_DllAPI const std::string& ros_discovery_server_env();
 
+RTPS_DllAPI bool ros_super_client_env();
+
 /**
  * Returns the guidPrefix associated to the given server id
  * @param[in] id of the default server whose guidPrefix we want to retrieve
@@ -233,9 +237,11 @@ using fastdds::rtps::RemoteServerList_t;
 using fastdds::rtps::DEFAULT_ROS2_SERVER_PORT;
 using fastdds::rtps::DEFAULT_ROS2_SERVER_GUIDPREFIX;
 using fastdds::rtps::DEFAULT_ROS2_MASTER_URI;
+using fastdds::rtps::ROS_SUPER_CLIENT;
 using fastdds::rtps::load_environment_server_info;
 using fastdds::rtps::ros_discovery_server_env;
 using fastdds::rtps::get_server_client_default_guidPrefix;
+using fastdds::rtps::ros_super_client_env;
 
 } // fastrtps
 } // rtps

--- a/include/fastdds/rtps/attributes/ServerAttributes.h
+++ b/include/fastdds/rtps/attributes/ServerAttributes.h
@@ -178,6 +178,13 @@ const char* const DEFAULT_ROS2_SERVER_GUIDPREFIX = "44.53.00.5f.45.50.52.4f.53.4
  */
 const char* const DEFAULT_ROS2_MASTER_URI = "ROS_DISCOVERY_SERVER";
 
+/* Environment variable to transform a SIMPLE participant in a SUPER CLIENT.
+ * If the participant is not SIMPLE, the variable doesn't have any effects.
+ * The variable can assume the following values:
+ *    - FALSE, false, False, 0
+ *    - TRUE, true, True, 1
+ * If the variable is not set, the program will behave like the variable is set to false.
+ */
 const char* const ROS_SUPER_CLIENT = "ROS_SUPER_CLIENT";
 
 /**
@@ -213,6 +220,10 @@ RTPS_DllAPI bool load_environment_server_info(
  */
 RTPS_DllAPI const std::string& ros_discovery_server_env();
 
+/**
+ * Get the value of environment variable ROS_SUPER_CLIENT
+ * @return The value of environment variable ROS_SUPER_CLIENT. False if the variable is not defined.
+ */
 RTPS_DllAPI bool ros_super_client_env();
 
 /**

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -537,8 +537,6 @@ RTPSParticipant* RTPSDomainImpl::clientServerEnvironmentCreationOverride(
         const RTPSParticipantAttributes& att,
         RTPSParticipantListener* listen)
 {
-    bool set_super_client = ros_super_client_env();
-
     // Check the specified discovery protocol: if other than simple it has priority over ros environment variable
     if (att.builtin.discovery_config.discoveryProtocol != DiscoveryProtocol_t::SIMPLE)
     {

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -579,6 +579,7 @@ RTPSParticipant* RTPSDomainImpl::clientServerEnvironmentCreationOverride(
     client_att.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::CLIENT;
     // RemoteServerAttributes already fill in above
 
+    // Check if the client must become a super client
     if (ros_super_client_env())
     {
         client_att.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SUPER_CLIENT;

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -537,6 +537,9 @@ RTPSParticipant* RTPSDomainImpl::clientServerEnvironmentCreationOverride(
         const RTPSParticipantAttributes& att,
         RTPSParticipantListener* listen)
 {
+    bool set_super_client = ros_super_client_env();
+    std::cout << "*** ROS_SUPER_CLIENT: " << set_super_client << std::endl;
+
     // Check the specified discovery protocol: if other than simple it has priority over ros environment variable
     if (att.builtin.discovery_config.discoveryProtocol != DiscoveryProtocol_t::SIMPLE)
     {

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -582,6 +582,16 @@ RTPSParticipant* RTPSDomainImpl::clientServerEnvironmentCreationOverride(
     client_att.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::CLIENT;
     // RemoteServerAttributes already fill in above
 
+    if (ros_super_client_env())
+    {
+        client_att.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SUPER_CLIENT;
+        std::cout << "entered4 *** ROS_SUPER_CLIENT: TRUE" << std::endl;
+    }
+    else
+    {
+        std::cout << "entered4 *** ROS_SUPER_CLIENT: FALSE" << std::endl;
+    }
+
     RTPSParticipant* part = createParticipant(domain_id, enabled, client_att, listen);
     if (nullptr != part)
     {

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -538,7 +538,6 @@ RTPSParticipant* RTPSDomainImpl::clientServerEnvironmentCreationOverride(
         RTPSParticipantListener* listen)
 {
     bool set_super_client = ros_super_client_env();
-    std::cout << "*** ROS_SUPER_CLIENT: " << set_super_client << std::endl;
 
     // Check the specified discovery protocol: if other than simple it has priority over ros environment variable
     if (att.builtin.discovery_config.discoveryProtocol != DiscoveryProtocol_t::SIMPLE)
@@ -585,11 +584,6 @@ RTPSParticipant* RTPSDomainImpl::clientServerEnvironmentCreationOverride(
     if (ros_super_client_env())
     {
         client_att.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SUPER_CLIENT;
-        std::cout << "entered4 *** ROS_SUPER_CLIENT: TRUE" << std::endl;
-    }
-    else
-    {
-        std::cout << "entered4 *** ROS_SUPER_CLIENT: FALSE" << std::endl;
     }
 
     RTPSParticipant* part = createParticipant(domain_id, enabled, client_att, listen);

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -939,26 +939,18 @@ bool ros_super_client_env()
     SystemInfo::get_env(ROS_SUPER_CLIENT, super_client_str);
     if (super_client_str != "")
     {
-        try
+        if (find(true_vec.begin(), true_vec.end(), super_client_str) != true_vec.end())
         {
-            if (find(true_vec.begin(), true_vec.end(), super_client_str) != true_vec.end())
-            {
-                super_client = true;
-            }
-            else if (find(false_vec.begin(), false_vec.end(), super_client_str) != false_vec.end())
-            {
-                super_client = false;
-            }
-            else
-            {
-                std::stringstream ss;
-                ss << "Invalid ROS_SUPER_CLIENT argument " << super_client_str;
-                throw std::invalid_argument(ss.str());
-            }
+            super_client = true;
         }
-        catch (std::exception& e)
+        else if (find(false_vec.begin(), false_vec.end(), super_client_str) != false_vec.end())
         {
-            EPROSIMA_LOG_ERROR(SERVER_CLIENT_DISCOVERY, e.what());
+            super_client = false;
+        }
+        else
+        {
+            std::string ss = "Invalid ROS_SUPER_CLIENT argument";
+            EPROSIMA_LOG_ERROR(SERVER_CLIENT_DISCOVERY, ss);
         }
     }
     return super_client;

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -949,8 +949,8 @@ bool ros_super_client_env()
         }
         else
         {
-            std::string ss = "Invalid ROS_SUPER_CLIENT argument";
-            EPROSIMA_LOG_ERROR(SERVER_CLIENT_DISCOVERY, ss);
+            EPROSIMA_LOG_ERROR(RTPS_PDP,
+                    "Invalid value for ROS_SUPER_CLIENT environment variable : " << super_client_str);
         }
     }
     return super_client;

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -929,6 +929,41 @@ void PDPClient::match_pdp_reader_nts_(
     }
 }
 
+bool ros_super_client_env()
+{
+    std::string super_client_str;
+    bool super_client = false;
+    std::vector<std::string> true_vec = {"TRUE", "true", "True", "1"};
+    std::vector<std::string> false_vec = {"FALSE", "false", "False", "0"};
+
+    SystemInfo::get_env(ROS_SUPER_CLIENT, super_client_str);
+    if (super_client_str != "")
+    {
+        try
+        {
+            if (find(true_vec.begin(), true_vec.end(), super_client_str) != true_vec.end())
+            {
+                super_client = true;
+            }
+            else if (find(false_vec.begin(), false_vec.end(), super_client_str) != false_vec.end())
+            {
+                super_client = false;
+            }
+            else
+            {
+                std::stringstream ss;
+                ss << "Invalid ROS_SUPER_CLIENT argument " << super_client_str;
+                throw std::invalid_argument(ss.str());
+            }
+        }
+        catch (std::exception& e)
+        {
+            EPROSIMA_LOG_ERROR(SERVER_CLIENT_DISCOVERY, e.what());
+        }
+    }
+    return super_client;
+}
+
 const std::string& ros_discovery_server_env()
 {
     static std::string servers;

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -877,6 +877,95 @@ TEST(ParticipantTests, SimpleParticipantRemoteServerListConfiguration)
 
 
 /**
+ * Test that a SIMPLE participant is transformed into a CLIENT if the variable ROS_SUPER_CLIENT is false and into a SUPERCLIENT if it's true.
+ * It also checks that the environment variable has priority over the coded QoS settings.
+ */
+TEST(ParticipantTests, TransformSimpleParticipantToSuperclientByEnvVariable)
+{
+    set_environment_variable();
+
+#ifdef _WIN32
+    ASSERT_EQ(0, _putenv_s(rtps::ROS_SUPER_CLIENT, "false"));
+#else
+    ASSERT_EQ(0, setenv(rtps::ROS_SUPER_CLIENT, "false", 1));
+#endif // _WIN32
+
+    rtps::RemoteServerList_t output;
+    rtps::RemoteServerList_t qos_output;
+    expected_remote_server_list_output(output);
+
+    DomainParticipantQos qos;
+    set_participant_qos(qos, qos_output);
+
+    DomainParticipant* participant = DomainParticipantFactory::get_instance()->create_participant(
+        (uint32_t)GET_PID() % 230, qos);
+    ASSERT_NE(nullptr, participant);
+
+    fastrtps::rtps::RTPSParticipantAttributes attributes;
+    get_rtps_attributes(participant, attributes);
+    EXPECT_EQ(attributes.builtin.discovery_config.discoveryProtocol, fastrtps::rtps::DiscoveryProtocol::CLIENT);
+    EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, output);
+
+#ifdef _WIN32
+    ASSERT_EQ(0, _putenv_s(rtps::ROS_SUPER_CLIENT, "true"));
+#else
+    ASSERT_EQ(0, setenv(rtps::ROS_SUPER_CLIENT, "true", 1));
+#endif // _WIN32
+
+    DomainParticipant* participant_2 = DomainParticipantFactory::get_instance()->create_participant(
+        (uint32_t)GET_PID() % 230, qos);
+    ASSERT_NE(nullptr, participant_2);
+
+    fastrtps::rtps::RTPSParticipantAttributes attributes_2;
+    get_rtps_attributes(participant_2, attributes_2);
+    EXPECT_EQ(attributes_2.builtin.discovery_config.discoveryProtocol, fastrtps::rtps::DiscoveryProtocol::SUPER_CLIENT);
+    EXPECT_EQ(attributes_2.builtin.discovery_config.m_DiscoveryServers, output);
+
+    // check UDPv6 transport is there
+    auto udpv6_check = [](fastrtps::rtps::RTPSParticipantAttributes& attributes) -> bool
+            {
+                for (auto& transportDescriptor : attributes.userTransports)
+                {
+                    if ( nullptr != dynamic_cast<fastdds::rtps::UDPv6TransportDescriptor*>(transportDescriptor.get()))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            };
+    EXPECT_TRUE(udpv6_check(attributes));
+
+    DomainParticipantQos result_qos = participant->get_qos();
+    EXPECT_EQ(result_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers, qos_output);
+    EXPECT_EQ(ReturnCode_t::RETCODE_OK, participant->set_qos(result_qos));
+
+    // check UDPv6 transport is there
+    auto udpv6_check_2 = [](fastrtps::rtps::RTPSParticipantAttributes& attributes_2) -> bool
+            {
+                for (auto& transportDescriptor : attributes_2.userTransports)
+                {
+                    if ( nullptr != dynamic_cast<fastdds::rtps::UDPv6TransportDescriptor*>(transportDescriptor.get()))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            };
+    EXPECT_TRUE(udpv6_check_2(attributes_2));
+
+    result_qos = participant_2->get_qos();
+    EXPECT_EQ(result_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers, qos_output);
+    EXPECT_EQ(ReturnCode_t::RETCODE_OK, participant_2->set_qos(result_qos));
+
+    EXPECT_EQ(ReturnCode_t::RETCODE_OK, DomainParticipantFactory::get_instance()->delete_participant(participant));
+    EXPECT_EQ(ReturnCode_t::RETCODE_OK, DomainParticipantFactory::get_instance()->delete_participant(participant_2));
+}
+
+
+
+/**
  * Test that:
  * + checks a SIMPLE participant is transformed into a CLIENT.
  * + the environment variable resolves DNS inputs adding both IPv4 and IPv6 locators


### PR DESCRIPTION
<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Define a super client setting a new environment variable ROS_SUPER_CLIENT
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.12.x 2.11.x 2.10.x 2.6.x


## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally; test case: eProsima/Discovery-Server#65 <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    Related documentation PR: eProsima/Fast-DDS-docs#596
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
