### PR TITLE
Remove a pessimizing move.

### DIFF
--- a/thirdparty/filewatch/FileWatch.hpp
+++ b/thirdparty/filewatch/FileWatch.hpp
@@ -207,7 +207,7 @@ namespace filewatch {
                 throw std::system_error(GetLastError(), std::system_category());
             }
 #endif // WIN32
-            _callback_thread = std::move(std::thread([this]() {
+            _callback_thread = std::thread([this]() {
                 try {
                     callback_thread();
                 } catch (...) {
@@ -216,8 +216,8 @@ namespace filewatch {
                     }
                     catch (...) {} // set_exception() may throw too
                 }
-            }));
-            _watch_thread = std::move(std::thread([this]() {
+            });
+            _watch_thread = std::thread([this]() {
                 try {
                     monitor_directory();
                 } catch (...) {
@@ -226,7 +226,7 @@ namespace filewatch {
                     }
                     catch (...) {} // set_exception() may throw too
                 }
-            }));
+            });
 
             std::future<void> future = _running.get_future();
             future.get(); //block until the monitor_directory is up and running


### PR DESCRIPTION
When compiling Fast-DDS with clang, it shows a warning that the use of std::move in FileWatch.hpp is pessimizing. Remove the unnecessary std::move here, which fixes the warning.

Note that this is against the 2.11.x branch, which is what we are using in ROS 2.  But I can retarget it to `master` if that is preferred.

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [N/A] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [N/A] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [??] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [N/A] New feature has been added to the `versions.md` file (if applicable).
- [N/A] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [ ] Applicable backports have been included in the description.


## Reviewer Checklist
- [ ] The PR has a milestone assigned.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
