### PR TITLE
[20662] Select reusable workflow version depending on target branch in nightly jobs

### DIFF
--- a/.github/workflows/nightly-mac-ci.yml
+++ b/.github/workflows/nightly-mac-ci.yml
@@ -6,37 +6,86 @@ on:
     - cron: '0 1 * * *'
 
 jobs:
-  nightly-sec-mac-ci:
+  nightly-mac-ci-master:
     strategy:
       fail-fast: false
       matrix:
-        fastdds-branch:
-          - 'master'
-          - '2.13.x'
-          - '2.12.x'
-          - '2.10.x'
-          - '2.6.x'
-          - '3.0.x-devel'
-    uses: ./.github/workflows/reusable-mac-ci.yml
+        security:
+          - 'ON'
+          - 'OFF'
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-mac-ci.yml@master
     with:
-      label: 'nightly-sec-mac-ci-${{ matrix.fastdds-branch }}'
-      cmake-args: "-DSECURITY=ON"
+      label: 'nightly-sec-${{ matrix.security }}-mac-ci-master'
+      cmake-args: "-DSECURITY=${{ matrix.security }}"
       ctest-args: "-LE xfail"
-      fastdds-branch: '${{ matrix.fastdds-branch }}'
+      fastdds-branch: 'master'
 
-  nightly-nosec-mac-ci:
+  nightly-mac-ci-2_13_x:
     strategy:
       fail-fast: false
       matrix:
-        fastdds-branch:
-          - 'master'
-          - '2.13.x'
-          - '2.12.x'
-          - '2.10.x'
-          - '2.6.x'
-    uses: ./.github/workflows/reusable-mac-ci.yml
+        security:
+          - 'ON'
+          - 'OFF'
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-mac-ci.yml@2.13.x
     with:
-      label: 'nightly-nosec-mac-ci-${{ matrix.fastdds-branch }}'
-      cmake-args: "-DSECURITY=OFF"
+      label: 'nightly-sec-${{ matrix.security }}-mac-ci-2.13.x'
+      cmake-args: "-DSECURITY=${{ matrix.security }}"
       ctest-args: "-LE xfail"
-      fastdds-branch: '${{ matrix.fastdds-branch }}'
+      fastdds-branch: '2.13.x'
+
+  nightly-mac-ci-2_12_x:
+    strategy:
+      fail-fast: false
+      matrix:
+        security:
+          - 'ON'
+          - 'OFF'
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-mac-ci.yml@2.12.x
+    with:
+      label: 'nightly-sec-${{ matrix.security }}-mac-ci-2.12.x'
+      cmake-args: "-DSECURITY=${{ matrix.security }}"
+      ctest-args: "-LE xfail"
+      fastdds-branch: '2.12.x'
+
+  nightly-mac-ci-2_10_x:
+    strategy:
+      fail-fast: false
+      matrix:
+        security:
+          - 'ON'
+          - 'OFF'
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-mac-ci.yml@2.10.x
+    with:
+      label: 'nightly-sec-${{ matrix.security }}-mac-ci-2.10.x'
+      cmake-args: "-DSECURITY=${{ matrix.security }}"
+      ctest-args: "-LE xfail"
+      fastdds-branch: '2.10.x'
+
+  nightly-mac-ci-2_6_x:
+    strategy:
+      fail-fast: false
+      matrix:
+        security:
+          - 'ON'
+          - 'OFF'
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-mac-ci.yml@2.6.x
+    with:
+      label: 'nightly-sec-${{ matrix.security }}-mac-ci-2.6.x'
+      cmake-args: "-DSECURITY=${{ matrix.security }}"
+      ctest-args: "-LE xfail"
+      fastdds-branch: '2.6.x'
+
+  nightly-mac-ci-3_0_x-devel:
+    strategy:
+      fail-fast: false
+      matrix:
+        security:
+          - 'ON'
+          - 'OFF'
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-mac-ci.yml@3.0.x-devel
+    with:
+      label: 'nightly-sec-${{ matrix.security }}-mac-ci-3.0.x-devel'
+      cmake-args: "-DSECURITY=${{ matrix.security }}"
+      ctest-args: "-LE xfail"
+      fastdds-branch: '3.0.x-devel'

--- a/.github/workflows/nightly-ubuntu-ci.yml
+++ b/.github/workflows/nightly-ubuntu-ci.yml
@@ -6,24 +6,104 @@ on:
     - cron: '0 1 * * *'
 
 jobs:
-  nightly-sec-ubuntu-ci:
-
+  nightly-ubuntu-ci-master:
     strategy:
       fail-fast: false
       matrix:
         os-image:
           - 'ubuntu-22.04'
-        fastdds-branch:
-          - 'master'
-          - '2.13.x'
-          - '2.12.x'
-          - '2.10.x'
-          - '2.6.x'
-          - '3.0.x-devel'
-    uses: ./.github/workflows/reusable-ubuntu-ci.yml
+        security:
+          - 'ON'
+          - 'OFF'
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-ubuntu-ci.yml@master
     with:
       os-image: ${{ matrix.os-image }}
-      label: '${{ matrix.os-image }}-nightly-sec-ubuntu-ci-${{ matrix.fastdds-branch }}'
-      cmake-args: "-DSECURITY=ON"
+      label: '${{ matrix.os-image }}-nightly-sec-${{ matrix.security }}-ubuntu-ci-master'
+      cmake-args: "-DSECURITY=${{ matrix.security }}"
       ctest-args: "-LE xfail"
-      fastdds-branch: '${{ matrix.fastdds-branch }}'
+      fastdds-branch: 'master'
+
+  nightly-ubuntu-ci-2_13_x:
+    strategy:
+      fail-fast: false
+      matrix:
+        os-image:
+          - 'ubuntu-22.04'
+        security:
+          - 'ON'
+          - 'OFF'
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-ubuntu-ci.yml@2.13.x
+    with:
+      os-image: ${{ matrix.os-image }}
+      label: '${{ matrix.os-image }}-nightly-sec-${{ matrix.security }}-ubuntu-ci-2.13.x'
+      cmake-args: "-DSECURITY=${{ matrix.security }}"
+      ctest-args: "-LE xfail"
+      fastdds-branch: '2.13.x'
+
+  nightly-ubuntu-ci-2_12_x:
+    strategy:
+      fail-fast: false
+      matrix:
+        os-image:
+          - 'ubuntu-22.04'
+        security:
+          - 'ON'
+          - 'OFF'
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-ubuntu-ci.yml@2.12.x
+    with:
+      os-image: ${{ matrix.os-image }}
+      label: '${{ matrix.os-image }}-nightly-sec-${{ matrix.security }}-ubuntu-ci-2.12.x'
+      cmake-args: "-DSECURITY=${{ matrix.security }}"
+      ctest-args: "-LE xfail"
+      fastdds-branch: '2.12.x'
+
+  nightly-ubuntu-ci-2_10_x:
+    strategy:
+      fail-fast: false
+      matrix:
+        os-image:
+          - 'ubuntu-22.04'
+        security:
+          - 'ON'
+          - 'OFF'
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-ubuntu-ci.yml@2.10.x
+    with:
+      os-image: ${{ matrix.os-image }}
+      label: '${{ matrix.os-image }}-nightly-sec-${{ matrix.security }}-ubuntu-ci-2.10.x'
+      cmake-args: "-DSECURITY=${{ matrix.security }}"
+      ctest-args: "-LE xfail"
+      fastdds-branch: '2.10.x'
+
+  nightly-ubuntu-ci-2_6_x:
+    strategy:
+      fail-fast: false
+      matrix:
+        os-image:
+          - 'ubuntu-22.04'
+        security:
+          - 'ON'
+          - 'OFF'
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-ubuntu-ci.yml@2.6.x
+    with:
+      os-image: ${{ matrix.os-image }}
+      label: '${{ matrix.os-image }}-nightly-sec-${{ matrix.security }}-ubuntu-ci-2.6.x'
+      cmake-args: "-DSECURITY=${{ matrix.security }}"
+      ctest-args: "-LE xfail"
+      fastdds-branch: '2.6.x'
+
+  nightly-ubuntu-ci-3_0_x-devel:
+    strategy:
+      fail-fast: false
+      matrix:
+        os-image:
+          - 'ubuntu-22.04'
+        security:
+          - 'ON'
+          - 'OFF'
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-ubuntu-ci.yml@3.0.x-devel
+    with:
+      os-image: ${{ matrix.os-image }}
+      label: '${{ matrix.os-image }}-nightly-sec-${{ matrix.security }}-ubuntu-ci-3.0.x-devel'
+      cmake-args: "-DSECURITY=${{ matrix.security }}"
+      ctest-args: "-LE xfail"
+      fastdds-branch: '3.0.x-devel'

--- a/.github/workflows/nightly-windows-ci.yml
+++ b/.github/workflows/nightly-windows-ci.yml
@@ -6,37 +6,86 @@ on:
     - cron: '0 1 * * *'
 
 jobs:
-  nightly-sec-windows-ci:
+  nightly-windows-ci-master:
     strategy:
       fail-fast: false
       matrix:
-        fastdds-branch:
-          - 'master'
-          - '2.13.x'
-          - '2.12.x'
-          - '2.10.x'
-          - '2.6.x'
-          - '3.0.x-devel'
-    uses: ./.github/workflows/reusable-windows-ci.yml
+        security:
+          - 'ON'
+          - 'OFF'
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-windows-ci.yml@master
     with:
-      label: 'nightly-sec-windows-ci-${{ matrix.fastdds-branch }}'
-      cmake-args: "-DSECURITY=ON"
+      label: 'nightly-sec-${{ matrix.security }}-windows-ci-master'
+      cmake-args: "-DSECURITY=${{ matrix.security }}"
       ctest-args: "-LE xfail"
-      fastdds_branch: '${{ matrix.fastdds-branch }}'
+      fastdds_branch: 'master'
 
-  nightly-nosec-windows-ci:
+  nightly-windows-ci-2_13_x:
     strategy:
       fail-fast: false
       matrix:
-        fastdds-branch:
-          - 'master'
-          - '2.13.x'
-          - '2.12.x'
-          - '2.10.x'
-          - '2.6.x'
-    uses: ./.github/workflows/reusable-windows-ci.yml
+        security:
+          - 'ON'
+          - 'OFF'
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-windows-ci.yml@2.13.x
     with:
-      label: 'nightly-nosec-windows-ci-${{ matrix.fastdds-branch }}'
-      cmake-args: "-DSECURITY=OFF"
+      label: 'nightly-sec-${{ matrix.security }}-windows-ci-2.13.x'
+      cmake-args: "-DSECURITY=${{ matrix.security }}"
       ctest-args: "-LE xfail"
-      fastdds_branch: '${{ matrix.fastdds-branch }}'
+      fastdds_branch: '2.13.x'
+
+  nightly-windows-ci-2_12_x:
+    strategy:
+      fail-fast: false
+      matrix:
+        security:
+          - 'ON'
+          - 'OFF'
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-windows-ci.yml@2.12.x
+    with:
+      label: 'nightly-sec-${{ matrix.security }}-windows-ci-2.12.x'
+      cmake-args: "-DSECURITY=${{ matrix.security }}"
+      ctest-args: "-LE xfail"
+      fastdds_branch: '2.12.x'
+
+  nightly-windows-ci-2_10_x:
+    strategy:
+      fail-fast: false
+      matrix:
+        security:
+          - 'ON'
+          - 'OFF'
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-windows-ci.yml@2.10.x
+    with:
+      label: 'nightly-sec-${{ matrix.security }}-windows-ci-2.10.x'
+      cmake-args: "-DSECURITY=${{ matrix.security }}"
+      ctest-args: "-LE xfail"
+      fastdds_branch: '2.10.x'
+
+  nightly-windows-ci-2_6_x:
+    strategy:
+      fail-fast: false
+      matrix:
+        security:
+          - 'ON'
+          - 'OFF'
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-windows-ci.yml@2.6.x
+    with:
+      label: 'nightly-sec-${{ matrix.security }}-windows-ci-2.6.x'
+      cmake-args: "-DSECURITY=${{ matrix.security }}"
+      ctest-args: "-LE xfail"
+      fastdds_branch: '2.6.x'
+
+  nightly-windows-ci-3_0_x-devel:
+    strategy:
+      fail-fast: false
+      matrix:
+        security:
+          - 'ON'
+          - 'OFF'
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-windows-ci.yml@3.0.x-devel
+    with:
+      label: 'nightly-sec-${{ matrix.security }}-windows-ci-3.0.x-devel'
+      cmake-args: "-DSECURITY=${{ matrix.security }}"
+      ctest-args: "-LE xfail"
+      fastdds_branch: '3.0.x-devel'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR updates the nightly jobs to select the reusable workflow version depending on the branch tested. Sadly, `uses` keyword is context agnostic, so the version cannot be taken from the `fastdds-branch` matrix. Instead, a separate specific job for each tested version needs to be created. Furthermore, this PR makes the security option a matrix parameter, so both `ON` and `OFF` configurations are run for all versions in all platforms.

A manually triggered job can be seen [here](https://github.com/eProsima/Fast-DDS/actions/runs/8338751045).

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.13.x 2.12.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- _N/A_: The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
