### PR TITLE
[20017] Fix warning in Mac rewarding unnecessary lambda capture

### DIFF
--- a/test/blackbox/common/BlackboxTestsTransportSHM.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportSHM.cpp
@@ -116,16 +116,19 @@ TEST(SHM, IgnoreNonExistentSegment)
     // Create and quickly destroy several participants in several threads
 #ifdef _WIN32
     constexpr size_t num_threads = 1;
-    constexpr size_t num_parts = 2;
 #else
     constexpr size_t num_threads = 10;
-    constexpr size_t num_parts = 10;
 #endif  // _WIN32
     std::vector<std::thread> threads;
     for (size_t i = 0; i < num_threads; i++)
     {
-        threads.push_back(std::thread([num_parts]()
+        threads.push_back(std::thread([]()
                 {
+#ifdef _WIN32
+                    constexpr size_t num_parts = 2;
+#else
+                    constexpr size_t num_parts = 10;
+#endif  // _WIN32
                     for (size_t i = 0; i < num_parts; ++i)
                     {
                         PubSubWriter<Data1mbPubSubType> late_writer(TEST_TOPIC_NAME);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR fixes a warning introduced by #4036.

**Backport note:** Since #4036 has not yet been backported (to 2.12.x), it would be a nice idea to backport it along with this one.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.11.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
