### PR TITLE
[20584] Effectively assert automatic/manual_by_participant liveliness

### DIFF
--- a/include/fastdds/rtps/writer/LivelinessManager.h
+++ b/include/fastdds/rtps/writer/LivelinessManager.h
@@ -105,8 +105,9 @@ public:
             Duration_t lease_duration);
 
     /**
-     * @brief Asserts liveliness of writers with given liveliness kind
+     * @brief Asserts liveliness of writers with given liveliness kind and GuidPrefix
      * @param kind Liveliness kind
+     * @param guid_prefix The guid prefix of the writers to assert liveliness of
      * @return True if liveliness was successfully asserted
      */
     bool assert_liveliness(

--- a/include/fastdds/rtps/writer/LivelinessManager.h
+++ b/include/fastdds/rtps/writer/LivelinessManager.h
@@ -110,7 +110,8 @@ public:
      * @return True if liveliness was successfully asserted
      */
     bool assert_liveliness(
-            LivelinessQosPolicyKind kind);
+            LivelinessQosPolicyKind kind,
+            GuidPrefix_t guid_prefix);
 
     /**
      * @brief A method to check any writer of the given kind is alive

--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -974,7 +974,9 @@ bool WLP::assert_liveliness_manual_by_participant()
 {
     if (manual_by_participant_writers_.size() > 0)
     {
-        return pub_liveliness_manager_->assert_liveliness(MANUAL_BY_PARTICIPANT_LIVELINESS_QOS);
+        return pub_liveliness_manager_->assert_liveliness(
+            MANUAL_BY_PARTICIPANT_LIVELINESS_QOS,
+            mp_participant->getGuid().guidPrefix);
     }
     return false;
 }

--- a/src/cpp/rtps/builtin/liveliness/WLPListener.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLPListener.cpp
@@ -145,11 +145,11 @@ void WLPListener::onNewCacheChangeAdded(
     history->getMutex()->unlock();
     if (mp_WLP->automatic_readers_)
     {
-        mp_WLP->sub_liveliness_manager_->assert_liveliness(AUTOMATIC_LIVELINESS_QOS);
+        mp_WLP->sub_liveliness_manager_->assert_liveliness(AUTOMATIC_LIVELINESS_QOS, guidP);
     }
     if (livelinessKind == MANUAL_BY_PARTICIPANT_LIVELINESS_QOS)
     {
-        mp_WLP->sub_liveliness_manager_->assert_liveliness(MANUAL_BY_PARTICIPANT_LIVELINESS_QOS);
+        mp_WLP->sub_liveliness_manager_->assert_liveliness(MANUAL_BY_PARTICIPANT_LIVELINESS_QOS, guidP);
     }
     mp_WLP->mp_builtinProtocols->mp_PDP->getMutex()->unlock();
     history->getMutex()->lock();

--- a/src/cpp/rtps/writer/LivelinessManager.cpp
+++ b/src/cpp/rtps/writer/LivelinessManager.cpp
@@ -187,7 +187,8 @@ bool LivelinessManager::assert_liveliness(
                 {
                     for (LivelinessData& w: writers_)
                     {
-                        if (w.kind == writer.kind)
+                        if (w.kind == writer.kind &&
+                            w.guid.guidPrefix == guid.guidPrefix)
                         {
                             assert_writer_liveliness(w);
                         }
@@ -232,7 +233,8 @@ bool LivelinessManager::assert_liveliness(
 }
 
 bool LivelinessManager::assert_liveliness(
-        LivelinessQosPolicyKind kind)
+        LivelinessQosPolicyKind kind,
+        GuidPrefix_t guid_prefix)
 {
 
     if (!manage_automatic_ && kind == LivelinessQosPolicyKind::AUTOMATIC_LIVELINESS_QOS)
@@ -253,7 +255,8 @@ bool LivelinessManager::assert_liveliness(
 
         for (LivelinessData& writer: writers_)
         {
-            if (writer.kind == kind)
+            if (writer.kind == kind &&
+                guid_prefix == writer.guid.guidPrefix)
             {
                 assert_writer_liveliness(writer);
             }

--- a/src/cpp/rtps/writer/LivelinessManager.cpp
+++ b/src/cpp/rtps/writer/LivelinessManager.cpp
@@ -188,7 +188,7 @@ bool LivelinessManager::assert_liveliness(
                     for (LivelinessData& w: writers_)
                     {
                         if (w.kind == writer.kind &&
-                            w.guid.guidPrefix == guid.guidPrefix)
+                                w.guid.guidPrefix == guid.guidPrefix)
                         {
                             assert_writer_liveliness(w);
                         }
@@ -256,7 +256,7 @@ bool LivelinessManager::assert_liveliness(
         for (LivelinessData& writer: writers_)
         {
             if (writer.kind == kind &&
-                guid_prefix == writer.guid.guidPrefix)
+                    guid_prefix == writer.guid.guidPrefix)
             {
                 assert_writer_liveliness(writer);
             }

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -623,7 +623,7 @@ public:
         std::unique_lock<std::mutex> lock(sub_liveliness_mutex_);
         sub_liveliness_cv_.wait_for(lock, max_wait, [this, &expected_num_lost]() -> bool
                 {
-                    return expected_num_lost >= sub_times_liveliness_lost_;
+                    return sub_times_liveliness_lost_ >= expected_num_lost;
                 });
 
         return sub_times_liveliness_lost_;

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -623,7 +623,7 @@ public:
         std::unique_lock<std::mutex> lock(sub_liveliness_mutex_);
         sub_liveliness_cv_.wait_for(lock, max_wait, [this, &expected_num_lost]() -> bool
                 {
-                    return expected_num_lost == sub_times_liveliness_lost_;
+                    return expected_num_lost >= sub_times_liveliness_lost_;
                 });
 
         return sub_times_liveliness_lost_;

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -613,6 +613,22 @@ public:
                 });
     }
 
+    template<class _Rep,
+            class _Period
+            >
+    size_t sub_wait_liveliness_lost_for(
+            unsigned int expected_num_lost,
+            const std::chrono::duration<_Rep, _Period>& max_wait)
+    {
+        std::unique_lock<std::mutex> lock(sub_liveliness_mutex_);
+        sub_liveliness_cv_.wait_for(lock, max_wait, [this, &expected_num_lost]() -> bool
+                {
+                    return expected_num_lost == sub_times_liveliness_lost_;
+                });
+
+        return sub_times_liveliness_lost_;
+    }
+
     PubSubParticipant& property_policy(
             const eprosima::fastrtps::rtps::PropertyPolicy property_policy)
     {

--- a/test/blackbox/api/fastrtps_deprecated/PubSubParticipant.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubParticipant.hpp
@@ -401,6 +401,22 @@ public:
                 });
     }
 
+    template<class _Rep,
+            class _Period
+            >
+    size_t sub_wait_liveliness_lost_for(
+            unsigned int expected_num_lost,
+            const std::chrono::duration<_Rep, _Period>& max_wait)
+    {
+        std::unique_lock<std::mutex> lock(sub_liveliness_mutex_);
+        sub_liveliness_cv_.wait_for(lock, max_wait, [this, &expected_num_lost]() -> bool
+                {
+                    return expected_num_lost == sub_times_liveliness_lost_;
+                });
+
+        return sub_times_liveliness_lost_;
+    }
+
     PubSubParticipant& property_policy(
             const eprosima::fastrtps::rtps::PropertyPolicy property_policy)
     {

--- a/test/blackbox/api/fastrtps_deprecated/PubSubParticipant.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubParticipant.hpp
@@ -411,7 +411,7 @@ public:
         std::unique_lock<std::mutex> lock(sub_liveliness_mutex_);
         sub_liveliness_cv_.wait_for(lock, max_wait, [this, &expected_num_lost]() -> bool
                 {
-                    return expected_num_lost == sub_times_liveliness_lost_;
+                    return expected_num_lost >= sub_times_liveliness_lost_;
                 });
 
         return sub_times_liveliness_lost_;

--- a/test/blackbox/api/fastrtps_deprecated/PubSubParticipant.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubParticipant.hpp
@@ -411,7 +411,7 @@ public:
         std::unique_lock<std::mutex> lock(sub_liveliness_mutex_);
         sub_liveliness_cv_.wait_for(lock, max_wait, [this, &expected_num_lost]() -> bool
                 {
-                    return expected_num_lost >= sub_times_liveliness_lost_;
+                    return sub_times_liveliness_lost_ >= expected_num_lost;
                 });
 
         return sub_times_liveliness_lost_;

--- a/test/blackbox/common/BlackboxTestsLivelinessQos.cpp
+++ b/test/blackbox/common/BlackboxTestsLivelinessQos.cpp
@@ -1977,13 +1977,13 @@ TEST(LivelinessTests, Reader_Successfully_Asserts_Liveliness_on_a_Disconnected_W
             .add_user_transport_to_pparams(testTransport)
             .liveliness_lease_duration(eprosima::fastrtps::Time_t(1, 0))
             .liveliness_kind(eprosima::fastdds::dds::AUTOMATIC_LIVELINESS_QOS)
-            .liveliness_announcement_period(eprosima::fastrtps::Time_t(0, 900000000))
+            .liveliness_announcement_period(eprosima::fastrtps::Time_t(0, 500000000))
             .init();
 
     writer_2.lease_duration(c_TimeInfinite, 1)
             .liveliness_lease_duration(eprosima::fastrtps::Time_t(1, 0))
             .liveliness_kind(eprosima::fastdds::dds::AUTOMATIC_LIVELINESS_QOS)
-            .liveliness_announcement_period(eprosima::fastrtps::Time_t(0, 900000000))
+            .liveliness_announcement_period(eprosima::fastrtps::Time_t(0, 500000000))
             .init();
 
     // Wait for discovery to occur. Liveliness should be recovered twice,

--- a/test/blackbox/common/BlackboxTestsLivelinessQos.cpp
+++ b/test/blackbox/common/BlackboxTestsLivelinessQos.cpp
@@ -26,6 +26,8 @@
 #include <gtest/gtest.h>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 
+#include <rtps/transport/test_UDPv4Transport.h>
+
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 
@@ -1944,6 +1946,54 @@ TEST(LivelinessTests, Detect_Deadlock_ManualByParticipant_Intraprocess)
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
     // Test failure is due to timeout
+}
+
+// Regression test of Refs #20584, github issue #4373
+TEST(LivelinessTests, Reader_Successfully_Asserts_Liveliness_on_a_Disconnected_Writer)
+{
+    // Create a TestTransport to simulate a network shutdown (Ctrl+C)
+    auto testTransport = std::make_shared<eprosima::fastdds::rtps::test_UDPv4TransportDescriptor>();
+
+    // Create two writer participants
+    PubSubWriter<HelloWorldPubSubType> writer_1(TEST_TOPIC_NAME);
+    PubSubWriter<HelloWorldPubSubType> writer_2(TEST_TOPIC_NAME + "2");
+
+    // Create a reader participant containing 2 subscribers and readers
+    PubSubParticipant<HelloWorldPubSubType> reader(0, 2, 0, 2);
+
+    reader.init_participant();
+    // Define the reader's lease duration in 1.6 secs
+    reader.sub_liveliness_lease_duration(eprosima::fastrtps::Time_t(1, 600000000));
+
+    // Create Subscribers and readers, one for each writer
+    reader.sub_topic_name(TEST_TOPIC_NAME);
+    reader.init_subscriber(0);
+    reader.sub_topic_name(TEST_TOPIC_NAME + "2");
+    reader.init_subscriber(1);
+
+    // Create writers
+    writer_1.disable_builtin_transport()
+            .add_user_transport_to_pparams(testTransport)
+            .liveliness_lease_duration(eprosima::fastrtps::Time_t(1, 0))
+            .liveliness_kind(eprosima::fastdds::dds::AUTOMATIC_LIVELINESS_QOS)
+            .liveliness_announcement_period(eprosima::fastrtps::Time_t(0, 900000000))
+            .init();
+
+    writer_2.liveliness_lease_duration(eprosima::fastrtps::Time_t(1, 0))
+            .liveliness_kind(eprosima::fastdds::dds::AUTOMATIC_LIVELINESS_QOS)
+            .liveliness_announcement_period(eprosima::fastrtps::Time_t(0, 900000000))
+            .init();
+
+    // Wait for discovery to occur. Liveliness should be recovered twice,
+    // one per matched reader.
+    reader.sub_wait_liveliness_recovered(2);
+
+    // Simulate a Ctrl+C in one of the writers
+    eprosima::fastdds::rtps::test_UDPv4Transport::test_UDPv4Transport_ShutdownAllNetwork = true;
+
+    // After 1.6 secs, we should receive a on_liveliness_changed(status lost)
+    // in the TEST_TOPIC_NAME reader that was matched with the disconnected writer_1
+    ASSERT_EQ(reader.sub_wait_liveliness_lost_for(1, std::chrono::seconds(4)), 1u);
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P

--- a/test/blackbox/common/BlackboxTestsLivelinessQos.cpp
+++ b/test/blackbox/common/BlackboxTestsLivelinessQos.cpp
@@ -1973,13 +1973,15 @@ TEST(LivelinessTests, Reader_Successfully_Asserts_Liveliness_on_a_Disconnected_W
 
     // Create writers
     writer_1.disable_builtin_transport()
+            .lease_duration(c_TimeInfinite, 1)
             .add_user_transport_to_pparams(testTransport)
             .liveliness_lease_duration(eprosima::fastrtps::Time_t(1, 0))
             .liveliness_kind(eprosima::fastdds::dds::AUTOMATIC_LIVELINESS_QOS)
             .liveliness_announcement_period(eprosima::fastrtps::Time_t(0, 900000000))
             .init();
 
-    writer_2.liveliness_lease_duration(eprosima::fastrtps::Time_t(1, 0))
+    writer_2.lease_duration(c_TimeInfinite, 1)
+            .liveliness_lease_duration(eprosima::fastrtps::Time_t(1, 0))
             .liveliness_kind(eprosima::fastdds::dds::AUTOMATIC_LIVELINESS_QOS)
             .liveliness_announcement_period(eprosima::fastrtps::Time_t(0, 900000000))
             .init();

--- a/test/unittest/rtps/writer/LivelinessManagerTests.cpp
+++ b/test/unittest/rtps/writer/LivelinessManagerTests.cpp
@@ -173,7 +173,7 @@ TEST_F(LivelinessManagerTests, AssertLivelinessByKind)
     liveliness_manager.add_writer(GUID_t(guidP, 6), MANUAL_BY_TOPIC_LIVELINESS_QOS, Duration_t(10));
 
     // Assert liveliness of automatic writers (the rest should be unchanged)
-    EXPECT_TRUE(liveliness_manager.assert_liveliness(AUTOMATIC_LIVELINESS_QOS));
+    EXPECT_TRUE(liveliness_manager.assert_liveliness(AUTOMATIC_LIVELINESS_QOS, guidP));
     auto liveliness_data = liveliness_manager.get_liveliness_data();
     EXPECT_EQ(liveliness_data[0].status, LivelinessData::WriterStatus::ALIVE);
     EXPECT_EQ(liveliness_data[1].status, LivelinessData::WriterStatus::ALIVE);
@@ -183,7 +183,7 @@ TEST_F(LivelinessManagerTests, AssertLivelinessByKind)
     EXPECT_EQ(liveliness_data[5].status, LivelinessData::WriterStatus::NOT_ASSERTED);
 
     // Assert liveliness of manual by participant writers
-    EXPECT_TRUE(liveliness_manager.assert_liveliness(MANUAL_BY_PARTICIPANT_LIVELINESS_QOS));
+    EXPECT_TRUE(liveliness_manager.assert_liveliness(MANUAL_BY_PARTICIPANT_LIVELINESS_QOS, guidP));
     liveliness_data = liveliness_manager.get_liveliness_data();
     EXPECT_EQ(liveliness_data[0].status, LivelinessData::WriterStatus::ALIVE);
     EXPECT_EQ(liveliness_data[1].status, LivelinessData::WriterStatus::ALIVE);
@@ -193,7 +193,7 @@ TEST_F(LivelinessManagerTests, AssertLivelinessByKind)
     EXPECT_EQ(liveliness_data[5].status, LivelinessData::WriterStatus::NOT_ASSERTED);
 
     // Assert liveliness of manual by topic writers
-    EXPECT_TRUE(liveliness_manager.assert_liveliness(MANUAL_BY_TOPIC_LIVELINESS_QOS));
+    EXPECT_TRUE(liveliness_manager.assert_liveliness(MANUAL_BY_TOPIC_LIVELINESS_QOS, guidP));
     liveliness_data = liveliness_manager.get_liveliness_data();
     EXPECT_EQ(liveliness_data[0].status, LivelinessData::WriterStatus::ALIVE);
     EXPECT_EQ(liveliness_data[1].status, LivelinessData::WriterStatus::ALIVE);
@@ -434,7 +434,7 @@ TEST_F(LivelinessManagerTests, TimerOwnerCalculation)
     liveliness_manager.add_writer(GUID_t(guidP, 2), AUTOMATIC_LIVELINESS_QOS, Duration_t(1000 * 1e-3));
     liveliness_manager.add_writer(GUID_t(guidP, 3), AUTOMATIC_LIVELINESS_QOS, Duration_t(500 * 1e-3));
 
-    liveliness_manager.assert_liveliness(AUTOMATIC_LIVELINESS_QOS);
+    liveliness_manager.assert_liveliness(AUTOMATIC_LIVELINESS_QOS, guidP);
 
     wait_liveliness_lost(1u);
     EXPECT_EQ(writer_losing_liveliness, GUID_t(guidP, 1));

--- a/test/unittest/rtps/writer/LivelinessManagerTests.cpp
+++ b/test/unittest/rtps/writer/LivelinessManagerTests.cpp
@@ -25,75 +25,87 @@
 
 class LivelinessManagerTests : public ::testing::Test
 {
-    public:
+public:
 
-        LivelinessManagerTests() : service_() {}
+    LivelinessManagerTests()
+        : service_()
+    {
+    }
 
-        void SetUp()
-        {
-            service_.init_thread();
+    void SetUp()
+    {
+        service_.init_thread();
 
-            writer_losing_liveliness = eprosima::fastrtps::rtps::GUID_t();
-            writer_recovering_liveliness = eprosima::fastrtps::rtps::GUID_t();
-            num_writers_lost = 0;
-            num_writers_recovered = 0;
-        }
+        writer_losing_liveliness = eprosima::fastrtps::rtps::GUID_t();
+        writer_recovering_liveliness = eprosima::fastrtps::rtps::GUID_t();
+        num_writers_lost = 0;
+        num_writers_recovered = 0;
+    }
 
-        void TearDown()
-        {
-        }
+    void TearDown()
+    {
+    }
 
-        void run()
-        {
-        }
+    void run()
+    {
+    }
 
-        eprosima::fastrtps::rtps::ResourceEvent service_;
+    eprosima::fastrtps::rtps::ResourceEvent service_;
 
-        // Callback to test the liveliness manager
+    // Callback to test the liveliness manager
 
-        void liveliness_changed(eprosima::fastrtps::rtps::GUID_t guid,
-                                const eprosima::fastrtps::LivelinessQosPolicyKind&,
-                                const eprosima::fastrtps::Duration_t&,
-                                int alive_change,
-                                int not_alive_change)
-        {
-            if (alive_change > 0)
-            {
-                std::unique_lock<std::mutex> lock(liveliness_recovered_mutex_);
-                writer_recovering_liveliness = guid;
-                num_writers_recovered++;
-                liveliness_recovered_cv_.notify_one();
-            }
-            else if (not_alive_change > 0)
-            {
-                std::unique_lock<std::mutex> lock(liveliness_lost_mutex_);
-                writer_losing_liveliness = guid;
-                num_writers_lost++;
-                liveliness_lost_cv_.notify_one();
-            }
-        }
-
-        void wait_liveliness_lost(unsigned int num_lost)
-        {
-            std::unique_lock<std::mutex> lock(liveliness_lost_mutex_);
-            liveliness_lost_cv_.wait(lock, [&](){ return num_writers_lost == num_lost; });
-        }
-
-        void wait_liveliness_recovered(unsigned int num_recovered)
+    void liveliness_changed(
+            eprosima::fastrtps::rtps::GUID_t guid,
+            const eprosima::fastrtps::LivelinessQosPolicyKind&,
+            const eprosima::fastrtps::Duration_t&,
+            int alive_change,
+            int not_alive_change)
+    {
+        if (alive_change > 0)
         {
             std::unique_lock<std::mutex> lock(liveliness_recovered_mutex_);
-            liveliness_recovered_cv_.wait(lock, [&](){ return num_writers_recovered == num_recovered;});
+            writer_recovering_liveliness = guid;
+            num_writers_recovered++;
+            liveliness_recovered_cv_.notify_one();
         }
+        else if (not_alive_change > 0)
+        {
+            std::unique_lock<std::mutex> lock(liveliness_lost_mutex_);
+            writer_losing_liveliness = guid;
+            num_writers_lost++;
+            liveliness_lost_cv_.notify_one();
+        }
+    }
 
-        eprosima::fastrtps::rtps::GUID_t writer_losing_liveliness;
-        eprosima::fastrtps::rtps::GUID_t writer_recovering_liveliness;
-        unsigned int num_writers_lost;
-        unsigned int num_writers_recovered;
+    void wait_liveliness_lost(
+            unsigned int num_lost)
+    {
+        std::unique_lock<std::mutex> lock(liveliness_lost_mutex_);
+        liveliness_lost_cv_.wait(lock, [&]()
+                {
+                    return num_writers_lost == num_lost;
+                });
+    }
 
-        std::mutex liveliness_lost_mutex_;
-        std::condition_variable liveliness_lost_cv_;
-        std::mutex liveliness_recovered_mutex_;
-        std::condition_variable liveliness_recovered_cv_;
+    void wait_liveliness_recovered(
+            unsigned int num_recovered)
+    {
+        std::unique_lock<std::mutex> lock(liveliness_recovered_mutex_);
+        liveliness_recovered_cv_.wait(lock, [&]()
+                {
+                    return num_writers_recovered == num_recovered;
+                });
+    }
+
+    eprosima::fastrtps::rtps::GUID_t writer_losing_liveliness;
+    eprosima::fastrtps::rtps::GUID_t writer_recovering_liveliness;
+    unsigned int num_writers_lost;
+    unsigned int num_writers_recovered;
+
+    std::mutex liveliness_lost_mutex_;
+    std::condition_variable liveliness_lost_cv_;
+    std::mutex liveliness_recovered_mutex_;
+    std::condition_variable liveliness_recovered_cv_;
 };
 
 namespace  eprosima {
@@ -107,8 +119,8 @@ using eprosima::fastrtps::rtps::GUID_t;
 TEST_F(LivelinessManagerTests, WriterCanAlwaysBeAdded)
 {
     LivelinessManager liveliness_manager(
-                nullptr,
-                service_);
+        nullptr,
+        service_);
 
     GuidPrefix_t guidP;
     guidP.value[0] = 1;
@@ -134,8 +146,8 @@ TEST_F(LivelinessManagerTests, WriterCanAlwaysBeAdded)
 TEST_F(LivelinessManagerTests, WriterCannotBeRemovedTwice)
 {
     LivelinessManager liveliness_manager(
-                nullptr,
-                service_);
+        nullptr,
+        service_);
 
     GuidPrefix_t guidP;
     guidP.value[0] = 1;
@@ -159,8 +171,8 @@ TEST_F(LivelinessManagerTests, WriterCannotBeRemovedTwice)
 TEST_F(LivelinessManagerTests, AssertLivelinessByKind)
 {
     LivelinessManager liveliness_manager(
-                nullptr,
-                service_);
+        nullptr,
+        service_);
 
     GuidPrefix_t guidP;
     guidP.value[0] = 1;
@@ -215,8 +227,8 @@ TEST_F(LivelinessManagerTests, AssertLivelinessByKind)
 TEST_F(LivelinessManagerTests, AssertLivelinessByWriter)
 {
     LivelinessManager liveliness_manager(
-                nullptr,
-                service_);
+        nullptr,
+        service_);
 
     GuidPrefix_t guidP;
     guidP.value[0] = 1;
@@ -230,9 +242,9 @@ TEST_F(LivelinessManagerTests, AssertLivelinessByWriter)
 
     // If a manual by topic writer is asserted the other writers are unchanged
     EXPECT_TRUE(liveliness_manager.assert_liveliness(
-                    GUID_t(guidP, 6),
-                    MANUAL_BY_TOPIC_LIVELINESS_QOS,
-                    Duration_t(1)));
+                GUID_t(guidP, 6),
+                MANUAL_BY_TOPIC_LIVELINESS_QOS,
+                Duration_t(1)));
     auto liveliness_data = liveliness_manager.get_liveliness_data();
     EXPECT_EQ(liveliness_data[0].status, LivelinessData::WriterStatus::NOT_ASSERTED);
     EXPECT_EQ(liveliness_data[1].status, LivelinessData::WriterStatus::NOT_ASSERTED);
@@ -242,9 +254,9 @@ TEST_F(LivelinessManagerTests, AssertLivelinessByWriter)
     EXPECT_EQ(liveliness_data[5].status, LivelinessData::WriterStatus::ALIVE);
 
     EXPECT_TRUE(liveliness_manager.assert_liveliness(
-                    GUID_t(guidP, 5),
-                    MANUAL_BY_TOPIC_LIVELINESS_QOS,
-                    Duration_t(1)));
+                GUID_t(guidP, 5),
+                MANUAL_BY_TOPIC_LIVELINESS_QOS,
+                Duration_t(1)));
     liveliness_data = liveliness_manager.get_liveliness_data();
     EXPECT_EQ(liveliness_data[0].status, LivelinessData::WriterStatus::NOT_ASSERTED);
     EXPECT_EQ(liveliness_data[1].status, LivelinessData::WriterStatus::NOT_ASSERTED);
@@ -255,9 +267,9 @@ TEST_F(LivelinessManagerTests, AssertLivelinessByWriter)
 
     // If an automatic writer is asserted all automatic writers are asserted as well
     EXPECT_TRUE(liveliness_manager.assert_liveliness(
-                    GUID_t(guidP, 1),
-                    AUTOMATIC_LIVELINESS_QOS,
-                    Duration_t(1)));
+                GUID_t(guidP, 1),
+                AUTOMATIC_LIVELINESS_QOS,
+                Duration_t(1)));
     liveliness_data = liveliness_manager.get_liveliness_data();
     EXPECT_EQ(liveliness_data[0].status, LivelinessData::WriterStatus::ALIVE);
     EXPECT_EQ(liveliness_data[1].status, LivelinessData::WriterStatus::ALIVE);
@@ -268,9 +280,9 @@ TEST_F(LivelinessManagerTests, AssertLivelinessByWriter)
 
     // If a manual by participant writer is asserted all manual by participant writers are asserted as well
     EXPECT_TRUE(liveliness_manager.assert_liveliness(
-                    GUID_t(guidP, 4),
-                    MANUAL_BY_PARTICIPANT_LIVELINESS_QOS,
-                    Duration_t(1)));
+                GUID_t(guidP, 4),
+                MANUAL_BY_PARTICIPANT_LIVELINESS_QOS,
+                Duration_t(1)));
     liveliness_data = liveliness_manager.get_liveliness_data();
     EXPECT_EQ(liveliness_data[0].status, LivelinessData::WriterStatus::ALIVE);
     EXPECT_EQ(liveliness_data[1].status, LivelinessData::WriterStatus::ALIVE);
@@ -285,21 +297,22 @@ TEST_F(LivelinessManagerTests, AssertLivelinessByWriter)
     EXPECT_GT(liveliness_data[2].time, std::chrono::steady_clock::now());
     EXPECT_GT(liveliness_data[3].time, std::chrono::steady_clock::now());
     EXPECT_GT(liveliness_data[4].time, std::chrono::steady_clock::now());
-    EXPECT_GT(liveliness_data[5].time, std::chrono::steady_clock::now());}
+    EXPECT_GT(liveliness_data[5].time, std::chrono::steady_clock::now());
+}
 
 //! Tests the case when the timer expires and liveliness manager is managing two automatic writers with different
 //! lease durations
 TEST_F(LivelinessManagerTests, TimerExpired_Automatic)
 {
     LivelinessManager liveliness_manager(
-                std::bind(&LivelinessManagerTests::liveliness_changed,
-                          this,
-                          std::placeholders::_1,
-                          std::placeholders::_2,
-                          std::placeholders::_3,
-                          std::placeholders::_4,
-                          std::placeholders::_5),
-                service_);
+        std::bind(&LivelinessManagerTests::liveliness_changed,
+        this,
+        std::placeholders::_1,
+        std::placeholders::_2,
+        std::placeholders::_3,
+        std::placeholders::_4,
+        std::placeholders::_5),
+        service_);
 
     GuidPrefix_t guidP;
     guidP.value[0] = 1;
@@ -330,14 +343,14 @@ TEST_F(LivelinessManagerTests, TimerExpired_Automatic)
 TEST_F(LivelinessManagerTests, TimerExpired_ManualByParticipant)
 {
     LivelinessManager liveliness_manager(
-                std::bind(&LivelinessManagerTests::liveliness_changed,
-                          this,
-                          std::placeholders::_1,
-                          std::placeholders::_2,
-                          std::placeholders::_3,
-                          std::placeholders::_4,
-                          std::placeholders::_5),
-                service_);
+        std::bind(&LivelinessManagerTests::liveliness_changed,
+        this,
+        std::placeholders::_1,
+        std::placeholders::_2,
+        std::placeholders::_3,
+        std::placeholders::_4,
+        std::placeholders::_5),
+        service_);
 
 
     GuidPrefix_t guidP;
@@ -371,14 +384,14 @@ TEST_F(LivelinessManagerTests, TimerExpired_ManualByParticipant)
 TEST_F(LivelinessManagerTests, TimerExpired_ManualByTopic)
 {
     LivelinessManager liveliness_manager(
-                std::bind(&LivelinessManagerTests::liveliness_changed,
-                          this,
-                          std::placeholders::_1,
-                          std::placeholders::_2,
-                          std::placeholders::_3,
-                          std::placeholders::_4,
-                          std::placeholders::_5),
-                service_);
+        std::bind(&LivelinessManagerTests::liveliness_changed,
+        this,
+        std::placeholders::_1,
+        std::placeholders::_2,
+        std::placeholders::_3,
+        std::placeholders::_4,
+        std::placeholders::_5),
+        service_);
 
 
     GuidPrefix_t guidP;
@@ -417,14 +430,14 @@ TEST_F(LivelinessManagerTests, TimerExpired_ManualByTopic)
 TEST_F(LivelinessManagerTests, TimerOwnerCalculation)
 {
     LivelinessManager liveliness_manager(
-                std::bind(&LivelinessManagerTests::liveliness_changed,
-                          this,
-                          std::placeholders::_1,
-                          std::placeholders::_2,
-                          std::placeholders::_3,
-                          std::placeholders::_4,
-                          std::placeholders::_5),
-                service_);
+        std::bind(&LivelinessManagerTests::liveliness_changed,
+        this,
+        std::placeholders::_1,
+        std::placeholders::_2,
+        std::placeholders::_3,
+        std::placeholders::_4,
+        std::placeholders::_5),
+        service_);
 
 
     GuidPrefix_t guidP;
@@ -454,14 +467,14 @@ TEST_F(LivelinessManagerTests, TimerOwnerCalculation)
 TEST_F(LivelinessManagerTests, TimerOwnerRemoved)
 {
     LivelinessManager liveliness_manager(
-                std::bind(&LivelinessManagerTests::liveliness_changed,
-                          this,
-                          std::placeholders::_1,
-                          std::placeholders::_2,
-                          std::placeholders::_3,
-                          std::placeholders::_4,
-                          std::placeholders::_5),
-                service_);
+        std::bind(&LivelinessManagerTests::liveliness_changed,
+        this,
+        std::placeholders::_1,
+        std::placeholders::_2,
+        std::placeholders::_3,
+        std::placeholders::_4,
+        std::placeholders::_5),
+        service_);
 
 
     GuidPrefix_t guidP;
@@ -478,10 +491,12 @@ TEST_F(LivelinessManagerTests, TimerOwnerRemoved)
     EXPECT_EQ(num_writers_lost, 1u);
 }
 
-}
-}
+} // namespace fastrtps
+} // namespace eprosima
 
-int main(int argc, char **argv)
+int main(
+        int argc,
+        char** argv)
 {
     testing::InitGoogleMock(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR brings a bugfix when asserting `AUTOMATIC` `MANUAL_BY_PARTICIPANT` liveliness kinds. In the scenario of having a participant with two datareaders (each of them with a lease duration of 2 secs) and other two participants with one publisher each one configured with `AUTOMATIC_LIVELINESS`. If we suddenly kill one of the publishers (network disconnection or Ctrl+C), the `on_liveliness_changed()` is not received on the reader side when we would expect it to happen (after 2 secs).

The problem stems from the fact that currently, in the reader-side participant, it is enough having an alive writer with the same kind (`AUTOMATIC_LIVELINESS`) to assert the liveliness of all of its readers with the same kind regardless of the participant.

This PR makes the liveliness assertion participant-aware by means of the `guidPrefix`. 

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.12.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
Fixes #4373 

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [X] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
