### PR TITLE
[20722] Force unlimited ResourceLimits if lower or equal to zero

### DIFF
--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -1728,21 +1728,21 @@ public:
      * @brief Specifies the maximum number of data-samples the DataWriter (or DataReader) can manage across all the
      * instances associated with it. Represents the maximum samples the middleware can store for any one DataWriter
      * (or DataReader). <br>
-     * Value 0 means infinite resources. By default, 5000.
+     * Value less or equal to 0 means infinite resources. By default, 5000.
      *
      * @warning It is inconsistent if `max_samples < (max_instances * max_samples_per_instance)`.
      */
     int32_t max_samples;
     /**
      * @brief Represents the maximum number of instances DataWriter (or DataReader) can manage. <br>
-     * Value 0 means infinite resources. By default, 10.
+     * Value less or equal to 0 means infinite resources. By default, 10.
      *
      * @warning It is inconsistent if `(max_instances * max_samples_per_instance) > max_samples`.
      */
     int32_t max_instances;
     /**
      * @brief Represents the maximum number of samples of any one instance a DataWriter(or DataReader) can manage. <br>
-     * Value 0 means infinite resources. By default, 400.
+     * Value less or equal to 0 means infinite resources. By default, 400.
      *
      * @warning It is inconsistent if `(max_instances * max_samples_per_instance) > max_samples`.
      */

--- a/src/cpp/fastdds/publisher/DataWriterHistory.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterHistory.cpp
@@ -67,12 +67,12 @@ DataWriterHistory::DataWriterHistory(
     , topic_att_(topic_att)
     , unacknowledged_sample_removed_functor_(unack_sample_remove_functor)
 {
-    if (resource_limited_qos_.max_instances == 0)
+    if (resource_limited_qos_.max_instances <= 0)
     {
         resource_limited_qos_.max_instances = std::numeric_limits<int32_t>::max();
     }
 
-    if (resource_limited_qos_.max_samples_per_instance == 0)
+    if (resource_limited_qos_.max_samples_per_instance <= 0)
     {
         resource_limited_qos_.max_samples_per_instance = std::numeric_limits<int32_t>::max();
     }

--- a/src/cpp/fastdds/publisher/DataWriterHistory.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterHistory.cpp
@@ -67,6 +67,11 @@ DataWriterHistory::DataWriterHistory(
     , topic_att_(topic_att)
     , unacknowledged_sample_removed_functor_(unack_sample_remove_functor)
 {
+    if (resource_limited_qos_.max_samples <= 0)
+    {
+        resource_limited_qos_.max_samples = std::numeric_limits<int32_t>::max();
+    }
+
     if (resource_limited_qos_.max_instances <= 0)
     {
         resource_limited_qos_.max_instances = std::numeric_limits<int32_t>::max();

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
@@ -70,17 +70,17 @@ DataReaderHistory::DataReaderHistory(
     , type_(type.get())
     , get_key_object_(nullptr)
 {
-    if (resource_limited_qos_.max_samples == 0)
+    if (resource_limited_qos_.max_samples <= 0)
     {
         resource_limited_qos_.max_samples = std::numeric_limits<int32_t>::max();
     }
 
-    if (resource_limited_qos_.max_instances == 0)
+    if (resource_limited_qos_.max_instances <= 0)
     {
         resource_limited_qos_.max_instances = std::numeric_limits<int32_t>::max();
     }
 
-    if (resource_limited_qos_.max_samples_per_instance == 0)
+    if (resource_limited_qos_.max_samples_per_instance <= 0)
     {
         resource_limited_qos_.max_samples_per_instance = std::numeric_limits<int32_t>::max();
     }

--- a/src/cpp/fastrtps_deprecated/publisher/PublisherHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/publisher/PublisherHistory.cpp
@@ -66,12 +66,12 @@ PublisherHistory::PublisherHistory(
     , resource_limited_qos_(topic_att.resourceLimitsQos)
     , topic_att_(topic_att)
 {
-    if (resource_limited_qos_.max_instances == 0)
+    if (resource_limited_qos_.max_instances <= 0)
     {
         resource_limited_qos_.max_instances = std::numeric_limits<int32_t>::max();
     }
 
-    if (resource_limited_qos_.max_samples_per_instance == 0)
+    if (resource_limited_qos_.max_samples_per_instance <= 0)
     {
         resource_limited_qos_.max_samples_per_instance = std::numeric_limits<int32_t>::max();
     }

--- a/src/cpp/fastrtps_deprecated/publisher/PublisherHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/publisher/PublisherHistory.cpp
@@ -66,6 +66,11 @@ PublisherHistory::PublisherHistory(
     , resource_limited_qos_(topic_att.resourceLimitsQos)
     , topic_att_(topic_att)
 {
+    if (resource_limited_qos_.max_samples <= 0)
+    {
+        resource_limited_qos_.max_samples = std::numeric_limits<int32_t>::max();
+    }
+
     if (resource_limited_qos_.max_instances <= 0)
     {
         resource_limited_qos_.max_instances = std::numeric_limits<int32_t>::max();

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -96,17 +96,17 @@ SubscriberHistory::SubscriberHistory(
         get_key_object_ = type_->createData();
     }
 
-    if (resource_limited_qos_.max_samples == 0)
+    if (resource_limited_qos_.max_samples <= 0)
     {
         resource_limited_qos_.max_samples = std::numeric_limits<int32_t>::max();
     }
 
-    if (resource_limited_qos_.max_instances == 0)
+    if (resource_limited_qos_.max_instances <= 0)
     {
         resource_limited_qos_.max_instances = std::numeric_limits<int32_t>::max();
     }
 
-    if (resource_limited_qos_.max_samples_per_instance == 0)
+    if (resource_limited_qos_.max_samples_per_instance <= 0)
     {
         resource_limited_qos_.max_samples_per_instance = std::numeric_limits<int32_t>::max();
     }

--- a/test/mock/rtps/PublisherHistory/fastdds/publisher/DataWriterHistory.hpp
+++ b/test/mock/rtps/PublisherHistory/fastdds/publisher/DataWriterHistory.hpp
@@ -79,6 +79,11 @@ public:
         , topic_att_(topic_att)
         , unacknowledged_sample_removed_functor_(unack_sample_remove_functor)
     {
+        if (resource_limited_qos_.max_samples <= 0)
+        {
+            resource_limited_qos_.max_samples = std::numeric_limits<int32_t>::max();
+        }
+
         if (resource_limited_qos_.max_instances <= 0)
         {
             resource_limited_qos_.max_instances = std::numeric_limits<int32_t>::max();

--- a/test/mock/rtps/PublisherHistory/fastdds/publisher/DataWriterHistory.hpp
+++ b/test/mock/rtps/PublisherHistory/fastdds/publisher/DataWriterHistory.hpp
@@ -79,12 +79,12 @@ public:
         , topic_att_(topic_att)
         , unacknowledged_sample_removed_functor_(unack_sample_remove_functor)
     {
-        if (resource_limited_qos_.max_instances == 0)
+        if (resource_limited_qos_.max_instances <= 0)
         {
             resource_limited_qos_.max_instances = std::numeric_limits<int32_t>::max();
         }
 
-        if (resource_limited_qos_.max_samples_per_instance == 0)
+        if (resource_limited_qos_.max_samples_per_instance <= 0)
         {
             resource_limited_qos_.max_samples_per_instance = std::numeric_limits<int32_t>::max();
         }

--- a/test/mock/rtps/PublisherHistory/fastrtps/publisher/PublisherHistory.h
+++ b/test/mock/rtps/PublisherHistory/fastrtps/publisher/PublisherHistory.h
@@ -74,12 +74,12 @@ public:
         , resource_limited_qos_(topic_att.resourceLimitsQos)
         , topic_att_(topic_att)
     {
-        if (resource_limited_qos_.max_instances == 0)
+        if (resource_limited_qos_.max_instances <= 0)
         {
             resource_limited_qos_.max_instances = std::numeric_limits<int32_t>::max();
         }
 
-        if (resource_limited_qos_.max_samples_per_instance == 0)
+        if (resource_limited_qos_.max_samples_per_instance <= 0)
         {
             resource_limited_qos_.max_samples_per_instance = std::numeric_limits<int32_t>::max();
         }

--- a/test/mock/rtps/PublisherHistory/fastrtps/publisher/PublisherHistory.h
+++ b/test/mock/rtps/PublisherHistory/fastrtps/publisher/PublisherHistory.h
@@ -74,6 +74,11 @@ public:
         , resource_limited_qos_(topic_att.resourceLimitsQos)
         , topic_att_(topic_att)
     {
+        if (resource_limited_qos_.max_samples <= 0)
+        {
+            resource_limited_qos_.max_samples = std::numeric_limits<int32_t>::max();
+        }
+
         if (resource_limited_qos_.max_instances <= 0)
         {
             resource_limited_qos_.max_instances = std::numeric_limits<int32_t>::max();

--- a/test/performance/throughput/ThroughputPublisher.cpp
+++ b/test/performance/throughput/ThroughputPublisher.cpp
@@ -527,7 +527,7 @@ void ThroughputPublisher::run(
         else
         {
             // Ensure that the max samples is at least the demand
-            if (dw_qos.resource_limits().max_samples < 0 ||
+            if (dw_qos.resource_limits().max_samples <= 0 ||
                     static_cast<uint32_t>(dw_qos.resource_limits().max_samples) < max_demand)
             {
                 EPROSIMA_LOG_WARNING(THROUGHPUTPUBLISHER, "Setting resource limit max samples to " << max_demand);

--- a/test/performance/throughput/ThroughputSubscriber.cpp
+++ b/test/performance/throughput/ThroughputSubscriber.cpp
@@ -585,7 +585,7 @@ int ThroughputSubscriber::process_message()
                         else
                         {
                             // Ensure that the max samples is at least the demand
-                            if (dr_qos.resource_limits().max_samples < 0 ||
+                            if (dr_qos.resource_limits().max_samples <= 0 ||
                                     static_cast<uint32_t>(dr_qos.resource_limits().max_samples) < max_demand)
                             {
                                 EPROSIMA_LOG_WARNING(THROUGHPUTSUBSCRIBER,

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -1820,7 +1820,10 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyNotKeyed)
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
     // which also means infinite value, and does not make any change.
+    // Updated to check negative values (Redmine ticket #20722)
+    qos.resource_limits().max_samples = -1;
     qos.resource_limits().max_instances = -1;
+    qos.resource_limits().max_samples_per_instance = -1;
 
     DataWriter* data_writer2 = publisher->create_datawriter(topic, qos);
     ASSERT_NE(data_writer2, nullptr);
@@ -1867,7 +1870,10 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyNotKeyed)
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
     // which also means infinite value.
     // By not using instances, instance allocation consistency is not checked.
+    // Updated to check negative values (Redmine ticket #20722)
+    qos2.resource_limits().max_samples = -1;
     qos2.resource_limits().max_instances = -1;
+    qos2.resource_limits().max_samples_per_instance = -1;
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_writer1->set_qos(qos2));
 
@@ -1938,8 +1944,10 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyKeyed)
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
     // which also means infinite value.
-    qos.resource_limits().max_samples = 0;
+    // Updated to check negative values (Redmine ticket #20722)
+    qos.resource_limits().max_samples = -1;
     qos.resource_limits().max_instances = -1;
+    qos.resource_limits().max_samples_per_instance = -1;
 
     DataWriter* data_writer2 = publisher->create_datawriter(topic, qos);
     ASSERT_NE(data_writer2, nullptr);
@@ -1991,8 +1999,10 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyKeyed)
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
     // which also means infinite value.
-    qos2.resource_limits().max_samples = 0;
+    // Updated to check negative values (Redmine ticket #20722)
+    qos2.resource_limits().max_samples = 1;
     qos2.resource_limits().max_instances = -1;
+    qos2.resource_limits().max_samples_per_instance = -1;
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_writer1->set_qos(qos2));
 

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -2000,7 +2000,7 @@ TEST(DataWriterTests, InstancePolicyAllocationConsistencyKeyed)
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
     // which also means infinite value.
     // Updated to check negative values (Redmine ticket #20722)
-    qos2.resource_limits().max_samples = 1;
+    qos2.resource_limits().max_samples = -1;
     qos2.resource_limits().max_instances = -1;
     qos2.resource_limits().max_samples_per_instance = -1;
 

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -3281,7 +3281,10 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyNotKeyed)
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
     // which also means infinite value, and does not make any change.
+    // Updated to check negative values (Redmine ticket #20722)
+    qos.resource_limits().max_samples = -1;
     qos.resource_limits().max_instances = -1;
+    qos.resource_limits().max_samples_per_instance = -1;
 
     DataReader* data_reader2 = subscriber->create_datareader(topic, qos);
     ASSERT_NE(data_reader2, nullptr);
@@ -3334,7 +3337,10 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyNotKeyed)
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
     // which also means infinite value.
     // By not using instances, instance allocation consistency is not checked.
+    // Updated to check negative values (Redmine ticket #20722)
+    qos2.resource_limits().max_samples = -1;
     qos2.resource_limits().max_instances = -1;
+    qos2.resource_limits().max_samples_per_instance = -1;
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_reader2->set_qos(qos2));
 
@@ -3405,8 +3411,10 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyKeyed)
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
     // which also means infinite value.
-    qos.resource_limits().max_samples = 0;
+    // Updated to check negative values (Redmine ticket #20722)
+    qos.resource_limits().max_samples = -1;
     qos.resource_limits().max_instances = -1;
+    qos.resource_limits().max_samples_per_instance = -1;
 
     DataReader* data_reader2 = subscriber->create_datareader(topic, qos);
     ASSERT_NE(data_reader2, nullptr);
@@ -3464,8 +3472,10 @@ TEST_F(DataReaderTests, InstancePolicyAllocationConsistencyKeyed)
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
     // which also means infinite value.
-    qos2.resource_limits().max_samples = 0;
+    // Updated to check negative values (Redmine ticket #20722)
+    qos2.resource_limits().max_samples = -1;
     qos2.resource_limits().max_instances = -1;
+    qos2.resource_limits().max_samples_per_instance = -1;
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_data_reader2->set_qos(qos2));
 

--- a/test/unittest/dds/topic/TopicTests.cpp
+++ b/test/unittest/dds/topic/TopicTests.cpp
@@ -261,7 +261,10 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyNotKeyed)
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
     // which also means infinite value, and does not make any change.
+    // Updated to check negative values (Redmine ticket #20722)
+    qos.resource_limits().max_samples = -1;
     qos.resource_limits().max_instances = -1;
+    qos.resource_limits().max_samples_per_instance = -1;
 
     Topic* topic2 = participant->create_topic("footopic2", type.get_type_name(), qos);
     ASSERT_NE(topic2, nullptr);
@@ -308,7 +311,10 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyNotKeyed)
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
     // which also means infinite value.
     // By not using instances, instance allocation consistency is not checked.
+    // Updated to check negative values (Redmine ticket #20722)
+    qos2.resource_limits().max_samples = -1;
     qos2.resource_limits().max_instances = -1;
+    qos2.resource_limits().max_samples_per_instance = -1;
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_topic1->set_qos(qos2));
 
@@ -377,8 +383,10 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyKeyed)
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
     // which also means infinite value.
-    qos.resource_limits().max_samples = 0;
+    // Updated to check negative values (Redmine ticket #20722)
+    qos.resource_limits().max_samples = -1;
     qos.resource_limits().max_instances = -1;
+    qos.resource_limits().max_samples_per_instance = -1;
 
     Topic* topic2 = participant->create_topic("footopic2", type.get_type_name(), qos);
     ASSERT_NE(topic2, nullptr);
@@ -430,8 +438,10 @@ TEST(TopicTests, InstancePolicyAllocationConsistencyKeyed)
 
     // Below an ampliation of the last comprobation, for which it is proved the case of < 0 (-1),
     // which also means infinite value.
-    qos2.resource_limits().max_samples = 0;
+    // Updated to check negative values (Redmine ticket #20722)
+    qos2.resource_limits().max_samples = -1;
     qos2.resource_limits().max_instances = -1;
+    qos2.resource_limits().max_samples_per_instance = -1;
 
     ASSERT_EQ(ReturnCode_t::RETCODE_OK, default_topic1->set_qos(qos2));
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR forces the ResourceLimitsQoS values (`max_samples`, `max_instances` and `max_samples_per_instance`) to be considered as unlimited if a value **greater than zero** is **NOT** provided.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
Fixes #4609

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    Related documentation PR: eProsima/Fast-DDS-docs#738
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
