### PR TITLE
[20351] Fix on_sample_lost notification on best-effort readers for framented samples

### DIFF
--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -710,6 +710,25 @@ bool StatelessReader::processDataFragMsg(
                 {
                     if (work_change->sequenceNumber < change_to_add->sequenceNumber)
                     {
+                        SequenceNumber_t updated_seq = work_change->sequenceNumber;
+                        SequenceNumber_t previous_seq{ 0, 0 };
+                        previous_seq = update_last_notified(writer_guid, updated_seq);
+
+                        // Notify lost samples
+                        auto listener = getListener();
+                        if (listener != nullptr)
+                        {
+                            if (SequenceNumber_t{ 0, 0 } != previous_seq)
+                            {
+                                assert(previous_seq < updated_seq);
+                                uint64_t tmp = (updated_seq - previous_seq).to64long();
+                                int32_t lost_samples = tmp > static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) ?
+                                    std::numeric_limits<int32_t>::max() : static_cast<int32_t>(tmp);
+                                assert (0 < lost_samples);
+                                listener->on_sample_lost(this, lost_samples);
+                            }
+                        }
+
                         // Pending change should be dropped. Check if it can be reused
                         if (sampleSize <= work_change->serializedPayload.max_size)
                         {

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -722,8 +722,9 @@ bool StatelessReader::processDataFragMsg(
                             {
                                 assert(previous_seq < updated_seq);
                                 uint64_t tmp = (updated_seq - previous_seq).to64long();
-                                int32_t lost_samples = tmp > static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) ?
-                                    std::numeric_limits<int32_t>::max() : static_cast<int32_t>(tmp);
+                                int32_t lost_samples =
+                                        tmp > static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) ?
+                                        std::numeric_limits<int32_t>::max() : static_cast<int32_t>(tmp);
                                 assert (0 < lost_samples);
                                 listener->on_sample_lost(this, lost_samples);
                             }

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -733,7 +733,7 @@ void sample_lost_test_dw_init(
 
                 // generate losses
                 if ((writerID.value[3] & 0xC0) == 0 // only user endpoints
-                    && (1 == first_fragment)        // only first fragment
+                        && (1 == first_fragment)    // only first fragment
                         && (sn == SequenceNumber_t{0, 2} ||
                         sn == SequenceNumber_t(0, 3) ||
                         sn == SequenceNumber_t(0, 4) ||

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -674,8 +674,9 @@ TEST_P(DDSStatus, DataAvailableConditions)
     subscriber_reader.wait_waitset_timeout();
 }
 
+template<typename T>
 void sample_lost_test_dw_init(
-        PubSubWriter<HelloWorldPubSubType>& writer)
+        PubSubWriter<T>& writer)
 {
     auto testTransport = std::make_shared<test_UDPv4TransportDescriptor>();
     testTransport->drop_data_messages_filter_ = [](eprosima::fastrtps::rtps::CDRMessage_t& msg)-> bool
@@ -711,6 +712,42 @@ void sample_lost_test_dw_init(
 
                 return false;
             };
+    testTransport->drop_data_frag_messages_filter_ = [](eprosima::fastrtps::rtps::CDRMessage_t& msg)-> bool
+            {
+                uint32_t old_pos = msg.pos;
+
+                // see RTPS DDS 9.4.5.4 DataFrag Submessage
+                EntityId_t readerID, writerID;
+                SequenceNumber_t sn;
+                uint32_t first_fragment = 0;
+
+                msg.pos += 2; // flags
+                msg.pos += 2; // octets to inline quos
+                CDRMessage::readEntityId(&msg, &readerID);
+                CDRMessage::readEntityId(&msg, &writerID);
+                CDRMessage::readSequenceNumber(&msg, &sn);
+                CDRMessage::readUInt32(&msg, &first_fragment);
+
+                // restore buffer pos
+                msg.pos = old_pos;
+
+                // generate losses
+                if ((writerID.value[3] & 0xC0) == 0 // only user endpoints
+                    && (1 == first_fragment)        // only first fragment
+                        && (sn == SequenceNumber_t{0, 2} ||
+                        sn == SequenceNumber_t(0, 3) ||
+                        sn == SequenceNumber_t(0, 4) ||
+                        sn == SequenceNumber_t(0, 6) ||
+                        sn == SequenceNumber_t(0, 8) ||
+                        sn == SequenceNumber_t(0, 10) ||
+                        sn == SequenceNumber_t(0, 11) ||
+                        sn == SequenceNumber_t(0, 13)))
+                {
+                    return true;
+                }
+
+                return false;
+            };
 
 
     writer.disable_builtin_transport()
@@ -721,19 +758,22 @@ void sample_lost_test_dw_init(
 
 }
 
+template<typename T>
 void sample_lost_test_dr_init(
-        PubSubReader<HelloWorldPubSubType>& reader,
+        PubSubReader<T>& reader,
         std::function<void(const eprosima::fastdds::dds::SampleLostStatus& status)> functor)
 {
+    reader.socket_buffer_size(20 * 1024 * 1024);
     reader.sample_lost_status_functor(functor)
             .init();
 
     ASSERT_TRUE(reader.isInitialized());
 }
 
+template<typename T>
 void sample_lost_test_init(
-        PubSubReader<HelloWorldPubSubType>& reader,
-        PubSubWriter<HelloWorldPubSubType>& writer,
+        PubSubReader<T>& reader,
+        PubSubWriter<T>& writer,
         std::function<void(const eprosima::fastdds::dds::SampleLostStatus& status)> functor)
 {
     sample_lost_test_dw_init(writer);
@@ -799,6 +839,78 @@ TEST(DDSStatus, sample_lost_be_dw_be_dr)
     test_step_cv.wait(lock, [&test_step]()
             {
                 return 4 == test_step;
+            });
+}
+
+/*!
+ * \test DDS-STS-SLS-01 Test `SampleLostStatus` in a Best-Effort DataWriter and a Best-Effort DataReader communication.
+ * This is also a regression test for bug redmine 20162
+ */
+TEST(DDSStatus, sample_lost_be_dw_be_dr_fragments)
+{
+    PubSubReader<Data1mbPubSubType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<Data1mbPubSubType> writer(TEST_TOPIC_NAME);
+
+    std::mutex test_step_mtx;
+    std::condition_variable test_step_cv;
+    uint8_t test_step = 0;
+
+    writer.reliability(eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS);
+    reader.reliability(eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS);
+
+    sample_lost_test_init(reader, writer, [&test_step_mtx, &test_step_cv, &test_step](
+                const eprosima::fastdds::dds::SampleLostStatus& status)
+            {
+                {
+                    std::unique_lock<std::mutex> lock(test_step_mtx);
+                    std::cout << status.total_count << " " << status.total_count_change << std::endl;
+                    if (0 == test_step && 1 == status.total_count && 1 == status.total_count_change)
+                    {
+                        ++test_step;
+                    }
+                    else if (1 == test_step && 2 == status.total_count && 1 == status.total_count_change)
+                    {
+                        ++test_step;
+                    }
+                    else if (2 == test_step && 3 == status.total_count && 1 == status.total_count_change)
+                    {
+                        ++test_step;
+                    }
+                    else if (3 == test_step && 4 == status.total_count && 1 == status.total_count_change)
+                    {
+                        ++test_step;
+                    }
+                    else if (4 == test_step && 5 == status.total_count && 1 == status.total_count_change)
+                    {
+                        ++test_step;
+                    }
+                    else if (5 == test_step && 6 == status.total_count && 1 == status.total_count_change)
+                    {
+                        ++test_step;
+                    }
+                    else if (6 == test_step && 7 == status.total_count && 1 == status.total_count_change)
+                    {
+                        ++test_step;
+                    }
+                    else
+                    {
+                        test_step = 0;
+                    }
+                }
+
+                test_step_cv.notify_all();
+            });
+
+
+    auto data = default_data300kb_data_generator(13);
+
+    reader.startReception(data);
+    writer.send(data, 100);
+
+    std::unique_lock<std::mutex> lock(test_step_mtx);
+    test_step_cv.wait(lock, [&test_step]()
+            {
+                return 7 == test_step;
             });
 }
 

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -32,7 +32,7 @@ using namespace eprosima::fastrtps::xmlparser;
 using test_UDPv4TransportDescriptor = eprosima::fastdds::rtps::test_UDPv4TransportDescriptor;
 
 #define INCOMPATIBLE_TEST_TOPIC_NAME std::string( \
-            std::string("incompatible_") + TEST_TOPIC_NAME)
+        std::string("incompatible_") + TEST_TOPIC_NAME)
 
 
 enum communication_type

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -32,7 +32,7 @@ using namespace eprosima::fastrtps::xmlparser;
 using test_UDPv4TransportDescriptor = eprosima::fastdds::rtps::test_UDPv4TransportDescriptor;
 
 #define INCOMPATIBLE_TEST_TOPIC_NAME std::string( \
-        std::string("incompatible_") + TEST_TOPIC_NAME)
+            std::string("incompatible_") + TEST_TOPIC_NAME)
 
 
 enum communication_type
@@ -768,7 +768,10 @@ void sample_lost_test_dr_init(
     // We want to ensure that samples are only lost due to the custom filter we have set in sample_lost_test_dw_init.
     // Since we are going to send 300KB samples in the test for fragments, let's increase the buffer size to avoid any
     // other possible loss.
-    constexpr uint32_t BUFFER_SIZE = 20ul * 1024ul * 1024ul;
+    constexpr uint32_t BUFFER_SIZE =
+            300ul * 1024ul // sample size
+            * 13ul       // number of samples
+            * 2ul;       // 2x to avoid any possible loss
     reader.socket_buffer_size(BUFFER_SIZE);
     reader.sample_lost_status_functor(functor)
             .init();

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -768,7 +768,8 @@ void sample_lost_test_dr_init(
     // We want to ensure that samples are only lost due to the custom filter we have set in sample_lost_test_dw_init.
     // Since we are going to send 300KB samples in the test for fragments, let's increase the buffer size to avoid any
     // other possible loss.
-    reader.socket_buffer_size(20 * 1024 * 1024);
+    constexpr uint32_t BUFFER_SIZE = 20ul * 1024ul * 1024ul;
+    reader.socket_buffer_size(BUFFER_SIZE);
     reader.sample_lost_status_functor(functor)
             .init();
 

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -684,7 +684,8 @@ void sample_lost_test_dw_init(
                 uint32_t old_pos = msg.pos;
 
                 // see RTPS DDS 9.4.5.3 Data Submessage
-                EntityId_t readerID, writerID;
+                EntityId_t readerID;
+                EntityId_t writerID;
                 SequenceNumber_t sn;
 
                 msg.pos += 2; // flags
@@ -717,7 +718,8 @@ void sample_lost_test_dw_init(
                 uint32_t old_pos = msg.pos;
 
                 // see RTPS DDS 9.4.5.4 DataFrag Submessage
-                EntityId_t readerID, writerID;
+                EntityId_t readerID;
+                EntityId_t writerID;
                 SequenceNumber_t sn;
                 uint32_t first_fragment = 0;
 
@@ -763,6 +765,9 @@ void sample_lost_test_dr_init(
         PubSubReader<T>& reader,
         std::function<void(const eprosima::fastdds::dds::SampleLostStatus& status)> functor)
 {
+    // We want to ensure that samples are only lost due to the custom filter we have set in sample_lost_test_dw_init.
+    // Since we are going to send 300KB samples in the test for fragments, let's increase the buffer size to avoid any
+    // other possible loss.
     reader.socket_buffer_size(20 * 1024 * 1024);
     reader.sample_lost_status_functor(functor)
             .init();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
When some fragments are lost on every sample, best-effort readers were not notifying `on_sample_lost` events.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.12.x 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
