### PR TITLE
[20020] Remove SHM locator from metatrafficUnicastLocList in LARGE_DATA

### DIFF
--- a/src/cpp/rtps/attributes/RTPSParticipantAttributes.cpp
+++ b/src/cpp/rtps/attributes/RTPSParticipantAttributes.cpp
@@ -203,7 +203,6 @@ static void setup_transports_large_data(
         att.userTransports.push_back(shm_transport);
 
         auto shm_loc = fastdds::rtps::SHMLocator::create_locator(0, fastdds::rtps::SHMLocator::Type::UNICAST);
-        att.builtin.metatrafficUnicastLocatorList.push_back(shm_loc);
         att.defaultUnicastLocatorList.push_back(shm_loc);
 
         auto tcp_transport = create_tcpv4_transport(att);
@@ -240,7 +239,6 @@ static void setup_transports_large_datav6(
         att.userTransports.push_back(shm_transport);
 
         auto shm_loc = fastdds::rtps::SHMLocator::create_locator(0, fastdds::rtps::SHMLocator::Type::UNICAST);
-        att.builtin.metatrafficUnicastLocatorList.push_back(shm_loc);
         att.defaultUnicastLocatorList.push_back(shm_loc);
 
         auto tcp_transport = create_tcpv6_transport(att);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR apply a bugfix removing the SHM locators of the metatrafficUnicastLocator in the LARGE_DATA mode.

@Merfigyio backport 2.6.x 2.10.x 2.11.x 2.12.x

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.11.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [X] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- _N/A_ Check CI results: changes do not issue any warning.
- _N/A_ Check CI results: failing tests are unrelated with the changes.
