### PR TITLE
Fix warnings when compiling for Windows x86 [20519]

### DIFF
--- a/src/cpp/utils/threading/threading_win32.ipp
+++ b/src/cpp/utils/threading/threading_win32.ipp
@@ -21,12 +21,13 @@
 
 namespace eprosima {
 
-template<typename... Args>
+template<typename ... Args>
 static void set_name_to_current_thread_impl(
-    const char* fmt, Args... args)
+        const char* fmt,
+        Args... args)
 {
     char thread_name[16]{};
-    snprintf(thread_name, 16, fmt, args...);
+    snprintf(thread_name, 16, fmt, args ...);
 
     std::wstringstream stream;
     stream << thread_name;
@@ -63,7 +64,8 @@ static void configure_current_thread_priority(
     {
         if (0 == SetThreadPriority(GetCurrentThread(), priority))
         {
-            EPROSIMA_LOG_ERROR(SYSTEM, "Error '" << GetLastError() << "' configuring priority for thread " << GetCurrentThread());
+            EPROSIMA_LOG_ERROR(SYSTEM,
+                    "Error '" << GetLastError() << "' configuring priority for thread " << GetCurrentThread());
         }
     }
 }
@@ -73,9 +75,10 @@ static void configure_current_thread_affinity(
 {
     if (affinity_mask != 0)
     {
-        if (0 == SetThreadAffinityMask(GetCurrentThread(), affinity_mask))
+        if (0 == SetThreadAffinityMask(GetCurrentThread(), static_cast<DWORD_PTR>(affinity_mask)))
         {
-            EPROSIMA_LOG_ERROR(SYSTEM, "Error '" << GetLastError() << "' configuring affinity for thread " << GetCurrentThread());
+            EPROSIMA_LOG_ERROR(SYSTEM,
+                    "Error '" << GetLastError() << "' configuring affinity for thread " << GetCurrentThread());
         }
     }
 }

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -575,7 +575,7 @@ public:
                 {
                     return current_unread_count_ >= n_unread;
                 });
-        return current_unread_count_;
+        return static_cast<size_t>(current_unread_count_);
     }
 
     void block(

--- a/test/blackbox/common/BlackboxTestsNetworkConf.cpp
+++ b/test/blackbox/common/BlackboxTestsNetworkConf.cpp
@@ -429,7 +429,7 @@ TEST_P(NetworkConfig, PubSubAsymmetricInterfaceWhitelistLocalhostOnly)
 {
 #ifdef _WIN32
     GTEST_SKIP() << "This test is skipped on Windows";
-#endif // _WIN32
+#else
     std::vector<IPFinder::info_IP> no_interfaces;
 
     std::vector<IPFinder::info_IP> locahost_interface_only;
@@ -481,6 +481,7 @@ TEST_P(NetworkConfig, PubSubAsymmetricInterfaceWhitelistLocalhostOnly)
             interface_whitelist_test(no_interfaces, locahost_interface_only, true);
         }
     }
+#endif // _WIN32
 }
 
 // Regression test for redmine issue #18854 to check in UDP that setting the interface whitelist in one

--- a/test/blackbox/common/BlackboxTestsTransportUDP.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportUDP.cpp
@@ -524,7 +524,7 @@ void deliver_datagram_from_file(
     std::basic_ifstream<char> file(filename, std::ios::binary | std::ios::in);
 
     file.seekg(0, file.end);
-    auto file_size = file.tellg();
+    size_t file_size = static_cast<size_t>(file.tellg());
     file.seekg(0, file.beg);
 
     std::vector<uint8_t> buf(file_size);

--- a/test/blackbox/common/BlackboxTestsTransportUDP.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportUDP.cpp
@@ -524,7 +524,7 @@ void deliver_datagram_from_file(
     std::basic_ifstream<char> file(filename, std::ios::binary | std::ios::in);
 
     file.seekg(0, file.end);
-    size_t file_size = file.tellg();
+    auto file_size = file.tellg();
     file.seekg(0, file.beg);
 
     std::vector<uint8_t> buf(file_size);

--- a/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
@@ -835,12 +835,8 @@ struct ConnectionListSampleValidator : public SampleValidator
 
                                     return expected_locators_found;
                                 }
-                                else
-                                {
-                                    return false;
-                                }
 
-                                return true;
+                                return false;
                             });
 
             ASSERT_NE(it, total_msgs.end());


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Fix warnings when compiling for Windows x86
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.13.x 2.12.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- *N/A* Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- *N/A* Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- *N/A* Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.

