### PR TITLE
[20306] Ignore 0x8007 if coming from other vendor

### DIFF
--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
@@ -469,6 +469,7 @@ bool ParticipantProxyData::readFromCDRMessage(
                         // TODO(eduponz): This is a workaround for the moment, as it is implicitly assuming
                         // that the vendor ID parameter came before this one. In the future, we should propagate
                         // the vendor ID from the RTPS message header using the CacheChange and check it here.
+                        FASTDDS_TODO_BEFORE(2, 14, "Add vendor ID to CacheChange");
                         if (c_VendorId_eProsima != m_VendorId)
                         {
                             return true;

--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
@@ -464,6 +464,16 @@ bool ParticipantProxyData::readFromCDRMessage(
                     }
                     case fastdds::dds::PID_NETWORK_CONFIGURATION_SET:
                     {
+                        // This is a custom PID defined by eProsima, so if the DATA(p)'s
+                        // vendor ID is not ours we need just ignore it.
+                        // TODO(eduponz): This is a workaround for the moment, as it is implicitly assuming
+                        // that the vendor ID parameter came before this one. In the future, we should propagate
+                        // the vendor ID from the RTPS message header using the CacheChange and check it here.
+                        if (c_VendorId_eProsima != m_VendorId)
+                        {
+                            return true;
+                        }
+
                         ParameterNetworkConfigSet_t p(pid, plength);
                         if (!fastdds::dds::ParameterSerializer<ParameterNetworkConfigSet_t>::read_from_cdr_message(p,
                                 msg, plength))

--- a/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
+++ b/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
@@ -462,7 +462,7 @@ TEST(BuiltinDataSerializationTests, other_vendor_parameter_list_with_custom_pids
     ParticipantProxyData out(RTPSParticipantAllocationAttributes{});
     out.m_networkConfiguration = 0;
     EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, true, network, false, true)));
-    ASSERT_EQ(out.m_networkConfiguration, 0);
+    ASSERT_EQ(out.m_networkConfiguration, 0u);
 }
 
 /*!

--- a/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
+++ b/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
@@ -427,6 +427,44 @@ TEST(BuiltinDataSerializationTests, property_list_with_binary_properties)
     EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, true, network, false, true)));
 }
 
+// Regression test for redmine ticket 20306
+TEST(BuiltinDataSerializationTests, other_vendor_parameter_list_with_custom_pids)
+{
+    octet data_p_buffer[] =
+    {
+        // Encapsulation
+        0x00, 0x03, 0x00, 0x00,
+
+        // PID_PROTOCOL_VERSION
+        0x15, 0, 4, 0,
+        2, 1, 0, 0,
+
+        // PID_VENDORID
+        0x16, 0, 4, 0,
+        2, 0, 0, 0,
+
+        // PID_PARTICIPANT_GUID
+        0x50, 0, 16, 0,
+        1, 16, 54, 83, 136, 247, 149, 252, 47, 105, 174, 141, 0, 0, 1, 193,
+
+        // PID_NETWORK_CONFIGURATION_SET
+        0x07, 0x80, 8, 0,
+        1, 2, 3, 4, 5, 6, 7, 8,
+
+        // PID_SENTINEL
+        0x01, 0, 0, 0
+    };
+
+    CDRMessage_t msg(0);
+    msg.init(data_p_buffer, static_cast<uint32_t>(sizeof(data_p_buffer)));
+    msg.length = msg.max_size;
+
+    ParticipantProxyData out(RTPSParticipantAllocationAttributes{});
+    out.m_networkConfiguration = 0;
+    EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, true, network, false, true)));
+    ASSERT_EQ(out.m_networkConfiguration, 0);
+}
+
 /*!
  * \test RTPS-CFT-CFP-01 Tests serialization of `ContentFilterProperty_t` works successfully without parameters.
  */

--- a/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
+++ b/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
@@ -445,7 +445,7 @@ TEST(BuiltinDataSerializationTests, other_vendor_parameter_list_with_custom_pids
 
         // PID_PARTICIPANT_GUID
         0x50, 0, 16, 0,
-        1, 16, 54, 83, 136, 247, 149, 252, 47, 105, 174, 141, 0, 0, 1, 193,
+        2, 0, 54, 83, 136, 247, 149, 252, 47, 105, 174, 141, 0, 0, 1, 193,
 
         // PID_NETWORK_CONFIGURATION_SET
         0x07, 0x80, 8, 0,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR fixes an interoperability issue introduced in #3733 occurring when a different vendor sends a DATA(p) which parameter list is to contain a parameter with PID 0x8007, which in Fast DDS is a custom PID (`PID_NETWORK_CONFIGURATION_SET`). When that happens, the deserialization in Fast DDS most likely fails or even worse gets a wrong interpretation.

Tested with [CycloneDDS ShapesDemo](https://github.com/atolab/dds-ishapes) and Fast DDS ShapesDemo (setting the `auto_fill_type_information` to `false` using eProsima/ShapesDemo#107).

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.12.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
