### PR TITLE
[20272] Update Fast DDS types with Fast DDS Gen to include <cstdint> in v1 types

### DIFF
--- a/examples/cpp/dds/AdvancedConfigurationExample/AdvancedConfiguration.cxx
+++ b/examples/cpp/dds/AdvancedConfigurationExample/AdvancedConfiguration.cxx
@@ -129,6 +129,7 @@ uint32_t& AdvancedConfiguration::index()
     return m_index;
 }
 
+
 /*!
  * @brief This function copies the value in member message
  * @param _message New value to be copied in member message
@@ -167,6 +168,7 @@ std::array<char, 20>& AdvancedConfiguration::message()
     return m_message;
 }
 
+
 /*!
  * @brief This function copies the value in member data
  * @param _data New value to be copied in member data
@@ -204,6 +206,7 @@ std::vector<uint8_t>& AdvancedConfiguration::data()
 {
     return m_data;
 }
+
 
 // Include auxiliary functions like for serializing/deserializing.
 #include "AdvancedConfigurationCdrAux.ipp"

--- a/examples/cpp/dds/AdvancedConfigurationExample/AdvancedConfigurationPubSubTypes.h
+++ b/examples/cpp/dds/AdvancedConfigurationExample/AdvancedConfigurationPubSubTypes.h
@@ -107,7 +107,7 @@ public:
     }
 
     eProsima_user_DllExport inline bool is_plain(
-            eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
+        eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
     {
         static_cast<void>(data_representation);
         return false;

--- a/examples/cpp/dds/AdvancedConfigurationExample/AdvancedConfigurationv1.cxx
+++ b/examples/cpp/dds/AdvancedConfigurationExample/AdvancedConfigurationv1.cxx
@@ -38,20 +38,16 @@ using namespace eprosima::fastcdr::exception;
 
 #include <utility>
 
-namespace helper {
-namespace internal {
+namespace helper { namespace internal {
 
-enum class Size
-{
+enum class Size {
     UInt8,
     UInt16,
     UInt32,
     UInt64,
 };
 
-constexpr Size get_size(
-        int s)
-{
+constexpr Size get_size(int s) {
     return (s <= 8 ) ? Size::UInt8:
            (s <= 16) ? Size::UInt16:
            (s <= 32) ? Size::UInt32: Size::UInt64;
@@ -61,36 +57,31 @@ template<Size s>
 struct FindTypeH;
 
 template<>
-struct FindTypeH<Size::UInt8>
-{
+struct FindTypeH<Size::UInt8> {
     using type = std::uint8_t;
 };
 
 template<>
-struct FindTypeH<Size::UInt16>
-{
+struct FindTypeH<Size::UInt16> {
     using type = std::uint16_t;
 };
 
 template<>
-struct FindTypeH<Size::UInt32>
-{
+struct FindTypeH<Size::UInt32> {
     using type = std::uint32_t;
 };
 
 template<>
-struct FindTypeH<Size::UInt64>
-{
+struct FindTypeH<Size::UInt64> {
     using type = std::uint64_t;
 };
-} // namespace internal
+}
 
 template<int S>
-struct FindType
-{
+struct FindType {
     using type = typename internal::FindTypeH<internal::get_size(S)>::type;
 };
-} // namespace helper
+}
 
 #define AdvancedConfiguration_max_cdr_typesize 132ULL;
 
@@ -216,6 +207,7 @@ size_t AdvancedConfiguration::getCdrSerializedSize(
     return current_alignment - initial_alignment;
 }
 
+
 void AdvancedConfiguration::serialize(
         eprosima::fastcdr::Cdr& scdr) const
 {
@@ -244,6 +236,7 @@ void AdvancedConfiguration::deserialize(
 
 
 }
+
 
 bool AdvancedConfiguration::isKeyDefined()
 {
@@ -284,6 +277,7 @@ uint32_t& AdvancedConfiguration::index()
     return m_index;
 }
 
+
 /*!
  * @brief This function copies the value in member message
  * @param _message New value to be copied in member message
@@ -322,6 +316,7 @@ std::array<char, 20>& AdvancedConfiguration::message()
     return m_message;
 }
 
+
 /*!
  * @brief This function copies the value in member data
  * @param _data New value to be copied in member data
@@ -359,5 +354,8 @@ std::vector<uint8_t>& AdvancedConfiguration::data()
 {
     return m_data;
 }
+
+
+
 
 #endif // FASTCDR_VERSION_MAJOR == 1

--- a/examples/cpp/dds/AdvancedConfigurationExample/AdvancedConfigurationv1.h
+++ b/examples/cpp/dds/AdvancedConfigurationExample/AdvancedConfigurationv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)
@@ -207,11 +208,11 @@ public:
 
 
     /*!
-     * @brief This function returns the maximum serialized size of an object
-     * depending on the buffer alignment.
-     * @param current_alignment Buffer alignment.
-     * @return Maximum serialized size.
-     */
+    * @brief This function returns the maximum serialized size of an object
+    * depending on the buffer alignment.
+    * @param current_alignment Buffer alignment.
+    * @return Maximum serialized size.
+    */
     eProsima_user_DllExport static size_t getMaxCdrSerializedSize(
             size_t current_alignment = 0);
 
@@ -245,16 +246,17 @@ public:
 
 
     /*!
-     * @brief This function tells you if the Key has been defined for this type
-     */
+    * @brief This function tells you if the Key has been defined for this type
+    */
     eProsima_user_DllExport static bool isKeyDefined();
 
     /*!
-     * @brief This function serializes the key members of an object using CDR serialization.
-     * @param cdr CDR serialization object.
-     */
+    * @brief This function serializes the key members of an object using CDR serialization.
+    * @param cdr CDR serialization object.
+    */
     eProsima_user_DllExport void serializeKey(
             eprosima::fastcdr::Cdr& cdr) const;
+
 
 private:
 

--- a/examples/cpp/dds/BasicConfigurationExample/HelloWorldv1.h
+++ b/examples/cpp/dds/BasicConfigurationExample/HelloWorldv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/Configurability/samplev1.h
+++ b/examples/cpp/dds/Configurability/samplev1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/ContentFilteredTopicExample/HelloWorldv1.h
+++ b/examples/cpp/dds/ContentFilteredTopicExample/HelloWorldv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/CustomListenerExample/Topicv1.h
+++ b/examples/cpp/dds/CustomListenerExample/Topicv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/CustomPayloadPoolExample/CustomPayloadPoolDatav1.h
+++ b/examples/cpp/dds/CustomPayloadPoolExample/CustomPayloadPoolDatav1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/DeadlineQoSExample/deadlinepayloadv1.h
+++ b/examples/cpp/dds/DeadlineQoSExample/deadlinepayloadv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/DisablePositiveACKs/Topicv1.h
+++ b/examples/cpp/dds/DisablePositiveACKs/Topicv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/DiscoveryServerExample/types/HelloWorldv1.h
+++ b/examples/cpp/dds/DiscoveryServerExample/types/HelloWorldv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/Filtering/FilteringExamplev1.h
+++ b/examples/cpp/dds/Filtering/FilteringExamplev1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/FlowControlExample/FlowControlExample.h
+++ b/examples/cpp/dds/FlowControlExample/FlowControlExample.h
@@ -183,7 +183,7 @@ public:
 
 private:
 
-    std::array<char, 600000> m_message;
+    std::array<char, 600000> m_message{0};
     char m_wasFast{0};
 
 };

--- a/examples/cpp/dds/FlowControlExample/FlowControlExample.h
+++ b/examples/cpp/dds/FlowControlExample/FlowControlExample.h
@@ -183,7 +183,7 @@ public:
 
 private:
 
-    std::array<char, 600000> m_message{0};
+    std::array<char, 600000> m_message;
     char m_wasFast{0};
 
 };

--- a/examples/cpp/dds/FlowControlExample/FlowControlExamplev1.h
+++ b/examples/cpp/dds/FlowControlExample/FlowControlExamplev1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/HelloWorldExample/HelloWorldv1.h
+++ b/examples/cpp/dds/HelloWorldExample/HelloWorldv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/HelloWorldExampleDataSharing/HelloWorldv1.h
+++ b/examples/cpp/dds/HelloWorldExampleDataSharing/HelloWorldv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/HelloWorldExampleSharedMem/HelloWorld.h
+++ b/examples/cpp/dds/HelloWorldExampleSharedMem/HelloWorld.h
@@ -212,7 +212,7 @@ private:
 
     uint32_t m_index{0};
     std::string m_message;
-    std::array<char, 1024*1024> m_data;
+    std::array<char, 1024*1024> m_data{0};
 
 };
 

--- a/examples/cpp/dds/HelloWorldExampleSharedMem/HelloWorld.h
+++ b/examples/cpp/dds/HelloWorldExampleSharedMem/HelloWorld.h
@@ -212,7 +212,7 @@ private:
 
     uint32_t m_index{0};
     std::string m_message;
-    std::array<char, 1024*1024> m_data{0};
+    std::array<char, 1024*1024> m_data;
 
 };
 

--- a/examples/cpp/dds/HelloWorldExampleSharedMem/HelloWorldv1.h
+++ b/examples/cpp/dds/HelloWorldExampleSharedMem/HelloWorldv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/HelloWorldExampleTCP/HelloWorldv1.h
+++ b/examples/cpp/dds/HelloWorldExampleTCP/HelloWorldv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/HistoryKind/samplev1.h
+++ b/examples/cpp/dds/HistoryKind/samplev1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/Keys/samplev1.h
+++ b/examples/cpp/dds/Keys/samplev1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/LateJoiners/samplev1.h
+++ b/examples/cpp/dds/LateJoiners/samplev1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/LifespanQoSExample/Lifespanv1.h
+++ b/examples/cpp/dds/LifespanQoSExample/Lifespanv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/LivelinessQoS/Topicv1.h
+++ b/examples/cpp/dds/LivelinessQoS/Topicv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/OwnershipStrengthQoSExample/OwnershipStrengthv1.h
+++ b/examples/cpp/dds/OwnershipStrengthQoSExample/OwnershipStrengthv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/RequestReplyExample/Calculatorv1.h
+++ b/examples/cpp/dds/RequestReplyExample/Calculatorv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/SampleConfig_Controller/samplev1.h
+++ b/examples/cpp/dds/SampleConfig_Controller/samplev1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/SampleConfig_Events/samplev1.h
+++ b/examples/cpp/dds/SampleConfig_Events/samplev1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/SampleConfig_Multimedia/samplev1.h
+++ b/examples/cpp/dds/SampleConfig_Multimedia/samplev1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/SecureHelloWorldExample/HelloWorldv1.h
+++ b/examples/cpp/dds/SecureHelloWorldExample/HelloWorldv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/StaticHelloWorldExample/HelloWorldv1.h
+++ b/examples/cpp/dds/StaticHelloWorldExample/HelloWorldv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/WriterLoansExample/LoanableHelloWorldv1.h
+++ b/examples/cpp/dds/WriterLoansExample/LoanableHelloWorldv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/examples/cpp/dds/ZeroCopyExample/LoanableHelloWorldv1.h
+++ b/examples/cpp/dds/ZeroCopyExample/LoanableHelloWorldv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/src/cpp/statistics/types/monitorservice_typesv1.h
+++ b/src/cpp/statistics/types/monitorservice_typesv1.h
@@ -30,12 +30,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/src/cpp/statistics/types/typesv1.h
+++ b/src/cpp/statistics/types/typesv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/test/blackbox/types/Data1mbv1.h
+++ b/test/blackbox/types/Data1mbv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/test/blackbox/types/Data64kbv1.h
+++ b/test/blackbox/types/Data64kbv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/test/blackbox/types/FixedSizedv1.h
+++ b/test/blackbox/types/FixedSizedv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/test/blackbox/types/HelloWorldv1.h
+++ b/test/blackbox/types/HelloWorldv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/test/blackbox/types/KeyedData1mbv1.h
+++ b/test/blackbox/types/KeyedData1mbv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/test/blackbox/types/KeyedHelloWorldv1.h
+++ b/test/blackbox/types/KeyedHelloWorldv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/test/blackbox/types/StringTestv1.h
+++ b/test/blackbox/types/StringTestv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/test/blackbox/types/TestIncludeRegression3361v1.h
+++ b/test/blackbox/types/TestIncludeRegression3361v1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/test/blackbox/types/TestRegression3361v1.h
+++ b/test/blackbox/types/TestRegression3361v1.h
@@ -30,12 +30,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/test/blackbox/types/statistics/typesv1.h
+++ b/test/blackbox/types/statistics/typesv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/test/profiling/allocations/AllocTestTypev1.h
+++ b/test/profiling/allocations/AllocTestTypev1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypev1.h
+++ b/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypev1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/test/unittest/dynamic_types/idl/Basicv1.h
+++ b/test/unittest/dynamic_types/idl/Basicv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/test/unittest/dynamic_types/idl/Testv1.h
+++ b/test/unittest/dynamic_types/idl/Testv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/test/unittest/dynamic_types/idl/new_features_4_2v1.h
+++ b/test/unittest/dynamic_types/idl/new_features_4_2v1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/test/unittest/xtypes/idl/Typesv1.h
+++ b/test/unittest/xtypes/idl/Typesv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/test/unittest/xtypes/idl/WideEnumv1.h
+++ b/test/unittest/xtypes/idl/WideEnumv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/test/xtypes/idl/Typesv1.h
+++ b/test/xtypes/idl/Typesv1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR updates the Fast DDS types with Fast DDS Gen (compiled with the https://github.com/eProsima/Fast-DDS-Gen/pull/290 fix) that includes the `<cstdint>` header in v1 types. It is required to correctly compile against Fast CDR v1 with `gcc 13.2.0` (https://github.com/eProsima/Fast-DDS/pull/4337).

I checked the compilation in an `Ubuntu 24.04` (`gcc 13.2.0`) with both, tests enabled and disabled, and it solves the issue.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.12.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- **N/A** Applicable backports have been included in the description.


## Reviewer Checklist
- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
