### PR TITLE
[20255] Fix max clash with Windows CI

### DIFF
--- a/.github/workflows/reusable-windows-ci.yml
+++ b/.github/workflows/reusable-windows-ci.yml
@@ -144,6 +144,8 @@ jobs:
 
       - name: Install OpenSSL
         uses: eProsima/eprosima-CI/windows/install_openssl@v0
+        with:
+          version: '3.1.1'
 
       - name: Update OpenSSL environment variables
         run: |

--- a/include/fastdds/rtps/messages/CDRMessage.hpp
+++ b/include/fastdds/rtps/messages/CDRMessage.hpp
@@ -269,7 +269,7 @@ inline SequenceNumberSet_t CDRMessage::readSequenceNumberSet(
     valid &= (seqNum.high >= 0);
     if (valid && std::numeric_limits<int32_t>::max() == seqNum.high)
     {
-        numBits = (std::min)(numBits, std::numeric_limits<uint32_t>::max() - seqNum.low);
+        numBits = (std::min)(numBits, (std::numeric_limits<uint32_t>::max)() - seqNum.low);
     }
 
     uint32_t n_longs = (numBits + 31u) / 32u;

--- a/include/fastdds/rtps/security/logging/Logging.h
+++ b/include/fastdds/rtps/security/logging/Logging.h
@@ -188,7 +188,7 @@ private:
     LogOptions log_options_;
     GUID_t guid_;
     std::string guid_str_;
-    uint32_t domain_id_ = std::numeric_limits<uint32_t>::max();
+    uint32_t domain_id_ = (std::numeric_limits<uint32_t>::max)();
     std::string domain_id_str_;
 };
 

--- a/include/fastrtps/utils/fixed_size_bitmap.hpp
+++ b/include/fastrtps/utils/fixed_size_bitmap.hpp
@@ -324,7 +324,7 @@ public:
             const T& from,
             const T& to)
     {
-        constexpr uint32_t full_mask = std::numeric_limits<uint32_t>::max();
+        constexpr uint32_t full_mask = (std::numeric_limits<uint32_t>::max)();
 
         // Adapt incoming range to range limits
         T min = (base_ >= from) ? base_ : from;
@@ -431,7 +431,7 @@ public:
         short shift = num_bits & 31u;
         if (0 < num_bits && shift != 0)
         {
-            bitmap_[num_items - 1] &= ~(std::numeric_limits<uint32_t>::max() >> shift);
+            bitmap_[num_items - 1] &= ~((std::numeric_limits<uint32_t>::max)() >> shift);
         }
         calc_maximum_bit_set(num_items, 0);
     }

--- a/src/cpp/fastdds/subscriber/history/DataReaderInstance.hpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderInstance.hpp
@@ -47,7 +47,7 @@ struct DataReaderInstance
     //! The list of alive writers for this instance
     WriterCollection alive_writers;
     //! GUID and strength of the current maximum strength writer
-    WriterOwnership current_owner{ {}, std::numeric_limits<uint32_t>::max() };
+    WriterOwnership current_owner{ {}, (std::numeric_limits<uint32_t>::max)() };
     //! The time when the group will miss the deadline
     std::chrono::steady_clock::time_point next_deadline_us;
     //! Current view state of the instance
@@ -195,10 +195,10 @@ private:
             current_owner.first = writer_guid;
             ret_val = true;
         }
-        else if (std::numeric_limits<uint32_t>::max() == ownership_strength) // uint32_t::max indicates we are in SHARED_OWNERSHIP_QOS.
+        else if ((std::numeric_limits<uint32_t>::max)() == ownership_strength) // uint32_t::max indicates we are in SHARED_OWNERSHIP_QOS.
         {
             assert(eprosima::fastrtps::rtps::c_Guid_Unknown == current_owner.first);
-            assert(std::numeric_limits<uint32_t>::max() == current_owner.second);
+            assert((std::numeric_limits<uint32_t>::max)() == current_owner.second);
             ret_val = true;
         }
         else if (eprosima::fastrtps::rtps::c_Guid_Unknown == current_owner.first) // Without owner.
@@ -247,7 +247,7 @@ private:
                 writer_guid < current_owner.first)
                 )
         {
-            if (std::numeric_limits<uint32_t>::max() != ownership_strength) // Not SHARED_OWNERSHIP_QOS
+            if ((std::numeric_limits<uint32_t>::max)() != ownership_strength) // Not SHARED_OWNERSHIP_QOS
             {
                 current_owner.first = writer_guid;
                 current_owner.second = ownership_strength;

--- a/src/cpp/rtps/DataSharing/WriterPool.hpp
+++ b/src/cpp/rtps/DataSharing/WriterPool.hpp
@@ -182,7 +182,8 @@ public:
             {
                 EPROSIMA_LOG_ERROR(DATASHARING_PAYLOADPOOL, "Failed to create segment " << segment_name_
                                                                                         << ": Segment size is too large: " << estimated_size_for_payloads_pool
-                                                                                        << " (max is " << std::numeric_limits<uint32_t>::max() << ")."
+                                                                                        << " (max is " <<
+                                    (std::numeric_limits<uint32_t>::max)() << ")."
                                                                                         << " Please reduce the maximum size of the history");
                 return false;
             }

--- a/src/cpp/rtps/DataSharing/WriterPool.hpp
+++ b/src/cpp/rtps/DataSharing/WriterPool.hpp
@@ -183,7 +183,7 @@ public:
                 EPROSIMA_LOG_ERROR(DATASHARING_PAYLOADPOOL, "Failed to create segment " << segment_name_
                                                                                         << ": Segment size is too large: " << estimated_size_for_payloads_pool
                                                                                         << " (max is " <<
-                                    (std::numeric_limits<uint32_t>::max)() << ")."
+                        (std::numeric_limits<uint32_t>::max)() << ")."
                                                                                         << " Please reduce the maximum size of the history");
                 return false;
             }

--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -52,7 +52,7 @@ static void set_builtin_reader_history_attributes(
         const ResourceLimitedContainerConfig& allocation,
         bool is_secure)
 {
-    constexpr uint32_t c_upper_limit = std::numeric_limits<uint32_t>::max() / 2u;
+    constexpr uint32_t c_upper_limit = (std::numeric_limits<uint32_t>::max)() / 2u;
 
     hatt.payloadMaxSize = is_secure ? 128 : 28;
 

--- a/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp
+++ b/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp
@@ -946,7 +946,7 @@ public:
 
         uint32_t limitation = get_max_payload();
 
-        if (std::numeric_limits<uint32_t>::max() != limitation)
+        if ((std::numeric_limits<uint32_t>::max)() != limitation)
         {
             sched.set_bandwith_limitation(limitation);
         }
@@ -1473,7 +1473,7 @@ private:
     typename std::enable_if<!std::is_base_of<FlowControllerLimitedAsyncPublishMode, PubMode>::value, uint32_t>::type
     constexpr get_max_payload_impl() const
     {
-        return std::numeric_limits<uint32_t>::max();
+        return (std::numeric_limits<uint32_t>::max)();
     }
 
     fastrtps::TimedMutex mutex_;

--- a/src/cpp/rtps/history/CacheChangePool.cpp
+++ b/src/cpp/rtps/history/CacheChangePool.cpp
@@ -67,7 +67,7 @@ void CacheChangePool::init(
     }
     else
     {
-        max_pool_size_ = std::numeric_limits<uint32_t>::max();
+        max_pool_size_ = (std::numeric_limits<uint32_t>::max)();
     }
 
     switch (memory_mode_)

--- a/src/cpp/rtps/history/TopicPayloadPool.cpp
+++ b/src/cpp/rtps/history/TopicPayloadPool.cpp
@@ -212,7 +212,7 @@ void TopicPayloadPool::update_maximum_size(
     {
         if (config.maximum_size == 0)
         {
-            max_pool_size_ = std::numeric_limits<uint32_t>::max();
+            max_pool_size_ = (std::numeric_limits<uint32_t>::max)();
             ++infinite_histories_count_;
         }
         else

--- a/src/cpp/rtps/network/NetworkFactory.cpp
+++ b/src/cpp/rtps/network/NetworkFactory.cpp
@@ -36,8 +36,8 @@ using SendResourceList = fastdds::rtps::SendResourceList;
 
 NetworkFactory::NetworkFactory(
         const RTPSParticipantAttributes& PParam)
-    : maxMessageSizeBetweenTransports_(std::numeric_limits<uint32_t>::max())
-    , minSendBufferSize_(std::numeric_limits<uint32_t>::max())
+    : maxMessageSizeBetweenTransports_((std::numeric_limits<uint32_t>::max)())
+    , minSendBufferSize_((std::numeric_limits<uint32_t>::max)())
     , network_configuration_(0)
 {
     const std::string* enforce_metatraffic = nullptr;
@@ -121,7 +121,7 @@ bool NetworkFactory::RegisterTransport(
 {
     bool wasRegistered = false;
 
-    uint32_t minSendBufferSize = std::numeric_limits<uint32_t>::max();
+    uint32_t minSendBufferSize = (std::numeric_limits<uint32_t>::max)();
 
     std::unique_ptr<TransportInterface> transport(descriptor->create_transport());
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1720,9 +1720,9 @@ bool RTPSParticipantImpl::createReceiverResources(
     // An auxilary buffer is needed in the ReceiverResource to to decrypt the message,
     // that imposes a limit in the received messages size even if the transport allows (uint32_t) messages size.
     uint32_t max_receiver_buffer_size =
-            is_secure() ? std::numeric_limits<uint16_t>::max() : std::numeric_limits<uint32_t>::max();
+            is_secure() ? std::numeric_limits<uint16_t>::max() : (std::numeric_limits<uint32_t>::max)();
 #else
-    uint32_t max_receiver_buffer_size = std::numeric_limits<uint32_t>::max();
+    uint32_t max_receiver_buffer_size = (std::numeric_limits<uint32_t>::max)();
 #endif // if HAVE_SECURITY
 
     for (auto it_loc = Locator_list.begin(); it_loc != Locator_list.end(); ++it_loc)
@@ -2101,9 +2101,9 @@ uint32_t RTPSParticipantImpl::getMaxMessageSize() const
     // that imposes a limit in the received messages size even if the transport allows (uint32_t) messages size.
     // So the sender limits also its size.
     uint32_t max_receiver_buffer_size =
-            is_secure() ? std::numeric_limits<uint16_t>::max() : std::numeric_limits<uint32_t>::max();
+            is_secure() ? std::numeric_limits<uint16_t>::max() : (std::numeric_limits<uint32_t>::max)();
 #else
-    uint32_t max_receiver_buffer_size = std::numeric_limits<uint32_t>::max();
+    uint32_t max_receiver_buffer_size = (std::numeric_limits<uint32_t>::max)();
 #endif // if HAVE_SECURITY
 
     return (std::min)(

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -635,7 +635,7 @@ bool StatefulReader::processDataMsg(
                 EPROSIMA_LOG_WARNING(RTPS_MSG_IN, IDSTRING "Problem copying CacheChange, received data is: "
                         << change->serializedPayload.length << " bytes and max size in reader "
                         << m_guid << " is "
-                        << (fixed_payload_size_ > 0 ? fixed_payload_size_ : std::numeric_limits<uint32_t>::max()));
+                        << (fixed_payload_size_ > 0 ? fixed_payload_size_ : (std::numeric_limits<uint32_t>::max)()));
                 change_pool_->release_cache(change_to_add);
                 return false;
             }
@@ -1110,7 +1110,7 @@ bool StatefulReader::change_received(
     }
     else
     {
-        a_change->reader_info.writer_ownership_strength = std::numeric_limits<uint32_t>::max();
+        a_change->reader_info.writer_ownership_strength = (std::numeric_limits<uint32_t>::max)();
     }
 
     // NOTE: Depending on QoS settings, one change can be removed from history

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -329,7 +329,7 @@ bool StatelessReader::change_received(
         }
         else
         {
-            change->reader_info.writer_ownership_strength = std::numeric_limits<uint32_t>::max();
+            change->reader_info.writer_ownership_strength = (std::numeric_limits<uint32_t>::max)();
         }
 
         if (mp_history->received_change(change, 0))
@@ -631,7 +631,7 @@ bool StatelessReader::processDataMsg(
                 EPROSIMA_LOG_WARNING(RTPS_MSG_IN, IDSTRING "Problem copying CacheChange, received data is: "
                         << change->serializedPayload.length << " bytes and max size in reader "
                         << m_guid << " is "
-                        << (fixed_payload_size_ > 0 ? fixed_payload_size_ : std::numeric_limits<uint32_t>::max()));
+                        << (fixed_payload_size_ > 0 ? fixed_payload_size_ : (std::numeric_limits<uint32_t>::max)()));
                 change_pool_->release_cache(change_to_add);
                 return false;
             }

--- a/src/cpp/rtps/security/logging/Logging.cpp
+++ b/src/cpp/rtps/security/logging/Logging.cpp
@@ -174,12 +174,12 @@ bool Logging::set_domain_id(
         const uint32_t id,
         SecurityException& exception)
 {
-    if (std::numeric_limits<uint32_t>::max() == id)
+    if ((std::numeric_limits<uint32_t>::max)() == id)
     {
         exception = SecurityException("Invalid domaine id value.");
         return false;
     }
-    else if (std::numeric_limits<uint32_t>::max() != domain_id_)
+    else if ((std::numeric_limits<uint32_t>::max)() != domain_id_)
     {
         exception = SecurityException("Domaine id already set (" + std::to_string(domain_id_) + ")");
         return false;

--- a/src/cpp/rtps/transport/shared_mem/test_SharedMemTransport.cpp
+++ b/src/cpp/rtps/transport/shared_mem/test_SharedMemTransport.cpp
@@ -23,7 +23,7 @@ namespace rtps {
 test_SharedMemTransportDescriptor::test_SharedMemTransportDescriptor()
     : SharedMemTransportDescriptor()
 {
-    big_buffer_size_ = std::numeric_limits<uint32_t>::max();
+    big_buffer_size_ = (std::numeric_limits<uint32_t>::max)();
     big_buffer_size_send_count_ = nullptr;
     big_buffer_size_recv_count_ = nullptr;
 }

--- a/src/cpp/security/cryptography/AESGCMGMAC_KeyFactory.cpp
+++ b/src/cpp/security/cryptography/AESGCMGMAC_KeyFactory.cpp
@@ -314,7 +314,7 @@ std::shared_ptr<ParticipantCryptoHandle> AESGCMGMAC_KeyFactory::register_matched
 
         (*RPCrypto)->max_blocks_per_session = local_participant_handle->max_blocks_per_session;
         (*RPCrypto)->Session.session_block_counter = local_participant_handle->max_blocks_per_session + 1;
-        (*RPCrypto)->Session.session_id = std::numeric_limits<uint32_t>::max();
+        (*RPCrypto)->Session.session_id = (std::numeric_limits<uint32_t>::max)();
         if ((*RPCrypto)->Session.session_id == local_participant_handle->Session.session_id)
         {
             (*RPCrypto)->Session.session_id -= 1;
@@ -529,7 +529,7 @@ DatareaderCryptoHandle* AESGCMGMAC_KeyFactory::register_matched_remote_datareade
 
     auto session = &(*RRCrypto)->Sessions[0];
     session->session_block_counter = local_writer_handle->Sessions[0].session_block_counter;
-    session->session_id = std::numeric_limits<uint32_t>::max();
+    session->session_id = (std::numeric_limits<uint32_t>::max)();
     if (session->session_id == local_writer_handle->Sessions[0].session_id)
     {
         session->session_id -= 1;
@@ -551,7 +551,7 @@ DatareaderCryptoHandle* AESGCMGMAC_KeyFactory::register_matched_remote_datareade
 
         session++;
         session->session_block_counter = local_writer_handle->Sessions[0].session_block_counter;
-        session->session_id = std::numeric_limits<uint32_t>::max();
+        session->session_id = (std::numeric_limits<uint32_t>::max)();
         if (session->session_id == local_writer_handle->Sessions[0].session_id)
         {
             session->session_id -= 1;
@@ -732,7 +732,7 @@ DatawriterCryptoHandle* AESGCMGMAC_KeyFactory::register_matched_remote_datawrite
     (*RWCrypto)->max_blocks_per_session = local_reader_handle->max_blocks_per_session;
     auto session = &(*RWCrypto)->Sessions[0];
     session->session_block_counter = local_reader_handle->Sessions[0].session_block_counter;
-    session->session_id = std::numeric_limits<uint32_t>::max();
+    session->session_id = (std::numeric_limits<uint32_t>::max)();
     if (session->session_id == local_reader_handle->Sessions[0].session_id)
     {
         session->session_id -= 1;

--- a/src/cpp/security/cryptography/AESGCMGMAC_Types.h
+++ b/src/cpp/security/cryptography/AESGCMGMAC_Types.h
@@ -137,7 +137,7 @@ struct SecureDataTag
 
 struct KeySessionData
 {
-    uint32_t session_id = std::numeric_limits<uint32_t>::max();
+    uint32_t session_id = (std::numeric_limits<uint32_t>::max)();
     std::array<uint8_t, 32> SessionKey = c_empty_key_material;
     uint64_t session_block_counter = 0;
 };

--- a/test/unittest/dds/topic/DDSSQLFilter/DDSSQLFilterTests.cpp
+++ b/test/unittest/dds/topic/DDSSQLFilter/DDSSQLFilterTests.cpp
@@ -785,7 +785,7 @@ private:
             std::array<ContentFilterTestType, 5>& data)
     {
         constexpr uint32_t min = std::numeric_limits<uint32_t>::lowest();
-        constexpr uint32_t max = std::numeric_limits<uint32_t>::max();
+        constexpr uint32_t max = (std::numeric_limits<uint32_t>::max)();
 
         std::array<uint32_t, 5> values{ min, max / 4, max / 3, max / 2, max };
 

--- a/test/unittest/utils/BitmapRangeTests.cpp
+++ b/test/unittest/utils/BitmapRangeTests.cpp
@@ -461,7 +461,7 @@ TEST_F(BitmapRangeTests, serialization)
 
     num_bits = 20u;
     num_longs = 1u;
-    bitmap.fill(std::numeric_limits<uint32_t>::max());
+    bitmap.fill((std::numeric_limits<uint32_t>::max)());
     uut.bitmap_set(num_bits, bitmap.data());
     uut.bitmap_get(num_bits, bitmap, num_longs);
     EXPECT_EQ(num_bits, 20u);
@@ -474,14 +474,14 @@ TEST_F(BitmapRangeTests, serialization)
     do
     {
         uint32_t test_bits = test_longs * sizeof(value_type) * 8;
-        bitmap.fill(std::numeric_limits<uint32_t>::max());
+        bitmap.fill((std::numeric_limits<uint32_t>::max)());
         uut.bitmap_set(test_bits, bitmap.data());
         uut.bitmap_get(num_bits, bitmap, num_longs);
         EXPECT_EQ(num_bits, test_bits);
         EXPECT_EQ(num_longs, test_longs);
 
         // use a vector as result pattern
-        std::vector<value_type> pattern(test_longs, std::numeric_limits<uint32_t>::max());
+        std::vector<value_type> pattern(test_longs, (std::numeric_limits<uint32_t>::max)());
         pattern.resize(bitmap.max_size(), 0);
         EXPECT_TRUE(std::equal(bitmap.begin(), bitmap.end(), pattern.begin()));
     }

--- a/test/unittest/xmlparser/XMLProfileParserTests.cpp
+++ b/test/unittest/xmlparser/XMLProfileParserTests.cpp
@@ -1743,9 +1743,9 @@ TEST_F(XMLProfileParserBasicTests, SHM_transport_descriptors_config)
         transport);
 
     ASSERT_NE(descriptor, nullptr);
-    ASSERT_EQ(descriptor->segment_size(), std::numeric_limits<uint32_t>::max());
-    ASSERT_EQ(descriptor->port_queue_capacity(), std::numeric_limits<uint32_t>::max());
-    ASSERT_EQ(descriptor->healthy_check_timeout_ms(), std::numeric_limits<uint32_t>::max());
+    ASSERT_EQ(descriptor->segment_size(), (std::numeric_limits<uint32_t>::max)());
+    ASSERT_EQ(descriptor->port_queue_capacity(), (std::numeric_limits<uint32_t>::max)());
+    ASSERT_EQ(descriptor->healthy_check_timeout_ms(), (std::numeric_limits<uint32_t>::max)());
     ASSERT_EQ(descriptor->rtps_dump_file(), "test_file.dump");
     ASSERT_EQ(descriptor->maxMessageSize, 128000u);
     ASSERT_EQ(descriptor->max_message_size(), 128000u);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Several Github Windows CI have started to fail for the same reason, even though the base branches are different:
 
* https://github.com/eProsima/Fast-DDS/actions/runs/7538695931/job/20519719577#step:18:501
* https://github.com/eProsima/Fast-DDS/actions/runs/7537913605/job/20517574924?pr=4246
* https://github.com/eProsima/Fast-DDS/actions/runs/7537990202/job/20517771780?pr=4247

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.12.x 2.11.x 2.10.x 2.6.x 

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
