### PR TITLE
[20692] Make sample_lost_be_dw_be_dr_fragments test less flakey

### DIFF
--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -781,9 +781,9 @@ void sample_lost_test_init(
     // Since we are going to send 300KB samples in the test for fragments, let's increase the buffer size to avoid any
     // other possible loss.
     constexpr uint32_t BUFFER_SIZE =
-        300ul * 1024ul // sample size
-        * 13ul         // number of samples
-        * 2ul;         // 2x to avoid any possible loss
+            300ul * 1024ul // sample size
+            * 13ul         // number of samples
+            * 2ul;         // 2x to avoid any possible loss
     reader.socket_buffer_size(BUFFER_SIZE);
     writer.socket_buffer_size(BUFFER_SIZE);
 

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -765,14 +765,6 @@ void sample_lost_test_dr_init(
         PubSubReader<T>& reader,
         std::function<void(const eprosima::fastdds::dds::SampleLostStatus& status)> functor)
 {
-    // We want to ensure that samples are only lost due to the custom filter we have set in sample_lost_test_dw_init.
-    // Since we are going to send 300KB samples in the test for fragments, let's increase the buffer size to avoid any
-    // other possible loss.
-    constexpr uint32_t BUFFER_SIZE =
-            300ul * 1024ul // sample size
-            * 13ul       // number of samples
-            * 2ul;       // 2x to avoid any possible loss
-    reader.socket_buffer_size(BUFFER_SIZE);
     reader.sample_lost_status_functor(functor)
             .init();
 
@@ -785,6 +777,16 @@ void sample_lost_test_init(
         PubSubWriter<T>& writer,
         std::function<void(const eprosima::fastdds::dds::SampleLostStatus& status)> functor)
 {
+    // We want to ensure that samples are only lost due to the custom filter we have set in sample_lost_test_dw_init.
+    // Since we are going to send 300KB samples in the test for fragments, let's increase the buffer size to avoid any
+    // other possible loss.
+    constexpr uint32_t BUFFER_SIZE =
+        300ul * 1024ul // sample size
+        * 13ul         // number of samples
+        * 2ul;         // 2x to avoid any possible loss
+    reader.socket_buffer_size(BUFFER_SIZE);
+    writer.socket_buffer_size(BUFFER_SIZE);
+
     sample_lost_test_dw_init(writer);
     sample_lost_test_dr_init(reader, functor);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Blackbox test `sample_lost_be_dw_be_dr_fragments` has been failing from time to time.
It fails because more samples than expected are lost.
The socket buffer size was only configured for the reader so fragments could have been lost in the writer.
This PR configures the socket buffer size in both the reader and the writer.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- *N/A* Applicable backports have been included in the description.
    - This will not be directly backported, but cherry-picked in the backports of #4187, which is the one that added the offending test. Those backports are: #4608, #4606, and #4607


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
