### PR TITLE
[20729] Allow processing of AckNack submessages with count == 0

### DIFF
--- a/include/fastdds/rtps/writer/ReaderProxy.h
+++ b/include/fastdds/rtps/writer/ReaderProxy.h
@@ -307,9 +307,10 @@ public:
     bool check_and_set_acknack_count(
             uint32_t acknack_count)
     {
-        if (last_acknack_count_ < acknack_count)
+        if (acknack_count >= next_expected_acknack_count_)
         {
-            last_acknack_count_ = acknack_count;
+            next_expected_acknack_count_ = acknack_count;
+            ++next_expected_acknack_count_;
             return true;
         }
 
@@ -442,8 +443,8 @@ private:
     TimedEvent* initial_heartbeat_event_;
     //! Are timed events enabled?
     std::atomic_bool timers_enabled_;
-    //! Last ack/nack count
-    uint32_t last_acknack_count_;
+    //! Next expected ack/nack count
+    uint32_t next_expected_acknack_count_;
     //! Last  NACKFRAG count.
     uint32_t last_nackfrag_count_;
 

--- a/include/fastdds/rtps/writer/ReaderProxy.h
+++ b/include/fastdds/rtps/writer/ReaderProxy.h
@@ -300,9 +300,11 @@ public:
     }
 
     /**
-     * Called when an ACKNACK is received to set a new value for the count of the last received ACKNACK.
+     * Called when an ACKNACK is received to set a new value for the minimum count accepted for following received
+     * ACKNACKs.
+     *
      * @param acknack_count The count of the received ACKNACK.
-     * @return true if internal count changed (i.e. new ACKNACK is accepted)
+     * @return true if internal count changed (i.e. received ACKNACK is accepted)
      */
     bool check_and_set_acknack_count(
             uint32_t acknack_count)

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -60,20 +60,24 @@ ReaderProxy::ReaderProxy(
     , next_expected_acknack_count_(0)
     , last_nackfrag_count_(0)
 {
-    nack_supression_event_ = new TimedEvent(writer_->getRTPSParticipant()->getEventResource(),
-                    [&]() -> bool
-                    {
-                        writer_->perform_nack_supression(guid());
-                        return false;
-                    },
-                    TimeConv::Time_t2MilliSecondsDouble(times.nackSupressionDuration));
+    auto participant = writer_->getRTPSParticipant();
+    if (nullptr != participant)
+    {
+        nack_supression_event_ = new TimedEvent(participant->getEventResource(),
+                        [&]() -> bool
+                        {
+                            writer_->perform_nack_supression(guid());
+                            return false;
+                        },
+                        TimeConv::Time_t2MilliSecondsDouble(times.nackSupressionDuration));
 
-    initial_heartbeat_event_ = new TimedEvent(writer_->getRTPSParticipant()->getEventResource(),
-                    [&]() -> bool
-                    {
-                        writer_->intraprocess_heartbeat(this);
-                        return false;
-                    }, 0);
+        initial_heartbeat_event_ = new TimedEvent(participant->getEventResource(),
+                        [&]() -> bool
+                        {
+                            writer_->intraprocess_heartbeat(this);
+                            return false;
+                        }, 0);
+    }
 
     stop();
 }
@@ -135,7 +139,7 @@ void ReaderProxy::start(
     }
 
     timers_enabled_.store(is_remote_and_reliable());
-    if (is_local_reader())
+    if (is_local_reader() && initial_heartbeat_event_)
     {
         initial_heartbeat_event_->restart_timer();
     }
@@ -173,17 +177,23 @@ void ReaderProxy::stop()
 
 void ReaderProxy::disable_timers()
 {
-    if (timers_enabled_.exchange(false))
+    if (timers_enabled_.exchange(false) && nack_supression_event_)
     {
         nack_supression_event_->cancel_timer();
     }
-    initial_heartbeat_event_->cancel_timer();
+    if (initial_heartbeat_event_)
+    {
+        initial_heartbeat_event_->cancel_timer();
+    }
 }
 
 void ReaderProxy::update_nack_supression_interval(
         const Duration_t& interval)
 {
-    nack_supression_event_->update_interval(interval);
+    if (nack_supression_event_)
+    {
+        nack_supression_event_->update_interval(interval);
+    }
 }
 
 void ReaderProxy::add_change(
@@ -191,7 +201,7 @@ void ReaderProxy::add_change(
         bool is_relevant,
         bool restart_nack_supression)
 {
-    if (restart_nack_supression && timers_enabled_.load())
+    if (restart_nack_supression && timers_enabled_.load() && nack_supression_event_)
     {
         nack_supression_event_->restart_timer();
     }
@@ -205,7 +215,7 @@ void ReaderProxy::add_change(
         bool restart_nack_supression,
         const std::chrono::time_point<std::chrono::steady_clock>& max_blocking_time)
 {
-    if (restart_nack_supression && timers_enabled_)
+    if (restart_nack_supression && timers_enabled_ && nack_supression_event_)
     {
         nack_supression_event_->restart_timer(max_blocking_time);
     }
@@ -459,7 +469,7 @@ void ReaderProxy::from_unsent_to_status(
     // It will use acked_changes_set().
     assert(is_reliable_);
 
-    if (restart_nack_supression && is_remote_and_reliable())
+    if (restart_nack_supression && is_remote_and_reliable() && nack_supression_event_)
     {
         assert(timers_enabled_.load());
         nack_supression_event_->restart_timer();

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -57,7 +57,7 @@ ReaderProxy::ReaderProxy(
     , nack_supression_event_(nullptr)
     , initial_heartbeat_event_(nullptr)
     , timers_enabled_(false)
-    , last_acknack_count_(0)
+    , next_expected_acknack_count_(0)
     , last_nackfrag_count_(0)
 {
     nack_supression_event_ = new TimedEvent(writer_->getRTPSParticipant()->getEventResource(),
@@ -166,7 +166,7 @@ void ReaderProxy::stop()
     disable_timers();
 
     changes_for_reader_.clear();
-    last_acknack_count_ = 0;
+    next_expected_acknack_count_ = 0;
     last_nackfrag_count_ = 0;
     changes_low_mark_ = SequenceNumber_t();
 }

--- a/test/unittest/rtps/writer/ReaderProxyTests.cpp
+++ b/test/unittest/rtps/writer/ReaderProxyTests.cpp
@@ -382,6 +382,38 @@ TEST(ReaderProxyTests, has_been_delivered_test)
     expect_result({0, 3}, false, false);
 }
 
+// Test expectations regarding acknack count.
+// Serves as a regression test for redmine issue #20729.
+TEST(ReaderProxyTests, acknack_count)
+{
+    StatefulWriter writer_mock;
+    WriterTimes w_times;
+    RemoteLocatorsAllocationAttributes alloc;
+    ReaderProxy rproxy(w_times, alloc, &writer_mock);
+
+    ReaderProxyData reader_attributes(0, 0);
+    reader_attributes.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+    rproxy.start(reader_attributes);
+
+    // Check that the initial acknack count is 0.
+    EXPECT_TRUE(rproxy.check_and_set_acknack_count(0u));
+    // Check that it is not accepted twice.
+    EXPECT_FALSE(rproxy.check_and_set_acknack_count(0u));
+    // Check that it is accepted if it is incremented.
+    EXPECT_TRUE(rproxy.check_and_set_acknack_count(1u));
+    // Check that it is not accepted twice.
+    EXPECT_FALSE(rproxy.check_and_set_acknack_count(1u));
+    // Check that it is not accepted if it is decremented.
+    EXPECT_FALSE(rproxy.check_and_set_acknack_count(0u));
+    // Check that it is accepted if it has a big increment.
+    EXPECT_TRUE(rproxy.check_and_set_acknack_count(100u));
+    // Check that previous values are rejected.
+    for (uint32_t i = 0; i <= 100u; ++i)
+    {
+        EXPECT_FALSE(rproxy.check_and_set_acknack_count(i));
+    }
+}
+
 } // namespace rtps
 } // namespace fastrtps
 } // namespace eprosima


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
As spotted by https://github.com/omg-dds/dds-rtps/issues/35, Fast DDS ignores AckNack messages where the `count` field is `0`.

This PR adds a unit test for `ReaderProxy::check_and_set_acknack_count`, and fixes the issue by changing the check on `acknack_count` from *last received* to *next expected*.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist
- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
