### PR TITLE
[20438] LARGE_DATA Participants logic with same listening ports

### DIFF
--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -775,7 +775,15 @@ bool TCPTransportInterface::OpenOutputChannel(
             for (const auto& infoIP : locNames)
             {
                 Locator newloc(physical_locator);
-                IPLocator::setIPv4(newloc, infoIP.locator);
+                if (transport_kind_ == LOCATOR_KIND_TCPv4)
+                {
+                    IPLocator::setIPv4(newloc, infoIP.locator);
+                }
+                else
+                {
+                    IPLocator::setIPv6(newloc, infoIP.locator);
+                }
+
                 if (is_interface_allowed(newloc))
                 {
                     list.push_back(newloc);

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -766,10 +766,36 @@ bool TCPTransportInterface::OpenOutputChannel(
             listening_port = config->listening_ports.front();
         }
 
+        bool local_lower_interface = false;
+        if (IPLocator::getPhysicalPort(physical_locator) == listening_port)
+        {
+            std::vector<Locator> list;
+            std::vector<fastrtps::rtps::IPFinder::info_IP> locNames;
+            get_ips(locNames);
+            for (const auto& infoIP : locNames)
+            {
+                Locator newloc(physical_locator);
+                IPLocator::setIPv4(newloc, infoIP.locator);
+                if (is_interface_allowed(newloc))
+                {
+                    list.push_back(newloc);
+                }
+            }
+            if (list.empty())
+            {
+                EPROSIMA_LOG_ERROR(RTCP, "Could not find a valid local interface to connect to " << physical_locator);
+                return false;
+            }
+            else if (list.front() < physical_locator)
+            {
+                local_lower_interface = true;
+            }
+        }
+
         // If the remote physical port is higher than our listening port, a new CONNECT channel needs to be created and connected
         // and the locator added to the send_resource_list.
         // If the remote physical port is lower than our listening port, only the locator needs to be added to the send_resource_list.
-        if (IPLocator::getPhysicalPort(physical_locator) > listening_port)
+        if (IPLocator::getPhysicalPort(physical_locator) > listening_port || local_lower_interface)
         {
             // Client side (either Server-Client or LARGE_DATA)
             EPROSIMA_LOG_INFO(OpenOutputChannel, "OpenOutputChannel: [CONNECT] (physical: "

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -772,9 +772,9 @@ bool TCPTransportInterface::OpenOutputChannel(
             std::vector<Locator> list;
             std::vector<fastrtps::rtps::IPFinder::info_IP> local_interfaces;
             get_ips(local_interfaces);
-            for (const auto& interface : local_interfaces)
+            for (const auto& interface_it : local_interfaces)
             {
-                Locator interface_loc(interface.locator);
+                Locator interface_loc(interface_it.locator);
                 interface_loc.port = physical_locator.port;
                 if (is_interface_allowed(interface_loc))
                 {

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -2136,6 +2136,36 @@ TEST_F(TCPv4Tests, reconnect_after_open_port_failure)
     client_resource_list.clear();
 }
 
+// This test verifies that OpenOutputChannel correctly handles a remote locator with
+// same physical port as the local listening port.
+TEST_F(TCPv4Tests, opening_output_channel_with_same_locator_as_local_listening_port)
+{
+    TCPv4TransportDescriptor descriptor;
+    descriptor.add_listener_port(g_default_port);
+    TCPv4Transport transportUnderTest(descriptor);
+    transportUnderTest.init();
+
+    // Two locators with the same port as the local listening port, but different addresses
+    Locator_t lowerOutputChannelLocator;
+    lowerOutputChannelLocator.kind = LOCATOR_KIND_TCPv4;
+    lowerOutputChannelLocator.port = g_output_port;
+    IPLocator::setLogicalPort(lowerOutputChannelLocator, g_output_port);
+    Locator_t higherOutputChannelLocator = lowerOutputChannelLocator;
+    IPLocator::setIPv4(lowerOutputChannelLocator, 1, 1, 1, 1);
+    IPLocator::setIPv4(higherOutputChannelLocator, 255, 255, 255, 255);
+
+    SendResourceList send_resource_list;
+
+    // If the remote address is lower than the local one, no channel must be created but it must be added to the send_resource_list
+    ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, lowerOutputChannelLocator));
+    ASSERT_FALSE(transportUnderTest.is_output_channel_open_for(lowerOutputChannelLocator));
+    ASSERT_FALSE(send_resource_list.empty());
+    // If the remote address is higher than the local one, a CONNECT channel must be created and added to the send_resource_list
+    ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, higherOutputChannelLocator));
+    ASSERT_TRUE(transportUnderTest.is_output_channel_open_for(higherOutputChannelLocator));
+    ASSERT_EQ(send_resource_list.size(), 2);
+}
+
 void TCPv4Tests::HELPER_SetDescriptorDefaults()
 {
     descriptor.add_listener_port(g_default_port);

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -2148,8 +2148,8 @@ TEST_F(TCPv4Tests, opening_output_channel_with_same_locator_as_local_listening_p
     // Two locators with the same port as the local listening port, but different addresses
     Locator_t lowerOutputChannelLocator;
     lowerOutputChannelLocator.kind = LOCATOR_KIND_TCPv4;
-    lowerOutputChannelLocator.port = g_output_port;
-    IPLocator::setLogicalPort(lowerOutputChannelLocator, g_output_port);
+    lowerOutputChannelLocator.port = g_default_port;
+    IPLocator::setLogicalPort(lowerOutputChannelLocator, g_default_port);
     Locator_t higherOutputChannelLocator = lowerOutputChannelLocator;
     IPLocator::setIPv4(lowerOutputChannelLocator, 1, 1, 1, 1);
     IPLocator::setIPv4(higherOutputChannelLocator, 255, 255, 255, 255);

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -2140,7 +2140,6 @@ TEST_F(TCPv4Tests, reconnect_after_open_port_failure)
 // same physical port as the local listening port.
 TEST_F(TCPv4Tests, opening_output_channel_with_same_locator_as_local_listening_port)
 {
-    descriptor.add_listener_port(g_default_port);
     TCPv4Transport transportUnderTest(descriptor);
     transportUnderTest.init();
 

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -2140,7 +2140,6 @@ TEST_F(TCPv4Tests, reconnect_after_open_port_failure)
 // same physical port as the local listening port.
 TEST_F(TCPv4Tests, opening_output_channel_with_same_locator_as_local_listening_port)
 {
-    TCPv4TransportDescriptor descriptor;
     descriptor.add_listener_port(g_default_port);
     TCPv4Transport transportUnderTest(descriptor);
     transportUnderTest.init();

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -2157,7 +2157,7 @@ TEST_F(TCPv4Tests, opening_output_channel_with_same_locator_as_local_listening_p
     // If the remote address is lower than the local one, no channel must be created but it must be added to the send_resource_list
     ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, lowerOutputChannelLocator));
     ASSERT_FALSE(transportUnderTest.is_output_channel_open_for(lowerOutputChannelLocator));
-    ASSERT_FALSE(send_resource_list.empty());
+    ASSERT_EQ(send_resource_list.size(), 1);
     // If the remote address is higher than the local one, a CONNECT channel must be created and added to the send_resource_list
     ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, higherOutputChannelLocator));
     ASSERT_TRUE(transportUnderTest.is_output_channel_open_for(higherOutputChannelLocator));

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -486,6 +486,32 @@ TEST_F(TCPv6Tests, reconnect_after_open_port_failure)
     client_resource_list.clear();
 }
 
+TEST_F(TCPv6Tests, opening_output_channel_with_same_locator_as_local_listening_port)
+{
+    descriptor.add_listener_port(g_default_port);
+    TCPv6Transport transportUnderTest(descriptor);
+    transportUnderTest.init();
+
+    // Two locators with the same port as the local listening port, but different addresses
+    Locator_t lowerOutputChannelLocator;
+    lowerOutputChannelLocator.kind = LOCATOR_KIND_TCPv6;
+    lowerOutputChannelLocator.port = g_default_port;
+    IPLocator::setLogicalPort(lowerOutputChannelLocator, g_default_port);
+    Locator_t higherOutputChannelLocator = lowerOutputChannelLocator;
+    IPLocator::setIPv6(lowerOutputChannelLocator, "::");
+    IPLocator::setIPv6(higherOutputChannelLocator, "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
+
+    SendResourceList send_resource_list;
+
+    // If the remote address is lower than the local one, no channel must be created but it must be added to the send_resource_list
+    ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, lowerOutputChannelLocator));
+    ASSERT_FALSE(transportUnderTest.is_output_channel_open_for(lowerOutputChannelLocator));
+    ASSERT_FALSE(send_resource_list.empty());
+    // If the remote address is higher than the local one, a CONNECT channel must be created and added to the send_resource_list
+    ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, higherOutputChannelLocator));
+    ASSERT_TRUE(transportUnderTest.is_output_channel_open_for(higherOutputChannelLocator));
+    ASSERT_EQ(send_resource_list.size(), 2);
+}
 
 /*
    TEST_F(TCPv6Tests, send_and_receive_between_both_secure_ports)

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -506,7 +506,7 @@ TEST_F(TCPv6Tests, opening_output_channel_with_same_locator_as_local_listening_p
     // If the remote address is lower than the local one, no channel must be created but it must be added to the send_resource_list
     ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, lowerOutputChannelLocator));
     ASSERT_FALSE(transportUnderTest.is_output_channel_open_for(lowerOutputChannelLocator));
-    ASSERT_FALSE(send_resource_list.empty());
+    ASSERT_EQ(send_resource_list.size(), 1);
     // If the remote address is higher than the local one, a CONNECT channel must be created and added to the send_resource_list
     ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, higherOutputChannelLocator));
     ASSERT_TRUE(transportUnderTest.is_output_channel_open_for(higherOutputChannelLocator));


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This feature adds support for the unlikely case in which two participants configured with the LARGE_DATA builtin transports obtain randomly the same listening port. This case can only occur if the participants are located in different hosts and, thus, each of them has a different IP address.
Due to the logic implemented in the channel negotiation of the LARGE_DATA topology, unnecessary channels might be created if this case occurs, which will be addressed in the future.

@Mergifyio backport 2.12.x 2.10.x 2.6.x
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.12.x 2.11.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [_N/A_] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [_N/A_] New feature has been added to the `versions.md` file (if applicable).
- [_N/A_] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [X] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
