### PR TITLE
[20672] Use a plain switch for NetmaskFilterKind std::ostream& operator<<

### DIFF
--- a/src/cpp/rtps/transport/network/NetmaskFilterKind.cpp
+++ b/src/cpp/rtps/transport/network/NetmaskFilterKind.cpp
@@ -17,10 +17,7 @@
  */
 
 #include <ostream>
-#include <sstream>
-#include <stdexcept>
 #include <string>
-#include <unordered_map>
 
 #include <fastdds/rtps/transport/network/NetmaskFilterKind.hpp>
 
@@ -32,21 +29,31 @@ std::ostream& operator <<(
         std::ostream& output,
         const NetmaskFilterKind& netmask_filter_kind)
 {
-    std::string netmask_filter_kind_str = "UNKNOWN";
-    static const std::unordered_map<NetmaskFilterKind, std::string> conversion_map =
+    switch (netmask_filter_kind)
     {
-        {NetmaskFilterKind::OFF, "OFF"},
-        {NetmaskFilterKind::AUTO, "AUTO"},
-        {NetmaskFilterKind::ON, "ON"}
-    };
-
-    auto it = conversion_map.find(netmask_filter_kind);
-    if (it != conversion_map.end())
-    {
-        netmask_filter_kind_str = it->second;
+        case NetmaskFilterKind::OFF:
+        {
+            output << "OFF";
+            break;
+        }
+        case NetmaskFilterKind::AUTO:
+        {
+            output << "AUTO";
+            break;
+        }
+        case NetmaskFilterKind::ON:
+        {
+            output << "ON";
+            break;
+        }
+        default:
+        {
+            output << "UNKNOWN";
+            break;
+        }
     }
 
-    return output << netmask_filter_kind_str;
+    return output;
 }
 
 } // namsepace rtps


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR refactors the `std::ostream& operator <<` so that it uses a plain switch instead of an unordered map, since the previous implementation was failing to compile under some compilers `clang 15` because the enum class does not define any hashing function. It seems that our supported compilers could deduce that the enum class was in fact an int and that's why it did not get detected on CI.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- _N/A_: The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
