### PR TITLE
[20608][20610] Address XMLProfiles fuzzer regressions

### DIFF
--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -150,14 +150,14 @@ static void set_builtin_transports_from_env_var(
                 if (std::regex_search(env_value, mr, msg_size_regex, std::regex_constants::match_not_null))
                 {
                     std::string value = mr[2];
-                    std::string unit = (mr[3] == "") ? "B" : mr[3].str();
+                    std::string unit = mr[3].str();
                     options.maxMessageSize = eprosima::fastdds::dds::utils::parse_value_and_units(value, unit);
                 }
                 // Sockets_size parser
                 if (std::regex_search(env_value, mr, sockets_size_regex, std::regex_constants::match_not_null))
                 {
                     std::string value = mr[2];
-                    std::string unit = (mr[3] == "") ? "B" : mr[3].str();
+                    std::string unit = mr[3].str();
                     options.sockets_buffer_size = eprosima::fastdds::dds::utils::parse_value_and_units(value, unit);
                 }
                 // Non-blocking-send parser

--- a/src/cpp/rtps/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLElementParser.cpp
@@ -4767,7 +4767,7 @@ XMLP_ret XMLParser::getXMLBuiltinTransports(
                 if (std::regex_search(temp, mr, msg_size_regex, std::regex_constants::match_not_null))
                 {
                     std::string value = mr[1];
-                    std::string unit = (mr[2] == "") ? "B" : mr[2].str();
+                    std::string unit = mr[2].str();
                     bt_opts->maxMessageSize = eprosima::fastdds::dds::utils::parse_value_and_units(value, unit);
                 }
             }
@@ -4799,7 +4799,7 @@ XMLP_ret XMLParser::getXMLBuiltinTransports(
                 if (std::regex_search(temp, mr, sockets_size_regex, std::regex_constants::match_not_null))
                 {
                     std::string value = mr[1];
-                    std::string unit = (mr[2] == "") ? "B" : mr[2].str();
+                    std::string unit = mr[2].str();
                     bt_opts->sockets_buffer_size = eprosima::fastdds::dds::utils::parse_value_and_units(value, unit);
                 }
             }

--- a/src/cpp/utils/UnitsParser.cpp
+++ b/src/cpp/utils/UnitsParser.cpp
@@ -64,7 +64,17 @@ uint32_t parse_value_and_units(
         {"GIB", 1024 * 1024 * 1024},
     };
 
-    uint64_t num = std::stoull(value);
+    uint64_t num = 0;
+    try
+    {
+        num = std::stoull(value);
+    }
+    catch (std::out_of_range&)
+    {
+        throw std::invalid_argument("Failed to parse value from string." \
+                      " The number is too large to be converted to bytes (Max: (2^32)-1 Bytes).");
+    }
+
     to_uppercase(units);
 
     std::regex pattern(R"(([kibmgKIBMG]{1,3})|(\d+))");

--- a/src/cpp/utils/UnitsParser.cpp
+++ b/src/cpp/utils/UnitsParser.cpp
@@ -77,7 +77,7 @@ uint32_t parse_value_and_units(
 
     to_uppercase(units);
 
-    std::regex pattern(R"(([kibmgKIBMG]{1,3})|(\d+))");
+    std::regex pattern(R"(([bB]{1})|([kibmgKIBMG]{2,3})|(\d+))");
     if (!std::regex_match(units, pattern))
     {
         throw std::invalid_argument(

--- a/src/cpp/utils/UnitsParser.cpp
+++ b/src/cpp/utils/UnitsParser.cpp
@@ -55,6 +55,7 @@ uint32_t parse_value_and_units(
         std::string units)
 {
     static const std::map<std::string, std::uint32_t> magnitudes = {
+        {"", 1},
         {"B", 1},
         {"KB", 1000},
         {"MB", 1000 * 1000},
@@ -77,13 +78,16 @@ uint32_t parse_value_and_units(
 
     to_uppercase(units);
 
-    std::regex pattern(R"(([bB]{1})|([kibmgKIBMG]{2,3})|(\d+))");
-    if (!std::regex_match(units, pattern))
+    unsigned int magnitude = 0;
+    try
+    {
+        magnitude = magnitudes.at(units);
+    }
+    catch (std::out_of_range&)
     {
         throw std::invalid_argument(
                   "The units are not in the expected format. Use: {B, KB, MG, GB, KIB, MIB, GIB}.");
     }
-    const auto magnitude = magnitudes.at(units);
 
     // Check whether the product of number * magnitude overflows
     if (num > std::numeric_limits<std::uint32_t>::max() / magnitude)

--- a/src/cpp/utils/UnitsParser.cpp
+++ b/src/cpp/utils/UnitsParser.cpp
@@ -78,7 +78,7 @@ uint32_t parse_value_and_units(
 
     to_uppercase(units);
 
-    unsigned int magnitude = 0;
+    uint32_t magnitude = 0;
     try
     {
         magnitude = magnitudes.at(units);

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -72,6 +72,7 @@ TEST_F(XMLParserTests, regressions)
     EXPECT_EQ(XMLP_ret::XML_OK, XMLParser::loadXML("regressions/simple_participant_profiles_ok.xml", root));
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/20186_profile_bin.xml", root));
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/20187_profile_bin.xml", root));
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/20608_profile_bin.xml", root));
 }
 
 TEST_F(XMLParserTests, NoFile)

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -73,6 +73,7 @@ TEST_F(XMLParserTests, regressions)
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/20186_profile_bin.xml", root));
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/20187_profile_bin.xml", root));
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/20608_profile_bin.xml", root));
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/20610_profile_bin.xml", root));
 }
 
 TEST_F(XMLParserTests, NoFile)

--- a/test/unittest/xmlparser/regressions/20608_profile_bin.xml
+++ b/test/unittest/xmlparser/regressions/20608_profile_bin.xml
@@ -1,0 +1,1 @@
+<profiles><participant><rtps><builtinTransports max_msg_size="88888888888888888884"/></rtps></participant></profiles>

--- a/test/unittest/xmlparser/regressions/20610_profile_bin.xml
+++ b/test/unittest/xmlparser/regressions/20610_profile_bin.xml
@@ -1,0 +1,1 @@
+<profiles><participant><rtps><builtinTransports max_msg_size="1i"/></rtps></participant></profiles>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR addresses the regressions described in [20608](https://eprosima.easyredmine.com/issues/20608) and [20610](https://eprosima.easyredmine.com/issues/20610). One has to  do with catching an out of bounds exception and the other with fixing the regex pattern.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!--@Mergifyio backport 2.13.x 2.12.x 2.10.x 2.6.x-->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- **N/A** Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
