### PR TITLE
[20187] Add catch of out-of-range exception for thread settings port

### DIFF
--- a/src/cpp/rtps/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLElementParser.cpp
@@ -4579,7 +4579,8 @@ XMLP_ret XMLParser::getXMLThreadSettingsWithPort(
                 ret = XMLP_ret::XML_ERROR;
                 break;
             }
-            catch (const std::out_of_range& except) {
+            catch (const std::out_of_range& except)
+            {
                 EPROSIMA_LOG_ERROR(XMLPARSER,
                         "Value of the port attribute " << attrib->Value() << " out of range. " <<
                         except.what());

--- a/src/cpp/rtps/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLElementParser.cpp
@@ -4579,6 +4579,13 @@ XMLP_ret XMLParser::getXMLThreadSettingsWithPort(
                 ret = XMLP_ret::XML_ERROR;
                 break;
             }
+            catch (const std::out_of_range& except) {
+                EPROSIMA_LOG_ERROR(XMLPARSER,
+                        "Value of the port attribute " << attrib->Value() << " out of range. " <<
+                        except.what());
+                ret = XMLP_ret::XML_ERROR;
+                break;
+            }
         }
         else
         {

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -71,6 +71,7 @@ TEST_F(XMLParserTests, regressions)
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/simple_participant_profiles_nok.xml", root));
     EXPECT_EQ(XMLP_ret::XML_OK, XMLParser::loadXML("regressions/simple_participant_profiles_ok.xml", root));
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/20186_profile_bin.xml", root));
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/20187_profile_bin.xml", root));
 }
 
 TEST_F(XMLParserTests, NoFile)

--- a/test/unittest/xmlparser/regressions/20187_profile_bin.xml
+++ b/test/unittest/xmlparser/regressions/20187_profile_bin.xml
@@ -1,0 +1,1 @@
+<log><thread_settings port="88888888888888888884"/></log>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
When a value out of the range is assigned to the attribute `port` of `thread_settings`, an exception was thrown but not catched. This PR adds a catch of out-of-range exception and a regression test.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- N/A New feature has been added to the `versions.md` file (if applicable).
- N/A New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
