### PR TITLE
[20570] Fix warnings on tests on Windows 32bits

### DIFF
--- a/test/blackbox/common/BlackboxTestsTransportSHM.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportSHM.cpp
@@ -155,7 +155,7 @@ TEST(SHM, IgnoreNonExistentSegment)
     }
     // Check logs
     Log::Flush();
-    EXPECT_EQ(helper_consumer->ConsumedEntries().size(), 0);
+    EXPECT_EQ(helper_consumer->ConsumedEntries().size(), 0u);
 
     // Clean-up
     Log::Reset();  // This calls to ClearConsumers, which deletes the registered consumer

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -694,7 +694,7 @@ TEST(DDSBasic, participant_ignore_local_endpoints_two_participants)
     EXPECT_TRUE(samples.empty());
 
     // Wait for reception
-    EXPECT_EQ(reader.block_for_all(std::chrono::seconds(1)), 5);
+    EXPECT_EQ(reader.block_for_all(std::chrono::seconds(1)), 5u);
 }
 
 /**

--- a/test/blackbox/common/DDSBlackboxTestsContentFilter.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsContentFilter.cpp
@@ -373,7 +373,7 @@ protected:
             }
             else
             {
-                EXPECT_EQ(filter_counter.content_filter_info_count, 0);
+                EXPECT_EQ(filter_counter.content_filter_info_count, 0u);
                 EXPECT_EQ(filter_counter.max_filter_signature_number, 0u);
             }
         }

--- a/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
@@ -1253,7 +1253,7 @@ TEST(DDSMonitorServiceTest, monitor_service_simple_proxy)
     writer_proxy_msg.status_kind(eprosima::fastdds::statistics::PROXY);
     StatisticsGUIDList guids = MSP.get_writer_guids();
 
-    ASSERT_EQ(guids.size(), 1);
+    ASSERT_EQ(guids.size(), 1u);
     writer_proxy_msg.local_entity(guids.back());
 
     expected_msgs.push_back(writer_proxy_msg);

--- a/test/blackbox/common/RTPSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsDiscovery.cpp
@@ -809,11 +809,11 @@ TEST_P(RTPSDiscovery, ContentFilterRegistrationWithoutCFP)
                     return Iterations::DISCOVERED_READER == iteration || Iterations::WITH_ERROR == iteration;
                 });
         ASSERT_EQ(Iterations::DISCOVERED_READER, iteration);
-        ASSERT_EQ(0, content_filter_property.content_filtered_topic_name.size());
-        ASSERT_EQ(0, content_filter_property.related_topic_name.size());
-        ASSERT_EQ(0, content_filter_property.filter_class_name.size());
-        ASSERT_EQ(0, content_filter_property.filter_expression.size());
-        ASSERT_EQ(0, content_filter_property.expression_parameters.size());
+        ASSERT_EQ(0u, content_filter_property.content_filtered_topic_name.size());
+        ASSERT_EQ(0u, content_filter_property.related_topic_name.size());
+        ASSERT_EQ(0u, content_filter_property.filter_class_name.size());
+        ASSERT_EQ(0u, content_filter_property.filter_expression.size());
+        ASSERT_EQ(0u, content_filter_property.expression_parameters.size());
     }
 
     // Test second iteration: expect ReaderDiscoveryInfo::CHANGED_QOS_READER.
@@ -825,11 +825,11 @@ TEST_P(RTPSDiscovery, ContentFilterRegistrationWithoutCFP)
                     return Iterations::CHANGED_QOS_READER == iteration || Iterations::WITH_ERROR == iteration;
                 });
         ASSERT_EQ(Iterations::CHANGED_QOS_READER, iteration);
-        ASSERT_EQ(0, content_filter_property.content_filtered_topic_name.size());
-        ASSERT_EQ(0, content_filter_property.related_topic_name.size());
-        ASSERT_EQ(0, content_filter_property.filter_class_name.size());
-        ASSERT_EQ(0, content_filter_property.filter_expression.size());
-        ASSERT_EQ(0, content_filter_property.expression_parameters.size());
+        ASSERT_EQ(0u, content_filter_property.content_filtered_topic_name.size());
+        ASSERT_EQ(0u, content_filter_property.related_topic_name.size());
+        ASSERT_EQ(0u, content_filter_property.filter_class_name.size());
+        ASSERT_EQ(0u, content_filter_property.filter_expression.size());
+        ASSERT_EQ(0u, content_filter_property.expression_parameters.size());
     }
 }
 

--- a/test/unittest/dds/subscriber/DataReaderInstanceTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderInstanceTests.cpp
@@ -70,7 +70,7 @@ TEST(DataReaderInstance, writer_update_its_ownership_strength)
     // Anything changes because it is not an "alive" writer of the instance.
     ASSERT_EQ(dw3_guid, instance.current_owner.first);
     ASSERT_EQ(14u, instance.current_owner.second);
-    ASSERT_EQ(3, instance.alive_writers.size());
+    ASSERT_EQ(3u, instance.alive_writers.size());
 }
 
 /*!

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -2136,7 +2136,7 @@ TEST_F(DataReaderTests, check_read_take_iteration)
         EXPECT_EQ(data_reader_->take_instance(data, infos, 1, handles[i]),
                 ReturnCode_t::RETCODE_OK);
 
-        EXPECT_EQ(i, std::atoi(data[0].message().data()));
+        EXPECT_EQ(static_cast<int>(i), std::atoi(data[0].message().data()));
 
         EXPECT_EQ(ReturnCode_t::RETCODE_OK, data_reader_->return_loan(data, infos));
     }

--- a/test/unittest/dds/subscriber/SubscriberTests.cpp
+++ b/test/unittest/dds/subscriber/SubscriberTests.cpp
@@ -496,15 +496,15 @@ TEST(SubscriberTests, ChangeDefaultDataReaderQos)
     EXPECT_EQ(2, wqos.endpoint().entity_id);
     EXPECT_EQ(eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE, wqos.endpoint().history_memory_policy);
     // .reader_resource_limits
-    EXPECT_EQ(30, wqos.reader_resource_limits().matched_publisher_allocation.initial);
-    EXPECT_EQ(300, wqos.reader_resource_limits().matched_publisher_allocation.maximum);
-    EXPECT_EQ(4, wqos.reader_resource_limits().matched_publisher_allocation.increment);
-    EXPECT_EQ(40, wqos.reader_resource_limits().sample_infos_allocation.initial);
-    EXPECT_EQ(400, wqos.reader_resource_limits().sample_infos_allocation.maximum);
-    EXPECT_EQ(5, wqos.reader_resource_limits().sample_infos_allocation.increment);
-    EXPECT_EQ(50, wqos.reader_resource_limits().outstanding_reads_allocation.initial);
-    EXPECT_EQ(500, wqos.reader_resource_limits().outstanding_reads_allocation.maximum);
-    EXPECT_EQ(6, wqos.reader_resource_limits().outstanding_reads_allocation.increment);
+    EXPECT_EQ(30u, wqos.reader_resource_limits().matched_publisher_allocation.initial);
+    EXPECT_EQ(300u, wqos.reader_resource_limits().matched_publisher_allocation.maximum);
+    EXPECT_EQ(4u, wqos.reader_resource_limits().matched_publisher_allocation.increment);
+    EXPECT_EQ(40u, wqos.reader_resource_limits().sample_infos_allocation.initial);
+    EXPECT_EQ(400u, wqos.reader_resource_limits().sample_infos_allocation.maximum);
+    EXPECT_EQ(5u, wqos.reader_resource_limits().sample_infos_allocation.increment);
+    EXPECT_EQ(50u, wqos.reader_resource_limits().outstanding_reads_allocation.initial);
+    EXPECT_EQ(500u, wqos.reader_resource_limits().outstanding_reads_allocation.maximum);
+    EXPECT_EQ(6u, wqos.reader_resource_limits().outstanding_reads_allocation.increment);
     EXPECT_EQ(33, wqos.reader_resource_limits().max_samples_per_read);
     // .data_sharing
     EXPECT_EQ(eprosima::fastdds::dds::ON, wqos.data_sharing().kind());

--- a/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
+++ b/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
@@ -97,7 +97,7 @@ void assert_is_empty_content_filter(
     ASSERT_EQ("", filter_property.related_topic_name.to_string());
     ASSERT_EQ("", filter_property.filter_class_name.to_string());
     ASSERT_EQ("", filter_property.filter_expression);
-    ASSERT_EQ(0, filter_property.expression_parameters.size());
+    ASSERT_EQ(0u, filter_property.expression_parameters.size());
 }
 
 TEST(BuiltinDataSerializationTests, ok_with_defaults)

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -1511,7 +1511,7 @@ TEST_F(TCPv4Tests, secure_non_blocking_send)
        as communication lacks most of the discovery messages using a raw socket as participant.
      */
     auto sender_unbound_channel_resources = senderTransportUnderTest.get_unbound_channel_resources();
-    ASSERT_TRUE(sender_unbound_channel_resources.size() == 1);
+    ASSERT_TRUE(sender_unbound_channel_resources.size() == 1u);
     auto sender_channel_resource =
             std::static_pointer_cast<TCPChannelResourceBasic>(sender_unbound_channel_resources[0]);
 
@@ -1945,7 +1945,7 @@ TEST_F(TCPv4Tests, client_announced_local_port_uniqueness)
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-    ASSERT_EQ(receiveTransportUnderTest.get_channel_resources().size(), 2);
+    ASSERT_EQ(receiveTransportUnderTest.get_channel_resources().size(), 2u);
 }
 
 #ifndef _WIN32
@@ -2009,7 +2009,7 @@ TEST_F(TCPv4Tests, non_blocking_send)
        as communication lacks most of the discovery messages using a raw socket as participant.
      */
     auto sender_unbound_channel_resources = senderTransportUnderTest.get_unbound_channel_resources();
-    ASSERT_TRUE(sender_unbound_channel_resources.size() == 1);
+    ASSERT_TRUE(sender_unbound_channel_resources.size() == 1u);
     auto sender_channel_resource =
             std::static_pointer_cast<TCPChannelResourceBasic>(sender_unbound_channel_resources[0]);
 
@@ -2138,11 +2138,11 @@ TEST_F(TCPv4Tests, opening_output_channel_with_same_locator_as_local_listening_p
     // If the remote address is lower than the local one, no channel must be created but it must be added to the send_resource_list
     ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, lowerOutputChannelLocator));
     ASSERT_FALSE(transportUnderTest.is_output_channel_open_for(lowerOutputChannelLocator));
-    ASSERT_EQ(send_resource_list.size(), 1);
+    ASSERT_EQ(send_resource_list.size(), 1u);
     // If the remote address is higher than the local one, a CONNECT channel must be created and added to the send_resource_list
     ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, higherOutputChannelLocator));
     ASSERT_TRUE(transportUnderTest.is_output_channel_open_for(higherOutputChannelLocator));
-    ASSERT_EQ(send_resource_list.size(), 2);
+    ASSERT_EQ(send_resource_list.size(), 2u);
 }
 
 void TCPv4Tests::HELPER_SetDescriptorDefaults()

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -196,7 +196,7 @@ TEST_F(TCPv6Tests, autofill_port)
     transportUnderTest_autofill.init();
 
     EXPECT_TRUE(transportUnderTest_autofill.configuration()->listening_ports[0] != 0);
-    EXPECT_TRUE(transportUnderTest_autofill.configuration()->listening_ports.size() == 1);
+    EXPECT_TRUE(transportUnderTest_autofill.configuration()->listening_ports.size() == 1u);
 }
 
 static void GetIP6s(
@@ -297,7 +297,7 @@ TEST_F(TCPv6Tests, client_announced_local_port_uniqueness)
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-    ASSERT_EQ(receiveTransportUnderTest.get_channel_resources().size(), 2);
+    ASSERT_EQ(receiveTransportUnderTest.get_channel_resources().size(), 2u);
 }
 
 #ifndef _WIN32
@@ -361,7 +361,7 @@ TEST_F(TCPv6Tests, non_blocking_send)
        as communication lacks most of the discovery messages using a raw socket as participant.
      */
     auto sender_unbound_channel_resources = senderTransportUnderTest.get_unbound_channel_resources();
-    ASSERT_TRUE(sender_unbound_channel_resources.size() == 1);
+    ASSERT_TRUE(sender_unbound_channel_resources.size() == 1u);
     auto sender_channel_resource =
             std::static_pointer_cast<TCPChannelResourceBasic>(sender_unbound_channel_resources[0]);
 
@@ -493,7 +493,7 @@ TEST_F(TCPv6Tests, opening_output_channel_with_same_locator_as_local_listening_p
     // If the remote address is higher than the local one, a CONNECT channel must be created and added to the send_resource_list
     ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, higherOutputChannelLocator));
     ASSERT_TRUE(transportUnderTest.is_output_channel_open_for(higherOutputChannelLocator));
-    ASSERT_EQ(send_resource_list.size(), 2);
+    ASSERT_EQ(send_resource_list.size(), 2u);
 }
 
 /*


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR fixes warnings on tests when compiled in Windows 32-bits.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.13.x 2.12.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- *N/A* Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- *N/A* Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- *N/A* Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.

