### PR TITLE
[20517] Force usage of semicolon in FASTDDS_TODO_BEFORE macro

### DIFF
--- a/include/fastdds/dds/domain/DomainParticipantListener.hpp
+++ b/include/fastdds/dds/domain/DomainParticipantListener.hpp
@@ -70,7 +70,7 @@ public:
      * @param[out] participant Pointer to the Participant which discovered the remote participant.
      * @param[out] info Remote participant information. User can take ownership of the object.
      */
-    FASTDDS_TODO_BEFORE(3, 0, "Remove this overload")
+    FASTDDS_TODO_BEFORE(3, 0, "Remove this overload");
     virtual void on_participant_discovery(
             DomainParticipant* participant,
             fastrtps::rtps::ParticipantDiscoveryInfo&& info)

--- a/include/fastdds/rtps/transport/TCPTransportDescriptor.h
+++ b/include/fastdds/rtps/transport/TCPTransportDescriptor.h
@@ -251,13 +251,13 @@ struct TCPTransportDescriptor : public SocketTransportDescriptor
     //! Increment between logical ports to try during RTCP negotiation
     uint16_t logical_port_increment;
 
-    FASTDDS_TODO_BEFORE(3, 0, "Eliminate tcp_negotiation_timeout, variable not in use.")
+    FASTDDS_TODO_BEFORE(3, 0, "Eliminate tcp_negotiation_timeout, variable not in use.");
     uint32_t tcp_negotiation_timeout;
 
     //! Enables the TCP_NODELAY socket option
     bool enable_tcp_nodelay;
 
-    FASTDDS_TODO_BEFORE(3, 0, "Eliminate wait_for_tcp_negotiation, variable not in use.")
+    FASTDDS_TODO_BEFORE(3, 0, "Eliminate wait_for_tcp_negotiation, variable not in use.");
     bool wait_for_tcp_negotiation;
 
     //! Enables the calculation and sending of CRC on message headers

--- a/include/fastdds/rtps/writer/IReaderDataFilter.hpp
+++ b/include/fastdds/rtps/writer/IReaderDataFilter.hpp
@@ -19,4 +19,4 @@
 // This file was moved as part of the implementation of content filtered topics
 #include <fastdds/rtps/interfaces/IReaderDataFilter.hpp>
 
-FASTDDS_TODO_BEFORE(3, 0, "This header should be removed")
+FASTDDS_TODO_BEFORE(3, 0, "This header should be removed");

--- a/include/fastrtps/config.h.in
+++ b/include/fastrtps/config.h.in
@@ -122,7 +122,7 @@
 #define FASTDDS_TODO_BEFORE(major, minor, msg)                                          \
     static_assert((FASTRTPS_VERSION_MAJOR < major) ||                                   \
             (FASTRTPS_VERSION_MAJOR == major && FASTRTPS_VERSION_MINOR < minor),  \
-            "TODO before version " #major "." #minor " : " #msg);
+            "TODO before version " #major "." #minor " : " #msg)
 
 #if FASTCDR_VERSION_MAJOR > 1
 #define FASTDDS_SER_METHOD_DEPRECATED(major, entity_name, msg) FASTDDS_DEPRECATED_UNTIL(major, entity_name, msg)

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -88,7 +88,7 @@ static const int s_default_keep_alive_timeout = 15000; // 15 SECONDS
 //static const int s_clean_deleted_sockets_pool_timeout = 100; // 100 MILLISECONDS
 
 FASTDDS_TODO_BEFORE(3, 0,
-        "Eliminate s_default_tcp_negotitation_timeout, variable used to initialize deprecate attribute.")
+        "Eliminate s_default_tcp_negotitation_timeout, variable used to initialize deprecate attribute.");
 static const int s_default_tcp_negotitation_timeout = 5000; // 5 Seconds
 
 TCPTransportDescriptor::TCPTransportDescriptor()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Up until this PR, the `FASTDDS_TODO_BEFORE` macro added a semicolon after its `static_assert`. This means that when using the macro, if a semicolon is added, a second semicolon ends up on the source after pre-processing, which can result in a compiler warning because of that extra semicolon. This PR:

- [x] Removes the semicolon from the static assert within the `FASTDDS_TODO_BEFORE` macro so that the use of semicolon upon usage is enforced.
- [x] Updates all the usages to add a semicolon.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.13.x 2.12.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
