### PR TITLE
[20511] Remove use of deprecated FindPythonInterp

### DIFF
--- a/cmake/common/test_wrapper.cmake.in
+++ b/cmake/common/test_wrapper.cmake.in
@@ -1,8 +1,8 @@
-find_package(PythonInterp 3)
+find_package(Python3 COMPONENTS Interpreter)
 
 # Clean first so the exit code comes from the second process
-message(STATUS "test_wrapper - Running command: ${PYTHON_EXECUTABLE} @PROJECT_BINARY_DIR@/tools/fastdds/fastdds.py shm clean")
-execute_process(COMMAND ${PYTHON_EXECUTABLE} @PROJECT_BINARY_DIR@/tools/fastdds/fastdds.py shm clean)
+message(STATUS "test_wrapper - Running command: ${Python3_EXECUTABLE} @PROJECT_BINARY_DIR@/tools/fastdds/fastdds.py shm clean")
+execute_process(COMMAND ${Python3_EXECUTABLE} @PROJECT_BINARY_DIR@/tools/fastdds/fastdds.py shm clean)
 
 message(STATUS "test_wrapper - Running command: ${ACTUAL_TEST} ${ACTUAL_ARGS}")
 execute_process(COMMAND ${ACTUAL_TEST} ${ACTUAL_ARGS})

--- a/test/CTestCustom.cmake.in
+++ b/test/CTestCustom.cmake.in
@@ -1,3 +1,3 @@
-find_package(PythonInterp 3)
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../tools/fastdds/fastdds.py shm clean)
+execute_process(COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../tools/fastdds/fastdds.py shm clean)

--- a/test/communication/CMakeLists.txt
+++ b/test/communication/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_package(PythonInterp 3)
+find_package(Python3 COMPONENTS Interpreter)
 
 ###############################################################################
 # Binaries
@@ -202,9 +202,9 @@ if(SECURITY)
         ${CMAKE_CURRENT_BINARY_DIR}/permissions_helloworld_securehelloworld.smime COPYONLY)
 endif()
 
-if(PYTHONINTERP_FOUND)
+if(Python3_Interpreter_FOUND)
     add_test(NAME SimpleCommunicationBestEffort
-        COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${PYTHON_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/simple_communication.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
+        COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${Python3_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/simple_communication.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
 
     # Set test with label NoMemoryCheck
     set_property(TEST SimpleCommunicationBestEffort PROPERTY LABELS "NoMemoryCheck")
@@ -222,7 +222,7 @@ if(PYTHONINTERP_FOUND)
     endif()
 
     add_test(NAME SimpleCommunicationReliable
-        COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${PYTHON_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/simple_communication.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
+        COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${Python3_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/simple_communication.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
 
     # Set test with label NoMemoryCheck
     set_property(TEST SimpleCommunicationReliable PROPERTY LABELS "NoMemoryCheck")
@@ -240,7 +240,7 @@ if(PYTHONINTERP_FOUND)
     endif()
 
     add_test(NAME SimpleCommunicationReliableBestEffort
-        COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${PYTHON_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/simple_communication.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
+        COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${Python3_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/simple_communication.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
 
     # Set test with label NoMemoryCheck
     set_property(TEST SimpleCommunicationReliableBestEffort PROPERTY LABELS "NoMemoryCheck")
@@ -258,7 +258,7 @@ if(PYTHONINTERP_FOUND)
     endif()
 
     add_test(NAME SimpleMixCommunicationBestEffort
-        COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${PYTHON_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/simple_mix_communication.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
+        COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${Python3_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/simple_mix_communication.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
 
     # Set test with label NoMemoryCheck
     set_property(TEST SimpleMixCommunicationBestEffort PROPERTY LABELS "NoMemoryCheck")
@@ -276,7 +276,7 @@ if(PYTHONINTERP_FOUND)
     endif()
 
     add_test(NAME SimpleMixCommunicationReliable
-        COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${PYTHON_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/simple_mix_communication.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
+        COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${Python3_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/simple_mix_communication.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
 
     # Set test with label NoMemoryCheck
     set_property(TEST SimpleMixCommunicationReliable PROPERTY LABELS "NoMemoryCheck")
@@ -295,7 +295,7 @@ if(PYTHONINTERP_FOUND)
 
     if(SECURITY)
         add_test(NAME SimpleCommunicationSecureBestEffort
-            COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${PYTHON_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/simple_communication.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
+            COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${Python3_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/simple_communication.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
 
         # Set test with label NoMemoryCheck
         set_property(TEST SimpleCommunicationSecureBestEffort PROPERTY LABELS "NoMemoryCheck")
@@ -317,7 +317,7 @@ if(PYTHONINTERP_FOUND)
         endif()
 
         add_test(NAME SimpleCommunicationSecureMsgCryptoBestEffort
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_subs_secure_crypto_communication.py
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_subs_secure_crypto_communication.py
             --pub $<TARGET_FILE:SimpleCommunicationPublisher>
             --xml-pub secure_msg_crypto_besteffort_pub_profile.xml
             --sub $<TARGET_FILE:SimpleCommunicationSubscriber>
@@ -334,7 +334,7 @@ if(PYTHONINTERP_FOUND)
         endif()
 
         add_test(NAME SimpleCommunicationSecureMsgSubmsgCryptoBestEffort
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_subs_secure_crypto_communication.py
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_subs_secure_crypto_communication.py
             --pub $<TARGET_FILE:SimpleCommunicationPublisher>
             --xml-pub secure_msg_submsg_crypto_besteffort_pub_profile.xml
             --sub $<TARGET_FILE:SimpleCommunicationSubscriber>
@@ -351,7 +351,7 @@ if(PYTHONINTERP_FOUND)
         endif()
 
         add_test(NAME SimpleCommunicationSecureSubmsgCryptoBestEffort
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_subs_secure_crypto_communication.py
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_subs_secure_crypto_communication.py
             --pub $<TARGET_FILE:SimpleCommunicationPublisher>
             --xml-pub secure_submsg_crypto_besteffort_pub_profile.xml
             --sub $<TARGET_FILE:SimpleCommunicationSubscriber>
@@ -368,7 +368,7 @@ if(PYTHONINTERP_FOUND)
         endif()
 
         add_test(NAME SecureDiscoverServerSimplePubSubSecureMsgCrypto
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/secure_ds_pubsub_secure_crypto_communication.py
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/secure_ds_pubsub_secure_crypto_communication.py
             --pub $<TARGET_FILE:SimpleCommunicationPublisher>
             --xml-pub secure_ds_simple_secure_msg_crypto_pub_profile.xml
             --sub $<TARGET_FILE:SimpleCommunicationSubscriber>
@@ -388,7 +388,7 @@ if(PYTHONINTERP_FOUND)
         endif()
 
         add_test(NAME SecureDiscoverServerSimplePubSubSecureNoDiscoveryNoRTPSProtectionMsgCrypto
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/secure_ds_pubsub_secure_crypto_communication.py
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/secure_ds_pubsub_secure_crypto_communication.py
             --pub $<TARGET_FILE:SimpleCommunicationPublisher>
             --xml-pub secure_ds_simple_secure_no_discovery_no_rtps_protection_pub_profile.xml
             --sub $<TARGET_FILE:SimpleCommunicationSubscriber>
@@ -408,7 +408,7 @@ if(PYTHONINTERP_FOUND)
         endif()
 
         add_test(NAME SecureDiscoverServerSimplePubSubSecureNoDiscoveryProtectionMsgCrypto
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/secure_ds_pubsub_secure_crypto_communication.py
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/secure_ds_pubsub_secure_crypto_communication.py
             --pub $<TARGET_FILE:SimpleCommunicationPublisher>
             --xml-pub secure_ds_simple_secure_no_discovery_protection_pub_profile.xml
             --sub $<TARGET_FILE:SimpleCommunicationSubscriber>
@@ -428,7 +428,7 @@ if(PYTHONINTERP_FOUND)
         endif()
 
         add_test(NAME SecureDiscoverServerSimplePubSubSecureNoRTPSProtectionMsgCrypto
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/secure_ds_pubsub_secure_crypto_communication.py
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/secure_ds_pubsub_secure_crypto_communication.py
             --pub $<TARGET_FILE:SimpleCommunicationPublisher>
             --xml-pub secure_ds_simple_secure_no_rtps_protection_pub_profile.xml
             --sub $<TARGET_FILE:SimpleCommunicationSubscriber>
@@ -448,7 +448,7 @@ if(PYTHONINTERP_FOUND)
         endif()
 
         add_test(NAME TwoSecureDiscoverServersSimplePubSubSecureMsgCrypto
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_secure_ds_pubsub_secure_crypto_communication.py
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_secure_ds_pubsub_secure_crypto_communication.py
             --pub $<TARGET_FILE:SimpleCommunicationPublisher>
             --xml-pub secure_ds_simple_secure_msg_crypto_pub_profile.xml
             --sub $<TARGET_FILE:SimpleCommunicationSubscriber>
@@ -467,7 +467,7 @@ if(PYTHONINTERP_FOUND)
         endif()
 
         add_test(NAME TwoSecureDiscoverServersSimplePubSubSecureNoDiscoveryNoRTPSProtectionMsgCrypto
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_secure_ds_pubsub_secure_crypto_communication.py
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_secure_ds_pubsub_secure_crypto_communication.py
             --pub $<TARGET_FILE:SimpleCommunicationPublisher>
             --xml-pub secure_ds_simple_secure_no_discovery_no_rtps_protection_pub_profile.xml
             --sub $<TARGET_FILE:SimpleCommunicationSubscriber>
@@ -486,7 +486,7 @@ if(PYTHONINTERP_FOUND)
         endif()
 
         add_test(NAME TwoSecureDiscoverServersSimplePubSubSecureNoDiscoveryProtectionMsgCrypto
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_secure_ds_pubsub_secure_crypto_communication.py
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_secure_ds_pubsub_secure_crypto_communication.py
             --pub $<TARGET_FILE:SimpleCommunicationPublisher>
             --xml-pub secure_ds_simple_secure_no_discovery_protection_pub_profile.xml
             --sub $<TARGET_FILE:SimpleCommunicationSubscriber>
@@ -505,7 +505,7 @@ if(PYTHONINTERP_FOUND)
         endif()
 
         add_test(NAME TwoSecureDiscoverServersSimplePubSubSecureNoRTPSProtectionMsgCrypto
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_secure_ds_pubsub_secure_crypto_communication.py
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_secure_ds_pubsub_secure_crypto_communication.py
             --pub $<TARGET_FILE:SimpleCommunicationPublisher>
             --xml-pub secure_ds_simple_secure_no_rtps_protection_pub_profile.xml
             --sub $<TARGET_FILE:SimpleCommunicationSubscriber>
@@ -524,7 +524,7 @@ if(PYTHONINTERP_FOUND)
         endif()
 
         add_test(NAME AllowUnauthenticatedSimplePubSecureNoRTPSProtectionSubNonSecure
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_subs_secure_crypto_communication.py
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_subs_secure_crypto_communication.py
             --n-subs 1
             --pub $<TARGET_FILE:SimpleCommunicationPublisher>
             --xml-pub simple_secure_allow_unauthenticated_pub_profile.xml
@@ -544,7 +544,7 @@ if(PYTHONINTERP_FOUND)
     endif()
 
     add_test(NAME LivelinessAssertion
-        COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${PYTHON_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/liveliness_assertion.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
+        COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${Python3_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/liveliness_assertion.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
 
     # Set test with label NoMemoryCheck
     set_property(TEST LivelinessAssertion PROPERTY LABELS "NoMemoryCheck")
@@ -559,7 +559,7 @@ if(PYTHONINTERP_FOUND)
             "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$<TARGET_FILE_DIR:fastcdr>\\;${WIN_PATH}")
     endif()
     add_test(NAME AutomaticLivelinessAssertion
-        COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${PYTHON_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/automatic_liveliness_assertion.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
+        COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${Python3_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/automatic_liveliness_assertion.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
 
     # Set test with label NoMemoryCheck
     set_property(TEST AutomaticLivelinessAssertion PROPERTY LABELS "NoMemoryCheck")
@@ -575,7 +575,7 @@ if(PYTHONINTERP_FOUND)
     endif()
 
     add_test(NAME TwoPublishersCommunicationBestEffort
-        COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${PYTHON_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/two_publishers_communication.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
+        COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${Python3_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/two_publishers_communication.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
 
     # Set test with label NoMemoryCheck
     set_property(TEST TwoPublishersCommunicationBestEffort PROPERTY LABELS "NoMemoryCheck")
@@ -593,7 +593,7 @@ if(PYTHONINTERP_FOUND)
     endif()
 
     add_test(NAME TwoPublishersCommunicationReliable
-        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/two_publishers_communication.py)
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/two_publishers_communication.py)
 
     # Set test with label NoMemoryCheck
     set_property(TEST TwoPublishersCommunicationReliable PROPERTY LABELS "NoMemoryCheck")
@@ -611,7 +611,7 @@ if(PYTHONINTERP_FOUND)
     endif()
 
     add_test(NAME SimpleCommunicationBestEffortFixed
-        COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${PYTHON_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/simple_communication.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
+        COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${Python3_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/simple_communication.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
 
     # Set test with label NoMemoryCheck
     set_property(TEST SimpleCommunicationBestEffortFixed PROPERTY LABELS "NoMemoryCheck")
@@ -633,7 +633,7 @@ if(PYTHONINTERP_FOUND)
     endif()
 
     add_test(NAME SHMCommunicationSubscriberDiesWhileProcessingMessage
-        COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${PYTHON_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/shm_communication_subscriber_dies_while_processing_message.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
+        COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${Python3_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/shm_communication_subscriber_dies_while_processing_message.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
 
     # Set test with label NoMemoryCheck
     set_property(TEST SHMCommunicationSubscriberDiesWhileProcessingMessage PROPERTY LABELS "NoMemoryCheck")

--- a/test/dds/communication/CMakeLists.txt
+++ b/test/dds/communication/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_package(PythonInterp 3)
+find_package(Python3 COMPONENTS Interpreter)
 
 add_definitions(
     -DBOOST_ASIO_STANDALONE
@@ -165,10 +165,10 @@ endif()
 ###############################################################################
 # Tests specification
 ###############################################################################
-if(PYTHONINTERP_FOUND)
+if(Python3_Interpreter_FOUND)
     # Dynamic types test
     add_test(NAME DDSSimpleCommunicationTypeDiscovery
-        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/simple_communication_dynamic.py)
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/simple_communication_dynamic.py)
 
     # Set test with label NoMemoryCheck
     set_property(TEST DDSSimpleCommunicationTypeDiscovery PROPERTY LABELS "NoMemoryCheck")
@@ -190,7 +190,7 @@ if(PYTHONINTERP_FOUND)
         set(TEST_NAME DDSCommunication_${TEST_DEFINITION})
         add_test(
             NAME ${TEST_NAME}
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/${TEST_BUILDER}
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/${TEST_BUILDER}
             ${TEST_DEFINITION}.json
             )
 

--- a/test/dds/discovery/CMakeLists.txt
+++ b/test/dds/discovery/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
-    find_package(PythonInterp 3)
+    find_package(Python3 COMPONENTS Interpreter)
 
     ###########################################################################
     # Binaries
@@ -46,9 +46,9 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
         math(EXPR W_UNICAST_PORT_RANDOM_NUMBER "${W_UNICAST_PORT_RANDOM_NUMBER} + 1024")
     endif()
 
-    if(PYTHONINTERP_FOUND AND NOT APPLE AND NOT WIN32)
+    if(Python3_Interpreter_FOUND AND NOT APPLE AND NOT WIN32)
         add_test(NAME AddDiscoveryServerToListFromEnvironmentFile
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/client_server_dynamic_discovery.py)
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/client_server_dynamic_discovery.py)
 
         set_property(TEST AddDiscoveryServerToListFromEnvironmentFile PROPERTY ENVIRONMENT
             "CLIENT_SERVER_DYNAMIC_DISCOVERY_BIN=$<TARGET_FILE:DDSParticipantDiscovery>")

--- a/test/performance/latency/CMakeLists.txt
+++ b/test/performance/latency/CMakeLists.txt
@@ -104,8 +104,8 @@ endforeach(latency_test_name)
 ###########################################################################
 # Create tests                                                            #
 ###########################################################################
-find_package(PythonInterp 3 REQUIRED)
-if(PYTHONINTERP_FOUND)
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+if(Python3_Interpreter_FOUND)
     # Loop over the test names
     foreach(latency_test_name ${LATENCY_TEST_LIST})
 
@@ -135,7 +135,7 @@ if(PYTHONINTERP_FOUND)
         # Add the test
         add_test(
             NAME performance.latency.${latency_test_name}
-            COMMAND ${PYTHON_EXECUTABLE}
+            COMMAND ${Python3_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/latency_tests.py
             ${LATENCY_TEST_BIN}
             --xml_file ${CMAKE_CURRENT_SOURCE_DIR}/xml/${latency_test_name}.xml
@@ -172,7 +172,7 @@ if(PYTHONINTERP_FOUND)
 
             add_test(
                 NAME performance.latency.${latency_test_name}.security
-                COMMAND ${PYTHON_EXECUTABLE}
+                COMMAND ${Python3_EXECUTABLE}
                 ${CMAKE_CURRENT_SOURCE_DIR}/latency_tests.py
                 ${LATENCY_TEST_BIN}
                 --xml_file ${CMAKE_CURRENT_SOURCE_DIR}/xml/${latency_test_name}.xml
@@ -198,7 +198,7 @@ if(PYTHONINTERP_FOUND)
 
             add_test(
                 NAME performance.latency.${latency_test_name}.data_sharing
-                COMMAND ${PYTHON_EXECUTABLE}
+                COMMAND ${Python3_EXECUTABLE}
                 ${CMAKE_CURRENT_SOURCE_DIR}/latency_tests.py
                 ${LATENCY_TEST_BIN}
                 --xml_file ${CMAKE_CURRENT_SOURCE_DIR}/xml/${latency_test_name}.xml
@@ -218,7 +218,7 @@ if(PYTHONINTERP_FOUND)
 
             add_test(
                 NAME performance.latency.${latency_test_name}.data_loans
-                COMMAND ${PYTHON_EXECUTABLE}
+                COMMAND ${Python3_EXECUTABLE}
                 ${CMAKE_CURRENT_SOURCE_DIR}/latency_tests.py
                 ${LATENCY_TEST_BIN}
                 --xml_file ${CMAKE_CURRENT_SOURCE_DIR}/xml/${latency_test_name}.xml
@@ -236,7 +236,7 @@ if(PYTHONINTERP_FOUND)
 
                 add_test(
                     NAME performance.latency.${latency_test_name}.data_loans.security
-                    COMMAND ${PYTHON_EXECUTABLE}
+                    COMMAND ${Python3_EXECUTABLE}
                     ${CMAKE_CURRENT_SOURCE_DIR}/latency_tests.py
                     ${LATENCY_TEST_BIN}
                     --xml_file ${CMAKE_CURRENT_SOURCE_DIR}/xml/${latency_test_name}.xml
@@ -265,7 +265,7 @@ if(PYTHONINTERP_FOUND)
 
             add_test(
                 NAME performance.latency.${latency_test_name}.data_loans_and_sharing
-                COMMAND ${PYTHON_EXECUTABLE}
+                COMMAND ${Python3_EXECUTABLE}
                 ${CMAKE_CURRENT_SOURCE_DIR}/latency_tests.py
                 ${LATENCY_TEST_BIN}
                 --xml_file ${CMAKE_CURRENT_SOURCE_DIR}/xml/${latency_test_name}.xml

--- a/test/performance/throughput/CMakeLists.txt
+++ b/test/performance/throughput/CMakeLists.txt
@@ -104,8 +104,8 @@ endforeach(throughput_test_name)
 ###########################################################################
 # Create tests                                                            #
 ###########################################################################
-find_package(PythonInterp 3 REQUIRED)
-if(PYTHONINTERP_FOUND)
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+if(Python3_Interpreter_FOUND)
     # Loop over the test names
     foreach(throughput_test_name ${THROUGHPUT_TEST_LIST})
 
@@ -135,7 +135,7 @@ if(PYTHONINTERP_FOUND)
         # Add the test
         add_test(
             NAME performance.throughput.${throughput_test_name}
-            COMMAND ${PYTHON_EXECUTABLE}
+            COMMAND ${Python3_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py
             --xml_file ${CMAKE_CURRENT_SOURCE_DIR}/xml/${throughput_test_name}.xml
             --recoveries_file ${CMAKE_CURRENT_SOURCE_DIR}/recoveries.csv
@@ -171,7 +171,7 @@ if(PYTHONINTERP_FOUND)
 
             add_test(
                 NAME performance.throughput.${throughput_test_name}.security
-                COMMAND ${PYTHON_EXECUTABLE}
+                COMMAND ${Python3_EXECUTABLE}
                 ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py
                 --xml_file ${CMAKE_CURRENT_SOURCE_DIR}/xml/${throughput_test_name}.xml
                 --recoveries_file ${CMAKE_CURRENT_SOURCE_DIR}/recoveries.csv
@@ -197,7 +197,7 @@ if(PYTHONINTERP_FOUND)
 
             add_test(
                 NAME performance.throughput.${throughput_test_name}.data_sharing
-                COMMAND ${PYTHON_EXECUTABLE}
+                COMMAND ${Python3_EXECUTABLE}
                 ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py
                 --xml_file ${CMAKE_CURRENT_SOURCE_DIR}/xml/${throughput_test_name}.xml
                 --recoveries_file ${CMAKE_CURRENT_SOURCE_DIR}/recoveries.csv
@@ -217,7 +217,7 @@ if(PYTHONINTERP_FOUND)
 
             add_test(
                 NAME performance.throughput.${throughput_test_name}.data_loans
-                COMMAND ${PYTHON_EXECUTABLE}
+                COMMAND ${Python3_EXECUTABLE}
                 ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py
                 --xml_file ${CMAKE_CURRENT_SOURCE_DIR}/xml/${throughput_test_name}.xml
                 --recoveries_file ${CMAKE_CURRENT_SOURCE_DIR}/recoveries.csv
@@ -234,7 +234,7 @@ if(PYTHONINTERP_FOUND)
 
                 add_test(
                     NAME performance.throughput.${throughput_test_name}.data_loans.security
-                    COMMAND ${PYTHON_EXECUTABLE}
+                    COMMAND ${Python3_EXECUTABLE}
                     ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py
                     --xml_file ${CMAKE_CURRENT_SOURCE_DIR}/xml/${throughput_test_name}.xml
                     --recoveries_file ${CMAKE_CURRENT_SOURCE_DIR}/recoveries.csv
@@ -263,7 +263,7 @@ if(PYTHONINTERP_FOUND)
 
             add_test(
                 NAME performance.throughput.${throughput_test_name}.data_loans_and_sharing
-                COMMAND ${PYTHON_EXECUTABLE}
+                COMMAND ${Python3_EXECUTABLE}
                 ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py
                 --xml_file ${CMAKE_CURRENT_SOURCE_DIR}/xml/${throughput_test_name}.xml
                 --recoveries_file ${CMAKE_CURRENT_SOURCE_DIR}/recoveries.csv

--- a/test/performance/video/CMakeLists.txt
+++ b/test/performance/video/CMakeLists.txt
@@ -160,15 +160,15 @@ if(GST_FOUND)
     ###########################################################################
     # Create tests                                                            #
     ###########################################################################
-    find_package(PythonInterp 3 REQUIRED)
-    if(PYTHONINTERP_FOUND)
+    find_package(Python3 COMPONENTS Interpreter REQUIRED)
+    if(Python3_Interpreter_FOUND)
         if(GST_FOUND)
             # Loop over the test names
             foreach(video_test_name ${VIDEO_TEST_LIST})
                 # Add the test
                 add_test(
                     NAME performance.video.${video_test_name}
-                    COMMAND ${PYTHON_EXECUTABLE}
+                    COMMAND ${Python3_EXECUTABLE}
                     ${CMAKE_CURRENT_SOURCE_DIR}/video_tests.py
                     --xml_file ${CMAKE_CURRENT_SOURCE_DIR}/xml/${video_test_name}.xml
                 )
@@ -209,7 +209,7 @@ if(GST_FOUND)
                     # Add the secure verison
                     add_test(
                         NAME performance.video.${video_test_name}_security
-                        COMMAND ${PYTHON_EXECUTABLE}
+                        COMMAND ${Python3_EXECUTABLE}
                         ${CMAKE_CURRENT_SOURCE_DIR}/video_tests.py
                         --xml_file ${CMAKE_CURRENT_SOURCE_DIR}/xml/${video_test_name}.xml
                     )

--- a/test/profiling/CMakeLists.txt
+++ b/test/profiling/CMakeLists.txt
@@ -48,14 +48,14 @@ configure_file("cycles_tests.py" "cycles_tests.py")
 configure_file("memory_tests.py" "memory_tests.py")
 configure_file("memory_analysis.py" "memory_analysis.py")
 
-find_package(PythonInterp 3 REQUIRED)
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
-if(PYTHONINTERP_FOUND)
+if(Python3_Interpreter_FOUND)
     ###############################################################################
     # MemoryTest
     ###############################################################################
     add_test(NAME MemoryTest
-        COMMAND ${PYTHON_EXECUTABLE} memory_tests.py)
+        COMMAND ${Python3_EXECUTABLE} memory_tests.py)
 
     # Set test with label NoMemoryCheck
     set_property(TEST MemoryTest PROPERTY LABELS "NoMemoryCheck")
@@ -77,7 +77,7 @@ if(PYTHONINTERP_FOUND)
     # CyclesTest
     ###############################################################################
     add_test(NAME CyclesTest
-        COMMAND ${PYTHON_EXECUTABLE} cycles_tests.py)
+        COMMAND ${Python3_EXECUTABLE} cycles_tests.py)
 
     # Set test with label NoMemoryCheck
     set_property(TEST CyclesTest PROPERTY LABELS "NoMemoryCheck")

--- a/test/system/tools/fastdds/CMakeLists.txt
+++ b/test/system/tools/fastdds/CMakeLists.txt
@@ -16,9 +16,9 @@
 # Create tests                                                            #
 ###########################################################################
 
-find_package(PythonInterp 3 REQUIRED)
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
-if(PYTHONINTERP_FOUND)
+if(Python3_Interpreter_FOUND)
 
     set(TESTS
         test_fastdds_installed
@@ -31,7 +31,7 @@ if(PYTHONINTERP_FOUND)
     foreach(TEST IN LISTS TESTS)
         add_test(
                 NAME system.tools.fastdds.${TEST}
-                COMMAND ${PYTHON_EXECUTABLE}
+                COMMAND ${Python3_EXECUTABLE}
                 ${CMAKE_CURRENT_SOURCE_DIR}/tests.py
                 ${CMAKE_INSTALL_PREFIX}
                 ${TEST}

--- a/test/system/tools/fds/CMakeLists.txt
+++ b/test/system/tools/fds/CMakeLists.txt
@@ -16,9 +16,9 @@
 # Create tests                                                            #
 ###########################################################################
 
-find_package(PythonInterp 3 REQUIRED)
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
-if(PYTHONINTERP_FOUND)
+if(Python3_Interpreter_FOUND)
 
     set(TESTS
         test_fast_discovery_closure
@@ -97,7 +97,7 @@ if(PYTHONINTERP_FOUND)
            add_test(
                     NAME system.tools.fastdds.${TEST}
                     COMMAND powershell "-File" ${PWS_LAUNCHER}
-                            ${PYTHON_EXECUTABLE}
+                            ${Python3_EXECUTABLE}
                             ${CMAKE_CURRENT_SOURCE_DIR}/tests.py
                             $<TARGET_FILE:fast-discovery-server>
                             ${TEST}
@@ -105,7 +105,7 @@ if(PYTHONINTERP_FOUND)
         else()
             add_test(
                     NAME system.tools.fastdds.${TEST}
-                    COMMAND ${PYTHON_EXECUTABLE}
+                    COMMAND ${Python3_EXECUTABLE}
                             ${CMAKE_CURRENT_SOURCE_DIR}/tests.py
                             $<TARGET_FILE:fast-discovery-server>
                             ${TEST}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

[`FindPythonInterp`](https://cmake.org/cmake/help/latest/policy/CMP0148.html) has been deprecated since CMake 3.12. This PR finds the python interpreter within CMake files using the supported [`FindPython3`](https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3). This change if motivated by the intention of supporting Ubuntu 24.04, that ships CMake 3.28.3, version in which a CMake warning about `FindPythonInterp` is shown; this warning was introduced in CMake 3.27.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.13.x 2.12.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- _N/A_: The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- _N/A_: Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
