### PR TITLE
[19587] Include variety of terminate proccess signals handler in discovery server

### DIFF
--- a/tools/fds/server.cpp
+++ b/tools/fds/server.cpp
@@ -561,6 +561,9 @@ int fastdds_discovery_server(
         // Handle signal SIGINT for every thread
         signal(SIGINT, sigint_handler);
         signal(SIGTERM, sigint_handler);
+#ifndef _WIN32
+        signal(SIGHUP, sigint_handler);
+#endif // ifndef _WIN32
 
         bool has_security = false;
         if (guid_prefix != pServer->guid().guidPrefix)

--- a/tools/fds/server.cpp
+++ b/tools/fds/server.cpp
@@ -561,6 +561,13 @@ int fastdds_discovery_server(
         // Handle signal SIGINT for every thread
         signal(SIGINT, sigint_handler);
         signal(SIGTERM, sigint_handler);
+        signal(SIGQUIT, sigint_handler);
+        signal(SIGILL, sigint_handler);
+        signal(SIGABRT, sigint_handler);
+        signal(SIGBUS, sigint_handler);
+        signal(SIGFPE, sigint_handler);
+        signal(SIGSEGV, sigint_handler);
+        signal(SIGPIPE, sigint_handler);
 #ifndef _WIN32
         signal(SIGHUP, sigint_handler);
 #endif // ifndef _WIN32

--- a/tools/fds/server.cpp
+++ b/tools/fds/server.cpp
@@ -566,9 +566,9 @@ int fastdds_discovery_server(
         signal(SIGABRT, sigint_handler);
         signal(SIGBUS, sigint_handler);
         signal(SIGFPE, sigint_handler);
+#ifndef _WIN32
         signal(SIGSEGV, sigint_handler);
         signal(SIGPIPE, sigint_handler);
-#ifndef _WIN32
         signal(SIGHUP, sigint_handler);
 #endif // ifndef _WIN32
 

--- a/tools/fds/server.cpp
+++ b/tools/fds/server.cpp
@@ -561,8 +561,8 @@ int fastdds_discovery_server(
         // Handle signal SIGINT for every thread
         signal(SIGINT, sigint_handler);
         signal(SIGTERM, sigint_handler);
-        signal(SIGQUIT, sigint_handler);
 #ifndef _WIN32
+        signal(SIGQUIT, sigint_handler);
         signal(SIGHUP, sigint_handler);
 #endif // ifndef _WIN32
 

--- a/tools/fds/server.cpp
+++ b/tools/fds/server.cpp
@@ -562,13 +562,7 @@ int fastdds_discovery_server(
         signal(SIGINT, sigint_handler);
         signal(SIGTERM, sigint_handler);
         signal(SIGQUIT, sigint_handler);
-        signal(SIGILL, sigint_handler);
-        signal(SIGABRT, sigint_handler);
-        signal(SIGBUS, sigint_handler);
-        signal(SIGFPE, sigint_handler);
 #ifndef _WIN32
-        signal(SIGSEGV, sigint_handler);
-        signal(SIGPIPE, sigint_handler);
         signal(SIGHUP, sigint_handler);
 #endif // ifndef _WIN32
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
While closing the terminal by clicking the X button, it seems that the signal emitted was SIGHUP.
For that reason, by handling that signal the application properly closes in those scenarios.

It may be interesting to handle this signal also in several eProsima products. What do you think about the following list, @Mario-DL?
Fast DDS CLI, Fast DDS pipe, router, monitor, record, replay, spy.

**EDIT:**
After [research](https://www-uxsup.csx.cam.ac.uk/courses/moved.Building/signals.pdf) , I've included the following signals to handle as terminate:
1. SIGQUIT: Quit signal. Similar to SIGINT, but also produces a core dump of the process.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.12.x 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
