### PR TITLE
[20311] Add missing TypeLookup listeners

### DIFF
--- a/include/fastdds/dds/builtin/typelookup/TypeLookupManager.hpp
+++ b/include/fastdds/dds/builtin/typelookup/TypeLookupManager.hpp
@@ -292,10 +292,10 @@ private:
      */
 
     void request_cache_change_acked(
-        fastrtps::rtps::CacheChange_t* change);
+            fastrtps::rtps::CacheChange_t* change);
 
     void reply_cache_change_acked(
-        fastrtps::rtps::CacheChange_t* change);
+            fastrtps::rtps::CacheChange_t* change);
 };
 
 } /* namespace builtin */

--- a/include/fastdds/dds/builtin/typelookup/TypeLookupManager.hpp
+++ b/include/fastdds/dds/builtin/typelookup/TypeLookupManager.hpp
@@ -60,7 +60,9 @@ extern const fastrtps::rtps::SampleIdentity INVALID_SAMPLE_IDENTITY;
 class TypeLookupManager
 {
     friend class TypeLookupRequestListener;
+    friend class TypeLookupRequestWListener;
     friend class TypeLookupReplyListener;
+    friend class TypeLookupReplyWListener;
 
 public:
 
@@ -243,9 +245,11 @@ private:
 
     //!Request Listener object.
     TypeLookupRequestListener* request_listener_;
+    TypeLookupRequestWListener* request_wlistener_;
 
     //!Reply Listener object.
     TypeLookupReplyListener* reply_listener_;
+    TypeLookupReplyWListener* reply_wlistener_;
 
     std::mutex temp_data_lock_;
     fastrtps::rtps::ReaderProxyData temp_reader_proxy_data_;
@@ -286,6 +290,12 @@ private:
         bool create_secure_endpoints();
      #endif
      */
+
+    void request_cache_change_acked(
+        fastrtps::rtps::CacheChange_t* change);
+
+    void reply_cache_change_acked(
+        fastrtps::rtps::CacheChange_t* change);
 };
 
 } /* namespace builtin */

--- a/include/fastdds/dds/builtin/typelookup/TypeLookupManager.hpp
+++ b/include/fastdds/dds/builtin/typelookup/TypeLookupManager.hpp
@@ -60,9 +60,7 @@ extern const fastrtps::rtps::SampleIdentity INVALID_SAMPLE_IDENTITY;
 class TypeLookupManager
 {
     friend class TypeLookupRequestListener;
-    friend class TypeLookupRequestWListener;
     friend class TypeLookupReplyListener;
-    friend class TypeLookupReplyWListener;
 
 public:
 
@@ -245,11 +243,9 @@ private:
 
     //!Request Listener object.
     TypeLookupRequestListener* request_listener_;
-    TypeLookupRequestWListener* request_wlistener_;
 
     //!Reply Listener object.
     TypeLookupReplyListener* reply_listener_;
-    TypeLookupReplyWListener* reply_wlistener_;
 
     std::mutex temp_data_lock_;
     fastrtps::rtps::ReaderProxyData temp_reader_proxy_data_;

--- a/include/fastdds/dds/builtin/typelookup/TypeLookupReplyListener.hpp
+++ b/include/fastdds/dds/builtin/typelookup/TypeLookupReplyListener.hpp
@@ -72,7 +72,7 @@ public:
      */
     void onNewCacheChangeAdded(
             fastrtps::rtps::RTPSReader* reader,
-            const fastrtps::rtps::CacheChange_t* const  change) override;
+            const fastrtps::rtps::CacheChange_t* const change) override;
 
 private:
 
@@ -117,5 +117,5 @@ private:
 } /* namespace dds */
 } /* namespace fastdds */
 } /* namespace eprosima */
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif /* TYPELOOKUP_REPLY_LISTENER_HPP_*/

--- a/include/fastdds/dds/builtin/typelookup/TypeLookupReplyListener.hpp
+++ b/include/fastdds/dds/builtin/typelookup/TypeLookupReplyListener.hpp
@@ -21,6 +21,8 @@
 #define TYPELOOKUP_REPLY_LISTENER_HPP_
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #include <fastrtps/rtps/reader/ReaderListener.h>
+#include <fastrtps/rtps/writer/WriterListener.h>
+
 
 namespace eprosima {
 namespace fastrtps {
@@ -79,6 +81,36 @@ private:
 
     //! A pointer to the TypeObject factory.
     fastrtps::types::TypeObjectFactory* factory_;
+};
+
+class TypeLookupReplyWListener : public fastrtps::rtps::WriterListener
+{
+public:
+
+    /**
+     * @brief Constructor
+     * @param pwlp Pointer to the writer liveliness protocol
+     */
+    TypeLookupReplyWListener(
+            TypeLookupManager* pwlp);
+
+    /**
+     * @brief Destructor
+     */
+    virtual ~TypeLookupReplyWListener() override;
+
+    void onWriterChangeReceivedByAll(
+            fastrtps::rtps::RTPSWriter*,
+            fastrtps::rtps::CacheChange_t* change) override;
+
+private:
+
+    //! A pointer to the typelookup manager
+    TypeLookupManager* tlm_;
+
+    //! A pointer to the TypeObject factory.
+    fastrtps::types::TypeObjectFactory* factory_;
+
 };
 
 } /* namespace builtin */

--- a/include/fastdds/dds/builtin/typelookup/TypeLookupReplyListener.hpp
+++ b/include/fastdds/dds/builtin/typelookup/TypeLookupReplyListener.hpp
@@ -49,7 +49,7 @@ class TypeLookupManager;
  * Class TypeLookupReplyListener that receives the typelookup request messages of remote endpoints.
  * @ingroup TYPES_MODULE
  */
-class TypeLookupReplyListener : public fastrtps::rtps::ReaderListener
+class TypeLookupReplyListener : public fastrtps::rtps::ReaderListener, public fastrtps::rtps::WriterListener
 {
 public:
 
@@ -74,31 +74,11 @@ public:
             fastrtps::rtps::RTPSReader* reader,
             const fastrtps::rtps::CacheChange_t* const change) override;
 
-private:
-
-    //! A pointer to the typelookup manager
-    TypeLookupManager* tlm_;
-
-    //! A pointer to the TypeObject factory.
-    fastrtps::types::TypeObjectFactory* factory_;
-};
-
-class TypeLookupReplyWListener : public fastrtps::rtps::WriterListener
-{
-public:
-
     /**
-     * @brief Constructor
-     * @param pwlp Pointer to the writer liveliness protocol
+     * @brief This method is called when all the readers matched with this Writer acknowledge that a cache
+     * change has been received.
+     * @param change The cache change
      */
-    TypeLookupReplyWListener(
-            TypeLookupManager* pwlp);
-
-    /**
-     * @brief Destructor
-     */
-    virtual ~TypeLookupReplyWListener() override;
-
     void onWriterChangeReceivedByAll(
             fastrtps::rtps::RTPSWriter*,
             fastrtps::rtps::CacheChange_t* change) override;
@@ -110,7 +90,6 @@ private:
 
     //! A pointer to the TypeObject factory.
     fastrtps::types::TypeObjectFactory* factory_;
-
 };
 
 } /* namespace builtin */

--- a/include/fastdds/dds/builtin/typelookup/TypeLookupRequestListener.hpp
+++ b/include/fastdds/dds/builtin/typelookup/TypeLookupRequestListener.hpp
@@ -21,6 +21,8 @@
 #define TYPELOOKUP_REQUEST_LISTENER_HPP_
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #include <fastrtps/rtps/reader/ReaderListener.h>
+#include <fastrtps/rtps/writer/WriterListener.h>
+
 
 namespace eprosima {
 namespace fastrtps {
@@ -71,6 +73,36 @@ public:
     void onNewCacheChangeAdded(
             fastrtps::rtps::RTPSReader* reader,
             const fastrtps::rtps::CacheChange_t* const  change) override;
+
+private:
+
+    //! A pointer to the typelookup manager
+    TypeLookupManager* tlm_;
+
+    //! A pointer to the TypeObject factory.
+    fastrtps::types::TypeObjectFactory* factory_;
+
+};
+
+class TypeLookupRequestWListener : public fastrtps::rtps::WriterListener
+{
+public:
+
+    /**
+     * @brief Constructor
+     * @param pwlp Pointer to the writer liveliness protocol
+     */
+    TypeLookupRequestWListener(
+            TypeLookupManager* pwlp);
+
+    /**
+     * @brief Destructor
+     */
+    virtual ~TypeLookupRequestWListener() override;
+
+    void onWriterChangeReceivedByAll(
+            fastrtps::rtps::RTPSWriter*,
+            fastrtps::rtps::CacheChange_t* change) override;
 
 private:
 

--- a/include/fastdds/dds/builtin/typelookup/TypeLookupRequestListener.hpp
+++ b/include/fastdds/dds/builtin/typelookup/TypeLookupRequestListener.hpp
@@ -72,7 +72,7 @@ public:
      */
     void onNewCacheChangeAdded(
             fastrtps::rtps::RTPSReader* reader,
-            const fastrtps::rtps::CacheChange_t* const  change) override;
+            const fastrtps::rtps::CacheChange_t* const change) override;
 
 private:
 
@@ -118,5 +118,5 @@ private:
 } /* namespace dds */
 } /* namespace fastdds */
 } /* namespace eprosima */
-#endif
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif /* TYPELOOKUP_REQUEST_LISTENER_HPP_*/

--- a/include/fastdds/dds/builtin/typelookup/TypeLookupRequestListener.hpp
+++ b/include/fastdds/dds/builtin/typelookup/TypeLookupRequestListener.hpp
@@ -49,7 +49,7 @@ class TypeLookupManager;
  * Class TypeLookupRequestListener that receives the typelookup request messages of remote endpoints.
  * @ingroup TYPES_MODULE
  */
-class TypeLookupRequestListener : public fastrtps::rtps::ReaderListener
+class TypeLookupRequestListener : public fastrtps::rtps::ReaderListener, public fastrtps::rtps::WriterListener
 {
 public:
 
@@ -74,32 +74,11 @@ public:
             fastrtps::rtps::RTPSReader* reader,
             const fastrtps::rtps::CacheChange_t* const change) override;
 
-private:
-
-    //! A pointer to the typelookup manager
-    TypeLookupManager* tlm_;
-
-    //! A pointer to the TypeObject factory.
-    fastrtps::types::TypeObjectFactory* factory_;
-
-};
-
-class TypeLookupRequestWListener : public fastrtps::rtps::WriterListener
-{
-public:
-
     /**
-     * @brief Constructor
-     * @param pwlp Pointer to the writer liveliness protocol
+     * @brief This method is called when all the readers matched with this Writer acknowledge that a cache
+     * change has been received.
+     * @param change The cache change
      */
-    TypeLookupRequestWListener(
-            TypeLookupManager* pwlp);
-
-    /**
-     * @brief Destructor
-     */
-    virtual ~TypeLookupRequestWListener() override;
-
     void onWriterChangeReceivedByAll(
             fastrtps::rtps::RTPSWriter*,
             fastrtps::rtps::CacheChange_t* change) override;

--- a/src/cpp/fastdds/builtin/typelookup/TypeLookupManager.cpp
+++ b/src/cpp/fastdds/builtin/typelookup/TypeLookupManager.cpp
@@ -68,7 +68,9 @@ TypeLookupManager::TypeLookupManager(
     , builtin_request_reader_history_(nullptr)
     , builtin_reply_reader_history_(nullptr)
     , request_listener_(nullptr)
+    , request_wlistener_(nullptr)
     , reply_listener_(nullptr)
+    , reply_wlistener_(nullptr)
     , temp_reader_proxy_data_(
         prot->mp_participantImpl->getRTPSParticipantAttributes().allocation.locators.max_unicast_locators,
         prot->mp_participantImpl->getRTPSParticipantAttributes().allocation.locators.max_multicast_locators)
@@ -124,6 +126,9 @@ TypeLookupManager::~TypeLookupManager()
     delete builtin_reply_writer_history_;
     delete builtin_request_reader_history_;
     delete builtin_reply_reader_history_;
+
+    delete request_wlistener_;
+    delete reply_wlistener_;
 
     delete reply_listener_;
     delete request_listener_;
@@ -368,6 +373,8 @@ bool TypeLookupManager::create_endpoints()
             EPROSIMA_LOG_ERROR(TYPELOOKUP_SERVICE, "Typelookup request writer creation failed.");
             delete builtin_request_writer_history_;
             builtin_request_writer_history_ = nullptr;
+            delete request_wlistener_;
+            request_wlistener_ = nullptr;
             return false;
         }
     }
@@ -395,6 +402,8 @@ bool TypeLookupManager::create_endpoints()
             EPROSIMA_LOG_ERROR(TYPELOOKUP_SERVICE, "Typelookup reply writer creation failed.");
             delete builtin_reply_writer_history_;
             builtin_reply_writer_history_ = nullptr;
+            delete reply_wlistener_;
+            reply_wlistener_ = nullptr;
             return false;
         }
     }

--- a/src/cpp/fastdds/builtin/typelookup/TypeLookupManager.cpp
+++ b/src/cpp/fastdds/builtin/typelookup/TypeLookupManager.cpp
@@ -716,7 +716,7 @@ void TypeLookupManager::request_cache_change_acked(
 }
 
 void TypeLookupManager::reply_cache_change_acked(
-fastrtps::rtps::CacheChange_t* change)
+        fastrtps::rtps::CacheChange_t* change)
 {
     builtin_reply_writer_history_->remove_change(change);
 }

--- a/src/cpp/fastdds/builtin/typelookup/TypeLookupManager.cpp
+++ b/src/cpp/fastdds/builtin/typelookup/TypeLookupManager.cpp
@@ -368,14 +368,12 @@ bool TypeLookupManager::create_endpoints()
         else
         {
             EPROSIMA_LOG_ERROR(TYPELOOKUP_SERVICE, "Typelookup request writer creation failed.");
-            delete builtin_request_writer_history_;
-            builtin_request_writer_history_ = nullptr;
             ret = false;
         }
     }
 
     // Built-in reply writer
-    if (builtin_protocols_->m_att.typelookup_config.use_server)
+    if (ret && builtin_protocols_->m_att.typelookup_config.use_server)
     {
         reply_listener_ = new TypeLookupReplyListener(this);
         builtin_reply_writer_history_ = new WriterHistory(hatt);
@@ -395,8 +393,6 @@ bool TypeLookupManager::create_endpoints()
         else
         {
             EPROSIMA_LOG_ERROR(TYPELOOKUP_SERVICE, "Typelookup reply writer creation failed.");
-            delete builtin_reply_writer_history_;
-            builtin_reply_writer_history_ = nullptr;
             ret = false;
         }
     }
@@ -414,7 +410,7 @@ bool TypeLookupManager::create_endpoints()
     ratt.endpoint.durabilityKind = fastrtps::rtps::VOLATILE;
 
     // Built-in request reader
-    if (builtin_protocols_->m_att.typelookup_config.use_server)
+    if (ret && builtin_protocols_->m_att.typelookup_config.use_server)
     {
         if (nullptr == request_listener_)
         {
@@ -437,14 +433,12 @@ bool TypeLookupManager::create_endpoints()
         else
         {
             EPROSIMA_LOG_ERROR(TYPELOOKUP_SERVICE, "Typelookup request reader creation failed.");
-            delete builtin_request_reader_history_;
-            builtin_request_reader_history_ = nullptr;
             ret = false;
         }
     }
 
     // Built-in reply reader
-    if (builtin_protocols_->m_att.typelookup_config.use_client)
+    if (ret && builtin_protocols_->m_att.typelookup_config.use_client)
     {
         if (nullptr == reply_listener_)
         {
@@ -467,25 +461,49 @@ bool TypeLookupManager::create_endpoints()
         else
         {
             EPROSIMA_LOG_ERROR(TYPELOOKUP_SERVICE, "Typelookup reply reader creation failed.");
-            delete builtin_reply_reader_history_;
-            builtin_reply_reader_history_ = nullptr;
             ret = false;
         }
     }
 
+    // Clean up if something failed.
     if (!ret)
     {
-        if (request_listener_ != nullptr)
+        if (nullptr != builtin_request_writer_history_)
+        {
+            delete builtin_request_writer_history_;
+            builtin_request_writer_history_ = nullptr;
+        }
+
+        if (nullptr != builtin_reply_writer_history_)
+        {
+            delete builtin_reply_writer_history_;
+            builtin_reply_writer_history_ = nullptr;
+        }
+
+        if (nullptr != builtin_request_reader_history_)
+        {
+            delete builtin_request_reader_history_;
+            builtin_request_reader_history_ = nullptr;
+        }
+
+        if (nullptr != builtin_reply_reader_history_)
+        {
+            delete builtin_reply_reader_history_;
+            builtin_reply_reader_history_ = nullptr;
+        }
+
+        if (nullptr != request_listener_)
         {
             delete request_listener_;
             request_listener_ = nullptr;
         }
-        if (reply_listener_ != nullptr)
+        if (nullptr != reply_listener_)
         {
             delete reply_listener_;
             reply_listener_ = nullptr;
         }
     }
+
     return ret;
 }
 

--- a/src/cpp/fastdds/builtin/typelookup/TypeLookupManager.cpp
+++ b/src/cpp/fastdds/builtin/typelookup/TypeLookupManager.cpp
@@ -326,6 +326,8 @@ ReaderHistory* TypeLookupManager::get_builtin_reply_reader_history()
  */
 bool TypeLookupManager::create_endpoints()
 {
+    bool ret = true;
+
     const RTPSParticipantAttributes& pattr = participant_->getRTPSParticipantAttributes();
 
     // Built-in history attributes.
@@ -368,9 +370,7 @@ bool TypeLookupManager::create_endpoints()
             EPROSIMA_LOG_ERROR(TYPELOOKUP_SERVICE, "Typelookup request writer creation failed.");
             delete builtin_request_writer_history_;
             builtin_request_writer_history_ = nullptr;
-            delete request_listener_;
-            request_listener_ = nullptr;
-            return false;
+            ret = false;
         }
     }
 
@@ -397,9 +397,7 @@ bool TypeLookupManager::create_endpoints()
             EPROSIMA_LOG_ERROR(TYPELOOKUP_SERVICE, "Typelookup reply writer creation failed.");
             delete builtin_reply_writer_history_;
             builtin_reply_writer_history_ = nullptr;
-            delete reply_listener_;
-            reply_listener_ = nullptr;
-            return false;
+            ret = false;
         }
     }
 
@@ -418,7 +416,10 @@ bool TypeLookupManager::create_endpoints()
     // Built-in request reader
     if (builtin_protocols_->m_att.typelookup_config.use_server)
     {
-        request_listener_ = new TypeLookupRequestListener(this);
+        if (nullptr == request_listener_)
+        {
+            request_listener_ = new TypeLookupRequestListener(this);
+        }
         builtin_request_reader_history_ = new ReaderHistory(hatt);
 
         RTPSReader* req_reader;
@@ -438,16 +439,17 @@ bool TypeLookupManager::create_endpoints()
             EPROSIMA_LOG_ERROR(TYPELOOKUP_SERVICE, "Typelookup request reader creation failed.");
             delete builtin_request_reader_history_;
             builtin_request_reader_history_ = nullptr;
-            delete request_listener_;
-            request_listener_ = nullptr;
-            return false;
+            ret = false;
         }
     }
 
     // Built-in reply reader
     if (builtin_protocols_->m_att.typelookup_config.use_client)
     {
-        reply_listener_ = new TypeLookupReplyListener(this);
+        if (nullptr == reply_listener_)
+        {
+            reply_listener_ = new TypeLookupReplyListener(this);
+        }
         builtin_reply_reader_history_ = new ReaderHistory(hatt);
 
         RTPSReader* rep_reader;
@@ -467,13 +469,24 @@ bool TypeLookupManager::create_endpoints()
             EPROSIMA_LOG_ERROR(TYPELOOKUP_SERVICE, "Typelookup reply reader creation failed.");
             delete builtin_reply_reader_history_;
             builtin_reply_reader_history_ = nullptr;
-            delete reply_listener_;
-            reply_listener_ = nullptr;
-            return false;
+            ret = false;
         }
     }
 
-    return true;
+    if (!ret)
+    {
+        if (request_listener_ != nullptr)
+        {
+            delete request_listener_;
+            request_listener_ = nullptr;
+        }
+        if (reply_listener_ != nullptr)
+        {
+            delete reply_listener_;
+            reply_listener_ = nullptr;
+        }
+    }
+    return ret;
 }
 
 /* TODO Implement if security is needed.

--- a/src/cpp/fastdds/builtin/typelookup/TypeLookupManager.cpp
+++ b/src/cpp/fastdds/builtin/typelookup/TypeLookupManager.cpp
@@ -68,9 +68,7 @@ TypeLookupManager::TypeLookupManager(
     , builtin_request_reader_history_(nullptr)
     , builtin_reply_reader_history_(nullptr)
     , request_listener_(nullptr)
-    , request_wlistener_(nullptr)
     , reply_listener_(nullptr)
-    , reply_wlistener_(nullptr)
     , temp_reader_proxy_data_(
         prot->mp_participantImpl->getRTPSParticipantAttributes().allocation.locators.max_unicast_locators,
         prot->mp_participantImpl->getRTPSParticipantAttributes().allocation.locators.max_multicast_locators)
@@ -126,9 +124,6 @@ TypeLookupManager::~TypeLookupManager()
     delete builtin_reply_writer_history_;
     delete builtin_request_reader_history_;
     delete builtin_reply_reader_history_;
-
-    delete request_wlistener_;
-    delete reply_wlistener_;
 
     delete reply_listener_;
     delete request_listener_;
@@ -353,7 +348,7 @@ bool TypeLookupManager::create_endpoints()
     // Built-in request writer
     if (builtin_protocols_->m_att.typelookup_config.use_client)
     {
-        request_wlistener_ = new TypeLookupRequestWListener(this);
+        request_listener_ = new TypeLookupRequestListener(this);
         builtin_request_writer_history_ = new WriterHistory(hatt);
 
         RTPSWriter* req_writer;
@@ -361,7 +356,7 @@ bool TypeLookupManager::create_endpoints()
                     &req_writer,
                     watt,
                     builtin_request_writer_history_,
-                    request_wlistener_,
+                    request_listener_,
                     fastrtps::rtps::c_EntityId_TypeLookup_request_writer,
                     true))
         {
@@ -373,8 +368,8 @@ bool TypeLookupManager::create_endpoints()
             EPROSIMA_LOG_ERROR(TYPELOOKUP_SERVICE, "Typelookup request writer creation failed.");
             delete builtin_request_writer_history_;
             builtin_request_writer_history_ = nullptr;
-            delete request_wlistener_;
-            request_wlistener_ = nullptr;
+            delete request_listener_;
+            request_listener_ = nullptr;
             return false;
         }
     }
@@ -382,7 +377,7 @@ bool TypeLookupManager::create_endpoints()
     // Built-in reply writer
     if (builtin_protocols_->m_att.typelookup_config.use_server)
     {
-        reply_wlistener_ = new TypeLookupReplyWListener(this);
+        reply_listener_ = new TypeLookupReplyListener(this);
         builtin_reply_writer_history_ = new WriterHistory(hatt);
 
         RTPSWriter* rep_writer;
@@ -390,7 +385,7 @@ bool TypeLookupManager::create_endpoints()
                     &rep_writer,
                     watt,
                     builtin_reply_writer_history_,
-                    reply_wlistener_,
+                    reply_listener_,
                     fastrtps::rtps::c_EntityId_TypeLookup_reply_writer,
                     true))
         {
@@ -402,8 +397,8 @@ bool TypeLookupManager::create_endpoints()
             EPROSIMA_LOG_ERROR(TYPELOOKUP_SERVICE, "Typelookup reply writer creation failed.");
             delete builtin_reply_writer_history_;
             builtin_reply_writer_history_ = nullptr;
-            delete reply_wlistener_;
-            reply_wlistener_ = nullptr;
+            delete reply_listener_;
+            reply_listener_ = nullptr;
             return false;
         }
     }
@@ -579,7 +574,7 @@ bool TypeLookupManager::send_request(
         payload.max_size = change->serializedPayload.max_size - 4;
         payload.data = change->serializedPayload.data + 4;
 
-        bool serialize_ret = request_type_.serialize(&req, &payload, DataRepresentationId_t::XCDR_DATA_REPRESENTATION);
+        bool serialize_ret = request_type_.serialize(&req, &payload, DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
         if (!serialize_ret)
         {
             payload.data = nullptr;
@@ -628,7 +623,7 @@ bool TypeLookupManager::send_reply(
         payload.max_size = change->serializedPayload.max_size - 4;
         payload.data = change->serializedPayload.data + 4;
 
-        bool serialize_ret = reply_type_.serialize(&rep, &payload, DataRepresentationId_t::XCDR_DATA_REPRESENTATION);
+        bool serialize_ret = reply_type_.serialize(&rep, &payload, DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
         if (!serialize_ret)
         {
             payload.data = nullptr;

--- a/src/cpp/fastdds/builtin/typelookup/TypeLookupReplyListener.cpp
+++ b/src/cpp/fastdds/builtin/typelookup/TypeLookupReplyListener.cpp
@@ -116,6 +116,24 @@ void TypeLookupReplyListener::onNewCacheChangeAdded(
     reader->getHistory()->remove_change(change);
 }
 
+TypeLookupReplyWListener::TypeLookupReplyWListener(
+        TypeLookupManager* manager)
+    : tlm_(manager)
+    , factory_(TypeObjectFactory::get_instance())
+{
+}
+
+TypeLookupReplyWListener::~TypeLookupReplyWListener()
+{
+}
+
+void TypeLookupReplyWListener::onWriterChangeReceivedByAll(
+            fastrtps::rtps::RTPSWriter*,
+            fastrtps::rtps::CacheChange_t* change)
+{
+    tlm_->reply_cache_change_acked(change);
+}
+
 } // namespace builtin
 } // namespace dds
 } // namespace fastdds

--- a/src/cpp/fastdds/builtin/typelookup/TypeLookupReplyListener.cpp
+++ b/src/cpp/fastdds/builtin/typelookup/TypeLookupReplyListener.cpp
@@ -128,8 +128,8 @@ TypeLookupReplyWListener::~TypeLookupReplyWListener()
 }
 
 void TypeLookupReplyWListener::onWriterChangeReceivedByAll(
-            fastrtps::rtps::RTPSWriter*,
-            fastrtps::rtps::CacheChange_t* change)
+        fastrtps::rtps::RTPSWriter*,
+        fastrtps::rtps::CacheChange_t* change)
 {
     tlm_->reply_cache_change_acked(change);
 }

--- a/src/cpp/fastdds/builtin/typelookup/TypeLookupReplyListener.cpp
+++ b/src/cpp/fastdds/builtin/typelookup/TypeLookupReplyListener.cpp
@@ -116,18 +116,7 @@ void TypeLookupReplyListener::onNewCacheChangeAdded(
     reader->getHistory()->remove_change(change);
 }
 
-TypeLookupReplyWListener::TypeLookupReplyWListener(
-        TypeLookupManager* manager)
-    : tlm_(manager)
-    , factory_(TypeObjectFactory::get_instance())
-{
-}
-
-TypeLookupReplyWListener::~TypeLookupReplyWListener()
-{
-}
-
-void TypeLookupReplyWListener::onWriterChangeReceivedByAll(
+void TypeLookupReplyListener::onWriterChangeReceivedByAll(
         fastrtps::rtps::RTPSWriter*,
         fastrtps::rtps::CacheChange_t* change)
 {

--- a/src/cpp/fastdds/builtin/typelookup/TypeLookupRequestListener.cpp
+++ b/src/cpp/fastdds/builtin/typelookup/TypeLookupRequestListener.cpp
@@ -162,8 +162,8 @@ TypeLookupRequestWListener::~TypeLookupRequestWListener()
 }
 
 void TypeLookupRequestWListener::onWriterChangeReceivedByAll(
-            fastrtps::rtps::RTPSWriter*,
-            fastrtps::rtps::CacheChange_t* change)
+        fastrtps::rtps::RTPSWriter*,
+        fastrtps::rtps::CacheChange_t* change)
 {
     tlm_->request_cache_change_acked(change);
 }

--- a/src/cpp/fastdds/builtin/typelookup/TypeLookupRequestListener.cpp
+++ b/src/cpp/fastdds/builtin/typelookup/TypeLookupRequestListener.cpp
@@ -150,6 +150,24 @@ void TypeLookupRequestListener::onNewCacheChangeAdded(
     reader->getHistory()->remove_change(change);
 }
 
+TypeLookupRequestWListener::TypeLookupRequestWListener(
+        TypeLookupManager* manager)
+    : tlm_(manager)
+    , factory_(TypeObjectFactory::get_instance())
+{
+}
+
+TypeLookupRequestWListener::~TypeLookupRequestWListener()
+{
+}
+
+void TypeLookupRequestWListener::onWriterChangeReceivedByAll(
+            fastrtps::rtps::RTPSWriter*,
+            fastrtps::rtps::CacheChange_t* change)
+{
+    tlm_->request_cache_change_acked(change);
+}
+
 } // namespace builtin
 } // namespace dds
 } // namespace fastdds

--- a/src/cpp/fastdds/builtin/typelookup/TypeLookupRequestListener.cpp
+++ b/src/cpp/fastdds/builtin/typelookup/TypeLookupRequestListener.cpp
@@ -150,18 +150,7 @@ void TypeLookupRequestListener::onNewCacheChangeAdded(
     reader->getHistory()->remove_change(change);
 }
 
-TypeLookupRequestWListener::TypeLookupRequestWListener(
-        TypeLookupManager* manager)
-    : tlm_(manager)
-    , factory_(TypeObjectFactory::get_instance())
-{
-}
-
-TypeLookupRequestWListener::~TypeLookupRequestWListener()
-{
-}
-
-void TypeLookupRequestWListener::onWriterChangeReceivedByAll(
+void TypeLookupRequestListener::onWriterChangeReceivedByAll(
         fastrtps::rtps::RTPSWriter*,
         fastrtps::rtps::CacheChange_t* change)
 {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This pull request addresses an issue where Fast DDS fails to discover certain types when receiving a significant number of dynamic types (approximately 25).

This PR implements the `onWriterChangeReceivedByAll` listener for both `TypeLookupReplyListener` and `TypeLookupRequestListener`. This enables the deletion of changes received by all readers matched with the writer from the history. It prevents the `CacheChange` from becoming saturated, thus enabling the system to accommodate further changes effectively.

@Mergifyio backport 2.12.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_; Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- N/A New feature has been added to the `versions.md` file (if applicable).
- N/A New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
