### PR TITLE
[20655] Fix flakey Log tests

### DIFF
--- a/test/unittest/logging/LogTests.cpp
+++ b/test/unittest/logging/LogTests.cpp
@@ -533,13 +533,12 @@ TEST_F(LogTests, stdouterr_consumer_stream)
 std::vector<Log::Entry> LogTests::HELPER_WaitForEntries(
         uint32_t amount)
 {
-    size_t entries = 0;
     for (uint32_t i = 0; i != AsyncTries; i++)
     {
-        entries = mockConsumer->ConsumedEntries().size();
-        if (entries == amount)
+        auto entries = mockConsumer->ConsumedEntries();
+        if (entries.size() == amount)
         {
-            break;
+            return entries;
         }
         this_thread::sleep_for(chrono::milliseconds(AsyncWaitMs));
     }

--- a/test/unittest/logging/log_macros/LogMacros.hpp
+++ b/test/unittest/logging/log_macros/LogMacros.hpp
@@ -59,13 +59,12 @@ public:
     std::vector<Log::Entry> HELPER_WaitForEntries(
             uint32_t amount)
     {
-        size_t entries = 0;
         for (uint32_t i = 0; i != AsyncTries; i++)
         {
-            entries = mockConsumer->ConsumedEntries().size();
-            if (entries == amount)
+            auto entries = mockConsumer->ConsumedEntries();
+            if (entries.size() == amount)
             {
-                break;
+                return entries;
             }
             this_thread::sleep_for(chrono::milliseconds(AsyncWaitMs));
         }

--- a/test/unittest/logging/log_macros/LogMacrosDefaultTests.cpp
+++ b/test/unittest/logging/log_macros/LogMacrosDefaultTests.cpp
@@ -48,15 +48,20 @@ TEST_F(LogMacrosTests, default_macros_test)
 # endif  // Visual Studio specific behavior
 #endif  // Check default macro values
 
-#if !HAVE_LOG_NO_INFO && \
+    // Result depends on the log configuration
+#if !HAVE_LOG_NO_INFO &&  \
+    (defined(FASTDDS_ENFORCE_LOG_INFO) || \
     ((defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG)) && (defined(_DEBUG) || defined(__DEBUG) || \
-    !defined(NDEBUG)))
-    static constexpr unsigned int expected_result = 3;
+    !defined(NDEBUG))))
+    constexpr unsigned int expected_result = 3;
 #else
-    static constexpr unsigned int expected_result = 2;
+    constexpr unsigned int expected_result = 2;
 #endif // debug macros check
 
-    auto consumedEntries = HELPER_WaitForEntries(expected_result);
+    // Warning and error should always be logged.
+    // Info might be logged depending on the log configuration.
+    // We always wait for 3 entries, though not all of them might be present.
+    auto consumedEntries = HELPER_WaitForEntries(3u);
     ASSERT_EQ(expected_result, consumedEntries.size());
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Test `LogMacrosTests.default_macros_test` has been sporadically failing in Github CI, especially on Windows.
Analysis showed it was due to a race condition in `HELPER_WaitForEntries`, and the test not accounting for the value of `FASTDDS_ENFORCE_LOG_INFO`.

This PR fixes the race condition in `HELPER_WaitForEntries` by early returning the collection of log entries, and fixes `default_macros_test` by always waiting for 3 entries and then checking that the expected number of entries is returned, also taking into consideration the value of `FASTDDS_ENFORCE_LOG_INFO`.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
