### PR TITLE
[20542] Pin CMake version and vm.mmap_rnd_bits in sanitizer workflows

### DIFF
--- a/.github/workflows/address-sanitizers.yaml
+++ b/.github/workflows/address-sanitizers.yaml
@@ -40,6 +40,10 @@ jobs:
         FASTDDS_BRANCH: ${{ github.head_ref || github.event.inputs.fastdds_branch || 'master' }}
 
     steps:
+      # https://github.com/actions/runner-images/issues/9491
+      - name: Fix kernel mmap rnd bits
+        run: sudo sysctl vm.mmap_rnd_bits=28
+
       - name: Install apt packages
         uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
         with:
@@ -133,6 +137,10 @@ jobs:
       DEFAULT_DISCOVERY_SERVER_BRANCH: ${{ github.event.inputs.discovery_server_branch || 'master' }}
 
     steps:
+      # https://github.com/actions/runner-images/issues/9491
+      - name: Fix kernel mmap rnd bits
+        run: sudo sysctl vm.mmap_rnd_bits=28
+
       - name: Install apt packages
         uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
         with:

--- a/.github/workflows/address-sanitizers.yaml
+++ b/.github/workflows/address-sanitizers.yaml
@@ -80,10 +80,12 @@ jobs:
           cd ./src/fastrtps
           git checkout ${{ env.FASTDDS_BRANCH }}
 
-      - name: Install GTest
-        uses: eProsima/eProsima-CI/ubuntu/install_gtest@v0
+      - name: Fetch Fast DDS ASan dependencies
+        uses: eProsima/eProsima-CI/multiplatform/vcs_import@v0
         with:
-          version: v1.12.1
+          vcs_repos_file: ${{ github.workspace }}/src/fastrtps/.github/workflows/config/asan.repos
+          destination_workspace: src
+          skip_existing: 'true'
 
       - name: Build workspace
         run: |

--- a/.github/workflows/address-sanitizers.yaml
+++ b/.github/workflows/address-sanitizers.yaml
@@ -19,7 +19,7 @@ on:
       - '**.md'
       - '**.txt'
       - '!**/CMakeLists.txt'
-      
+
   schedule:
     - cron: '0 1 * * *'
 
@@ -44,6 +44,11 @@ jobs:
         uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
         with:
           packages: curl grep libasio-dev libtinyxml2-dev python3 python3-pip software-properties-common wget
+
+      - name: Get minimum supported version of CMake
+        uses: eProsima/eProsima-CI/external/get-cmake@v0
+        with:
+          cmakeVersion: '3.22.6'
 
       - name: Setup CCache
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0

--- a/.github/workflows/address-sanitizers.yaml
+++ b/.github/workflows/address-sanitizers.yaml
@@ -138,6 +138,11 @@ jobs:
         with:
           packages: curl grep libasio-dev libtinyxml2-dev python3 python3-pip software-properties-common wget
 
+      - name: Get minimum supported version of CMake
+        uses: eProsima/eProsima-CI/external/get-cmake@v0
+        with:
+          cmakeVersion: '3.22.6'
+
       - name: Install colcon
         uses: eProsima/eProsima-CI/ubuntu/install_colcon@v0
 

--- a/.github/workflows/address-sanitizers.yaml
+++ b/.github/workflows/address-sanitizers.yaml
@@ -151,6 +151,9 @@ jobs:
         with:
           cmakeVersion: '3.22.6'
 
+      - name: Setup CCache
+        uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
+
       - name: Install colcon
         uses: eProsima/eProsima-CI/ubuntu/install_colcon@v0
 

--- a/.github/workflows/config/asan.repos
+++ b/.github/workflows/config/asan.repos
@@ -1,0 +1,5 @@
+repositories:
+    googletest-distribution:
+        type: git
+        url: https://github.com/google/googletest.git
+        version: release-1.12.1

--- a/.github/workflows/config/asan_colcon.meta
+++ b/.github/workflows/config/asan_colcon.meta
@@ -12,8 +12,13 @@ names:
             - "-DFASTDDS_STATISTICS=ON"
             - "-DSANITIZER=Address"
             - "-DCMAKE_CXX_FLAGS='-Werror'"
-
     discovery-server:
         cmake-args:
             -"-DCMAKE_BUILD_TYPE=Debug"
             -"-DSANITIZER=Address"
+    googletest-distribution:
+        cmake-args:
+            - "-Dgtest_force_shared_crt=ON"
+            - "-DBUILD_SHARED_LIBS=ON"
+            - "-DBUILD_GMOCK=ON"
+

--- a/.github/workflows/config/asan_colcon.meta
+++ b/.github/workflows/config/asan_colcon.meta
@@ -14,8 +14,8 @@ names:
             - "-DCMAKE_CXX_FLAGS='-Werror'"
     discovery-server:
         cmake-args:
-            -"-DCMAKE_BUILD_TYPE=Debug"
-            -"-DSANITIZER=Address"
+            - "-DCMAKE_BUILD_TYPE=Debug"
+            - "-DSANITIZER=Address"
     googletest-distribution:
         cmake-args:
             - "-Dgtest_force_shared_crt=ON"

--- a/.github/workflows/config/tsan_colcon.meta
+++ b/.github/workflows/config/tsan_colcon.meta
@@ -16,3 +16,8 @@ names:
             - "-DFASTDDS_STATISTICS=ON"
             - "-DCMAKE_C_FLAGS='-fsanitize=thread -O2 -g -fno-omit-frame-pointer'"
             - "-DCMAKE_CXX_FLAGS='-fsanitize=thread -O2 -g -fno-omit-frame-pointer'"
+    googletest-distribution:
+        cmake-args:
+            - "-Dgtest_force_shared_crt=ON"
+            - "-DBUILD_SHARED_LIBS=ON"
+            - "-DBUILD_GMOCK=ON"

--- a/.github/workflows/reusable-mac-ci.yml
+++ b/.github/workflows/reusable-mac-ci.yml
@@ -55,7 +55,7 @@ jobs:
           python-version: '3.11'
 
       - name: Get minimum supported version of CMake
-        uses: lukka/get-cmake@latest
+        uses: eProsima/eProsima-CI/external/get-cmake@v0
         with:
           cmakeVersion: '3.22.6'
 

--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -49,7 +49,7 @@ jobs:
           ref: ${{ inputs.fastdds-branch }}
 
       - name: Get minimum supported version of CMake
-        uses: lukka/get-cmake@latest
+        uses: eProsima/eProsima-CI/external/get-cmake@v0
         with:
           cmakeVersion: '3.22.6'
 

--- a/.github/workflows/reusable-windows-ci.yml
+++ b/.github/workflows/reusable-windows-ci.yml
@@ -49,7 +49,7 @@ jobs:
           ref: ${{ inputs.fastdds_branch }}
 
       - name: Get minimum supported version of CMake
-        uses: lukka/get-cmake@latest
+        uses: eProsima/eProsima-CI/external/get-cmake@v0
         with:
           cmakeVersion: '3.22.6'
 

--- a/.github/workflows/thread-sanitizer.yaml
+++ b/.github/workflows/thread-sanitizer.yaml
@@ -50,6 +50,10 @@ jobs:
         CXX: g++-12
 
     steps:
+      # https://github.com/actions/runner-images/issues/9491
+      - name: Fix kernel mmap rnd bits
+        run: sudo sysctl vm.mmap_rnd_bits=28
+
       - name: Install apt packages
         uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
         with:

--- a/.github/workflows/thread-sanitizer.yaml
+++ b/.github/workflows/thread-sanitizer.yaml
@@ -90,10 +90,12 @@ jobs:
           cd ./src/fastrtps
           git checkout ${{ env.FASTDDS_BRANCH }}
 
-      - name: Install GTest
-        uses: eProsima/eProsima-CI/ubuntu/install_gtest@v0
+      - name: Fetch Fast DDS CI dependencies
+        uses: eProsima/eProsima-CI/multiplatform/vcs_import@v0
         with:
-          version: release-1.11.0
+          vcs_repos_file: ${{ github.workspace }}/src/fastrtps/.github/workflows/config/ci.repos
+          destination_workspace: src
+          skip_existing: 'true'
 
       - name: Build workspace
         run: |

--- a/.github/workflows/thread-sanitizer.yaml
+++ b/.github/workflows/thread-sanitizer.yaml
@@ -25,7 +25,7 @@ on:
 
   schedule:
     - cron: '0 1 * * *'
-    
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -54,6 +54,11 @@ jobs:
         uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
         with:
           packages: curl grep libasio-dev libtinyxml2-dev python3 python3-pip software-properties-common wget
+
+      - name: Get minimum supported version of CMake
+        uses: eProsima/eProsima-CI/external/get-cmake@v0
+        with:
+          cmakeVersion: '3.22.6'
 
       - name: Setup CCache
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Since the roll out of [Github Ubuntu 22.04 (20240310) Image](https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20240310.1), ASan and TSan jobs have been failing. The issue was reported in actions/runner-images#9491 and fixed in actions/runner-images#9513. Until that fix is deployed, this PR:

1. Sets kernel param `vm.mmap_rnd_bits` to 28 as a workaround
2. Pins the CMake version used in all 3 sanitizer jobs.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.12.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- _N/A_: The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
