### PR TITLE
[20703] Add missing total_count_change deadline missed status to monitor service types

### DIFF
--- a/include/fastdds/statistics/monitorservice_types.idl
+++ b/include/fastdds/statistics/monitorservice_types.idl
@@ -67,6 +67,7 @@ module statistics {
 	struct DeadlineMissedStatus_s
 	{
 		unsigned long total_count;
+		unsigned long total_count_change;
 		octet last_instance_handle[16];
 	};
 

--- a/src/cpp/statistics/types/monitorservice_types.cxx
+++ b/src/cpp/statistics/types/monitorservice_types.cxx
@@ -781,6 +781,7 @@ DeadlineMissedStatus_s::DeadlineMissedStatus_s(
         const DeadlineMissedStatus_s& x)
 {
     m_total_count = x.m_total_count;
+    m_total_count_change = x.m_total_count_change;
     m_last_instance_handle = x.m_last_instance_handle;
 }
 
@@ -788,6 +789,7 @@ DeadlineMissedStatus_s::DeadlineMissedStatus_s(
         DeadlineMissedStatus_s&& x) noexcept
 {
     m_total_count = x.m_total_count;
+    m_total_count_change = x.m_total_count_change;
     m_last_instance_handle = std::move(x.m_last_instance_handle);
 }
 
@@ -796,6 +798,7 @@ DeadlineMissedStatus_s& DeadlineMissedStatus_s::operator =(
 {
 
     m_total_count = x.m_total_count;
+    m_total_count_change = x.m_total_count_change;
     m_last_instance_handle = x.m_last_instance_handle;
     return *this;
 }
@@ -805,6 +808,7 @@ DeadlineMissedStatus_s& DeadlineMissedStatus_s::operator =(
 {
 
     m_total_count = x.m_total_count;
+    m_total_count_change = x.m_total_count_change;
     m_last_instance_handle = std::move(x.m_last_instance_handle);
     return *this;
 }
@@ -813,6 +817,7 @@ bool DeadlineMissedStatus_s::operator ==(
         const DeadlineMissedStatus_s& x) const
 {
     return (m_total_count == x.m_total_count &&
+           m_total_count_change == x.m_total_count_change &&
            m_last_instance_handle == x.m_last_instance_handle);
 }
 
@@ -848,6 +853,35 @@ uint32_t DeadlineMissedStatus_s::total_count() const
 uint32_t& DeadlineMissedStatus_s::total_count()
 {
     return m_total_count;
+}
+
+
+/*!
+ * @brief This function sets a value in member total_count_change
+ * @param _total_count_change New value for member total_count_change
+ */
+void DeadlineMissedStatus_s::total_count_change(
+        uint32_t _total_count_change)
+{
+    m_total_count_change = _total_count_change;
+}
+
+/*!
+ * @brief This function returns the value of member total_count_change
+ * @return Value of member total_count_change
+ */
+uint32_t DeadlineMissedStatus_s::total_count_change() const
+{
+    return m_total_count_change;
+}
+
+/*!
+ * @brief This function returns a reference to member total_count_change
+ * @return Reference to member total_count_change
+ */
+uint32_t& DeadlineMissedStatus_s::total_count_change()
+{
+    return m_total_count_change;
 }
 
 

--- a/src/cpp/statistics/types/monitorservice_types.h
+++ b/src/cpp/statistics/types/monitorservice_types.h
@@ -812,6 +812,26 @@ public:
 
 
     /*!
+     * @brief This function sets a value in member total_count_change
+     * @param _total_count_change New value for member total_count_change
+     */
+    eProsima_user_DllExport void total_count_change(
+            uint32_t _total_count_change);
+
+    /*!
+     * @brief This function returns the value of member total_count_change
+     * @return Value of member total_count_change
+     */
+    eProsima_user_DllExport uint32_t total_count_change() const;
+
+    /*!
+     * @brief This function returns a reference to member total_count_change
+     * @return Reference to member total_count_change
+     */
+    eProsima_user_DllExport uint32_t& total_count_change();
+
+
+    /*!
      * @brief This function copies the value in member last_instance_handle
      * @param _last_instance_handle New value to be copied in member last_instance_handle
      */
@@ -840,6 +860,7 @@ public:
 private:
 
     uint32_t m_total_count{0};
+    uint32_t m_total_count_change{0};
     std::array<uint8_t, 16> m_last_instance_handle{0};
 
 };

--- a/src/cpp/statistics/types/monitorservice_typesCdrAux.hpp
+++ b/src/cpp/statistics/types/monitorservice_typesCdrAux.hpp
@@ -33,7 +33,7 @@ constexpr uint32_t eprosima_fastdds_statistics_BaseStatus_s_max_key_cdr_typesize
 
 
 
-constexpr uint32_t eprosima_fastdds_statistics_DeadlineMissedStatus_s_max_cdr_typesize {24UL};
+constexpr uint32_t eprosima_fastdds_statistics_DeadlineMissedStatus_s_max_cdr_typesize {28UL};
 constexpr uint32_t eprosima_fastdds_statistics_DeadlineMissedStatus_s_max_key_cdr_typesize {0UL};
 
 

--- a/src/cpp/statistics/types/monitorservice_typesCdrAux.ipp
+++ b/src/cpp/statistics/types/monitorservice_typesCdrAux.ipp
@@ -558,6 +558,9 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                 data.total_count(), current_alignment);
 
         calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.total_count_change(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
                 data.last_instance_handle(), current_alignment);
 
 
@@ -581,7 +584,8 @@ eProsima_user_DllExport void serialize(
 
     scdr
         << eprosima::fastcdr::MemberId(0) << data.total_count()
-        << eprosima::fastcdr::MemberId(1) << data.last_instance_handle()
+        << eprosima::fastcdr::MemberId(1) << data.total_count_change()
+        << eprosima::fastcdr::MemberId(2) << data.last_instance_handle()
 ;
     scdr.end_serialize_type(current_state);
 }
@@ -606,6 +610,10 @@ eProsima_user_DllExport void deserialize(
                                             break;
 
                                         case 1:
+                                                dcdr >> data.total_count_change();
+                                            break;
+
+                                        case 2:
                                                 dcdr >> data.last_instance_handle();
                                             break;
 

--- a/src/cpp/statistics/types/monitorservice_typesv1.cxx
+++ b/src/cpp/statistics/types/monitorservice_typesv1.cxx
@@ -92,7 +92,7 @@ struct FindType {
 
 
 
-#define eprosima_fastdds_statistics_DeadlineMissedStatus_s_max_cdr_typesize 24ULL;
+#define eprosima_fastdds_statistics_DeadlineMissedStatus_s_max_cdr_typesize 28ULL;
 #define eprosima_fastdds_statistics_detail_EntityId_s_max_cdr_typesize 8ULL;
 #define eprosima_fastdds_statistics_QosPolicyCount_s_max_cdr_typesize 12ULL;
 #define eprosima_fastdds_statistics_detail_SequenceNumber_s_max_cdr_typesize 12ULL;
@@ -1301,6 +1301,8 @@ DeadlineMissedStatus_s::DeadlineMissedStatus_s()
 {
     // unsigned long m_total_count
     m_total_count = 0;
+    // unsigned long m_total_count_change
+    m_total_count_change = 0;
     // octet m_last_instance_handle
     memset(&m_last_instance_handle, 0, ((16)) * 1);
 
@@ -1316,6 +1318,9 @@ DeadlineMissedStatus_s::DeadlineMissedStatus_s(
     m_total_count = x.m_total_count;
 
 
+    m_total_count_change = x.m_total_count_change;
+
+
     m_last_instance_handle = x.m_last_instance_handle;
 
 }
@@ -1324,6 +1329,9 @@ DeadlineMissedStatus_s::DeadlineMissedStatus_s(
         DeadlineMissedStatus_s&& x) noexcept
 {
     m_total_count = x.m_total_count;
+
+
+    m_total_count_change = x.m_total_count_change;
 
 
     m_last_instance_handle = std::move(x.m_last_instance_handle);
@@ -1336,6 +1344,9 @@ DeadlineMissedStatus_s& DeadlineMissedStatus_s::operator =(
     m_total_count = x.m_total_count;
 
 
+    m_total_count_change = x.m_total_count_change;
+
+
     m_last_instance_handle = x.m_last_instance_handle;
 
     return *this;
@@ -1347,6 +1358,9 @@ DeadlineMissedStatus_s& DeadlineMissedStatus_s::operator =(
     m_total_count = x.m_total_count;
 
 
+    m_total_count_change = x.m_total_count_change;
+
+
     m_last_instance_handle = std::move(x.m_last_instance_handle);
 
     return *this;
@@ -1356,6 +1370,7 @@ bool DeadlineMissedStatus_s::operator ==(
         const DeadlineMissedStatus_s& x) const
 {
     return (m_total_count == x.m_total_count &&
+           m_total_count_change == x.m_total_count_change &&
            m_last_instance_handle == x.m_last_instance_handle);
 }
 
@@ -1382,6 +1397,9 @@ size_t DeadlineMissedStatus_s::getCdrSerializedSize(
     current_alignment += 4 + eprosima::fastcdr::Cdr::alignment(current_alignment, 4);
 
 
+    current_alignment += 4 + eprosima::fastcdr::Cdr::alignment(current_alignment, 4);
+
+
     current_alignment += (((16)) * 1) + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
 
 
@@ -1395,6 +1413,8 @@ void DeadlineMissedStatus_s::serialize(
 {
     scdr << m_total_count;
 
+    scdr << m_total_count_change;
+
     scdr << m_last_instance_handle;
 
 
@@ -1404,6 +1424,10 @@ void DeadlineMissedStatus_s::deserialize(
         eprosima::fastcdr::Cdr& dcdr)
 {
     dcdr >> m_total_count;
+
+
+
+    dcdr >> m_total_count_change;
 
 
 
@@ -1450,6 +1474,35 @@ uint32_t DeadlineMissedStatus_s::total_count() const
 uint32_t& DeadlineMissedStatus_s::total_count()
 {
     return m_total_count;
+}
+
+
+/*!
+ * @brief This function sets a value in member total_count_change
+ * @param _total_count_change New value for member total_count_change
+ */
+void DeadlineMissedStatus_s::total_count_change(
+        uint32_t _total_count_change)
+{
+    m_total_count_change = _total_count_change;
+}
+
+/*!
+ * @brief This function returns the value of member total_count_change
+ * @return Value of member total_count_change
+ */
+uint32_t DeadlineMissedStatus_s::total_count_change() const
+{
+    return m_total_count_change;
+}
+
+/*!
+ * @brief This function returns a reference to member total_count_change
+ * @return Reference to member total_count_change
+ */
+uint32_t& DeadlineMissedStatus_s::total_count_change()
+{
+    return m_total_count_change;
 }
 
 

--- a/src/cpp/statistics/types/monitorservice_typesv1.h
+++ b/src/cpp/statistics/types/monitorservice_typesv1.h
@@ -1070,6 +1070,26 @@ namespace eprosima {
 
 
                 /*!
+                 * @brief This function sets a value in member total_count_change
+                 * @param _total_count_change New value for member total_count_change
+                 */
+                eProsima_user_DllExport void total_count_change(
+                        uint32_t _total_count_change);
+
+                /*!
+                 * @brief This function returns the value of member total_count_change
+                 * @return Value of member total_count_change
+                 */
+                eProsima_user_DllExport uint32_t total_count_change() const;
+
+                /*!
+                 * @brief This function returns a reference to member total_count_change
+                 * @return Reference to member total_count_change
+                 */
+                eProsima_user_DllExport uint32_t& total_count_change();
+
+
+                /*!
                  * @brief This function copies the value in member last_instance_handle
                  * @param _last_instance_handle New value to be copied in member last_instance_handle
                  */
@@ -1150,6 +1170,7 @@ namespace eprosima {
             private:
 
                 uint32_t m_total_count;
+                uint32_t m_total_count_change;
                 std::array<uint8_t, 16> m_last_instance_handle;
 
             };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds a missing `total_count_change` field to `Deadlinemissedstatus` monitor service type.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist
- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [X] New feature has been added to the `versions.md` file (if applicable).
- [X] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [X] Applicable backports have been included in the description.


## Reviewer Checklist
- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
