### PR TITLE
[20166] Fix data race in PDPListener and SecurityManager

### DIFF
--- a/src/cpp/rtps/builtin/discovery/participant/DS/PDPSecurityInitiatorListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/DS/PDPSecurityInitiatorListener.cpp
@@ -71,15 +71,16 @@ void PDPSecurityInitiatorListener::process_alive_data(
 
     if (old_data == nullptr)
     {
+        auto callback_data = new_data;
         reader->getMutex().unlock();
         lock.unlock();
 
         //! notify security manager in order to start handshake
-        bool ret = parent_pdp_->getRTPSParticipant()->security_manager().discovered_participant(new_data);
+        bool ret = parent_pdp_->getRTPSParticipant()->security_manager().discovered_participant(callback_data);
         //! Reply to the remote participant
         if (ret)
         {
-            response_cb_(temp_participant_data_);
+            response_cb_(callback_data);
         }
 
         // Take again the reader lock

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -589,6 +589,8 @@ bool SecurityManager::discovered_participant(
     // Create or find information
     bool undiscovered = false;
     DiscoveredParticipantInfo::AuthUniquePtr remote_participant_info;
+    // Use the information from the collection
+    const ParticipantProxyData* remote_participant_data = nullptr;
     {
         std::lock_guard<shared_mutex> _(mutex_);
 
@@ -602,13 +604,14 @@ bool SecurityManager::discovered_participant(
 
         undiscovered = map_ret.second;
         remote_participant_info = map_ret.first->second->get_auth();
+        remote_participant_data = &map_ret.first->second->participant_data();
     }
 
     bool notify_part_authorized = false;
-    if (undiscovered && remote_participant_info)
+    if (undiscovered && remote_participant_info && remote_participant_data != nullptr)
     {
         // Configure the timed event but do not start it
-        const GUID_t guid = participant_data.m_guid;
+        const GUID_t guid = remote_participant_data->m_guid;
         remote_participant_info->event_.reset(new TimedEvent(participant_->getEventResource(),
                 [&, guid]() -> bool
                 {
@@ -622,8 +625,8 @@ bool SecurityManager::discovered_participant(
         // Validate remote participant.
         ValidationResult_t validation_ret = authentication_plugin_->validate_remote_identity(&remote_identity_handle,
                         *local_identity_handle_,
-                        participant_data.identity_token_,
-                        participant_data.m_guid, exception);
+                        remote_participant_data->identity_token_,
+                        remote_participant_data->m_guid, exception);
 
         switch (validation_ret)
         {
@@ -643,21 +646,21 @@ bool SecurityManager::discovered_participant(
             // TODO(Ricardo) Send event.
             default:
 
-                on_validation_failed(participant_data, exception);
+                on_validation_failed(*remote_participant_data, exception);
 
                 std::lock_guard<shared_mutex> _(mutex_);
 
                 // Remove created element, because authentication failed.
-                discovered_participants_.erase(participant_data.m_guid);
+                discovered_participants_.erase(remote_participant_data->m_guid);
 
                 //TODO(Ricardo) cryptograhy registration in AUTHENTICAITON_OK
                 return false;
         }
 
-        EPROSIMA_LOG_INFO(SECURITY, "Discovered participant " << participant_data.m_guid);
+        EPROSIMA_LOG_INFO(SECURITY, "Discovered participant " << remote_participant_data->m_guid);
 
         // Match entities
-        match_builtin_endpoints(participant_data);
+        match_builtin_endpoints(*remote_participant_data);
 
         // Store new remote handle.
         remote_participant_info->auth_status_ = auth_status;
@@ -669,7 +672,7 @@ bool SecurityManager::discovered_participant(
         {
             //TODO(Ricardo) Shared secret on this case?
             std::shared_ptr<SecretHandle> ss;
-            notify_part_authorized = participant_authorized(participant_data, remote_participant_info, ss);
+            notify_part_authorized = participant_authorized(*remote_participant_data, remote_participant_info, ss);
         }
     }
     else
@@ -692,15 +695,15 @@ bool SecurityManager::discovered_participant(
     if (remote_participant_info->auth_status_ == AUTHENTICATION_REQUEST_NOT_SEND)
     {
         // Maybe send request.
-        returnedValue = on_process_handshake(participant_data, remote_participant_info,
+        returnedValue = on_process_handshake(*remote_participant_data, remote_participant_info,
                         MessageIdentity(), HandshakeMessageToken(), notify_part_authorized);
     }
 
-    restore_discovered_participant_info(participant_data.m_guid, remote_participant_info);
+    restore_discovered_participant_info(remote_participant_data->m_guid, remote_participant_info);
 
     if (notify_part_authorized)
     {
-        notify_participant_authorized(participant_data);
+        notify_participant_authorized(*remote_participant_data);
     }
 
     return returnedValue;

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -3848,6 +3848,95 @@ TEST(Security, AllowUnauthenticatedParticipants_TwoParticipantsDifferentCertific
     ASSERT_FALSE(writer.is_matched());
 }
 
+// Regresion test for Refs #20166
+TEST(Security, InANonSecureParticipantWithTwoSecureParticipantScenario_TheTwoSecureParticipantsCorrectlyCommunicate)
+{
+    //! Create
+    PubSubReader<HelloWorldPubSubType> non_secure_reader("HelloWorldTopic");
+    PubSubReader<HelloWorldPubSubType> secure_reader("HelloWorldTopic");
+    PubSubWriter<HelloWorldPubSubType> secure_writer("HelloWorldTopic");
+
+    non_secure_reader.history_depth(10).
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            // Force a high number of announcements. Publish 1 every 1 ms
+            initial_announcements(1e6, {0, 1000000u}).init();
+
+    PropertyPolicy pub_property_policy, sub_property_policy;
+
+    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
+            "builtin.PKI-DH"));
+    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
+            "file://" + std::string(certs_path) + "/maincacert.pem"));
+    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
+            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
+    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
+            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
+            "builtin.AES-GCM-GMAC"));
+    pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
+            "builtin.Access-Permissions"));
+    pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
+            "file://" + std::string(certs_path) + "/maincacert.pem"));
+    pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
+            "file://" + std::string(certs_path) + "/governance_helloworld_all_enable.smime"));
+    pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
+            "file://" + std::string(certs_path) + "/permissions_helloworld.smime"));
+
+    secure_writer.history_depth(10).
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            property_policy(pub_property_policy).init();
+
+    ASSERT_TRUE(secure_writer.isInitialized());
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
+            "builtin.PKI-DH"));
+    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
+            "file://" + std::string(certs_path) + "/maincacert.pem"));
+    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
+            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
+    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
+            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
+            "builtin.AES-GCM-GMAC"));
+    sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
+            "builtin.Access-Permissions"));
+    sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
+            "file://" + std::string(certs_path) + "/maincacert.pem"));
+    sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
+            "file://" + std::string(certs_path) +
+            "/governance_helloworld_all_enable.smime"));
+    sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
+            "file://" + std::string(certs_path) + "/permissions_helloworld.smime"));
+
+    secure_reader.history_depth(10).
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            property_policy(sub_property_policy).init();
+
+    ASSERT_TRUE(secure_reader.isInitialized());
+
+    //! Wait for the authorization
+    secure_reader.waitAuthorized();
+    secure_writer.waitAuthorized();
+
+    //! Wait for discovery
+    secure_writer.wait_discovery(std::chrono::seconds(5));
+    secure_reader.wait_discovery(std::chrono::seconds(5));
+
+    //! Data is correctly sent and received
+    auto data = default_helloworld_data_generator();
+
+    secure_reader.startReception(data);
+
+    secure_writer.send(data);
+
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+
+    secure_reader.block_for_all();
+}
+
 // *INDENT-OFF*
 TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_PermissionsDisableDiscoveryDisableAccessEncrypt_validation_ok_enable_discovery_enable_access_encrypt)
 // *INDENT-ON*


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR fixes a data race occurring in `PDPListenerSecurityInitiator`  affecting `SecurityManager`. The `temp_participant_data_` was being overwritten as `discovered_participant()` was being called without the `PDP` mutex taken. This causes a corruption when the secure participant was in the middle of matching to a previous secure participant.

This PR also ensures that the `discovered_participant()` method is using the `ParticipantProxyData` from the `discovered_participants` collection.

_Note: openning as draft as proper test needs to be added_

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.12.x 2.11.x 2.10.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [X] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
