### PR TITLE
[20238] Enabling multiple interfaces through whitelist in TCP servers 

### DIFF
--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -312,7 +312,7 @@ void TCPTransportInterface::calculate_crc(
 }
 
 uint16_t TCPTransportInterface::create_acceptor_socket(
-        const Locator& locator)
+        Locator& locator)
 {
     uint16_t final_port = 0;
     try
@@ -348,6 +348,14 @@ uint16_t TCPTransportInterface::create_acceptor_socket(
             std::vector<std::string> vInterfaces = get_binding_interfaces_list();
             for (std::string& sInterface : vInterfaces)
             {
+                if (locator.kind == LOCATOR_KIND_TCPv4)
+                {
+                    IPLocator::setIPv4(locator, sInterface);
+                }
+                else if (locator.kind == LOCATOR_KIND_TCPv6)
+                {
+                    IPLocator::setIPv6(locator, sInterface);
+                }
 #if TLS_FOUND
                 if (configuration()->apply_security)
                 {

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -312,7 +312,7 @@ void TCPTransportInterface::calculate_crc(
 }
 
 uint16_t TCPTransportInterface::create_acceptor_socket(
-        Locator& locator)
+        const Locator& locator)
 {
     uint16_t final_port = 0;
     try
@@ -348,19 +348,20 @@ uint16_t TCPTransportInterface::create_acceptor_socket(
             std::vector<std::string> vInterfaces = get_binding_interfaces_list();
             for (std::string& sInterface : vInterfaces)
             {
-                if (locator.kind == LOCATOR_KIND_TCPv4)
+                Locator loc = locator;
+                if (loc.kind == LOCATOR_KIND_TCPv4)
                 {
-                    IPLocator::setIPv4(locator, sInterface);
+                    IPLocator::setIPv4(loc, sInterface);
                 }
-                else if (locator.kind == LOCATOR_KIND_TCPv6)
+                else if (loc.kind == LOCATOR_KIND_TCPv6)
                 {
-                    IPLocator::setIPv6(locator, sInterface);
+                    IPLocator::setIPv6(loc, sInterface);
                 }
 #if TLS_FOUND
                 if (configuration()->apply_security)
                 {
                     std::shared_ptr<TCPAcceptorSecure> acceptor =
-                            std::make_shared<TCPAcceptorSecure>(io_service_, sInterface, locator);
+                            std::make_shared<TCPAcceptorSecure>(io_service_, sInterface, loc);
                     acceptors_[acceptor->locator()] = acceptor;
                     acceptor->accept(this, ssl_context_);
                     final_port = static_cast<uint16_t>(acceptor->locator().port);
@@ -369,7 +370,7 @@ uint16_t TCPTransportInterface::create_acceptor_socket(
 #endif // if TLS_FOUND
                 {
                     std::shared_ptr<TCPAcceptorBasic> acceptor =
-                            std::make_shared<TCPAcceptorBasic>(io_service_, sInterface, locator);
+                            std::make_shared<TCPAcceptorBasic>(io_service_, sInterface, loc);
                     acceptors_[acceptor->locator()] = acceptor;
                     acceptor->accept(this);
                     final_port = static_cast<uint16_t>(acceptor->locator().port);

--- a/src/cpp/rtps/transport/TCPTransportInterface.h
+++ b/src/cpp/rtps/transport/TCPTransportInterface.h
@@ -158,7 +158,7 @@ protected:
 
     //! Creates a TCP acceptor to wait for incoming connections by the given locator.
     uint16_t create_acceptor_socket(
-            Locator& locator);
+            const Locator& locator);
 
     virtual void get_ips(
             std::vector<fastrtps::rtps::IPFinder::info_IP>& loc_names,

--- a/src/cpp/rtps/transport/TCPTransportInterface.h
+++ b/src/cpp/rtps/transport/TCPTransportInterface.h
@@ -158,7 +158,7 @@ protected:
 
     //! Creates a TCP acceptor to wait for incoming connections by the given locator.
     uint16_t create_acceptor_socket(
-            const Locator& locator);
+            Locator& locator);
 
     virtual void get_ips(
             std::vector<fastrtps::rtps::IPFinder::info_IP>& loc_names,

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -600,12 +600,15 @@ TEST_F(TCPv4Tests, check_TCPv4_interface_whitelist_initialization)
     auto check_whitelist = transportUnderTest.get_interface_whitelist();
     for (auto& ip : mock_interfaces)
     {
-        ASSERT_NE(std::find(check_whitelist.begin(), check_whitelist.end(), asio::ip::address_v4::from_string(ip)), check_whitelist.end());
+        ASSERT_NE(std::find(check_whitelist.begin(), check_whitelist.end(), asio::ip::address_v4::from_string(
+                    ip)), check_whitelist.end());
     }
 
     // Check that every interface is in the acceptors map
-    for (const auto& test : transportUnderTest.get_acceptors_map()) {
-        ASSERT_NE(std::find(mock_interfaces.begin(), mock_interfaces.end(), IPLocator::toIPv4string(test.first)), mock_interfaces.end());
+    for (const auto& test : transportUnderTest.get_acceptors_map())
+    {
+        ASSERT_NE(std::find(mock_interfaces.begin(), mock_interfaces.end(), IPLocator::toIPv4string(
+                    test.first)), mock_interfaces.end());
     }
 }
 

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -583,7 +583,6 @@ TEST_F(TCPv4Tests, check_TCPv4_interface_whitelist_initialization)
     // Add manually localhost to test adding multiple interfaces
     mock_interfaces.push_back("127.0.0.1");
 
-    TCPv4TransportDescriptor descriptor;
     for (auto& ip : mock_interfaces)
     {
         descriptor.interfaceWhiteList.emplace_back(ip);

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -587,7 +587,6 @@ TEST_F(TCPv4Tests, check_TCPv4_interface_whitelist_initialization)
     {
         descriptor.interfaceWhiteList.emplace_back(ip);
     }
-    descriptor.add_listener_port(g_default_port);
     MockTCPv4Transport transportUnderTest(descriptor);
     transportUnderTest.init();
 

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -251,7 +251,6 @@ TEST_F(TCPv6Tests, check_TCPv6_interface_whitelist_initialization)
     asio_interfaces.push_back("::1");
     locator_interfaces.push_back("::1");
 
-    TCPv6TransportDescriptor descriptor;
     for (auto& ip : locator_interfaces)
     {
         descriptor.interfaceWhiteList.emplace_back(ip);

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -268,12 +268,15 @@ TEST_F(TCPv6Tests, check_TCPv6_interface_whitelist_initialization)
     auto check_whitelist = transportUnderTest.get_interface_whitelist();
     for (auto& ip : asio_interfaces)
     {
-        ASSERT_NE(std::find(check_whitelist.begin(), check_whitelist.end(), asio::ip::address_v6::from_string(ip)), check_whitelist.end());
+        ASSERT_NE(std::find(check_whitelist.begin(), check_whitelist.end(), asio::ip::address_v6::from_string(
+                    ip)), check_whitelist.end());
     }
 
     // Check that every interface is in the acceptors map
-    for (const auto& test : transportUnderTest.get_acceptors_map()) {
-        ASSERT_NE(std::find(locator_interfaces.begin(), locator_interfaces.end(), IPLocator::toIPv6string(test.first)), locator_interfaces.end());
+    for (const auto& test : transportUnderTest.get_acceptors_map())
+    {
+        ASSERT_NE(std::find(locator_interfaces.begin(), locator_interfaces.end(), IPLocator::toIPv6string(
+                    test.first)), locator_interfaces.end());
     }
 }
 

--- a/test/unittest/transport/mock/MockTCPv4Transport.h
+++ b/test/unittest/transport/mock/MockTCPv4Transport.h
@@ -46,6 +46,16 @@ public:
         return unbound_channel_resources_;
     }
 
+    const std::vector<asio::ip::address_v4>& get_interface_whitelist() const
+    {
+        return interface_whitelist_;
+    }
+
+    const std::map<Locator_t, std::shared_ptr<fastdds::rtps::TCPAcceptor>>& get_acceptors_map() const
+    {
+        return acceptors_;
+    }
+
 };
 
 } // namespace rtps

--- a/test/unittest/transport/mock/MockTCPv6Transport.h
+++ b/test/unittest/transport/mock/MockTCPv6Transport.h
@@ -46,6 +46,16 @@ public:
         return unbound_channel_resources_;
     }
 
+    const std::vector<asio::ip::address_v6>& get_interface_whitelist() const
+    {
+        return interface_whitelist_;
+    }
+
+    const std::map<Locator_t, std::shared_ptr<fastdds::rtps::TCPAcceptor>>& get_acceptors_map() const
+    {
+        return acceptors_;
+    }
+
 };
 
 } // namespace rtps


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This pull request addresses a bug related to the initialization of TCP servers when multiple interfaces are added to the whitelist. The issue stemmed from the unnoticed overwriting of the acceptors_ map because of the comparison of locators without properly setting their addresses.

@Mergifyio backport 2.12.x 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [X] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
