### PR TITLE
[20625] Monitor service properly managing instances 

### DIFF
--- a/src/cpp/statistics/rtps/monitor-service/MonitorService.cpp
+++ b/src/cpp/statistics/rtps/monitor-service/MonitorService.cpp
@@ -17,7 +17,6 @@
  */
 
 #include <statistics/rtps/monitor-service/MonitorService.hpp>
-#include <statistics/rtps/StatisticsBase.hpp>
 
 #include <fastdds/publisher/DataWriterHistory.hpp>
 #include <fastdds/statistics/topic_names.hpp>
@@ -25,6 +24,7 @@
 
 #include <rtps/history/PoolConfig.h>
 #include <rtps/history/TopicPayloadPoolRegistry.hpp>
+#include <statistics/rtps/StatisticsBase.hpp>
 
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;

--- a/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
@@ -470,6 +470,7 @@ protected:
 struct SampleValidator
 {
     SampleValidator()
+        : assert_on_non_expected_msgs_(true)
     {
         validation_mask.set();
     }
@@ -477,8 +478,16 @@ struct SampleValidator
     SampleValidator(
             std::bitset<statistics::STATUSES_SIZE>& val_mask)
         : validation_mask(val_mask)
+        , assert_on_non_expected_msgs_(true)
     {
+    }
 
+    SampleValidator(
+            std::bitset<statistics::STATUSES_SIZE>& val_mask,
+            bool assert_on_non_expected_msgs)
+        : validation_mask(val_mask)
+        , assert_on_non_expected_msgs_(assert_on_non_expected_msgs)
+    {
     }
 
     //! Avoid declaring it as virtual
@@ -494,6 +503,7 @@ struct SampleValidator
     }
 
     std::bitset<statistics::STATUSES_SIZE> validation_mask;
+    bool assert_on_non_expected_msgs_;
 
 };
 
@@ -505,6 +515,7 @@ public:
     MonitorServiceConsumer()
         : PubSubReader<MonitorServiceType>(statistics::MONITOR_SERVICE_TOPIC, true, true)
         , sample_validator_( new SampleValidator())
+        , reader_history_kind_(eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS)
     {
 
     }
@@ -513,6 +524,17 @@ public:
             std::bitset<statistics::STATUSES_SIZE>& val_mask)
         : PubSubReader<MonitorServiceType>(statistics::MONITOR_SERVICE_TOPIC, true, true)
         , sample_validator_( new SampleValidator(val_mask))
+        , reader_history_kind_(eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS)
+    {
+
+    }
+
+    MonitorServiceConsumer(
+            std::bitset<statistics::STATUSES_SIZE>& val_mask,
+            bool assert_on_non_expected_msgs)
+        : PubSubReader<MonitorServiceType>(statistics::MONITOR_SERVICE_TOPIC, true, true)
+        , sample_validator_( new SampleValidator(val_mask, assert_on_non_expected_msgs))
+        , reader_history_kind_(eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS)
     {
 
     }
@@ -542,7 +564,7 @@ public:
     {
         reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS);
         durability_kind(eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS);
-        history_kind(eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS);
+        history_kind(reader_history_kind_);
         resource_limits_max_samples(4000);
         resource_limits_max_samples_per_instance(100);
         resource_limits_max_instances(30);
@@ -556,7 +578,7 @@ public:
     {
         reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS);
         durability_kind(eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS);
-        history_kind(eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS);
+        history_kind(reader_history_kind_);
         history_depth(1);
 
         participant_ = DomainParticipantFactory::get_instance()->create_participant(
@@ -568,6 +590,13 @@ public:
         init();
 
         statistics_part_ = statistics::dds::DomainParticipant::narrow(get_participant());
+    }
+
+    MonitorServiceConsumer& set_reader_history_kind(
+            HistoryQosPolicyKind kind)
+    {
+        reader_history_kind_ = kind;
+        return *this;
     }
 
     SequenceNumber_t start_reception(
@@ -633,6 +662,8 @@ protected:
     std::mutex validator_mtx_;
 
     statistics::dds::DomainParticipant* statistics_part_;
+
+    HistoryQosPolicyKind reader_history_kind_;
 };
 
 struct ProxySampleValidator : public SampleValidator
@@ -660,9 +691,8 @@ struct ProxySampleValidator : public SampleValidator
             {
                 std::cout << "Unexpected proxy " << statistics::to_fastdds_type(data.local_entity()) <<
                     data.status_kind() << std::endl;
+                return;
             }
-
-            ASSERT_NE(it, total_msgs.end());
 
             GUID_t guid = statistics::to_fastdds_type(data.local_entity());
 
@@ -729,11 +759,13 @@ struct ProxySampleValidator : public SampleValidator
             std::cout << "Received unregistration of instance "
                       << info.instance_handle << std::endl;
 
-            ASSERT_NE(it, total_msgs.end());
-
-            total_msgs.erase(it);
-            ++processed_count;
-            cv.notify_one();
+            if (assert_on_non_expected_msgs_)
+            {
+                ASSERT_NE(it, total_msgs.end());
+                total_msgs.erase(it);
+                ++processed_count;
+                cv.notify_one();
+            }
         }
     }
 
@@ -839,11 +871,13 @@ struct ConnectionListSampleValidator : public SampleValidator
                                 return false;
                             });
 
-            ASSERT_NE(it, total_msgs.end());
-
-            total_msgs.erase(it);
-            ++processed_count;
-            cv.notify_one();
+            if (assert_on_non_expected_msgs_)
+            {
+                ASSERT_NE(it, total_msgs.end());
+                total_msgs.erase(it);
+                ++processed_count;
+                cv.notify_one();
+            }
         }
     }
 
@@ -871,16 +905,18 @@ struct IncompatibleQoSSampleValidator : public SampleValidator
                                 == elem.value().incompatible_qos_status().last_policy_id());
                             });
 
-            ASSERT_NE(it, total_msgs.end());
+            if (assert_on_non_expected_msgs_)
+            {
+                ASSERT_NE(it, total_msgs.end());
+                total_msgs.erase(it);
+                ++processed_count;
+                cv.notify_one();
+            }
 
             std::cout << "Received QoS Incompatibility on local_entity "
                       << statistics::to_fastdds_type(data.local_entity())
                       << "\n\tLast policy id: " << data.value().incompatible_qos_status().last_policy_id()
                       << std::endl;
-
-            total_msgs.erase(it);
-            ++processed_count;
-            cv.notify_one();
         }
     }
 
@@ -908,16 +944,18 @@ struct LivelinessLostSampleValidator : public SampleValidator
                                 == elem.value().liveliness_lost_status().total_count());
                             });
 
-            ASSERT_NE(it, total_msgs.end());
+            if (assert_on_non_expected_msgs_)
+            {
+                ASSERT_NE(it, total_msgs.end());
+                total_msgs.erase(it);
+                ++processed_count;
+                cv.notify_one();
+            }
 
             std::cout << "Received QoS Incompatibility on local_entity "
                       << statistics::to_fastdds_type(data.local_entity())
                       << "\n\tLiveliness Lost Count: " << data.value().liveliness_lost_status().total_count()
                       << std::endl;
-
-            total_msgs.erase(it);
-            ++processed_count;
-            cv.notify_one();
         }
     }
 
@@ -950,11 +988,13 @@ struct LivelinessChangedSampleValidator : public SampleValidator
                       << "\n\tNot Alive Count: " << data.value().liveliness_changed_status().not_alive_count()
                       << std::endl;
 
-            ASSERT_NE(it, total_msgs.end());
-
-            total_msgs.erase(it);
-            ++processed_count;
-            cv.notify_one();
+            if (assert_on_non_expected_msgs_)
+            {
+                ASSERT_NE(it, total_msgs.end());
+                total_msgs.erase(it);
+                ++processed_count;
+                cv.notify_one();
+            }
         }
     }
 
@@ -969,6 +1009,11 @@ struct DeadlineMissedSampleValidator : public SampleValidator
             std::atomic<size_t>& processed_count,
             std::condition_variable& cv)
     {
+        std::cout << "Received Deadline Missed on local_entity "
+                  << statistics::to_fastdds_type(data.local_entity())
+                  << "\n\tTotal Count: " << data.value().deadline_missed_status().total_count()
+                  << std::endl;
+
         if (validation_mask[statistics::DEADLINE_MISSED]
                 && info.valid_data
                 && info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
@@ -987,11 +1032,13 @@ struct DeadlineMissedSampleValidator : public SampleValidator
                       << "\n\tTotal Count: " << data.value().deadline_missed_status().total_count()
                       << std::endl;
 
-            ASSERT_NE(it, total_msgs.end());
-
-            total_msgs.erase(it);
-            ++processed_count;
-            cv.notify_one();
+            if (assert_on_non_expected_msgs_)
+            {
+                ASSERT_NE(it, total_msgs.end());
+                total_msgs.erase(it);
+                ++processed_count;
+                cv.notify_one();
+            }
         }
     }
 
@@ -1024,11 +1071,13 @@ struct SampleLostSampleValidator : public SampleValidator
                       << std::endl;
 
 
-            ASSERT_NE(it, total_msgs.end());
-
-            total_msgs.erase(it);
-            ++processed_count;
-            cv.notify_one();
+            if (assert_on_non_expected_msgs_)
+            {
+                ASSERT_NE(it, total_msgs.end());
+                total_msgs.erase(it);
+                ++processed_count;
+                cv.notify_one();
+            }
         }
     }
 
@@ -2242,6 +2291,144 @@ TEST(DDSMonitorServiceTest, monitor_service_advanced_multiple_late_joiners)
         //! The assertion checking whether the on_data_availble() was called is assumed in the following one
         ASSERT_EQ(MSC.block_for_all(std::chrono::seconds(3)), expected_msgs.size());
     }
+#endif //FASTDDS_STATISTICS
+}
+
+/**
+ * Regression test for Redmine issue #20625.
+ *
+ * The monitor service writer must correctly handle instances, removing old changes
+ * when its going to publish a new change in the same instance since it is
+ * defined as KEEP_LAST 1.
+ */
+TEST(DDSMonitorServiceTest,  monitor_service_properly_handles_topic_instances)
+{
+#ifdef FASTDDS_STATISTICS
+
+    //! In this test we do not need to enforce the validation of samples
+    std::bitset<statistics::STATUSES_SIZE> validation_mask;
+
+    //! Setup
+    MonitorServiceConsumer MSC(validation_mask);
+
+    MSC.init_monitor_service_reader();
+
+    //! Setup
+    MonitorServiceParticipant MSP;
+    auto test_transport = std::make_shared<test_UDPv4TransportDescriptor>();
+
+    std::atomic<uint8_t> n_gap_messages{0};
+
+    test_transport->drop_gap_messages_filter_ = [&n_gap_messages](CDRMessage_t& msg)
+            {
+
+                // Jump the reader entity id
+                msg.pos += 4;
+                // Read the writer's entity id
+                eprosima::fastrtps::rtps::EntityId_t writer_entity_id;
+                eprosima::fastrtps::rtps::CDRMessage::readEntityId(&msg, &writer_entity_id);
+
+                if (ENTITYID_MONITOR_SERVICE_WRITER == writer_entity_id)
+                {
+                    n_gap_messages.fetch_add(1);
+                }
+
+                return false;
+            };
+
+    DomainParticipantQos participant_qos;
+    participant_qos.transport().user_transports.push_back(test_transport);
+    participant_qos.transport().use_builtin_transports = false;
+
+    MSP.setup(participant_qos);
+    MSP.enable_monitor_service();
+
+    DataReaderQos dr_qos;
+    DataWriterQos dw_qos;
+
+    //! Set deadline as 1 sec
+    dr_qos.deadline().period = eprosima::fastrtps::Time_t{1, 000000000};
+    dw_qos.deadline().period = eprosima::fastrtps::Time_t{1, 000000000};
+
+    MSP.create_and_add_reader(dr_qos);
+    MSP.create_and_add_writer(dw_qos);
+
+    MSC.start_reception(std::list<MonitorServiceType::type>());
+
+    auto samples = default_helloworld_data_generator(4);
+    // Default hb period is 3 secs.
+    // Ensure that the monitor service writer sends at least one
+    MSP.send(samples, 1150);
+
+    ASSERT_TRUE(n_gap_messages > 0u);
+#endif //FASTDDS_STATISTICS
+}
+
+/**
+ * Regression test for Redmine issue #20625.
+ *
+ * A monitor service consumer receives only the last instance status when late joins.
+ */
+TEST(DDSMonitorServiceTest,  monitor_service_late_joiner_consumer_receives_only_the_latest_instance_statuses)
+{
+#ifdef FASTDDS_STATISTICS
+
+    //! In this test we enforce validating DeadlineMissed samples only
+    std::bitset<statistics::STATUSES_SIZE> validation_mask;
+    validation_mask[statistics::DEADLINE_MISSED] = true;
+
+    //! Setup
+    MonitorServiceConsumer MSC(validation_mask, false);
+
+    //! Setup
+    MonitorServiceParticipant MSP;
+
+    MSP.setup();
+    MSP.enable_monitor_service();
+
+    DataReaderQos dr_qos;
+    DataWriterQos dw_qos;
+
+    //! Set deadline as 0,1 secs
+    dr_qos.deadline().period = eprosima::fastrtps::Time_t{0, 500000000};
+    dw_qos.deadline().period = eprosima::fastrtps::Time_t{0, 500000000};
+
+    MSP.create_and_add_reader(dr_qos);
+    MSP.create_and_add_writer(dw_qos);
+
+    std::list<MonitorServiceType::type> non_expected_msgs;
+    MonitorServiceType::type endpoint_deadline_msg;
+    StatisticsGUIDList r_guids, w_guids;
+
+    r_guids = MSP.get_reader_guids();
+    ASSERT_EQ(r_guids.size(), 1);
+    endpoint_deadline_msg.local_entity(r_guids.back());
+
+    statistics::DeadlineMissedStatus_s deadline_missed_status;
+    deadline_missed_status.total_count() = 2;
+    endpoint_deadline_msg.value().deadline_missed_status(deadline_missed_status);
+
+    non_expected_msgs.push_back(endpoint_deadline_msg);
+
+    w_guids = MSP.get_writer_guids();
+    ASSERT_EQ(w_guids.size(), 1);
+    endpoint_deadline_msg.local_entity(w_guids.back());
+
+    non_expected_msgs.push_back(endpoint_deadline_msg);
+
+    auto samples = default_helloworld_data_generator(5);
+
+    MSP.send(samples, 600);
+
+    // Late joiner consumer
+    MSC.set_reader_history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
+            .init_monitor_service_reader();
+
+    MSC.start_reception(non_expected_msgs);
+
+    // We expect not to have received any deadline missed status
+    // with a total count less than 5
+    ASSERT_FALSE(MSC.block_for_all(std::chrono::seconds(5)));
 #endif //FASTDDS_STATISTICS
 }
 

--- a/test/unittest/statistics/rtps/CMakeLists.txt
+++ b/test/unittest/statistics/rtps/CMakeLists.txt
@@ -146,24 +146,26 @@ target_compile_definitions(MonitorServiceTests PRIVATE FASTRTPS_NO_LIB
     )
 
 target_include_directories(MonitorServiceTests PRIVATE
+    mock/Publisher
     mock/StatisticsBase
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/BuiltinProtocols
-    ${PROJECT_SOURCE_DIR}/test/mock/rtps/external_locators
-    ${PROJECT_SOURCE_DIR}/test/mock/rtps/RTPSParticipantImpl
-    ${PROJECT_SOURCE_DIR}/test/mock/rtps/Endpoint
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/EDP
-    ${PROJECT_SOURCE_DIR}/test/mock/rtps/WLP
-    ${PROJECT_SOURCE_DIR}/test/mock/rtps/ReceiverResource
-    ${PROJECT_SOURCE_DIR}/test/mock/rtps/RTPSReader
-    ${PROJECT_SOURCE_DIR}/test/mock/rtps/StatefulReader
-    ${PROJECT_SOURCE_DIR}/test/mock/rtps/StatelessReader
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/Endpoint
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/external_locators
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/ExternalLocatorsProcessor
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/ReaderHistory
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/ReceiverResource
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/RTPSParticipantImpl
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/RTPSReader
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/RTPSWriter
-    ${PROJECT_SOURCE_DIR}/test/mock/rtps/StatefulWriter
-    ${PROJECT_SOURCE_DIR}/test/mock/rtps/StatelessWriter
-    ${PROJECT_SOURCE_DIR}/test/mock/rtps/WriterHistory
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/SecurityManager
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/StatefulReader
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/StatefulWriter
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/StatelessReader
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/StatelessWriter
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/TypeLookupManager
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/WLP
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/WriterHistory
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_BINARY_DIR}/include
     ${PROJECT_SOURCE_DIR}/src/cpp

--- a/test/unittest/statistics/rtps/mock/Publisher/fastdds/publisher/DataWriterHistory.hpp
+++ b/test/unittest/statistics/rtps/mock/Publisher/fastdds/publisher/DataWriterHistory.hpp
@@ -1,0 +1,85 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _FASTDDS_PUBLISHER_DATAWRITERHISTORY_HPP_
+#define _FASTDDS_PUBLISHER_DATAWRITERHISTORY_HPP_
+
+#include <chrono>
+#include <functional>
+#include <mutex>
+
+#include <gmock/gmock.h>
+
+#include <fastdds/rtps/history/WriterHistory.h>
+#include <fastdds/rtps/resources/ResourceManagement.h>
+#include <fastrtps/utils/TimedMutex.hpp>
+
+namespace eprosima {
+namespace fastrtps {
+
+class TopicAttributes;
+
+namespace rtps {
+
+class WriteParams;
+
+} // namespace rtps
+} // namespace fastrtps
+
+
+namespace fastdds {
+namespace dds {
+
+class DomainParticipant;
+class PublisherListener;
+class DataWriter;
+class DataWriterListener;
+class Topic;
+
+
+static fastrtps::rtps::HistoryAttributes to_history_attributes(
+        const fastrtps::TopicAttributes&,
+        uint32_t,
+        fastrtps::rtps::MemoryManagementPolicy_t)
+{
+
+    return fastrtps::rtps::HistoryAttributes();
+}
+
+class DataWriterHistory : public fastrtps::rtps::WriterHistory
+{
+public:
+
+    DataWriterHistory(
+            const fastrtps::TopicAttributes& topic_att,
+            uint32_t payloadMaxSize,
+            fastrtps::rtps::MemoryManagementPolicy_t mempolicy,
+            std::function<void (const fastrtps::rtps::InstanceHandle_t&)>)
+        : WriterHistory(to_history_attributes(topic_att, payloadMaxSize, mempolicy))
+    {
+    }
+
+    MOCK_METHOD4(add_pub_change, bool(
+                fastrtps::rtps::CacheChange_t*,
+                fastrtps::rtps::WriteParams&,
+                std::unique_lock<fastrtps::RecursiveTimedMutex>&,
+                const std::chrono::time_point<std::chrono::steady_clock>&));
+
+};
+
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif // _FASTDDS_PUBLISHER_DATAWRITERHISTORY_HPP_


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR fixes a misbehavior of the monitor service that was not truly managing instances since it requires a `DataWriterHistory` instead of a `WriterHistory`. Cachechanges owned by instances are now properly removed in successive updates to the same instance.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [X] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
