### PR TITLE
[20543] Create Participant with default profile (use environment XML configuration)

### DIFF
--- a/include/fastdds/dds/domain/DomainParticipantFactory.hpp
+++ b/include/fastdds/dds/domain/DomainParticipantFactory.hpp
@@ -103,6 +103,18 @@ public:
      */
     RTPS_DllAPI DomainParticipant* create_participant_with_default_profile();
 
+
+    /**
+     * Create a Participant with default domain id and qos.
+     *
+     * @return DomainParticipant pointer. (nullptr if not created.)
+     * @param listener DomainParticipantListener Pointer
+     * @param mask StatusMask Reference
+     */
+    RTPS_DllAPI DomainParticipant* create_participant_with_default_profile(
+            DomainParticipantListener* listener,
+            const StatusMask& mask);
+
     /**
      * Create a Participant.
      *

--- a/include/fastdds/dds/domain/DomainParticipantFactory.hpp
+++ b/include/fastdds/dds/domain/DomainParticipantFactory.hpp
@@ -99,6 +99,19 @@ public:
     /**
      * Create a Participant.
      *
+     * @param qos DomainParticipantQos Reference.
+     * @param listener DomainParticipantListener Pointer (default: nullptr)
+     * @param mask StatusMask Reference (default: all)
+     * @return DomainParticipant pointer. (nullptr if not created.)
+     */
+    RTPS_DllAPI DomainParticipant* create_participant(
+            const DomainParticipantQos& qos,
+            DomainParticipantListener* listener = nullptr,
+            const StatusMask& mask = StatusMask::all());
+
+    /**
+     * Create a Participant.
+     *
      * @param domain_id Domain Id.
      * @param profile_name Participant profile name.
      * @param listener DomainParticipantListener Pointer (default: nullptr)
@@ -341,6 +354,8 @@ protected:
     mutable std::mutex mtx_participants_;
 
     mutable bool default_xml_profiles_loaded;
+
+    DomainId_t default_domain_id_;
 
     DomainParticipantFactoryQos factory_qos_;
 

--- a/include/fastdds/dds/domain/DomainParticipantFactory.hpp
+++ b/include/fastdds/dds/domain/DomainParticipantFactory.hpp
@@ -97,15 +97,11 @@ public:
             const StatusMask& mask = StatusMask::all());
 
     /**
-     * Create a Participant.
+     * Create a Participant with default domain id and qos.
      *
-     * @param listener DomainParticipantListener Pointer (default: nullptr)
-     * @param mask StatusMask Reference (default: all)
      * @return DomainParticipant pointer. (nullptr if not created.)
      */
-    RTPS_DllAPI DomainParticipant* create_participant_with_default_profile(
-            DomainParticipantListener* listener = nullptr,
-            const StatusMask& mask = StatusMask::all());
+    RTPS_DllAPI DomainParticipant* create_participant_with_default_profile();
 
     /**
      * Create a Participant.

--- a/include/fastdds/dds/domain/DomainParticipantFactory.hpp
+++ b/include/fastdds/dds/domain/DomainParticipantFactory.hpp
@@ -99,13 +99,11 @@ public:
     /**
      * Create a Participant.
      *
-     * @param qos DomainParticipantQos Reference.
      * @param listener DomainParticipantListener Pointer (default: nullptr)
      * @param mask StatusMask Reference (default: all)
      * @return DomainParticipant pointer. (nullptr if not created.)
      */
-    RTPS_DllAPI DomainParticipant* create_participant(
-            const DomainParticipantQos& qos,
+    RTPS_DllAPI DomainParticipant* create_participant_with_default_profile(
             DomainParticipantListener* listener = nullptr,
             const StatusMask& mask = StatusMask::all());
 

--- a/include/fastdds/dds/domain/DomainParticipantFactory.hpp
+++ b/include/fastdds/dds/domain/DomainParticipantFactory.hpp
@@ -101,7 +101,7 @@ public:
      *
      * @return DomainParticipant pointer. (nullptr if not created.)
      */
-    RTPS_DllAPI DomainParticipant* create_participant_with_default_profile();
+    FASTDDS_EXPORTED_API DomainParticipant* create_participant_with_default_profile();
 
 
     /**
@@ -111,7 +111,7 @@ public:
      * @param listener DomainParticipantListener Pointer
      * @param mask StatusMask Reference
      */
-    RTPS_DllAPI DomainParticipant* create_participant_with_default_profile(
+    FASTDDS_EXPORTED_API DomainParticipant* create_participant_with_default_profile(
             DomainParticipantListener* listener,
             const StatusMask& mask);
 

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -210,7 +210,15 @@ DomainParticipant* DomainParticipantFactory::create_participant(
 DomainParticipant* DomainParticipantFactory::create_participant_with_default_profile()
 {
     load_profiles();
-    return create_participant(default_domain_id_, default_participant_qos_, nullptr, StatusMask::all());
+    return create_participant(default_domain_id_, default_participant_qos_, nullptr, StatusMask::none());
+}
+
+DomainParticipant* DomainParticipantFactory::create_participant_with_default_profile(
+        DomainParticipantListener* listener,
+        const StatusMask& mask)
+{
+    load_profiles();
+    return create_participant(default_domain_id_, default_participant_qos_, listener, mask);
 }
 
 DomainParticipant* DomainParticipantFactory::create_participant_with_profile(

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -207,12 +207,12 @@ DomainParticipant* DomainParticipantFactory::create_participant(
     return dom_part;
 }
 
-DomainParticipant* DomainParticipantFactory::create_participant(
-        const DomainParticipantQos& qos,
+DomainParticipant* DomainParticipantFactory::create_participant_with_default_profile(
         DomainParticipantListener* listen,
         const StatusMask& mask)
 {
-    return create_participant(default_domain_id_, qos, listen, mask);
+    load_profiles();
+    return create_participant(default_domain_id_, default_participant_qos_, listen, mask);
 }
 
 DomainParticipant* DomainParticipantFactory::create_participant_with_profile(

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -54,6 +54,7 @@ namespace dds {
 
 DomainParticipantFactory::DomainParticipantFactory()
     : default_xml_profiles_loaded(false)
+    , default_domain_id_(0)
     , default_participant_qos_(PARTICIPANT_QOS_DEFAULT)
     , topic_pool_(fastrtps::rtps::TopicPayloadPoolRegistry::instance())
     , rtps_domain_(fastrtps::rtps::RTPSDomainImpl::get_instance())
@@ -206,6 +207,14 @@ DomainParticipant* DomainParticipantFactory::create_participant(
     return dom_part;
 }
 
+DomainParticipant* DomainParticipantFactory::create_participant(
+        const DomainParticipantQos& qos,
+        DomainParticipantListener* listen,
+        const StatusMask& mask)
+{
+    return create_participant(default_domain_id_, qos, listen, mask);
+}
+
 DomainParticipant* DomainParticipantFactory::create_participant_with_profile(
         DomainId_t did,
         const std::string& profile_name,
@@ -239,7 +248,8 @@ DomainParticipant* DomainParticipantFactory::create_participant_with_profile(
     {
         DomainParticipantQos qos = default_participant_qos_;
         utils::set_qos_from_attributes(qos, attr.rtps);
-        return create_participant(attr.domainId, qos, listen, mask);
+        default_domain_id_ = attr.domainId;
+        return create_participant(default_domain_id_, qos, listen, mask);
     }
 
     return nullptr;
@@ -423,6 +433,7 @@ void DomainParticipantFactory::reset_default_participant_qos()
         ParticipantAttributes attr;
         XMLProfileManager::getDefaultParticipantAttributes(attr);
         utils::set_qos_from_attributes(default_participant_qos_, attr.rtps);
+        default_domain_id_ = attr.domainId;
     }
 }
 

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -209,8 +209,7 @@ DomainParticipant* DomainParticipantFactory::create_participant(
 
 DomainParticipant* DomainParticipantFactory::create_participant_with_default_profile()
 {
-    load_profiles();
-    return create_participant(default_domain_id_, default_participant_qos_, nullptr, StatusMask::none());
+    return create_participant_with_default_profile(nullptr, StatusMask::none());
 }
 
 DomainParticipant* DomainParticipantFactory::create_participant_with_default_profile(

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -363,6 +363,10 @@ ReturnCode_t DomainParticipantFactory::load_profiles()
         {
             reset_default_participant_qos();
         }
+        // Take the default domain id from the default participant profile
+        eprosima::fastrtps::ParticipantAttributes attr;
+        XMLProfileManager::getDefaultParticipantAttributes(attr);
+        default_domain_id_ = attr.domainId;
 
         RTPSDomain::set_filewatch_thread_config(factory_qos_.file_watch_threads(), factory_qos_.file_watch_threads());
     }
@@ -437,7 +441,6 @@ void DomainParticipantFactory::reset_default_participant_qos()
         ParticipantAttributes attr;
         XMLProfileManager::getDefaultParticipantAttributes(attr);
         utils::set_qos_from_attributes(default_participant_qos_, attr.rtps);
-        default_domain_id_ = attr.domainId;
     }
 }
 

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -156,7 +156,7 @@ ReturnCode_t DomainParticipantFactory::delete_participant(
 DomainParticipant* DomainParticipantFactory::create_participant(
         DomainId_t did,
         const DomainParticipantQos& qos,
-        DomainParticipantListener* listen,
+        DomainParticipantListener* listener,
         const StatusMask& mask)
 {
     load_profiles();
@@ -165,10 +165,10 @@ DomainParticipant* DomainParticipantFactory::create_participant(
 
     DomainParticipant* dom_part = new DomainParticipant(mask);
 #ifndef FASTDDS_STATISTICS
-    DomainParticipantImpl* dom_part_impl = new DomainParticipantImpl(dom_part, did, pqos, listen);
+    DomainParticipantImpl* dom_part_impl = new DomainParticipantImpl(dom_part, did, pqos, listener);
 #else
     eprosima::fastdds::statistics::dds::DomainParticipantImpl* dom_part_impl =
-            new eprosima::fastdds::statistics::dds::DomainParticipantImpl(dom_part, did, pqos, listen);
+            new eprosima::fastdds::statistics::dds::DomainParticipantImpl(dom_part, did, pqos, listener);
 #endif // FASTDDS_STATISTICS
 
     if (fastrtps::rtps::GUID_t::unknown() != dom_part_impl->guid())
@@ -207,18 +207,16 @@ DomainParticipant* DomainParticipantFactory::create_participant(
     return dom_part;
 }
 
-DomainParticipant* DomainParticipantFactory::create_participant_with_default_profile(
-        DomainParticipantListener* listen,
-        const StatusMask& mask)
+DomainParticipant* DomainParticipantFactory::create_participant_with_default_profile()
 {
     load_profiles();
-    return create_participant(default_domain_id_, default_participant_qos_, listen, mask);
+    return create_participant(default_domain_id_, default_participant_qos_, nullptr, StatusMask::all());
 }
 
 DomainParticipant* DomainParticipantFactory::create_participant_with_profile(
         DomainId_t did,
         const std::string& profile_name,
-        DomainParticipantListener* listen,
+        DomainParticipantListener* listener,
         const StatusMask& mask)
 {
     load_profiles();
@@ -229,7 +227,7 @@ DomainParticipant* DomainParticipantFactory::create_participant_with_profile(
     {
         DomainParticipantQos qos = default_participant_qos_;
         utils::set_qos_from_attributes(qos, attr.rtps);
-        return create_participant(did, qos, listen, mask);
+        return create_participant(did, qos, listener, mask);
     }
 
     return nullptr;
@@ -237,7 +235,7 @@ DomainParticipant* DomainParticipantFactory::create_participant_with_profile(
 
 DomainParticipant* DomainParticipantFactory::create_participant_with_profile(
         const std::string& profile_name,
-        DomainParticipantListener* listen,
+        DomainParticipantListener* listener,
         const StatusMask& mask)
 {
     load_profiles();
@@ -248,8 +246,7 @@ DomainParticipant* DomainParticipantFactory::create_participant_with_profile(
     {
         DomainParticipantQos qos = default_participant_qos_;
         utils::set_qos_from_attributes(qos, attr.rtps);
-        default_domain_id_ = attr.domainId;
-        return create_participant(default_domain_id_, qos, listen, mask);
+        return create_participant(attr.domainId, qos, listener, mask);
     }
 
     return nullptr;

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -66,6 +66,7 @@
 #include <xmlparser/attributes/SubscriberAttributes.hpp>
 
 #include "../../logging/mock/MockConsumer.h"
+#include "../../common/env_var_utils.hpp"
 
 #if defined(__cplusplus_winrt)
 #define GET_PID GetCurrentProcessId
@@ -571,22 +572,27 @@ TEST(ParticipantTests, CreateDomainParticipantWithProfile)
 
 TEST(ParticipantTests, CreateDomainParticipantWithDefaultProfile)
 {
-    // set XML profile as environment variable: "export FASTDDS_DEFAULT_PROFILES_FILE=test_xml_profile.xml"
-    setenv("FASTDDS_DEFAULT_PROFILES_FILE", "test_xml_profile.xml", true);
-
     uint32_t domain_id = 123u;          // This is the domain ID set in the default profile above
-    uint32_t default_domain_id = 0u;    // This is the default domain ID
+
+    // set XML profile as environment variable: "export FASTDDS_DEFAULT_PROFILES_FILE=test_xml_profile.xml"
+    eprosima::testing::set_environment_variable("FASTDDS_DEFAULT_PROFILES_FILE", "test_xml_profile.xml");
 
     //participant using the given profile
     DomainParticipant* default_env_participant =
             DomainParticipantFactory::get_instance()->create_participant_with_default_profile();
+
+    // unset XML profile environment variable
+    eprosima::testing::clear_environment_variable("FASTDDS_DEFAULT_PROFILES_FILE");
+
     ASSERT_NE(default_env_participant, nullptr);
     ASSERT_EQ(default_env_participant->get_domain_id(), domain_id);
     ASSERT_TRUE(DomainParticipantFactory::get_instance()->delete_participant(
                 default_env_participant) == ReturnCode_t::RETCODE_OK);
+}
 
-    // unset XML profile environment variable
-    unsetenv("FASTRTPS_DEFAULT_PROFILES_FILE");
+TEST(ParticipantTests, CreateDomainParticipantWithoutDefaultProfile)
+{
+    uint32_t default_domain_id = 0u;    // This is the default domain ID
 
     //participant using default values
     DomainParticipant* default_participant =

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -598,11 +598,11 @@ TEST(ParticipantTests, CreateDomainParticipantWithDefaultProfileListener)
     // set XML profile as environment variable: "export FASTDDS_DEFAULT_PROFILES_FILE=test_xml_profile.xml"
     eprosima::testing::set_environment_variable("FASTDDS_DEFAULT_PROFILES_FILE", "test_xml_profile.xml");
 
-    DomainParticipantListener* listener = new DomainParticipantListener();
+    DomainParticipantListener listener;
 
     //participant using the given profile
     DomainParticipant* default_env_participant =
-            DomainParticipantFactory::get_instance()->create_participant_with_default_profile(listener,
+            DomainParticipantFactory::get_instance()->create_participant_with_default_profile(&listener,
                     StatusMask::none());
 
     // unset XML profile environment variable
@@ -610,7 +610,7 @@ TEST(ParticipantTests, CreateDomainParticipantWithDefaultProfileListener)
 
     ASSERT_NE(default_env_participant, nullptr);
     ASSERT_EQ(default_env_participant->get_domain_id(), domain_id);
-    ASSERT_EQ(default_env_participant->get_listener(), listener);
+    ASSERT_EQ(default_env_participant->get_listener(), &listener);
     ASSERT_TRUE(DomainParticipantFactory::get_instance()->delete_participant(
                 default_env_participant) == ReturnCode_t::RETCODE_OK);
 }
@@ -633,15 +633,15 @@ TEST(ParticipantTests, CreateDomainParticipantWithoutDefaultProfileListener)
 {
     uint32_t default_domain_id = 0u;    // This is the default domain ID
 
-    DomainParticipantListener* listener = new DomainParticipantListener();
+    DomainParticipantListener listener;
 
     //participant using default values
     DomainParticipant* default_participant =
-            DomainParticipantFactory::get_instance()->create_participant_with_default_profile(listener,
+            DomainParticipantFactory::get_instance()->create_participant_with_default_profile(&listener,
                     StatusMask::none());
     ASSERT_NE(default_participant, nullptr);
     ASSERT_EQ(default_participant->get_domain_id(), default_domain_id);
-    ASSERT_EQ(default_participant->get_listener(), listener);
+    ASSERT_EQ(default_participant->get_listener(), &listener);
     ASSERT_TRUE(DomainParticipantFactory::get_instance()->delete_participant(
                 default_participant) == ReturnCode_t::RETCODE_OK);
 }

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -17,6 +17,7 @@
 #include <future>
 #include <memory>
 #include <sstream>
+#include <stdlib.h>
 #include <string>
 #include <thread>
 
@@ -566,6 +567,34 @@ TEST(ParticipantTests, CreateDomainParticipantWithProfile)
     ASSERT_EQ(participant->get_domain_id(), domain_id); //Keep the DID given to the method, not the one on the profile
     check_participant_with_profile(participant, "test_participant_profile");
     ASSERT_TRUE(DomainParticipantFactory::get_instance()->delete_participant(participant) == ReturnCode_t::RETCODE_OK);
+}
+
+TEST(ParticipantTests, CreateDomainParticipantWithDefaultProfile)
+{
+    // set XML profile as environment variable: "export FASTDDS_DEFAULT_PROFILES_FILE=test_xml_profile.xml"
+    setenv("FASTDDS_DEFAULT_PROFILES_FILE", "test_xml_profile.xml", true);
+
+    uint32_t domain_id = 123u;          // This is the domain ID set in the default profile above
+    uint32_t default_domain_id = 0u;    // This is the default domain ID
+
+    //participant using the given profile
+    DomainParticipant* default_env_participant =
+            DomainParticipantFactory::get_instance()->create_participant_with_default_profile();
+    ASSERT_NE(default_env_participant, nullptr);
+    ASSERT_EQ(default_env_participant->get_domain_id(), domain_id);
+    ASSERT_TRUE(DomainParticipantFactory::get_instance()->delete_participant(
+                default_env_participant) == ReturnCode_t::RETCODE_OK);
+
+    // unset XML profile environment variable
+    unsetenv("FASTRTPS_DEFAULT_PROFILES_FILE");
+
+    //participant using default values
+    DomainParticipant* default_participant =
+            DomainParticipantFactory::get_instance()->create_participant_with_default_profile();
+    ASSERT_NE(default_participant, nullptr);
+    ASSERT_EQ(default_participant->get_domain_id(), default_domain_id);
+    ASSERT_TRUE(DomainParticipantFactory::get_instance()->delete_participant(
+                default_participant) == ReturnCode_t::RETCODE_OK);
 }
 
 TEST(ParticipantTests, GetParticipantProfileQos)

--- a/versions.md
+++ b/versions.md
@@ -23,6 +23,7 @@ Forthcoming
   * StringMatching
   * TimeConversion
   * DBQueue
+* Added create participant methods that use environment XML profile for participant configuration.
 
 Version 2.14.0
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
DomainParticipant XML profile configuration allows setting the [domain id](https://fast-dds.docs.eprosima.com/en/latest/fastdds/xml_configuration/domainparticipant.html#domainparticipant-configuration) out of the rtps.
That domain ID is considered in the domain participant creation only if [the domain participant profile name is defined](https://github.com/eProsima/Fast-DDS/blob/5c87d9d02173f190f7b69cb4dbbb6041d9fcf177/src/cpp/fastdds/domain/DomainParticipantFactory.cpp#L242).

This PR stores (if exists) the Domain ID value while loading the default XML profile, and exposes new methods to simplify participant creation without requiring neither the Domain ID (uses the one set in the XML, or `0` by default), neither the QoS (uses the qos set in the XML, or PARTICIPANT_DEFAULT_QOS by default)

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.13.x 2.12.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    Related documentation PR: eProsima/Fast-DDS-docs#725
- **N/A** Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
