### PR TITLE
[20276] Discard already processed samples on PDPListener

### DIFF
--- a/include/fastdds/rtps/builtin/data/ParticipantProxyData.h
+++ b/include/fastdds/rtps/builtin/data/ParticipantProxyData.h
@@ -120,6 +120,8 @@ public:
     //!
     ProxyHashTable<WriterProxyData>* m_writers = nullptr;
 
+    SampleIdentity m_sample_identity;
+
     /**
      * Update the data.
      * @param pdata Object to copy the data from

--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
@@ -65,6 +65,7 @@ ParticipantProxyData::ParticipantProxyData(
     , should_check_lease_duration(false)
     , m_readers(new ProxyHashTable<ReaderProxyData>(allocation.readers))
     , m_writers(new ProxyHashTable<WriterProxyData>(allocation.writers))
+    , m_sample_identity()
 {
     m_userData.set_max_size(static_cast<uint32_t>(allocation.data_limits.max_user_data));
 }
@@ -99,6 +100,7 @@ ParticipantProxyData::ParticipantProxyData(
     // so there is no need to copy m_readers and m_writers
     , m_readers(nullptr)
     , m_writers(nullptr)
+    , m_sample_identity(pdata.m_sample_identity)
     , lease_duration_(pdata.lease_duration_)
 {
 }
@@ -758,6 +760,7 @@ void ParticipantProxyData::copy(
     isAlive = pdata.isAlive;
     m_userData = pdata.m_userData;
     m_properties = pdata.m_properties;
+    m_sample_identity = pdata.m_sample_identity;
 
     // This method is only called when a new participant is discovered.The destination of the copy
     // will always be a new ParticipantProxyData or one from the pool, so there is no need for

--- a/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
@@ -132,11 +132,16 @@ void PDPListener::onNewCacheChangeAdded(
                 if (guid == it->m_guid)
                 {
                     pdata = it;
-                    // This means this is the same DATA(p) that we have already processed
-                    if (it->m_sample_identity == change->write_params.sample_identity())
+
+                    // This means this is the same DATA(p) that we have already processed.
+                    // We do not compare sample_identity directly because it is not properly filled
+                    // in the change during desearialization.
+                    if (it->m_sample_identity.writer_guid() == change->writerGUID &&
+                            it->m_sample_identity.sequence_number() == change->sequenceNumber)
                     {
                         already_processed = true;
                     }
+
                     break;
                 }
             }
@@ -144,7 +149,8 @@ void PDPListener::onNewCacheChangeAdded(
             // Only notified the DATA(p) if it is not a repeated one
             if (!already_processed)
             {
-                temp_participant_data_.m_sample_identity = change->write_params.sample_identity();
+                temp_participant_data_.m_sample_identity.writer_guid(change->writerGUID);
+                temp_participant_data_.m_sample_identity.sequence_number(change->sequenceNumber);
                 process_alive_data(pdata, temp_participant_data_, writer_guid, reader, lock);
             }
         }

--- a/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
@@ -146,7 +146,7 @@ void PDPListener::onNewCacheChangeAdded(
                 }
             }
 
-            // Only notified the DATA(p) if it is not a repeated one
+            // Only process the DATA(p) if it is not a repeated one
             if (!already_processed)
             {
                 temp_participant_data_.m_sample_identity.writer_guid(change->writerGUID);

--- a/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
@@ -126,16 +126,27 @@ void PDPListener::onNewCacheChangeAdded(
 
             // Check if participant already exists (updated info)
             ParticipantProxyData* pdata = nullptr;
+            bool already_processed = false;
             for (ParticipantProxyData* it : parent_pdp_->participant_proxies_)
             {
                 if (guid == it->m_guid)
                 {
                     pdata = it;
+                    // This means this is the same DATA(p) that we have already processed
+                    if (it->m_sample_identity == change->write_params.sample_identity())
+                    {
+                        already_processed = true;
+                    }
                     break;
                 }
             }
 
-            process_alive_data(pdata, temp_participant_data_, writer_guid, reader, lock);
+            // Only notified the DATA(p) if it is not a repeated one
+            if (!already_processed)
+            {
+                temp_participant_data_.m_sample_identity = change->write_params.sample_identity();
+                process_alive_data(pdata, temp_participant_data_, writer_guid, reader, lock);
+            }
         }
     }
     else if (reader->matched_writer_is_matched(writer_guid))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR fixes a datarace in `PDPListener` that was causing assertions on Windows Debug. Prior to this PR, if a DATA(P) of an already discovered participant was received through multicast (the sample has already been processed since the data is the just the periodic announcement of the remote participant) while a DATA(uP) (or an update changing locators) is being processed on one of the metta-traffic unicast reception threads, then processing the DATA(P) could segfault while iterating over a collection of locators that the DATA(uP) processing has already deleted.

This PR fixes that data race by avoiding processing a sample which has already been processed, thus avoiding re-processing of periodic announcements.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.12.x 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
