### PR TITLE
Add serialization for Log::Kind to ostream

### DIFF
--- a/include/fastdds/dds/log/Log.hpp
+++ b/include/fastdds/dds/log/Log.hpp
@@ -178,6 +178,11 @@ public:
             Log::Kind);
 };
 
+//! Streams Log::Kind serialization
+std::ostream& operator <<(
+        std::ostream& os,
+        const Log::Kind& kind);
+
 /**
  * Consumes a log entry to output it somewhere.
  */

--- a/include/fastdds/dds/log/Log.hpp
+++ b/include/fastdds/dds/log/Log.hpp
@@ -179,9 +179,30 @@ public:
 };
 
 //! Streams Log::Kind serialization
-std::ostream& operator <<(
-        std::ostream& os,
-        const Log::Kind& kind);
+inline std::ostream& operator <<(
+        std::ostream& output,
+        const Log::Kind& kind)
+{
+    switch (kind){
+        case Log::Kind::Info:
+            output << "Info";
+            break;
+
+        case Log::Kind::Warning:
+            output << "Warning";
+            break;
+
+        case Log::Kind::Error:
+            output << "Error";
+            break;
+
+        default:
+            output << "Invalid Verbosity Kind.";
+            break;
+    }
+
+    return output;
+}
 
 /**
  * Consumes a log entry to output it somewhere.

--- a/src/cpp/fastdds/log/Log.cpp
+++ b/src/cpp/fastdds/log/Log.cpp
@@ -519,30 +519,6 @@ void LogConsumer::print_new_line(
     stream << def << std::endl;
 }
 
-std::ostream& operator <<(std::ostream& os, const Log::Kind& kind)
-{
-    switch (kind)
-    {
-        case Log::Kind::Info:
-            os << "Info";
-            break;
-
-        case Log::Kind::Warning:
-            os << "Warning";
-            break;
-
-        case Log::Kind::Error:
-            os << "Error";
-            break;
-
-        default:
-            os << "Invalid Verbosity Kind.";
-            break;
-    }
-
-    return os;
-}
-
 } //namespace dds
 } //namespace fastdds
 } //namespace eprosima

--- a/src/cpp/fastdds/log/Log.cpp
+++ b/src/cpp/fastdds/log/Log.cpp
@@ -474,11 +474,7 @@ void LogConsumer::print_header(
 
     std::string white = (color) ? C_B_WHITE : "";
 
-    std::string kind = (entry.kind == Log::Kind::Error) ? "Error" :
-            (entry.kind == Log::Kind::Warning) ? "Warning" :
-            (entry.kind == Log::Kind::Info) ? "Info" : "";
-
-    stream << c_b_color << "[" << white << entry.context.category << c_b_color << " " << kind << "] ";
+    stream << c_b_color << "[" << white << entry.context.category << c_b_color << " " << entry.kind << "] ";
 }
 
 void LogConsumer::print_context(
@@ -528,15 +524,15 @@ std::ostream& operator <<(std::ostream& os, const Log::Kind& kind)
     switch (kind)
     {
         case Log::Kind::Info:
-            os << "INFO";
+            os << "Info";
             break;
 
         case Log::Kind::Warning:
-            os << "WARNING";
+            os << "Warning";
             break;
 
         case Log::Kind::Error:
-            os << "ERROR";
+            os << "Error";
             break;
 
         default:

--- a/src/cpp/fastdds/log/Log.cpp
+++ b/src/cpp/fastdds/log/Log.cpp
@@ -523,6 +523,30 @@ void LogConsumer::print_new_line(
     stream << def << std::endl;
 }
 
+std::ostream& operator <<(std::ostream& os, const Log::Kind& kind)
+{
+    switch (kind)
+    {
+        case Log::Kind::Info:
+            os << "INFO";
+            break;
+
+        case Log::Kind::Warning:
+            os << "WARNING";
+            break;
+
+        case Log::Kind::Error:
+            os << "ERROR";
+            break;
+
+        default:
+            os << "Invalid Verbosity Kind.";
+            break;
+    }
+
+    return os;
+}
+
 } //namespace dds
 } //namespace fastdds
 } //namespace eprosima


### PR DESCRIPTION
# Add serialization for Log::Kind to ostream

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This commit introduces a new ostream serialization function for the Log::Kind enumeration, allowing seamless output to ostream objects. The function includes a switch statement of Log::Kind values to their corresponding string representations (INFO, WARNING, ERROR).

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- _N/A_: Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
