### PR TITLE
Fix the shared memory cleaning script.

### DIFF
--- a/tools/fastdds/shm/clean.py
+++ b/tools/fastdds/shm/clean.py
@@ -91,7 +91,7 @@ class Clean:
             The deleted file names
 
         """
-        segment_lock_re = re.compile('^fastrtps_(\\d|[a-z]){16}_el|_sl')
+        segment_lock_re = re.compile('^fastrtps_(\\d|[a-z]){16}(_el|_sl)')
 
         # Each segment has an "_el" lock file that is locked if the segment
         # is open and the owner process is alive
@@ -123,7 +123,7 @@ class Clean:
             the deleted file names
 
         """
-        port_lock_re = re.compile('^fastrtps_port\\d{,5}_el|_sl')
+        port_lock_re = re.compile('^fastrtps_port\\d{,5}(_el|_sl)')
         # Each port has an "_el | _sl" lock file that is locked if the port
         # is open and the owner process is alive
         port_locks = [


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
Fix the regular expression that leads to skipping the processing of shared lock files by `fastdds shm clean` command.

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

To reproduce the problem you can use next script:
```
Python 3.8.10 (default, Jun 22 2022, 20:18:18) 
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import re
>>> port_lock_re = re.compile('^fastrtps_port\\d{,5}_el|_sl')
>>> bool(port_lock_re.match('fastrtps_port7777_el'))
True
>>> bool(port_lock_re.match('fastrtps_port7777_sl'))
False      <----------------------------------------------------- here is a problem
>>> 
```
After this fix, the behavior will be as follow:
```
Python 3.8.10 (default, Jun 22 2022, 20:18:18) 
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import re
>>> port_lock_re = re.compile('^fastrtps_port\\d{,5}(_el|_sl)')
>>> bool(port_lock_re.match('fastrtps_port7777_el'))
True
>>> bool(port_lock_re.match('fastrtps_port7777_sl'))
True
>>> 
```

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.12.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
