### PR TITLE
[20648] Only run PRs CI when run-ci label is added

### DIFF
--- a/.github/workflows/address-sanitizers.yaml
+++ b/.github/workflows/address-sanitizers.yaml
@@ -13,6 +13,8 @@ on:
         default: 'master'
 
   pull_request:
+    types:
+      - labeled
     paths-ignore:
       - '**.md'
       - '**.txt'
@@ -28,9 +30,15 @@ concurrency:
 jobs:
   asan-test:
 
-    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'no-test') ||
-              contains(github.event.pull_request.labels.*.name, 'skip-ci') ||
-              contains(github.event.pull_request.labels.*.name, 'conflicts')) }}
+    if: ${{ (
+              (github.event_name == 'workflow_dispatch') ||
+              contains(github.event.pull_request.labels.*.name, 'run-ci')
+            ) &&
+            (
+              !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+              !contains(github.event.pull_request.labels.*.name, 'no-test') &&
+              !contains(github.event.pull_request.labels.*.name, 'conflicts')
+            ) }}
 
     runs-on: ubuntu-22.04
 
@@ -38,6 +46,23 @@ jobs:
         FASTDDS_BRANCH: ${{ github.head_ref || github.event.inputs.fastdds_branch || 'master' }}
 
     steps:
+      - name: Remove run-ci label if PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        with:
+          labels: run-ci
+          number: ${{ github.event.number }}
+          repo: eProsima/Fast-DDS
+          fail_on_error: 'false'
+
+      - name: Add ci-pending label if PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        with:
+          labels: ci-pending
+          number: ${{ github.event.number }}
+          repo: eProsima/Fast-DDS
+
       # https://github.com/actions/runner-images/issues/9491
       - name: Fix kernel mmap rnd bits
         run: sudo sysctl vm.mmap_rnd_bits=28
@@ -124,9 +149,15 @@ jobs:
 
   asan-discovery-server-test:
 
-    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'no-test') ||
-              contains(github.event.pull_request.labels.*.name, 'skip-ci') ||
-              contains(github.event.pull_request.labels.*.name, 'conflicts')) }}
+    if: ${{ (
+              (github.event_name == 'workflow_dispatch') ||
+              contains(github.event.pull_request.labels.*.name, 'run-ci')
+            ) &&
+            (
+              !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+              !contains(github.event.pull_request.labels.*.name, 'no-test') &&
+              !contains(github.event.pull_request.labels.*.name, 'conflicts')
+            ) }}
 
     runs-on: ubuntu-22.04
 
@@ -135,6 +166,23 @@ jobs:
       DEFAULT_DISCOVERY_SERVER_BRANCH: ${{ github.event.inputs.discovery_server_branch || 'master' }}
 
     steps:
+      - name: Remove run-ci label if PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        with:
+          labels: run-ci
+          number: ${{ github.event.number }}
+          repo: eProsima/Fast-DDS
+          fail_on_error: 'false'
+
+      - name: Add ci-pending label if PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        with:
+          labels: ci-pending
+          number: ${{ github.event.number }}
+          repo: eProsima/Fast-DDS
+
       # https://github.com/actions/runner-images/issues/9491
       - name: Fix kernel mmap rnd bits
         run: sudo sysctl vm.mmap_rnd_bits=28

--- a/.github/workflows/address-sanitizers.yaml
+++ b/.github/workflows/address-sanitizers.yaml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Add ci-pending label if PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        uses: eProsima/eProsima-CI/external/add_labels@feature/labels
         with:
           labels: ci-pending
           number: ${{ github.event.number }}
@@ -177,7 +177,7 @@ jobs:
 
       - name: Add ci-pending label if PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        uses: eProsima/eProsima-CI/external/add_labels@feature/labels
         with:
           labels: ci-pending
           number: ${{ github.event.number }}

--- a/.github/workflows/address-sanitizers.yaml
+++ b/.github/workflows/address-sanitizers.yaml
@@ -14,7 +14,7 @@ on:
 
   pull_request:
     types:
-      - labeled
+      - review_requested
     paths-ignore:
       - '**.md'
       - '**.txt'
@@ -31,10 +31,6 @@ jobs:
   asan-test:
 
     if: ${{ (
-              (github.event_name == 'workflow_dispatch') ||
-              contains(github.event.pull_request.labels.*.name, 'run-ci')
-            ) &&
-            (
               !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
               !contains(github.event.pull_request.labels.*.name, 'no-test') &&
               !contains(github.event.pull_request.labels.*.name, 'conflicts')
@@ -46,15 +42,6 @@ jobs:
         FASTDDS_BRANCH: ${{ github.head_ref || github.event.inputs.fastdds_branch || 'master' }}
 
     steps:
-      - name: Remove run-ci label if PR
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/remove_labels@v0
-        with:
-          labels: run-ci
-          number: ${{ github.event.number }}
-          repo: eProsima/Fast-DDS
-          fail_on_error: 'false'
-
       - name: Add ci-pending label if PR
         if: ${{ github.event_name == 'pull_request' }}
         uses: eProsima/eProsima-CI/external/add_labels@v0
@@ -150,10 +137,6 @@ jobs:
   asan-discovery-server-test:
 
     if: ${{ (
-              (github.event_name == 'workflow_dispatch') ||
-              contains(github.event.pull_request.labels.*.name, 'run-ci')
-            ) &&
-            (
               !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
               !contains(github.event.pull_request.labels.*.name, 'no-test') &&
               !contains(github.event.pull_request.labels.*.name, 'conflicts')
@@ -166,15 +149,6 @@ jobs:
       DEFAULT_DISCOVERY_SERVER_BRANCH: ${{ github.event.inputs.discovery_server_branch || 'master' }}
 
     steps:
-      - name: Remove run-ci label if PR
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/remove_labels@v0
-        with:
-          labels: run-ci
-          number: ${{ github.event.number }}
-          repo: eProsima/Fast-DDS
-          fail_on_error: 'false'
-
       - name: Add ci-pending label if PR
         if: ${{ github.event_name == 'pull_request' }}
         uses: eProsima/eProsima-CI/external/add_labels@v0

--- a/.github/workflows/address-sanitizers.yaml
+++ b/.github/workflows/address-sanitizers.yaml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Remove run-ci label if PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        uses: eProsima/eProsima-CI/external/remove_labels@v0
         with:
           labels: run-ci
           number: ${{ github.event.number }}
@@ -57,7 +57,7 @@ jobs:
 
       - name: Add ci-pending label if PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/add_labels@feature/labels
+        uses: eProsima/eProsima-CI/external/add_labels@v0
         with:
           labels: ci-pending
           number: ${{ github.event.number }}
@@ -168,7 +168,7 @@ jobs:
     steps:
       - name: Remove run-ci label if PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        uses: eProsima/eProsima-CI/external/remove_labels@v0
         with:
           labels: run-ci
           number: ${{ github.event.number }}
@@ -177,7 +177,7 @@ jobs:
 
       - name: Add ci-pending label if PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/add_labels@feature/labels
+        uses: eProsima/eProsima-CI/external/add_labels@v0
         with:
           labels: ci-pending
           number: ${{ github.event.number }}

--- a/.github/workflows/documentation-tests.yaml
+++ b/.github/workflows/documentation-tests.yaml
@@ -24,11 +24,34 @@ env:
 jobs:
   ubuntu-build-and-test-documentation:
     name: Documentation build and test
-    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'skip-ci') ||
-              contains(github.event.pull_request.labels.*.name, 'conflicts')) }}
+    if: ${{ (
+              (github.event_name == 'workflow_dispatch') ||
+              contains(github.event.pull_request.labels.*.name, 'run-ci')
+            ) &&
+            (
+              !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+              !contains(github.event.pull_request.labels.*.name, 'conflicts')
+            ) }}
 
     runs-on: ubuntu-22.04
     steps:
+      - name: Remove run-ci label if PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        with:
+          labels: run-ci
+          number: ${{ github.event.number }}
+          repo: eProsima/Fast-DDS
+          fail_on_error: 'false'
+
+      - name: Add ci-pending label if PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        with:
+          labels: ci-pending
+          number: ${{ github.event.number }}
+          repo: eProsima/Fast-DDS
+
       - name: Sync eProsima/Fast-DDS repository
         uses: eProsima/eProsima-CI/external/checkout@v0
         with:

--- a/.github/workflows/documentation-tests.yaml
+++ b/.github/workflows/documentation-tests.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Add ci-pending label if PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        uses: eProsima/eProsima-CI/external/add_labels@feature/labels
         with:
           labels: ci-pending
           number: ${{ github.event.number }}

--- a/.github/workflows/documentation-tests.yaml
+++ b/.github/workflows/documentation-tests.yaml
@@ -10,7 +10,7 @@ on:
 
   pull_request:
     types:
-      - labeled
+      - review_requested
     paths-ignore:
       - '**.md'
       - '**.txt'
@@ -27,25 +27,12 @@ jobs:
   ubuntu-build-and-test-documentation:
     name: Documentation build and test
     if: ${{ (
-              (github.event_name == 'workflow_dispatch') ||
-              contains(github.event.pull_request.labels.*.name, 'run-ci')
-            ) &&
-            (
               !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
               !contains(github.event.pull_request.labels.*.name, 'conflicts')
             ) }}
 
     runs-on: ubuntu-22.04
     steps:
-      - name: Remove run-ci label if PR
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/remove_labels@v0
-        with:
-          labels: run-ci
-          number: ${{ github.event.number }}
-          repo: eProsima/Fast-DDS
-          fail_on_error: 'false'
-
       - name: Add ci-pending label if PR
         if: ${{ github.event_name == 'pull_request' }}
         uses: eProsima/eProsima-CI/external/add_labels@v0

--- a/.github/workflows/documentation-tests.yaml
+++ b/.github/workflows/documentation-tests.yaml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - name: Remove run-ci label if PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        uses: eProsima/eProsima-CI/external/remove_labels@v0
         with:
           labels: run-ci
           number: ${{ github.event.number }}
@@ -48,7 +48,7 @@ jobs:
 
       - name: Add ci-pending label if PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/add_labels@feature/labels
+        uses: eProsima/eProsima-CI/external/add_labels@v0
         with:
           labels: ci-pending
           number: ${{ github.event.number }}

--- a/.github/workflows/documentation-tests.yaml
+++ b/.github/workflows/documentation-tests.yaml
@@ -9,6 +9,8 @@ on:
         default: 'master'
 
   pull_request:
+    types:
+      - labeled
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -26,7 +26,7 @@ on:
 
   pull_request:
     types:
-      - labeled
+      - review_requested
     paths-ignore:
       - '**.md'
       - '**.txt'
@@ -39,10 +39,6 @@ concurrency:
 jobs:
   mac-ci:
     if: ${{ (
-              (github.event_name == 'workflow_dispatch') ||
-              contains(github.event.pull_request.labels.*.name, 'run-ci')
-            ) &&
-            (
               !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
               !contains(github.event.pull_request.labels.*.name, 'conflicts')
             ) }}

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -25,6 +25,8 @@ on:
         required: true
 
   pull_request:
+    types:
+      - labeled
     paths-ignore:
       - '**.md'
       - '**.txt'
@@ -36,9 +38,15 @@ concurrency:
 
 jobs:
   mac-ci:
+    if: ${{ (
+              (github.event_name == 'workflow_dispatch') ||
+              contains(github.event.pull_request.labels.*.name, 'run-ci')
+            ) &&
+            (
+              !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+              !contains(github.event.pull_request.labels.*.name, 'conflicts')
+            ) }}
     uses: ./.github/workflows/reusable-mac-ci.yml
-    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'skip-ci') ||
-              contains(github.event.pull_request.labels.*.name, 'conflicts')) }}
     with:
       label: ${{ inputs.label || 'mac-ci' }}
       colcon-args: ${{ inputs.colcon-args }}

--- a/.github/workflows/reusable-mac-ci.yml
+++ b/.github/workflows/reusable-mac-ci.yml
@@ -44,15 +44,6 @@ jobs:
         cmake-build-type:
           - 'RelWithDebInfo'
     steps:
-      - name: Remove run-ci label if PR
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/remove_labels@v0
-        with:
-          labels: run-ci
-          number: ${{ github.event.number }}
-          repo: eProsima/Fast-DDS
-          fail_on_error: 'false'
-
       - name: Add ci-pending label if PR
         if: ${{ github.event_name == 'pull_request' }}
         uses: eProsima/eProsima-CI/external/add_labels@v0

--- a/.github/workflows/reusable-mac-ci.yml
+++ b/.github/workflows/reusable-mac-ci.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - name: Remove run-ci label if PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        uses: eProsima/eProsima-CI/external/remove_labels@v0
         with:
           labels: run-ci
           number: ${{ github.event.number }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Add ci-pending label if PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/add_labels@feature/labels
+        uses: eProsima/eProsima-CI/external/add_labels@v0
         with:
           labels: ci-pending
           number: ${{ github.event.number }}

--- a/.github/workflows/reusable-mac-ci.yml
+++ b/.github/workflows/reusable-mac-ci.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Add ci-pending label if PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        uses: eProsima/eProsima-CI/external/add_labels@feature/labels
         with:
           labels: ci-pending
           number: ${{ github.event.number }}

--- a/.github/workflows/reusable-mac-ci.yml
+++ b/.github/workflows/reusable-mac-ci.yml
@@ -44,6 +44,23 @@ jobs:
         cmake-build-type:
           - 'RelWithDebInfo'
     steps:
+      - name: Remove run-ci label if PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        with:
+          labels: run-ci
+          number: ${{ github.event.number }}
+          repo: eProsima/Fast-DDS
+          fail_on_error: 'false'
+
+      - name: Add ci-pending label if PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        with:
+          labels: ci-pending
+          number: ${{ github.event.number }}
+          repo: eProsima/Fast-DDS
+
       - name: Sync eProsima/Fast-DDS repository
         uses: eProsima/eProsima-CI/external/checkout@v0
         with:

--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Add ci-pending label if PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        uses: eProsima/eProsima-CI/external/add_labels@feature/labels
         with:
           labels: ci-pending
           number: ${{ github.event.number }}

--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -42,15 +42,6 @@ jobs:
         cmake-build-type:
           - 'RelWithDebInfo'
     steps:
-      - name: Remove run-ci label if PR
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/remove_labels@v0
-        with:
-          labels: run-ci
-          number: ${{ github.event.number }}
-          repo: eProsima/Fast-DDS
-          fail_on_error: 'false'
-
       - name: Add ci-pending label if PR
         if: ${{ github.event_name == 'pull_request' }}
         uses: eProsima/eProsima-CI/external/add_labels@v0

--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -42,6 +42,23 @@ jobs:
         cmake-build-type:
           - 'RelWithDebInfo'
     steps:
+      - name: Remove run-ci label if PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        with:
+          labels: run-ci
+          number: ${{ github.event.number }}
+          repo: eProsima/Fast-DDS
+          fail_on_error: 'false'
+
+      - name: Add ci-pending label if PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        with:
+          labels: ci-pending
+          number: ${{ github.event.number }}
+          repo: eProsima/Fast-DDS
+
       - name: Sync eProsima/Fast-DDS repository
         uses: eProsima/eProsima-CI/external/checkout@v0
         with:

--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - name: Remove run-ci label if PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        uses: eProsima/eProsima-CI/external/remove_labels@v0
         with:
           labels: run-ci
           number: ${{ github.event.number }}
@@ -53,7 +53,7 @@ jobs:
 
       - name: Add ci-pending label if PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/add_labels@feature/labels
+        uses: eProsima/eProsima-CI/external/add_labels@v0
         with:
           labels: ci-pending
           number: ${{ github.event.number }}

--- a/.github/workflows/reusable-windows-ci.yml
+++ b/.github/workflows/reusable-windows-ci.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Remove run-ci label if PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        uses: eProsima/eProsima-CI/external/remove_labels@v0
         with:
           labels: run-ci
           number: ${{ github.event.number }}
@@ -52,7 +52,7 @@ jobs:
 
       - name: Add ci-pending label if PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/add_labels@feature/labels
+        uses: eProsima/eProsima-CI/external/add_labels@v0
         with:
           labels: ci-pending
           number: ${{ github.event.number }}

--- a/.github/workflows/reusable-windows-ci.yml
+++ b/.github/workflows/reusable-windows-ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Add ci-pending label if PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        uses: eProsima/eProsima-CI/external/add_labels@feature/labels
         with:
           labels: ci-pending
           number: ${{ github.event.number }}

--- a/.github/workflows/reusable-windows-ci.yml
+++ b/.github/workflows/reusable-windows-ci.yml
@@ -41,6 +41,23 @@ jobs:
           - 'v141'
           - 'v142'
     steps:
+      - name: Remove run-ci label if PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        with:
+          labels: run-ci
+          number: ${{ github.event.number }}
+          repo: eProsima/Fast-DDS
+          fail_on_error: 'false'
+
+      - name: Add ci-pending label if PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        with:
+          labels: ci-pending
+          number: ${{ github.event.number }}
+          repo: eProsima/Fast-DDS
+
       - name: Sync eProsima/Fast-DDS repository
         uses: eProsima/eProsima-CI/external/checkout@v0
         with:

--- a/.github/workflows/reusable-windows-ci.yml
+++ b/.github/workflows/reusable-windows-ci.yml
@@ -41,15 +41,6 @@ jobs:
           - 'v141'
           - 'v142'
     steps:
-      - name: Remove run-ci label if PR
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/remove_labels@v0
-        with:
-          labels: run-ci
-          number: ${{ github.event.number }}
-          repo: eProsima/Fast-DDS
-          fail_on_error: 'false'
-
       - name: Add ci-pending label if PR
         if: ${{ github.event_name == 'pull_request' }}
         uses: eProsima/eProsima-CI/external/add_labels@v0

--- a/.github/workflows/thread-sanitizer.yaml
+++ b/.github/workflows/thread-sanitizer.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - name: Remove run-ci label if PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        uses: eProsima/eProsima-CI/external/remove_labels@v0
         with:
           labels: run-ci
           number: ${{ github.event.number }}
@@ -67,7 +67,7 @@ jobs:
 
       - name: Add ci-pending label if PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/add_labels@feature/labels
+        uses: eProsima/eProsima-CI/external/add_labels@v0
         with:
           labels: ci-pending
           number: ${{ github.event.number }}

--- a/.github/workflows/thread-sanitizer.yaml
+++ b/.github/workflows/thread-sanitizer.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Add ci-pending label if PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        uses: eProsima/eProsima-CI/external/add_labels@feature/labels
         with:
           labels: ci-pending
           number: ${{ github.event.number }}

--- a/.github/workflows/thread-sanitizer.yaml
+++ b/.github/workflows/thread-sanitizer.yaml
@@ -16,6 +16,8 @@ on:
         type: string
 
   pull_request:
+    types:
+      - labeled
     paths-ignore:
       - '**.md'
       - '**.txt'
@@ -33,9 +35,15 @@ jobs:
   ubuntu-sanitizer-run:
     name: Sanitizer Evaluation
 
-    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'no-test') ||
-              contains(github.event.pull_request.labels.*.name, 'skip-ci') ||
-              contains(github.event.pull_request.labels.*.name, 'conflicts')) }}
+    if: ${{ (
+              (github.event_name == 'workflow_dispatch') ||
+              contains(github.event.pull_request.labels.*.name, 'run-ci')
+            ) &&
+            (
+              !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+              !contains(github.event.pull_request.labels.*.name, 'no-test') &&
+              !contains(github.event.pull_request.labels.*.name, 'conflicts')
+            ) }}
 
     runs-on: ubuntu-22.04
 
@@ -48,6 +56,23 @@ jobs:
         CXX: g++-12
 
     steps:
+      - name: Remove run-ci label if PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        with:
+          labels: run-ci
+          number: ${{ github.event.number }}
+          repo: eProsima/Fast-DDS
+          fail_on_error: 'false'
+
+      - name: Add ci-pending label if PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: eProsima/eProsima-CI/external/remove_labels@feature/labels
+        with:
+          labels: ci-pending
+          number: ${{ github.event.number }}
+          repo: eProsima/Fast-DDS
+
       # https://github.com/actions/runner-images/issues/9491
       - name: Fix kernel mmap rnd bits
         run: sudo sysctl vm.mmap_rnd_bits=28

--- a/.github/workflows/thread-sanitizer.yaml
+++ b/.github/workflows/thread-sanitizer.yaml
@@ -17,7 +17,7 @@ on:
 
   pull_request:
     types:
-      - labeled
+      - review_requested
     paths-ignore:
       - '**.md'
       - '**.txt'
@@ -36,10 +36,6 @@ jobs:
     name: Sanitizer Evaluation
 
     if: ${{ (
-              (github.event_name == 'workflow_dispatch') ||
-              contains(github.event.pull_request.labels.*.name, 'run-ci')
-            ) &&
-            (
               !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
               !contains(github.event.pull_request.labels.*.name, 'no-test') &&
               !contains(github.event.pull_request.labels.*.name, 'conflicts')
@@ -56,15 +52,6 @@ jobs:
         CXX: g++-12
 
     steps:
-      - name: Remove run-ci label if PR
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/remove_labels@v0
-        with:
-          labels: run-ci
-          number: ${{ github.event.number }}
-          repo: eProsima/Fast-DDS
-          fail_on_error: 'false'
-
       - name: Add ci-pending label if PR
         if: ${{ github.event_name == 'pull_request' }}
         uses: eProsima/eProsima-CI/external/add_labels@v0

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -25,6 +25,8 @@ on:
         required: true
 
   pull_request:
+    types:
+      - labeled
     paths-ignore:
       - '**.md'
       - '**.txt'
@@ -43,6 +45,14 @@ jobs:
         os-image:
           - 'ubuntu-22.04'
 
+    if: ${{ (
+              (github.event_name == 'workflow_dispatch') ||
+              contains(github.event.pull_request.labels.*.name, 'run-ci')
+            ) &&
+            (
+              !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+              !contains(github.event.pull_request.labels.*.name, 'conflicts')
+            ) }}
     uses: ./.github/workflows/reusable-ubuntu-ci.yml
     with:
       os-image: ${{ matrix.os-image }}

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -26,14 +26,14 @@ on:
 
   pull_request:
     types:
-      - labeled
+      - review_requested
     paths-ignore:
       - '**.md'
       - '**.txt'
       - '!**/CMakeLists.txt'
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -46,10 +46,6 @@ jobs:
           - 'ubuntu-22.04'
 
     if: ${{ (
-              (github.event_name == 'workflow_dispatch') ||
-              contains(github.event.pull_request.labels.*.name, 'run-ci')
-            ) &&
-            (
               !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
               !contains(github.event.pull_request.labels.*.name, 'conflicts')
             ) }}

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -26,7 +26,7 @@ on:
 
   pull_request:
     types:
-      - labeled
+      - review_requested
     paths-ignore:
       - '**.md'
       - '**.txt'
@@ -39,10 +39,6 @@ concurrency:
 jobs:
   windows-ci:
     if: ${{ (
-              (github.event_name == 'workflow_dispatch') ||
-              contains(github.event.pull_request.labels.*.name, 'run-ci')
-            ) &&
-            (
               !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
               !contains(github.event.pull_request.labels.*.name, 'conflicts')
             ) }}

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -25,6 +25,8 @@ on:
         required: true
 
   pull_request:
+    types:
+      - labeled
     paths-ignore:
       - '**.md'
       - '**.txt'
@@ -36,9 +38,15 @@ concurrency:
 
 jobs:
   windows-ci:
+    if: ${{ (
+              (github.event_name == 'workflow_dispatch') ||
+              contains(github.event.pull_request.labels.*.name, 'run-ci')
+            ) &&
+            (
+              !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+              !contains(github.event.pull_request.labels.*.name, 'conflicts')
+            ) }}
     uses: ./.github/workflows/reusable-windows-ci.yml
-    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'skip-ci') ||
-              contains(github.event.pull_request.labels.*.name, 'conflicts')) }}
     with:
       label: ${{ inputs.label || 'windows-ci' }}
       colcon-args: ${{ inputs.colcon-args }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR changes the way Github CI is managed. From now on, to run CI, a label `run-ci` needs to be added to the PR. Once the CI starts, that label is removed and `ci-pending` one is added.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
This PR depends on:
* eProsima/eProsima-CI#80

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- _N/A_: The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
