### PR TITLE
[20504] Just show warning when inconsistency between depth and max_samples_per_instance

### DIFF
--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1882,9 +1882,11 @@ ReturnCode_t DataWriterImpl::check_qos(
             qos.resource_limits().max_samples_per_instance > 0 &&
             qos.history().depth > qos.resource_limits().max_samples_per_instance)
     {
-        EPROSIMA_LOG_ERROR(RTPS_QOS_CHECK,
-                "HISTORY DEPTH must be lower or equal to the max_samples_per_instance value.");
-        return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
+        EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK,
+                "HISTORY DEPTH '" << qos.history().depth <<
+                "' is inconsistent with max_samples_per_instance: '" << qos.resource_limits().max_samples_per_instance <<
+                "'. Consistency rule: depth <= max_samples_per_instance." <<
+                " Effectively using max_samples_per_instance as depth.");
     }
     return ReturnCode_t::RETCODE_OK;
 }

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1510,9 +1510,11 @@ ReturnCode_t DataReaderImpl::check_qos(
             qos.resource_limits().max_samples_per_instance > 0 &&
             qos.history().depth > qos.resource_limits().max_samples_per_instance)
     {
-        EPROSIMA_LOG_ERROR(RTPS_QOS_CHECK,
-                "HISTORY DEPTH must be lower or equal to the max_samples_per_instance value.");
-        return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
+        EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK,
+                "HISTORY DEPTH '" << qos.history().depth <<
+                "' is inconsistent with max_samples_per_instance: '" << qos.resource_limits().max_samples_per_instance <<
+                "'. Consistency rule: depth <= max_samples_per_instance." <<
+                " Effectively using max_samples_per_instance as depth.");
     }
     return ReturnCode_t::RETCODE_OK;
 }

--- a/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
@@ -297,6 +297,17 @@ TEST(DDSDataReader, ConsistentReliabilityWhenIntraprocess)
     xmlparser::XMLProfileManager::library_settings(library_settings);
 }
 
+/**
+ * This is a regression test for issue https://eprosima.easyredmine.com/issues/20504.
+ * It checks that a DataReader be created with default Qos and a large history depth.
+ */
+TEST(DDSDataReader, default_qos_large_history_depth)
+{
+    PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+    reader.history_depth(1000).init();
+    ASSERT_TRUE(reader.isInitialized());
+}
+
 #ifdef INSTANTIATE_TEST_SUITE_P
 #define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_SUITE_P(x, y, z, w)
 #else

--- a/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
@@ -421,6 +421,17 @@ TEST(DDSDataWriter, HeartbeatWhileDestruction)
     }
 }
 
+/**
+ * This is a regression test for issue https://eprosima.easyredmine.com/issues/20504.
+ * It checks that a DataWriter be created with default Qos and a large history depth.
+ */
+TEST(DDSDataWriter, default_qos_large_history_depth)
+{
+    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+    writer.history_depth(1000).init();
+    ASSERT_TRUE(writer.isInitialized());
+}
+
 #ifdef INSTANTIATE_TEST_SUITE_P
 #define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_SUITE_P(x, y, z, w)
 #else

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
 #include <condition_variable>
+#include <cstdint>
+#include <memory>
 #include <mutex>
 #include <thread>
 
@@ -28,6 +31,7 @@
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/DomainParticipantListener.hpp>
 #include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
+#include <fastdds/dds/log/Log.hpp>
 #include <fastdds/dds/publisher/DataWriter.hpp>
 #include <fastdds/dds/publisher/DataWriterListener.hpp>
 #include <fastdds/dds/publisher/Publisher.hpp>
@@ -40,9 +44,8 @@
 #include <fastdds/rtps/writer/RTPSWriter.h>
 #include <fastdds/rtps/writer/StatefulWriter.h>
 
-#include "../../logging/mock/MockConsumer.h"
-
 #include "../../common/CustomPayloadPool.hpp"
+#include "../../logging/mock/MockConsumer.h"
 
 namespace eprosima {
 namespace fastdds {
@@ -2064,6 +2067,75 @@ TEST(DataWriterTests, CustomPoolCreation)
     participant->delete_contained_entities();
 
     DomainParticipantFactory::get_instance()->delete_participant(participant);
+}
+
+TEST(DataWriterTests, history_depth_max_samples_per_instance_warning)
+{
+
+    /* Setup log so it may catch the expected warning */
+    Log::ClearConsumers();
+    MockConsumer* mockConsumer = new MockConsumer("RTPS_QOS_CHECK");
+    Log::RegisterConsumer(std::unique_ptr<LogConsumer>(mockConsumer));
+    Log::SetVerbosity(Log::Warning);
+
+    /* Create a participant, topic, and a publisher */
+    DomainParticipant* participant = DomainParticipantFactory::get_instance()->create_participant(0,
+                    PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
+
+    TypeSupport type(new TopicDataTypeMock());
+    type.register_type(participant);
+
+    Topic* topic = participant->create_topic("footopic", type.get_type_name(), TOPIC_QOS_DEFAULT);
+    ASSERT_NE(topic, nullptr);
+
+    Publisher* publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT);
+    ASSERT_NE(publisher, nullptr);
+
+    /* Create a datawriter with the QoS that should generate a warning */
+    DataWriterQos qos;
+    qos.history().depth = 10;
+    qos.resource_limits().max_samples_per_instance = 5;
+    DataWriter* datawriter_1 = publisher->create_datawriter(topic, qos);
+    ASSERT_NE(datawriter_1, nullptr);
+
+    /* Check that the config generated a warning */
+    auto wait_for_log_entries =
+            [&mockConsumer](const uint32_t amount, const uint32_t retries, const uint32_t wait_ms) -> size_t
+            {
+                size_t entries = 0;
+                for (uint32_t i = 0; i < retries; i++)
+                {
+                    entries = mockConsumer->ConsumedEntries().size();
+                    if (entries >= amount)
+                    {
+                        break;
+                    }
+                    std::this_thread::sleep_for(std::chrono::milliseconds(wait_ms));
+                }
+                return entries;
+            };
+
+    const size_t expected_entries = 1;
+    const uint32_t retries = 4;
+    const uint32_t wait_ms = 25;
+    ASSERT_EQ(wait_for_log_entries(expected_entries, retries, wait_ms), expected_entries);
+
+    /* Check that the datawriter can send data */
+    FooType data;
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, datawriter_1->write(&data, HANDLE_NIL));
+
+    /* Check that a correctly initialized writer does not produce any warning */
+    qos.history().depth = 10;
+    qos.resource_limits().max_samples_per_instance = 10;
+    DataWriter* datawriter_2 = publisher->create_datawriter(topic, qos);
+    ASSERT_NE(datawriter_2, nullptr);
+    ASSERT_EQ(wait_for_log_entries(expected_entries, retries, wait_ms), expected_entries);
+
+    /* Tear down */
+    participant->delete_contained_entities();
+    DomainParticipantFactory::get_instance()->delete_participant(participant);
+    Log::KillThread();
 }
 
 } // namespace dds

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -728,8 +728,10 @@ TEST(DataWriterTests, InvalidQos)
     EXPECT_EQ(inconsistent_code, datawriter->set_qos(qos)); // KEEP LAST 0 is inconsistent
     qos.history().depth = 2;
     EXPECT_EQ(ReturnCode_t::RETCODE_OK, datawriter->set_qos(qos)); // KEEP LAST 2 is OK
-    qos.resource_limits().max_samples_per_instance = 1;
-    EXPECT_EQ(inconsistent_code, datawriter->set_qos(qos)); // KEEP LAST 2 but max_samples_per_instance 1 is inconsistent
+    // KEEP LAST 2000 but max_samples_per_instance default (400) is inconsistent but right now it only shows a warning
+    // This test will fail whenever we enforce the consistency between depth and max_samples_per_instance.
+    qos.history().depth = 2000;
+    EXPECT_EQ(ReturnCode_t::RETCODE_OK, datawriter->set_qos(qos));
 
     ASSERT_TRUE(publisher->delete_datawriter(datawriter) == ReturnCode_t::RETCODE_OK);
     ASSERT_TRUE(participant->delete_topic(topic) == ReturnCode_t::RETCODE_OK);

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -704,9 +704,13 @@ TEST_F(DataReaderTests, InvalidQos)
     qos.history().kind = KEEP_LAST_HISTORY_QOS;
     qos.history().depth = 0;
     EXPECT_EQ(inconsistent_code, data_reader_->set_qos(qos)); // KEEP LAST 0 is inconsistent
-    qos.history().depth = 2;
-    qos.resource_limits().max_samples_per_instance = 1;
-    EXPECT_EQ(inconsistent_code, data_reader_->set_qos(qos)); // KEEP LAST 2 but max_samples_per_instance 1 is inconsistent
+    // KEEP LAST 2000 but max_samples_per_instance default (400) is inconsistent but right now it only shows a warning
+    // In the reader, this returns RETCODE_INMUTABLE_POLICY, because the depth cannot be changed on run time.
+    // Because of the implementation, we know de consistency is checked before the inmutability, so by checking the
+    // return against RETCODE_INMUTABLE_POLICY we are testing that the setting are not considered inconsistent yet.
+    // This test will fail whenever we enforce the consistency between depth and max_samples_per_instance.
+    qos.history().depth = 2000;
+    EXPECT_EQ(ReturnCode_t::RETCODE_IMMUTABLE_POLICY, data_reader_->set_qos(qos));
 
     /* Inmutable QoS */
     const ReturnCode_t inmutable_code = ReturnCode_t::RETCODE_IMMUTABLE_POLICY;

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -15,6 +15,7 @@
 #include <array>
 #include <cassert>
 #include <chrono>
+#include <cstdint>
 #include <forward_list>
 #include <iostream>
 #include <memory>
@@ -22,58 +23,50 @@
 #include <thread>
 #include <type_traits>
 
+#include <asio.hpp>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <fastcdr/Cdr.h>
 
 #include <fastdds/dds/builtin/topic/PublicationBuiltinTopicData.hpp>
-
+#include <fastdds/dds/core/condition/WaitSet.hpp>
 #include <fastdds/dds/core/Entity.hpp>
 #include <fastdds/dds/core/LoanableArray.hpp>
 #include <fastdds/dds/core/LoanableCollection.hpp>
 #include <fastdds/dds/core/LoanableSequence.hpp>
 #include <fastdds/dds/core/StackAllocatedSequence.hpp>
-#include <fastdds/dds/core/condition/WaitSet.hpp>
 #include <fastdds/dds/core/status/BaseStatus.hpp>
 #include <fastdds/dds/core/status/SampleRejectedStatus.hpp>
 #include <fastdds/dds/core/status/SubscriptionMatchedStatus.hpp>
-
-#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
+#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/DomainParticipantListener.hpp>
-
+#include <fastdds/dds/log/Log.hpp>
 #include <fastdds/dds/publisher/DataWriter.hpp>
 #include <fastdds/dds/publisher/Publisher.hpp>
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
 #include <fastdds/dds/publisher/qos/PublisherQos.hpp>
-
 #include <fastdds/dds/subscriber/DataReader.hpp>
 #include <fastdds/dds/subscriber/DataReaderListener.hpp>
-#include <fastdds/dds/subscriber/SampleInfo.hpp>
-#include <fastdds/dds/subscriber/Subscriber.hpp>
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 #include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
-
+#include <fastdds/dds/subscriber/SampleInfo.hpp>
+#include <fastdds/dds/subscriber/Subscriber.hpp>
 #include <fastdds/rtps/common/Locator.h>
-#include <fastrtps/utils/IPLocator.h>
-
-#include "FooBoundedType.hpp"
-#include "FooBoundedTypeSupport.hpp"
-
-#include "FooType.hpp"
-#include "FooTypeSupport.hpp"
-
-#include "../../logging/mock/MockConsumer.h"
-
 #include <fastdds/rtps/transport/test_UDPv4TransportDescriptor.h>
+#include <fastrtps/utils/IPLocator.h>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 
 #include "../../common/CustomPayloadPool.hpp"
+#include "../../logging/mock/MockConsumer.h"
 #include "fastdds/dds/common/InstanceHandle.hpp"
 #include "fastdds/dds/core/policy/QosPolicies.hpp"
-
-#include <asio.hpp>
+#include "FooBoundedType.hpp"
+#include "FooBoundedTypeSupport.hpp"
+#include "FooType.hpp"
+#include "FooTypeSupport.hpp"
 
 #if defined(__cplusplus_winrt)
 #define GET_PID GetCurrentProcessId
@@ -3653,6 +3646,71 @@ TEST_F(DataReaderTests, UpdateInmutableQos)
     /* Cleanup */
     participant->delete_contained_entities();
     DomainParticipantFactory::get_instance()->delete_participant(participant);
+}
+
+TEST_F(DataReaderTests, history_depth_max_samples_per_instance_warning)
+{
+
+    /* Setup log so it may catch the expected warning */
+    Log::ClearConsumers();
+    MockConsumer* mockConsumer = new MockConsumer("RTPS_QOS_CHECK");
+    Log::RegisterConsumer(std::unique_ptr<LogConsumer>(mockConsumer));
+    Log::SetVerbosity(Log::Warning);
+
+    /* Create a participant, topic, and a subscriber */
+    DomainParticipant* participant = DomainParticipantFactory::get_instance()->create_participant(0,
+                    PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
+
+    TypeSupport type(new FooTypeSupport());
+    type.register_type(participant);
+
+    Topic* topic = participant->create_topic("footopic", type.get_type_name(), TOPIC_QOS_DEFAULT);
+    ASSERT_NE(topic, nullptr);
+
+    Subscriber* subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
+    ASSERT_NE(subscriber, nullptr);
+
+    /* Create a datareader with the QoS that should generate a warning */
+    DataReaderQos qos;
+    qos.history().depth = 10;
+    qos.resource_limits().max_samples_per_instance = 5;
+    DataReader* datareader_1 = subscriber->create_datareader(topic, qos);
+    ASSERT_NE(datareader_1, nullptr);
+
+    /* Check that the config generated a warning */
+    auto wait_for_log_entries =
+            [&mockConsumer](const uint32_t amount, const uint32_t retries, const uint32_t wait_ms) -> size_t
+            {
+                size_t entries = 0;
+                for (uint32_t i = 0; i < retries; i++)
+                {
+                    entries = mockConsumer->ConsumedEntries().size();
+                    if (entries >= amount)
+                    {
+                        break;
+                    }
+                    std::this_thread::sleep_for(std::chrono::milliseconds(wait_ms));
+                }
+                return entries;
+            };
+
+    const size_t expected_entries = 1;
+    const uint32_t retries = 4;
+    const uint32_t wait_ms = 25;
+    ASSERT_EQ(wait_for_log_entries(expected_entries, retries, wait_ms), expected_entries);
+
+    /* Check that a correctly initialized datareader does not produce any warning */
+    qos.history().depth = 10;
+    qos.resource_limits().max_samples_per_instance = 10;
+    DataReader* datareader_2 = subscriber->create_datareader(topic, qos);
+    ASSERT_NE(datareader_2, nullptr);
+    ASSERT_EQ(wait_for_log_entries(expected_entries, retries, wait_ms), expected_entries);
+
+    /* Tear down */
+    participant->delete_contained_entities();
+    DomainParticipantFactory::get_instance()->delete_participant(participant);
+    Log::KillThread();
 }
 
 int main(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This addresses a regression in ROS 2 (ros2/ros2#1527) after #4375 was merged.

Whenever a DataWriter is created taking the default `DataWriterQos`, and changing the history depth to a value greater than 400, the creation of the DataWriter fails. Same happens when creating a DataReader.

This PR partially reverts #4375, so the inconsistency is shown as a warnings instead of making the entity creation fail.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.10.x

*For the other branches, we'll include this as part of the corresponding backport of #4375)

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. Related documentation PR: eProsima/Fast-DDS-docs#679
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
