### PR TITLE
[20141] Fix TCP reconnection after open logical port failure

### DIFF
--- a/src/cpp/rtps/transport/TCPChannelResource.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResource.cpp
@@ -176,9 +176,9 @@ void TCPChannelResource::add_logical_port_response(
         negotiating_logical_ports_.erase(it);
         if (portIt != pending_logical_output_ports_.end())
         {
-            pending_logical_output_ports_.erase(portIt);
             if (success)
             {
+                pending_logical_output_ports_.erase(portIt);
                 logical_output_ports_.push_back(port);
                 EPROSIMA_LOG_INFO(RTCP, "OpenedLogicalPort: " << port);
             }

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -2077,11 +2077,11 @@ TEST_F(TCPv4Tests, reconnect_after_open_port_failure)
     // Connect client to server
     EXPECT_TRUE(serverTransportUnderTest->OpenInputChannel(initialPeerLocator, nullptr, 0x00FF));
     SendResourceList client_resource_list;
-    ASSERT_TRUE(clientTransportUnderTest->OpenOutputChannel(client_resource_list ,initialPeerLocator));
+    ASSERT_TRUE(clientTransportUnderTest->OpenOutputChannel(client_resource_list, initialPeerLocator));
     ASSERT_FALSE(client_resource_list.empty());
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
     auto channel = clientTransportUnderTest->get_channel_resources().begin()->second;
-    
+
     // Logical port is opened
     ASSERT_TRUE(channel->is_logical_port_opened(7410));
 

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -2135,6 +2135,7 @@ TEST_F(TCPv4Tests, reconnect_after_open_port_failure)
 
     // Clear test
     EXPECT_TRUE(serverTransportUnderTest->CloseInputChannel(initialPeerLocator));
+    client_resource_list.clear();
     delete serverTransportUnderTest;
     delete clientTransportUnderTest;
 }

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -2069,9 +2069,7 @@ TEST_F(TCPv4Tests, reconnect_after_open_port_failure)
 
     // Add initial peer to the client
     Locator_t initialPeerLocator;
-    initialPeerLocator.kind = LOCATOR_KIND_TCPv4;
-    IPLocator::setIPv4(initialPeerLocator, 127, 0, 0, 1);
-    initialPeerLocator.port = port;
+    IPLocator::createLocator(LOCATOR_KIND_TCPv4, "127.0.0.1", port, initialPeerLocator);
     IPLocator::setLogicalPort(initialPeerLocator, 7410);
 
     // Connect client to server

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -2050,6 +2050,95 @@ TEST_F(TCPv4Tests, non_blocking_send)
 }
 #endif // ifndef _WIN32
 
+// This test verifies that a server can reconnect to a client after the client has once failed in a
+// openLogicalPort request
+TEST_F(TCPv4Tests, reconnect_after_open_port_failure)
+{
+    eprosima::fastdds::dds::Log::SetVerbosity(eprosima::fastdds::dds::Log::Warning);
+    uint16_t port = g_default_port;
+    // Create a TCP Server transport
+    TCPv4TransportDescriptor serverDescriptor;
+    serverDescriptor.add_listener_port(port);
+    TCPv4Transport* serverTransportUnderTest = new TCPv4Transport(serverDescriptor);
+    serverTransportUnderTest->init();
+
+    // Create a TCP Client transport
+    TCPv4TransportDescriptor clientDescriptor;
+    MockTCPv4Transport* clientTransportUnderTest = new MockTCPv4Transport(clientDescriptor);
+    clientTransportUnderTest->init();
+
+    // Add initial peer to the client
+    Locator_t initialPeerLocator;
+    initialPeerLocator.kind = LOCATOR_KIND_TCPv4;
+    IPLocator::setIPv4(initialPeerLocator, 127, 0, 0, 1);
+    initialPeerLocator.port = port;
+    IPLocator::setLogicalPort(initialPeerLocator, 7410);
+
+    // Connect client to server
+    EXPECT_TRUE(serverTransportUnderTest->OpenInputChannel(initialPeerLocator, nullptr, 0x00FF));
+    SendResourceList client_resource_list;
+    ASSERT_TRUE(clientTransportUnderTest->OpenOutputChannel(client_resource_list ,initialPeerLocator));
+    ASSERT_FALSE(client_resource_list.empty());
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    auto channel = clientTransportUnderTest->get_channel_resources().begin()->second;
+    
+    // Logical port is opened
+    ASSERT_TRUE(channel->is_logical_port_opened(7410));
+
+    // Disconnect server
+    EXPECT_TRUE(serverTransportUnderTest->CloseInputChannel(initialPeerLocator));
+    delete serverTransportUnderTest;
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    // Client should have passed logical port to pending list
+    ASSERT_FALSE(channel->is_logical_port_opened(7410));
+    ASSERT_TRUE(channel->is_logical_port_added(7410));
+
+    // Now try normal reconnection
+    serverTransportUnderTest = new TCPv4Transport(serverDescriptor);
+    serverTransportUnderTest->init();
+    ASSERT_TRUE(serverTransportUnderTest->OpenInputChannel(initialPeerLocator, nullptr, 0x00FF));
+    clientTransportUnderTest->send(nullptr, 0, channel, initialPeerLocator); // connect()
+
+    // Logical port is opened (moved from pending list)
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    ASSERT_TRUE(channel->is_logical_port_opened(7410));
+
+    // Disconnect server
+    EXPECT_TRUE(serverTransportUnderTest->CloseInputChannel(initialPeerLocator));
+    delete serverTransportUnderTest;
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    // Client should have passed logical port to pending list
+    ASSERT_FALSE(channel->is_logical_port_opened(7410));
+    ASSERT_TRUE(channel->is_logical_port_added(7410));
+
+    // Now try reconnect the server and close server's input channel before client's open logical
+    // port request, and then delete server and reconnect
+    serverTransportUnderTest = new TCPv4Transport(serverDescriptor);
+    serverTransportUnderTest->init();
+    ASSERT_TRUE(serverTransportUnderTest->OpenInputChannel(initialPeerLocator, nullptr, 0x00FF));
+    EXPECT_TRUE(serverTransportUnderTest->CloseInputChannel(initialPeerLocator));
+    clientTransportUnderTest->send(nullptr, 0, channel, initialPeerLocator); // connect()
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    delete serverTransportUnderTest;
+    ASSERT_FALSE(channel->is_logical_port_opened(7410));
+    ASSERT_TRUE(channel->is_logical_port_added(7410));
+
+    // Now try normal reconnection
+    serverTransportUnderTest = new TCPv4Transport(serverDescriptor);
+    serverTransportUnderTest->init();
+    ASSERT_TRUE(serverTransportUnderTest->OpenInputChannel(initialPeerLocator, nullptr, 0x00FF));
+    clientTransportUnderTest->send(nullptr, 0, channel, initialPeerLocator); // connect()
+
+    // Logical port is opened (moved from pending list)
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    ASSERT_TRUE(channel->is_logical_port_opened(7410));
+
+    // Clear test
+    EXPECT_TRUE(serverTransportUnderTest->CloseInputChannel(initialPeerLocator));
+    delete serverTransportUnderTest;
+    delete clientTransportUnderTest;
+}
+
 void TCPv4Tests::HELPER_SetDescriptorDefaults()
 {
     descriptor.add_listener_port(g_default_port);

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -2097,7 +2097,7 @@ TEST_F(TCPv4Tests, reconnect_after_open_port_failure)
     serverTransportUnderTest = new TCPv4Transport(serverDescriptor);
     serverTransportUnderTest->init();
     ASSERT_TRUE(serverTransportUnderTest->OpenInputChannel(initialPeerLocator, nullptr, 0x00FF));
-    clientTransportUnderTest->send(nullptr, 0, channel, initialPeerLocator); // connect()
+    clientTransportUnderTest->send(nullptr, 0, channel->locator(), initialPeerLocator); // connect()
 
     // Logical port is opened (moved from pending list)
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
@@ -2117,7 +2117,7 @@ TEST_F(TCPv4Tests, reconnect_after_open_port_failure)
     serverTransportUnderTest->init();
     ASSERT_TRUE(serverTransportUnderTest->OpenInputChannel(initialPeerLocator, nullptr, 0x00FF));
     EXPECT_TRUE(serverTransportUnderTest->CloseInputChannel(initialPeerLocator));
-    clientTransportUnderTest->send(nullptr, 0, channel, initialPeerLocator); // connect()
+    clientTransportUnderTest->send(nullptr, 0, channel->locator(), initialPeerLocator); // connect()
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
     delete serverTransportUnderTest;
     ASSERT_FALSE(channel->is_logical_port_opened(7410));
@@ -2127,7 +2127,7 @@ TEST_F(TCPv4Tests, reconnect_after_open_port_failure)
     serverTransportUnderTest = new TCPv4Transport(serverDescriptor);
     serverTransportUnderTest->init();
     ASSERT_TRUE(serverTransportUnderTest->OpenInputChannel(initialPeerLocator, nullptr, 0x00FF));
-    clientTransportUnderTest->send(nullptr, 0, channel, initialPeerLocator); // connect()
+    clientTransportUnderTest->send(nullptr, 0, channel->locator(), initialPeerLocator); // connect()
 
     // Logical port is opened (moved from pending list)
     std::this_thread::sleep_for(std::chrono::milliseconds(300));

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -447,7 +447,7 @@ TEST_F(TCPv6Tests, reconnect_after_open_port_failure)
     serverTransportUnderTest = new TCPv6Transport(serverDescriptor);
     serverTransportUnderTest->init();
     ASSERT_TRUE(serverTransportUnderTest->OpenInputChannel(initialPeerLocator, nullptr, 0x00FF));
-    clientTransportUnderTest->send(nullptr, 0, channel, initialPeerLocator); // connect()
+    clientTransportUnderTest->send(nullptr, 0, channel->locator(), initialPeerLocator); // connect()
 
     // Logical port is opened (moved from pending list)
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
@@ -467,7 +467,7 @@ TEST_F(TCPv6Tests, reconnect_after_open_port_failure)
     serverTransportUnderTest->init();
     ASSERT_TRUE(serverTransportUnderTest->OpenInputChannel(initialPeerLocator, nullptr, 0x00FF));
     EXPECT_TRUE(serverTransportUnderTest->CloseInputChannel(initialPeerLocator));
-    clientTransportUnderTest->send(nullptr, 0, channel, initialPeerLocator); // connect()
+    clientTransportUnderTest->send(nullptr, 0, channel->locator(), initialPeerLocator); // connect()
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
     delete serverTransportUnderTest;
     ASSERT_FALSE(channel->is_logical_port_opened(7410));
@@ -477,7 +477,7 @@ TEST_F(TCPv6Tests, reconnect_after_open_port_failure)
     serverTransportUnderTest = new TCPv6Transport(serverDescriptor);
     serverTransportUnderTest->init();
     ASSERT_TRUE(serverTransportUnderTest->OpenInputChannel(initialPeerLocator, nullptr, 0x00FF));
-    clientTransportUnderTest->send(nullptr, 0, channel, initialPeerLocator); // connect()
+    clientTransportUnderTest->send(nullptr, 0, channel->locator(), initialPeerLocator); // connect()
 
     // Logical port is opened (moved from pending list)
     std::this_thread::sleep_for(std::chrono::milliseconds(300));

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -409,12 +409,12 @@ TEST_F(TCPv6Tests, reconnect_after_open_port_failure)
     // Create a TCP Server transport
     TCPv6TransportDescriptor serverDescriptor;
     serverDescriptor.add_listener_port(port);
-    TCPv6Transport* serverTransportUnderTest = new TCPv6Transport(serverDescriptor);
+    std::unique_ptr<TCPv6Transport> serverTransportUnderTest(new TCPv6Transport(serverDescriptor));
     serverTransportUnderTest->init();
 
     // Create a TCP Client transport
     TCPv6TransportDescriptor clientDescriptor;
-    MockTCPv6Transport* clientTransportUnderTest = new MockTCPv6Transport(clientDescriptor);
+    std::unique_ptr<MockTCPv6Transport> clientTransportUnderTest(new MockTCPv6Transport(clientDescriptor));
     clientTransportUnderTest->init();
 
     // Add initial peer to the client
@@ -437,14 +437,14 @@ TEST_F(TCPv6Tests, reconnect_after_open_port_failure)
 
     // Disconnect server
     EXPECT_TRUE(serverTransportUnderTest->CloseInputChannel(initialPeerLocator));
-    delete serverTransportUnderTest;
+    serverTransportUnderTest.reset();
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
     // Client should have passed logical port to pending list
     ASSERT_FALSE(channel->is_logical_port_opened(7410));
     ASSERT_TRUE(channel->is_logical_port_added(7410));
 
     // Now try normal reconnection
-    serverTransportUnderTest = new TCPv6Transport(serverDescriptor);
+    serverTransportUnderTest.reset(new TCPv6Transport(serverDescriptor));
     serverTransportUnderTest->init();
     ASSERT_TRUE(serverTransportUnderTest->OpenInputChannel(initialPeerLocator, nullptr, 0x00FF));
     clientTransportUnderTest->send(nullptr, 0, channel->locator(), initialPeerLocator); // connect()
@@ -455,7 +455,7 @@ TEST_F(TCPv6Tests, reconnect_after_open_port_failure)
 
     // Disconnect server
     EXPECT_TRUE(serverTransportUnderTest->CloseInputChannel(initialPeerLocator));
-    delete serverTransportUnderTest;
+    serverTransportUnderTest.reset();
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
     // Client should have passed logical port to pending list
     ASSERT_FALSE(channel->is_logical_port_opened(7410));
@@ -463,18 +463,18 @@ TEST_F(TCPv6Tests, reconnect_after_open_port_failure)
 
     // Now try reconnect the server and close server's input channel before client's open logical
     // port request, and then delete server and reconnect
-    serverTransportUnderTest = new TCPv6Transport(serverDescriptor);
+    serverTransportUnderTest.reset(new TCPv6Transport(serverDescriptor));
     serverTransportUnderTest->init();
     ASSERT_TRUE(serverTransportUnderTest->OpenInputChannel(initialPeerLocator, nullptr, 0x00FF));
     EXPECT_TRUE(serverTransportUnderTest->CloseInputChannel(initialPeerLocator));
     clientTransportUnderTest->send(nullptr, 0, channel->locator(), initialPeerLocator); // connect()
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
-    delete serverTransportUnderTest;
+    serverTransportUnderTest.reset();
     ASSERT_FALSE(channel->is_logical_port_opened(7410));
     ASSERT_TRUE(channel->is_logical_port_added(7410));
 
     // Now try normal reconnection
-    serverTransportUnderTest = new TCPv6Transport(serverDescriptor);
+    serverTransportUnderTest.reset(new TCPv6Transport(serverDescriptor));
     serverTransportUnderTest->init();
     ASSERT_TRUE(serverTransportUnderTest->OpenInputChannel(initialPeerLocator, nullptr, 0x00FF));
     clientTransportUnderTest->send(nullptr, 0, channel->locator(), initialPeerLocator); // connect()
@@ -486,8 +486,6 @@ TEST_F(TCPv6Tests, reconnect_after_open_port_failure)
     // Clear test
     EXPECT_TRUE(serverTransportUnderTest->CloseInputChannel(initialPeerLocator));
     client_resource_list.clear();
-    delete serverTransportUnderTest;
-    delete clientTransportUnderTest;
 }
 
 

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -400,6 +400,96 @@ TEST_F(TCPv6Tests, non_blocking_send)
 }
 #endif // ifndef _WIN32
 
+// This test verifies that a server can reconnect to a client after the client has once failed in a
+// openLogicalPort request
+TEST_F(TCPv6Tests, reconnect_after_open_port_failure)
+{
+    eprosima::fastdds::dds::Log::SetVerbosity(eprosima::fastdds::dds::Log::Warning);
+    uint16_t port = g_default_port;
+    // Create a TCP Server transport
+    TCPv6TransportDescriptor serverDescriptor;
+    serverDescriptor.add_listener_port(port);
+    TCPv6Transport* serverTransportUnderTest = new TCPv6Transport(serverDescriptor);
+    serverTransportUnderTest->init();
+
+    // Create a TCP Client transport
+    TCPv6TransportDescriptor clientDescriptor;
+    MockTCPv6Transport* clientTransportUnderTest = new MockTCPv6Transport(clientDescriptor);
+    clientTransportUnderTest->init();
+
+    // Add initial peer to the client
+    Locator_t initialPeerLocator;
+    initialPeerLocator.kind = LOCATOR_KIND_TCPv6;
+    IPLocator::setIPv6(initialPeerLocator, "::1");
+    initialPeerLocator.port = port;
+    IPLocator::setLogicalPort(initialPeerLocator, 7410);
+
+    // Connect client to server
+    EXPECT_TRUE(serverTransportUnderTest->OpenInputChannel(initialPeerLocator, nullptr, 0x00FF));
+    SendResourceList client_resource_list;
+    ASSERT_TRUE(clientTransportUnderTest->OpenOutputChannel(client_resource_list ,initialPeerLocator));
+    ASSERT_FALSE(client_resource_list.empty());
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    auto channel = clientTransportUnderTest->get_channel_resources().begin()->second;
+    
+    // Logical port is opened
+    ASSERT_TRUE(channel->is_logical_port_opened(7410));
+
+    // Disconnect server
+    EXPECT_TRUE(serverTransportUnderTest->CloseInputChannel(initialPeerLocator));
+    delete serverTransportUnderTest;
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    // Client should have passed logical port to pending list
+    ASSERT_FALSE(channel->is_logical_port_opened(7410));
+    ASSERT_TRUE(channel->is_logical_port_added(7410));
+
+    // Now try normal reconnection
+    serverTransportUnderTest = new TCPv6Transport(serverDescriptor);
+    serverTransportUnderTest->init();
+    ASSERT_TRUE(serverTransportUnderTest->OpenInputChannel(initialPeerLocator, nullptr, 0x00FF));
+    clientTransportUnderTest->send(nullptr, 0, channel, initialPeerLocator); // connect()
+
+    // Logical port is opened (moved from pending list)
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    ASSERT_TRUE(channel->is_logical_port_opened(7410));
+
+    // Disconnect server
+    EXPECT_TRUE(serverTransportUnderTest->CloseInputChannel(initialPeerLocator));
+    delete serverTransportUnderTest;
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    // Client should have passed logical port to pending list
+    ASSERT_FALSE(channel->is_logical_port_opened(7410));
+    ASSERT_TRUE(channel->is_logical_port_added(7410));
+
+    // Now try reconnect the server and close server's input channel before client's open logical
+    // port request, and then delete server and reconnect
+    serverTransportUnderTest = new TCPv6Transport(serverDescriptor);
+    serverTransportUnderTest->init();
+    ASSERT_TRUE(serverTransportUnderTest->OpenInputChannel(initialPeerLocator, nullptr, 0x00FF));
+    EXPECT_TRUE(serverTransportUnderTest->CloseInputChannel(initialPeerLocator));
+    clientTransportUnderTest->send(nullptr, 0, channel, initialPeerLocator); // connect()
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    delete serverTransportUnderTest;
+    ASSERT_FALSE(channel->is_logical_port_opened(7410));
+    ASSERT_TRUE(channel->is_logical_port_added(7410));
+
+    // Now try normal reconnection
+    serverTransportUnderTest = new TCPv6Transport(serverDescriptor);
+    serverTransportUnderTest->init();
+    ASSERT_TRUE(serverTransportUnderTest->OpenInputChannel(initialPeerLocator, nullptr, 0x00FF));
+    clientTransportUnderTest->send(nullptr, 0, channel, initialPeerLocator); // connect()
+
+    // Logical port is opened (moved from pending list)
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    ASSERT_TRUE(channel->is_logical_port_opened(7410));
+
+    // Clear test
+    EXPECT_TRUE(serverTransportUnderTest->CloseInputChannel(initialPeerLocator));
+    delete serverTransportUnderTest;
+    delete clientTransportUnderTest;
+}
+
+
 /*
    TEST_F(TCPv6Tests, send_and_receive_between_both_secure_ports)
    {

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -419,9 +419,7 @@ TEST_F(TCPv6Tests, reconnect_after_open_port_failure)
 
     // Add initial peer to the client
     Locator_t initialPeerLocator;
-    initialPeerLocator.kind = LOCATOR_KIND_TCPv6;
-    IPLocator::setIPv6(initialPeerLocator, "::1");
-    initialPeerLocator.port = port;
+    IPLocator::createLocator(LOCATOR_KIND_TCPv6, "::1", port, initialPeerLocator);
     IPLocator::setLogicalPort(initialPeerLocator, 7410);
 
     // Connect client to server

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -485,6 +485,7 @@ TEST_F(TCPv6Tests, reconnect_after_open_port_failure)
 
     // Clear test
     EXPECT_TRUE(serverTransportUnderTest->CloseInputChannel(initialPeerLocator));
+    client_resource_list.clear();
     delete serverTransportUnderTest;
     delete clientTransportUnderTest;
 }

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -427,11 +427,11 @@ TEST_F(TCPv6Tests, reconnect_after_open_port_failure)
     // Connect client to server
     EXPECT_TRUE(serverTransportUnderTest->OpenInputChannel(initialPeerLocator, nullptr, 0x00FF));
     SendResourceList client_resource_list;
-    ASSERT_TRUE(clientTransportUnderTest->OpenOutputChannel(client_resource_list ,initialPeerLocator));
+    ASSERT_TRUE(clientTransportUnderTest->OpenOutputChannel(client_resource_list, initialPeerLocator));
     ASSERT_FALSE(client_resource_list.empty());
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
     auto channel = clientTransportUnderTest->get_channel_resources().begin()->second;
-    
+
     // Logical port is opened
     ASSERT_TRUE(channel->is_logical_port_opened(7410));
 

--- a/test/unittest/transport/mock/MockTCPv4Transport.h
+++ b/test/unittest/transport/mock/MockTCPv4Transport.h
@@ -59,10 +59,10 @@ public:
     bool send(
             const fastrtps::rtps::octet* send_buffer,
             uint32_t send_buffer_size,
-            std::shared_ptr<TCPChannelResource>& channel,
+            const fastrtps::rtps::Locator_t& send_resource_locator,
             const Locator_t& remote_locator)
     {
-        return TCPv4Transport::send(send_buffer, send_buffer_size, channel, remote_locator);
+        return TCPv4Transport::send(send_buffer, send_buffer_size, send_resource_locator, remote_locator);
     }
 
 };

--- a/test/unittest/transport/mock/MockTCPv4Transport.h
+++ b/test/unittest/transport/mock/MockTCPv4Transport.h
@@ -56,6 +56,15 @@ public:
         return acceptors_;
     }
 
+    bool send(
+            const fastrtps::rtps::octet* send_buffer,
+            uint32_t send_buffer_size,
+            std::shared_ptr<TCPChannelResource>& channel,
+            const Locator_t& remote_locator)
+    {
+        return TCPv4Transport::send(send_buffer, send_buffer_size, channel, remote_locator);
+    }
+
 };
 
 } // namespace rtps

--- a/test/unittest/transport/mock/MockTCPv6Transport.h
+++ b/test/unittest/transport/mock/MockTCPv6Transport.h
@@ -55,7 +55,7 @@ public:
     {
         return acceptors_;
     }
-    
+
     bool send(
             const fastrtps::rtps::octet* send_buffer,
             uint32_t send_buffer_size,

--- a/test/unittest/transport/mock/MockTCPv6Transport.h
+++ b/test/unittest/transport/mock/MockTCPv6Transport.h
@@ -55,6 +55,15 @@ public:
     {
         return acceptors_;
     }
+    
+    bool send(
+            const fastrtps::rtps::octet* send_buffer,
+            uint32_t send_buffer_size,
+            std::shared_ptr<TCPChannelResource>& channel,
+            const Locator_t& remote_locator)
+    {
+        return TCPv6Transport::send(send_buffer, send_buffer_size, channel, remote_locator);
+    }
 
 };
 

--- a/test/unittest/transport/mock/MockTCPv6Transport.h
+++ b/test/unittest/transport/mock/MockTCPv6Transport.h
@@ -59,10 +59,10 @@ public:
     bool send(
             const fastrtps::rtps::octet* send_buffer,
             uint32_t send_buffer_size,
-            std::shared_ptr<TCPChannelResource>& channel,
+            const fastrtps::rtps::Locator_t& send_resource_locator,
             const Locator_t& remote_locator)
     {
-        return TCPv6Transport::send(send_buffer, send_buffer_size, channel, remote_locator);
+        return TCPv6Transport::send(send_buffer, send_buffer_size, send_resource_locator, remote_locator);
     }
 
 };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
When a client sends an openLogicalPortRequest while the server's input channels are already closed, it previously resulted in the deletion of the requested logical port from pending_logical_output_ports_, making server reconnection impossible. This update addresses the issue by ensuring that a port in pending_logical_output_ports_ is only removed if it is being transferred to the logical_output_ports_ vector. This change is enables effective server reconnection after an initial failure in an openLogicalPort request.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.12.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- N/A Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- N/A New feature has been added to the `versions.md` file (if applicable).
- N/A New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
