### PR TITLE
[20021] TCP support for Discovery server CLI and env. var.

### DIFF
--- a/examples/cpp/dds/DiscoveryServerExample/DiscoveryServerPublisher.cpp
+++ b/examples/cpp/dds/DiscoveryServerExample/DiscoveryServerPublisher.cpp
@@ -41,8 +41,6 @@ using namespace eprosima::fastdds::rtps;
 
 std::atomic<bool> HelloWorldPublisher::stop_(false);
 
-const uint16_t pub_tcp_port = 21100;
-
 HelloWorldPublisher::HelloWorldPublisher()
     : participant_(nullptr)
     , publisher_(nullptr)
@@ -127,7 +125,7 @@ bool HelloWorldPublisher::init(
             auto descriptor_tmp = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
             // descriptor_tmp->interfaceWhiteList.push_back(ip_server_address);
             // One listening port must be added either in the pub or the sub
-            // descriptor_tmp->add_listener_port(pub_tcp_port);
+            descriptor_tmp->add_listener_port(0);
             descriptor = descriptor_tmp;
 
             server_locator.kind = LOCATOR_KIND_TCPv4;
@@ -141,7 +139,7 @@ bool HelloWorldPublisher::init(
             auto descriptor_tmp = std::make_shared<eprosima::fastdds::rtps::TCPv6TransportDescriptor>();
             // descriptor_tmp->interfaceWhiteList.push_back(ip_server_address);
             // One listening port must be added either in the pub or the sub
-            // descriptor_tmp->add_listener_port(pub_tcp_port);
+            descriptor_tmp->add_listener_port(0);
             descriptor = descriptor_tmp;
 
             server_locator.kind = LOCATOR_KIND_TCPv6;

--- a/examples/cpp/dds/DiscoveryServerExample/DiscoveryServerPublisher.cpp
+++ b/examples/cpp/dds/DiscoveryServerExample/DiscoveryServerPublisher.cpp
@@ -144,7 +144,7 @@ bool HelloWorldPublisher::init(
 
             server_locator.kind = LOCATOR_KIND_TCPv6;
             eprosima::fastrtps::rtps::IPLocator::setLogicalPort(server_locator, server_port);
-            eprosima::fastrtps::rtps::IPLocator::setIPv4(server_locator, ip_server_address);
+            eprosima::fastrtps::rtps::IPLocator::setIPv6(server_locator, ip_server_address);
             break;
         }
 

--- a/examples/cpp/dds/DiscoveryServerExample/DiscoveryServerPublisher.cpp
+++ b/examples/cpp/dds/DiscoveryServerExample/DiscoveryServerPublisher.cpp
@@ -41,6 +41,8 @@ using namespace eprosima::fastdds::rtps;
 
 std::atomic<bool> HelloWorldPublisher::stop_(false);
 
+const uint16_t pub_tcp_port = 21100;
+
 HelloWorldPublisher::HelloWorldPublisher()
     : participant_(nullptr)
     , publisher_(nullptr)
@@ -117,6 +119,34 @@ bool HelloWorldPublisher::init(
 
             server_locator.kind = LOCATOR_KIND_UDPv6;
             eprosima::fastrtps::rtps::IPLocator::setIPv6(server_locator, ip_server_address);
+            break;
+        }
+
+        case TransportKind::TCPv4:
+        {
+            auto descriptor_tmp = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
+            // descriptor_tmp->interfaceWhiteList.push_back(ip_server_address);
+            // One listening port must be added either in the pub or the sub
+            // descriptor_tmp->add_listener_port(pub_tcp_port);
+            descriptor = descriptor_tmp;
+
+            server_locator.kind = LOCATOR_KIND_TCPv4;
+            eprosima::fastrtps::rtps::IPLocator::setLogicalPort(server_locator, server_port);
+            eprosima::fastrtps::rtps::IPLocator::setIPv4(server_locator, ip_server_address);
+            break;
+        }
+
+        case TransportKind::TCPv6:
+        {
+            auto descriptor_tmp = std::make_shared<eprosima::fastdds::rtps::TCPv6TransportDescriptor>();
+            // descriptor_tmp->interfaceWhiteList.push_back(ip_server_address);
+            // One listening port must be added either in the pub or the sub
+            // descriptor_tmp->add_listener_port(pub_tcp_port);
+            descriptor = descriptor_tmp;
+
+            server_locator.kind = LOCATOR_KIND_TCPv6;
+            eprosima::fastrtps::rtps::IPLocator::setLogicalPort(server_locator, server_port);
+            eprosima::fastrtps::rtps::IPLocator::setIPv4(server_locator, ip_server_address);
             break;
         }
 

--- a/examples/cpp/dds/DiscoveryServerExample/DiscoveryServerServer.cpp
+++ b/examples/cpp/dds/DiscoveryServerExample/DiscoveryServerServer.cpp
@@ -26,6 +26,8 @@
 #include <fastdds/rtps/transport/shared_mem/SharedMemTransportDescriptor.h>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
 #include <fastdds/rtps/transport/UDPv6TransportDescriptor.h>
+#include <fastdds/rtps/transport/TCPv4TransportDescriptor.h>
+#include <fastdds/rtps/transport/TCPv6TransportDescriptor.h>
 #include <fastrtps/attributes/ParticipantAttributes.h>
 
 #include "DiscoveryServerServer.h"
@@ -134,6 +136,38 @@ bool DiscoveryServer::init(
             eprosima::fastrtps::rtps::IPLocator::setIPv6(listening_locator, ip_listening_address);
             connection_locator.kind = LOCATOR_KIND_UDPv6;
             eprosima::fastrtps::rtps::IPLocator::setIPv6(connection_locator, ip_connection_address);
+            break;
+        }
+
+        case TransportKind::TCPv4:
+        {
+            auto descriptor_tmp = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
+            // descriptor_tmp->interfaceWhiteList.push_back(ip_listening_address);
+            descriptor_tmp->add_listener_port(server_port);
+            descriptor = descriptor_tmp;
+
+            listening_locator.kind = LOCATOR_KIND_TCPv4;
+            eprosima::fastrtps::rtps::IPLocator::setLogicalPort(listening_locator, server_port);
+            eprosima::fastrtps::rtps::IPLocator::setIPv4(listening_locator, ip_listening_address);
+            connection_locator.kind = LOCATOR_KIND_TCPv4;
+            eprosima::fastrtps::rtps::IPLocator::setIPv4(connection_locator, ip_connection_address);
+            eprosima::fastrtps::rtps::IPLocator::setLogicalPort(connection_locator, connection_server_port);
+            break;
+        }
+
+        case TransportKind::TCPv6:
+        {
+            auto descriptor_tmp = std::make_shared<eprosima::fastdds::rtps::TCPv6TransportDescriptor>();
+            // descriptor_tmp->interfaceWhiteList.push_back(ip_listening_address);
+            descriptor_tmp->add_listener_port(server_port);
+            descriptor = descriptor_tmp;
+
+            listening_locator.kind = LOCATOR_KIND_TCPv6;
+            eprosima::fastrtps::rtps::IPLocator::setLogicalPort(listening_locator, server_port);
+            eprosima::fastrtps::rtps::IPLocator::setIPv6(listening_locator, ip_listening_address);
+            connection_locator.kind = LOCATOR_KIND_TCPv6;
+            eprosima::fastrtps::rtps::IPLocator::setIPv6(connection_locator, ip_connection_address);
+            eprosima::fastrtps::rtps::IPLocator::setLogicalPort(connection_locator, connection_server_port);
             break;
         }
 

--- a/examples/cpp/dds/DiscoveryServerExample/DiscoveryServerSubscriber.cpp
+++ b/examples/cpp/dds/DiscoveryServerExample/DiscoveryServerSubscriber.cpp
@@ -44,8 +44,6 @@ std::atomic<bool> HelloWorldSubscriber::stop_(false);
 std::mutex HelloWorldSubscriber::terminate_cv_mtx_;
 std::condition_variable HelloWorldSubscriber::terminate_cv_;
 
-const uint16_t sub_tcp_port = 21200;
-
 HelloWorldSubscriber::HelloWorldSubscriber()
     : participant_(nullptr)
     , subscriber_(nullptr)
@@ -130,7 +128,7 @@ bool HelloWorldSubscriber::init(
             auto descriptor_tmp = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
             // descriptor_tmp->interfaceWhiteList.push_back(ip_server_address);
             // One listening port must be added either in the pub or the sub
-            descriptor_tmp->add_listener_port(sub_tcp_port);
+            descriptor_tmp->add_listener_port(0);
             descriptor = descriptor_tmp;
 
             server_locator.kind = LOCATOR_KIND_TCPv4;
@@ -144,7 +142,7 @@ bool HelloWorldSubscriber::init(
             auto descriptor_tmp = std::make_shared<eprosima::fastdds::rtps::TCPv6TransportDescriptor>();
             // descriptor_tmp->interfaceWhiteList.push_back(ip_server_address);
             // One listening port must be added either in the pub or the sub
-            descriptor_tmp->add_listener_port(sub_tcp_port);
+            descriptor_tmp->add_listener_port(0);
             descriptor = descriptor_tmp;
 
             server_locator.kind = LOCATOR_KIND_TCPv6;

--- a/examples/cpp/dds/DiscoveryServerExample/DiscoveryServerSubscriber.cpp
+++ b/examples/cpp/dds/DiscoveryServerExample/DiscoveryServerSubscriber.cpp
@@ -29,6 +29,8 @@
 #include <fastdds/rtps/transport/shared_mem/SharedMemTransportDescriptor.h>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
 #include <fastdds/rtps/transport/UDPv6TransportDescriptor.h>
+#include <fastdds/rtps/transport/TCPv4TransportDescriptor.h>
+#include <fastdds/rtps/transport/TCPv6TransportDescriptor.h>
 #include <fastrtps/attributes/ParticipantAttributes.h>
 #include <fastrtps/attributes/SubscriberAttributes.h>
 #include <fastrtps/utils/IPLocator.h>
@@ -41,6 +43,8 @@ using namespace eprosima::fastdds::rtps;
 std::atomic<bool> HelloWorldSubscriber::stop_(false);
 std::mutex HelloWorldSubscriber::terminate_cv_mtx_;
 std::condition_variable HelloWorldSubscriber::terminate_cv_;
+
+const uint16_t sub_tcp_port = 21200;
 
 HelloWorldSubscriber::HelloWorldSubscriber()
     : participant_(nullptr)
@@ -118,6 +122,34 @@ bool HelloWorldSubscriber::init(
 
             server_locator.kind = LOCATOR_KIND_UDPv6;
             eprosima::fastrtps::rtps::IPLocator::setIPv6(server_locator, ip_server_address);
+            break;
+        }
+
+        case TransportKind::TCPv4:
+        {
+            auto descriptor_tmp = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
+            // descriptor_tmp->interfaceWhiteList.push_back(ip_server_address);
+            // One listening port must be added either in the pub or the sub
+            descriptor_tmp->add_listener_port(sub_tcp_port);
+            descriptor = descriptor_tmp;
+
+            server_locator.kind = LOCATOR_KIND_TCPv4;
+            eprosima::fastrtps::rtps::IPLocator::setLogicalPort(server_locator, server_port);
+            eprosima::fastrtps::rtps::IPLocator::setIPv4(server_locator, ip_server_address);
+            break;
+        }
+
+        case TransportKind::TCPv6:
+        {
+            auto descriptor_tmp = std::make_shared<eprosima::fastdds::rtps::TCPv6TransportDescriptor>();
+            // descriptor_tmp->interfaceWhiteList.push_back(ip_server_address);
+            // One listening port must be added either in the pub or the sub
+            descriptor_tmp->add_listener_port(sub_tcp_port);
+            descriptor = descriptor_tmp;
+
+            server_locator.kind = LOCATOR_KIND_TCPv6;
+            eprosima::fastrtps::rtps::IPLocator::setLogicalPort(server_locator, server_port);
+            eprosima::fastrtps::rtps::IPLocator::setIPv4(server_locator, ip_server_address);
             break;
         }
 

--- a/examples/cpp/dds/DiscoveryServerExample/DiscoveryServer_main.cpp
+++ b/examples/cpp/dds/DiscoveryServerExample/DiscoveryServer_main.cpp
@@ -173,9 +173,17 @@ int main(
                     {
                         transport = TransportKind::UDPv6;
                     }
+                    else if (transport_str == "tcpv4")
+                    {
+                        transport = TransportKind::TCPv4;
+                    }
+                    else if (transport_str == "tcpv6")
+                    {
+                        transport = TransportKind::TCPv6;
+                    }
                     else
                     {
-                        print_warning("udpv4|udpv6", opt.name);
+                        print_warning("udpv4|udpv6|tcpv4|tcpv6", opt.name);
                     }
 
                     break;

--- a/examples/cpp/dds/DiscoveryServerExample/README.md
+++ b/examples/cpp/dds/DiscoveryServerExample/README.md
@@ -33,8 +33,8 @@ Publisher options:
                     Server address (Default address: 127.0.0.1).
   -p <num>        --connection-port=<num>
                     Server listening port (Default port: 16166).
-                  --transport=<udpv4|udpv6>
-                    Use Transport Protocol [udpv4|udpv6] (Default: udpv4).
+                  --transport=<udpv4|udpv6|tcpv4|tcpv6>
+                    Use Transport Protocol [udpv4|udpv6|tcpv4|tcpv6] (Default: udpv4).
   -d <num>        --connection-discovery-server-id <num>
                     Id of the Discovery Server to connect with. GUID will be
                     calculated from id (Default: 0).
@@ -49,8 +49,8 @@ Subscriber options:
                     Server address (Default address: 127.0.0.1).
   -p <num>        --connection-port=<num>
                     Server listening port (Default port: 16166).
-                  --transport=<udpv4|udpv6>
-                    Use Transport Protocol [udpv4|udpv6] (Default: udpv4).
+                  --transport=<udpv4|udpv6|tcpv4|tcpv6>
+                    Use Transport Protocol [udpv4|udpv6|tcpv4|tcpv6] (Default: udpv4).
   -d <num>        --connection-discovery-server-id <num>
                     Id of the Discovery Server to connect with. GUID will be
                     calculated from id (Default: 0).
@@ -63,8 +63,8 @@ DiscoveryServer options:
                     GUID will be calculated from id (Default: 0).
                   --listening-port=<num>
                     Server listening port (Default port: 16166).
-                  --transport=<udpv4|udpv6>
-                    Use Transport Protocol [udpv4|udpv6] (Default: udpv4).
+                  --transport=<udpv4|udpv6|tcpv4|tcpv6>
+                    Use Transport Protocol [udpv4|udpv6|tcpv4|tcpv6] (Default: udpv4).
   -c <IPaddress>  --connection-address=<IPaddress>
                     Server address (Default address: 127.0.0.1).
   -p <num>        --connection-port=<num>

--- a/examples/cpp/dds/DiscoveryServerExample/arg_configuration.h
+++ b/examples/cpp/dds/DiscoveryServerExample/arg_configuration.h
@@ -140,7 +140,9 @@ struct Arg : public option::Arg
             if (
                 // transport == "shm" ||
                 transport == "udpv4" ||
-                transport == "udpv6"
+                transport == "udpv6" ||
+                transport == "tcpv4" ||
+                transport == "tcpv6"
                 )
             {
                 return option::ARG_OK;
@@ -235,7 +237,7 @@ const option::Descriptor usage[] = {
         "",
         "transport",
         Arg::Transport,
-        "  \t--transport <trans> \tUse Transport Protocol [udpv4|udpv6] (UDPv4 by default)."
+        "  \t--transport <trans> \tUse Transport Protocol [udpv4|udpv6|tcpv4|tcpv6] (UDPv4 by default)."
     },
     {
         CONNECTION_DISCOVERY_SERVER_ID,
@@ -287,7 +289,7 @@ const option::Descriptor usage[] = {
         "",
         "transport",
         Arg::Transport,
-        "  \t--transport <trans> \tUse Transport Protocol [udpv4|udpv6] (UDPv4 by default)."
+        "  \t--transport <trans> \tUse Transport Protocol [udpv4|udpv6|tcpv4|tcpv6] (UDPv4 by default)."
     },
     {
         CONNECTION_DISCOVERY_SERVER_ID,
@@ -331,7 +333,7 @@ const option::Descriptor usage[] = {
         "",
         "transport",
         Arg::Transport,
-        "  \t--transport <trans> \tUse Transport Protocol [udpv4|udpv6] (UDPv4 by default)."
+        "  \t--transport <trans> \tUse Transport Protocol [udpv4|udpv6|tcpv4|tcpv6] (UDPv4 by default)."
     },
     {
         CONNECTION_PORT,

--- a/examples/cpp/dds/DiscoveryServerExample/common.h
+++ b/examples/cpp/dds/DiscoveryServerExample/common.h
@@ -27,6 +27,8 @@ enum class TransportKind
 {
     UDPv4,
     UDPv6,
+    TCPv4,
+    TCPv6,
     SHM,
 };
 
@@ -56,7 +58,7 @@ inline std::string get_ip_from_dns(
     std::pair<std::set<std::string>, std::set<std::string>> dns_response =
             eprosima::fastrtps::rtps::IPLocator::resolveNameDNS(domain_name);
 
-    if (kind == TransportKind::UDPv4)
+    if (kind == TransportKind::UDPv4 || kind == TransportKind::TCPv4)
     {
         if (dns_response.first.empty())
         {
@@ -70,7 +72,7 @@ inline std::string get_ip_from_dns(
             return solution;
         }
     }
-    else if (kind == TransportKind::UDPv6)
+    else if (kind == TransportKind::UDPv6 || kind == TransportKind::TCPv6)
     {
         if (dns_response.second.empty())
         {

--- a/include/fastdds/rtps/attributes/ServerAttributes.h
+++ b/include/fastdds/rtps/attributes/ServerAttributes.h
@@ -159,11 +159,11 @@ std::basic_ostream<charT>& operator <<(
     return output;
 }
 
-// port used if the ros environment variable doesn't specifies one
+// port used if the ros environment variable doesn't specify one
 constexpr uint16_t DEFAULT_ROS2_SERVER_PORT = 11811;
 // default server base guidPrefix
 const char* const DEFAULT_ROS2_SERVER_GUIDPREFIX = "44.53.00.5f.45.50.52.4f.53.49.4d.41";
-// port used by default for tcp transport 
+// port used by default for tcp transport
 constexpr uint16_t DEFAULT_TCP_SERVER_PORT = 42100;
 
 /* Environment variable to specify a semicolon-separated list of UDPv4 locators (ip:port) that define remote server

--- a/include/fastdds/rtps/attributes/ServerAttributes.h
+++ b/include/fastdds/rtps/attributes/ServerAttributes.h
@@ -159,10 +159,12 @@ std::basic_ostream<charT>& operator <<(
     return output;
 }
 
-// port use if the ros environment variable doesn't specified one
+// port used if the ros environment variable doesn't specifies one
 constexpr uint16_t DEFAULT_ROS2_SERVER_PORT = 11811;
 // default server base guidPrefix
 const char* const DEFAULT_ROS2_SERVER_GUIDPREFIX = "44.53.00.5f.45.50.52.4f.53.49.4d.41";
+// port used by default for tcp transport 
+constexpr uint16_t DEFAULT_TCP_SERVER_PORT = 42100;
 
 /* Environment variable to specify a semicolon-separated list of UDPv4 locators (ip:port) that define remote server
  * locators.

--- a/include/fastdds/rtps/common/Locator.h
+++ b/include/fastdds/rtps/common/Locator.h
@@ -371,7 +371,14 @@ inline std::ostream& operator <<(
     }
 
     // Stream port
-    output << "]:" << loc.port;
+    if (loc.kind == LOCATOR_KIND_TCPv4 || loc.kind == LOCATOR_KIND_TCPv6)
+    {
+        output << "]:" << std::to_string(IPLocator::getPhysicalPort(loc)) << "-" << std::to_string(IPLocator::getLogicalPort(loc));
+    }
+    else
+    {
+        output << "]:" << loc.port;
+    }
 
     return output;
 }

--- a/include/fastdds/rtps/common/Locator.h
+++ b/include/fastdds/rtps/common/Locator.h
@@ -373,7 +373,8 @@ inline std::ostream& operator <<(
     // Stream port
     if (loc.kind == LOCATOR_KIND_TCPv4 || loc.kind == LOCATOR_KIND_TCPv6)
     {
-        output << "]:" << std::to_string(IPLocator::getPhysicalPort(loc)) << "-" << std::to_string(IPLocator::getLogicalPort(loc));
+        output << "]:" << std::to_string(IPLocator::getPhysicalPort(loc)) << "-" << std::to_string(IPLocator::getLogicalPort(
+                    loc));
     }
     else
     {

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -25,6 +25,7 @@
 #include <regex>
 #include <string>
 #include <thread>
+#include <random> // TODO: use TCP autofill feature
 
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/rtps/history/WriterHistory.h>
@@ -35,6 +36,8 @@
 #include <rtps/transport/UDPv4Transport.h>
 #include <rtps/transport/UDPv6Transport.h>
 #include <rtps/transport/test_UDPv4Transport.h>
+#include <rtps/transport/TCPv4Transport.h>
+#include <rtps/transport/TCPv6Transport.h>
 
 #include <fastrtps/utils/IPFinder.h>
 #include <fastrtps/utils/IPLocator.h>
@@ -565,6 +568,30 @@ RTPSParticipant* RTPSDomainImpl::clientServerEnvironmentCreationOverride(
         {
             // extend builtin transports with the UDPv6 transport
             auto descriptor = std::make_shared<fastdds::rtps::UDPv6TransportDescriptor>();
+            descriptor->sendBufferSize = client_att.sendSocketBufferSize;
+            descriptor->receiveBufferSize = client_att.listenSocketBufferSize;
+            client_att.userTransports.push_back(std::move(descriptor));
+            break;
+        }
+        if (server.requires_transport<LOCATOR_KIND_TCPv4>())
+        {
+            // extend builtin transports with the TCPv4 transport
+            auto descriptor = std::make_shared<fastdds::rtps::TCPv4TransportDescriptor>();
+            // TODO: use TCP autofill feature
+            srand(time(0));
+            descriptor->add_listener_port(30000 + rand() % 10000);
+            descriptor->sendBufferSize = client_att.sendSocketBufferSize;
+            descriptor->receiveBufferSize = client_att.listenSocketBufferSize;
+            client_att.userTransports.push_back(std::move(descriptor));
+            break;
+        }
+        if (server.requires_transport<LOCATOR_KIND_TCPv6>())
+        {
+            // extend builtin transports with the TCPv6 transport
+            auto descriptor = std::make_shared<fastdds::rtps::TCPv6TransportDescriptor>();
+            // TODO: use TCP autofill feature
+            srand(time(0));
+            descriptor->add_listener_port(30000 + rand() % 10000);
             descriptor->sendBufferSize = client_att.sendSocketBufferSize;
             descriptor->receiveBufferSize = client_att.listenSocketBufferSize;
             client_att.userTransports.push_back(std::move(descriptor));

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -587,7 +587,7 @@ RTPSParticipant* RTPSDomainImpl::clientServerEnvironmentCreationOverride(
                 {
                     if (!p4)
                     {
-                        if (p4 = std::dynamic_pointer_cast<fastdds::rtps::TCPv4TransportDescriptor>(sp))
+                        if ((p4 = std::dynamic_pointer_cast<fastdds::rtps::TCPv4TransportDescriptor>(sp)))
                         {
                             // TCPv4 transport already exists
                             no_tcpv4 = false;
@@ -624,7 +624,7 @@ RTPSParticipant* RTPSDomainImpl::clientServerEnvironmentCreationOverride(
                     if (!p6)
                     {
                         // try to find a descriptor matching the listener port setup
-                        if (p6 = std::dynamic_pointer_cast<fastdds::rtps::TCPv6TransportDescriptor>(sp))
+                        if ((p6 = std::dynamic_pointer_cast<fastdds::rtps::TCPv6TransportDescriptor>(sp)))
                         {
                             // TCPv6 transport already exists
                             no_tcpv6 = false;

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -560,7 +560,7 @@ RTPSParticipant* RTPSDomainImpl::clientServerEnvironmentCreationOverride(
         return nullptr;
     }
 
-    // Check if some server requires the UDPv6 transport
+    // Check if some server requires the UDPv6, TCPv4 or TCPv6 transport
     for (auto& server : server_list)
     {
         if (server.requires_transport<LOCATOR_KIND_UDPv6>())
@@ -610,7 +610,7 @@ RTPSParticipant* RTPSDomainImpl::clientServerEnvironmentCreationOverride(
         }
         if (server.requires_transport<LOCATOR_KIND_TCPv6>())
         {
-            // Check if a TCPv4 transport exists. Otherwise create it
+            // Check if a TCPv6 transport exists. Otherwise create it
             fastdds::rtps::TCPTransportDescriptor* pT = nullptr;
             std::shared_ptr<fastdds::rtps::TCPv6TransportDescriptor> p6;
             bool no_tcpv6 = true;
@@ -635,7 +635,7 @@ RTPSParticipant* RTPSDomainImpl::clientServerEnvironmentCreationOverride(
             }
             if (no_tcpv6)
             {
-                // Extend builtin transports with the TCPv4 transport
+                // Extend builtin transports with the TCPv6 transport
                 auto descriptor = std::make_shared<fastdds::rtps::TCPv6TransportDescriptor>();
                 // Add automatic port
                 descriptor->add_listener_port(0);

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -25,7 +25,6 @@
 #include <regex>
 #include <string>
 #include <thread>
-#include <random> // TODO: use TCP autofill feature
 
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/rtps/history/WriterHistory.h>
@@ -556,17 +555,17 @@ RTPSParticipant* RTPSDomainImpl::clientServerEnvironmentCreationOverride(
     RemoteServerList_t& server_list = client_att.builtin.discovery_config.m_DiscoveryServers;
     if (load_environment_server_info(server_list) && server_list.empty())
     {
-        // it's not an error, the environment variable may not be set. Any issue with environment
+        // It's not an error, the environment variable may not be set. Any issue with environment
         // variable syntax is EPROSIMA_LOG_ERROR already
         return nullptr;
     }
 
-    // check if some server requires the UDPv6 transport
+    // Check if some server requires the UDPv6 transport
     for (auto& server : server_list)
     {
         if (server.requires_transport<LOCATOR_KIND_UDPv6>())
         {
-            // extend builtin transports with the UDPv6 transport
+            // Extend builtin transports with the UDPv6 transport
             auto descriptor = std::make_shared<fastdds::rtps::UDPv6TransportDescriptor>();
             descriptor->sendBufferSize = client_att.sendSocketBufferSize;
             descriptor->receiveBufferSize = client_att.listenSocketBufferSize;
@@ -575,27 +574,75 @@ RTPSParticipant* RTPSDomainImpl::clientServerEnvironmentCreationOverride(
         }
         if (server.requires_transport<LOCATOR_KIND_TCPv4>())
         {
-            // extend builtin transports with the TCPv4 transport
-            auto descriptor = std::make_shared<fastdds::rtps::TCPv4TransportDescriptor>();
-            // TODO: use TCP autofill feature
-            srand(time(0));
-            descriptor->add_listener_port(30000 + rand() % 10000);
-            descriptor->sendBufferSize = client_att.sendSocketBufferSize;
-            descriptor->receiveBufferSize = client_att.listenSocketBufferSize;
-            client_att.userTransports.push_back(std::move(descriptor));
-            break;
+            // Check if a TCPv4 transport exists. Otherwise create it
+            fastdds::rtps::TCPTransportDescriptor* pT = nullptr;
+            std::shared_ptr<fastdds::rtps::TCPv4TransportDescriptor> p4;
+            bool no_tcpv4 = true;
+
+            for (auto sp : client_att.userTransports)
+            {
+                pT = dynamic_cast<fastdds::rtps::TCPTransportDescriptor*>(sp.get());
+
+                if (pT != nullptr)
+                {
+                    if (!p4)
+                    {
+                        if (p4 = std::dynamic_pointer_cast<fastdds::rtps::TCPv4TransportDescriptor>(sp))
+                        {
+                            // TCPv4 transport already exists
+                            no_tcpv4 = false;
+                            break;
+                        }
+                    }
+                }
+            }
+            if (no_tcpv4)
+            {
+                // Extend builtin transports with the TCPv4 transport
+                auto descriptor = std::make_shared<fastdds::rtps::TCPv4TransportDescriptor>();
+                // Add automatic port
+                descriptor->add_listener_port(0);
+                descriptor->sendBufferSize = client_att.sendSocketBufferSize;
+                descriptor->receiveBufferSize = client_att.listenSocketBufferSize;
+                client_att.userTransports.push_back(std::move(descriptor));
+            }
+
         }
         if (server.requires_transport<LOCATOR_KIND_TCPv6>())
         {
-            // extend builtin transports with the TCPv6 transport
-            auto descriptor = std::make_shared<fastdds::rtps::TCPv6TransportDescriptor>();
-            // TODO: use TCP autofill feature
-            srand(time(0));
-            descriptor->add_listener_port(30000 + rand() % 10000);
-            descriptor->sendBufferSize = client_att.sendSocketBufferSize;
-            descriptor->receiveBufferSize = client_att.listenSocketBufferSize;
-            client_att.userTransports.push_back(std::move(descriptor));
-            break;
+            // Check if a TCPv4 transport exists. Otherwise create it
+            fastdds::rtps::TCPTransportDescriptor* pT = nullptr;
+            std::shared_ptr<fastdds::rtps::TCPv6TransportDescriptor> p6;
+            bool no_tcpv6 = true;
+
+            for (auto sp : client_att.userTransports)
+            {
+                pT = dynamic_cast<fastdds::rtps::TCPTransportDescriptor*>(sp.get());
+
+                if (pT != nullptr)
+                {
+                    if (!p6)
+                    {
+                        // try to find a descriptor matching the listener port setup
+                        if (p6 = std::dynamic_pointer_cast<fastdds::rtps::TCPv6TransportDescriptor>(sp))
+                        {
+                            // TCPv6 transport already exists
+                            no_tcpv6 = false;
+                            break;
+                        }
+                    }
+                }
+            }
+            if (no_tcpv6)
+            {
+                // Extend builtin transports with the TCPv4 transport
+                auto descriptor = std::make_shared<fastdds::rtps::TCPv6TransportDescriptor>();
+                // Add automatic port
+                descriptor->add_listener_port(0);
+                descriptor->sendBufferSize = client_att.sendSocketBufferSize;
+                descriptor->receiveBufferSize = client_att.listenSocketBufferSize;
+                client_att.userTransports.push_back(std::move(descriptor));
+            }
         }
     }
 
@@ -615,13 +662,13 @@ RTPSParticipant* RTPSDomainImpl::clientServerEnvironmentCreationOverride(
     RTPSParticipant* part = createParticipant(domain_id, enabled, client_att, listen);
     if (nullptr != part)
     {
-        // client successfully created
+        // Client successfully created
         EPROSIMA_LOG_INFO(DOMAIN, "Auto default server-client setup. Default client created.");
         part->mp_impl->client_override(true);
         return part;
     }
 
-    // unable to create auto server-client default participants
+    // Unable to create auto server-client default participants
     EPROSIMA_LOG_ERROR(DOMAIN, "Auto default server-client setup. Unable to create the client.");
     return nullptr;
 }

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -987,9 +987,11 @@ bool load_environment_server_info(
     const static std::regex ROS2_IPV4_ADDRESSPORT_PATTERN(R"(^((?:[0-9]{1,3}\.){3}[0-9]{1,3})?:?(?:(\d+))?$)");
     const static std::regex ROS2_IPV6_ADDRESSPORT_PATTERN(
         R"(^\[?((?:[0-9a-fA-F]{0,4}\:){0,7}[0-9a-fA-F]{0,4})?(?:\])?:?(?:(\d+))?$)");
-    const static std::regex ROS2_DNS_DOMAINPORT_PATTERN(R"(^(UDPv[46]?:\[[\w\.:-]{0,63}\]|[\w\.:-]{0,63}):?(?:(\d+))?$)");
+    // Regex to handle DNS and UDPv4/6 expressions
+    const static std::regex ROS2_DNS_DOMAINPORT_PATTERN(R"(^(UDPv[46]?:\[[\w\.:-]{0,63}\]|[\w\.-]{0,63}):?(?:(\d+))?$)");
+    // Regex to handle TCPv4/6 expressions
     const static std::regex ROS2_DNS_DOMAINPORT_PATTERN_TCP(
-        R"(^(TCPv[46]?:\[[\w\.:-]{0,63}\]|[\w\.:-]{0,63}):?(?:(\d+))?$)");
+        R"(^(TCPv[46]?:\[[\w\.:-]{0,63}\]):?(?:(\d+))?$)");
 
     // Filling port info
     auto process_port = [](int port, Locator_t& server)

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -987,14 +987,9 @@ bool load_environment_server_info(
     const static std::regex ROS2_IPV4_ADDRESSPORT_PATTERN(R"(^((?:[0-9]{1,3}\.){3}[0-9]{1,3})?:?(?:(\d+))?$)");
     const static std::regex ROS2_IPV6_ADDRESSPORT_PATTERN(
         R"(^\[?((?:[0-9a-fA-F]{0,4}\:){0,7}[0-9a-fA-F]{0,4})?(?:\])?:?(?:(\d+))?$)");
-<<<<<<< Updated upstream
-    const static std::regex ROS2_DNS_DOMAINPORT_PATTERN(R"(^(UDPv[46]?:\[[\w\.-]{0,63}\]|[\w\.-]{0,63}):?(?:(\d+))?$)");
-    const static std::regex ROS2_DNS_DOMAINPORT_PATTERN_TCP(R"(^(TCPv[46]?:\[[\w\.-]{0,63}\]|[\w\.-]{0,63}):?(?:(\d+))?$)");
-=======
     const static std::regex ROS2_DNS_DOMAINPORT_PATTERN(R"(^(UDPv[46]?:\[[\w\.:-]{0,63}\]|[\w\.:-]{0,63}):?(?:(\d+))?$)");
     const static std::regex ROS2_DNS_DOMAINPORT_PATTERN_TCP(
         R"(^(TCPv[46]?:\[[\w\.:-]{0,63}\]|[\w\.:-]{0,63}):?(?:(\d+))?$)");
->>>>>>> Stashed changes
 
     // Filling port info
     auto process_port = [](int port, Locator_t& server)

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -987,7 +987,14 @@ bool load_environment_server_info(
     const static std::regex ROS2_IPV4_ADDRESSPORT_PATTERN(R"(^((?:[0-9]{1,3}\.){3}[0-9]{1,3})?:?(?:(\d+))?$)");
     const static std::regex ROS2_IPV6_ADDRESSPORT_PATTERN(
         R"(^\[?((?:[0-9a-fA-F]{0,4}\:){0,7}[0-9a-fA-F]{0,4})?(?:\])?:?(?:(\d+))?$)");
+<<<<<<< Updated upstream
     const static std::regex ROS2_DNS_DOMAINPORT_PATTERN(R"(^(UDPv[46]?:\[[\w\.-]{0,63}\]|[\w\.-]{0,63}):?(?:(\d+))?$)");
+    const static std::regex ROS2_DNS_DOMAINPORT_PATTERN_TCP(R"(^(TCPv[46]?:\[[\w\.-]{0,63}\]|[\w\.-]{0,63}):?(?:(\d+))?$)");
+=======
+    const static std::regex ROS2_DNS_DOMAINPORT_PATTERN(R"(^(UDPv[46]?:\[[\w\.:-]{0,63}\]|[\w\.:-]{0,63}):?(?:(\d+))?$)");
+    const static std::regex ROS2_DNS_DOMAINPORT_PATTERN_TCP(
+        R"(^(TCPv[46]?:\[[\w\.:-]{0,63}\]|[\w\.:-]{0,63}):?(?:(\d+))?$)");
+>>>>>>> Stashed changes
 
     // Filling port info
     auto process_port = [](int port, Locator_t& server)
@@ -1216,6 +1223,100 @@ bool load_environment_server_info(
                                     }
 
                                     process_port( port, server_locator);
+                                    flist.push_front(server_locator);
+                                }
+                            }
+                        }
+                    }
+
+                    if (flist.empty())
+                    {
+                        std::stringstream ss;
+                        ss << "Wrong domain name passed into the server's list " << locator;
+                        throw std::invalid_argument(ss.str());
+                    }
+
+                    // add server to the list
+                    add_server2qos(server_id, std::move(flist), attributes);
+                }
+                // try resolve TCP DNS
+                else if (std::regex_match(locator, mr, ROS2_DNS_DOMAINPORT_PATTERN_TCP,
+                        std::regex_constants::match_not_null))
+                {
+                    std::forward_list<Locator> flist;
+
+                    {
+                        std::stringstream new_locator(locator,
+                                std::ios_base::in |
+                                std::ios_base::out |
+                                std::ios_base::ate);
+
+                        // first try the formal notation, add default port if necessary
+                        if (!mr[2].matched)
+                        {
+                            new_locator << ":" << DEFAULT_TCP_SERVER_PORT;
+                        }
+
+                        new_locator >> server_locator;
+                    }
+
+                    // Otherwise add all resolved locators
+                    switch ( server_locator.kind )
+                    {
+                        case LOCATOR_KIND_TCPv4:
+                        case LOCATOR_KIND_TCPv6:
+                            IPLocator::setLogicalPort(server_locator, server_locator.port);
+                            flist.push_front(server_locator);
+                            break;
+                        case LOCATOR_KIND_INVALID:
+                        {
+                            std::smatch::iterator it = mr.cbegin();
+
+                            // traverse submatches
+                            if (++it != mr.cend())
+                            {
+                                std::string domain_name = it->str();
+                                std::set<std::string> ipv4, ipv6;
+                                std::tie(ipv4, ipv6) = IPLocator::resolveNameDNS(domain_name);
+
+                                // get port if any
+                                int port = DEFAULT_TCP_SERVER_PORT;
+                                if (++it != mr.cend() && it->matched)
+                                {
+                                    port = stoi(it->str());
+                                }
+
+                                for ( const std::string& loc : ipv4 )
+                                {
+                                    server_locator.kind = LOCATOR_KIND_TCPv4;
+                                    server_locator.set_Invalid_Address();
+                                    IPLocator::setIPv4(server_locator, loc);
+
+                                    if (IPLocator::isAny(server_locator))
+                                    {
+                                        // A server cannot be reach in all interfaces, it's clearly a localhost call
+                                        IPLocator::setIPv4(server_locator, "127.0.0.1");
+                                    }
+
+                                    process_port( port, server_locator);
+                                    IPLocator::setLogicalPort(server_locator, port);
+                                    flist.push_front(server_locator);
+                                }
+
+                                for ( const std::string& loc : ipv6 )
+                                {
+                                    server_locator.kind = LOCATOR_KIND_TCPv6;
+                                    server_locator.set_Invalid_Address();
+                                    IPLocator::setIPv6(server_locator, loc);
+
+                                    if (IPLocator::isAny(server_locator))
+                                    {
+                                        // A server cannot be reach in all interfaces, it's clearly a localhost call
+                                        IPLocator::setIPv6(server_locator, "::1");
+                                    }
+
+                                    process_port( port, server_locator);
+                                    IPLocator::setLogicalPort(server_locator, port);
                                     flist.push_front(server_locator);
                                 }
                             }

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -1262,7 +1262,7 @@ bool load_environment_server_info(
                     {
                         case LOCATOR_KIND_TCPv4:
                         case LOCATOR_KIND_TCPv6:
-                            IPLocator::setLogicalPort(server_locator, server_locator.port);
+                            IPLocator::setLogicalPort(server_locator, static_cast<uint16_t>(server_locator.port));
                             flist.push_front(server_locator);
                             break;
                         case LOCATOR_KIND_INVALID:
@@ -1296,7 +1296,7 @@ bool load_environment_server_info(
                                     }
 
                                     process_port( port, server_locator);
-                                    IPLocator::setLogicalPort(server_locator, port);
+                                    IPLocator::setLogicalPort(server_locator, static_cast<uint16_t>(port));
                                     flist.push_front(server_locator);
                                 }
 
@@ -1313,7 +1313,7 @@ bool load_environment_server_info(
                                     }
 
                                     process_port( port, server_locator);
-                                    IPLocator::setLogicalPort(server_locator, port);
+                                    IPLocator::setLogicalPort(server_locator, static_cast<uint16_t>(port));
                                     flist.push_front(server_locator);
                                 }
                             }

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -1666,12 +1666,12 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
 
     // 15. Single TCPv4 address without specifying a custom listening port
 
-    string text = "TCPv4:[192.168.36.34]";
+    text = "TCPv4:[192.168.36.34]";
 
     att.clear();
     output.clear();
     standard.clear();
-    IPLocator::setIPv4(loc_tcp, text);
+    IPLocator::setIPv4(loc_tcp, "192.168.36.34");
     IPLocator::setPhysicalPort(loc_tcp, DEFAULT_TCP_SERVER_PORT);
     IPLocator::setLogicalPort(loc_tcp, DEFAULT_TCP_SERVER_PORT);
     att.metatrafficUnicastLocatorList.push_back(loc_tcp);
@@ -1683,12 +1683,12 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
 
     // 16. Single TCPv6 address without specifying a custom listening port
 
-    string text = "TCPv6:[192.168.36.34]";
+    text = "TCPv6:[2a02:26f0:dd:499::356e]";
 
     att.clear();
     output.clear();
     standard.clear();
-    IPLocator::setIPv6(loc_tcp_6, text);
+    IPLocator::setIPv6(loc_tcp_6, "2a02:26f0:dd:499::356e");
     IPLocator::setPhysicalPort(loc_tcp_6, DEFAULT_TCP_SERVER_PORT);
     IPLocator::setLogicalPort(loc_tcp_6, DEFAULT_TCP_SERVER_PORT);
     att.metatrafficUnicastLocatorList.push_back(loc_tcp_6);
@@ -1700,12 +1700,12 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
 
     // 17. Single TCPv4 address specifying a custom listening port
 
-    string text = "TCPv4:[192.168.36.34]:14520";
+    text = "TCPv4:[192.168.36.34]:14520";
 
     att.clear();
     output.clear();
     standard.clear();
-    IPLocator::setIPv4(loc_tcp, text);
+    IPLocator::setIPv4(loc_tcp, "192.168.36.34");
     IPLocator::setPhysicalPort(loc_tcp, 14520);
     IPLocator::setLogicalPort(loc_tcp, 14520);
     att.metatrafficUnicastLocatorList.push_back(loc_tcp);
@@ -1717,12 +1717,12 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
 
     // 18. Single TCPv6 address specifying a custom listening port
 
-    string text = "TCPv6:[192.168.36.34]:14520";
+    text = "TCPv6:[2a02:26f0:dd:499::356e]:14520";
 
     att.clear();
     output.clear();
     standard.clear();
-    IPLocator::setIPv6(loc_tcp_6, text);
+    IPLocator::setIPv6(loc_tcp_6, "2a02:26f0:dd:499::356e");
     IPLocator::setPhysicalPort(loc_tcp_6, 14520);
     IPLocator::setLogicalPort(loc_tcp_6, 14520);
     att.metatrafficUnicastLocatorList.push_back(loc_tcp_6);
@@ -1742,6 +1742,9 @@ TEST(Discovery, ServerClientEnvironmentSetUpDNS)
     RemoteServerList_t output, standard;
     RemoteServerAttributes att;
     Locator_t loc, loc6(LOCATOR_KIND_UDPv6, 0);
+
+    Locator_t loc_tcp(LOCATOR_KIND_TCPv4, 0);
+    Locator_t loc_tcp_6(LOCATOR_KIND_TCPv6, 0);
 
     // 1. single server DNS address resolution without specific port provided
     std::string text = "www.acme.com.test";
@@ -1816,10 +1819,10 @@ TEST(Discovery, ServerClientEnvironmentSetUpDNS)
     att.clear();
     output.clear();
     standard.clear();
-    IPLocator::setIPv4(loc, "216.58.215.164");
-    IPLocator::setPhysicalPort(loc, DEFAULT_TCP_SERVER_PORT);
-    IPLocator::setLogicalPort(loc, DEFAULT_TCP_SERVER_PORT);
-    att.metatrafficUnicastLocatorList.push_back(loc);
+    IPLocator::setIPv4(loc_tcp, "216.58.215.164");
+    IPLocator::setPhysicalPort(loc_tcp, DEFAULT_TCP_SERVER_PORT);
+    IPLocator::setLogicalPort(loc_tcp, DEFAULT_TCP_SERVER_PORT);
+    att.metatrafficUnicastLocatorList.push_back(loc_tcp);
     get_server_client_default_guidPrefix(0, att.guidPrefix);
     standard.push_back(att);
 
@@ -1832,10 +1835,10 @@ TEST(Discovery, ServerClientEnvironmentSetUpDNS)
     att.clear();
     output.clear();
     standard.clear();
-    IPLocator::setIPv6(loc6, "2a00:1450:400e:803::2004");
-    IPLocator::setPhysicalPort(loc6, DEFAULT_TCP_SERVER_PORT);
-    IPLocator::setLogicalPort(loc, DEFAULT_TCP_SERVER_PORT);
-    att.metatrafficUnicastLocatorList.push_back(loc6);
+    IPLocator::setIPv6(loc_tcp_6, "2a00:1450:400e:803::2004");
+    IPLocator::setPhysicalPort(loc_tcp_6, DEFAULT_TCP_SERVER_PORT);
+    IPLocator::setLogicalPort(loc_tcp_6, DEFAULT_TCP_SERVER_PORT);
+    att.metatrafficUnicastLocatorList.push_back(loc_tcp_6);
     get_server_client_default_guidPrefix(0, att.guidPrefix);
     standard.push_back(att);
 
@@ -1879,10 +1882,10 @@ TEST(Discovery, ServerClientEnvironmentSetUpDNS)
     att.clear();
     output.clear();
     standard.clear();
-    IPLocator::setIPv4(loc, "216.58.215.164");
-    IPLocator::setPhysicalPort(loc, 14520);
-    IPLocator::setLogicalPort(loc, 14520);
-    att.metatrafficUnicastLocatorList.push_back(loc);
+    IPLocator::setIPv4(loc_tcp, "216.58.215.164");
+    IPLocator::setPhysicalPort(loc_tcp, 14520);
+    IPLocator::setLogicalPort(loc_tcp, 14520);
+    att.metatrafficUnicastLocatorList.push_back(loc_tcp);
     get_server_client_default_guidPrefix(0, att.guidPrefix);
     standard.push_back(att);
 
@@ -1895,10 +1898,10 @@ TEST(Discovery, ServerClientEnvironmentSetUpDNS)
     att.clear();
     output.clear();
     standard.clear();
-    IPLocator::setIPv6(loc6, "2a00:1450:400e:803::2004");
-    IPLocator::setPhysicalPort(loc6, 14520);
-    IPLocator::setLogicalPort(loc, 14520);
-    att.metatrafficUnicastLocatorList.push_back(loc6);
+    IPLocator::setIPv6(loc_tcp_6, "2a00:1450:400e:803::2004");
+    IPLocator::setPhysicalPort(loc_tcp_6, 14520);
+    IPLocator::setLogicalPort(loc_tcp_6, 14520);
+    att.metatrafficUnicastLocatorList.push_back(loc_tcp_6);
     get_server_client_default_guidPrefix(0, att.guidPrefix);
     standard.push_back(att);
 

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -1737,6 +1737,36 @@ TEST(Discovery, ServerClientEnvironmentSetUpDNS)
     ASSERT_TRUE(load_environment_server_info(text, output));
     ASSERT_EQ(output, standard);
 
+    // TCPv4
+    text = "TCPv4:[www.acme.com.test]";
+
+    att.clear();
+    output.clear();
+    standard.clear();
+    IPLocator::setIPv4(loc, "216.58.215.164");
+    IPLocator::setPhysicalPort(loc, DEFAULT_TCP_SERVER_PORT);
+    att.metatrafficUnicastLocatorList.push_back(loc);
+    get_server_client_default_guidPrefix(0, att.guidPrefix);
+    standard.push_back(att);
+
+    ASSERT_TRUE(load_environment_server_info(text, output));
+    ASSERT_EQ(output, standard);
+
+    // TCPv6
+    text = "TCPv6:[www.acme.com.test]";
+
+    att.clear();
+    output.clear();
+    standard.clear();
+    IPLocator::setIPv6(loc6, "2a00:1450:400e:803::2004");
+    IPLocator::setPhysicalPort(loc6, DEFAULT_TCP_SERVER_PORT);
+    att.metatrafficUnicastLocatorList.push_back(loc6);
+    get_server_client_default_guidPrefix(0, att.guidPrefix);
+    standard.push_back(att);
+
+    ASSERT_TRUE(load_environment_server_info(text, output));
+    ASSERT_EQ(output, standard);
+
     // 4. single server DNS address specifying a custom locator type and listening port
     // UDPv4
     text = "UDPv4:[www.acme.com.test]:14520";
@@ -1768,8 +1798,38 @@ TEST(Discovery, ServerClientEnvironmentSetUpDNS)
     ASSERT_TRUE(load_environment_server_info(text, output));
     ASSERT_EQ(output, standard);
 
-    // Any other Locator kind should fail
-    text = "TCPv4:[www.acme.com.test]";
+    // TCPv4
+    text = "TCPv4:[www.acme.com.test]:14520";
+
+    att.clear();
+    output.clear();
+    standard.clear();
+    IPLocator::setIPv4(loc, "216.58.215.164");
+    IPLocator::setPhysicalPort(loc, 14520);
+    att.metatrafficUnicastLocatorList.push_back(loc);
+    get_server_client_default_guidPrefix(0, att.guidPrefix);
+    standard.push_back(att);
+
+    ASSERT_TRUE(load_environment_server_info(text, output));
+    ASSERT_EQ(output, standard);
+
+    // TCPv6
+    text = "TCPv6:[www.acme.com.test]:14520";
+
+    att.clear();
+    output.clear();
+    standard.clear();
+    IPLocator::setIPv6(loc6, "2a00:1450:400e:803::2004");
+    IPLocator::setPhysicalPort(loc6, 14520);
+    att.metatrafficUnicastLocatorList.push_back(loc6);
+    get_server_client_default_guidPrefix(0, att.guidPrefix);
+    standard.push_back(att);
+
+    ASSERT_TRUE(load_environment_server_info(text, output));
+    ASSERT_EQ(output, standard);
+
+    // SHM Locator kind should fail
+    text = "SHM:[www.acme.com.test]";
 
     output.clear();
     ASSERT_FALSE(load_environment_server_info(text, output));

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -1391,7 +1391,7 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
     Locator_t loc, loc6(LOCATOR_KIND_UDPv6, 0);
 
     // We are going to use several test string and check they are properly parsed and turn into RemoteServerList_t
-    // 1. single server address without specific port provided
+    // 1. Single server address without specific port provided
     string text = "192.168.36.34";
 
     att.clear();
@@ -1406,7 +1406,7 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
     ASSERT_TRUE(load_environment_server_info(text, output));
     ASSERT_EQ(output, standard);
 
-    // 2. single server IPv6 address without specific port provided
+    // 2. Single server IPv6 address without specific port provided
     text = "2a02:26f0:dd:499::356e";
 
     att.clear();
@@ -1421,7 +1421,7 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
     ASSERT_TRUE(load_environment_server_info(text, output));
     ASSERT_EQ(output, standard);
 
-    // 3. single server address specifying a custom listening port
+    // 3. Single server address specifying a custom listening port
     text = "192.168.36.34:14520";
 
     att.clear();
@@ -1436,7 +1436,7 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
     ASSERT_TRUE(load_environment_server_info(text, output));
     ASSERT_EQ(output, standard);
 
-    // 4. single server IPv6 address specifying a custom listening port
+    // 4. Single server IPv6 address specifying a custom listening port
     text = "[2001:470:142:5::116]:14520";
 
     att.clear();
@@ -1451,7 +1451,7 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
     ASSERT_TRUE(load_environment_server_info(text, output));
     ASSERT_EQ(output, standard);
 
-    // 5. check any locator is turned into localhost
+    // 5. Check any locator is turned into localhost
     text = "0.0.0.0:14520;[::]:14520";
 
     att.clear();
@@ -1473,20 +1473,20 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
     ASSERT_TRUE(load_environment_server_info(text, output));
     ASSERT_EQ(output, standard);
 
-    // 6. check empty string scenario is handled
+    // 6. Check empty string scenario is handled
     text = "";
     output.clear();
 
     ASSERT_TRUE(load_environment_server_info(text, output));
     ASSERT_TRUE(output.empty());
 
-    // 7. check at least one server be present scenario is hadled
+    // 7. Check at least one server be present scenario is hadled
     text = ";;;;";
     output.clear();
 
     ASSERT_FALSE(load_environment_server_info(text, output));
 
-    // 8. check several server scenario
+    // 8. Check several server scenario
     text = "192.168.36.34:14520;172.29.55.77:8783;172.30.80.1:31090";
 
     output.clear();
@@ -1516,7 +1516,7 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
     ASSERT_TRUE(load_environment_server_info(text, output));
     ASSERT_EQ(output, standard);
 
-    // 9. check several server scenario with IPv6 addresses too
+    // 9. Check several server scenario with IPv6 addresses too
     text = "192.168.36.34:14520;[2a02:ec80:600:ed1a::3]:8783;172.30.80.1:31090";
 
     output.clear();
@@ -1546,7 +1546,7 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
     ASSERT_TRUE(load_environment_server_info(text, output));
     ASSERT_EQ(output, standard);
 
-    // 10. check multicast addresses are identified as such
+    // 10. Check multicast addresses are identified as such
     text = "239.255.0.1;ff1e::ffff:efff:1";
 
     output.clear();
@@ -1569,7 +1569,7 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
     ASSERT_TRUE(load_environment_server_info(text, output));
     ASSERT_EQ(output, standard);
 
-    // 11. check ignore some servers scenario
+    // 11. Check ignore some servers scenario
     text = ";192.168.36.34:14520;;172.29.55.77:8783;172.30.80.1:31090;";
 
     output.clear();
@@ -1654,6 +1654,79 @@ TEST(Discovery, ServerClientEnvironmentSetUp)
     IPLocator::setPhysicalPort(loc, 31090);
     att.metatrafficUnicastLocatorList.push_back(loc);
     get_server_client_default_guidPrefix(2, att.guidPrefix);
+    standard.push_back(att);
+
+    ASSERT_TRUE(load_environment_server_info(text, output));
+    ASSERT_EQ(output, standard);
+
+    // TCP transport
+
+    Locator_t loc_tcp(LOCATOR_KIND_TCPv4, 0);
+    Locator_t loc_tcp_6(LOCATOR_KIND_TCPv6, 0);
+
+    // 15. Single TCPv4 address without specifying a custom listening port
+
+    string text = "TCPv4:[192.168.36.34]";
+
+    att.clear();
+    output.clear();
+    standard.clear();
+    IPLocator::setIPv4(loc_tcp, text);
+    IPLocator::setPhysicalPort(loc_tcp, DEFAULT_TCP_SERVER_PORT);
+    IPLocator::setLogicalPort(loc_tcp, DEFAULT_TCP_SERVER_PORT);
+    att.metatrafficUnicastLocatorList.push_back(loc_tcp);
+    get_server_client_default_guidPrefix(0, att.guidPrefix);
+    standard.push_back(att);
+
+    ASSERT_TRUE(load_environment_server_info(text, output));
+    ASSERT_EQ(output, standard);
+
+    // 16. Single TCPv6 address without specifying a custom listening port
+
+    string text = "TCPv6:[192.168.36.34]";
+
+    att.clear();
+    output.clear();
+    standard.clear();
+    IPLocator::setIPv6(loc_tcp_6, text);
+    IPLocator::setPhysicalPort(loc_tcp_6, DEFAULT_TCP_SERVER_PORT);
+    IPLocator::setLogicalPort(loc_tcp_6, DEFAULT_TCP_SERVER_PORT);
+    att.metatrafficUnicastLocatorList.push_back(loc_tcp_6);
+    get_server_client_default_guidPrefix(0, att.guidPrefix);
+    standard.push_back(att);
+
+    ASSERT_TRUE(load_environment_server_info(text, output));
+    ASSERT_EQ(output, standard);
+
+    // 17. Single TCPv4 address specifying a custom listening port
+
+    string text = "TCPv4:[192.168.36.34]:14520";
+
+    att.clear();
+    output.clear();
+    standard.clear();
+    IPLocator::setIPv4(loc_tcp, text);
+    IPLocator::setPhysicalPort(loc_tcp, 14520);
+    IPLocator::setLogicalPort(loc_tcp, 14520);
+    att.metatrafficUnicastLocatorList.push_back(loc_tcp);
+    get_server_client_default_guidPrefix(0, att.guidPrefix);
+    standard.push_back(att);
+
+    ASSERT_TRUE(load_environment_server_info(text, output));
+    ASSERT_EQ(output, standard);
+
+    // 18. Single TCPv6 address specifying a custom listening port
+
+    string text = "TCPv6:[192.168.36.34]:14520";
+
+    att.clear();
+    output.clear();
+    standard.clear();
+    IPLocator::setIPv6(loc_tcp_6, text);
+    IPLocator::setPhysicalPort(loc_tcp_6, 14520);
+    IPLocator::setLogicalPort(loc_tcp_6, 14520);
+    att.metatrafficUnicastLocatorList.push_back(loc_tcp_6);
+    get_server_client_default_guidPrefix(0, att.guidPrefix);
     standard.push_back(att);
 
     ASSERT_TRUE(load_environment_server_info(text, output));
@@ -1745,6 +1818,7 @@ TEST(Discovery, ServerClientEnvironmentSetUpDNS)
     standard.clear();
     IPLocator::setIPv4(loc, "216.58.215.164");
     IPLocator::setPhysicalPort(loc, DEFAULT_TCP_SERVER_PORT);
+    IPLocator::setLogicalPort(loc, DEFAULT_TCP_SERVER_PORT);
     att.metatrafficUnicastLocatorList.push_back(loc);
     get_server_client_default_guidPrefix(0, att.guidPrefix);
     standard.push_back(att);
@@ -1760,6 +1834,7 @@ TEST(Discovery, ServerClientEnvironmentSetUpDNS)
     standard.clear();
     IPLocator::setIPv6(loc6, "2a00:1450:400e:803::2004");
     IPLocator::setPhysicalPort(loc6, DEFAULT_TCP_SERVER_PORT);
+    IPLocator::setLogicalPort(loc, DEFAULT_TCP_SERVER_PORT);
     att.metatrafficUnicastLocatorList.push_back(loc6);
     get_server_client_default_guidPrefix(0, att.guidPrefix);
     standard.push_back(att);
@@ -1806,6 +1881,7 @@ TEST(Discovery, ServerClientEnvironmentSetUpDNS)
     standard.clear();
     IPLocator::setIPv4(loc, "216.58.215.164");
     IPLocator::setPhysicalPort(loc, 14520);
+    IPLocator::setLogicalPort(loc, 14520);
     att.metatrafficUnicastLocatorList.push_back(loc);
     get_server_client_default_guidPrefix(0, att.guidPrefix);
     standard.push_back(att);
@@ -1821,6 +1897,7 @@ TEST(Discovery, ServerClientEnvironmentSetUpDNS)
     standard.clear();
     IPLocator::setIPv6(loc6, "2a00:1450:400e:803::2004");
     IPLocator::setPhysicalPort(loc6, 14520);
+    IPLocator::setLogicalPort(loc, 14520);
     att.metatrafficUnicastLocatorList.push_back(loc6);
     get_server_client_default_guidPrefix(0, att.guidPrefix);
     standard.push_back(att);

--- a/test/unittest/utils/LocatorTests.cpp
+++ b/test/unittest/utils/LocatorTests.cpp
@@ -1250,7 +1250,7 @@ TEST_F(IPLocatorTests, to_string)
 
     // TCPv4
     IPLocator::createLocator(LOCATOR_KIND_TCPv4, "0.0.1.1", 2u, locator);
-    ASSERT_EQ(IPLocator::to_string(locator), "TCPv4:[0.0.1.1]:2");
+    ASSERT_EQ(IPLocator::to_string(locator), "TCPv4:[0.0.1.1]:2-0");
 
     // UDPv6
     IPLocator::createLocator(LOCATOR_KIND_UDPv6, "200::", 3u, locator);
@@ -1258,7 +1258,7 @@ TEST_F(IPLocatorTests, to_string)
 
     // TCPv6
     IPLocator::createLocator(LOCATOR_KIND_TCPv6, "::2", 4u, locator);
-    ASSERT_EQ(IPLocator::to_string(locator), "TCPv6:[::2]:4");
+    ASSERT_EQ(IPLocator::to_string(locator), "TCPv6:[::2]:4-0");
 
     // SHM
     IPLocator::createLocator(LOCATOR_KIND_SHM, "", 5u, locator);
@@ -1560,7 +1560,7 @@ TEST(LocatorTests, LocatorList_serialization)
 
     // Full list
     ss_filled << locator_list;
-    ASSERT_EQ(ss_filled.str(), "[UDPv4:[1.1.1.1]:1,TCPv4:[2.2.2.2]:2]");
+    ASSERT_EQ(ss_filled.str(), "[UDPv4:[1.1.1.1]:1,TCPv4:[2.2.2.2]:2-0]");
 }
 
 /*
@@ -1872,7 +1872,7 @@ TEST(LocatorDNSTests, dns_locator)
                 else
                 {
                     std::stringstream ss_address;
-                    ss_address << type << ":[" << ip << "]:1024";
+                    ss_address << type << ":[" << ip << "]:1024-0";
                     std::stringstream ss_locator;
                     ss_locator << locator;
                     EXPECT_EQ(ss_address.str(), ss_locator.str()) << "Wrong translation " << ss_locator.str()

--- a/tools/fds/server.cpp
+++ b/tools/fds/server.cpp
@@ -243,7 +243,7 @@ int fastdds_discovery_server(
      *    5. No information provided.
      *          Locator: UDPv4:[0.0.0.0]:11811
      *
-     * The CLI has priority over the XML file configuration.
+     * The UDP CLI has priority over the XML file configuration.
      */
 
     // If the number of specify ports doesn't match the number of IPs the last port is used.
@@ -300,6 +300,7 @@ int fastdds_discovery_server(
     else if (nullptr == pOp && nullptr != pO_port)
     {
         // UDP port AND TCP port/address has been specified without specifying UDP address
+        participantQos.wire_protocol().builtin.metatrafficUnicastLocatorList.clear();
         participantQos.wire_protocol().builtin.metatrafficUnicastLocatorList.push_back(locator4);
     }
     else if (nullptr != pOp)
@@ -510,13 +511,13 @@ int fastdds_discovery_server(
                 if (type == LOCATOR_KIND_TCPv4)
                 {
                     auto tcp_descriptor = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
-                    tcp_descriptor->add_listener_port(locator_tcp_4.port);
+                    tcp_descriptor->add_listener_port(static_cast<uint16_t>(locator_tcp_4.port));
                     participantQos.transport().user_transports.push_back(tcp_descriptor);
                 }
                 else
                 {
                     auto tcp_descriptor = std::make_shared<eprosima::fastdds::rtps::TCPv6TransportDescriptor>();
-                    tcp_descriptor->add_listener_port(locator_tcp_6.port);
+                    tcp_descriptor->add_listener_port(static_cast<uint16_t>(locator_tcp_6.port));
                     participantQos.transport().user_transports.push_back(tcp_descriptor);
                 }
 

--- a/tools/fds/server.cpp
+++ b/tools/fds/server.cpp
@@ -387,8 +387,8 @@ int fastdds_discovery_server(
     }
 
     // Add TCP default locators addresses
-    Locator locator_tcp_4(4, rtps::DEFAULT_TCP_SERVER_PORT);
-    Locator locator_tcp_6(8, rtps::DEFAULT_TCP_SERVER_PORT);
+    Locator locator_tcp_4(LOCATOR_KIND_TCPv4, rtps::DEFAULT_TCP_SERVER_PORT);
+    Locator locator_tcp_6(LOCATOR_KIND_TCPv6, rtps::DEFAULT_TCP_SERVER_PORT);
     bool default_port = true;
 
     // Retrieve first TCP port

--- a/tools/fds/server.cpp
+++ b/tools/fds/server.cpp
@@ -297,9 +297,9 @@ int fastdds_discovery_server(
         participantQos.wire_protocol().builtin.metatrafficUnicastLocatorList.clear();
         participantQos.wire_protocol().builtin.metatrafficUnicastLocatorList.push_back(locator4);
     }
-    else if (nullptr != pO_port)
+    else if (nullptr == pOp && nullptr != pO_port)
     {
-        // UDP port AND TCP port/address has been specified
+        // UDP port AND TCP port/address has been specified without specifying UDP address
         participantQos.wire_protocol().builtin.metatrafficUnicastLocatorList.push_back(locator4);
     }
     else if (nullptr != pOp)

--- a/tools/fds/server.cpp
+++ b/tools/fds/server.cpp
@@ -491,12 +491,6 @@ int fastdds_discovery_server(
                     .push_back( LOCATOR_KIND_TCPv4 == type ? locator_tcp_4 : locator_tcp_6 );
 
             // Create user transport
-<<<<<<< Updated upstream
-            auto tcp_descriptor = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
-            tcp_descriptor->add_listener_port(locator_tcp_4.port);
-            participantQos.transport().user_transports.push_back(tcp_descriptor);
-             
-=======
             if (type == LOCATOR_KIND_TCPv4)
             {
                 auto tcp_descriptor = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
@@ -509,7 +503,6 @@ int fastdds_discovery_server(
                 tcp_descriptor->add_listener_port(locator_tcp_6.port);
                 participantQos.transport().user_transports.push_back(tcp_descriptor);
             }
->>>>>>> Stashed changes
 
             pO_tcp = pO_tcp->next();
             if (pO_tcp_port)
@@ -522,7 +515,7 @@ int fastdds_discovery_server(
                 if (!default_port)
                 {
                     std::cout << "Error: the number of specified tcp ports doesn't match the ip addresses" << std::endl
-                          << "       provided. TCP transports cannot share their port number." << std::endl;
+                              << "       provided. TCP transports cannot share their port number." << std::endl;
                     return 1;
                 }
                 // One default port has already been used

--- a/tools/fds/server.h
+++ b/tools/fds/server.h
@@ -79,7 +79,7 @@ const option::Descriptor usage[] = {
       "\t              address, a name can be specified.\n"},
 
     { TCP_PORT,  0, "q",  "tcp-port",         Arg::check_tcp_port,
-      "  -q  \t--tcp-port    TCP port chosen to listen the clients. Defaults to 16166\n" },
+      "  -q  \t--tcp-port    TCP port chosen to listen the clients. Defaults to 42100\n" },
 
     { BACKUP,    0, "b",  "backup",       Arg::None,
       "  -b  \t--backup      Creates a server with a backup file associated.\n" },

--- a/tools/fds/server.h
+++ b/tools/fds/server.h
@@ -132,7 +132,7 @@ const option::Descriptor usage[] = {
       "\t8.  Launch a server with id 0 (first on ROS_DISCOVERY_SERVER) reading\n"
       "\t    specific profile_name configuration from XML file.\n\n"
       "\t    $ " FAST_SERVER_BINARY " -i 0 -x profile_name@config.xml\n\n"
-      
+
       "\t9.  Launch a server with id 0 (first on ROS_DISCOVERY_SERVER) listening\n"
       "\t    on localhost with default TCP port 42100.\n\n"
       "\t    $ " FAST_SERVER_BINARY " -i 0 -t 127.0.0.1\n\n"

--- a/tools/fds/server.h
+++ b/tools/fds/server.h
@@ -25,8 +25,9 @@ enum  optionIndex
     UNKNOWN,
     HELP,
     SERVERID,
-    IPADDRESS,
+    UDPADDRESS,
     PORT,
+    TCPADDRESS,
     BACKUP,
     XML_FILE
 };
@@ -53,29 +54,34 @@ const option::Descriptor usage[] = {
       "\nUsage: " FAST_SERVER_BINARY " [optional parameters] \nGeneral options:" },
 
     { HELP,      0, "h",  "help",         Arg::None,
-      "  -h  \t--help       Produce help message.\n" },
+      "  -h  \t--help        Produce help message.\n" },
 
     { SERVERID,  0, "i", "server-id",    Arg::check_server_id,
-      "  -i \t--server-id  Unique server identifier. Specifies zero based server\n"
-      "\t             position in ROS_DISCOVERY_SERVER environment variable.\n" },
+      "  -i \t--server-id   Unique server identifier. Specifies zero based server\n"
+      "\t              position in ROS_DISCOVERY_SERVER environment variable.\n" },
 
-    { IPADDRESS, 0, "l", "ip-address",   Arg::required,
-      "  -l \t--ip-address IPv4/IPv6 address chosen to listen the clients. Defaults\n"
-      "\t             to any (0.0.0.0/::0). Instead of an address, a name can\n"
-      "\t             be specified."},
+    { UDPADDRESS, 0, "l", "udp-address",   Arg::required,
+      "  -l \t--udp-address  IPv4/IPv6 address chosen to listen the clients. Defaults\n"
+      "\t              to any (0.0.0.0/::0). Instead of an address, a name can\n"
+      "\t              be specified.\n"},
 
     { PORT,      0, "p",  "port",         Arg::check_udp_port,
-      "  -p  \t--port       UDP port chosen to listen the clients. Defaults to 11811\n" },
+      "  -p  \t--port        UDP port chosen to listen the clients. Defaults to 11811\n" },
+
+    { TCPADDRESS, 0, "t", "tcp-address",   Arg::required,
+      "  -t \t--tcp-address IPv4/IPv6 address chosen to listen the clients using\n"
+      "\t              TCP transport. Defaults to any (0.0.0.0/::0). Instead of an \n"
+      "\t              address, a name can be specified."},
 
     { BACKUP,    0, "b",  "backup",       Arg::None,
-      "  -b  \t--backup     Creates a server with a backup file associated.\n" },
+      "  -b  \t--backup      Creates a server with a backup file associated.\n" },
 
     { XML_FILE,  0, "x",  "xml-file",     Arg::required,
-      "  -x  \t--xml-file   Gets config from XML file. If there is any argument in \n"
-      "\t             common with the config of the XML, the XML argument will \n"
-      "\t             be overriden. A XML file with several profiles will take\n"
-      "\t             the profile with \"is_default_profile=\"true\"\" unless \n"
-      "\t             another profile using uri with \"@\" character is defined.\n"},
+      "  -x  \t--xml-file    Gets config from XML file. If there is any argument in \n"
+      "\t              common with the config of the XML, the XML argument will \n"
+      "\t              be overriden. A XML file with several profiles will take\n"
+      "\t              the profile with \"is_default_profile=\"true\"\" unless \n"
+      "\t              another profile using uri with \"@\" character is defined.\n"},
 
     { UNKNOWN,   0, "",  "",              Arg::None,
       "Examples:\n"
@@ -83,41 +89,41 @@ const option::Descriptor usage[] = {
       "\t1. Launch a default server with id 0 (first on ROS_DISCOVERY_SERVER)\n"
       "\t   listening on all available interfaces on UDP port 11811. Only one\n"
       "\t   server can use default values per machine.\n\n"
-      "\t$ " FAST_SERVER_BINARY " -i 0\n\n"
+      "\t   $ " FAST_SERVER_BINARY " -i 0\n\n"
 
       "\t2. Launch a default server with id 1 (second on ROS_DISCOVERY_SERVER)\n"
       "\t   listening on localhost with UDP port 14520. Only localhost clients\n"
       "\t   can reach the server using as ROS_DISCOVERY_SERVER=;127.0.0.1:14520\n\n"
-      "\t$ " FAST_SERVER_BINARY " -i 1 -l 127.0.0.1 -p 14520\n\n"
+      "\t   $ " FAST_SERVER_BINARY " -i 1 -l 127.0.0.1 -p 14520\n\n"
 
       "\t3. Launch a default server with id 1 (second on ROS_DISCOVERY_SERVER)\n"
       "\t   listening on UDPv6 address with UDP port 14520.\n\n"
-      "\t$ " FAST_SERVER_BINARY " -i 1 -l 2a02:ec80:600:ed1a::3 -p 14520\n\n"
+      "\t   $ " FAST_SERVER_BINARY " -i 1 -l 2a02:ec80:600:ed1a::3 -p 14520\n\n"
 
       "\t4. Launch a default server with id 2 (third on ROS_DISCOVERY_SERVER)\n"
       "\t   listening on Wi-Fi (192.163.6.34) and Ethernet (172.20.96.1) local\n"
       "\t   interfaces with UDP ports 8783 and 51083 respectively\n"
       "\t   (addresses and ports are made up for the example).\n\n"
-      "\t$ " FAST_SERVER_BINARY " -i 2 -l 192.163.6.34 -p 8783 -l 172.20.96.1 -p 51083\n\n"
+      "\t   $ " FAST_SERVER_BINARY " -i 2 -l 192.163.6.34 -p 8783 -l 172.20.96.1 -p 51083\n\n"
 
       "\t5. Launch a default server with id 3 (fourth on ROS_DISCOVERY_SERVER)\n"
       "\t   listening on 172.31.44.1 with UDP port 12345 and provided with a\n"
       "\t   backup file. If the server crashes it will automatically restore its\n"
       "\t   previous state when reenacted.\n\n"
-      "\t$ " FAST_SERVER_BINARY " -i 3 -l 172.31.44.1 -p 12345 -b\n\n"
+      "\t   $ " FAST_SERVER_BINARY " -i 3 -l 172.31.44.1 -p 12345 -b\n\n"
 
       "\t6. Launch a default server with id 0 (first on ROS_DISCOVERY_SERVER)\n"
       "\t   listening on localhost with UDP port 14520 Only localhost clients\n"
       "\t   can reach the server defining as ROS_DISCOVERY_SERVER=localhost:14520\n\n"
-      "\t$ " FAST_SERVER_BINARY " -i 0 -l localhost -p 14520\n\n"
+      "\t   $ " FAST_SERVER_BINARY " -i 0 -l localhost -p 14520\n\n"
 
       "\t7. Launch a server with id 0 (first on ROS_DISCOVERY_SERVER) reading\n"
       "\t   default configuration from XML file.\n\n"
-      "\t$ " FAST_SERVER_BINARY " -i 0 -x config.xml\n\n"
+      "\t   $ " FAST_SERVER_BINARY " -i 0 -x config.xml\n\n"
 
       "\t6 Launch a server with id 0 (first on ROS_DISCOVERY_SERVER) reading\n"
       "\t   specific profile_name configuration from XML file.\n\n"
-      "\t$ " FAST_SERVER_BINARY " -i 0 -x profile_name@config.xml"},
+      "\t   $ " FAST_SERVER_BINARY " -i 0 -x profile_name@config.xml"},
 
     { 0, 0, 0, 0, 0, 0 }
 };

--- a/versions.md
+++ b/versions.md
@@ -5,6 +5,9 @@ Forthcoming
 * Added monitor service feature.
 * Added the possibility to define interfaces in the whitelist by interface name.
 * Enable support for DataRepresentationQos to select the CDR encoding.
+* Added the possibility to define a listening port equal to 0 in TCP Transport
+* Added support for TCP to Fast DDS CLI and environment variable
+* Enable Discovery Server example through TCP
 
 Version 2.12.0
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR adds TCPv4/6 support for both the Fast DDS CLI and the ROS_DISCOVERY_SERVER environment variable. 

@Mergifyio backport 2.12.x 2.11.x 2.10.x 2.6.x

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.11.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
  Related tests: https://github.com/eProsima/Discovery-Server/pull/66 (PR)
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [X] New feature has been documented/Current behavior is correctly described in the documentation.
    Related documentation PR: https://github.com/eProsima/Fast-DDS-docs/pull/599 (PR) 
- [X] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
