### PR TITLE
[20243] Custom pools on DDS layer feature (backport #3755)

### DIFF
--- a/include/fastdds/dds/publisher/Publisher.hpp
+++ b/include/fastdds/dds/publisher/Publisher.hpp
@@ -155,13 +155,15 @@ public:
      * @param qos QoS of the DataWriter.
      * @param listener Pointer to the listener (default: nullptr).
      * @param mask StatusMask that holds statuses the listener responds to (default: all).
+     * @param payload_pool IPayloadPool shared pointer that defines writer payload (default: nullptr).
      * @return Pointer to the created DataWriter. nullptr if failed.
      */
     RTPS_DllAPI DataWriter* create_datawriter(
             Topic* topic,
             const DataWriterQos& qos,
             DataWriterListener* listener = nullptr,
-            const StatusMask& mask = StatusMask::all());
+            const StatusMask& mask = StatusMask::all(),
+            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool = nullptr);
 
     /**
      * This operation creates a DataWriter. The returned DataWriter will be attached and belongs to the Publisher.
@@ -170,13 +172,15 @@ public:
      * @param profile_name DataWriter profile name.
      * @param listener Pointer to the listener (default: nullptr).
      * @param mask StatusMask that holds statuses the listener responds to (default: all).
+     * @param payload_pool IPayloadPool shared pointer that defines writer payload (default: nullptr).
      * @return Pointer to the created DataWriter. nullptr if failed.
      */
     RTPS_DllAPI DataWriter* create_datawriter_with_profile(
             Topic* topic,
             const std::string& profile_name,
             DataWriterListener* listener = nullptr,
-            const StatusMask& mask = StatusMask::all());
+            const StatusMask& mask = StatusMask::all(),
+            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool = nullptr);
 
     /**
      * This operation deletes a DataWriter that belongs to the Publisher.

--- a/include/fastdds/dds/publisher/Publisher.hpp
+++ b/include/fastdds/dds/publisher/Publisher.hpp
@@ -155,15 +155,30 @@ public:
      * @param qos QoS of the DataWriter.
      * @param listener Pointer to the listener (default: nullptr).
      * @param mask StatusMask that holds statuses the listener responds to (default: all).
-     * @param payload_pool IPayloadPool shared pointer that defines writer payload (default: nullptr).
      * @return Pointer to the created DataWriter. nullptr if failed.
      */
     RTPS_DllAPI DataWriter* create_datawriter(
             Topic* topic,
             const DataWriterQos& qos,
             DataWriterListener* listener = nullptr,
-            const StatusMask& mask = StatusMask::all(),
-            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool = nullptr);
+            const StatusMask& mask = StatusMask::all());
+
+    /**
+     * This operation creates a DataWriter. The returned DataWriter will be attached and belongs to the Publisher.
+     *
+     * @param topic Topic the DataWriter will be listening
+     * @param qos QoS of the DataWriter.
+     * @param payload_pool IPayloadPool shared pointer that defines writer payload (default: nullptr).
+     * @param listener Pointer to the listener (default: nullptr).
+     * @param mask StatusMask that holds statuses the listener responds to (default: all).
+     * @return Pointer to the created DataWriter. nullptr if failed.
+     */
+    RTPS_DllAPI DataWriter* create_datawriter_with_payload_pool(
+            Topic* topic,
+            const DataWriterQos& qos,
+            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool,
+            DataWriterListener* listener = nullptr,
+            const StatusMask& mask = StatusMask::all());
 
     /**
      * This operation creates a DataWriter. The returned DataWriter will be attached and belongs to the Publisher.
@@ -172,15 +187,30 @@ public:
      * @param profile_name DataWriter profile name.
      * @param listener Pointer to the listener (default: nullptr).
      * @param mask StatusMask that holds statuses the listener responds to (default: all).
-     * @param payload_pool IPayloadPool shared pointer that defines writer payload (default: nullptr).
      * @return Pointer to the created DataWriter. nullptr if failed.
      */
     RTPS_DllAPI DataWriter* create_datawriter_with_profile(
             Topic* topic,
             const std::string& profile_name,
             DataWriterListener* listener = nullptr,
-            const StatusMask& mask = StatusMask::all(),
-            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool = nullptr);
+            const StatusMask& mask = StatusMask::all());
+
+    /**
+     * This operation creates a DataWriter. The returned DataWriter will be attached and belongs to the Publisher.
+     *
+     * @param topic Topic the DataWriter will be listening
+     * @param profile_name DataWriter profile name.
+     * @param payload_pool IPayloadPool shared pointer that defines writer payload (default: nullptr).
+     * @param listener Pointer to the listener (default: nullptr).
+     * @param mask StatusMask that holds statuses the listener responds to (default: all).
+     * @return Pointer to the created DataWriter. nullptr if failed.
+     */
+    RTPS_DllAPI DataWriter* create_datawriter_with_profile_with_payload_pool(
+            Topic* topic,
+            const std::string& profile_name,
+            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool,
+            DataWriterListener* listener = nullptr,
+            const StatusMask& mask = StatusMask::all());
 
     /**
      * This operation deletes a DataWriter that belongs to the Publisher.

--- a/include/fastdds/dds/subscriber/Subscriber.hpp
+++ b/include/fastdds/dds/subscriber/Subscriber.hpp
@@ -162,15 +162,30 @@ public:
      * @param reader_qos QoS of the DataReader.
      * @param listener Pointer to the listener (default: nullptr)
      * @param mask StatusMask that holds statuses the listener responds to (default: all).
-     * @param payload_pool IPayloadPool shared pointer that defines reader payload (default: nullptr).
      * @return Pointer to the created DataReader. nullptr if failed.
      */
     RTPS_DllAPI DataReader* create_datareader(
             TopicDescription* topic,
             const DataReaderQos& reader_qos,
             DataReaderListener* listener = nullptr,
-            const StatusMask& mask = StatusMask::all(),
-            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool = nullptr);
+            const StatusMask& mask = StatusMask::all());
+
+    /**
+     * This operation creates a DataReader. The returned DataReader will be attached and belong to the Subscriber.
+     *
+     * @param topic Topic the DataReader will be listening.
+     * @param reader_qos QoS of the DataReader.
+     * @param payload_pool IPayloadPool shared pointer that defines reader payload (default: nullptr).
+     * @param listener Pointer to the listener (default: nullptr)
+     * @param mask StatusMask that holds statuses the listener responds to (default: all).
+     * @return Pointer to the created DataReader. nullptr if failed.
+     */
+    RTPS_DllAPI DataReader* create_datareader_with_payload_pool(
+            TopicDescription* topic,
+            const DataReaderQos& reader_qos,
+            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool,
+            DataReaderListener* listener = nullptr,
+            const StatusMask& mask = StatusMask::all());
 
     /**
      * This operation creates a DataReader. The returned DataReader will be attached and belongs to the Subscriber.
@@ -179,15 +194,30 @@ public:
      * @param profile_name DataReader profile name.
      * @param listener Pointer to the listener (default: nullptr)
      * @param mask StatusMask that holds statuses the listener responds to (default: all).
-     * @param payload_pool IPayloadPool shared pointer that defines reader payload (default: nullptr).
      * @return Pointer to the created DataReader. nullptr if failed.
      */
     RTPS_DllAPI DataReader* create_datareader_with_profile(
             TopicDescription* topic,
             const std::string& profile_name,
             DataReaderListener* listener = nullptr,
-            const StatusMask& mask = StatusMask::all(),
-            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool = nullptr);
+            const StatusMask& mask = StatusMask::all());
+
+    /**
+     * This operation creates a DataReader. The returned DataReader will be attached and belongs to the Subscriber.
+     *
+     * @param topic Topic the DataReader will be listening.
+     * @param profile_name DataReader profile name.
+     * @param payload_pool IPayloadPool shared pointer that defines reader payload (default: nullptr).
+     * @param listener Pointer to the listener (default: nullptr)
+     * @param mask StatusMask that holds statuses the listener responds to (default: all).
+     * @return Pointer to the created DataReader. nullptr if failed.
+     */
+    RTPS_DllAPI DataReader* create_datareader_with_profile_with_payload_pool(
+            TopicDescription* topic,
+            const std::string& profile_name,
+            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool,
+            DataReaderListener* listener = nullptr,
+            const StatusMask& mask = StatusMask::all());
 
     /**
      * This operation deletes a DataReader that belongs to the Subscriber.

--- a/include/fastdds/dds/subscriber/Subscriber.hpp
+++ b/include/fastdds/dds/subscriber/Subscriber.hpp
@@ -162,13 +162,15 @@ public:
      * @param reader_qos QoS of the DataReader.
      * @param listener Pointer to the listener (default: nullptr)
      * @param mask StatusMask that holds statuses the listener responds to (default: all).
+     * @param payload_pool IPayloadPool shared pointer that defines reader payload (default: nullptr).
      * @return Pointer to the created DataReader. nullptr if failed.
      */
     RTPS_DllAPI DataReader* create_datareader(
             TopicDescription* topic,
             const DataReaderQos& reader_qos,
             DataReaderListener* listener = nullptr,
-            const StatusMask& mask = StatusMask::all());
+            const StatusMask& mask = StatusMask::all(),
+            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool = nullptr);
 
     /**
      * This operation creates a DataReader. The returned DataReader will be attached and belongs to the Subscriber.
@@ -177,13 +179,15 @@ public:
      * @param profile_name DataReader profile name.
      * @param listener Pointer to the listener (default: nullptr)
      * @param mask StatusMask that holds statuses the listener responds to (default: all).
+     * @param payload_pool IPayloadPool shared pointer that defines reader payload (default: nullptr).
      * @return Pointer to the created DataReader. nullptr if failed.
      */
     RTPS_DllAPI DataReader* create_datareader_with_profile(
             TopicDescription* topic,
             const std::string& profile_name,
             DataReaderListener* listener = nullptr,
-            const StatusMask& mask = StatusMask::all());
+            const StatusMask& mask = StatusMask::all(),
+            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool = nullptr);
 
     /**
      * This operation deletes a DataReader that belongs to the Subscriber.

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -146,7 +146,8 @@ DataWriterImpl::DataWriterImpl(
         TypeSupport type,
         Topic* topic,
         const DataWriterQos& qos,
-        DataWriterListener* listen)
+        DataWriterListener* listen,
+        std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool)
     : publisher_(p)
     , type_(type)
     , topic_(topic)
@@ -174,6 +175,12 @@ DataWriterImpl::DataWriterImpl(
     fastrtps::rtps::RTPSParticipantImpl::preprocess_endpoint_attributes<WRITER, 0x03, 0x02>(
         EntityId_t::unknown(), publisher_->get_participant_impl()->id_counter(), endpoint_attributes, guid_.entityId);
     guid_.guidPrefix = publisher_->get_participant_impl()->guid().guidPrefix;
+
+    if (payload_pool != nullptr)
+    {
+        is_custom_payload_pool_ = true;
+        payload_pool_ = payload_pool;
+    }
 }
 
 DataWriterImpl::DataWriterImpl(
@@ -1981,7 +1988,7 @@ bool DataWriterImpl::release_payload_pool()
 
     bool result = true;
 
-    if (is_data_sharing_compatible_)
+    if (is_data_sharing_compatible_ || is_custom_payload_pool_)
     {
         // No-op
     }
@@ -2036,6 +2043,11 @@ ReturnCode_t DataWriterImpl::check_datasharing_compatible(
             return ReturnCode_t::RETCODE_OK;
             break;
         case DataSharingKind::ON:
+            if (is_custom_payload_pool_)
+            {
+                EPROSIMA_LOG_ERROR(DATA_WRITER, "Custom payload pool detected. Cannot force Data sharing usage.");
+                return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
+            }
 #if HAVE_SECURITY
             if (has_security_enabled)
             {
@@ -2061,6 +2073,11 @@ ReturnCode_t DataWriterImpl::check_datasharing_compatible(
             return ReturnCode_t::RETCODE_OK;
             break;
         case DataSharingKind::AUTO:
+            if (is_custom_payload_pool_)
+            {
+                EPROSIMA_LOG_INFO(DATA_WRITER, "Custom payload pool detected. Data Sharing disabled.");
+                return ReturnCode_t::RETCODE_OK;
+            }
 #if HAVE_SECURITY
             if (has_security_enabled)
             {

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -108,7 +108,8 @@ protected:
             TypeSupport type,
             Topic* topic,
             const DataWriterQos& qos,
-            DataWriterListener* listener = nullptr);
+            DataWriterListener* listener = nullptr,
+            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool = nullptr);
 
     DataWriterImpl(
             PublisherImpl* p,
@@ -487,6 +488,8 @@ protected:
     uint32_t fixed_payload_size_ = 0u;
 
     std::shared_ptr<IPayloadPool> payload_pool_;
+
+    bool is_custom_payload_pool_ = false;
 
     std::unique_ptr<LoanCollection> loans_;
 

--- a/src/cpp/fastdds/publisher/Publisher.cpp
+++ b/src/cpp/fastdds/publisher/Publisher.cpp
@@ -112,18 +112,20 @@ DataWriter* Publisher::create_datawriter(
         Topic* topic,
         const DataWriterQos& qos,
         DataWriterListener* listener,
-        const StatusMask& mask)
+        const StatusMask& mask,
+        std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool)
 {
-    return impl_->create_datawriter(topic, qos, listener, mask);
+    return impl_->create_datawriter(topic, qos, listener, mask, payload_pool);
 }
 
 DataWriter* Publisher::create_datawriter_with_profile(
         Topic* topic,
         const std::string& profile_name,
         DataWriterListener* listener,
-        const StatusMask& mask)
+        const StatusMask& mask,
+        std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool)
 {
-    return impl_->create_datawriter_with_profile(topic, profile_name, listener, mask);
+    return impl_->create_datawriter_with_profile(topic, profile_name, listener, mask, payload_pool);
 }
 
 ReturnCode_t Publisher::delete_datawriter(

--- a/src/cpp/fastdds/publisher/Publisher.cpp
+++ b/src/cpp/fastdds/publisher/Publisher.cpp
@@ -112,8 +112,17 @@ DataWriter* Publisher::create_datawriter(
         Topic* topic,
         const DataWriterQos& qos,
         DataWriterListener* listener,
-        const StatusMask& mask,
-        std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool)
+        const StatusMask& mask)
+{
+    return impl_->create_datawriter(topic, qos, listener, mask, nullptr);
+}
+
+DataWriter* Publisher::create_datawriter_with_payload_pool(
+        Topic* topic,
+        const DataWriterQos& qos,
+        std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool,
+        DataWriterListener* listener,
+        const StatusMask& mask)
 {
     return impl_->create_datawriter(topic, qos, listener, mask, payload_pool);
 }
@@ -122,8 +131,17 @@ DataWriter* Publisher::create_datawriter_with_profile(
         Topic* topic,
         const std::string& profile_name,
         DataWriterListener* listener,
-        const StatusMask& mask,
-        std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool)
+        const StatusMask& mask)
+{
+    return impl_->create_datawriter_with_profile(topic, profile_name, listener, mask, nullptr);
+}
+
+DataWriter* Publisher::create_datawriter_with_profile_with_payload_pool(
+        Topic* topic,
+        const std::string& profile_name,
+        std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool,
+        DataWriterListener* listener,
+        const StatusMask& mask)
 {
     return impl_->create_datawriter_with_profile(topic, profile_name, listener, mask, payload_pool);
 }

--- a/src/cpp/fastdds/publisher/PublisherImpl.cpp
+++ b/src/cpp/fastdds/publisher/PublisherImpl.cpp
@@ -206,16 +206,18 @@ DataWriterImpl* PublisherImpl::create_datawriter_impl(
         const TypeSupport& type,
         Topic* topic,
         const DataWriterQos& qos,
-        DataWriterListener* listener)
+        DataWriterListener* listener,
+        std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool)
 {
-    return new DataWriterImpl(this, type, topic, qos, listener);
+    return new DataWriterImpl(this, type, topic, qos, listener, payload_pool);
 }
 
 DataWriter* PublisherImpl::create_datawriter(
         Topic* topic,
         const DataWriterQos& qos,
         DataWriterListener* listener,
-        const StatusMask& mask)
+        const StatusMask& mask,
+        std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool)
 {
     EPROSIMA_LOG_INFO(PUBLISHER, "CREATING WRITER IN TOPIC: " << topic->get_name());
     //Look for the correct type registration
@@ -234,7 +236,7 @@ DataWriter* PublisherImpl::create_datawriter(
         return nullptr;
     }
 
-    DataWriterImpl* impl = create_datawriter_impl(type_support, topic, qos, listener);
+    DataWriterImpl* impl = create_datawriter_impl(type_support, topic, qos, listener, payload_pool);
     return create_datawriter(topic, impl, mask);
 }
 
@@ -269,7 +271,8 @@ DataWriter* PublisherImpl::create_datawriter_with_profile(
         Topic* topic,
         const std::string& profile_name,
         DataWriterListener* listener,
-        const StatusMask& mask)
+        const StatusMask& mask,
+        std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool)
 {
     // TODO (ILG): Change when we have full XML support for DDS QoS profiles
     PublisherAttributes attr;
@@ -277,7 +280,7 @@ DataWriter* PublisherImpl::create_datawriter_with_profile(
     {
         DataWriterQos qos = default_datawriter_qos_;
         utils::set_qos_from_attributes(qos, attr);
-        return create_datawriter(topic, qos, listener, mask);
+        return create_datawriter(topic, qos, listener, mask, payload_pool);
     }
 
     return nullptr;

--- a/src/cpp/fastdds/publisher/PublisherImpl.hpp
+++ b/src/cpp/fastdds/publisher/PublisherImpl.hpp
@@ -105,13 +105,15 @@ public:
             Topic* topic,
             const DataWriterQos& qos,
             DataWriterListener* listener,
-            const StatusMask& mask = StatusMask::all());
+            const StatusMask& mask = StatusMask::all(),
+            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool = nullptr);
 
     DataWriter* create_datawriter_with_profile(
             Topic* topic,
             const std::string& profile_name,
             DataWriterListener* listener,
-            const StatusMask& mask = StatusMask::all());
+            const StatusMask& mask = StatusMask::all(),
+            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool = nullptr);
 
     ReturnCode_t delete_datawriter(
             const DataWriter* writer);
@@ -255,7 +257,8 @@ protected:
             const TypeSupport& type,
             Topic* topic,
             const DataWriterQos& qos,
-            DataWriterListener* listener);
+            DataWriterListener* listener,
+            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool);
 
     static void set_qos(
             PublisherQos& to,

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -102,7 +102,8 @@ DataReaderImpl::DataReaderImpl(
         const TypeSupport& type,
         TopicDescription* topic,
         const DataReaderQos& qos,
-        DataReaderListener* listener)
+        DataReaderListener* listener,
+        std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool)
     : subscriber_(s)
     , type_(type)
     , topic_(topic)
@@ -124,6 +125,12 @@ DataReaderImpl::DataReaderImpl(
     RTPSParticipantImpl::preprocess_endpoint_attributes<READER, 0x04, 0x07>(
         EntityId_t::unknown(), subscriber_->get_participant_impl()->id_counter(), endpoint_attributes, guid_.entityId);
     guid_.guidPrefix = subscriber_->get_participant_impl()->guid().guidPrefix;
+
+    if (payload_pool != nullptr)
+    {
+        is_custom_payload_pool_ = true;
+        payload_pool_ = payload_pool;
+    }
 }
 
 ReturnCode_t DataReaderImpl::enable()
@@ -1724,13 +1731,17 @@ std::shared_ptr<IPayloadPool> DataReaderImpl::get_payload_pool()
 
     PoolConfig config = PoolConfig::from_history_attributes(history_.m_att);
 
-    if (!payload_pool_)
+    if (!sample_pool_)
     {
-        payload_pool_ = TopicPayloadPoolRegistry::get(topic_->get_impl()->get_rtps_topic_name(), config);
         sample_pool_ = std::make_shared<detail::SampleLoanManager>(config, type_);
     }
-
-    payload_pool_->reserve_history(config, true);
+    if (!is_custom_payload_pool_)
+    {
+        std::shared_ptr<ITopicPayloadPool> topic_payload_pool = TopicPayloadPoolRegistry::get(
+            topic_->get_impl()->get_rtps_topic_name(), config);
+        topic_payload_pool->reserve_history(config, true);
+        payload_pool_ = topic_payload_pool;
+    }
     return payload_pool_;
 }
 
@@ -1738,8 +1749,14 @@ void DataReaderImpl::release_payload_pool()
 {
     assert(payload_pool_);
 
-    PoolConfig config = PoolConfig::from_history_attributes(history_.m_att);
-    payload_pool_->release_history(config, true);
+    if (!is_custom_payload_pool_)
+    {
+        PoolConfig config = PoolConfig::from_history_attributes(history_.m_att);
+        std::shared_ptr<fastrtps::rtps::ITopicPayloadPool> topic_payload_pool =
+                std::dynamic_pointer_cast<fastrtps::rtps::ITopicPayloadPool>(payload_pool_);
+        topic_payload_pool->release_history(config, true);
+    }
+
     payload_pool_.reset();
 }
 

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -102,7 +102,8 @@ protected:
             const TypeSupport& type,
             TopicDescription* topic,
             const DataReaderQos& qos,
-            DataReaderListener* listener = nullptr);
+            DataReaderListener* listener = nullptr,
+            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool = nullptr);
 
 public:
 
@@ -482,8 +483,10 @@ protected:
 
     DataReader* user_datareader_ = nullptr;
 
-    std::shared_ptr<ITopicPayloadPool> payload_pool_;
     std::shared_ptr<detail::SampleLoanManager> sample_pool_;
+    std::shared_ptr<IPayloadPool> payload_pool_;
+
+    bool is_custom_payload_pool_ = false;
 
     detail::SampleInfoPool sample_info_pool_;
     detail::DataReaderLoanManager loan_manager_;

--- a/src/cpp/fastdds/subscriber/Subscriber.cpp
+++ b/src/cpp/fastdds/subscriber/Subscriber.cpp
@@ -106,18 +106,20 @@ DataReader* Subscriber::create_datareader(
         TopicDescription* topic,
         const DataReaderQos& reader_qos,
         DataReaderListener* listener,
-        const StatusMask& mask)
+        const StatusMask& mask,
+        std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool)
 {
-    return impl_->create_datareader(topic, reader_qos, listener, mask);
+    return impl_->create_datareader(topic, reader_qos, listener, mask, payload_pool);
 }
 
 DataReader* Subscriber::create_datareader_with_profile(
         TopicDescription* topic,
         const std::string& profile_name,
         DataReaderListener* listener,
-        const StatusMask& mask)
+        const StatusMask& mask,
+        std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool)
 {
-    return impl_->create_datareader_with_profile(topic, profile_name, listener, mask);
+    return impl_->create_datareader_with_profile(topic, profile_name, listener, mask, payload_pool);
 }
 
 ReturnCode_t Subscriber::delete_datareader(

--- a/src/cpp/fastdds/subscriber/Subscriber.cpp
+++ b/src/cpp/fastdds/subscriber/Subscriber.cpp
@@ -106,8 +106,17 @@ DataReader* Subscriber::create_datareader(
         TopicDescription* topic,
         const DataReaderQos& reader_qos,
         DataReaderListener* listener,
-        const StatusMask& mask,
-        std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool)
+        const StatusMask& mask)
+{
+    return impl_->create_datareader(topic, reader_qos, listener, mask, nullptr);
+}
+
+DataReader* Subscriber::create_datareader_with_payload_pool(
+        TopicDescription* topic,
+        const DataReaderQos& reader_qos,
+        std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool,
+        DataReaderListener* listener,
+        const StatusMask& mask)
 {
     return impl_->create_datareader(topic, reader_qos, listener, mask, payload_pool);
 }
@@ -116,8 +125,17 @@ DataReader* Subscriber::create_datareader_with_profile(
         TopicDescription* topic,
         const std::string& profile_name,
         DataReaderListener* listener,
-        const StatusMask& mask,
-        std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool)
+        const StatusMask& mask)
+{
+    return impl_->create_datareader_with_profile(topic, profile_name, listener, mask, nullptr);
+}
+
+DataReader* Subscriber::create_datareader_with_profile_with_payload_pool(
+        TopicDescription* topic,
+        const std::string& profile_name,
+        std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool,
+        DataReaderListener* listener,
+        const StatusMask& mask)
 {
     return impl_->create_datareader_with_profile(topic, profile_name, listener, mask, payload_pool);
 }

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -175,16 +175,18 @@ DataReaderImpl* SubscriberImpl::create_datareader_impl(
         const TypeSupport& type,
         TopicDescription* topic,
         const DataReaderQos& qos,
-        DataReaderListener* listener)
+        DataReaderListener* listener,
+        std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool)
 {
-    return new DataReaderImpl(this, type, topic, qos, listener);
+    return new DataReaderImpl(this, type, topic, qos, listener, payload_pool);
 }
 
 DataReader* SubscriberImpl::create_datareader(
         TopicDescription* topic,
         const DataReaderQos& qos,
         DataReaderListener* listener,
-        const StatusMask& mask)
+        const StatusMask& mask,
+        std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool)
 {
     EPROSIMA_LOG_INFO(SUBSCRIBER, "CREATING SUBSCRIBER IN TOPIC: " << topic->get_name());
     //Look for the correct type registration
@@ -205,7 +207,7 @@ DataReader* SubscriberImpl::create_datareader(
 
     topic->get_impl()->reference();
 
-    DataReaderImpl* impl = create_datareader_impl(type_support, topic, qos, listener);
+    DataReaderImpl* impl = create_datareader_impl(type_support, topic, qos, listener, payload_pool);
     DataReader* reader = new DataReader(impl, mask);
     impl->user_datareader_ = reader;
 
@@ -230,7 +232,8 @@ DataReader* SubscriberImpl::create_datareader_with_profile(
         TopicDescription* topic,
         const std::string& profile_name,
         DataReaderListener* listener,
-        const StatusMask& mask)
+        const StatusMask& mask,
+        std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool)
 {
     // TODO (ILG): Change when we have full XML support for DDS QoS profiles
     SubscriberAttributes attr;
@@ -238,7 +241,7 @@ DataReader* SubscriberImpl::create_datareader_with_profile(
     {
         DataReaderQos qos = default_datareader_qos_;
         utils::set_qos_from_attributes(qos, attr);
-        return create_datareader(topic, qos, listener, mask);
+        return create_datareader(topic, qos, listener, mask, payload_pool);
     }
 
     return nullptr;

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
@@ -97,13 +97,15 @@ public:
             TopicDescription* topic,
             const DataReaderQos& reader_qos,
             DataReaderListener* listener = nullptr,
-            const StatusMask& mask = StatusMask::all());
+            const StatusMask& mask = StatusMask::all(),
+            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool = nullptr);
 
     DataReader* create_datareader_with_profile(
             TopicDescription* topic,
             const std::string& profile_name,
             DataReaderListener* listener,
-            const StatusMask& mask = StatusMask::all());
+            const StatusMask& mask = StatusMask::all(),
+            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool = nullptr);
 
     ReturnCode_t delete_datareader(
             const DataReader* reader);
@@ -298,7 +300,8 @@ protected:
             const TypeSupport& type,
             TopicDescription* topic,
             const DataReaderQos& qos,
-            DataReaderListener* listener);
+            DataReaderListener* listener,
+            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool);
 };
 
 } /* namespace dds */

--- a/src/cpp/statistics/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/statistics/fastdds/publisher/DataWriterImpl.hpp
@@ -58,8 +58,9 @@ public:
             efd::Topic* topic,
             const efd::DataWriterQos& qos,
             efd::DataWriterListener* listener,
+            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool,
             std::shared_ptr<IListener> stat_listener)
-        : BaseType(p, type, topic, qos, listener)
+        : BaseType(p, type, topic, qos, listener, payload_pool)
         , statistics_listener_(stat_listener)
     {
     }

--- a/src/cpp/statistics/fastdds/publisher/PublisherImpl.hpp
+++ b/src/cpp/statistics/fastdds/publisher/PublisherImpl.hpp
@@ -62,9 +62,10 @@ public:
             const efd::TypeSupport& type,
             efd::Topic* topic,
             const efd::DataWriterQos& qos,
-            efd::DataWriterListener* listener) override
+            efd::DataWriterListener* listener,
+            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool) override
     {
-        return new DataWriterImpl(this, type, topic, qos, listener, statistics_listener_);
+        return new DataWriterImpl(this, type, topic, qos, listener, payload_pool, statistics_listener_);
     }
 
 private:

--- a/src/cpp/statistics/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/statistics/fastdds/subscriber/DataReaderImpl.hpp
@@ -48,8 +48,9 @@ public:
             efd::TopicDescription* topic,
             const efd::DataReaderQos& qos,
             efd::DataReaderListener* listener,
+            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool,
             std::shared_ptr<IListener> stat_listener)
-        : BaseType(s, type, topic, qos, listener)
+        : BaseType(s, type, topic, qos, listener, payload_pool)
         , statistics_listener_(stat_listener)
     {
     }

--- a/src/cpp/statistics/fastdds/subscriber/SubscriberImpl.hpp
+++ b/src/cpp/statistics/fastdds/subscriber/SubscriberImpl.hpp
@@ -53,9 +53,10 @@ public:
             const efd::TypeSupport& type,
             efd::TopicDescription* topic,
             const efd::DataReaderQos& qos,
-            efd::DataReaderListener* listener) override
+            efd::DataReaderListener* listener,
+            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool) override
     {
-        return new DataReaderImpl(this, type, topic, qos, listener, statistics_listener_);
+        return new DataReaderImpl(this, type, topic, qos, listener, payload_pool, statistics_listener_);
     }
 
 private:

--- a/test/blackbox/api/dds-pim/CustomPayloadPool.hpp
+++ b/test/blackbox/api/dds-pim/CustomPayloadPool.hpp
@@ -1,0 +1,104 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file CustomPayloadPool.hpp
+ */
+
+#ifndef DDS_CUSTOM_PAYLOAD_POOL_HPP
+#define DDS_CUSTOM_PAYLOAD_POOL_HPP
+
+#include <assert.h>
+#include <cstdint>
+#include <stdio.h>
+#include <string.h>
+
+class CustomPayloadPool : public eprosima::fastrtps::rtps::IPayloadPool
+{
+public:
+
+    ~CustomPayloadPool() = default;
+
+    bool get_payload(
+            unsigned int size,
+            eprosima::fastrtps::rtps::CacheChange_t& cache_change)
+    {
+        // Reserve new memory for the payload buffer
+        unsigned char* payload = new unsigned char[size];
+
+        // Assign the payload buffer to the CacheChange and update sizes
+        cache_change.serializedPayload.data = payload;
+        cache_change.serializedPayload.length = size;
+        cache_change.serializedPayload.max_size = size;
+
+        // Tell the CacheChange who needs to release its payload
+        cache_change.payload_owner(this);
+
+        ++requested_payload_count;
+
+        return true;
+    }
+
+    bool get_payload(
+            eprosima::fastrtps::rtps::SerializedPayload_t& data,
+            eprosima::fastrtps::rtps::IPayloadPool*& /*data_owner*/,
+            eprosima::fastrtps::rtps::CacheChange_t& cache_change)
+    {
+        // Reserve new memory for the payload buffer
+        unsigned char* payload = new unsigned char[data.length];
+
+        // Copy the data
+        memcpy(payload, data.data, data.length);
+
+        // Assign the payload buffer to the CacheChange and update sizes
+        cache_change.serializedPayload.data = payload;
+        cache_change.serializedPayload.length = data.length;
+        cache_change.serializedPayload.max_size = data.length;
+
+        // Tell the CacheChange who needs to release its payload
+        cache_change.payload_owner(this);
+
+        ++requested_payload_count;
+
+        return true;
+    }
+
+    bool release_payload(
+            eprosima::fastrtps::rtps::CacheChange_t& cache_change)
+    {
+        // Ensure precondition
+        assert(this == cache_change.payload_owner());
+
+        // Dealloc the buffer of the payload
+        delete[] cache_change.serializedPayload.data;
+
+        // Reset sizes and pointers
+        cache_change.serializedPayload.data = nullptr;
+        cache_change.serializedPayload.length = 0;
+        cache_change.serializedPayload.max_size = 0;
+
+        // Reset the owner of the payload
+        cache_change.payload_owner(nullptr);
+
+        ++returned_payload_count;
+
+        return true;
+    }
+
+    uint32_t requested_payload_count = 0;
+    uint32_t returned_payload_count = 0;
+
+};
+
+#endif  // DDS_CUSTOM_PAYLOAD_POOL_HPP

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -42,6 +42,7 @@
 #include <fastrtps/types/TypesBase.h>
 
 #include "BlackboxTests.hpp"
+#include "../api/dds-pim/CustomPayloadPool.hpp"
 #include "../api/dds-pim/PubSubReader.hpp"
 #include "../api/dds-pim/PubSubWriter.hpp"
 #include "../api/dds-pim/PubSubWriterReader.hpp"
@@ -694,6 +695,67 @@ TEST(DDSBasic, participant_ignore_local_endpoints_two_participants)
 
     // Wait for reception
     EXPECT_EQ(reader.block_for_all(std::chrono::seconds(1)), 5);
+}
+
+/**
+ * @test This test checks both the visibility of custom pool functions
+ *  for DataReader and DataWriters while also testing their correct
+ *  behavior
+ */
+TEST(DDSBasic, endpoint_custom_payload_pools)
+{
+    DomainParticipant* participant =
+            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
+
+    Subscriber* subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
+    ASSERT_NE(subscriber, nullptr);
+
+    Publisher* publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT);
+    ASSERT_NE(publisher, nullptr);
+
+    // Register type
+    TypeSupport type;
+
+    type.reset(new StringTestPubSubType());
+    type.register_type(participant);
+    ASSERT_NE(nullptr, type);
+
+    type.register_type(participant);
+
+    Topic* topic = participant->create_topic("footopic", type.get_type_name(), TOPIC_QOS_DEFAULT);
+    ASSERT_NE(topic, nullptr);
+
+    // Next QoS config checks the default qos configuration,
+    // create_datareader() should not return nullptr.
+    DataReaderQos reader_qos = DATAREADER_QOS_DEFAULT;
+
+    std::shared_ptr<CustomPayloadPool> reader_payload_pool = std::make_shared<CustomPayloadPool>();
+
+    std::shared_ptr<CustomPayloadPool> writer_payload_pool = std::make_shared<CustomPayloadPool>();
+
+    DataReader* data_reader = subscriber->create_datareader(
+        topic, reader_qos, nullptr, StatusMask::all(), reader_payload_pool);
+
+    DataWriterQos writer_qos = DATAWRITER_QOS_DEFAULT;
+
+    DataWriter* data_writer = publisher->create_datawriter(
+        topic, writer_qos, nullptr, StatusMask::all(), writer_payload_pool);
+
+    ASSERT_NE(data_reader, nullptr);
+    ASSERT_NE(data_writer, nullptr);
+
+    StringTest data;
+    data.message("Lorem Ipsum");
+
+    data_writer->write(&data, HANDLE_NIL);
+
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    ASSERT_EQ(reader_payload_pool->requested_payload_count, 1u);
+    ASSERT_EQ(writer_payload_pool->requested_payload_count, 1u);
+
+    participant->delete_contained_entities();
 }
 
 } // namespace dds

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -734,13 +734,13 @@ TEST(DDSBasic, endpoint_custom_payload_pools)
 
     std::shared_ptr<CustomPayloadPool> writer_payload_pool = std::make_shared<CustomPayloadPool>();
 
-    DataReader* data_reader = subscriber->create_datareader(
-        topic, reader_qos, nullptr, StatusMask::all(), reader_payload_pool);
+    DataReader* data_reader = subscriber->create_datareader_with_payload_pool(
+        topic, reader_qos, reader_payload_pool, nullptr, StatusMask::all());
 
     DataWriterQos writer_qos = DATAWRITER_QOS_DEFAULT;
 
-    DataWriter* data_writer = publisher->create_datawriter(
-        topic, writer_qos, nullptr, StatusMask::all(), writer_payload_pool);
+    DataWriter* data_writer = publisher->create_datawriter_with_payload_pool(
+        topic, writer_qos, writer_payload_pool, nullptr, StatusMask::all());
 
     ASSERT_NE(data_reader, nullptr);
     ASSERT_NE(data_writer, nullptr);

--- a/test/unittest/common/CustomPayloadPool.hpp
+++ b/test/unittest/common/CustomPayloadPool.hpp
@@ -1,0 +1,104 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file CustomPayloadPool.hpp
+ */
+
+#ifndef DDS_CUSTOM_PAYLOAD_POOL_HPP
+#define DDS_CUSTOM_PAYLOAD_POOL_HPP
+
+#include <assert.h>
+#include <cstdint>
+#include <stdio.h>
+#include <string.h>
+
+class CustomPayloadPool : public eprosima::fastrtps::rtps::IPayloadPool
+{
+public:
+
+    ~CustomPayloadPool() = default;
+
+    bool get_payload(
+            unsigned int size,
+            eprosima::fastrtps::rtps::CacheChange_t& cache_change)
+    {
+        // Reserve new memory for the payload buffer
+        unsigned char* payload = new unsigned char[size];
+
+        // Assign the payload buffer to the CacheChange and update sizes
+        cache_change.serializedPayload.data = payload;
+        cache_change.serializedPayload.length = size;
+        cache_change.serializedPayload.max_size = size;
+
+        // Tell the CacheChange who needs to release its payload
+        cache_change.payload_owner(this);
+
+        ++requested_payload_count;
+
+        return true;
+    }
+
+    bool get_payload(
+            eprosima::fastrtps::rtps::SerializedPayload_t& data,
+            eprosima::fastrtps::rtps::IPayloadPool*& /*data_owner*/,
+            eprosima::fastrtps::rtps::CacheChange_t& cache_change)
+    {
+        // Reserve new memory for the payload buffer
+        unsigned char* payload = new unsigned char[data.length];
+
+        // Copy the data
+        memcpy(payload, data.data, data.length);
+
+        // Assign the payload buffer to the CacheChange and update sizes
+        cache_change.serializedPayload.data = payload;
+        cache_change.serializedPayload.length = data.length;
+        cache_change.serializedPayload.max_size = data.length;
+
+        // Tell the CacheChange who needs to release its payload
+        cache_change.payload_owner(this);
+
+        ++requested_payload_count;
+
+        return true;
+    }
+
+    bool release_payload(
+            eprosima::fastrtps::rtps::CacheChange_t& cache_change)
+    {
+        // Ensure precondition
+        assert(this == cache_change.payload_owner());
+
+        // Dealloc the buffer of the payload
+        delete[] cache_change.serializedPayload.data;
+
+        // Reset sizes and pointers
+        cache_change.serializedPayload.data = nullptr;
+        cache_change.serializedPayload.length = 0;
+        cache_change.serializedPayload.max_size = 0;
+
+        // Reset the owner of the payload
+        cache_change.payload_owner(nullptr);
+
+        ++returned_payload_count;
+
+        return true;
+    }
+
+    uint32_t requested_payload_count = 0;
+    uint32_t returned_payload_count = 0;
+
+};
+
+#endif  // DDS_CUSTOM_PAYLOAD_POOL_HPP

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -1977,7 +1977,9 @@ TEST(DataWriterTests, CustomPoolCreation)
 
     DataWriterQos writer_qos = DATAWRITER_QOS_DEFAULT;
 
-    DataWriter* data_writer = publisher->create_datawriter(topic, writer_qos, payload_pool, nullptr, StatusMask::all());
+    DataWriter* data_writer =
+            publisher->create_datawriter_with_payload_pool(
+        topic, writer_qos, payload_pool, nullptr, StatusMask::all());
 
     ASSERT_NE(data_writer, nullptr);
     ASSERT_NE(data_reader, nullptr);

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -41,6 +41,10 @@
 #include <fastdds/rtps/writer/StatefulWriter.h>
 
 #include "../../logging/mock/MockConsumer.h"
+#include "../../common/CustomPayloadPool.hpp"
+
+#include <mutex>
+#include <condition_variable>
 
 namespace eprosima {
 namespace fastdds {
@@ -1939,6 +1943,54 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyKeyed)
     qos2.resource_limits().max_samples_per_instance = 500;
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_writer1->set_qos(qos2));
+}
+
+
+/*
+ * This test checks the proper behavior of the custom payload pool DataReader overload.
+ */
+TEST(DataWriterTests, CustomPoolCreation)
+{
+    DomainParticipant* participant =
+            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
+
+    Subscriber* subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
+    ASSERT_NE(subscriber, nullptr);
+
+    Publisher* publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT);
+    ASSERT_NE(publisher, nullptr);
+
+    TypeSupport type(new TopicDataTypeMock());
+    type.register_type(participant);
+
+    Topic* topic = participant->create_topic("footopic", type.get_type_name(), TOPIC_QOS_DEFAULT);
+    ASSERT_NE(topic, nullptr);
+
+    // Next QoS config checks the default qos configuration,
+    // create_datareader() should not return nullptr.
+    DataReaderQos reader_qos = DATAREADER_QOS_DEFAULT;
+
+    std::shared_ptr<CustomPayloadPool> payload_pool = std::make_shared<CustomPayloadPool>();
+
+    DataReader* data_reader = subscriber->create_datareader(topic, reader_qos);
+
+    DataWriterQos writer_qos = DATAWRITER_QOS_DEFAULT;
+
+    DataWriter* data_writer = publisher->create_datawriter(topic, writer_qos, nullptr, StatusMask::all(), payload_pool);
+
+    ASSERT_NE(data_writer, nullptr);
+    ASSERT_NE(data_reader, nullptr);
+
+    FooType data;
+
+    data_writer->write(&data, HANDLE_NIL);
+
+    ASSERT_EQ(payload_pool->requested_payload_count, 1u);
+
+    participant->delete_contained_entities();
+
+    DomainParticipantFactory::get_instance()->delete_participant(participant);
 }
 
 } // namespace dds

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -1977,7 +1977,7 @@ TEST(DataWriterTests, CustomPoolCreation)
 
     DataWriterQos writer_qos = DATAWRITER_QOS_DEFAULT;
 
-    DataWriter* data_writer = publisher->create_datawriter(topic, writer_qos, nullptr, StatusMask::all(), payload_pool);
+    DataWriter* data_writer = publisher->create_datawriter(topic, writer_qos, payload_pool, nullptr, StatusMask::all());
 
     ASSERT_NE(data_writer, nullptr);
     ASSERT_NE(data_reader, nullptr);

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -3522,7 +3522,7 @@ TEST_F(DataReaderTests, CustomPoolCreation)
     std::shared_ptr<CustomPayloadPool> payload_pool = std::make_shared<CustomPayloadPool>();
 
     DataReader* data_reader =
-            subscriber->create_datareader(topic, reader_qos, nullptr, StatusMask::all(), payload_pool);
+            subscriber->create_datareader(topic, reader_qos, payload_pool, nullptr, StatusMask::all());
 
     DataWriterQos writer_qos = DATAWRITER_QOS_DEFAULT;
     writer_qos.reliability().kind = eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS;

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -3522,7 +3522,8 @@ TEST_F(DataReaderTests, CustomPoolCreation)
     std::shared_ptr<CustomPayloadPool> payload_pool = std::make_shared<CustomPayloadPool>();
 
     DataReader* data_reader =
-            subscriber->create_datareader(topic, reader_qos, payload_pool, nullptr, StatusMask::all());
+            subscriber->create_datareader_with_payload_pool(
+        topic, reader_qos, payload_pool, nullptr, StatusMask::all());
 
     DataWriterQos writer_qos = DATAWRITER_QOS_DEFAULT;
     writer_qos.reliability().kind = eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS;

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantMockTests/mock/statistics/fastdds/publisher/PublisherImpl.hpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantMockTests/mock/statistics/fastdds/publisher/PublisherImpl.hpp
@@ -75,9 +75,10 @@ public:
             const efd::TypeSupport& type,
             efd::Topic* topic,
             const efd::DataWriterQos& qos,
-            efd::DataWriterListener* listener) override
+            efd::DataWriterListener* listener,
+            std::shared_ptr<fastrtps::rtps::IPayloadPool> payload_pool) override
     {
-        return new DataWriterImpl(this, type, topic, qos, listener, statistics_listener_);
+        return new DataWriterImpl(this, type, topic, qos, listener, payload_pool, statistics_listener_);
     }
 
     efd::DataWriter* create_datawriter(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This pull request aims to expose the usage of a custom payload pool implementation on the DDS layer

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.12.x 2.11.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- N/A New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- N/A Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
