### PR TITLE
[19587] Use `SO_EXCLUSIVEADDRUSE` for Win32 unicast listening sockets

### DIFF
--- a/src/cpp/rtps/transport/UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/UDPv4Transport.cpp
@@ -305,6 +305,13 @@ eProsimaUDPSocket UDPv4Transport::OpenAndBindInputSocket(
                     ASIO_OS_DEF(SOL_SOCKET), SO_REUSEPORT>(true));
 #endif // if defined(__QNX__)
     }
+    else
+    {
+#if defined(_WIN32)
+        getSocketPtr(socket)->set_option(asio::detail::socket_option::integer<
+                    ASIO_OS_DEF(SOL_SOCKET), SO_EXCLUSIVEADDRUSE>(1));
+#endif // if defined(_WIN32)
+    }
 
     getSocketPtr(socket)->bind(generate_endpoint(sIp, port));
     return socket;

--- a/src/cpp/rtps/transport/UDPv6Transport.cpp
+++ b/src/cpp/rtps/transport/UDPv6Transport.cpp
@@ -308,6 +308,13 @@ eProsimaUDPSocket UDPv6Transport::OpenAndBindInputSocket(
                     ASIO_OS_DEF(SOL_SOCKET), SO_REUSEPORT>(true));
 #endif // if defined(__QNX__)
     }
+    else
+    {
+#if defined(_WIN32)
+        getSocketPtr(socket)->set_option(asio::detail::socket_option::integer<
+                    ASIO_OS_DEF(SOL_SOCKET), SO_EXCLUSIVEADDRUSE>(1));
+#endif // if defined(_WIN32)
+    }
 
     getSocketPtr(socket)->bind(generate_endpoint(sIp, port));
 

--- a/test/blackbox/common/BlackboxTestsNetworkConf.cpp
+++ b/test/blackbox/common/BlackboxTestsNetworkConf.cpp
@@ -546,6 +546,37 @@ TEST_P(NetworkConfig, PubGetSendingLocatorsWhitelist)
     }
 }
 
+// Regression test for redmine issue #19587
+TEST_P(NetworkConfig, double_binding_fails)
+{
+    PubSubReader<HelloWorldPubSubType> p1(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> p2(TEST_TOPIC_NAME);
+
+    // Create a participant without whitelist
+    p1.disable_builtin_transport().add_user_transport_to_pparams(descriptor_);
+    p1.init();
+    ASSERT_TRUE(p1.isInitialized());
+
+    // Add the announced addresses to the interface whitelist
+    LocatorList_t locators_p1;
+    p1.get_native_reader().get_listening_locators(locators_p1);
+    for (const auto& loc : locators_p1)
+    {
+        descriptor_->interfaceWhiteList.push_back(IPLocator::ip_to_string(loc));
+    }
+
+    // Try to listen on the same locators as the first participant
+    p2.disable_builtin_transport().add_user_transport_to_pparams(descriptor_);
+    p2.set_default_unicast_locators(locators_p1);
+    p2.init();
+    ASSERT_TRUE(p2.isInitialized());
+
+    // Should be listening on different locators
+    LocatorList_t locators_p2;
+    p2.get_native_reader().get_listening_locators(locators_p2);
+    EXPECT_FALSE(locators_p1 == locators_p2);
+}
+
 #ifdef INSTANTIATE_TEST_SUITE_P
 #define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_SUITE_P(x, y, z, w)
 #else

--- a/test/unittest/transport/UDPv4Tests.cpp
+++ b/test/unittest/transport/UDPv4Tests.cpp
@@ -704,6 +704,27 @@ TEST_F(UDPv4Tests, simple_throughput)
             , std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count() / (num_samples_per_batch * 1000.0));
 }
 
+// Regression test for redmine issue #19587
+TEST_F(UDPv4Tests, double_binding_fails)
+{
+    auto whitelist_descriptor = descriptor;
+    whitelist_descriptor.interfaceWhiteList.emplace_back("127.0.0.1");
+
+    UDPv4Transport default_transport(descriptor);
+    UDPv4Transport whitelist_transport(whitelist_descriptor);
+
+    Locator_t locator;
+    IPLocator::createLocator(LOCATOR_KIND_UDPv4, "127.0.0.1", g_default_port, locator);
+
+    MockReceiverResource whitelist_receiver(whitelist_transport, locator);
+    EXPECT_TRUE(whitelist_receiver.is_valid());
+    EXPECT_TRUE(whitelist_transport.IsInputChannelOpen(locator));
+
+    MockReceiverResource default_receiver(default_transport, locator);
+    EXPECT_FALSE(default_receiver.is_valid());
+    EXPECT_FALSE(default_transport.IsInputChannelOpen(locator));
+}
+
 void UDPv4Tests::HELPER_SetDescriptorDefaults()
 {
     descriptor.maxMessageSize = 5;

--- a/test/unittest/transport/UDPv6Tests.cpp
+++ b/test/unittest/transport/UDPv6Tests.cpp
@@ -745,6 +745,27 @@ TEST_F(UDPv6Tests, simple_throughput)
             , std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count() / (num_samples_per_batch * 1000.0));
 }
 
+// Regression test for redmine issue #19587
+TEST_F(UDPv6Tests, double_binding_fails)
+{
+    auto whitelist_descriptor = descriptor;
+    whitelist_descriptor.interfaceWhiteList.emplace_back("::1");
+
+    UDPv6Transport default_transport(descriptor);
+    UDPv6Transport whitelist_transport(whitelist_descriptor);
+
+    Locator_t locator;
+    IPLocator::createLocator(LOCATOR_KIND_UDPv6, "::1", g_default_port, locator);
+
+    MockReceiverResource whitelist_receiver(whitelist_transport, locator);
+    EXPECT_TRUE(whitelist_receiver.is_valid());
+    EXPECT_TRUE(whitelist_transport.IsInputChannelOpen(locator));
+
+    MockReceiverResource default_receiver(default_transport, locator);
+    EXPECT_FALSE(default_receiver.is_valid());
+    EXPECT_FALSE(default_transport.IsInputChannelOpen(locator));
+}
+
 void UDPv6Tests::HELPER_SetDescriptorDefaults()
 {
     descriptor.maxMessageSize = 5;

--- a/test/unittest/transport/mock/MockReceiverResource.h
+++ b/test/unittest/transport/mock/MockReceiverResource.h
@@ -31,6 +31,10 @@ class MockReceiverResource : public ReceiverResource
 {
 public:
 
+    bool is_valid() const {
+        return mValid;
+    }
+
     virtual void OnDataReceived(
             const octet*,
             const uint32_t,

--- a/test/unittest/transport/mock/MockReceiverResource.h
+++ b/test/unittest/transport/mock/MockReceiverResource.h
@@ -31,7 +31,8 @@ class MockReceiverResource : public ReceiverResource
 {
 public:
 
-    bool is_valid() const {
+    bool is_valid() const
+    {
         return mValid;
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Fixes a bug in Windows where a participant without whitelist ends up listening on the same unicast ports as a participant with whitelist. This made the whitelist participant get the incoming traffic to that port, making the non-whitelist one deaf to it.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.12.x 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
