### PR TITLE
[20239] Make DataWriters always send the key hash on keyed topics

### DIFF
--- a/src/cpp/rtps/messages/submessages/DataMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/DataMsg.hpp
@@ -42,7 +42,8 @@ struct DataMsgUtils
     {
         inlineQosFlag =
                 (nullptr != inlineQos) ||
-                ((WITH_KEY == topicKind) && (!change->writerGUID.is_builtin() || expectsInlineQos || change->kind != ALIVE)) ||
+                ((WITH_KEY == topicKind) &&
+                (!change->writerGUID.is_builtin() || expectsInlineQos || change->kind != ALIVE)) ||
                 (change->write_params.related_sample_identity() != SampleIdentity::unknown());
 
         dataFlag = ALIVE == change->kind &&

--- a/src/cpp/rtps/messages/submessages/DataMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/DataMsg.hpp
@@ -42,7 +42,7 @@ struct DataMsgUtils
     {
         inlineQosFlag =
                 (nullptr != inlineQos) ||
-                ((WITH_KEY == topicKind) && (expectsInlineQos || change->kind != ALIVE)) ||
+                ((WITH_KEY == topicKind) && (!change->writerGUID.is_builtin() || expectsInlineQos || change->kind != ALIVE)) ||
                 (change->write_params.related_sample_identity() != SampleIdentity::unknown());
 
         dataFlag = ALIVE == change->kind &&
@@ -129,7 +129,7 @@ struct DataMsgUtils
                     change->write_params.related_sample_identity());
         }
 
-        if (WITH_KEY == topicKind && (expectsInlineQos || ALIVE != change->kind))
+        if (WITH_KEY == topicKind && (!change->writerGUID.is_builtin() || expectsInlineQos || ALIVE != change->kind))
         {
             fastdds::dds::ParameterSerializer<Parameter_t>::add_parameter_key(msg, change->instanceHandle);
 

--- a/test/blackbox/common/BlackboxTestsKeys.cpp
+++ b/test/blackbox/common/BlackboxTestsKeys.cpp
@@ -17,6 +17,8 @@
 #include "PubSubReader.hpp"
 #include "PubSubWriter.hpp"
 
+#include <fastrtps/transport/test_UDPv4TransportDescriptor.h>
+
 TEST(KeyedTopic, RegistrationNonKeyedFail)
 {
     PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
@@ -179,6 +181,101 @@ TEST(KeyedTopic, UnregisterWhenHistoryKeepAll)
 
     ASSERT_TRUE(writer.unregister_instance(data.front(), instance_handle_1));
     ASSERT_TRUE(writer.unregister_instance(data.back(), instance_handle_2));
+}
+
+// Regression test for redmine issue #20239
+TEST(KeyedTopic, DataWriterAlwaysSendTheSerializedKeyViaInlineQoS)
+{
+    PubSubWriter<KeyedHelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+    // By default, the reader's expect_inline_qos is false
+    PubSubReader<KeyedHelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+
+    auto testTransport = std::make_shared<eprosima::fastdds::rtps::test_UDPv4TransportDescriptor>();
+
+    bool writer_sends_inline_qos = false;
+    bool writer_sends_pid_key_hash = false;
+
+    testTransport->drop_data_messages_filter_ = [&writer_sends_inline_qos,
+                    &writer_sends_pid_key_hash](eprosima::fastrtps::rtps::CDRMessage_t& msg) -> bool
+            {
+                // Check for inline_qos
+                uint8_t flags = msg.buffer[msg.pos - 3];
+                auto old_pos = msg.pos;
+
+                // Skip extraFlags, read octetsToInlineQos, and calculate inline qos position.
+                msg.pos += 2;
+                uint16_t to_inline_qos = 0;
+                eprosima::fastrtps::rtps::CDRMessage::readUInt16(&msg, &to_inline_qos);
+                uint32_t inline_qos_pos = msg.pos + to_inline_qos;
+
+                // Filters are only applied to user data
+                // no need to check if the packets comer from a builtin
+
+                writer_sends_inline_qos = (flags & (1 << 1));
+
+                // Stop seeking if inline qos are not present
+                // Fail the test afterwards
+                if (!writer_sends_inline_qos)
+                {
+                    return false;
+                }
+                else
+                {
+                    // Process inline qos
+                    msg.pos = inline_qos_pos;
+                    while (msg.pos < msg.length)
+                    {
+                        uint16_t pid = 0;
+                        uint16_t plen = 0;
+
+                        eprosima::fastrtps::rtps::CDRMessage::readUInt16(&msg, &pid);
+                        eprosima::fastrtps::rtps::CDRMessage::readUInt16(&msg, &plen);
+                        uint32_t next_pos = msg.pos + plen;
+
+                        if (pid == eprosima::fastdds::dds::PID_KEY_HASH)
+                        {
+                            writer_sends_pid_key_hash = true;
+                        }
+                        else if (pid == eprosima::fastdds::dds::PID_SENTINEL)
+                        {
+                            break;
+                        }
+
+                        msg.pos = next_pos;
+                    }
+
+                    msg.pos = old_pos;
+                }
+
+                // Do not drop the packet in any case
+                return false;
+            };
+
+    writer.
+            disable_builtin_transport().
+            add_user_transport_to_pparams(testTransport).
+            init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    reader.init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    auto data = default_keyedhelloworld_data_generator(5);
+
+    reader.startReception(data);
+    writer.send(data);
+
+    // In this test all data should be sent.
+    EXPECT_TRUE(data.empty());
+    reader.block_for_all();
+
+    EXPECT_TRUE(writer_sends_inline_qos & writer_sends_pid_key_hash);
 }
 
 /* Uncomment when DDS API supports NO_WRITERS_ALIVE

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -1732,7 +1732,7 @@ TEST(DDSStatus, sample_rejected_key_re_dw_re_dr_keep_all_max_samples_2)
     ASSERT_EQ(5u, test_status.total_count);
     ASSERT_EQ(5u, test_status.total_count_change);
     ASSERT_EQ(eprosima::fastdds::dds::REJECTED_BY_SAMPLES_LIMIT, test_status.last_reason);
-    ASSERT_EQ(c_InstanceHandle_Unknown, test_status.last_instance_handle);
+    ASSERT_NE(c_InstanceHandle_Unknown, test_status.last_instance_handle);
 }
 
 /*!
@@ -1832,7 +1832,7 @@ TEST(DDSStatus, sample_rejected_key_large_re_dw_re_dr_keep_all_max_samples_2)
     ASSERT_EQ(5u, test_status.total_count);
     ASSERT_EQ(5u, test_status.total_count_change);
     ASSERT_EQ(eprosima::fastdds::dds::REJECTED_BY_SAMPLES_LIMIT, test_status.last_reason);
-    ASSERT_EQ(c_InstanceHandle_Unknown, test_status.last_instance_handle);
+    ASSERT_NE(c_InstanceHandle_Unknown, test_status.last_instance_handle);
 }
 
 /*!
@@ -1926,7 +1926,7 @@ TEST(DDSStatus, sample_rejected_key_re_dw_re_dr_keep_last_max_samples_2)
     ASSERT_EQ(5u, test_status.total_count);
     ASSERT_EQ(5u, test_status.total_count_change);
     ASSERT_EQ(eprosima::fastdds::dds::REJECTED_BY_SAMPLES_LIMIT, test_status.last_reason);
-    ASSERT_EQ(c_InstanceHandle_Unknown, test_status.last_instance_handle);
+    ASSERT_NE(c_InstanceHandle_Unknown, test_status.last_instance_handle);
 }
 
 /*!
@@ -2026,7 +2026,7 @@ TEST(DDSStatus, sample_rejected_key_large_re_dw_re_dr_keep_last_max_samples_2)
     ASSERT_EQ(5u, test_status.total_count);
     ASSERT_EQ(5u, test_status.total_count_change);
     ASSERT_EQ(eprosima::fastdds::dds::REJECTED_BY_SAMPLES_LIMIT, test_status.last_reason);
-    ASSERT_EQ(c_InstanceHandle_Unknown, test_status.last_instance_handle);
+    ASSERT_NE(c_InstanceHandle_Unknown, test_status.last_instance_handle);
 }
 
 /*!


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR corrects the behavior of the DataWriters on keyed topics. Currently, if the DataReader does not `expect_inline_qos`, then the DataWriter is not sending the key despite of publishing on a keyed topic.

This PR makes the DataWriter always send the key regardless of the configuration of the reader if the topic is keyed.

_Note: the builtin endpoints are retrieving the key in their listeners. In fact, its the first thing they do (`computeKey()`). It is true that they are the filling the `instancehandle` from the `PID_ENDPOINT_GUID` instead of the `PID_KEY_HASH` which could be arguable if we are strict, but in essence, both carry the same information, the complete `guid` of the entity_ 

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.12.x 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [X] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
