### PR TITLE
[20401] Check History QoS inconsistencies

### DIFF
--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1877,6 +1877,14 @@ ReturnCode_t DataWriterImpl::check_qos(
         EPROSIMA_LOG_ERROR(RTPS_QOS_CHECK, "HISTORY DEPTH must be higher than 0 if HISTORY KIND is KEEP_LAST.");
         return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
     }
+    if (qos.history().kind == KEEP_LAST_HISTORY_QOS && qos.history().depth > 0 &&
+            qos.resource_limits().max_samples_per_instance > 0 &&
+            qos.history().depth > qos.resource_limits().max_samples_per_instance)
+    {
+        EPROSIMA_LOG_ERROR(RTPS_QOS_CHECK,
+                "HISTORY DEPTH must be lower or equal to the max_samples_per_instance value.");
+        return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
+    }
     return ReturnCode_t::RETCODE_OK;
 }
 

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1872,6 +1872,11 @@ ReturnCode_t DataWriterImpl::check_qos(
         EPROSIMA_LOG_ERROR(RTPS_QOS_CHECK, "DATA_SHARING cannot be used with memory policies other than PREALLOCATED.");
         return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
     }
+    if (qos.history().kind == KEEP_LAST_HISTORY_QOS && qos.history().depth <= 0)
+    {
+        EPROSIMA_LOG_ERROR(RTPS_QOS_CHECK, "HISTORY DEPTH must be higher than 0 if HISTORY KIND is KEEP_LAST.");
+        return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
+    }
     return ReturnCode_t::RETCODE_OK;
 }
 

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1501,6 +1501,11 @@ ReturnCode_t DataReaderImpl::check_qos(
         EPROSIMA_LOG_ERROR(DDS_QOS_CHECK, "unique_network_request cannot be set along specific locators");
         return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
     }
+    if (qos.history().kind == KEEP_LAST_HISTORY_QOS && qos.history().depth <= 0)
+    {
+        EPROSIMA_LOG_ERROR(RTPS_QOS_CHECK, "HISTORY DEPTH must be higher than 0 if HISTORY KIND is KEEP_LAST.");
+        return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
+    }
     return ReturnCode_t::RETCODE_OK;
 }
 

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1506,6 +1506,14 @@ ReturnCode_t DataReaderImpl::check_qos(
         EPROSIMA_LOG_ERROR(RTPS_QOS_CHECK, "HISTORY DEPTH must be higher than 0 if HISTORY KIND is KEEP_LAST.");
         return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
     }
+    if (qos.history().kind == KEEP_LAST_HISTORY_QOS && qos.history().depth > 0 &&
+            qos.resource_limits().max_samples_per_instance > 0 &&
+            qos.history().depth > qos.resource_limits().max_samples_per_instance)
+    {
+        EPROSIMA_LOG_ERROR(RTPS_QOS_CHECK,
+                "HISTORY DEPTH must be lower or equal to the max_samples_per_instance value.");
+        return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
+    }
     return ReturnCode_t::RETCODE_OK;
 }
 

--- a/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
@@ -380,6 +380,7 @@ TEST(DDSDataWriter, OfferedDeadlineMissedListener)
  *   - Only affects TRANSPORT case (UDP or SHM communication, data_sharing and intraprocess disabled)
  *   - Destruction order matters: writer must be destroyed before reader (otherwise heartbeats would no be sent while
  *     destroying the writer)
+ * Edit: this test has been updated to ensure that HistoryQoS and ResourceLimitQoS constraints are met (#20401).
  */
 TEST(DDSDataWriter, HeartbeatWhileDestruction)
 {
@@ -392,13 +393,21 @@ TEST(DDSDataWriter, HeartbeatWhileDestruction)
         // A high number of samples increases the probability of the data race to occur
         size_t n_samples = 1000;
 
-        reader.reliability(RELIABLE_RELIABILITY_QOS).durability_kind(TRANSIENT_LOCAL_DURABILITY_QOS).init();
+        reader.reliability(RELIABLE_RELIABILITY_QOS)
+                .durability_kind(TRANSIENT_LOCAL_DURABILITY_QOS)
+                .init();
         ASSERT_TRUE(reader.isInitialized());
 
-        writer.reliability(RELIABLE_RELIABILITY_QOS).durability_kind(TRANSIENT_LOCAL_DURABILITY_QOS).history_kind(
-            KEEP_LAST_HISTORY_QOS).history_depth(static_cast<int32_t>(n_samples)).heartbeat_period_seconds(0).
-                heartbeat_period_nanosec(
-            20 * 1000).init();
+        writer.reliability(RELIABLE_RELIABILITY_QOS)
+                .durability_kind(TRANSIENT_LOCAL_DURABILITY_QOS)
+                .history_kind(KEEP_LAST_HISTORY_QOS)
+                .history_depth(static_cast<int32_t>(n_samples))
+                .resource_limits_max_samples(static_cast<int32_t>(n_samples))
+                .resource_limits_max_instances(static_cast<int32_t>(1))
+                .resource_limits_max_samples_per_instance(static_cast<int32_t>(n_samples))
+                .heartbeat_period_seconds(0)
+                .heartbeat_period_nanosec(20 * 1000)
+                .init();
         ASSERT_TRUE(writer.isInitialized());
 
         reader.wait_discovery();

--- a/test/unittest/dds/profiles/test_xml_profile.xml
+++ b/test/unittest/dds/profiles/test_xml_profile.xml
@@ -497,6 +497,7 @@
             </matchedSubscribersAllocation>
         </data_writer>
 
+        <!-- This profile has been updated to ensure that HistoryQoS and ResourceLimitQoS constraints are met (#20401) -->
         <data_reader profile_name="test_subscriber_profile">
             <topic>
                 <historyQos>
@@ -504,9 +505,9 @@
                     <depth>500</depth>
                 </historyQos>
                 <resourceLimitsQos>
-                    <max_samples>10</max_samples>
+                    <max_samples>2500</max_samples>
                     <max_instances>5</max_instances>
-                    <max_samples_per_instance>2</max_samples_per_instance>
+                    <max_samples_per_instance>500</max_samples_per_instance>
                     <allocated_samples>10</allocated_samples>
                 </resourceLimitsQos>
             </topic>

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -719,6 +719,15 @@ TEST(DataWriterTests, InvalidQos)
     qos.endpoint().history_memory_policy = eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
     EXPECT_EQ(ReturnCode_t::RETCODE_OK, datawriter->set_qos(qos));
 
+    qos = DATAWRITER_QOS_DEFAULT;
+    qos.history().kind = KEEP_LAST_HISTORY_QOS;
+    qos.history().depth = 0;
+    EXPECT_EQ(inconsistent_code, datawriter->set_qos(qos)); // KEEP LAST 0 is inconsistent
+    qos.history().depth = 2;
+    EXPECT_EQ(ReturnCode_t::RETCODE_OK, datawriter->set_qos(qos)); // KEEP LAST 2 is OK
+    qos.resource_limits().max_samples_per_instance = 1;
+    EXPECT_EQ(inconsistent_code, datawriter->set_qos(qos)); // KEEP LAST 2 but max_samples_per_instance 1 is inconsistent
+
     ASSERT_TRUE(publisher->delete_datawriter(datawriter) == ReturnCode_t::RETCODE_OK);
     ASSERT_TRUE(participant->delete_topic(topic) == ReturnCode_t::RETCODE_OK);
     ASSERT_TRUE(participant->delete_publisher(publisher) == ReturnCode_t::RETCODE_OK);

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -707,6 +707,14 @@ TEST_F(DataReaderTests, InvalidQos)
     qos.properties().properties().emplace_back("fastdds.unique_network_flows", "");
     EXPECT_EQ(inconsistent_code, data_reader_->set_qos(qos));
 
+    qos = DATAREADER_QOS_DEFAULT;
+    qos.history().kind = KEEP_LAST_HISTORY_QOS;
+    qos.history().depth = 0;
+    EXPECT_EQ(inconsistent_code, data_reader_->set_qos(qos)); // KEEP LAST 0 is inconsistent
+    qos.history().depth = 2;
+    qos.resource_limits().max_samples_per_instance = 1;
+    EXPECT_EQ(inconsistent_code, data_reader_->set_qos(qos)); // KEEP LAST 2 but max_samples_per_instance 1 is inconsistent
+
     /* Inmutable QoS */
     const ReturnCode_t inmutable_code = ReturnCode_t::RETCODE_IMMUTABLE_POLICY;
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR introduces a check to ensure that the history QoS is consistent in both DataWriter and DataReader creation.
In this case, it checks that if history kind is set as `KEEP_LAST`, the history depth must be higher than zero.

**Edit**: Check between history depth and resource limits' `max_samples_per_instance` also included

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.12.x 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
Fixes #4365 

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    Related documentation PR: eProsima/Fast-DDS-docs#664
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
