### PR TITLE
[20653] Increase sleep to miss the deadline in macOS flaky tests

### DIFF
--- a/test/blackbox/common/DDSBlackboxTestsOwnershipQos.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsOwnershipQos.cpp
@@ -701,9 +701,11 @@ TEST_P(OwnershipQos, exclusive_kind_non_keyed_reliable_deadline)
     PubSubWriter<HelloWorldPubSubType> writer1(TEST_TOPIC_NAME);
     PubSubWriter<HelloWorldPubSubType> writer2(TEST_TOPIC_NAME);
 
-    reader.ownership_exclusive().reliability(RELIABLE_RELIABILITY_QOS).deadline_period({0, 100000000}).init();
-    writer1.ownership_strength(1).deadline_period({0, 100000000}).init();
-    writer2.ownership_strength(2).deadline_period({0, 100000000}).init();
+    reader.ownership_exclusive().reliability(RELIABLE_RELIABILITY_QOS).deadline_period({0, 500000000}).lease_duration(
+        {50, 0}, {3, 0}).init();
+    writer1.ownership_strength(1).deadline_period({0, 500000000}).lease_duration({50, 0}, {3, 0}).init();
+    writer2.ownership_strength(2).deadline_period({0, 500000000}).lease_duration({50, 0}, {3, 0}).init();
+
 
     ASSERT_TRUE(reader.isInitialized());
     ASSERT_TRUE(writer1.isInitialized());
@@ -748,7 +750,7 @@ TEST_P(OwnershipQos, exclusive_kind_non_keyed_reliable_deadline)
     writer1.send_sample(data.front());
     denied_samples.push_back(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(110));
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
     writer1.send_sample(data.front());
     data.pop_front();
@@ -778,9 +780,10 @@ TEST_P(OwnershipQos, exclusive_kind_keyed_reliable_deadline)
     PubSubWriter<KeyedHelloWorldPubSubType> writer1(TEST_TOPIC_NAME);
     PubSubWriter<KeyedHelloWorldPubSubType> writer2(TEST_TOPIC_NAME);
 
-    reader.ownership_exclusive().reliability(RELIABLE_RELIABILITY_QOS).deadline_period({0, 100000000}).init();
-    writer1.ownership_strength(1).deadline_period({0, 100000000}).init();
-    writer2.ownership_strength(2).deadline_period({0, 100000000}).init();
+    reader.ownership_exclusive().reliability(RELIABLE_RELIABILITY_QOS).deadline_period({0, 500000000}).lease_duration(
+        {50, 0}, {3, 0}).init();
+    writer1.ownership_strength(1).deadline_period({0, 500000000}).lease_duration({50, 0}, {3, 0}).init();
+    writer2.ownership_strength(2).deadline_period({0, 500000000}).lease_duration({50, 0}, {3, 0}).init();
 
     ASSERT_TRUE(reader.isInitialized());
     ASSERT_TRUE(writer1.isInitialized());
@@ -842,7 +845,7 @@ TEST_P(OwnershipQos, exclusive_kind_keyed_reliable_deadline)
     writer1.send_sample(data.front());
     denied_samples.push_back(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(110));
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
     writer1.send_sample(data.front());
     data.pop_front();
@@ -853,7 +856,7 @@ TEST_P(OwnershipQos, exclusive_kind_keyed_reliable_deadline)
     writer1.send_sample(data.front());
     denied_samples.push_back(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(110));
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
     writer1.send_sample(data.front());
     data.pop_front();
@@ -864,7 +867,7 @@ TEST_P(OwnershipQos, exclusive_kind_keyed_reliable_deadline)
     writer1.send_sample(data.front());
     denied_samples.push_back(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(110));
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
     writer1.send_sample(data.front());
     data.pop_front();

--- a/test/blackbox/common/DDSBlackboxTestsOwnershipQos.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsOwnershipQos.cpp
@@ -721,46 +721,46 @@ TEST_P(OwnershipQos, exclusive_kind_non_keyed_reliable_deadline)
 
     writer1.send_sample(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
 
     writer2.send_sample(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
 
     writer1.send_sample(data.front());
     denied_samples.push_back(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
 
     writer2.send_sample(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
 
     writer1.send_sample(data.front());
     denied_samples.push_back(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
 
     writer2.send_sample(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
 
     writer1.send_sample(data.front());
     denied_samples.push_back(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(110));
 
     writer1.send_sample(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
 
     writer1.send_sample(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
 
     writer1.send_sample(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
 
     reader.block_for_seq({0, 7});
     ASSERT_EQ(denied_samples.size(), reader.data_not_received().size());

--- a/test/blackbox/common/DDSBlackboxTestsOwnershipQos.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsOwnershipQos.cpp
@@ -721,29 +721,29 @@ TEST_P(OwnershipQos, exclusive_kind_non_keyed_reliable_deadline)
 
     writer1.send_sample(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
     writer2.send_sample(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
     writer1.send_sample(data.front());
     denied_samples.push_back(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
     writer2.send_sample(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
     writer1.send_sample(data.front());
     denied_samples.push_back(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
     writer2.send_sample(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
     writer1.send_sample(data.front());
     denied_samples.push_back(data.front());
@@ -752,15 +752,15 @@ TEST_P(OwnershipQos, exclusive_kind_non_keyed_reliable_deadline)
 
     writer1.send_sample(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
     writer1.send_sample(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
     writer1.send_sample(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
     reader.block_for_seq({0, 7});
     ASSERT_EQ(denied_samples.size(), reader.data_not_received().size());
@@ -800,27 +800,13 @@ TEST_P(OwnershipQos, exclusive_kind_keyed_reliable_deadline)
     data.pop_front();
     writer1.send_sample(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
     writer2.send_sample(data.front());
     data.pop_front();
     writer2.send_sample(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-
-    writer1.send_sample(data.front());
-    denied_samples.push_back(data.front());
-    data.pop_front();
-    writer1.send_sample(data.front());
-    denied_samples.push_back(data.front());
-    data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-
-    writer2.send_sample(data.front());
-    data.pop_front();
-    writer2.send_sample(data.front());
-    data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
     writer1.send_sample(data.front());
     denied_samples.push_back(data.front());
@@ -828,13 +814,13 @@ TEST_P(OwnershipQos, exclusive_kind_keyed_reliable_deadline)
     writer1.send_sample(data.front());
     denied_samples.push_back(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
     writer2.send_sample(data.front());
     data.pop_front();
     writer2.send_sample(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
     writer1.send_sample(data.front());
     denied_samples.push_back(data.front());
@@ -842,18 +828,21 @@ TEST_P(OwnershipQos, exclusive_kind_keyed_reliable_deadline)
     writer1.send_sample(data.front());
     denied_samples.push_back(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
-    writer1.send_sample(data.front());
+    writer2.send_sample(data.front());
     data.pop_front();
     writer2.send_sample(data.front());
     data.pop_front();
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+    writer1.send_sample(data.front());
     denied_samples.push_back(data.front());
     data.pop_front();
     writer1.send_sample(data.front());
     denied_samples.push_back(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(110));
 
     writer1.send_sample(data.front());
     data.pop_front();
@@ -864,7 +853,18 @@ TEST_P(OwnershipQos, exclusive_kind_keyed_reliable_deadline)
     writer1.send_sample(data.front());
     denied_samples.push_back(data.front());
     data.pop_front();
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(110));
+
+    writer1.send_sample(data.front());
+    data.pop_front();
+    writer2.send_sample(data.front());
+    data.pop_front();
+    denied_samples.push_back(data.front());
+    data.pop_front();
+    writer1.send_sample(data.front());
+    denied_samples.push_back(data.front());
+    data.pop_front();
+    std::this_thread::sleep_for(std::chrono::milliseconds(110));
 
     writer1.send_sample(data.front());
     data.pop_front();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR increases the sleep between samples sent to miss the deadline in ownership flaky tests " exclusive_kind_non_keyed_reliable_deadline"
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
 @Mergifyio backport 2.13.x 2.10.x 

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- N/A Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- N/A Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- N/A New feature has been added to the `versions.md` file (if applicable).
- N/A New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
