### PR TITLE
[20502] TCP non_blocking_send moved to TCPTransportDescriptor

### DIFF
--- a/include/fastdds/rtps/transport/TCPTransportDescriptor.h
+++ b/include/fastdds/rtps/transport/TCPTransportDescriptor.h
@@ -289,7 +289,7 @@ struct TCPTransportDescriptor : public SocketTransportDescriptor
      * as if the datagram is sent but lost (i.e. throughput may be reduced). This value is
      * specially useful on high-frequency writers.
      *
-     * When set to false, calls to send() will block until the send buffer has space for the
+     * When set to false, which is the default, calls to send() will block until the send buffer has space for the
      * datagram. This may cause application lock.
      */
     bool non_blocking_send;

--- a/include/fastdds/rtps/transport/TCPTransportDescriptor.h
+++ b/include/fastdds/rtps/transport/TCPTransportDescriptor.h
@@ -53,6 +53,10 @@ namespace rtps {
  *
  * - \c tls_config: Configuration for TLS.
  *
+ * - \c non_blocking_send: do not block on send operations. When it is set to true, send operations will return
+ *      immediately if the buffer might get full, but no error will be returned to the upper layer. This means
+ *      that the application will behave as if the datagram is sent and lost.
+ *
  * @ingroup TRANSPORT_MODULE
  */
 struct TCPTransportDescriptor : public SocketTransportDescriptor
@@ -275,6 +279,20 @@ struct TCPTransportDescriptor : public SocketTransportDescriptor
 
     //! Thread settings for the accept connections thread
     ThreadSettings accept_thread;
+
+    /**
+     * Whether to use non-blocking calls to send().
+     *
+     * When set to true, calls to send() will return immediately if the send buffer might get full.
+     * This may happen when receive buffer on reader's side is full. No error will be returned
+     * to the upper layer. This means that the application will behave
+     * as if the datagram is sent but lost (i.e. throughput may be reduced). This value is
+     * specially useful on high-frequency writers.
+     *
+     * When set to false, calls to send() will block until the send buffer has space for the
+     * datagram. This may cause application lock.
+     */
+    bool non_blocking_send;
 
     //! Add listener port to the listening_ports list
     void add_listener_port(

--- a/resources/xsd/fastRTPS_profiles.xsd
+++ b/resources/xsd/fastRTPS_profiles.xsd
@@ -853,7 +853,7 @@
         ├ interfaceWhiteList        [0~*],                     (NOT  available for   SHM type)
         |   └ address               [ipv4Address|ipv6Address]
         ├ TTL                       [uint8],                   (ONLY available for  UDP  type)
-        ├ non_blocking_send         [boolean],                 (ONLY available for  UDP  type)
+        ├ non_blocking_send         [boolean],                 (NOT  available for   SHM type)
         ├ output_port               [uint16],                  (ONLY available for  UDP  type)
         ├ wan_addr                  [ipv4AddressFormat],       (ONLY available for TCPv4 type)
         ├ keep_alive_frequency_ms   [uint32],                  (ONLY available for TCP   type)

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
@@ -153,7 +153,7 @@ size_t TCPChannelResourceBasic::send(
     {
         std::lock_guard<std::mutex> send_guard(send_mutex_);
 
-        if (parent_->get_non_blocking_send() &&
+        if (parent_->configuration()->non_blocking_send &&
                 !check_socket_send_buffer(header_size + size, socket_->native_handle()))
         {
             return 0;

--- a/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
@@ -210,7 +210,7 @@ size_t TCPChannelResourceSecure::send(
 
     if (eConnecting < connection_status_)
     {
-        if (parent_->get_non_blocking_send() &&
+        if (parent_->configuration()->non_blocking_send &&
                 !check_socket_send_buffer(header_size + size,
                 secure_socket_->lowest_layer().native_handle()))
         {

--- a/src/cpp/rtps/transport/TCPTransportInterface.h
+++ b/src/cpp/rtps/transport/TCPTransportInterface.h
@@ -81,19 +81,6 @@ protected:
     asio::io_service io_service_timers_;
     std::unique_ptr<asio::ip::tcp::socket> initial_peer_local_locator_socket_;
     uint16_t initial_peer_local_locator_port_;
-    /**
-     * Whether to use non-blocking calls to send().
-     *
-     * When set to true, calls to send() will return immediately if the send buffer is full.
-     * This may happen when receive buffer on reader's side is full. No error will be returned
-     * to the upper layer. This means that the application will behave
-     * as if the datagram is sent but lost (i.e. throughput may be reduced). This value is
-     * specially useful on high-frequency writers.
-     *
-     * When set to false, calls to send() will block until the send buffer has space for the
-     * datagram. This may cause application lock.
-     */
-    bool non_blocking_send_;
 
 #if TLS_FOUND
     asio::ssl::context ssl_context_;
@@ -472,11 +459,6 @@ public:
      */
     void fill_local_physical_port(
             Locator& locator) const;
-
-    bool get_non_blocking_send() const
-    {
-        return non_blocking_send_;
-    }
 
 };
 

--- a/src/cpp/rtps/xmlparser/XMLParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLParser.cpp
@@ -710,6 +710,14 @@ XMLP_ret XMLParser::parseXMLCommonTCPTransportData(
                     return XMLP_ret::XML_ERROR;
                 }
             }
+            // non_blocking_send - boolType
+            else if (strcmp(name, NON_BLOCKING_SEND) == 0)
+            {
+                if (XMLP_ret::XML_OK != getXMLBool(p_aux0, &pTCPDesc->non_blocking_send, 0))
+                {
+                    return XMLP_ret::XML_ERROR;
+                }
+            }
             else if (strcmp(name, LISTENING_PORTS) == 0)
             {
                 // listening_ports uint16ListType

--- a/test/mock/rtps/TCPTransportDescriptor/fastrtps/transport/TCPTransportDescriptor.h
+++ b/test/mock/rtps/TCPTransportDescriptor/fastrtps/transport/TCPTransportDescriptor.h
@@ -172,6 +172,7 @@ typedef struct TCPTransportDescriptor : public SocketTransportDescriptor
     bool calculate_crc;
     bool check_crc;
     bool apply_security;
+    bool non_blocking_send;
 
     TLSConfig tls_config;
 

--- a/test/system/tools/xmlvalidation/XMLTesterExample_profile.xml
+++ b/test/system/tools/xmlvalidation/XMLTesterExample_profile.xml
@@ -51,6 +51,7 @@
                 <calculate_crc>false</calculate_crc>
                 <check_crc>false</check_crc>
                 <enable_tcp_nodelay>false</enable_tcp_nodelay>
+                <non_blocking_send>false</non_blocking_send>
             </transport_descriptor>
             <!-- UDP sample transport descriptor. Several options are common with TCP -->
             <transport_descriptor>

--- a/test/system/tools/xmlvalidation/all_profile.xml
+++ b/test/system/tools/xmlvalidation/all_profile.xml
@@ -893,6 +893,7 @@
                 <calculate_crc>false</calculate_crc>
                 <check_crc>false</check_crc>
                 <enable_tcp_nodelay>false</enable_tcp_nodelay>
+                <non_blocking_send>false</non_blocking_send>
             </transport_descriptor>
 
             <transport_descriptor>

--- a/test/system/tools/xmlvalidation/transportDescriptor_profile.xml
+++ b/test/system/tools/xmlvalidation/transportDescriptor_profile.xml
@@ -86,6 +86,7 @@
                 <calculate_crc>false</calculate_crc>
                 <check_crc>false</check_crc>
                 <enable_tcp_nodelay>false</enable_tcp_nodelay>
+                <non_blocking_send>false</non_blocking_send>
             </transport_descriptor>
 
             <transport_descriptor>

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -21,7 +21,6 @@
 #include "mock/MockTCPChannelResource.h"
 #include "mock/MockTCPv4Transport.h"
 #include <fastdds/dds/log/Log.hpp>
-#include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
 #include <fastrtps/transport/TCPv4TransportDescriptor.h>
 #include <fastrtps/utils/Semaphore.h>
 #include <fastrtps/utils/IPFinder.h>
@@ -1426,6 +1425,7 @@ TEST_F(TCPv4Tests, secure_non_blocking_send)
     using TLSHSRole = TCPTransportDescriptor::TLSConfig::TLSHandShakeRole;
     TCPv4TransportDescriptor senderDescriptor;
     senderDescriptor.add_listener_port(port);
+    senderDescriptor.non_blocking_send = true;
     senderDescriptor.sendBufferSize = msg_size;
     senderDescriptor.tls_config.handshake_role = TLSHSRole::CLIENT;
     senderDescriptor.tls_config.verify_file = "ca.crt";
@@ -1435,9 +1435,7 @@ TEST_F(TCPv4Tests, secure_non_blocking_send)
     senderDescriptor.tls_config.add_option(TLSOptions::NO_SSLV2);
     senderDescriptor.tls_config.add_option(TLSOptions::NO_COMPRESSION);
     MockTCPv4Transport senderTransportUnderTest(senderDescriptor);
-    eprosima::fastrtps::rtps::RTPSParticipantAttributes att;
-    att.properties.properties().emplace_back("fastdds.tcp_transport.non_blocking_send", "true");
-    senderTransportUnderTest.init(&att.properties);
+    senderTransportUnderTest.init();
 
     // Create a TCP Client socket.
     // The creation of a reception transport for testing this functionality is not
@@ -1976,11 +1974,10 @@ TEST_F(TCPv4Tests, non_blocking_send)
     // Create a TCP Server transport
     TCPv4TransportDescriptor senderDescriptor;
     senderDescriptor.add_listener_port(port);
+    senderDescriptor.non_blocking_send = true;
     senderDescriptor.sendBufferSize = msg_size;
     MockTCPv4Transport senderTransportUnderTest(senderDescriptor);
-    eprosima::fastrtps::rtps::RTPSParticipantAttributes att;
-    att.properties.properties().emplace_back("fastdds.tcp_transport.non_blocking_send", "true");
-    senderTransportUnderTest.init(&att.properties);
+    senderTransportUnderTest.init();
 
     // Create a TCP Client socket.
     // The creation of a reception transport for testing this functionality is not

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -326,11 +326,10 @@ TEST_F(TCPv6Tests, non_blocking_send)
     // Create a TCP Server transport
     TCPv6TransportDescriptor senderDescriptor;
     senderDescriptor.add_listener_port(port);
+    senderDescriptor.non_blocking_send = true;
     senderDescriptor.sendBufferSize = msg_size;
     MockTCPv6Transport senderTransportUnderTest(senderDescriptor);
-    eprosima::fastrtps::rtps::RTPSParticipantAttributes att;
-    att.properties.properties().emplace_back("fastdds.tcp_transport.non_blocking_send", "true");
-    senderTransportUnderTest.init(&att.properties);
+    senderTransportUnderTest.init();
 
     // Create a TCP Client socket.
     // The creation of a reception transport for testing this functionality is not

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -1020,6 +1020,7 @@ TEST_F(XMLParserTests, parseXMLTransportData)
                     <calculate_crc>false</calculate_crc>\
                     <check_crc>false</check_crc>\
                     <enable_tcp_nodelay>false</enable_tcp_nodelay>\
+                    <non_blocking_send>true</non_blocking_send>\
                     <tls><!-- TLS Section --></tls>\
                     <keep_alive_thread>\
                         <scheduling_policy>12</scheduling_policy>\
@@ -1086,6 +1087,7 @@ TEST_F(XMLParserTests, parseXMLTransportData)
         EXPECT_EQ(pTCPv4Desc->listening_ports[0], 5100u);
         EXPECT_EQ(pTCPv4Desc->listening_ports[1], 5200u);
         EXPECT_EQ(pTCPv4Desc->keep_alive_thread, modified_thread_settings);
+        EXPECT_EQ(pTCPv4Desc->non_blocking_send, true);
         EXPECT_EQ(pTCPv4Desc->accept_thread, modified_thread_settings);
         EXPECT_EQ(pTCPv4Desc->default_reception_threads(), modified_thread_settings);
         EXPECT_EQ(pTCPv4Desc->get_thread_config_for_port(12345), modified_thread_settings);
@@ -1115,8 +1117,9 @@ TEST_F(XMLParserTests, parseXMLTransportData)
         EXPECT_EQ(pTCPv6Desc->logical_port_increment, 2u);
         EXPECT_EQ(pTCPv6Desc->listening_ports[0], 5100u);
         EXPECT_EQ(pTCPv6Desc->listening_ports[1], 5200u);
-        EXPECT_EQ(pTCPv4Desc->keep_alive_thread, modified_thread_settings);
-        EXPECT_EQ(pTCPv4Desc->accept_thread, modified_thread_settings);
+        EXPECT_EQ(pTCPv6Desc->keep_alive_thread, modified_thread_settings);
+        EXPECT_EQ(pTCPv6Desc->non_blocking_send, true);
+        EXPECT_EQ(pTCPv6Desc->accept_thread, modified_thread_settings);
         EXPECT_EQ(pTCPv6Desc->default_reception_threads(), modified_thread_settings);
         EXPECT_EQ(pTCPv6Desc->get_thread_config_for_port(12345), modified_thread_settings);
         EXPECT_EQ(pTCPv6Desc->get_thread_config_for_port(12346), modified_thread_settings);
@@ -1236,6 +1239,7 @@ TEST_F(XMLParserTests, parseXMLTransportData_NegativeClauses)
         "calculate_crc",
         "check_crc",
         "enable_tcp_nodelay",
+        "non_blocking_send",
         "tls",
         "keep_alive_thread",
         "accept_thread",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Previously, the `non_blocking_send` mode for TCP was set as a non-consolidated QoS. It will now be configured as an attribute of the `TCPTransportDescriptor`.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.12.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- N/A Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- N/A New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    Related documentation PR: eProsima/Fast-DDS-docs https://github.com/eProsima/Fast-DDS-docs/pull/678
- N/A Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
