### PR TITLE
[20269] Fix CCache usage on Github Windows CI

### DIFF
--- a/.github/workflows/reusable-windows-ci.yml
+++ b/.github/workflows/reusable-windows-ci.yml
@@ -38,8 +38,8 @@ jobs:
         cmake-config:
           - 'RelWithDebInfo'
         vs-toolset:
-          - 'v141'
-          - 'v142'
+          - '14.16'
+          - '14.29'
     steps:
       - name: Sync eProsima/Fast-DDS repository
         uses: actions/checkout@v3
@@ -101,14 +101,18 @@ jobs:
           $env_variables +=
             'CXXFLAGS=/MP',
             'CONFIG_TYPE=--config ${{ matrix.cmake-config }}',
-            'BIN_ARCH=-A x64',
-            'HOST_ARCH=-T ${{ matrix.vs-toolset }},host=x64',
             ('VSPWSH=' + $pwshmodule)
 
           # download the pull request branches on fetch
           git config --global remote.origin.fetch '+refs/pull/*:refs/remotes/origin/pull/*'
 
           $env_variables | Out-File $Env:GITHUB_ENV -Append -Encoding OEM
+
+      - name: Set up MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+          toolset: ${{ matrix.vs-toolset }}
 
       - name: Enable WER
         id: WERSetup
@@ -472,14 +476,6 @@ jobs:
                       "ccache", "${{ steps.ninja.outputs.cmake_generator }}"
 
           $cmakeargs = '--cmake-args --no-warn-unused-cli ${{ inputs.cmake-args }} '
-
-          # On Windows we must load the developer environment and chose a config
-          $pwshmodule = gi $Env:VSPWSH
-          Import-Module $pwshmodule
-          Enter-VsDevShell -SetDefaultWindowTitle -VsInstallPath $pwshmodule.Directory.Parent.Parent `
-                            -StartInPath (pwd) -DevCmdArguments '/arch=x64 /host_arch=x64'
-
-          $cmakeargs += "$Env:BIN_ARCH $Env:HOST_ARCH"
 
           # Show the args
           EchoArgs $buildargs --metas ci.meta --executor sequential ${{ inputs.colcon-args }} $cmakeargs.split(" ")

--- a/.github/workflows/reusable-windows-ci.yml
+++ b/.github/workflows/reusable-windows-ci.yml
@@ -51,8 +51,17 @@ jobs:
         with:
           cmakeVersion: '3.22.6'
 
+      - name: Setting ninja
+        id: ninja
+        if: github.event.schedule == ''
+        shell: pwsh
+        run: |
+          echo "cmake_generator=ninja" >> $Env:GITHUB_OUTPUT
+
       - name: Setup CCache
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
+        with:
+          windows_compile_environment: msvc
 
       - name: Patch SDK for source indexing
         run: |
@@ -459,7 +468,8 @@ jobs:
                       "--symlink-install",
                       "--event-handlers=console_direct+",
                       "--packages-up-to", "fastrtps",
-                      "--mixin", $translate["${{ matrix.cmake-config }}"]
+                      "--mixin", $translate["${{ matrix.cmake-config }}"],
+                      "ccache", "${{ steps.ninja.outputs.cmake_generator }}"
 
           $cmakeargs = '--cmake-args --no-warn-unused-cli ${{ inputs.cmake-args }} '
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR fixes the usage of CCache for Github Windows CI, so it is actually used.
It does so by using Ninja as generator for the PR jobs (not the nighties). To do that, the VS prompt had to be set beforehand (instead of specifying architecture using CMake). This is done via an [external action](https://github.com/ilammy/msvc-dev-cmd) to select both the architecture and the VSC++ compiler. Relevant links for the reviewer: 

* https://blog.knatten.org/2022/08/26/microsoft-c-versions-explained/
* https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.12.x 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- _N/A_:The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
