### PR TITLE
[20599] Protect asio exception hotfix

### DIFF
--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -265,10 +265,14 @@ Locator TCPTransportInterface::remote_endpoint_to_locator(
 {
     Locator locator;
     asio::error_code ec;
-    endpoint_to_locator(channel->remote_endpoint(ec), locator);
+    auto endpoint = channel->local_endpoint(ec);
     if (ec)
     {
         LOCATOR_INVALID(locator);
+    }
+    else
+    {
+        endpoint_to_locator(endpoint, locator);
     }
     return locator;
 }
@@ -278,10 +282,14 @@ Locator TCPTransportInterface::local_endpoint_to_locator(
 {
     Locator locator;
     asio::error_code ec;
-    endpoint_to_locator(channel->local_endpoint(ec), locator);
+    auto endpoint = channel->local_endpoint(ec);
     if (ec)
     {
         LOCATOR_INVALID(locator);
+    }
+    else
+    {
+        endpoint_to_locator(endpoint, locator);
     }
     return locator;
 }

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -265,7 +265,7 @@ Locator TCPTransportInterface::remote_endpoint_to_locator(
 {
     Locator locator;
     asio::error_code ec;
-    auto endpoint = channel->local_endpoint(ec);
+    auto endpoint = channel->remote_endpoint(ec);
     if (ec)
     {
         LOCATOR_INVALID(locator);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR introduces a hotfix to check the error code returned by asio when requesting the local_endpoint before trying to convert it to a locator. 

 @Mergifyio backport 2.13.x 2.12.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [_N/A_] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [_N/A_] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [_N/A_] New feature has been added to the `versions.md` file (if applicable).
- [_N/A_] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [X] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
