### PR TITLE
[19939] TCP deadlock on channel reuse

### DIFF
--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -930,9 +930,9 @@ void TCPTransportInterface::perform_listen_operation(
                 TransportReceiverInterface* receiver = it->second.first;
                 ReceiverInUseCV* receiver_in_use = it->second.second;
                 receiver_in_use->cv.wait(scopedLock, [&]()
-                    {
-                        return receiver_in_use->in_use == false;
-                    });
+                        {
+                            return receiver_in_use->in_use == false;
+                        });
                 if (TCPChannelResource::eConnectionStatus::eConnecting < channel->connection_status())
                 {
                     receiver_in_use->in_use = true;

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -258,6 +258,21 @@ void TCPTransportInterface::bind_socket(
     auto it_remove = std::find(unbound_channel_resources_.begin(), unbound_channel_resources_.end(), channel);
     assert(it_remove != unbound_channel_resources_.end());
     unbound_channel_resources_.erase(it_remove);
+
+    unbound_lock.unlock();
+
+    // Look for an existing channel that matches this physical locator
+    auto existing_channel = channel_resources_.find(channel->locator());
+    // If the channel exists, check if the channel reference wait until it finishes its tasks
+    if (existing_channel != channel_resources_.end())
+    {
+        // Disconnect the old channel
+        existing_channel->second->disconnect();
+        scopedLock.unlock();
+        existing_channel->second->clear();
+        scopedLock.lock();
+    }
+
     channel_resources_[channel->locator()] = channel;
 
 }
@@ -678,9 +693,6 @@ bool TCPTransportInterface::OpenOutputChannel(
                 if (existing_channel != channel_resources_.end() &&
                         existing_channel->second != tcp_sender_resource->channel())
                 {
-                    // Disconnect the old channel
-                    tcp_sender_resource->channel()->disconnect();
-                    tcp_sender_resource->channel()->clear();
                     // Update sender resource with new channel
                     tcp_sender_resource->channel() = existing_channel->second;
                 }
@@ -917,10 +929,17 @@ void TCPTransportInterface::perform_listen_operation(
             {
                 TransportReceiverInterface* receiver = it->second.first;
                 ReceiverInUseCV* receiver_in_use = it->second.second;
-                receiver_in_use->in_use = true;
-                scopedLock.unlock();
-                receiver->OnDataReceived(msg.buffer, msg.length, channel->locator(), remote_locator);
-                scopedLock.lock();
+                receiver_in_use->cv.wait(scopedLock, [&]()
+                    {
+                        return receiver_in_use->in_use == false;
+                    });
+                if (TCPChannelResource::eConnectionStatus::eConnecting < channel->connection_status())
+                {
+                    receiver_in_use->in_use = true;
+                    scopedLock.unlock();
+                    receiver->OnDataReceived(msg.buffer, msg.length, channel->locator(), remote_locator);
+                    scopedLock.lock();
+                }
                 receiver_in_use->in_use = false;
                 receiver_in_use->cv.notify_one();
             }

--- a/test/blackbox/common/BlackboxTestsTransportTCP.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportTCP.cpp
@@ -615,8 +615,10 @@ TEST_P(TransportTCP, TCPv6_copy)
     EXPECT_EQ(tcpv6_transport_copy, tcpv6_transport);
 }
 
-// Test connection is successfully restablished after dropping and relaunching a TCP client (requester)
+// Test connection is successfully restablished after dropping and relaunching a TCP client (requester), 
+// when the server's listening thread for the old client hasn't processed all its messages.
 // Issue -> https://github.com/eProsima/Fast-DDS/issues/2409
+// Issue -> https://github.com/eProsima/Fast-DDS/issues/4026
 TEST(TransportTCP, Client_reconnection)
 {
     TCPReqRepHelloWorldReplier* replier;
@@ -624,7 +626,7 @@ TEST(TransportTCP, Client_reconnection)
     const uint16_t nmsgs = 5;
 
     replier = new TCPReqRepHelloWorldReplier;
-    replier->init(1, 0, global_port);
+    replier->init(1, 0, global_port, 0, nullptr, true);
 
     ASSERT_TRUE(replier->isInitialized());
 

--- a/test/blackbox/common/BlackboxTestsTransportTCP.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportTCP.cpp
@@ -615,7 +615,7 @@ TEST_P(TransportTCP, TCPv6_copy)
     EXPECT_EQ(tcpv6_transport_copy, tcpv6_transport);
 }
 
-// Test connection is successfully restablished after dropping and relaunching a TCP client (requester), 
+// Test connection is successfully restablished after dropping and relaunching a TCP client (requester),
 // when the server's listening thread for the old client hasn't processed all its messages.
 // Issue -> https://github.com/eProsima/Fast-DDS/issues/2409
 // Issue -> https://github.com/eProsima/Fast-DDS/issues/4026

--- a/test/blackbox/common/TCPReqRepHelloWorldReplier.cpp
+++ b/test/blackbox/common/TCPReqRepHelloWorldReplier.cpp
@@ -134,7 +134,7 @@ void TCPReqRepHelloWorldReplier::init(
     puattr.topic.topicDataType = type_.getName();
     puattr.topic.topicName = "HelloWorldTopicReply";
     configPublisher("Reply");
-    if(use_bussy_listener)
+    if (use_bussy_listener)
     {
         reply_publisher_ = Domain::createPublisher(participant_, puattr, &reply_bussy_listener_);
     }

--- a/test/blackbox/common/TCPReqRepHelloWorldReplier.cpp
+++ b/test/blackbox/common/TCPReqRepHelloWorldReplier.cpp
@@ -41,7 +41,6 @@ using namespace eprosima::fastrtps::rtps;
 TCPReqRepHelloWorldReplier::TCPReqRepHelloWorldReplier()
     : request_listener_(*this)
     , reply_listener_(*this)
-    , reply_bussy_listener_(*this)
     , participant_(nullptr)
     , request_subscriber_(nullptr)
     , reply_publisher_(nullptr)
@@ -67,7 +66,7 @@ void TCPReqRepHelloWorldReplier::init(
         uint16_t listeningPort,
         uint32_t maxInitialPeer,
         const char* certs_path,
-        bool use_bussy_listener)
+        bool use_busy_listener)
 {
     ParticipantAttributes pattr;
     pattr.domainId = domainId;
@@ -134,15 +133,13 @@ void TCPReqRepHelloWorldReplier::init(
     puattr.topic.topicDataType = type_.getName();
     puattr.topic.topicName = "HelloWorldTopicReply";
     configPublisher("Reply");
-    if (use_bussy_listener)
+    if (use_busy_listener)
     {
-        reply_publisher_ = Domain::createPublisher(participant_, puattr, &reply_bussy_listener_);
+        reply_listener_.use_busy_listener(true);
     }
-    else
-    {
-        reply_publisher_ = Domain::createPublisher(participant_, puattr, &reply_listener_);
-    }
+    reply_publisher_ = Domain::createPublisher(participant_, puattr, &reply_listener_);
     ASSERT_NE(reply_publisher_, nullptr);
+
 
     initialized_ = true;
 }

--- a/test/blackbox/common/TCPReqRepHelloWorldReplier.cpp
+++ b/test/blackbox/common/TCPReqRepHelloWorldReplier.cpp
@@ -41,6 +41,7 @@ using namespace eprosima::fastrtps::rtps;
 TCPReqRepHelloWorldReplier::TCPReqRepHelloWorldReplier()
     : request_listener_(*this)
     , reply_listener_(*this)
+    , reply_bussy_listener_(*this)
     , participant_(nullptr)
     , request_subscriber_(nullptr)
     , reply_publisher_(nullptr)
@@ -65,7 +66,8 @@ void TCPReqRepHelloWorldReplier::init(
         int domainId,
         uint16_t listeningPort,
         uint32_t maxInitialPeer,
-        const char* certs_path)
+        const char* certs_path,
+        bool use_bussy_listener)
 {
     ParticipantAttributes pattr;
     pattr.domainId = domainId;
@@ -132,7 +134,14 @@ void TCPReqRepHelloWorldReplier::init(
     puattr.topic.topicDataType = type_.getName();
     puattr.topic.topicName = "HelloWorldTopicReply";
     configPublisher("Reply");
-    reply_publisher_ = Domain::createPublisher(participant_, puattr, &reply_listener_);
+    if(use_bussy_listener)
+    {
+        reply_publisher_ = Domain::createPublisher(participant_, puattr, &reply_bussy_listener_);
+    }
+    else
+    {
+        reply_publisher_ = Domain::createPublisher(participant_, puattr, &reply_listener_);
+    }
     ASSERT_NE(reply_publisher_, nullptr);
 
     initialized_ = true;

--- a/test/blackbox/common/TCPReqRepHelloWorldReplier.hpp
+++ b/test/blackbox/common/TCPReqRepHelloWorldReplier.hpp
@@ -92,6 +92,7 @@ public:
         RequestListener(
                 TCPReqRepHelloWorldReplier& replier)
             : replier_(replier)
+            , use_busy_listener_(false)
         {
         }
 
@@ -107,6 +108,16 @@ public:
             {
                 replier_.matched();
             }
+            else if (info.status == eprosima::fastrtps::rtps::REMOVED_MATCHING && use_busy_listener_)
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            }
+        }
+
+        void use_busy_listener(
+                const bool& value)
+        {
+            use_busy_listener_ = value;
         }
 
     private:
@@ -115,47 +126,10 @@ public:
                 const RequestListener&) = delete;
 
         TCPReqRepHelloWorldReplier& replier_;
+        bool use_busy_listener_;
 
     }
     reply_listener_;
-
-    class RequestBussyListener : public eprosima::fastrtps::PublisherListener
-    {
-    public:
-
-        RequestBussyListener(
-                TCPReqRepHelloWorldReplier& replier)
-            : replier_(replier)
-        {
-        }
-
-        ~RequestBussyListener()
-        {
-        }
-
-        void onPublicationMatched(
-                eprosima::fastrtps::Publisher* /*pub*/,
-                eprosima::fastrtps::rtps::MatchingInfo& info)
-        {
-            if (info.status == eprosima::fastrtps::rtps::MATCHED_MATCHING)
-            {
-                replier_.matched();
-            }
-            else if (info.status == eprosima::fastrtps::rtps::REMOVED_MATCHING)
-            {
-                std::this_thread::sleep_for(std::chrono::milliseconds(500));
-            }
-        }
-
-    private:
-
-        RequestBussyListener& operator =(
-                const RequestBussyListener&) = delete;
-
-        TCPReqRepHelloWorldReplier& replier_;
-
-    }
-    reply_bussy_listener_;
 
     TCPReqRepHelloWorldReplier();
     virtual ~TCPReqRepHelloWorldReplier();
@@ -165,7 +139,7 @@ public:
             uint16_t listeningPort,
             uint32_t maxInitialPeer = 0,
             const char* certs_path = nullptr,
-            bool use_bussy_listener = false);
+            bool use_busy_listener = false);
     bool isInitialized() const
     {
         return initialized_;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
TCP channel reuse required joining the thread in charge of the previous channel. However, this call to `join()` involved taking some mutex that prevented the old thread from finishing its tasks, leading to a deadlock.
The disabling of the old channel has been relocated as well as the protection of some other channel resources.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.12.x 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
Fixes #4026 
<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
-  *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
