### PR TITLE
[20227] Prevent index overflow and correctly assert the end iterator in DataSharing

### DIFF
--- a/src/cpp/rtps/DataSharing/DataSharingPayloadPool.cpp
+++ b/src/cpp/rtps/DataSharing/DataSharingPayloadPool.cpp
@@ -42,7 +42,10 @@ void DataSharingPayloadPool::advance(
         uint64_t& index) const
 {
     // lower part is the index, upper part is the loop counter
-    ++index;
+    if (static_cast<uint32_t>(index) + 1 <= descriptor_->history_size)
+    {
+        ++index;
+    }
     if (static_cast<uint32_t>(index) % descriptor_->history_size == 0)
     {
         index = ((index >> 32) + 1) << 32;

--- a/src/cpp/rtps/DataSharing/ReaderPool.hpp
+++ b/src/cpp/rtps/DataSharing/ReaderPool.hpp
@@ -132,13 +132,15 @@ public:
         {
             CacheChange_t ch;
             SequenceNumber_t last_sequence = c_SequenceNumber_Unknown;
-            get_next_unread_payload(ch, last_sequence);
-            while (ch.sequenceNumber != SequenceNumber_t::unknown())
+            uint64_t current_end = end();
+            get_next_unread_payload(ch, last_sequence, current_end);
+            while (ch.sequenceNumber != SequenceNumber_t::unknown() || next_payload_ != current_end)
             {
+                current_end = end();
                 advance(next_payload_);
-                get_next_unread_payload(ch, last_sequence);
+                get_next_unread_payload(ch, last_sequence, current_end);
             }
-            assert(next_payload_ == end());
+            assert(next_payload_ == current_end);
         }
 
         return true;

--- a/test/dds/communication/CMakeLists.txt
+++ b/test/dds/communication/CMakeLists.txt
@@ -115,6 +115,7 @@ list(APPEND TEST_DEFINITIONS
     zero_copy_sub_communication
     mix_zero_copy_communication
     close_TCP_client
+    simple_data_sharing_stress
     )
 
 

--- a/test/dds/communication/PubSubMain.cpp
+++ b/test/dds/communication/PubSubMain.cpp
@@ -68,6 +68,7 @@ int main(
     uint32_t wait = 0;
     uint32_t samples = 4;
     uint32_t publishers = 1;
+    uint32_t timeout = 86400000; // 24 hours in ms
     // The first loop could be easily ignored by the reader
     uint32_t publisher_loops = 2;
     uint32_t interval = 250;
@@ -131,6 +132,16 @@ int main(
             }
 
             interval = strtol(argv[arg_count], nullptr, 10);
+        }
+        else if (strcmp(argv[arg_count], "--timeout") == 0)
+        {
+            if (++arg_count >= argc)
+            {
+                std::cout << "--timeout expects a parameter" << std::endl;
+                return -1;
+            }
+
+            timeout = strtol(argv[arg_count], nullptr, 10);
         }
         else if (strcmp(argv[arg_count], "--magic") == 0)
         {
@@ -197,7 +208,7 @@ int main(
 
         if (subscriber.init(seed, magic))
         {
-            result = subscriber.run(notexit) ? 0 : -1;
+            result = subscriber.run(notexit, timeout) ? 0 : -1;
         }
 
         publisher_thread.join();

--- a/test/dds/communication/PubSubMain.cpp
+++ b/test/dds/communication/PubSubMain.cpp
@@ -37,20 +37,22 @@ using namespace eprosima::fastdds::dds;
  * --xmlfile <path>
  * --publishers <int>
  * --publisher_loops <int>
+ * --interval <int>
  */
 
 void publisher_run(
         PublisherModule* publisher,
         uint32_t wait,
         uint32_t samples,
-        uint32_t loops)
+        uint32_t loops,
+        uint32_t interval)
 {
     if (wait > 0)
     {
         publisher->wait_discovery(wait);
     }
 
-    publisher->run(samples, loops);
+    publisher->run(samples, loops, interval);
 }
 
 int main(
@@ -68,6 +70,7 @@ int main(
     uint32_t publishers = 1;
     // The first loop could be easily ignored by the reader
     uint32_t publisher_loops = 2;
+    uint32_t interval = 250;
     char* xml_file = nullptr;
     std::string magic;
 
@@ -118,6 +121,16 @@ int main(
             }
 
             samples = strtol(argv[arg_count], nullptr, 10);
+        }
+        else if (strcmp(argv[arg_count], "--interval") == 0)
+        {
+            if (++arg_count >= argc)
+            {
+                std::cout << "--interval expects a parameter" << std::endl;
+                return -1;
+            }
+
+            interval = strtol(argv[arg_count], nullptr, 10);
         }
         else if (strcmp(argv[arg_count], "--magic") == 0)
         {
@@ -180,7 +193,7 @@ int main(
 
     if (publisher.init(seed, magic))
     {
-        std::thread publisher_thread(publisher_run, &publisher, wait, samples, publisher_loops);
+        std::thread publisher_thread(publisher_run, &publisher, wait, samples, publisher_loops, interval);
 
         if (subscriber.init(seed, magic))
         {

--- a/test/dds/communication/PublisherMain.cpp
+++ b/test/dds/communication/PublisherMain.cpp
@@ -31,6 +31,7 @@ using namespace eprosima::fastdds::dds;
  * --samples <int>
  * --magic <str>
  * --xmlfile <path>
+ * --interval <int>
  */
 
 int main(
@@ -45,6 +46,7 @@ int main(
     uint32_t wait = 0;
     char* xml_file = nullptr;
     uint32_t samples = 4;
+    uint32_t interval = 250;
     std::string magic;
 
     while (arg_count < argc)
@@ -91,6 +93,16 @@ int main(
 
             samples = strtol(argv[arg_count], nullptr, 10);
         }
+        else if (strcmp(argv[arg_count], "--interval") == 0)
+        {
+            if (++arg_count >= argc)
+            {
+                std::cout << "--interval expects a parameter" << std::endl;
+                return -1;
+            }
+
+            interval = strtol(argv[arg_count], nullptr, 10);
+        }
         else if (strcmp(argv[arg_count], "--magic") == 0)
         {
             if (++arg_count >= argc)
@@ -134,7 +146,7 @@ int main(
             publisher.wait_discovery(wait);
         }
 
-        publisher.run(samples);
+        publisher.run(samples, 0, interval);
         return 0;
     }
 

--- a/test/dds/communication/PublisherModule.cpp
+++ b/test/dds/communication/PublisherModule.cpp
@@ -61,14 +61,14 @@ bool PublisherModule::init(
         uint32_t seed,
         const std::string& magic)
 {
-    std::cout << "Initializing Publisher" << std::endl;
+    std::cout <<  "Initializing Publisher" << std::endl;
 
     participant_ =
             DomainParticipantFactory::get_instance()->create_participant(seed % 230, PARTICIPANT_QOS_DEFAULT, this);
 
     if (participant_ == nullptr)
     {
-        std::cout << "Error creating publisher participant" << std::endl;
+        EPROSIMA_LOG_ERROR(PUBLISHER_MODULE, "Error creating publisher participant");
         return false;
     }
 
@@ -92,14 +92,14 @@ bool PublisherModule::init(
     publisher_ = participant_->create_publisher(PUBLISHER_QOS_DEFAULT, this);
     if (publisher_ == nullptr)
     {
-        std::cout << "Error creating publisher" << std::endl;
+        EPROSIMA_LOG_ERROR(PUBLISHER_MODULE, "Error creating publisher");
         return false;
     }
 
     topic_ = participant_->create_topic(topic_name.str(), type_.get_type_name(), TOPIC_QOS_DEFAULT);
     if (topic_ == nullptr)
     {
-        std::cout << "Error creating publisher topic" << std::endl;
+        EPROSIMA_LOG_ERROR(PUBLISHER_MODULE, "Error creating publisher topic");
         return false;
     }
 
@@ -111,7 +111,7 @@ bool PublisherModule::init(
     writer_ = publisher_->create_datawriter(topic_, wqos, this);
     if (writer_ == nullptr)
     {
-        std::cout << "Error creating publisher datawriter" << std::endl;
+        EPROSIMA_LOG_ERROR(PUBLISHER_MODULE, "Error creating publisher datawriter");
         return false;
     }
     std::cout << "Writer created correctly in topic " << topic_->get_name()
@@ -134,7 +134,8 @@ void PublisherModule::wait_discovery(
 
 void PublisherModule::run(
         uint32_t samples,
-        const uint32_t loops)
+        const uint32_t loops,
+        uint32_t interval)
 {
     uint32_t current_loop = 0;
     uint16_t index = 1;
@@ -166,7 +167,7 @@ void PublisherModule::run(
                 data->message("HelloWorld");
             }
         }
-        std::cout << "Publisher writting index " << index << std::endl;
+        EPROSIMA_LOG_INFO(PUBLISHER_MODULE, "Publisher writting index " << index);
         writer_->write(sample);
 
         if (index == samples)
@@ -184,7 +185,7 @@ void PublisherModule::run(
             type_.delete_data(sample);
         }
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(250));
+        std::this_thread::sleep_for(std::chrono::milliseconds(interval));
     }
 }
 

--- a/test/dds/communication/PublisherModule.hpp
+++ b/test/dds/communication/PublisherModule.hpp
@@ -80,7 +80,8 @@ public:
 
     void run(
             uint32_t samples,
-            uint32_t loops = 0);
+            uint32_t loops = 0,
+            uint32_t interval = 250);
 
 private:
 

--- a/test/dds/communication/SubscriberMain.cpp
+++ b/test/dds/communication/SubscriberMain.cpp
@@ -45,7 +45,7 @@ int main(
     uint32_t seed = 7800;
     uint32_t samples = 4;
     uint32_t publishers = 1;
-    uint32_t timeout = 0;
+    uint32_t timeout = 86400000; // 24 h in ms
     char* xml_file = nullptr;
     std::string magic;
 

--- a/test/dds/communication/SubscriberMain.cpp
+++ b/test/dds/communication/SubscriberMain.cpp
@@ -41,9 +41,11 @@ int main(
     bool notexit = false;
     bool fixed_type = false;
     bool zero_copy = false;
+    bool succeed_on_timeout = false;
     uint32_t seed = 7800;
     uint32_t samples = 4;
     uint32_t publishers = 1;
+    uint32_t timeout = 0;
     char* xml_file = nullptr;
     std::string magic;
 
@@ -60,6 +62,10 @@ int main(
         else if (strcmp(argv[arg_count], "--zero_copy") == 0)
         {
             zero_copy = true;
+        }
+        else if (strcmp(argv[arg_count], "--succeed_on_timeout") == 0)
+        {
+            succeed_on_timeout = true;
         }
         else if (strcmp(argv[arg_count], "--seed") == 0)
         {
@@ -90,6 +96,16 @@ int main(
             }
 
             magic = argv[arg_count];
+        }
+        else if (strcmp(argv[arg_count], "--timeout") == 0)
+        {
+            if (++arg_count >= argc)
+            {
+                std::cout << "--run-for expects a parameter" << std::endl;
+                return -1;
+            }
+
+            timeout = strtol(argv[arg_count], nullptr, 10);
         }
         else if (strcmp(argv[arg_count], "--xmlfile") == 0)
         {
@@ -125,11 +141,11 @@ int main(
         DomainParticipantFactory::get_instance()->load_XML_profiles_file(xml_file);
     }
 
-    SubscriberModule subscriber(publishers, samples, fixed_type, zero_copy);
+    SubscriberModule subscriber(publishers, samples, fixed_type, zero_copy, succeed_on_timeout);
 
     if (subscriber.init(seed, magic))
     {
-        return subscriber.run(notexit) ? 0 : -1;
+        return subscriber.run(notexit, timeout) ? 0 : -1;
     }
 
     return -1;

--- a/test/dds/communication/SubscriberMain.cpp
+++ b/test/dds/communication/SubscriberMain.cpp
@@ -31,6 +31,8 @@ using namespace eprosima::fastdds::dds;
  * --magic <str>
  * --xmlfile <path>
  * --publishers <int>
+ * --succeed_on_timeout
+ * --timeout <int>
  */
 
 int main(

--- a/test/dds/communication/SubscriberModule.cpp
+++ b/test/dds/communication/SubscriberModule.cpp
@@ -148,7 +148,7 @@ bool SubscriberModule::run_for(
         std::this_thread::sleep_for(std::chrono::milliseconds(250));
     }
 
-    if(run_)
+    if (run_)
     {
         auto t0 = std::chrono::steady_clock::now();
         std::unique_lock<std::mutex> lock(mutex_);
@@ -302,8 +302,9 @@ void SubscriberModule::on_data_available(
                 if (info.instance_state == ALIVE_INSTANCE_STATE)
                 {
                     std::unique_lock<std::mutex> lock(mutex_);
-                    EPROSIMA_LOG_INFO(SUBSCRIBER_MODULE, "Received sample (" << info.sample_identity.writer_guid() << " - " <<
-                        info.sample_identity.sequence_number() << "): index(" << sample.index() << ")");
+                    EPROSIMA_LOG_INFO(SUBSCRIBER_MODULE,
+                            "Received sample (" << info.sample_identity.writer_guid() << " - " <<
+                            info.sample_identity.sequence_number() << "): index(" << sample.index() << ")");
                     if (max_number_samples_ <= ++number_samples_[info.sample_identity.writer_guid()])
                     {
                         cv_.notify_all();
@@ -319,9 +320,10 @@ void SubscriberModule::on_data_available(
                 if (info.instance_state == ALIVE_INSTANCE_STATE)
                 {
                     std::unique_lock<std::mutex> lock(mutex_);
-                    EPROSIMA_LOG_INFO(SUBSCRIBER_MODULE, "Received sample (" << info.sample_identity.writer_guid() << " - " <<
-                        info.sample_identity.sequence_number() << "): index(" << sample.index() << "), message("
-                              << sample.message() << ")");
+                    EPROSIMA_LOG_INFO(SUBSCRIBER_MODULE,
+                            "Received sample (" << info.sample_identity.writer_guid() << " - " <<
+                            info.sample_identity.sequence_number() << "): index(" << sample.index() << "), message("
+                                                << sample.message() << ")");
                     if (max_number_samples_ <= ++number_samples_[info.sample_identity.writer_guid()])
                     {
                         cv_.notify_all();

--- a/test/dds/communication/SubscriberModule.hpp
+++ b/test/dds/communication/SubscriberModule.hpp
@@ -45,11 +45,13 @@ public:
             const uint32_t publishers,
             const uint32_t max_number_samples,
             bool fixed_type = false,
-            bool zero_copy = false)
+            bool zero_copy = false,
+            bool succeed_on_timeout = false)
         : publishers_(publishers)
         , max_number_samples_(max_number_samples)
         , fixed_type_(zero_copy || fixed_type) // If zero copy active, fixed type is required
         , zero_copy_(zero_copy)
+        , succeeed_on_timeout_(succeed_on_timeout)
     {
     }
 
@@ -81,7 +83,8 @@ public:
             const std::string& magic);
 
     bool run(
-            bool notexit);
+            bool notexit,
+            uint32_t timeout = 0);
 
     bool run_for(
             bool notexit,
@@ -97,6 +100,7 @@ private:
     bool fixed_type_ = false;
     bool zero_copy_ = false;
     bool run_ = true;
+    bool succeeed_on_timeout_ = false;
     DomainParticipant* participant_ = nullptr;
     TypeSupport type_;
     Subscriber* subscriber_ = nullptr;

--- a/test/dds/communication/SubscriberModule.hpp
+++ b/test/dds/communication/SubscriberModule.hpp
@@ -84,7 +84,7 @@ public:
 
     bool run(
             bool notexit,
-            uint32_t timeout = 0);
+            uint32_t timeout = 86400000);
 
     bool run_for(
             bool notexit,

--- a/test/dds/communication/definitions_example.json
+++ b/test/dds/communication/definitions_example.json
@@ -13,7 +13,8 @@
             "wait" : 0,
             "samples" : 4,
             "magic" : "str",
-            "xmlfile" : "path/file.xml"
+            "xmlfile" : "path/file.xml",
+            "interval" : 250
         },
         {
             "kind" : "subscriber",
@@ -24,7 +25,9 @@
             "samples" : 4,
             "magic" : "str",
             "xmlfile" : "path/file.xml",
-            "publishers" : 1
+            "publishers" : 1,
+            "timeout" : 20,
+            "succeed_on_timeout" : false
         },
         {
             "kind" : "pubsub",
@@ -38,7 +41,8 @@
             "magic" : "str",
             "xmlfile" : "path/file.xml",
             "publishers" : 1,
-            "publisher_loops" : 2
+            "publisher_loops" : 2,
+            "interval" : 250
         }
     ]
 }

--- a/test/dds/communication/simple_data_sharing_stress.json
+++ b/test/dds/communication/simple_data_sharing_stress.json
@@ -1,0 +1,18 @@
+{
+    "description" : "Test to check that Data Sharing correctly behaves under stress",
+    "participants" : [
+        {
+            "kind" : "subscriber",
+            "fixed_type" : true,
+            "samples" : "1000000",
+            "timeout" : "20000",
+            "succeed_on_timeout" : true
+        },
+        {
+            "kind" : "publisher",
+            "fixed_type" : true,
+            "interval" : "0",
+            "sleep_before_exec" : "1"
+        }
+    ]
+}

--- a/test/dds/communication/test_build.py
+++ b/test/dds/communication/test_build.py
@@ -48,7 +48,7 @@ def define_args(tests_definition):
 
         if 'kind' not in test.keys():
             print('ARGUMENT ERROR : '
-                  'Test definition requites <kind> field for each participant')
+                  'Test definition requires <kind> field for each participant')
             continue
 
         # All processes has seed argument
@@ -58,7 +58,9 @@ def define_args(tests_definition):
                               'wait',
                               'magic',
                               'publishers',
-                              'sleep_before_exec']
+                              'sleep_before_exec',
+                              'interval',
+                              'timeout']
 
         for argument in possible_arguments:
             if argument in test.keys():
@@ -69,7 +71,8 @@ def define_args(tests_definition):
         possible_flags = ['exit_on_lost_liveliness',
                           'zero_copy',
                           'fixed_type',
-                          'notexit']
+                          'notexit',
+                          'succeed_on_timeout']
 
         for flag in possible_flags:
             if flag in test.keys():


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

When a DataSharing compatible publisher and subscriber were launched at high frequency (publication interval set to `0`), it happened two different issues:
* The current `notified_end` of the segment iterator was being updated before being actually checked, making an `assert()` compare two different versions of this iterator.
* On the other hand, unrelated with the previous observation, a corner case of advancing twice the `next_payload_` counter could occur.

Apart from the included test, in order to reproduce the first issue it is enough to launch a `BasicConfigurationExample` with a `bounded` type and no sleep between`writes()`. Launching, killing and relaunching the subscriber should trigger the `assertion`.
For reproducing the second issue, launch the subscriber first and then the publisher, a `SIGSEV` will be triggered in `20 seconds` or so.

This PR includes two fixes that mitigate the problem.
The idea of the test is that if in 20 seconds we have not crashed by some of the above issues, we give the test as passed.

**Important note** It was noticed that enabling all the verbosity messages in the test, makes the test not work properly under `colcon` since the `timeout` notification of the `SubscriberModule.cpp` condition variable is never fired. It seems that the test stresses the cpu and the timeout notification is lost. However, if the `python3` is directly invoked from a terminal (outside colcon), then there is no problem even if all the logs are enabled.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.12.x 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X ] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [X] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
