### PR TITLE
[20413] Fix doxygen docs warnings. Prepare for compiling with Doxygen 1.10.0

### DIFF
--- a/include/fastrtps/config/doxygen_modules.h
+++ b/include/fastrtps/config/doxygen_modules.h
@@ -80,6 +80,16 @@
  * This module contains all classes and methods associated with RTPSReader and its specifications, as well as other necessary classes.
  */
 
+/** @defgroup TYPES_MODULE Contains the builtin generated types
+ * @namespace eprosima::fastrtps::types
+ * @ingroup FASTRTPS_MODULE
+ */
+
+/** @defgroup XMLPARSER_MODULE Contains all the modules related with the XMLParser
+ * @namespace eprosima::fastrtps::xmlparser
+ * @ingroup FASTRTPS_MODULE
+ */
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 /** @defgroup PARAMETER_MODULE Qos Module

--- a/include/fastrtps/types/AnnotationParameterValue.h
+++ b/include/fastrtps/types/AnnotationParameterValue.h
@@ -59,7 +59,7 @@ namespace types {
 
 /*!
  * @brief This class represents the structure ExtendedAnnotationParameterValue defined by the user in the IDL file.
- * @ingroup ANNOTATIONPARAMETERVALUE
+ * @ingroup TYPES_MODULE
  */
 class ExtendedAnnotationParameterValue
 {
@@ -110,7 +110,8 @@ public:
      * @param current_alignment Buffer alignment.
      * @return Serialized size.
      */
-    FASTDDS_SER_METHOD_DEPRECATED(3, "eprosima::fastrtps::types::ExtendedAnnotationParameterValue::getCdrSerializedSize()",
+    FASTDDS_SER_METHOD_DEPRECATED(3,
+            "eprosima::fastrtps::types::ExtendedAnnotationParameterValue::getCdrSerializedSize()",
             "In favor of version using eprosima::fastcdr::calculate_serialized_size.")
     RTPS_DllAPI static size_t getCdrSerializedSize(
             const ExtendedAnnotationParameterValue& data,
@@ -166,7 +167,7 @@ private:
 };
 /*!
  * @brief This class represents the union AnnotationParameterValue defined by the user in the IDL file.
- * @ingroup ANNOTATIONPARAMETERVALUE
+ * @ingroup TYPES_MODULE
  */
 class AnnotationParameterValue
 {
@@ -824,7 +825,7 @@ private:
 
 /*!
  * @brief This class represents the structure AppliedAnnotationParameter defined by the user in the IDL file.
- * @ingroup ANNOTATIONPARAMETERVALUE
+ * @ingroup TYPES_MODULE
  */
 class AppliedAnnotationParameter
 {
@@ -1393,7 +1394,8 @@ public:
     }
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
-    FASTDDS_SER_METHOD_DEPRECATED(3, "eprosima::fastrtps::types::AppliedBuiltinMemberAnnotations::getCdrSerializedSize()",
+    FASTDDS_SER_METHOD_DEPRECATED(3,
+            "eprosima::fastrtps::types::AppliedBuiltinMemberAnnotations::getCdrSerializedSize()",
             "In favor of version using eprosima::fastcdr::calculate_serialized_size.")
     RTPS_DllAPI static size_t getCdrSerializedSize(
             const AppliedBuiltinMemberAnnotations& data,

--- a/include/fastrtps/types/TypeIdentifierTypes.h
+++ b/include/fastrtps/types/TypeIdentifierTypes.h
@@ -54,7 +54,7 @@ class StringLTypeDefn;
 
 /*!
  * @brief This class represents the structure StringSTypeDefn defined by the user in the IDL file.
- * @ingroup TYPEIDENTIFIERTYPES
+ * @ingroup TYPES_MODULE
  */
 class StringSTypeDefn final
 {
@@ -173,7 +173,7 @@ private:
 };
 /*!
  * @brief This class represents the structure StringLTypeDefn defined by the user in the IDL file.
- * @ingroup TYPEIDENTIFIERTYPES
+ * @ingroup TYPES_MODULE
  */
 class StringLTypeDefn final
 {
@@ -292,7 +292,7 @@ private:
 };
 /*!
  * @brief This class represents the structure PlainCollectionHeader defined by the user in the IDL file.
- * @ingroup TYPEIDENTIFIERTYPES
+ * @ingroup TYPES_MODULE
  */
 class PlainCollectionHeader final
 {
@@ -436,7 +436,7 @@ private:
 };
 /*!
  * @brief This class represents the structure PlainSequenceSElemDefn defined by the user in the IDL file.
- * @ingroup TYPEIDENTIFIERTYPES
+ * @ingroup TYPES_MODULE
  */
 class PlainSequenceSElemDefn final
 {
@@ -616,7 +616,7 @@ private:
 };
 /*!
  * @brief This class represents the structure PlainSequenceLElemDefn defined by the user in the IDL file.
- * @ingroup TYPEIDENTIFIERTYPES
+ * @ingroup TYPES_MODULE
  */
 class PlainSequenceLElemDefn final
 {
@@ -796,7 +796,7 @@ private:
 };
 /*!
  * @brief This class represents the structure PlainArraySElemDefn defined by the user in the IDL file.
- * @ingroup TYPEIDENTIFIERTYPES
+ * @ingroup TYPES_MODULE
  */
 class PlainArraySElemDefn final
 {
@@ -986,7 +986,7 @@ private:
 };
 /*!
  * @brief This class represents the structure PlainArrayLElemDefn defined by the user in the IDL file.
- * @ingroup TYPEIDENTIFIERTYPES
+ * @ingroup TYPES_MODULE
  */
 class PlainArrayLElemDefn final
 {
@@ -1176,7 +1176,7 @@ private:
 };
 /*!
  * @brief This class represents the structure PlainMapSTypeDefn defined by the user in the IDL file.
- * @ingroup TYPEIDENTIFIERTYPES
+ * @ingroup TYPES_MODULE
  */
 class PlainMapSTypeDefn final
 {
@@ -1411,7 +1411,7 @@ private:
 };
 /*!
  * @brief This class represents the structure PlainMapLTypeDefn defined by the user in the IDL file.
- * @ingroup TYPEIDENTIFIERTYPES
+ * @ingroup TYPES_MODULE
  */
 class PlainMapLTypeDefn final
 {
@@ -1646,7 +1646,7 @@ private:
 };
 /*!
  * @brief This class represents the structure StronglyConnectedComponentId defined by the user in the IDL file.
- * @ingroup TYPEIDENTIFIERTYPES
+ * @ingroup TYPES_MODULE
  */
 class StronglyConnectedComponentId final
 {
@@ -1829,7 +1829,7 @@ private:
 };
 /*!
  * @brief This class represents the structure ExtendedTypeDefn defined by the user in the IDL file.
- * @ingroup TYPEIDENTIFIERTYPES
+ * @ingroup TYPES_MODULE
  */
 class ExtendedTypeDefn final
 {

--- a/include/fastrtps/types/TypeObjectHashId.h
+++ b/include/fastrtps/types/TypeObjectHashId.h
@@ -46,7 +46,7 @@ typedef octet EquivalenceHash[14];
 
 /*!
  * @brief This class represents the union TypeObjectHashId defined by the user in the IDL file.
- * @ingroup TYPEOBJECTHASHID
+ * @ingroup TYPES_MODULE
  */
 class TypeObjectHashId
 {

--- a/include/fastrtps/xmlparser/XMLEndpointParser.h
+++ b/include/fastrtps/xmlparser/XMLEndpointParser.h
@@ -75,7 +75,7 @@ public:
 
 /**
  * Class XMLEndpointParser used to parse the XML file that contains information about remote endpoints.
- * @ingroup DISCVOERYMODULE
+ * @ingroup DISCOVERY_MODULE
  */
 class XMLEndpointParser : XMLParser
 {

--- a/include/fastrtps/xmlparser/XMLProfileManager.h
+++ b/include/fastrtps/xmlparser/XMLProfileManager.h
@@ -52,7 +52,7 @@ using xmlfile_map_iterator_t = xmlfiles_map_t::iterator;
 
 /**
  * Class XMLProfileManager, used to make available profiles from XML file.
- * @ingroup XMLPROFILEMANAGER_MODULE
+ * @ingroup XMLPARSER_MODULE
  */
 class XMLProfileManager
 {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR fixes some minor typos and declares some extra `groups` into the `doxygen_modules.h` file that fixes a compilation warning stating that the `@ingroup` doxygen macros did not point to a valid group. 

Before doxygen `1.10.0` it was not considered a warning, but, as we define `WARN_AS_ERROR` to `YES` in the `doxyfile.in`, we fail to compile with with `doxygen >= 1.10.0` since it is treated as a warning henceforth.

Two considerations:
* This PR does NOT upgrade the `doxyfile.in` to `1.10.0` yet, so building with `doxygen 1.10.0` and `-DBUILD_DOCUMENTATION=ON` outputs a bunch of info messages complaining that some of the configuration options are obsolete, but now, the compilation finishes successfully.
* Some of the fixes affect the `/types` directory which is going to be deprecated with the new XTypes refactor.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.12.x 2.11.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
Fixes #4370 

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- **N/A** The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
-**N/A** Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [X] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
