### PR TITLE
[20658] Fix leak in `SecurityManager::participant_volatile_message_secure_writer_`

### DIFF
--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -1263,7 +1263,7 @@ bool SecurityManager::create_participant_volatile_message_secure_writer()
     RTPSWriter* wout = nullptr;
     if (participant_->createWriter(&wout, watt, participant_volatile_message_secure_pool_,
             participant_volatile_message_secure_writer_history_,
-            nullptr, participant_volatile_message_secure_writer_entity_id, true))
+            this, participant_volatile_message_secure_writer_entity_id, true))
     {
         participant_->set_endpoint_rtps_protection_supports(wout, false);
         participant_volatile_message_secure_writer_ = dynamic_cast<StatefulWriter*>(wout);
@@ -4340,4 +4340,17 @@ bool SecurityManager::DiscoveredParticipantInfo::check_guid_comes_from(
         }
     }
     return ret;
+}
+
+void SecurityManager::onWriterChangeReceivedByAll(
+        RTPSWriter* writer,
+        CacheChange_t* change)
+{
+    static_cast<void>(writer);
+    assert(writer == participant_volatile_message_secure_writer_);
+
+    if (nullptr != participant_volatile_message_secure_writer_history_)
+    {
+        participant_volatile_message_secure_writer_history_->remove_change(change);
+    }
 }

--- a/src/cpp/rtps/security/SecurityManager.h
+++ b/src/cpp/rtps/security/SecurityManager.h
@@ -37,6 +37,7 @@
 #include <fastdds/rtps/resources/TimedEvent.h>
 #include <fastdds/rtps/security/authentication/Handshake.h>
 #include <fastdds/rtps/security/common/ParticipantGenericMessage.h>
+#include <fastdds/rtps/writer/WriterListener.h>
 #include <fastrtps/utils/ProxyPool.hpp>
 #include <fastrtps/utils/shared_mutex.hpp>
 
@@ -45,6 +46,7 @@ namespace fastrtps {
 namespace rtps {
 
 class RTPSParticipantImpl;
+class RTPSWriter;
 class StatelessWriter;
 class StatelessReader;
 class StatefulWriter;
@@ -66,7 +68,7 @@ struct EndpointSecurityAttributes;
  *
  * @ingroup SECURITY_MODULE
  */
-class SecurityManager
+class SecurityManager : private WriterListener
 {
 public:
 
@@ -873,6 +875,10 @@ private:
             std::this_thread::yield();
         }
     }
+
+    void onWriterChangeReceivedByAll(
+            RTPSWriter* writer,
+            CacheChange_t* change) override;
 
     /**
      * Syncronization object for plugin initialization, <tt>mutex_</tt> protection is not necessary to guarantee plugin

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -3266,6 +3266,112 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
     }
 }
 
+// Regression test of Refs #20658, Github #4553.
+TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_validation_toggle_partition)
+{
+    PubSubWriter<HelloWorldPubSubType> writer("HelloWorldTopic");
+    PubSubReader<HelloWorldPubSubType> reader_p_1("HelloWorldTopic");
+    PubSubReader<HelloWorldPubSubType> reader_p_2("HelloWorldTopic");
+
+    std::string governance_file("governance_helloworld_all_enable.smime");
+
+    // Prepare subscriptions security properties
+    PropertyPolicy sub_property_policy;
+    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
+            "builtin.PKI-DH"));
+    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
+            "file://" + std::string(certs_path) + "/maincacert.pem"));
+    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
+            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
+    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
+            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
+            "builtin.AES-GCM-GMAC"));
+    sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
+            "builtin.Access-Permissions"));
+    sub_property_policy.properties().emplace_back(Property(
+                "dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                "file://" + std::string(certs_path) + "/maincacert.pem"));
+    sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
+            "file://" + std::string(certs_path) + "/" + governance_file));
+    sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
+            "file://" + std::string(certs_path) + "/permissions_helloworld_partitions.smime"));
+
+    // Initialize one reader on each partition
+    reader_p_1.partition("Partition1").
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            property_policy(sub_property_policy).
+            init();
+    ASSERT_TRUE(reader_p_1.isInitialized());
+
+    reader_p_2.partition("Partition2").
+            reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+            property_policy(sub_property_policy).
+            init();
+    ASSERT_TRUE(reader_p_2.isInitialized());
+
+    // Prepare publication security properties
+    PropertyPolicy pub_property_policy;
+    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
+            "builtin.PKI-DH"));
+    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
+            "file://" + std::string(certs_path) + "/maincacert.pem"));
+    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
+            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
+    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
+            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
+            "builtin.AES-GCM-GMAC"));
+    pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
+            "builtin.Access-Permissions"));
+    pub_property_policy.properties().emplace_back(Property(
+                "dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                "file://" + std::string(certs_path) + "/maincacert.pem"));
+    pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
+            "file://" + std::string(certs_path) + "/" + governance_file));
+    pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
+            "file://" + std::string(certs_path) + "/permissions_helloworld_partitions.smime"));
+
+    // Initialize a writer on both partitions
+    writer.partition("Partition1").partition("Partition2").
+            property_policy(pub_property_policy).
+            init();
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Wait for all entities to discover each other
+    reader_p_1.wait_discovery();
+    reader_p_2.wait_discovery();
+    writer.wait_discovery(2u);
+
+    constexpr size_t num_samples = 100;
+    auto data = default_helloworld_data_generator(num_samples);
+    reader_p_1.startReception(data);
+    reader_p_2.startReception(data);
+
+    for (size_t i = 0; i < num_samples; ++i)
+    {
+        if (0 == i % 2)
+        {
+            writer.update_partition("Partition1");
+            reader_p_2.wait_writer_undiscovery();
+            reader_p_1.wait_discovery();
+        }
+        else
+        {
+            writer.update_partition("Partition2");
+            reader_p_1.wait_writer_undiscovery();
+            reader_p_2.wait_discovery();
+        }
+
+        writer.send_sample(data.front());
+        data.pop_front();
+        writer.waitForAllAcked(std::chrono::milliseconds(100));
+    }
+
+    EXPECT_EQ(num_samples / 2u, reader_p_1.getReceivedCount());
+    EXPECT_EQ(num_samples / 2u, reader_p_2.getReceivedCount());
+}
+
 template <typename DataType>
 void prepare_pkcs11_nodes(
         PubSubReader<DataType>& reader,

--- a/test/unittest/rtps/security/SecurityHandshakeProcessTests.cpp
+++ b/test/unittest/rtps/security/SecurityHandshakeProcessTests.cpp
@@ -337,7 +337,12 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_begin_handshake_r
     info.guid = participant_data.m_guid;
     EXPECT_CALL(*participant_.getListener(), onParticipantAuthentication(_, info)).Times(1);
 
+    CacheChange_t* kx_change = new CacheChange_t(500);
+    expect_kx_exchange(kx_change);
+
     stateless_reader_->listener_->onNewCacheChangeAdded(stateless_reader_, change);
+
+    volatile_writer_->listener_->onWriterChangeReceivedByAll(volatile_writer_, kx_change);
 
     return_handle(remote_identity_handle);
     return_handle(handshake_handle);
@@ -522,9 +527,14 @@ TEST_F(SecurityTest, discovered_participant_process_message_pending_handshake_re
             WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle),
             Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
 
+    CacheChange_t* kx_change = new CacheChange_t(500);
+    expect_kx_exchange(kx_change);
+
     ParticipantProxyData participant_data;
     fill_participant_key(participant_data.m_guid);
     ASSERT_TRUE(manager_.discovered_participant(participant_data));
+
+    volatile_writer_->listener_->onWriterChangeReceivedByAll(volatile_writer_, kx_change);
 
     ParticipantGenericMessage message;
     message.message_identity().source_guid(participant_data.m_guid);
@@ -722,7 +732,12 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_process_handshake
     info.guid = remote_participant_key;
     EXPECT_CALL(*participant_.getListener(), onParticipantAuthentication(_, info)).Times(1);
 
+    CacheChange_t* kx_change = new CacheChange_t(500);
+    expect_kx_exchange(kx_change);
+
     stateless_reader_->listener_->onNewCacheChangeAdded(stateless_reader_, change);
+
+    volatile_writer_->listener_->onWriterChangeReceivedByAll(volatile_writer_, kx_change);
 }
 
 TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_reply_new_change_fail)
@@ -1116,7 +1131,12 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_process_handshake
     info.guid = remote_participant_key;
     EXPECT_CALL(*participant_.getListener(), onParticipantAuthentication(_, info)).Times(1);
 
+    CacheChange_t* kx_change = new CacheChange_t(500);
+    expect_kx_exchange(kx_change);
+
     stateless_reader_->listener_->onNewCacheChangeAdded(stateless_reader_, change);
+
+    volatile_writer_->listener_->onWriterChangeReceivedByAll(volatile_writer_, kx_change);
 }
 
 int main(

--- a/test/unittest/rtps/security/SecurityTests.cpp
+++ b/test/unittest/rtps/security/SecurityTests.cpp
@@ -21,7 +21,7 @@ void SecurityTest::initialization_ok()
     ::testing::DefaultValue<const ParticipantSecurityAttributes&>::Set(security_attributes_);
     stateless_writer_ = new ::testing::NiceMock<StatelessWriter>(&participant_);
     stateless_reader_ = new ::testing::NiceMock<StatelessReader>();
-    volatile_writer_ = new ::testing::NiceMock<StatefulWriter>(&participant_);
+    volatile_writer_ = new ::testing::StrictMock<StatefulWriter>(&participant_);
     volatile_reader_ = new ::testing::NiceMock<StatefulReader>();
 
     EXPECT_CALL(*auth_plugin_, validate_local_identity(_, _, _, _, _, _)).Times(1).
@@ -34,15 +34,18 @@ void SecurityTest::initialization_ok()
             WillOnce(Return(true));
     EXPECT_CALL(participant_, createWriter_mock(_, _, _, _, _, _)).Times(2).
             WillOnce(DoAll(SetArgPointee<0>(stateless_writer_), Return(true))).
-            WillOnce(DoAll(SetArgPointee<0>(volatile_writer_), Return(true)));
+            WillOnce(DoAll(SaveArg<3>(&volatile_writer_->listener_), SetArgPointee<0>(volatile_writer_), Return(true)));
     EXPECT_CALL(participant_, createReader_mock(_, _, _, _, _, _, _)).Times(2).
             WillOnce(DoAll(SetArgPointee<0>(stateless_reader_), Return(true))).
             WillOnce(DoAll(SetArgPointee<0>(volatile_reader_), Return(true)));
+
+    EXPECT_CALL(*volatile_writer_, set_separate_sending(true)).Times(1);
 
     security_activated_ = manager_.init(security_attributes_, participant_properties_);
     ASSERT_TRUE(security_activated_);
     ASSERT_TRUE(manager_.is_security_initialized());
     ASSERT_TRUE(manager_.create_entities());
+    ASSERT_TRUE(volatile_writer_->listener_ != nullptr);
 }
 
 void SecurityTest::initialization_auth_ok()
@@ -242,7 +245,12 @@ void SecurityTest::final_message_process_ok(
     info.guid = remote_participant_key;
     EXPECT_CALL(*participant_.getListener(), onParticipantAuthentication(_, info)).Times(1);
 
+    CacheChange_t* kx_change = new CacheChange_t(200);
+    expect_kx_exchange(kx_change);
+
     stateless_reader_->listener_->onNewCacheChangeAdded(stateless_reader_, change);
+
+    volatile_writer_->listener_->onWriterChangeReceivedByAll(volatile_writer_, kx_change);
 
     if (final_message_change == nullptr)
     {
@@ -252,6 +260,21 @@ void SecurityTest::final_message_process_ok(
     {
         *final_message_change = change2;
     }
+}
+
+void SecurityTest::expect_kx_exchange(
+        CacheChange_t* kx_change)
+{
+    EXPECT_CALL(*volatile_writer_, new_change(_, _, _)).Times(1).WillOnce(
+        DoAll(Invoke([kx_change](const std::function<uint32_t()>& f, ChangeKind_t, InstanceHandle_t)
+        {
+            kx_change->serializedPayload.reserve(f());
+        }),
+        Return(kx_change)));
+    EXPECT_CALL(*volatile_writer_->history_, add_change_mock(kx_change)).Times(1).
+            WillOnce(Return(true));
+    EXPECT_CALL(*volatile_writer_->history_, remove_change_mock(kx_change)).Times(1).
+            WillOnce(Return(true));
 }
 
 void SecurityTest::destroy_manager_and_change(

--- a/test/unittest/rtps/security/SecurityTests.hpp
+++ b/test/unittest/rtps/security/SecurityTests.hpp
@@ -124,6 +124,9 @@ protected:
     void final_message_process_ok(
             CacheChange_t** final_message_change = nullptr);
 
+    void expect_kx_exchange(
+            CacheChange_t* kx_change);
+
     void destroy_manager_and_change(
             CacheChange_t*& change,
             bool was_added = true);
@@ -159,7 +162,7 @@ public:
     ::testing::NiceMock<RTPSParticipantImpl> participant_;
     ::testing::NiceMock<StatelessWriter>* stateless_writer_;
     ::testing::NiceMock<StatelessReader>* stateless_reader_;
-    ::testing::NiceMock<StatefulWriter>* volatile_writer_;
+    ::testing::StrictMock<StatefulWriter>* volatile_writer_;
     ::testing::NiceMock<StatefulReader>* volatile_reader_;
     PDP pdp_;
     SecurityPluginFactory plugin_factory_;

--- a/test/unittest/rtps/security/SecurityValidationRemoteTests.cpp
+++ b/test/unittest/rtps/security/SecurityValidationRemoteTests.cpp
@@ -158,7 +158,12 @@ TEST_F(SecurityTest, discovered_participant_validation_remote_identity_pending_h
     info.guid = participant_data.m_guid;
     EXPECT_CALL(*participant_.getListener(), onParticipantAuthentication(_, info)).Times(1);
 
+    CacheChange_t* kx_change = new CacheChange_t(500);
+    expect_kx_exchange(kx_change);
+
     ASSERT_TRUE(manager_.discovered_participant(participant_data));
+
+    volatile_writer_->listener_->onWriterChangeReceivedByAll(volatile_writer_, kx_change);
 
     return_handle(remote_identity_handle);
     return_handle(handshake_handle);
@@ -325,7 +330,12 @@ TEST_F(SecurityTest, discovered_participant_validation_remote_identity_pending_h
     info.guid = participant_data.m_guid;
     EXPECT_CALL(*participant_.getListener(), onParticipantAuthentication(_, info)).Times(1);
 
+    CacheChange_t* kx_change = new CacheChange_t(500);
+    expect_kx_exchange(kx_change);
+
     ASSERT_TRUE(manager_.discovered_participant(participant_data));
+
+    volatile_writer_->listener_->onWriterChangeReceivedByAll(volatile_writer_, kx_change);
 
     destroy_manager_and_change(change);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This is a fix for #4553, which reported an increase in memory consumption when the partition of a secure DataWriter is changed. The consumption came from the history of the `participant_volatile_message_secure_writer_` not being correctly cleared.

This PR:
* adds a black-box test reproducing the behavior depicted in #4553
* converts `volatile_writer_` in the security tests into a `StrictMock`, and adds expectations for the added change to be released
* Fixes #4553 by making `SecurityManager` implement `rtps::WriterListener` and removing changes from history when they are acknowledged (i.e. making `participant_volatile_message_secure_writer_` truly behave as volatile)

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox with ❌ or __NO__.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
