### PR TITLE
[20592][20679] Fix hidden overloaded virtual methods

### DIFF
--- a/.github/workflows/address-sanitizers.yaml
+++ b/.github/workflows/address-sanitizers.yaml
@@ -13,8 +13,6 @@ on:
         default: '2.10.x'
 
   pull_request:
-    branches:
-      - '2.10.x'
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/.github/workflows/documentation-tests.yaml
+++ b/.github/workflows/documentation-tests.yaml
@@ -9,8 +9,6 @@ on:
         default: '2.10.x'
 
   pull_request:
-    branches:
-      - '2.10.x'
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -25,8 +25,6 @@ on:
         required: true
 
   pull_request:
-    branches:
-      - '2.10.x'
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -97,7 +97,7 @@ jobs:
           colcon_meta_file: ${{ github.workspace }}/src/fastrtps/.github/workflows/config/ci.meta
           colcon_build_args: ${{ inputs.colcon-args }}
           cmake_args: ${{ inputs.cmake-args }}
-          cmake_args_default: -DCMAKE_CXX_FLAGS="-Werror -Wall"
+          cmake_args_default: -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra -Wpedantic -Wunused-value -Woverloaded-virtual" -DFASTDDS_EXAMPLE_TESTS=ON
           cmake_build_type: ${{ matrix.cmake-build-type }}
           workspace: ${{ github.workspace }}
 

--- a/.github/workflows/thread-sanitizer.yaml
+++ b/.github/workflows/thread-sanitizer.yaml
@@ -16,8 +16,6 @@ on:
         type: string
 
   pull_request:
-    branches:
-      - '2.10.x'
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -24,6 +24,12 @@ on:
         type: string
         required: true
 
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - '!**/CMakeLists.txt'
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -25,8 +25,6 @@ on:
         required: true
 
   pull_request:
-    branches:
-      - '2.10.x'
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/examples/cpp/dds/LivelinessQoS/LivelinessSubscriber.h
+++ b/examples/cpp/dds/LivelinessQoS/LivelinessSubscriber.h
@@ -101,9 +101,15 @@ private:
 
     class PartListener : public eprosima::fastdds::dds::DomainParticipantListener
     {
+    public:
+
         virtual void on_participant_discovery(
                 eprosima::fastdds::dds::DomainParticipant* participant,
                 eprosima::fastrtps::rtps::ParticipantDiscoveryInfo&& info) override;
+
+    private:
+
+        using eprosima::fastdds::dds::DomainParticipantListener::on_participant_discovery;
     };
 
     PartListener part_listener_;

--- a/examples/cpp/rtps/Persistent/TestReaderPersistent.h
+++ b/examples/cpp/rtps/Persistent/TestReaderPersistent.h
@@ -66,6 +66,10 @@ public:
 
         uint32_t n_received;
         uint32_t n_matched;
+
+    private:
+
+        using eprosima::fastrtps::rtps::ReaderListener::onReaderMatched;
     }
     m_listener;
 };

--- a/examples/cpp/rtps/Persistent/TestWriterPersistent.h
+++ b/examples/cpp/rtps/Persistent/TestWriterPersistent.h
@@ -62,6 +62,10 @@ public:
         }
 
         int n_matched;
+
+    private:
+
+        using eprosima::fastrtps::rtps::WriterListener::onWriterMatched;
     }
     m_listener;
 };

--- a/examples/cpp/rtps/Registered/TestReaderRegistered.h
+++ b/examples/cpp/rtps/Registered/TestReaderRegistered.h
@@ -66,6 +66,10 @@ public:
 
         uint32_t n_received;
         uint32_t n_matched;
+
+    private:
+
+        using eprosima::fastrtps::rtps::ReaderListener::onReaderMatched;
     }
     m_listener;
 };

--- a/examples/cpp/rtps/Registered/TestWriterRegistered.h
+++ b/examples/cpp/rtps/Registered/TestWriterRegistered.h
@@ -62,6 +62,10 @@ public:
         }
 
         int n_matched;
+
+    private:
+
+        using eprosima::fastrtps::rtps::WriterListener::onWriterMatched;
     }
     m_listener;
 };

--- a/include/fastrtps/subscriber/SubscriberHistory.h
+++ b/include/fastrtps/subscriber/SubscriberHistory.h
@@ -179,6 +179,9 @@ public:
 
 private:
 
+    using rtps::ReaderHistory::completed_change;
+    using rtps::ReaderHistory::received_change;
+
     using t_m_Inst_Caches = std::map<rtps::InstanceHandle_t, KeyedChanges>;
 
     //!Map where keys are instance handles and values vectors of cache changes

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -717,6 +717,11 @@ protected:
         DomainParticipantImpl* participant_;
         int callback_counter_ = 0;
 
+    private:
+
+        using fastrtps::rtps::RTPSParticipantListener::onParticipantDiscovery;
+        using fastrtps::rtps::RTPSParticipantListener::onReaderDiscovery;
+        using fastrtps::rtps::RTPSParticipantListener::onWriterDiscovery;
     }
     rtps_listener_;
 

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -454,6 +454,10 @@ protected:
                 const fastrtps::rtps::ReaderProxyData* reader_info) override;
 
         DataWriterImpl* data_writer_;
+
+    private:
+
+        using fastrtps::rtps::WriterListener::onWriterMatched;
     }
     writer_listener_;
 

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -446,6 +446,10 @@ protected:
                 const fastrtps::rtps::CacheChange_t* const change) override;
 
         DataReaderImpl* data_reader_;
+
+    private:
+
+        using fastrtps::rtps::ReaderListener::onReaderMatched;
     }
     reader_listener_;
 

--- a/src/cpp/fastrtps_deprecated/participant/ParticipantImpl.h
+++ b/src/cpp/fastrtps_deprecated/participant/ParticipantImpl.h
@@ -233,6 +233,12 @@ private:
 
         ParticipantImpl* mp_participantimpl;
 
+    private:
+
+        using rtps::RTPSParticipantListener::onParticipantDiscovery;
+        using rtps::RTPSParticipantListener::onReaderDiscovery;
+        using rtps::RTPSParticipantListener::onWriterDiscovery;
+
     }
     m_rtps_listener;
 

--- a/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.h
+++ b/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.h
@@ -243,6 +243,10 @@ private:
                 const LivelinessLostStatus& status) override;
 
         PublisherImpl* mp_publisherImpl;
+
+    private:
+
+        using rtps::WriterListener::onWriterMatched;
     }
     m_writerListener;
 

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberImpl.h
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberImpl.h
@@ -221,6 +221,10 @@ private:
                 rtps::RTPSReader* reader,
                 const LivelinessChangedStatus& status) override;
         SubscriberImpl* mp_subscriberImpl;
+
+    private:
+
+        using rtps::ReaderListener::onReaderMatched;
     }
     m_readerListener;
 

--- a/src/cpp/rtps/DataSharing/ReaderPool.hpp
+++ b/src/cpp/rtps/DataSharing/ReaderPool.hpp
@@ -284,6 +284,8 @@ protected:
 
 private:
 
+    using DataSharingPayloadPool::init_shared_memory;
+
     bool is_volatile_;              //< Whether the reader is volatile or not
     uint64_t next_payload_;         //< Index of the next history position to read
     SequenceNumber_t last_sn_;      //< Sequence number of the last read payload

--- a/src/cpp/rtps/DataSharing/WriterPool.hpp
+++ b/src/cpp/rtps/DataSharing/WriterPool.hpp
@@ -353,6 +353,8 @@ public:
 
 private:
 
+    using DataSharingPayloadPool::init_shared_memory;
+
     octet* payloads_pool_;          //< Shared pool of payloads
 
     uint32_t max_data_size_;        //< Maximum size of the serialized payload data

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.h
@@ -109,8 +109,8 @@ public:
      */
     void announceParticipantState(
             bool new_change,
-            bool dispose = false,
-            WriteParams& wparams = WriteParams::WRITE_PARAM_DEFAULT) override;
+            bool dispose,
+            WriteParams& wparams) override;
 
     /**
      * These methods wouldn't be needed under perfect server operation

--- a/src/cpp/rtps/builtin/discovery/participant/timedevent/DSClientEvent.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/timedevent/DSClientEvent.cpp
@@ -90,7 +90,8 @@ bool DSClientEvent::event()
         // This marks to announceParticipantState that the announcement is only meant for missing servers,
         // so it is not a periodic announcement
         mp_PDP->_serverPing = true;
-        mp_PDP->announceParticipantState(false);
+        WriteParams __wp = WriteParams();
+        mp_PDP->announceParticipantState(false, false, __wp);
         EPROSIMA_LOG_INFO(CLIENT_PDP_THREAD,
                 "Client " << mp_PDP->getRTPSParticipant()->getGuid() << " PDP announcement");
     }

--- a/src/cpp/rtps/history/BasicPayloadPool_impl/Base.hpp
+++ b/src/cpp/rtps/history/BasicPayloadPool_impl/Base.hpp
@@ -18,6 +18,8 @@
 
 class BaseImpl : public IPayloadPool
 {
+public:
+
     bool get_payload(
             uint32_t size,
             CacheChange_t& cache_change) override

--- a/src/cpp/rtps/history/BasicPayloadPool_impl/PreallocatedWithRealloc.hpp
+++ b/src/cpp/rtps/history/BasicPayloadPool_impl/PreallocatedWithRealloc.hpp
@@ -39,5 +39,7 @@ public:
 
 private:
 
+    using BaseImpl::get_payload;
+
     uint32_t min_payload_size_;
 };

--- a/src/cpp/rtps/history/TopicPayloadPool_impl/Dynamic.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPool_impl/Dynamic.hpp
@@ -86,6 +86,10 @@ protected:
         return DYNAMIC_RESERVE_MEMORY_MODE;
     }
 
+private:
+
+    using TopicPayloadPool::get_payload;
+
 };
 
 }  // namespace rtps

--- a/src/cpp/rtps/history/TopicPayloadPool_impl/DynamicReusable.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPool_impl/DynamicReusable.hpp
@@ -41,6 +41,10 @@ protected:
         return DYNAMIC_REUSABLE_MEMORY_MODE;
     }
 
+private:
+
+    using TopicPayloadPool::get_payload;
+
 };
 
 }  // namespace rtps

--- a/src/cpp/rtps/history/TopicPayloadPool_impl/Preallocated.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPool_impl/Preallocated.hpp
@@ -80,6 +80,8 @@ protected:
 
 private:
 
+    using TopicPayloadPool::get_payload;
+
     uint32_t payload_size_;
     uint32_t minimum_pool_size_;    //< Minimum initial pool size (sum of all histories)
 };

--- a/src/cpp/rtps/history/TopicPayloadPool_impl/PreallocatedWithRealloc.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPool_impl/PreallocatedWithRealloc.hpp
@@ -80,6 +80,8 @@ protected:
 
 private:
 
+    using TopicPayloadPool::get_payload;
+
     uint32_t min_payload_size_;
     uint32_t minimum_pool_size_;    //< Minimum initial pool size (sum of all histories)
 };

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -192,6 +192,8 @@ private:
 
     private:
 
+        using eprosima::fastdds::dds::DomainParticipantListener::on_participant_discovery;
+
         ParticipantListener& operator =(
                 const ParticipantListener&) = delete;
         PubSubParticipant* participant_;

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -142,6 +142,9 @@ protected:
 
     private:
 
+        using eprosima::fastdds::dds::DomainParticipantListener::on_participant_discovery;
+        using eprosima::fastdds::dds::DomainParticipantListener::on_publisher_discovery;
+
         ParticipantListener& operator =(
                 const ParticipantListener&) = delete;
         PubSubReader& reader_;

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -156,6 +156,10 @@ class PubSubWriter
 
     private:
 
+        using eprosima::fastdds::dds::DomainParticipantListener::on_participant_discovery;
+        using eprosima::fastdds::dds::DomainParticipantListener::on_publisher_discovery;
+        using eprosima::fastdds::dds::DomainParticipantListener::on_subscriber_discovery;
+
         ParticipantListener& operator =(
                 const ParticipantListener&) = delete;
 

--- a/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
@@ -168,6 +168,10 @@ class PubSubWriterReader
 
     private:
 
+        using eprosima::fastdds::dds::DomainParticipantListener::on_participant_discovery;
+        using eprosima::fastdds::dds::DomainParticipantListener::on_publisher_discovery;
+        using eprosima::fastdds::dds::DomainParticipantListener::on_subscriber_discovery;
+
         //! Mutex guarding all info collections
         mutable std::mutex info_mutex_;
         //! The discovered participants excluding the participant this listener is listening to

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -477,8 +477,10 @@ TEST(DDSBasic, PidRelatedSampleIdentity)
 TEST(DDSBasic, IgnoreParticipant)
 {
 
-    struct IgnoringDomainParticipantListener : public DomainParticipantListener
+    class IgnoringDomainParticipantListener : public DomainParticipantListener
     {
+    public:
+
         std::atomic_int num_matched{0};
         std::atomic_int num_ignored{0};
 
@@ -505,6 +507,9 @@ TEST(DDSBasic, IgnoreParticipant)
             }
         }
 
+    private:
+
+        using DomainParticipantListener::on_participant_discovery;
     };
     // Set DomainParticipantFactory to create disabled entities
     DomainParticipantFactoryQos factory_qos;

--- a/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
@@ -448,6 +448,8 @@ TEST(DDSDiscovery, ParticipantProxyPhysicalData)
 
     private:
 
+        using DomainParticipantListener::on_participant_discovery;
+
         std::condition_variable* cv_;
 
         std::mutex* mtx_;
@@ -613,6 +615,9 @@ TEST(DDSDiscovery, DDSDiscoveryDoesNotDropUDPLocator)
             }
         }
 
+    private:
+
+        using DomainParticipantListener::on_participant_discovery;
     };
 
     DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();

--- a/test/blackbox/common/DDSBlackboxTestsFindTopic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsFindTopic.cpp
@@ -49,8 +49,10 @@ class DDSFindTopicTest : public testing::Test
     /**
      * A dummy type support class.
      */
-    struct TestType : public TopicDataType
+    class TestType : public TopicDataType
     {
+    public:
+
         TestType()
             : TopicDataType()
         {
@@ -96,6 +98,10 @@ class DDSFindTopicTest : public testing::Test
             return false;
         }
 
+    private:
+
+        using TopicDataType::getSerializedSizeProvider;
+        using TopicDataType::serialize;
     };
 
 public:

--- a/test/blackbox/common/RTPSWithRegistrationReader.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationReader.hpp
@@ -110,6 +110,8 @@ private:
 
     private:
 
+        using eprosima::fastrtps::rtps::ReaderListener::onReaderMatched;
+
         Listener& operator =(
                 const Listener&) = delete;
 

--- a/test/blackbox/common/RTPSWithRegistrationWriter.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationWriter.hpp
@@ -97,6 +97,8 @@ private:
 
     private:
 
+        using eprosima::fastrtps::rtps::WriterListener::onWriterMatched;
+
         Listener& operator =(
                 const Listener&) = delete;
 

--- a/test/dds/communication/PublisherDynamic.cpp
+++ b/test/dds/communication/PublisherDynamic.cpp
@@ -114,6 +114,8 @@ public:
 
 private:
 
+    using DomainParticipantListener::on_participant_discovery;
+
     bool exit_on_lost_liveliness_;
 };
 

--- a/test/dds/communication/PublisherModule.hpp
+++ b/test/dds/communication/PublisherModule.hpp
@@ -85,6 +85,8 @@ public:
 
 private:
 
+    using DomainParticipantListener::on_participant_discovery;
+
     std::mutex mutex_;
     std::condition_variable cv_;
     unsigned int matched_ = 0;

--- a/test/dds/communication/SubscriberDynamic.cpp
+++ b/test/dds/communication/SubscriberDynamic.cpp
@@ -150,6 +150,8 @@ public:
 
 private:
 
+    using DomainParticipantListener::on_participant_discovery;
+
     std::promise<topic_type_names> is_worth_a_type_;
 };
 

--- a/test/dds/communication/SubscriberModule.hpp
+++ b/test/dds/communication/SubscriberModule.hpp
@@ -92,6 +92,8 @@ public:
 
 private:
 
+    using DomainParticipantListener::on_participant_discovery;
+
     std::mutex mutex_;
     std::condition_variable cv_;
     const uint32_t publishers_ = 0;

--- a/test/dds/discovery/ParticipantModule.hpp
+++ b/test/dds/discovery/ParticipantModule.hpp
@@ -52,6 +52,8 @@ public:
 
 private:
 
+    using DomainParticipantListener::on_participant_discovery;
+
     unsigned int matched_ = 0;
     DomainParticipant* participant_ = nullptr;
     DiscoveryProtocol_t discovery_protocol_;

--- a/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
+++ b/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
@@ -85,6 +85,10 @@ public:
 
     MOCK_METHOD2(onParticipantAuthentication, void (RTPSParticipant*, const ParticipantAuthenticationInfo&));
 #endif // if HAVE_SECURITY
+
+private:
+
+    using RTPSParticipantListener::onParticipantDiscovery;
 };
 
 class RTPSParticipantImpl

--- a/test/performance/latency/LatencyTestTypes.hpp
+++ b/test/performance/latency/LatencyTestTypes.hpp
@@ -142,6 +142,10 @@ public:
 
     // Name
     static const std::string type_name_;
+
+private:
+
+    using eprosima::fastrtps::TopicDataType::is_plain;
 };
 
 enum TESTCOMMAND : uint32_t

--- a/test/performance/throughput/ThroughputTypes.hpp
+++ b/test/performance/throughput/ThroughputTypes.hpp
@@ -179,6 +179,10 @@ public:
 
     // Name
     static const std::string type_name_;
+
+private:
+
+    using eprosima::fastrtps::TopicDataType::is_plain;
 };
 
 enum e_Command : uint32_t

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -219,6 +219,9 @@ public:
         return true;
     }
 
+private:
+
+    using TopicDataType::is_plain;
 };
 
 class BarType
@@ -2402,6 +2405,8 @@ TEST(ParticipantTests, SetListener)
 class CustomListener2 : public DomainParticipantListener
 {
 public:
+
+    using DomainParticipantListener::on_participant_discovery;
 
     CustomListener2()
         : future_(promise_.get_future())

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -346,6 +346,10 @@ TEST(DataWriterTests, get_guid)
         fastrtps::rtps::GUID_t guid;
         std::mutex mutex;
         std::condition_variable cv;
+
+    private:
+
+        using DomainParticipantListener::on_publisher_discovery;
     }
     discovery_listener;
 
@@ -1276,6 +1280,7 @@ class LoanableTypeSupport : public TopicDataType
 public:
 
     typedef LoanableType type;
+    using TopicDataType::is_plain;
 
     LoanableTypeSupport()
         : TopicDataType()
@@ -1431,6 +1436,8 @@ TEST(DataWriterTests, LoanPositiveTests)
 class LoanableTypeSupportTesting : public LoanableTypeSupport
 {
 public:
+
+    using LoanableTypeSupport::is_plain;
 
     bool is_plain_result = true;
     bool construct_sample_result = true;

--- a/test/unittest/dds/publisher/PublisherTests.cpp
+++ b/test/unittest/dds/publisher/PublisherTests.cpp
@@ -161,6 +161,9 @@ public:
         return true;
     }
 
+private:
+
+    using TopicDataType::is_plain;
 };
 
 

--- a/test/unittest/dds/status/ListenerTests.cpp
+++ b/test/unittest/dds/status/ListenerTests.cpp
@@ -535,6 +535,10 @@ public:
         return true;
     }
 
+private:
+
+    using TopicDataType::getSerializedSizeProvider;
+    using TopicDataType::serialize;
 };
 
 class UserListeners : public ::testing::Test

--- a/test/unittest/dds/subscriber/DataReaderHistoryTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderHistoryTests.cpp
@@ -21,13 +21,20 @@ public:
                 void* data,
                 eprosima::fastrtps::rtps::SerializedPayload_t* payload));
 
+    MOCK_METHOD3(serialize, bool(
+                void* data,
+                eprosima::fastrtps::rtps::SerializedPayload_t* payload,
+                DataRepresentationId_t data_representation));
+
     MOCK_METHOD2(deserialize, bool(
                 eprosima::fastrtps::rtps::SerializedPayload_t* payload,
                 void* data));
 
+    MOCK_METHOD2(getSerializedSizeProvider, std::function<uint32_t()> (
+                void* data, DataRepresentationId_t data_representation));
+
     MOCK_METHOD1(getSerializedSizeProvider, std::function<uint32_t()> (
                 void* data));
-
 
     MOCK_METHOD0(createData, void* ());
 

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -588,6 +588,10 @@ TEST_F(DataReaderTests, get_guid)
         GUID_t guid;
         std::mutex mutex;
         std::condition_variable cv;
+
+    private:
+
+        using DomainParticipantListener::on_subscriber_discovery;
     }
     discovery_listener;
 

--- a/test/unittest/dds/subscriber/FooBoundedTypeSupport.hpp
+++ b/test/unittest/dds/subscriber/FooBoundedTypeSupport.hpp
@@ -144,6 +144,9 @@ public:
         return false;
     }
 
+private:
+
+    using TopicDataType::is_plain;
 };
 
 } // namespace dds

--- a/test/unittest/dds/subscriber/FooTypeSupport.hpp
+++ b/test/unittest/dds/subscriber/FooTypeSupport.hpp
@@ -169,6 +169,9 @@ public:
         return true;
     }
 
+private:
+
+    using TopicDataType::is_plain;
 };
 
 } // namespace dds

--- a/test/unittest/dds/topic/TopicTests.cpp
+++ b/test/unittest/dds/topic/TopicTests.cpp
@@ -124,6 +124,10 @@ public:
         return true;
     }
 
+private:
+
+    using TopicDataType::getSerializedSizeProvider;
+    using TopicDataType::serialize;
 };
 
 TEST(TopicTests, ChangeTopicQos)

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantTests.cpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantTests.cpp
@@ -130,6 +130,10 @@ public:
         return true;
     }
 
+private:
+
+    using eprosima::fastdds::dds::TopicDataType::getSerializedSizeProvider;
+    using eprosima::fastdds::dds::TopicDataType::serialize;
 };
 
 class StatisticsDomainParticipantTests : public ::testing::Test


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR is a backport combining:
* #4516
* #4598

Before this PR, compiling with GCC option `-Woverloaded-virtual` resulted in compilation warnings due to overloaded virtual methods being hidden in derived classes that do not override all the parent's overloads. This PR:

1. Fixes all those warnings
2. Adds more warning reporting options GCC in Ubuntu CI on Github
3. Enables running Github Ubuntu CI on `pull_request` events
4. Enables running Github CI on PRs targeting intermediate branches

It substitutes:
* #4592
* #4601

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
