### PR TITLE
[20589] Set real TCP non_blocking_send limitation

### DIFF
--- a/src/cpp/rtps/transport/TCPChannelResource.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResource.cpp
@@ -362,7 +362,8 @@ bool TCPChannelResource::check_socket_send_buffer(
 
 
     size_t future_queue_size = size_t(bytesInSendQueue) + msg_size;
-    if (future_queue_size > size_t(parent_->configuration()->sendBufferSize))
+    // TCP actually allocates twice the size of the buffer requested.
+    if (future_queue_size > size_t(2 * parent_->configuration()->sendBufferSize))
     {
         return false;
     }

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -1337,7 +1337,6 @@ TEST_F(TCPv4Tests, secure_non_blocking_send)
     // Create a TCP Server transport
     using TLSOptions = TCPTransportDescriptor::TLSConfig::TLSOptions;
     using TLSVerifyMode = TCPTransportDescriptor::TLSConfig::TLSVerifyMode;
-    using TLSHSRole = TCPTransportDescriptor::TLSConfig::TLSHandShakeRole;
     TCPv4TransportDescriptor senderDescriptor;
     senderDescriptor.add_listener_port(port);
     senderDescriptor.apply_security = true;

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -1330,6 +1330,8 @@ TEST_F(TCPv4Tests, send_and_receive_between_both_secure_ports_with_sni)
 // destination that does not read or does it so slowly.
 TEST_F(TCPv4Tests, secure_non_blocking_send)
 {
+    eprosima::fastdds::dds::Log::SetVerbosity(eprosima::fastdds::dds::Log::Kind::Info);
+
     uint16_t port = g_default_port;
     uint32_t msg_size = eprosima::fastdds::rtps::s_minimumSocketBuffer;
     // Create a TCP Server transport
@@ -1338,10 +1340,13 @@ TEST_F(TCPv4Tests, secure_non_blocking_send)
     using TLSHSRole = TCPTransportDescriptor::TLSConfig::TLSHandShakeRole;
     TCPv4TransportDescriptor senderDescriptor;
     senderDescriptor.add_listener_port(port);
+    senderDescriptor.apply_security = true;
     senderDescriptor.non_blocking_send = true;
     senderDescriptor.sendBufferSize = msg_size;
-    senderDescriptor.tls_config.handshake_role = TLSHSRole::CLIENT;
-    senderDescriptor.tls_config.verify_file = "ca.crt";
+    senderDescriptor.tls_config.password = "fastddspwd";
+    senderDescriptor.tls_config.cert_chain_file = "fastdds.crt";
+    senderDescriptor.tls_config.private_key_file = "fastdds.key";
+    senderDescriptor.tls_config.tmp_dh_file = "dh_params.pem";
     senderDescriptor.tls_config.verify_mode = TLSVerifyMode::VERIFY_PEER;
     senderDescriptor.tls_config.add_option(TLSOptions::DEFAULT_WORKAROUNDS);
     senderDescriptor.tls_config.add_option(TLSOptions::SINGLE_DH_USE);
@@ -1356,8 +1361,8 @@ TEST_F(TCPv4Tests, secure_non_blocking_send)
     // saturate the reception socket of the datareader. This saturation requires
     // preventing the datareader from reading from the socket, what inevitably
     // happens continuously if instantiating and connecting the receiver transport.
-    // Hence, a raw socket is opened and connected to the server. There won't be read
-    // calls on that socket.
+    // Hence, a raw socket is opened and connected to the server. Read calls on that
+    // socket are controlled.
     Locator_t serverLoc;
     serverLoc.kind = LOCATOR_KIND_TCPv4;
     IPLocator::setIPv4(serverLoc, 127, 0, 0, 1);
@@ -1370,13 +1375,7 @@ TEST_F(TCPv4Tests, secure_non_blocking_send)
             {
                 return preverified;
             });
-    ssl_context.set_password_callback([](std::size_t, asio::ssl::context_base::password_purpose)
-            {
-                return "fastddspwd";
-            });
-    ssl_context.use_certificate_chain_file("fastdds.crt");
-    ssl_context.use_private_key_file("fastdds.key", asio::ssl::context::pem);
-    ssl_context.use_tmp_dh_file("dh_params.pem");
+    ssl_context.load_verify_file("ca.crt");
 
     uint32_t options = 0;
     options |= asio::ssl::context::default_workarounds;
@@ -1385,8 +1384,19 @@ TEST_F(TCPv4Tests, secure_non_blocking_send)
     options |= asio::ssl::context::no_compression;
     ssl_context.set_options(options);
 
-    // TCPChannelResourceSecure::connect() like connection
     asio::io_service io_service;
+    auto ioServiceFunction = [&]()
+            {
+#if ASIO_VERSION >= 101200
+                asio::executor_work_guard<asio::io_service::executor_type> work(io_service.get_executor());
+#else
+                io_service::work work(io_service_);
+#endif // if ASIO_VERSION >= 101200
+                io_service.run();
+            };
+    std::thread ioServiceThread(ioServiceFunction);    
+
+    // TCPChannelResourceSecure::connect() like connection
     asio::ip::tcp::resolver resolver(io_service);
     auto endpoints = resolver.resolve(
         IPLocator::ip_to_string(serverLoc),
@@ -1407,7 +1417,7 @@ TEST_F(TCPv4Tests, secure_non_blocking_send)
             )
             {
                 ASSERT_TRUE(!ec);
-                asio::ssl::stream_base::handshake_type role = asio::ssl::stream_base::server;
+                asio::ssl::stream_base::handshake_type role = asio::ssl::stream_base::client;
                 secure_socket->async_handshake(role,
                 [](const std::error_code& ec)
                 {
@@ -1423,6 +1433,7 @@ TEST_F(TCPv4Tests, secure_non_blocking_send)
        a connection. This channel will not be present in the server's channel_resources_ map
        as communication lacks most of the discovery messages using a raw socket as participant.
      */
+    // auto sender_unbound_channel_resources = senderTransportUnderTest.get_unbound_channel_resources();
     auto sender_unbound_channel_resources = senderTransportUnderTest.get_unbound_channel_resources();
     ASSERT_TRUE(sender_unbound_channel_resources.size() == 1u);
     auto sender_channel_resource =
@@ -1430,21 +1441,32 @@ TEST_F(TCPv4Tests, secure_non_blocking_send)
 
     // Prepare the message
     asio::error_code ec;
-    std::vector<octet> message(msg_size, 0);
+    std::vector<octet> message(msg_size*2, 0);
     const octet* data = message.data();
     size_t size = message.size();
 
     // Send the message with no header. Since TCP actually allocates twice the size of the buffer requested
-    // and we want to guarantee that the buffer might be full, we send the message more than twice.
-    size_t bytes_sent = 0;
-    for (int i = 0; i < 5; i++)
-    {
-        bytes_sent += sender_channel_resource->send(nullptr, 0, data, size, ec);
-    }
+    // it should be able to send a message of msg_size*2.
+    size_t bytes_sent = sender_channel_resource->send(nullptr, 0, data, size, ec);
+    ASSERT_EQ(bytes_sent, size);
 
-    ASSERT_EQ(bytes_sent, size * 2);
+    // Now wait until the receive buffer is flushed (send buffer will be empty too)
+    std::vector<octet> buffer(size, 0);
+    size_t bytes_read = 0;
+    bytes_read = asio::read(*secure_socket, asio::buffer(buffer.data(), size),  asio::transfer_exactly(size), ec);
+    ASSERT_EQ(ec, asio::error_code());
+    ASSERT_EQ(bytes_read, size);
+
+    // Now try to send a message that is bigger than the buffer size: (msg_size*2 + 1) + bytes_in_send_buffer(0) > 2*sendBufferSize 
+    message.resize(msg_size*2 + 1);
+    data = message.data();
+    size = message.size();
+    bytes_sent = sender_channel_resource->send(nullptr, 0, data, size, ec);
+    ASSERT_EQ(bytes_sent, 0u);
 
     secure_socket->lowest_layer().close(ec);
+    io_service.stop();
+    ioServiceThread.join();
 }
 #endif // ifndef _WIN32
 
@@ -1866,7 +1888,7 @@ TEST_F(TCPv4Tests, client_announced_local_port_uniqueness)
 }
 
 #ifndef _WIN32
-// The primary purpose of this test is to check the non-blocking behavior of a secure socket sending data to a
+// The primary purpose of this test is to check the non-blocking behavior of a socket sending data to a
 // destination that does not read or does it so slowly.
 TEST_F(TCPv4Tests, non_blocking_send)
 {
@@ -1886,8 +1908,8 @@ TEST_F(TCPv4Tests, non_blocking_send)
     // saturate the reception socket of the datareader. This saturation requires
     // preventing the datareader from reading from the socket, what inevitably
     // happens continuously if instantiating and connecting the receiver transport.
-    // Hence, a raw socket is opened and connected to the server. There won't be read
-    // calls on that socket.
+    // Hence, a raw socket is opened and connected to the server. Read calls on that
+    // socket are controlled.
     Locator_t serverLoc;
     serverLoc.kind = LOCATOR_KIND_TCPv4;
     IPLocator::setIPv4(serverLoc, 127, 0, 0, 1);
@@ -1932,19 +1954,26 @@ TEST_F(TCPv4Tests, non_blocking_send)
 
     // Prepare the message
     asio::error_code ec;
-    std::vector<octet> message(msg_size, 0);
+    std::vector<octet> message(msg_size*2, 0);
     const octet* data = message.data();
     size_t size = message.size();
 
     // Send the message with no header. Since TCP actually allocates twice the size of the buffer requested
-    // and we want to guarantee that the buffer might be full, we send the message more than twice.
-    size_t bytes_sent = 0;
-    for (int i = 0; i < 5; i++)
-    {
-        bytes_sent += sender_channel_resource->send(nullptr, 0, data, size, ec);
-    }
+    // it should be able to send a message of msg_size*2.
+    size_t bytes_sent = sender_channel_resource->send(nullptr, 0, data, size, ec);
+    ASSERT_EQ(bytes_sent, size);
 
-    ASSERT_EQ(bytes_sent, size * 2);
+    // Now wait until the receive buffer is flushed (send buffer will be empty too)
+    std::vector<octet> buffer(size, 0);
+    size_t bytes_read = asio::read(socket, asio::buffer(buffer, size), asio::transfer_exactly(size), ec);
+    ASSERT_EQ(bytes_read, size);
+
+    // Now try to send a message that is bigger than the buffer size: (msg_size*2 + 1) + bytes_in_send_buffer(0) > 2*sendBufferSize 
+    message.resize(msg_size*2 + 1);
+    data = message.data();
+    size = message.size();
+    bytes_sent = sender_channel_resource->send(nullptr, 0, data, size, ec);
+    ASSERT_EQ(bytes_sent, 0u);
 
     socket.shutdown(asio::ip::tcp::socket::shutdown_both);
     socket.cancel();

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -1434,7 +1434,8 @@ TEST_F(TCPv4Tests, secure_non_blocking_send)
     const octet* data = message.data();
     size_t size = message.size();
 
-    // Send the message with no header
+    // Send the message with no header. Since TCP actually allocates twice the size of the buffer requested
+    // and we want to guarantee that the buffer might be full, we send the message more than twice.
     for (int i = 0; i < 5; i++)
     {
         sender_channel_resource->send(nullptr, 0, data, size, ec);
@@ -1932,7 +1933,8 @@ TEST_F(TCPv4Tests, non_blocking_send)
     const octet* data = message.data();
     size_t size = message.size();
 
-    // Send the message with no header
+    // Send the message with no header. Since TCP actually allocates twice the size of the buffer requested
+    // and we want to guarantee that the buffer might be full, we send the message more than twice.
     for (int i = 0; i < 5; i++)
     {
         sender_channel_resource->send(nullptr, 0, data, size, ec);

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -1436,10 +1436,13 @@ TEST_F(TCPv4Tests, secure_non_blocking_send)
 
     // Send the message with no header. Since TCP actually allocates twice the size of the buffer requested
     // and we want to guarantee that the buffer might be full, we send the message more than twice.
+    size_t bytes_sent = 0;
     for (int i = 0; i < 5; i++)
     {
-        sender_channel_resource->send(nullptr, 0, data, size, ec);
+        bytes_sent += sender_channel_resource->send(nullptr, 0, data, size, ec);
     }
+
+    ASSERT_EQ(bytes_sent, size * 2);
 
     secure_socket->lowest_layer().close(ec);
 }
@@ -1935,10 +1938,13 @@ TEST_F(TCPv4Tests, non_blocking_send)
 
     // Send the message with no header. Since TCP actually allocates twice the size of the buffer requested
     // and we want to guarantee that the buffer might be full, we send the message more than twice.
+    size_t bytes_sent = 0;
     for (int i = 0; i < 5; i++)
     {
-        sender_channel_resource->send(nullptr, 0, data, size, ec);
+        bytes_sent += sender_channel_resource->send(nullptr, 0, data, size, ec);
     }
+
+    ASSERT_EQ(bytes_sent, size * 2);
 
     socket.shutdown(asio::ip::tcp::socket::shutdown_both);
     socket.cancel();

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -1394,7 +1394,7 @@ TEST_F(TCPv4Tests, secure_non_blocking_send)
 #endif // if ASIO_VERSION >= 101200
                 io_service.run();
             };
-    std::thread ioServiceThread(ioServiceFunction);    
+    std::thread ioServiceThread(ioServiceFunction);
 
     // TCPChannelResourceSecure::connect() like connection
     asio::ip::tcp::resolver resolver(io_service);
@@ -1441,7 +1441,7 @@ TEST_F(TCPv4Tests, secure_non_blocking_send)
 
     // Prepare the message
     asio::error_code ec;
-    std::vector<octet> message(msg_size*2, 0);
+    std::vector<octet> message(msg_size * 2, 0);
     const octet* data = message.data();
     size_t size = message.size();
 
@@ -1457,8 +1457,8 @@ TEST_F(TCPv4Tests, secure_non_blocking_send)
     ASSERT_EQ(ec, asio::error_code());
     ASSERT_EQ(bytes_read, size);
 
-    // Now try to send a message that is bigger than the buffer size: (msg_size*2 + 1) + bytes_in_send_buffer(0) > 2*sendBufferSize 
-    message.resize(msg_size*2 + 1);
+    // Now try to send a message that is bigger than the buffer size: (msg_size*2 + 1) + bytes_in_send_buffer(0) > 2*sendBufferSize
+    message.resize(msg_size * 2 + 1);
     data = message.data();
     size = message.size();
     bytes_sent = sender_channel_resource->send(nullptr, 0, data, size, ec);
@@ -1954,7 +1954,7 @@ TEST_F(TCPv4Tests, non_blocking_send)
 
     // Prepare the message
     asio::error_code ec;
-    std::vector<octet> message(msg_size*2, 0);
+    std::vector<octet> message(msg_size * 2, 0);
     const octet* data = message.data();
     size_t size = message.size();
 
@@ -1968,8 +1968,8 @@ TEST_F(TCPv4Tests, non_blocking_send)
     size_t bytes_read = asio::read(socket, asio::buffer(buffer, size), asio::transfer_exactly(size), ec);
     ASSERT_EQ(bytes_read, size);
 
-    // Now try to send a message that is bigger than the buffer size: (msg_size*2 + 1) + bytes_in_send_buffer(0) > 2*sendBufferSize 
-    message.resize(msg_size*2 + 1);
+    // Now try to send a message that is bigger than the buffer size: (msg_size*2 + 1) + bytes_in_send_buffer(0) > 2*sendBufferSize
+    message.resize(msg_size * 2 + 1);
     data = message.data();
     size = message.size();
     bytes_sent = sender_channel_resource->send(nullptr, 0, data, size, ec);

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -368,7 +368,7 @@ TEST_F(TCPv6Tests, non_blocking_send)
 
     // Prepare the message
     asio::error_code ec;
-    std::vector<octet> message(msg_size*2, 0);
+    std::vector<octet> message(msg_size * 2, 0);
     const octet* data = message.data();
     size_t size = message.size();
 
@@ -382,8 +382,8 @@ TEST_F(TCPv6Tests, non_blocking_send)
     size_t bytes_read = asio::read(socket, asio::buffer(buffer, size), asio::transfer_exactly(size), ec);
     ASSERT_EQ(bytes_read, size);
 
-    // Now try to send a message that is bigger than the buffer size: (msg_size*2 + 1) + bytes_in_send_buffer(0) > 2*sendBufferSize 
-    message.resize(msg_size*2 + 1);
+    // Now try to send a message that is bigger than the buffer size: (msg_size*2 + 1) + bytes_in_send_buffer(0) > 2*sendBufferSize
+    message.resize(msg_size * 2 + 1);
     data = message.data();
     size = message.size();
     bytes_sent = sender_channel_resource->send(nullptr, 0, data, size, ec);

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -302,7 +302,7 @@ TEST_F(TCPv6Tests, client_announced_local_port_uniqueness)
 }
 
 #ifndef _WIN32
-// The primary purpose of this test is to check the non-blocking behavior of a secure socket sending data to a
+// The primary purpose of this test is to check the non-blocking behavior of a socket sending data to a
 // destination that does not read or does it so slowly.
 TEST_F(TCPv6Tests, non_blocking_send)
 {
@@ -322,8 +322,8 @@ TEST_F(TCPv6Tests, non_blocking_send)
     // saturate the reception socket of the datareader. This saturation requires
     // preventing the datareader from reading from the socket, what inevitably
     // happens continuously if instantiating and connecting the receiver transport.
-    // Hence, a raw socket is opened and connected to the server. There won't be read
-    // calls on that socket.
+    // Hence, a raw socket is opened and connected to the server. Read calls on that
+    // socket are controlled.
     Locator_t serverLoc;
     serverLoc.kind = LOCATOR_KIND_TCPv6;
     IPLocator::setIPv6(serverLoc, "::1");
@@ -368,19 +368,26 @@ TEST_F(TCPv6Tests, non_blocking_send)
 
     // Prepare the message
     asio::error_code ec;
-    std::vector<octet> message(msg_size, 0);
+    std::vector<octet> message(msg_size*2, 0);
     const octet* data = message.data();
     size_t size = message.size();
 
     // Send the message with no header. Since TCP actually allocates twice the size of the buffer requested
-    // and we want to guarantee that the buffer might be full, we send the message more than twice.
-    size_t bytes_sent = 0;
-    for (int i = 0; i < 5; i++)
-    {
-        bytes_sent += sender_channel_resource->send(nullptr, 0, data, size, ec);
-    }
+    // it should be able to send a message of msg_size*2.
+    size_t bytes_sent = sender_channel_resource->send(nullptr, 0, data, size, ec);
+    ASSERT_EQ(bytes_sent, size);
 
-    ASSERT_EQ(bytes_sent, size * 2);
+    // Now wait until the receive buffer is flushed (send buffer will be empty too)
+    std::vector<octet> buffer(size, 0);
+    size_t bytes_read = asio::read(socket, asio::buffer(buffer, size), asio::transfer_exactly(size), ec);
+    ASSERT_EQ(bytes_read, size);
+
+    // Now try to send a message that is bigger than the buffer size: (msg_size*2 + 1) + bytes_in_send_buffer(0) > 2*sendBufferSize 
+    message.resize(msg_size*2 + 1);
+    data = message.data();
+    size = message.size();
+    bytes_sent = sender_channel_resource->send(nullptr, 0, data, size, ec);
+    ASSERT_EQ(bytes_sent, 0u);
 
     socket.shutdown(asio::ip::tcp::socket::shutdown_both);
     socket.cancel();

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -374,10 +374,13 @@ TEST_F(TCPv6Tests, non_blocking_send)
 
     // Send the message with no header. Since TCP actually allocates twice the size of the buffer requested
     // and we want to guarantee that the buffer might be full, we send the message more than twice.
+    size_t bytes_sent = 0;
     for (int i = 0; i < 5; i++)
     {
-        sender_channel_resource->send(nullptr, 0, data, size, ec);
+        bytes_sent += sender_channel_resource->send(nullptr, 0, data, size, ec);
     }
+
+    ASSERT_EQ(bytes_sent, size * 2);
 
     socket.shutdown(asio::ip::tcp::socket::shutdown_both);
     socket.cancel();

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -372,7 +372,8 @@ TEST_F(TCPv6Tests, non_blocking_send)
     const octet* data = message.data();
     size_t size = message.size();
 
-    // Send the message with no header
+    // Send the message with no header. Since TCP actually allocates twice the size of the buffer requested
+    // and we want to guarantee that the buffer might be full, we send the message more than twice.
     for (int i = 0; i < 5; i++)
     {
         sender_channel_resource->send(nullptr, 0, data, size, ec);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Since TCP actually allocates twice the size of the requested buffer, TCP `non_blocking_send` should not skip a send until this limit is reached.
This PR doubles the limit from which a send should not be tried if TCP `non_blocking_send` is set to true.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.12.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- N/A Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- N/A New feature has been added to the `versions.md` file (if applicable).
- N/A New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
