### PR TITLE
[20492] OpenOutputChannels / CloseOutputChannels that receive a LocatorSelectorEntry

### DIFF
--- a/include/fastdds/rtps/common/LocatorSelectorEntry.hpp
+++ b/include/fastdds/rtps/common/LocatorSelectorEntry.hpp
@@ -24,6 +24,7 @@
 #include <fastdds/rtps/common/Guid.h>
 #include <fastdds/rtps/common/Locator.h>
 #include <fastrtps/utils/collections/ResourceLimitedVector.hpp>
+#include <fastrtps/fastrtps_dll.h>
 
 namespace eprosima {
 namespace fastrtps {
@@ -35,7 +36,7 @@ namespace rtps {
  * This class holds the locators of a remote endpoint along with data required for the locator selection algorithm.
  * Can be easily integrated inside other classes, such as @ref ReaderProxyData and @ref WriterProxyData.
  */
-struct LocatorSelectorEntry
+struct RTPS_DllAPI LocatorSelectorEntry
 {
     /**
      * Holds the selection state of the locators held by a LocatorSelectorEntry

--- a/include/fastdds/rtps/common/LocatorSelectorEntry.hpp
+++ b/include/fastdds/rtps/common/LocatorSelectorEntry.hpp
@@ -24,7 +24,6 @@
 #include <fastdds/rtps/common/Guid.h>
 #include <fastdds/rtps/common/Locator.h>
 #include <fastrtps/utils/collections/ResourceLimitedVector.hpp>
-#include <fastrtps/fastrtps_dll.h>
 
 namespace eprosima {
 namespace fastrtps {
@@ -36,7 +35,7 @@ namespace rtps {
  * This class holds the locators of a remote endpoint along with data required for the locator selection algorithm.
  * Can be easily integrated inside other classes, such as @ref ReaderProxyData and @ref WriterProxyData.
  */
-struct RTPS_DllAPI LocatorSelectorEntry
+struct LocatorSelectorEntry
 {
     /**
      * Holds the selection state of the locators held by a LocatorSelectorEntry

--- a/include/fastdds/rtps/transport/TransportInterface.h
+++ b/include/fastdds/rtps/transport/TransportInterface.h
@@ -135,6 +135,18 @@ public:
             SendResourceList& sender_resource_list,
             const Locator&) = 0;
 
+    //! Must open the channel that maps to/from the given locator selector entry. This method must allocate,
+    //! reserve and mark any resources that are needed for said channel.
+    virtual bool OpenOutputChannel(
+            SendResourceList& sender_resource_list,
+            const fastrtps::rtps::LocatorSelectorEntry&);
+
+
+    //! Close the channel that maps to/from the given locator selector entry.
+    virtual void CloseOutputChannel(
+            SendResourceList& sender_resource_list,
+            const fastrtps::rtps::LocatorSelectorEntry&);
+
     /** Opens an input channel to receive incoming connections.
      *   If there is an existing channel it registers the receiver interface.
      */

--- a/include/fastdds/rtps/transport/TransportInterface.h
+++ b/include/fastdds/rtps/transport/TransportInterface.h
@@ -154,8 +154,6 @@ public:
      *
      * @param sender_resource_list Participant's send resource list.
      * @param locator_selector_entry Locator selector entry with the remote participant's locators.
-     *
-     * @return true if the channel was correctly closed or if it was already closed.
      */
     virtual void CloseOutputChannel(
             SendResourceList& sender_resource_list,

--- a/include/fastdds/rtps/transport/TransportInterface.h
+++ b/include/fastdds/rtps/transport/TransportInterface.h
@@ -21,6 +21,7 @@
 #include <fastdds/rtps/attributes/PropertyPolicy.h>
 #include <fastdds/rtps/common/Locator.h>
 #include <fastdds/rtps/common/LocatorSelector.hpp>
+#include <fastdds/rtps/common/LocatorSelectorEntry.hpp>
 #include <fastdds/rtps/common/PortParameters.h>
 #include <fastdds/rtps/transport/SenderResource.h>
 #include <fastdds/rtps/transport/TransportDescriptorInterface.h>
@@ -135,17 +136,30 @@ public:
             SendResourceList& sender_resource_list,
             const Locator&) = 0;
 
-    //! Must open the channel that maps to/from the given locator selector entry. This method must allocate,
-    //! reserve and mark any resources that are needed for said channel.
+    /**
+     * Must open the channel that maps to/from the given locator selector entry. This method must allocate,
+     * reserve and mark any resources that are needed for said channel.
+     *
+     * @param sender_resource_list Participant's send resource list.
+     * @param locator_selector_entry Locator selector entry with the remote participant's locators.
+     *
+     * @return true if the channel was correctly opened or if finding an already opened one.
+     */
     virtual bool OpenOutputChannel(
             SendResourceList& sender_resource_list,
-            const fastrtps::rtps::LocatorSelectorEntry&);
+            const fastrtps::rtps::LocatorSelectorEntry& locator_selector_entry);
 
-
-    //! Close the channel that maps to/from the given locator selector entry.
+    /**
+     * Close the channel that maps to/from the given locator selector entry.
+     *
+     * @param sender_resource_list Participant's send resource list.
+     * @param locator_selector_entry Locator selector entry with the remote participant's locators.
+     *
+     * @return true if the channel was correctly closed or if it was already closed.
+     */
     virtual void CloseOutputChannel(
             SendResourceList& sender_resource_list,
-            const fastrtps::rtps::LocatorSelectorEntry&);
+            const fastrtps::rtps::LocatorSelectorEntry& locator_selector_entry);
 
     /** Opens an input channel to receive incoming connections.
      *   If there is an existing channel it registers the receiver interface.

--- a/include/fastdds/rtps/transport/TransportInterface.h
+++ b/include/fastdds/rtps/transport/TransportInterface.h
@@ -141,7 +141,7 @@ public:
      * reserve and mark any resources that are needed for said channel.
      *
      * @param sender_resource_list Participant's send resource list.
-     * @param locator_selector_entry Locator selector entry with the remote participant's locators.
+     * @param locator_selector_entry Locator selector entry with the remote entity locators.
      *
      * @return true if the channel was correctly opened or if finding an already opened one.
      */
@@ -153,7 +153,7 @@ public:
      * Close the channel that maps to/from the given locator selector entry.
      *
      * @param sender_resource_list Participant's send resource list.
-     * @param locator_selector_entry Locator selector entry with the remote participant's locators.
+     * @param locator_selector_entry Locator selector entry with the remote entity locators.
      */
     virtual void CloseOutputChannel(
             SendResourceList& sender_resource_list,

--- a/include/fastdds/rtps/transport/TransportInterface.h
+++ b/include/fastdds/rtps/transport/TransportInterface.h
@@ -145,7 +145,7 @@ public:
      *
      * @return true if the channel was correctly opened or if finding an already opened one.
      */
-    virtual bool OpenOutputChannel(
+    virtual bool OpenOutputChannels(
             SendResourceList& sender_resource_list,
             const fastrtps::rtps::LocatorSelectorEntry& locator_selector_entry);
 
@@ -155,7 +155,7 @@ public:
      * @param sender_resource_list Participant's send resource list.
      * @param locator_selector_entry Locator selector entry with the remote entity locators.
      */
-    virtual void CloseOutputChannel(
+    virtual void CloseOutputChannels(
             SendResourceList& sender_resource_list,
             const fastrtps::rtps::LocatorSelectorEntry& locator_selector_entry);
 

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -124,6 +124,7 @@ set(${PROJECT_NAME}_source_files
     fastdds/builtin/typelookup/TypeLookupManager.cpp
     fastdds/builtin/typelookup/TypeLookupRequestListener.cpp
     fastdds/builtin/typelookup/TypeLookupReplyListener.cpp
+    rtps/transport/TransportInterface.cpp
     rtps/transport/ChainingTransport.cpp
     rtps/transport/ChannelResource.cpp
     rtps/transport/PortBasedTransportDescriptor.cpp

--- a/src/cpp/rtps/network/NetworkFactory.cpp
+++ b/src/cpp/rtps/network/NetworkFactory.cpp
@@ -477,6 +477,8 @@ void NetworkFactory::remove_participant_associated_send_resources(
         const LocatorList_t& remote_participant_locators,
         const LocatorList_t& participant_initial_peers) const
 {
+    // TODO(eduponz): Call the overload of CloseOutputChannel that takes a LocatorSelectorEntry for
+    // all transports and let them decide what to do.
     for (auto& transport : mRegisteredTransports)
     {
         TCPTransportInterface* tcp_transport = dynamic_cast<TCPTransportInterface*>(transport.get());

--- a/src/cpp/rtps/network/NetworkFactory.cpp
+++ b/src/cpp/rtps/network/NetworkFactory.cpp
@@ -484,7 +484,7 @@ void NetworkFactory::remove_participant_associated_send_resources(
         TCPTransportInterface* tcp_transport = dynamic_cast<TCPTransportInterface*>(transport.get());
         if (tcp_transport)
         {
-            tcp_transport->CloseOutputChannel(
+            tcp_transport->cleanup_sender_resources(
                 send_resource_list,
                 remote_participant_locators,
                 participant_initial_peers);

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -1888,7 +1888,7 @@ void TCPTransportInterface::fill_local_physical_port(
     }
 }
 
-void TCPTransportInterface::CloseOutputChannel(
+void TCPTransportInterface::cleanup_sender_resources(
         SendResourceList& send_resource_list,
         const LocatorList& remote_participant_locators,
         const LocatorList& participant_initial_peers) const

--- a/src/cpp/rtps/transport/TCPTransportInterface.h
+++ b/src/cpp/rtps/transport/TCPTransportInterface.h
@@ -480,7 +480,7 @@ public:
      * @param remote_participant_locators Set of locators associated to the remote participant.
      * @param participant_initial_peers List of locators associated to the initial peers of the local participant.
      */
-    void CloseOutputChannel(
+    void cleanup_sender_resources(
             SendResourceList& send_resource_list,
             const LocatorList& remote_participant_locators,
             const LocatorList& participant_initial_peers) const;

--- a/src/cpp/rtps/transport/TransportInterface.cpp
+++ b/src/cpp/rtps/transport/TransportInterface.cpp
@@ -22,7 +22,7 @@ namespace rtps {
 
 using LocatorSelectorEntry = fastrtps::rtps::LocatorSelectorEntry;
 
-bool TransportInterface::OpenOutputChannel(
+bool TransportInterface::OpenOutputChannels(
         SendResourceList& send_resource_list,
         const LocatorSelectorEntry& locator_selector_entry)
 {
@@ -40,7 +40,7 @@ bool TransportInterface::OpenOutputChannel(
     return success;
 }
 
-void TransportInterface::CloseOutputChannel(
+void TransportInterface::CloseOutputChannels(
         SendResourceList& sender_resource_list,
         const fastrtps::rtps::LocatorSelectorEntry& locator_selector_entry)
 {

--- a/src/cpp/rtps/transport/TransportInterface.cpp
+++ b/src/cpp/rtps/transport/TransportInterface.cpp
@@ -14,7 +14,7 @@
 
 #include <fastdds/rtps/transport/TransportInterface.h>
 
-#include <fastdds/rtps/common/LocatorSelector.hpp>
+#include <fastdds/rtps/common/LocatorSelectorEntry.hpp>
 
 
 namespace eprosima {

--- a/src/cpp/rtps/transport/TransportInterface.cpp
+++ b/src/cpp/rtps/transport/TransportInterface.cpp
@@ -16,7 +16,6 @@
 
 #include <fastdds/rtps/common/LocatorSelectorEntry.hpp>
 
-
 namespace eprosima {
 namespace fastdds {
 namespace rtps {

--- a/src/cpp/rtps/transport/TransportInterface.cpp
+++ b/src/cpp/rtps/transport/TransportInterface.cpp
@@ -1,0 +1,54 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fastdds/rtps/transport/TransportInterface.h>
+
+#include <fastdds/rtps/common/LocatorSelector.hpp>
+
+
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+
+using LocatorSelectorEntry = fastrtps::rtps::LocatorSelectorEntry;
+
+bool TransportInterface::OpenOutputChannel(
+            SendResourceList& send_resource_list,
+            const LocatorSelectorEntry& locator_selector_entry)
+{
+    bool success = false;
+    for (size_t i = 0; i < locator_selector_entry.state.multicast.size(); ++i)
+    {
+        size_t index = locator_selector_entry.state.multicast[i];
+        success |= OpenOutputChannel(send_resource_list, locator_selector_entry.multicast[index]);
+    }
+    for (size_t i = 0; i < locator_selector_entry.state.unicast.size(); ++i)
+    {
+        size_t index = locator_selector_entry.state.unicast[i];
+        success |= OpenOutputChannel(send_resource_list, locator_selector_entry.unicast[index]);
+    }
+    return success;
+}
+
+void TransportInterface::CloseOutputChannel(
+            SendResourceList& sender_resource_list,
+            const fastrtps::rtps::LocatorSelectorEntry& locator_selector_entry)
+{
+    static_cast<void>(sender_resource_list);
+    static_cast<void>(locator_selector_entry);
+}
+
+} // namespace rtps
+} // namespace fastrtps
+} // namespace eprosima

--- a/src/cpp/rtps/transport/TransportInterface.cpp
+++ b/src/cpp/rtps/transport/TransportInterface.cpp
@@ -24,8 +24,8 @@ namespace rtps {
 using LocatorSelectorEntry = fastrtps::rtps::LocatorSelectorEntry;
 
 bool TransportInterface::OpenOutputChannel(
-            SendResourceList& send_resource_list,
-            const LocatorSelectorEntry& locator_selector_entry)
+        SendResourceList& send_resource_list,
+        const LocatorSelectorEntry& locator_selector_entry)
 {
     bool success = false;
     for (size_t i = 0; i < locator_selector_entry.state.multicast.size(); ++i)
@@ -42,8 +42,8 @@ bool TransportInterface::OpenOutputChannel(
 }
 
 void TransportInterface::CloseOutputChannel(
-            SendResourceList& sender_resource_list,
-            const fastrtps::rtps::LocatorSelectorEntry& locator_selector_entry)
+        SendResourceList& sender_resource_list,
+        const fastrtps::rtps::LocatorSelectorEntry& locator_selector_entry)
 {
     static_cast<void>(sender_resource_list);
     static_cast<void>(locator_selector_entry);

--- a/test/unittest/dds/publisher/CMakeLists.txt
+++ b/test/unittest/dds/publisher/CMakeLists.txt
@@ -166,6 +166,7 @@ set(DATAWRITERTESTS_SOURCE DataWriterTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEvent.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEventImpl.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/RTPSDomain.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TransportInterface.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/PortBasedTransportDescriptor.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/shared_mem/SharedMemTransportDescriptor.cpp

--- a/test/unittest/rtps/discovery/CMakeLists.txt
+++ b/test/unittest/rtps/discovery/CMakeLists.txt
@@ -103,6 +103,7 @@ gtest_discover_tests(EdpTests)
 #PDP TESTS
 
 set(TCPTransportInterface_SOURCE
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TransportInterface.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/PortBasedTransportDescriptor.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/messages/RTPSMessageCreator.cpp

--- a/test/unittest/rtps/network/CMakeLists.txt
+++ b/test/unittest/rtps/network/CMakeLists.txt
@@ -29,6 +29,7 @@ set(NETWORKFACTORYTESTS_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/ResourceEvent.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEvent.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEventImpl.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TransportInterface.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/PortBasedTransportDescriptor.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/tcp/RTCPMessageManager.cpp

--- a/test/unittest/statistics/dds/CMakeLists.txt
+++ b/test/unittest/statistics/dds/CMakeLists.txt
@@ -241,6 +241,7 @@ if (SQLITE3_SUPPORT AND FASTDDS_STATISTICS AND NOT QNX)
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEvent.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEventImpl.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/RTPSDomain.cpp
+        ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TransportInterface.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/PortBasedTransportDescriptor.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/shared_mem/SharedMemTransportDescriptor.cpp
@@ -433,6 +434,7 @@ if (SQLITE3_SUPPORT AND FASTDDS_STATISTICS AND NOT QNX)
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/ResourceEvent.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEvent.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEventImpl.cpp
+        ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TransportInterface.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/PortBasedTransportDescriptor.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPAcceptor.cpp
@@ -671,4 +673,3 @@ if (SQLITE3_SUPPORT AND FASTDDS_STATISTICS AND NOT QNX)
     gtest_discover_tests(StatisticsDomainParticipantStatusQueryableTests)
 
 endif (SQLITE3_SUPPORT AND FASTDDS_STATISTICS AND NOT QNX)
-

--- a/test/unittest/statistics/rtps/CMakeLists.txt
+++ b/test/unittest/statistics/rtps/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(RTPSStatisticsTests fastrtps fastcdr GTest::gtest GTest::g
 gtest_discover_tests(RTPSStatisticsTests)
 
 set(TCPTransportInterface_SOURCE
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TransportInterface.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/PortBasedTransportDescriptor.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/messages/RTPSMessageCreator.cpp

--- a/test/unittest/transport/CMakeLists.txt
+++ b/test/unittest/transport/CMakeLists.txt
@@ -76,6 +76,7 @@ set(UDPV4TESTS_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/flowcontrol/ThroughputControllerDescriptor.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/NetworkFactory.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TransportInterface.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/PortBasedTransportDescriptor.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/UDPChannelResource.cpp
@@ -99,6 +100,7 @@ set(UDPV6TESTS_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/flowcontrol/ThroughputControllerDescriptor.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/NetworkFactory.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TransportInterface.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/PortBasedTransportDescriptor.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/UDPChannelResource.cpp
@@ -129,6 +131,7 @@ set(TCPV4TESTS_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/ResourceEvent.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEvent.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEventImpl.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TransportInterface.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/PortBasedTransportDescriptor.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/tcp/RTCPMessageManager.cpp
@@ -172,6 +175,7 @@ set(TCPV6TESTS_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/ResourceEvent.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEvent.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEventImpl.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TransportInterface.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/PortBasedTransportDescriptor.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/tcp/RTCPMessageManager.cpp
@@ -210,6 +214,7 @@ set(SHAREDMEMTESTS_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/flowcontrol/ThroughputControllerDescriptor.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/NetworkFactory.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TransportInterface.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/PortBasedTransportDescriptor.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -2116,7 +2116,7 @@ TEST_F(TCPv4Tests, remove_from_send_resource_list)
             IPLocator::setWan(wrong_output_locator, g_test_wan_address);
         }
         wrong_remote_participant_physical_locators.push_back(wrong_output_locator);
-        send_transport_under_test.CloseOutputChannel(
+        send_transport_under_test.cleanup_sender_resources(
             send_resource_list,
             wrong_remote_participant_physical_locators,
             initial_peer_list);
@@ -2125,7 +2125,7 @@ TEST_F(TCPv4Tests, remove_from_send_resource_list)
         // Using the correct locator should remove the channel resource
         LocatorList_t remote_participant_physical_locators;
         remote_participant_physical_locators.push_back(discovery_locator);
-        send_transport_under_test.CloseOutputChannel(
+        send_transport_under_test.cleanup_sender_resources(
             send_resource_list,
             remote_participant_physical_locators,
             initial_peer_list);
@@ -2140,7 +2140,7 @@ TEST_F(TCPv4Tests, remove_from_send_resource_list)
             IPLocator::setWan(initial_peer_locator, g_test_wan_address);
         }
         remote_participant_physical_locators.push_back(initial_peer_locator);
-        send_transport_under_test.CloseOutputChannel(
+        send_transport_under_test.cleanup_sender_resources(
             send_resource_list,
             remote_participant_physical_locators,
             initial_peer_list);

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -527,7 +527,7 @@ TEST_F(TCPv6Tests, remove_from_send_resource_list)
     IPLocator::createLocator(LOCATOR_KIND_TCPv6, "::1", g_default_port + 2, wrong_output_locator);
     IPLocator::setLogicalPort(wrong_output_locator, 7410);
     wrong_remote_participant_physical_locators.push_back(wrong_output_locator);
-    send_transport_under_test.CloseOutputChannel(
+    send_transport_under_test.cleanup_sender_resources(
         send_resource_list,
         wrong_remote_participant_physical_locators,
         initial_peer_list);
@@ -536,7 +536,7 @@ TEST_F(TCPv6Tests, remove_from_send_resource_list)
     // Using the correct locator should remove the channel resource
     LocatorList_t remote_participant_physical_locators;
     remote_participant_physical_locators.push_back(output_locator_1);
-    send_transport_under_test.CloseOutputChannel(
+    send_transport_under_test.cleanup_sender_resources(
         send_resource_list,
         remote_participant_physical_locators,
         initial_peer_list);
@@ -545,7 +545,7 @@ TEST_F(TCPv6Tests, remove_from_send_resource_list)
     // Using the initial peer locator should not remove the channel resource
     remote_participant_physical_locators.clear();
     remote_participant_physical_locators.push_back(output_locator_2);
-    send_transport_under_test.CloseOutputChannel(
+    send_transport_under_test.cleanup_sender_resources(
         send_resource_list,
         remote_participant_physical_locators,
         initial_peer_list);

--- a/versions.md
+++ b/versions.md
@@ -3,7 +3,7 @@ Forthcoming
 Migrate communication tests in `dds/communication` folder
 
 * Added authentication handshake properties.
-* Added methods OpenOutputChannel and CloseOutputChannel to TransportInterface with LocatorSelectorEntry argument.
+* Added methods OpenOutputChannels and CloseOutputChannels to TransportInterface with LocatorSelectorEntry argument.
 
 Version 2.13.0
 --------------

--- a/versions.md
+++ b/versions.md
@@ -3,6 +3,7 @@ Forthcoming
 Migrate communication tests in `dds/communication` folder
 
 * Added authentication handshake properties.
+* Added methods OpenOutputChannel and CloseOutputChannel to TransportInterface with LocatorSelectorEntry argument.
 
 Version 2.13.0
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Introduce new `OpenOutputChannels` and `CloseOutputChannels` methods to the `TransportInterface` base class, both accepting a `LocatorSelectorEntry` argument. This enhancement provides improved control over creating or destroying communication channels between participants.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.12.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
- This PR depends on  #4300 and must be merged after that one. 

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- N/A Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- ❌ Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- N/A New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- N/A Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
