### PR TITLE
[20060] Fix data race on writer destruction while sending hearbeat

### DIFF
--- a/src/cpp/rtps/writer/RTPSWriter.cpp
+++ b/src/cpp/rtps/writer/RTPSWriter.cpp
@@ -154,13 +154,14 @@ void RTPSWriter::deinit()
         {
             flow_controller_->remove_change(*it, std::chrono::steady_clock::now() + std::chrono::hours(24));
         }
-    }
-    for (auto it = mp_history->changesBegin(); it != mp_history->changesEnd(); ++it)
-    {
-        release_change(*it);
-    }
 
-    mp_history->m_changes.clear();
+        for (auto it = mp_history->changesBegin(); it != mp_history->changesEnd(); ++it)
+        {
+            release_change(*it);
+        }
+
+        mp_history->m_changes.clear();
+    }
     flow_controller_->unregister_writer(this);
 }
 

--- a/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
@@ -369,6 +369,44 @@ TEST(DDSDataWriter, OfferedDeadlineMissedListener)
     ASSERT_TRUE(ret);
 }
 
+/**
+ * Regression test for EasyRedmine issue https://eprosima.easyredmine.com/issues/20059
+ *
+ * The test creates a writer and reader that communicate with transient_local reliable QoS.
+ * The issue corresponds to a race condition involving writer's history destruction and heartbeat delivery, so in order
+ * to increment the probability of occurrence a high history depth and heartbeat frequency are used.
+ *
+ * Note:
+ *   - Only affects TRANSPORT case (UDP or SHM communication, data_sharing and intraprocess disabled)
+ *   - Destruction order matters: writer must be destroyed before reader (otherwise heartbeats would no be sent while
+ *     destroying the writer)
+ */
+TEST_P(DDSDataWriter, HeartbeatWhileDestruction)
+{
+    PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+
+    // A high number of samples increases the probability of the data race to occur
+    size_t n_samples = 1000;
+
+    reader.reliability(RELIABLE_RELIABILITY_QOS).durability_kind(TRANSIENT_LOCAL_DURABILITY_QOS).init();
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer.reliability(RELIABLE_RELIABILITY_QOS).durability_kind(TRANSIENT_LOCAL_DURABILITY_QOS).history_kind(
+        KEEP_LAST_HISTORY_QOS).history_depth(n_samples).heartbeat_period_seconds(0).heartbeat_period_nanosec(
+        20 * 1000).init();
+    ASSERT_TRUE(writer.isInitialized());
+
+    reader.wait_discovery();
+    writer.wait_discovery();
+
+    auto data = default_helloworld_data_generator(1000);
+    reader.startReception(data);
+    writer.send(data);
+
+    EXPECT_TRUE(data.empty());
+}
+
 #ifdef INSTANTIATE_TEST_SUITE_P
 #define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_SUITE_P(x, y, z, w)
 #else

--- a/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
@@ -396,14 +396,15 @@ TEST(DDSDataWriter, HeartbeatWhileDestruction)
         ASSERT_TRUE(reader.isInitialized());
 
         writer.reliability(RELIABLE_RELIABILITY_QOS).durability_kind(TRANSIENT_LOCAL_DURABILITY_QOS).history_kind(
-            KEEP_LAST_HISTORY_QOS).history_depth(n_samples).heartbeat_period_seconds(0).heartbeat_period_nanosec(
+            KEEP_LAST_HISTORY_QOS).history_depth(static_cast<int32_t>(n_samples)).heartbeat_period_seconds(0).
+                heartbeat_period_nanosec(
             20 * 1000).init();
         ASSERT_TRUE(writer.isInitialized());
 
         reader.wait_discovery();
         writer.wait_discovery();
 
-        auto data = default_helloworld_data_generator(1000);
+        auto data = default_helloworld_data_generator(n_samples);
         reader.startReception(data);
         writer.send(data);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->


There is a data race on the access to StatefulWriter's history between the events thread (sending heartbeat), and the main thread (or the one from where the writer is deleted), which results in a deadlock.

More specifically, the thread sending heartbeat gets stuck in an infinite loop (while within StatefulWriter's add_gaps_for_holes_in_history_ ) since the cache change involved had been released (hence its sequence number set to 0) from the thread destroying the writer (RTPSWriter::deinit) without protection. A priori, the solution would be to protect the destruction to avoid the data race.

This could be replicated often with BasicConfigurationExample, by increasing the heartbeat sending period to raise the probability of occurrence:

wqos.reliable_writer_qos().times.heartbeatPeriod.seconds = 0;

wqos.reliable_writer_qos().times.heartbeatPeriod.nanosec = 20 * 1000;

Example of execution:
./BasicConfigurationExample publisher -i 1 --transport=udp --reliable --transient
./BasicConfigurationExample subscriber --transport=udp --reliable --transient

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.12.x 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A*: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A*: New feature has been added to the `versions.md` file (if applicable).
- *N/A*: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
