### PR TITLE
[20679] Run Github Ubuntu CI on PRs

### DIFF
--- a/.github/workflows/address-sanitizers.yaml
+++ b/.github/workflows/address-sanitizers.yaml
@@ -13,8 +13,6 @@ on:
         default: 'master'
 
   pull_request:
-    branches:
-      - 'master'
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/.github/workflows/documentation-tests.yaml
+++ b/.github/workflows/documentation-tests.yaml
@@ -9,8 +9,6 @@ on:
         default: 'master'
 
   pull_request:
-    branches:
-      - 'master'
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -25,8 +25,6 @@ on:
         required: true
 
   pull_request:
-    branches:
-      - 'master'
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/.github/workflows/thread-sanitizer.yaml
+++ b/.github/workflows/thread-sanitizer.yaml
@@ -16,8 +16,6 @@ on:
         type: string
 
   pull_request:
-    branches:
-      - 'master'
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -24,6 +24,12 @@ on:
         type: string
         required: true
 
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - '!**/CMakeLists.txt'
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -25,8 +25,6 @@ on:
         required: true
 
   pull_request:
-    branches:
-      - 'master'
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/include/fastrtps/subscriber/SubscriberHistory.h
+++ b/include/fastrtps/subscriber/SubscriberHistory.h
@@ -179,6 +179,10 @@ public:
 
 private:
 
+    using rtps::ReaderHistory::completed_change;
+    using rtps::ReaderHistory::received_change;
+    using rtps::ReaderHistory::remove_change_nts;
+
     using t_m_Inst_Caches = std::map<rtps::InstanceHandle_t, KeyedChanges>;
 
     //!Map where keys are instance handles and values vectors of cache changes

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -662,6 +662,10 @@ protected:
             bool on_guard_;
         };
 
+        using fastrtps::rtps::RTPSParticipantListener::onParticipantDiscovery;
+        using fastrtps::rtps::RTPSParticipantListener::onReaderDiscovery;
+        using fastrtps::rtps::RTPSParticipantListener::onWriterDiscovery;
+
     public:
 
         MyRTPSParticipantListener(

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -459,6 +459,10 @@ protected:
 #endif //FASTDDS_STATISTICS
 
         DataWriterImpl* data_writer_;
+
+    private:
+
+        using fastrtps::rtps::WriterListener::onWriterMatched;
     }
     writer_listener_;
 

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -451,6 +451,10 @@ protected:
 #endif //FASTDDS_STATISTICS
 
         DataReaderImpl* data_reader_;
+
+    private:
+
+        using fastrtps::rtps::ReaderListener::onReaderMatched;
     }
     reader_listener_;
 

--- a/src/cpp/fastrtps_deprecated/participant/ParticipantImpl.h
+++ b/src/cpp/fastrtps_deprecated/participant/ParticipantImpl.h
@@ -233,6 +233,12 @@ private:
 
         ParticipantImpl* mp_participantimpl;
 
+    private:
+
+        using rtps::RTPSParticipantListener::onParticipantDiscovery;
+        using rtps::RTPSParticipantListener::onReaderDiscovery;
+        using rtps::RTPSParticipantListener::onWriterDiscovery;
+
     }
     m_rtps_listener;
 

--- a/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.h
+++ b/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.h
@@ -243,6 +243,10 @@ private:
                 const LivelinessLostStatus& status) override;
 
         PublisherImpl* mp_publisherImpl;
+
+    private:
+
+        using rtps::WriterListener::onWriterMatched;
     }
     m_writerListener;
 

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberImpl.h
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberImpl.h
@@ -221,6 +221,10 @@ private:
                 rtps::RTPSReader* reader,
                 const LivelinessChangedStatus& status) override;
         SubscriberImpl* mp_subscriberImpl;
+
+    private:
+
+        using rtps::ReaderListener::onReaderMatched;
     }
     m_readerListener;
 

--- a/src/cpp/rtps/DataSharing/ReaderPool.hpp
+++ b/src/cpp/rtps/DataSharing/ReaderPool.hpp
@@ -284,6 +284,8 @@ protected:
 
 private:
 
+    using DataSharingPayloadPool::init_shared_memory;
+
     bool is_volatile_;              //< Whether the reader is volatile or not
     uint64_t next_payload_;         //< Index of the next history position to read
     SequenceNumber_t last_sn_;      //< Sequence number of the last read payload

--- a/src/cpp/rtps/DataSharing/WriterPool.hpp
+++ b/src/cpp/rtps/DataSharing/WriterPool.hpp
@@ -353,6 +353,8 @@ public:
 
 private:
 
+    using DataSharingPayloadPool::init_shared_memory;
+
     octet* payloads_pool_;          //< Shared pool of payloads
 
     uint32_t max_data_size_;        //< Maximum size of the serialized payload data

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.h
@@ -178,6 +178,8 @@ protected:
 
 private:
 
+    using PDP::announceParticipantState;
+
     /**
      * Manually match the local PDP reader with the PDP writer of a given server. The function is
      * not thread safe (nts) in the sense that it does not take the PDP mutex. It does however take

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
@@ -317,6 +317,8 @@ protected:
 
 private:
 
+    using fastrtps::rtps::PDP::announceParticipantState;
+
 #if HAVE_SECURITY
     /**
      * Returns whether discovery should be secured

--- a/src/cpp/rtps/history/BasicPayloadPool_impl/Base.hpp
+++ b/src/cpp/rtps/history/BasicPayloadPool_impl/Base.hpp
@@ -18,6 +18,8 @@
 
 class BaseImpl : public IPayloadPool
 {
+public:
+
     bool get_payload(
             uint32_t size,
             CacheChange_t& cache_change) override

--- a/src/cpp/rtps/history/BasicPayloadPool_impl/PreallocatedWithRealloc.hpp
+++ b/src/cpp/rtps/history/BasicPayloadPool_impl/PreallocatedWithRealloc.hpp
@@ -39,5 +39,7 @@ public:
 
 private:
 
+    using BaseImpl::get_payload;
+
     uint32_t min_payload_size_;
 };

--- a/src/cpp/rtps/history/TopicPayloadPool_impl/Dynamic.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPool_impl/Dynamic.hpp
@@ -86,6 +86,10 @@ protected:
         return DYNAMIC_RESERVE_MEMORY_MODE;
     }
 
+private:
+
+    using TopicPayloadPool::get_payload;
+
 };
 
 }  // namespace rtps

--- a/src/cpp/rtps/history/TopicPayloadPool_impl/DynamicReusable.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPool_impl/DynamicReusable.hpp
@@ -41,6 +41,10 @@ protected:
         return DYNAMIC_REUSABLE_MEMORY_MODE;
     }
 
+private:
+
+    using TopicPayloadPool::get_payload;
+
 };
 
 }  // namespace rtps

--- a/src/cpp/rtps/history/TopicPayloadPool_impl/Preallocated.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPool_impl/Preallocated.hpp
@@ -80,6 +80,8 @@ protected:
 
 private:
 
+    using TopicPayloadPool::get_payload;
+
     uint32_t payload_size_;
     uint32_t minimum_pool_size_;    //< Minimum initial pool size (sum of all histories)
 };

--- a/src/cpp/rtps/history/TopicPayloadPool_impl/PreallocatedWithRealloc.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPool_impl/PreallocatedWithRealloc.hpp
@@ -80,6 +80,8 @@ protected:
 
 private:
 
+    using TopicPayloadPool::get_payload;
+
     uint32_t min_payload_size_;
     uint32_t minimum_pool_size_;    //< Minimum initial pool size (sum of all histories)
 };

--- a/src/cpp/rtps/transport/TCPTransportInterface.h
+++ b/src/cpp/rtps/transport/TCPTransportInterface.h
@@ -77,6 +77,8 @@ class TCPTransportInterface : public TransportInterface
 
     std::atomic<bool> alive_;
 
+    using TransportInterface::transform_remote_locator;
+
 protected:
 
     asio::io_service io_service_;

--- a/src/cpp/rtps/transport/UDPTransportInterface.h
+++ b/src/cpp/rtps/transport/UDPTransportInterface.h
@@ -40,6 +40,8 @@ class UDPTransportInterface : public TransportInterface
 {
     friend class UDPSenderResource;
 
+    using TransportInterface::transform_remote_locator;
+
 public:
 
     ~UDPTransportInterface() override;

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransport.h
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransport.h
@@ -201,6 +201,8 @@ public:
 
 private:
 
+    using TransportInterface::transform_remote_locator;
+
     //! Constructor with no descriptor is necessary for implementations derived from this class.
     SharedMemTransport();
 

--- a/src/cpp/statistics/rtps/monitor-service/MonitorServiceListener.hpp
+++ b/src/cpp/statistics/rtps/monitor-service/MonitorServiceListener.hpp
@@ -42,10 +42,7 @@ class MonitorServiceListener :
 public:
 
     MonitorServiceListener(
-            MonitorService* ms
-            );
-
-public:
+            MonitorService* ms);
 
     bool on_local_entity_status_change(
             const fastrtps::rtps::GUID_t& guid,
@@ -70,6 +67,9 @@ protected:
 
     MonitorService* monitor_srv_;
 
+private:
+
+    using fastrtps::rtps::WriterListener::onWriterMatched;
 
 };
 

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -2174,6 +2174,8 @@ TEST(Discovery, discovery_cyclone_participant_with_custom_pid)
 
     private:
 
+        using DomainParticipantListener::on_participant_discovery;
+
         std::atomic<uint8_t> discovered_participants_{0};
     };
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR:

1. Enables running Github Ubuntu CI on `pull_request` events.
2. Fixes hidden overloads erroneously left out by #4516 
3. Enables running Github CI on PRs targeting intermediate branches (not `master`). 

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
