### PR TITLE
[20019] Add Autofill port to TCP Transport

### DIFF
--- a/src/cpp/rtps/transport/TCPAcceptor.cpp
+++ b/src/cpp/rtps/transport/TCPAcceptor.cpp
@@ -32,6 +32,7 @@ TCPAcceptor::TCPAcceptor(
     , io_service_(&io_service)
 {
     endpoint_ = asio::ip::tcp::endpoint(parent->generate_protocol(), IPLocator::getPhysicalPort(locator_));
+    locator_.port = acceptor_.local_endpoint().port();
 }
 
 TCPAcceptor::TCPAcceptor(

--- a/src/cpp/rtps/transport/TCPAcceptor.cpp
+++ b/src/cpp/rtps/transport/TCPAcceptor.cpp
@@ -31,8 +31,8 @@ TCPAcceptor::TCPAcceptor(
     , locator_(locator)
     , io_service_(&io_service)
 {
-    endpoint_ = asio::ip::tcp::endpoint(parent->generate_protocol(), IPLocator::getPhysicalPort(locator_));
     locator_.port = acceptor_.local_endpoint().port();
+    endpoint_ = asio::ip::tcp::endpoint(parent->generate_protocol(), IPLocator::getPhysicalPort(locator_));
 }
 
 TCPAcceptor::TCPAcceptor(
@@ -44,6 +44,7 @@ TCPAcceptor::TCPAcceptor(
     , locator_(locator)
     , io_service_(&io_service)
 {
+    locator_.port = acceptor_.local_endpoint().port();
     endpoint_ = asio::ip::tcp::endpoint(asio::ip::address::from_string(interface),
                     IPLocator::getPhysicalPort(locator_));
 }

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -303,7 +303,7 @@ uint16_t TCPTransportInterface::create_acceptor_socket(
                         std::make_shared<TCPAcceptorSecure>(io_service_, this, locator);
                 acceptors_[acceptor->locator()] = acceptor;
                 acceptor->accept(this, ssl_context_);
-                final_port = acceptor->locator().port;
+                final_port = static_cast<uint16_t>(acceptor->locator().port);
             }
             else
 #endif // if TLS_FOUND
@@ -312,7 +312,7 @@ uint16_t TCPTransportInterface::create_acceptor_socket(
                         std::make_shared<TCPAcceptorBasic>(io_service_, this, locator);
                 acceptors_[acceptor->locator()] = acceptor;
                 acceptor->accept(this);
-                final_port = acceptor->locator().port;
+                final_port = static_cast<uint16_t>(acceptor->locator().port);
             }
 
             EPROSIMA_LOG_INFO(RTCP, " OpenAndBindInput (physical: " << IPLocator::getPhysicalPort(
@@ -332,7 +332,7 @@ uint16_t TCPTransportInterface::create_acceptor_socket(
                             std::make_shared<TCPAcceptorSecure>(io_service_, sInterface, locator);
                     acceptors_[acceptor->locator()] = acceptor;
                     acceptor->accept(this, ssl_context_);
-                    final_port = acceptor->locator().port;
+                    final_port = static_cast<uint16_t>(acceptor->locator().port);
                 }
                 else
 #endif // if TLS_FOUND
@@ -341,7 +341,7 @@ uint16_t TCPTransportInterface::create_acceptor_socket(
                             std::make_shared<TCPAcceptorBasic>(io_service_, sInterface, locator);
                     acceptors_[acceptor->locator()] = acceptor;
                     acceptor->accept(this);
-                    final_port = acceptor->locator().port;
+                    final_port = static_cast<uint16_t>(acceptor->locator().port);
                 }
 
                 EPROSIMA_LOG_INFO(RTCP, " OpenAndBindInput (physical: " << IPLocator::getPhysicalPort(

--- a/src/cpp/rtps/transport/TCPTransportInterface.h
+++ b/src/cpp/rtps/transport/TCPTransportInterface.h
@@ -139,7 +139,7 @@ protected:
             std::shared_ptr<TCPChannelResource>& channel);
 
     //! Creates a TCP acceptor to wait for incoming connections by the given locator.
-    bool create_acceptor_socket(
+    uint16_t create_acceptor_socket(
             const Locator& locator);
 
     virtual void get_ips(

--- a/src/cpp/rtps/transport/TCPv4Transport.cpp
+++ b/src/cpp/rtps/transport/TCPv4Transport.cpp
@@ -81,10 +81,10 @@ TCPv4Transport::TCPv4Transport(
         interface_whitelist_.emplace_back(ip::address_v4::from_string(interface));
     }
 
-    for (uint16_t port : configuration_.listening_ports)
+    for (uint16_t &port : configuration_.listening_ports)
     {
         Locator locator(LOCATOR_KIND_TCPv4, port);
-        create_acceptor_socket(locator);
+        port = create_acceptor_socket(locator);
     }
 
 #if !TLS_FOUND

--- a/src/cpp/rtps/transport/TCPv4Transport.cpp
+++ b/src/cpp/rtps/transport/TCPv4Transport.cpp
@@ -81,7 +81,7 @@ TCPv4Transport::TCPv4Transport(
         interface_whitelist_.emplace_back(ip::address_v4::from_string(interface));
     }
 
-    for (uint16_t &port : configuration_.listening_ports)
+    for (uint16_t& port : configuration_.listening_ports)
     {
         Locator locator(LOCATOR_KIND_TCPv4, port);
         port = create_acceptor_socket(locator);

--- a/src/cpp/rtps/transport/TCPv6Transport.cpp
+++ b/src/cpp/rtps/transport/TCPv6Transport.cpp
@@ -85,10 +85,10 @@ TCPv6Transport::TCPv6Transport(
         interface_whitelist_.emplace_back(ip::address_v6::from_string(interface));
     }
 
-    for (uint16_t port : configuration_.listening_ports)
+    for (uint16_t &port : configuration_.listening_ports)
     {
         Locator locator(LOCATOR_KIND_TCPv6, port);
-        create_acceptor_socket(locator);
+        port = create_acceptor_socket(locator);
     }
 
 #if !TLS_FOUND

--- a/src/cpp/rtps/transport/TCPv6Transport.cpp
+++ b/src/cpp/rtps/transport/TCPv6Transport.cpp
@@ -85,7 +85,7 @@ TCPv6Transport::TCPv6Transport(
         interface_whitelist_.emplace_back(ip::address_v6::from_string(interface));
     }
 
-    for (uint16_t &port : configuration_.listening_ports)
+    for (uint16_t& port : configuration_.listening_ports)
     {
         Locator locator(LOCATOR_KIND_TCPv6, port);
         port = create_acceptor_socket(locator);

--- a/test/blackbox/CMakeLists.txt
+++ b/test/blackbox/CMakeLists.txt
@@ -51,7 +51,7 @@ if(NOT LibP11_FOUND)
 endif() # LibP11_FOUND
 
 if(EPROSIMA_TEST_DNS_NOT_SET_UP)
-    set(dns_filter "Discovery.ServerClientEnvironmentSetUpDNS")
+    set(dns_filter "-Discovery.ServerClientEnvironmentSetUpDNS")
 endif()
 
 file(GLOB RTPS_BLACKBOXTESTS_TEST_SOURCE "common/RTPSBlackboxTests*.cpp")

--- a/test/blackbox/common/BlackboxTestsTransportTCP.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportTCP.cpp
@@ -24,6 +24,8 @@
 
 #include "TCPReqRepHelloWorldRequester.hpp"
 #include "TCPReqRepHelloWorldReplier.hpp"
+#include "PubSubReader.hpp"
+#include "PubSubWriter.hpp"
 
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
@@ -598,7 +600,7 @@ TEST_P(TransportTCP, TCPv6_equal_operator)
 // Test copy constructor and copy assignment for TCPv6
 TEST_P(TransportTCP, TCPv6_copy)
 {
-    // Change some varibles in order to check the non default cretion
+    // Change some varibles in order to check the non default creation
     TCPv6TransportDescriptor tcpv6_transport;
     tcpv6_transport.enable_tcp_nodelay = !tcpv6_transport.enable_tcp_nodelay; // change default value
     tcpv6_transport.max_logical_port = tcpv6_transport.max_logical_port + 10; // change default value
@@ -672,6 +674,66 @@ TEST(TransportTCP, Client_reconnection)
 
     delete replier;
     delete requester;
+}
+
+// Test copy constructor and copy assignment for TCPv4
+TEST_P(TransportTCP, TCPv4_autofill_port)
+{
+    PubSubReader<HelloWorldPubSubType> p1(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> p2(TEST_TOPIC_NAME);
+
+    // Add TCP Transport with listening port 0
+    auto p1_transport = std::make_shared<TCPv4TransportDescriptor>();
+    p1_transport->add_listener_port(0);
+    p1.disable_builtin_transport().add_user_transport_to_pparams(p1_transport);
+    p1.init();
+    ASSERT_TRUE(p1.isInitialized());
+
+    // Add TCP Transport with listening port different from 0
+    uint16_t port = 12345;
+    auto p2_transport = std::make_shared<TCPv4TransportDescriptor>();
+    p2_transport->add_listener_port(port);
+    p2.disable_builtin_transport().add_user_transport_to_pparams(p2_transport);
+    p2.init();
+    ASSERT_TRUE(p2.isInitialized());
+
+    LocatorList_t p1_locators;
+    p1.get_native_reader().get_listening_locators(p1_locators);
+    EXPECT_TRUE(IPLocator::getPhysicalPort(p1_locators.begin()[0]) != 0);
+
+    LocatorList_t p2_locators;
+    p2.get_native_reader().get_listening_locators(p2_locators);
+    EXPECT_TRUE(IPLocator::getPhysicalPort(p2_locators.begin()[0]) == port);
+}
+
+// Test copy constructor and copy assignment for TCPv6
+TEST_P(TransportTCP, TCPv6_autofill_port)
+{
+    PubSubReader<HelloWorldPubSubType> p1(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> p2(TEST_TOPIC_NAME);
+
+    // Add TCP Transport with listening port 0
+    auto p1_transport = std::make_shared<TCPv6TransportDescriptor>();
+    p1_transport->add_listener_port(0);
+    p1.disable_builtin_transport().add_user_transport_to_pparams(p1_transport);
+    p1.init();
+    ASSERT_TRUE(p1.isInitialized());
+
+    // Add TCP Transport with listening port different from 0
+    uint16_t port = 12345;
+    auto p2_transport = std::make_shared<TCPv6TransportDescriptor>();
+    p2_transport->add_listener_port(port);
+    p2.disable_builtin_transport().add_user_transport_to_pparams(p2_transport);
+    p2.init();
+    ASSERT_TRUE(p2.isInitialized());
+
+    LocatorList_t p1_locators;
+    p1.get_native_reader().get_listening_locators(p1_locators);
+    EXPECT_TRUE(IPLocator::getPhysicalPort(p1_locators.begin()[0]) != 0);
+
+    LocatorList_t p2_locators;
+    p2.get_native_reader().get_listening_locators(p2_locators);
+    EXPECT_TRUE(IPLocator::getPhysicalPort(p2_locators.begin()[0]) == port);
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -1620,6 +1620,42 @@ TEST_F(TCPv4Tests, header_read_interrumption)
     thread.join();
 }
 
+// This test verifies that the autofill port feature correctly sets an automatic port when 
+// the descriptors's port is set to 0.
+TEST_F(TCPv4Tests, autofill_port)
+{
+    // Check normal port assignation
+    TCPv4TransportDescriptor test_descriptor;
+    test_descriptor.add_listener_port(g_default_port);
+    TCPv4Transport transportUnderTest(test_descriptor);
+    transportUnderTest.init();
+
+    EXPECT_TRUE(transportUnderTest.configuration()->listening_ports[0] == g_default_port);
+
+    // Check default port assignation 
+    TCPv4TransportDescriptor test_descriptor_autofill;
+    test_descriptor_autofill.add_listener_port(0);
+    TCPv4Transport transportUnderTest_autofill(test_descriptor_autofill);
+    transportUnderTest_autofill.init();
+
+    EXPECT_TRUE(transportUnderTest_autofill.configuration()->listening_ports[0] != 0);
+    EXPECT_TRUE(transportUnderTest_autofill.configuration()->listening_ports.size() == 1);
+
+    uint16_t port = 12345;
+    TCPv4TransportDescriptor test_descriptor_multiple_autofill;
+    test_descriptor_multiple_autofill.add_listener_port(0);
+    test_descriptor_multiple_autofill.add_listener_port(port);
+    test_descriptor_multiple_autofill.add_listener_port(0);
+    TCPv4Transport transportUnderTest_multiple_autofill(test_descriptor_multiple_autofill);
+    transportUnderTest_multiple_autofill.init();
+
+    EXPECT_TRUE(transportUnderTest_multiple_autofill.configuration()->listening_ports[0] != 0);
+    EXPECT_TRUE(transportUnderTest_multiple_autofill.configuration()->listening_ports[1] == port);
+    EXPECT_TRUE(transportUnderTest_multiple_autofill.configuration()->listening_ports[2] != 0);
+    EXPECT_TRUE(transportUnderTest_multiple_autofill.configuration()->listening_ports[0] != transportUnderTest_multiple_autofill.configuration()->listening_ports[2]);
+    EXPECT_TRUE(transportUnderTest_multiple_autofill.configuration()->listening_ports.size() == 3);
+}
+
 void TCPv4Tests::HELPER_SetDescriptorDefaults()
 {
     descriptor.add_listener_port(g_default_port);

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -1620,7 +1620,7 @@ TEST_F(TCPv4Tests, header_read_interrumption)
     thread.join();
 }
 
-// This test verifies that the autofill port feature correctly sets an automatic port when 
+// This test verifies that the autofill port feature correctly sets an automatic port when
 // the descriptors's port is set to 0.
 TEST_F(TCPv4Tests, autofill_port)
 {
@@ -1632,7 +1632,7 @@ TEST_F(TCPv4Tests, autofill_port)
 
     EXPECT_TRUE(transportUnderTest.configuration()->listening_ports[0] == g_default_port);
 
-    // Check default port assignation 
+    // Check default port assignation
     TCPv4TransportDescriptor test_descriptor_autofill;
     test_descriptor_autofill.add_listener_port(0);
     TCPv4Transport transportUnderTest_autofill(test_descriptor_autofill);
@@ -1652,7 +1652,9 @@ TEST_F(TCPv4Tests, autofill_port)
     EXPECT_TRUE(transportUnderTest_multiple_autofill.configuration()->listening_ports[0] != 0);
     EXPECT_TRUE(transportUnderTest_multiple_autofill.configuration()->listening_ports[1] == port);
     EXPECT_TRUE(transportUnderTest_multiple_autofill.configuration()->listening_ports[2] != 0);
-    EXPECT_TRUE(transportUnderTest_multiple_autofill.configuration()->listening_ports[0] != transportUnderTest_multiple_autofill.configuration()->listening_ports[2]);
+    EXPECT_TRUE(
+        transportUnderTest_multiple_autofill.configuration()->listening_ports[0] !=
+        transportUnderTest_multiple_autofill.configuration()->listening_ports[2]);
     EXPECT_TRUE(transportUnderTest_multiple_autofill.configuration()->listening_ports.size() == 3);
 }
 

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -175,6 +175,42 @@ TEST_F(TCPv6Tests, opening_and_closing_input_channel)
     ASSERT_FALSE (transportUnderTest.IsInputChannelOpen(multicastFilterLocator));
     ASSERT_FALSE (transportUnderTest.CloseInputChannel(multicastFilterLocator));
 }
+
+// This test verifies that the autofill port feature correctly sets an automatic port when 
+// the descriptors's port is set to 0.
+TEST_F(TCPv6Tests, autofill_port)
+{
+    // Check normal port assignation
+    TCPv6TransportDescriptor test_descriptor;
+    test_descriptor.add_listener_port(g_default_port);
+    TCPv6Transport transportUnderTest(test_descriptor);
+    transportUnderTest.init();
+
+    EXPECT_TRUE(transportUnderTest.configuration()->listening_ports[0] == g_default_port);
+
+    // Check default port assignation 
+    TCPv6TransportDescriptor test_descriptor_autofill;
+    test_descriptor_autofill.add_listener_port(0);
+    TCPv6Transport transportUnderTest_autofill(test_descriptor_autofill);
+    transportUnderTest_autofill.init();
+
+    EXPECT_TRUE(transportUnderTest_autofill.configuration()->listening_ports[0] != 0);
+    EXPECT_TRUE(transportUnderTest_autofill.configuration()->listening_ports.size() == 1);
+
+    uint16_t port = 12345;
+    TCPv6TransportDescriptor test_descriptor_multiple_autofill;
+    test_descriptor_multiple_autofill.add_listener_port(0);
+    test_descriptor_multiple_autofill.add_listener_port(port);
+    test_descriptor_multiple_autofill.add_listener_port(0);
+    TCPv6Transport transportUnderTest_multiple_autofill(test_descriptor_multiple_autofill);
+    transportUnderTest_multiple_autofill.init();
+
+    EXPECT_TRUE(transportUnderTest_multiple_autofill.configuration()->listening_ports[0] != 0);
+    EXPECT_TRUE(transportUnderTest_multiple_autofill.configuration()->listening_ports[1] == port);
+    EXPECT_TRUE(transportUnderTest_multiple_autofill.configuration()->listening_ports[2] != 0);
+    EXPECT_TRUE(transportUnderTest_multiple_autofill.configuration()->listening_ports[0] != transportUnderTest_multiple_autofill.configuration()->listening_ports[2]);
+    EXPECT_TRUE(transportUnderTest_multiple_autofill.configuration()->listening_ports.size() == 3);
+}
 /*
    TEST_F(TCPv6Tests, send_and_receive_between_both_secure_ports)
    {

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -176,7 +176,7 @@ TEST_F(TCPv6Tests, opening_and_closing_input_channel)
     ASSERT_FALSE (transportUnderTest.CloseInputChannel(multicastFilterLocator));
 }
 
-// This test verifies that the autofill port feature correctly sets an automatic port when 
+// This test verifies that the autofill port feature correctly sets an automatic port when
 // the descriptors's port is set to 0.
 TEST_F(TCPv6Tests, autofill_port)
 {
@@ -188,7 +188,7 @@ TEST_F(TCPv6Tests, autofill_port)
 
     EXPECT_TRUE(transportUnderTest.configuration()->listening_ports[0] == g_default_port);
 
-    // Check default port assignation 
+    // Check default port assignation
     TCPv6TransportDescriptor test_descriptor_autofill;
     test_descriptor_autofill.add_listener_port(0);
     TCPv6Transport transportUnderTest_autofill(test_descriptor_autofill);
@@ -208,7 +208,9 @@ TEST_F(TCPv6Tests, autofill_port)
     EXPECT_TRUE(transportUnderTest_multiple_autofill.configuration()->listening_ports[0] != 0);
     EXPECT_TRUE(transportUnderTest_multiple_autofill.configuration()->listening_ports[1] == port);
     EXPECT_TRUE(transportUnderTest_multiple_autofill.configuration()->listening_ports[2] != 0);
-    EXPECT_TRUE(transportUnderTest_multiple_autofill.configuration()->listening_ports[0] != transportUnderTest_multiple_autofill.configuration()->listening_ports[2]);
+    EXPECT_TRUE(
+        transportUnderTest_multiple_autofill.configuration()->listening_ports[0] !=
+        transportUnderTest_multiple_autofill.configuration()->listening_ports[2]);
     EXPECT_TRUE(transportUnderTest_multiple_autofill.configuration()->listening_ports.size() == 3);
 }
 /*


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.11.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- [X] New feature has been documented/Current behavior is correctly described in the documentation.
    Related documentation PR: https://github.com/eProsima/Fast-DDS-docs/pull/598 (PR) 
- _N/A_ Applicable backports have been included in the description.


## Reviewer Checklist
- [X] The PR has a milestone assigned.
- [X] Check contributor checklist is correct.
- [X] Check CI results: changes do not issue any warning.
- [X] Check CI results: failing tests are unrelated with the changes.
