### PR TITLE
[20262] Add non-throwing getters for socket info

### DIFF
--- a/src/cpp/rtps/transport/TCPChannelResource.h
+++ b/src/cpp/rtps/transport/TCPChannelResource.h
@@ -133,7 +133,7 @@ public:
     virtual asio::ip::tcp::endpoint remote_endpoint() const = 0;
 
     virtual asio::ip::tcp::endpoint local_endpoint() const = 0;
-    
+
     virtual asio::ip::tcp::endpoint remote_endpoint(
             asio::error_code& ec) const = 0;
 

--- a/src/cpp/rtps/transport/TCPChannelResource.h
+++ b/src/cpp/rtps/transport/TCPChannelResource.h
@@ -133,6 +133,12 @@ public:
     virtual asio::ip::tcp::endpoint remote_endpoint() const = 0;
 
     virtual asio::ip::tcp::endpoint local_endpoint() const = 0;
+    
+    virtual asio::ip::tcp::endpoint remote_endpoint(
+            asio::error_code& ec) const = 0;
+
+    virtual asio::ip::tcp::endpoint local_endpoint(
+            asio::error_code& ec) const = 0;
 
     virtual void set_options(
             const TCPTransportDescriptor* options) = 0;

--- a/src/cpp/rtps/transport/TCPChannelResource.h
+++ b/src/cpp/rtps/transport/TCPChannelResource.h
@@ -130,13 +130,33 @@ public:
             size_t size,
             asio::error_code& ec) = 0;
 
+    /**
+     * @brief Gets the remote endpoint of the socket connection.
+     * @throws Exception on failure.
+     * @return asio::ip::tcp::endpoint of the remote endpoint.
+     */
     virtual asio::ip::tcp::endpoint remote_endpoint() const = 0;
 
+    /**
+     * @brief Gets the local endpoint of the socket connection.
+     * @throws Exception on failure.
+     * @return asio::ip::tcp::endpoint of the local endpoint.
+     */
     virtual asio::ip::tcp::endpoint local_endpoint() const = 0;
 
+    /**
+     * @brief Gets the remote endpoint, setting error code if any.
+     * @param ec Set to indicate what error occurred, if any.
+     * @return asio::ip::tcp::endpoint of the remote endpoint or returns a default-constructed endpoint object if an error occurred.
+     */
     virtual asio::ip::tcp::endpoint remote_endpoint(
             asio::error_code& ec) const = 0;
 
+    /**
+     * @brief Gets the local endpoint, setting error code if any.
+     * @param ec Set to indicate what error occurred, if any.
+     * @return asio::ip::tcp::endpoint of the remote endpoint or returns a default-constructed endpoint object if an error occurred.
+     */
     virtual asio::ip::tcp::endpoint local_endpoint(
             asio::error_code& ec) const = 0;
 

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
@@ -185,13 +185,13 @@ asio::ip::tcp::endpoint TCPChannelResourceBasic::local_endpoint() const
 }
 
 asio::ip::tcp::endpoint TCPChannelResourceBasic::remote_endpoint(
-    asio::error_code& ec) const
+        asio::error_code& ec) const
 {
     return socket_->remote_endpoint(ec);
 }
 
 asio::ip::tcp::endpoint TCPChannelResourceBasic::local_endpoint(
-    asio::error_code& ec) const
+        asio::error_code& ec) const
 {
     return socket_->local_endpoint(ec);
 }

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
@@ -181,7 +181,18 @@ asio::ip::tcp::endpoint TCPChannelResourceBasic::remote_endpoint() const
 
 asio::ip::tcp::endpoint TCPChannelResourceBasic::local_endpoint() const
 {
-    std::error_code ec;
+    return socket_->local_endpoint();
+}
+
+asio::ip::tcp::endpoint TCPChannelResourceBasic::remote_endpoint(
+    asio::error_code& ec) const
+{
+    return socket_->remote_endpoint(ec);
+}
+
+asio::ip::tcp::endpoint TCPChannelResourceBasic::local_endpoint(
+    asio::error_code& ec) const
+{
     return socket_->local_endpoint(ec);
 }
 

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.h
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.h
@@ -71,9 +71,9 @@ public:
 
     // Throwing asio calls
     asio::ip::tcp::endpoint remote_endpoint(
-                asio::error_code& ec) const override;
+            asio::error_code& ec) const override;
     asio::ip::tcp::endpoint local_endpoint(
-                asio::error_code& ec) const override;
+            asio::error_code& ec) const override;
 
     void set_options(
             const TCPTransportDescriptor* options) override;

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.h
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.h
@@ -65,11 +65,11 @@ public:
             size_t size,
             asio::error_code& ec) override;
 
-    // Non-throwing asio calls
+    // Throwing asio calls
     asio::ip::tcp::endpoint remote_endpoint() const override;
     asio::ip::tcp::endpoint local_endpoint() const override;
 
-    // Throwing asio calls
+    // Non-throwing asio calls
     asio::ip::tcp::endpoint remote_endpoint(
             asio::error_code& ec) const override;
     asio::ip::tcp::endpoint local_endpoint(

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.h
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.h
@@ -65,8 +65,15 @@ public:
             size_t size,
             asio::error_code& ec) override;
 
+    // Non-throwing asio calls
     asio::ip::tcp::endpoint remote_endpoint() const override;
     asio::ip::tcp::endpoint local_endpoint() const override;
+
+    // Throwing asio calls
+    asio::ip::tcp::endpoint remote_endpoint(
+                asio::error_code& ec) const override;
+    asio::ip::tcp::endpoint local_endpoint(
+                asio::error_code& ec) const override;
 
     void set_options(
             const TCPTransportDescriptor* options) override;

--- a/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
@@ -265,6 +265,18 @@ asio::ip::tcp::endpoint TCPChannelResourceSecure::local_endpoint() const
     return secure_socket_->lowest_layer().local_endpoint();
 }
 
+asio::ip::tcp::endpoint TCPChannelResourceSecure::remote_endpoint(
+        asio::error_code& ec) const
+{
+    return secure_socket_->lowest_layer().remote_endpoint(ec);
+}
+
+asio::ip::tcp::endpoint TCPChannelResourceSecure::local_endpoint(
+        asio::error_code& ec) const
+{
+    return secure_socket_->lowest_layer().local_endpoint(ec);
+}
+
 void TCPChannelResourceSecure::set_options(
         const TCPTransportDescriptor* options)
 {

--- a/src/cpp/rtps/transport/TCPChannelResourceSecure.h
+++ b/src/cpp/rtps/transport/TCPChannelResourceSecure.h
@@ -71,9 +71,9 @@ public:
 
     // Non-throwing asio calls
     asio::ip::tcp::endpoint remote_endpoint(
-                asio::error_code& ec) const override;
+            asio::error_code& ec) const override;
     asio::ip::tcp::endpoint local_endpoint(
-                asio::error_code& ec) const override;
+            asio::error_code& ec) const override;
 
     void set_options(
             const TCPTransportDescriptor* options) override;

--- a/src/cpp/rtps/transport/TCPChannelResourceSecure.h
+++ b/src/cpp/rtps/transport/TCPChannelResourceSecure.h
@@ -65,8 +65,15 @@ public:
             size_t size,
             asio::error_code& ec) override;
 
+    // Throwing asio calls
     asio::ip::tcp::endpoint remote_endpoint() const override;
     asio::ip::tcp::endpoint local_endpoint() const override;
+
+    // Non-throwing asio calls
+    asio::ip::tcp::endpoint remote_endpoint(
+                asio::error_code& ec) const override;
+    asio::ip::tcp::endpoint local_endpoint(
+                asio::error_code& ec) const override;
 
     void set_options(
             const TCPTransportDescriptor* options) override;

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -1185,7 +1185,7 @@ bool TCPTransportInterface::Receive(
                     {
                         if (!IsLocatorValid(remote_locator))
                         {
-                            endpoint_to_locator(channel->remote_endpoint(), remote_locator);  
+                            endpoint_to_locator(channel->remote_endpoint(), remote_locator);
                         }
                         IPLocator::setLogicalPort(remote_locator, tcp_header.logical_port);
                         EPROSIMA_LOG_INFO(RTCP_MSG_IN, "[RECEIVE] From: " << remote_locator \

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -898,7 +898,12 @@ void TCPTransportInterface::perform_listen_operation(
     if (rtcp_message_manager)
     {
         channel = channel_weak.lock();
-        endpoint_to_locator(channel->remote_endpoint(), remote_locator);
+        asio::error_code ec;
+        endpoint_to_locator(channel->remote_endpoint(ec), remote_locator);
+        if (ec)
+        {
+            remote_locator.kind = LOCATOR_KIND_INVALID;
+        }
 
         if (channel)
         {
@@ -1178,6 +1183,10 @@ bool TCPTransportInterface::Receive(
                     }
                     else
                     {
+                        if (!IsLocatorValid(remote_locator))
+                        {
+                            endpoint_to_locator(channel->remote_endpoint(), remote_locator);  
+                        }
                         IPLocator::setLogicalPort(remote_locator, tcp_header.logical_port);
                         EPROSIMA_LOG_INFO(RTCP_MSG_IN, "[RECEIVE] From: " << remote_locator \
                                                                           << " - " << receive_buffer_size << " bytes.");

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -912,10 +912,10 @@ void TCPTransportInterface::perform_listen_operation(
     {
         channel = channel_weak.lock();
 
-        remote_locator = remote_endpoint_to_locator(channel);
-
         if (channel)
         {
+            remote_locator = remote_endpoint_to_locator(channel);
+
             uint32_t port = channel->local_endpoint().port();
             set_name_to_current_thread("dds.tcp.%u", port);
 

--- a/src/cpp/rtps/transport/TCPTransportInterface.h
+++ b/src/cpp/rtps/transport/TCPTransportInterface.h
@@ -189,6 +189,12 @@ protected:
             Locator& locator) const = 0;
 
     /**
+     * Converts a remote endpoint to a locator if possible. Otherwise, it sets an invalid locator.
+     */
+    Locator remote_endpoint_to_locator(
+            const std::shared_ptr<TCPChannelResource>& channel) const;
+
+    /**
      * Shutdown method to close the connections of the transports.
      */
     void shutdown() override;

--- a/test/unittest/transport/mock/MockTCPChannelResource.cpp
+++ b/test/unittest/transport/mock/MockTCPChannelResource.cpp
@@ -67,6 +67,22 @@ asio::ip::tcp::endpoint MockTCPChannelResource::local_endpoint() const
     return ep;
 }
 
+asio::ip::tcp::endpoint MockTCPChannelResource::remote_endpoint(
+        asio::error_code& ec) const
+{
+    ec = asio::error_code();  // Indicate no error
+    asio::ip::tcp::endpoint ep;
+    return ep;
+}
+
+asio::ip::tcp::endpoint MockTCPChannelResource::local_endpoint(
+        asio::error_code& ec) const
+{
+    ec = asio::error_code();  // Indicate no error
+    asio::ip::tcp::endpoint ep;
+    return ep;
+}
+
 void MockTCPChannelResource::set_options(
         const TCPTransportDescriptor*)
 {

--- a/test/unittest/transport/mock/MockTCPChannelResource.h
+++ b/test/unittest/transport/mock/MockTCPChannelResource.h
@@ -59,6 +59,12 @@ public:
 
     asio::ip::tcp::endpoint local_endpoint() const override;
 
+    asio::ip::tcp::endpoint remote_endpoint(
+            asio::error_code& ec) const override;
+
+    asio::ip::tcp::endpoint local_endpoint(
+            asio::error_code& ec) const override;
+
     void set_options(
             const TCPTransportDescriptor* options) override;
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
In some instances, requesting server info after client connection caused exceptions (transport endpoint is not connected). This behavior was observed after PR #4258.
We now also use ASIO's non-throwing methods for this request, ensuring any errors are appropriately handled.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.12.x 2.11.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- N/A New feature has been added to the `versions.md` file (if applicable).
- N/A New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [ ] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
