### PR TITLE
[20652] Improve filtering of DNS tests

### DIFF
--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -31,7 +31,7 @@ on:
       - '!**/CMakeLists.txt'
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,12 +34,13 @@ set(MEMORYCHECK_SUPPRESSIONS_FILE ${MEMORYCHECK_SUPPRESSIONS_FILE_TMP} CACHE FIL
 
 # Check if /etc/hosts file has been modified to add dummy host test subjects
 if(WIN32)
-    execute_process(COMMAND powershell -C Resolve-DNSName www.acme.com.test
+    execute_process(COMMAND powershell -C Resolve-DNSName -Name www.acme.com.test -CacheOnly
         RESULT_VARIABLE EPROSIMA_TEST_DNS_NOT_SET_UP OUTPUT_QUIET ERROR_QUIET)
 else(WIN32)
     execute_process(COMMAND getent hosts www.acme.com.test
         RESULT_VARIABLE EPROSIMA_TEST_DNS_NOT_SET_UP OUTPUT_QUIET ERROR_QUIET)
 endif(WIN32)
+message(STATUS "EPROSIMA_TEST_DNS_NOT_SET_UP: '${EPROSIMA_TEST_DNS_NOT_SET_UP}'")
 
 ###############################################################################
 # Testing

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,10 +36,13 @@ set(MEMORYCHECK_SUPPRESSIONS_FILE ${MEMORYCHECK_SUPPRESSIONS_FILE_TMP} CACHE FIL
 if(WIN32)
     execute_process(COMMAND powershell -C Resolve-DNSName -Name www.acme.com.test -CacheOnly
         RESULT_VARIABLE EPROSIMA_TEST_DNS_NOT_SET_UP OUTPUT_QUIET ERROR_QUIET)
-else(WIN32)
+elif(APPLE)
+	execute_process(COMMAND dscacheutil -q host -a name www.acme.com.test
+		RESULT_VARIABLE EPROSIMA_TEST_DNS_NOT_SET_UP OUTPUT_QUIET ERROR_QUIET)
+else()
     execute_process(COMMAND getent hosts www.acme.com.test
         RESULT_VARIABLE EPROSIMA_TEST_DNS_NOT_SET_UP OUTPUT_QUIET ERROR_QUIET)
-endif(WIN32)
+endif()
 message(STATUS "EPROSIMA_TEST_DNS_NOT_SET_UP: '${EPROSIMA_TEST_DNS_NOT_SET_UP}'")
 
 ###############################################################################

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,8 +37,10 @@ if(WIN32)
     execute_process(COMMAND powershell -C Resolve-DNSName -Name www.acme.com.test -CacheOnly
         RESULT_VARIABLE EPROSIMA_TEST_DNS_NOT_SET_UP OUTPUT_QUIET ERROR_QUIET)
 elseif(APPLE)
-	execute_process(COMMAND dscacheutil -q host -a name www.acme.com.test
-		RESULT_VARIABLE EPROSIMA_TEST_DNS_NOT_SET_UP OUTPUT_QUIET ERROR_QUIET)
+	execute_process(
+        COMMAND dscacheutil -q host -a name www.acme.com.test
+        COMMAND grep www.acme.com.test
+        RESULT_VARIABLE EPROSIMA_TEST_DNS_NOT_SET_UP OUTPUT_QUIET ERROR_QUIET)
 else()
     execute_process(COMMAND getent hosts www.acme.com.test
         RESULT_VARIABLE EPROSIMA_TEST_DNS_NOT_SET_UP OUTPUT_QUIET ERROR_QUIET)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,7 +36,7 @@ set(MEMORYCHECK_SUPPRESSIONS_FILE ${MEMORYCHECK_SUPPRESSIONS_FILE_TMP} CACHE FIL
 if(WIN32)
     execute_process(COMMAND powershell -C Resolve-DNSName -Name www.acme.com.test -CacheOnly
         RESULT_VARIABLE EPROSIMA_TEST_DNS_NOT_SET_UP OUTPUT_QUIET ERROR_QUIET)
-elif(APPLE)
+elseif(APPLE)
 	execute_process(COMMAND dscacheutil -q host -a name www.acme.com.test
 		RESULT_VARIABLE EPROSIMA_TEST_DNS_NOT_SET_UP OUTPUT_QUIET ERROR_QUIET)
 else()

--- a/test/blackbox/CMakeLists.txt
+++ b/test/blackbox/CMakeLists.txt
@@ -107,7 +107,7 @@ target_include_directories(BlackboxTests_RTPS PRIVATE
 target_link_libraries(BlackboxTests_RTPS fastrtps fastcdr foonathan_memory GTest::gtest)
 gtest_discover_tests(BlackboxTests_RTPS
     TEST_PREFIX "BlackboxTests_RTPS."
-    TEST_FILTER ${pkcs_filter}
+    TEST_FILTER ${BLACKBOX_HIGH_LEVEL_IGNORED_TESTS}
     NO_PRETTY_VALUES
     )
 

--- a/test/blackbox/CMakeLists.txt
+++ b/test/blackbox/CMakeLists.txt
@@ -47,12 +47,19 @@ endif()
 
 # Filter pksc11 related tests if library is not available
 if(NOT LibP11_FOUND)
-    set(pkcs_filter "-*pkcs*")
+    set(pkcs_filter "*pkcs*")
 endif() # LibP11_FOUND
 
 if(EPROSIMA_TEST_DNS_NOT_SET_UP)
-    set(dns_filter "-*ServerClientEnvironmentSetUpDNS*")
+    set(dns_filter "*ServerClientEnvironmentSetUpDNS*")
 endif()
+
+string(JOIN ":" BLACKBOX_HIGH_LEVEL_IGNORED_TESTS ${pkcs_filter} ${dns_filter})
+if(NOT BLACKBOX_HIGH_LEVEL_IGNORED_TESTS STREQUAL "")
+	message(STATUS "Ignoring tests '${BLACKBOX_HIGH_LEVEL_IGNORED_TESTS}'")
+    string(PREPEND BLACKBOX_HIGH_LEVEL_IGNORED_TESTS "-")
+endif()
+message(STATUS "BLACKBOX_HIGH_LEVEL_IGNORED_TESTS set to '${BLACKBOX_HIGH_LEVEL_IGNORED_TESTS}'")
 
 file(GLOB RTPS_BLACKBOXTESTS_TEST_SOURCE "common/RTPSBlackboxTests*.cpp")
 set(RTPS_BLACKBOXTESTS_SOURCE ${RTPS_BLACKBOXTESTS_TEST_SOURCE}
@@ -226,7 +233,7 @@ if(FASTRTPS_API_TESTS)
             ENVIRONMENT "MULTICAST_PORT_RANDOM_NUMBER=${MULTICAST_PORT_RANDOM_NUMBER}"
             ENVIRONMENT $<IF:$<BOOL:${OPENSSL_CONF}>,OPENSSL_CONF=${OPENSSL_CONF},>
         TEST_PREFIX "BlackboxTests_FastRTPS."
-        TEST_FILTER ${pkcs_filter} ${dns_filter}
+        TEST_FILTER ${BLACKBOX_HIGH_LEVEL_IGNORED_TESTS}
         NO_PRETTY_VALUES
         )
 endif(FASTRTPS_API_TESTS)
@@ -281,7 +288,7 @@ if(FASTDDS_PIM_API_TESTS)
             ENVIRONMENT "MULTICAST_PORT_RANDOM_NUMBER=${MULTICAST_PORT_RANDOM_NUMBER}"
             ENVIRONMENT $<IF:$<BOOL:${OPENSSL_CONF}>,OPENSSL_CONF=${OPENSSL_CONF},>
         TEST_PREFIX "BlackboxTests_DDS_PIM."
-        TEST_FILTER ${pkcs_filter} ${dns_filter}
+        TEST_FILTER ${BLACKBOX_HIGH_LEVEL_IGNORED_TESTS}
         NO_PRETTY_VALUES
         )
 endif(FASTDDS_PIM_API_TESTS)

--- a/test/unittest/dds/participant/CMakeLists.txt
+++ b/test/unittest/dds/participant/CMakeLists.txt
@@ -47,6 +47,7 @@ target_link_libraries(ParticipantTests fastrtps fastcdr foonathan_memory
     ${CMAKE_DL_LIBS})
 
 if(EPROSIMA_TEST_DNS_NOT_SET_UP)
+    message(STATUS "Ignoring 'ParticipantTests.SimpleParticipantRemoteServerListConfigurationDNS'")
     set(dns_filter "-ParticipantTests.SimpleParticipantRemoteServerListConfigurationDNS")
 endif()
 

--- a/test/unittest/utils/CMakeLists.txt
+++ b/test/unittest/utils/CMakeLists.txt
@@ -148,18 +148,11 @@ if(QNX)
     target_link_libraries(LocatorTests socket)
 endif()
 if(EPROSIMA_TEST_DNS_NOT_SET_UP)
-    set(IGNORE_COMMAND LocatorDNSTests)
+    message(STATUS "Ignoring 'LocatorDNSTests*'")
+    set(IGNORE_COMMAND "-LocatorDNSTests*")
 endif()
 gtest_discover_tests(LocatorTests TEST_FILTER ${IGNORE_COMMAND})
 unset(IGNORE_COMMAND)
-# Skip DNS related tests when not running on our CI
-if(NOT(EPROSIMA_BUILD))
-    message(STATUS "Ignoring DNS tests")
-    set(CTEST_CUSTOM_TESTS_IGNORE
-        ${CTEST_CUSTOM_TESTS_IGNORE}
-        LocatorDNSTests
-        )
-endif()
 
 add_executable(FixedSizeQueueTests ${FIXEDSIZEQUEUETESTS_SOURCE})
 target_include_directories(FixedSizeQueueTests PRIVATE


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

When both PKCS#11 and DNS tests had to be disabled, the filter expression for gtest was incorrectly generated.
This made Ubuntu and MacOS CI on github fail.

Additionally, this PR fixes the commands used to detect whether the DNS local entries for the corresponding tests have been added, and adds some related informational messages to the CMake files.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- *N/A* The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
