### PR TITLE
[20049] Bug ReturnCode_t FASTDDS_STATISTICS=OFF

### DIFF
--- a/src/cpp/statistics/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipant.cpp
@@ -20,9 +20,9 @@
 
 #include <string>
 
+#include <fastdds/dds/core/ReturnCode.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
-#include <fastrtps/types/TypesBase.h>
 
 #include <statistics/fastdds/domain/DomainParticipantImpl.hpp>
 
@@ -31,7 +31,7 @@ namespace fastdds {
 namespace statistics {
 namespace dds {
 
-ReturnCode_t DomainParticipant::enable_statistics_datawriter(
+fastdds::dds::ReturnCode_t DomainParticipant::enable_statistics_datawriter(
         const std::string& topic_name,
         const eprosima::fastdds::dds::DataWriterQos& dwqos)
 {
@@ -45,7 +45,7 @@ ReturnCode_t DomainParticipant::enable_statistics_datawriter(
 #endif // FASTDDS_STATISTICS
 }
 
-ReturnCode_t DomainParticipant::enable_statistics_datawriter_with_profile(
+fastdds::dds::ReturnCode_t DomainParticipant::enable_statistics_datawriter_with_profile(
         const std::string& profile_name,
         const std::string& topic_name)
 {
@@ -60,7 +60,7 @@ ReturnCode_t DomainParticipant::enable_statistics_datawriter_with_profile(
 #endif // FASTDDS_STATISTICS
 }
 
-ReturnCode_t DomainParticipant::disable_statistics_datawriter(
+fastdds::dds::ReturnCode_t DomainParticipant::disable_statistics_datawriter(
         const std::string& topic_name)
 {
 #ifndef FASTDDS_STATISTICS


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
ReturnCode_t compilation error when compiling with FASTDDS_STATISTICS=OFF
<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.11.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- N/A Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- N/A Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- N/A Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- N/A Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- N/A New feature has been added to the `versions.md` file (if applicable).
- N/A New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- N/A Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
