### PR TITLE
[20742] Run `is_plain` method with the corresponding data representation

### DIFF
--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -469,7 +469,7 @@ ReturnCode_t DataWriterImpl::loan_sample(
             microseconds(::TimeConv::Time_t2MicroSecondsInt64(qos_.reliability().max_blocking_time));
 
     // Type should be plain and have space for the representation header
-    if (!type_->is_plain() || SerializedPayload_t::representation_header_size > type_->m_typeSize)
+    if (!type_->is_plain(data_representation_) || SerializedPayload_t::representation_header_size > type_->m_typeSize)
     {
         return ReturnCode_t::RETCODE_ILLEGAL_OPERATION;
     }
@@ -555,7 +555,7 @@ ReturnCode_t DataWriterImpl::discard_loan(
         void*& sample)
 {
     // Type should be plain and have space for the representation header
-    if (!type_->is_plain() || SerializedPayload_t::representation_header_size > type_->m_typeSize)
+    if (!type_->is_plain(data_representation_) || SerializedPayload_t::representation_header_size > type_->m_typeSize)
     {
         return ReturnCode_t::RETCODE_ILLEGAL_OPERATION;
     }
@@ -2018,7 +2018,7 @@ std::shared_ptr<IPayloadPool> DataWriterImpl::get_payload_pool()
         // When the user requested PREALLOCATED_WITH_REALLOC, but we know the type cannot
         // grow, we translate the policy into bare PREALLOCATED
         if (PREALLOCATED_WITH_REALLOC_MEMORY_MODE == history_.m_att.memoryPolicy &&
-                (type_->is_bounded() || type_->is_plain()))
+                (type_->is_bounded() || type_->is_plain(data_representation_)))
         {
             history_.m_att.memoryPolicy = PREALLOCATED_MEMORY_MODE;
         }
@@ -2043,7 +2043,7 @@ std::shared_ptr<IPayloadPool> DataWriterImpl::get_payload_pool()
         }
 
         // Prepare loans collection for plain types only
-        if (type_->is_plain())
+        if (type_->is_plain(data_representation_))
         {
             loans_.reset(new LoanCollection(config));
         }

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -217,6 +217,11 @@ ReturnCode_t DataReaderImpl::enable()
         att.endpoint.set_data_sharing_configuration(datasharing);
     }
 
+    // Set Datareader's DataRepresentationId taking into account the QoS.
+    data_representation_ = qos_.type_consistency().representation.m_value.empty()
+            || XCDR_DATA_REPRESENTATION == qos_.type_consistency().representation.m_value.at(0)
+                    ? XCDR_DATA_REPRESENTATION : XCDR2_DATA_REPRESENTATION;
+
     std::shared_ptr<IPayloadPool> pool = get_payload_pool();
     RTPSReader* reader = RTPSDomain::createRTPSReader(
         subscriber_->rtps_participant(),
@@ -1789,7 +1794,7 @@ std::shared_ptr<IPayloadPool> DataReaderImpl::get_payload_pool()
     // When the user requested PREALLOCATED_WITH_REALLOC, but we know the type cannot
     // grow, we translate the policy into bare PREALLOCATED
     if (PREALLOCATED_WITH_REALLOC_MEMORY_MODE == history_.m_att.memoryPolicy &&
-            (type_->is_bounded() || type_->is_plain()))
+            (type_->is_bounded() || type_->is_plain(data_representation_)))
     {
         history_.m_att.memoryPolicy = PREALLOCATED_MEMORY_MODE;
     }

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1787,14 +1787,19 @@ DataReaderListener* DataReaderImpl::get_listener_for(
 std::shared_ptr<IPayloadPool> DataReaderImpl::get_payload_pool()
 {
     // Check whether DataReader's type is plain in all its data representations
-    bool is_plain = type_->is_plain();
+    bool is_plain = true;
     if (qos_.type_consistency().representation.m_value.size() > 0)
     {
-        is_plain = true;
         for (auto data_representation : qos_.type_consistency().representation.m_value)
         {
             is_plain = is_plain && type_->is_plain(data_representation);
         }
+    }
+    // If data representation is not defined, consider both XCDR representations
+    else
+    {
+        is_plain = type_->is_plain(DataRepresentationId_t::XCDR_DATA_REPRESENTATION)
+            && type_->is_plain(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
     }
 
     // When the user requested PREALLOCATED_WITH_REALLOC, but we know the type cannot

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1803,7 +1803,8 @@ std::shared_ptr<IPayloadPool> DataReaderImpl::get_payload_pool()
 
     if (!sample_pool_)
     {
-        sample_pool_ = std::make_shared<detail::SampleLoanManager>(config, type_, type_->is_plain(data_representation_));
+        sample_pool_ =
+                std::make_shared<detail::SampleLoanManager>(config, type_, type_->is_plain(data_representation_));
     }
     if (!is_custom_payload_pool_)
     {

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -217,11 +217,6 @@ ReturnCode_t DataReaderImpl::enable()
         att.endpoint.set_data_sharing_configuration(datasharing);
     }
 
-    // Set Datareader's DataRepresentationId taking into account the QoS.
-    data_representation_ = qos_.type_consistency().representation.m_value.empty()
-            || XCDR_DATA_REPRESENTATION == qos_.type_consistency().representation.m_value.at(0)
-                    ? XCDR_DATA_REPRESENTATION : XCDR2_DATA_REPRESENTATION;
-
     std::shared_ptr<IPayloadPool> pool = get_payload_pool();
     RTPSReader* reader = RTPSDomain::createRTPSReader(
         subscriber_->rtps_participant(),
@@ -1791,10 +1786,17 @@ DataReaderListener* DataReaderImpl::get_listener_for(
 
 std::shared_ptr<IPayloadPool> DataReaderImpl::get_payload_pool()
 {
+    // Check whether DataReader's type is plain in all its data representations
+    bool is_plain = true;
+    for (auto data_representation : qos_.type_consistency().representation.m_value)
+    {
+        is_plain = is_plain && type_->is_plain(data_representation);
+    }
+
     // When the user requested PREALLOCATED_WITH_REALLOC, but we know the type cannot
     // grow, we translate the policy into bare PREALLOCATED
     if (PREALLOCATED_WITH_REALLOC_MEMORY_MODE == history_.m_att.memoryPolicy &&
-            (type_->is_bounded() || type_->is_plain(data_representation_)))
+            (type_->is_bounded() || is_plain))
     {
         history_.m_att.memoryPolicy = PREALLOCATED_MEMORY_MODE;
     }
@@ -1804,7 +1806,7 @@ std::shared_ptr<IPayloadPool> DataReaderImpl::get_payload_pool()
     if (!sample_pool_)
     {
         sample_pool_ =
-                std::make_shared<detail::SampleLoanManager>(config, type_, type_->is_plain(data_representation_));
+                std::make_shared<detail::SampleLoanManager>(config, type_, is_plain);
     }
     if (!is_custom_payload_pool_)
     {

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1799,7 +1799,7 @@ std::shared_ptr<IPayloadPool> DataReaderImpl::get_payload_pool()
     else
     {
         is_plain = type_->is_plain(DataRepresentationId_t::XCDR_DATA_REPRESENTATION)
-            && type_->is_plain(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
+                && type_->is_plain(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
     }
 
     // When the user requested PREALLOCATED_WITH_REALLOC, but we know the type cannot

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1803,7 +1803,7 @@ std::shared_ptr<IPayloadPool> DataReaderImpl::get_payload_pool()
 
     if (!sample_pool_)
     {
-        sample_pool_ = std::make_shared<detail::SampleLoanManager>(config, type_);
+        sample_pool_ = std::make_shared<detail::SampleLoanManager>(config, type_, type_->is_plain(data_representation_));
     }
     if (!is_custom_payload_pool_)
     {

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1787,10 +1787,14 @@ DataReaderListener* DataReaderImpl::get_listener_for(
 std::shared_ptr<IPayloadPool> DataReaderImpl::get_payload_pool()
 {
     // Check whether DataReader's type is plain in all its data representations
-    bool is_plain = true;
-    for (auto data_representation : qos_.type_consistency().representation.m_value)
+    bool is_plain = type_->is_plain();
+    if (qos_.type_consistency().representation.m_value.size() > 0)
     {
-        is_plain = is_plain && type_->is_plain(data_representation);
+        is_plain = true;
+        for (auto data_representation : qos_.type_consistency().representation.m_value)
+        {
+            is_plain = is_plain && type_->is_plain(data_representation);
+        }
     }
 
     // When the user requested PREALLOCATED_WITH_REALLOC, but we know the type cannot

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1814,8 +1814,7 @@ std::shared_ptr<IPayloadPool> DataReaderImpl::get_payload_pool()
 
     if (!sample_pool_)
     {
-        sample_pool_ =
-                std::make_shared<detail::SampleLoanManager>(config, type_, is_plain);
+        sample_pool_ = std::make_shared<detail::SampleLoanManager>(config, type_, is_plain);
     }
     if (!is_custom_payload_pool_)
     {

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -404,6 +404,8 @@ protected:
 
     fastrtps::rtps::GUID_t guid_;
 
+    DataRepresentationId_t data_representation_ {DEFAULT_DATA_REPRESENTATION};
+
     class InnerDataReaderListener : public fastrtps::rtps::ReaderListener
     {
     public:

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -404,8 +404,6 @@ protected:
 
     fastrtps::rtps::GUID_t guid_;
 
-    DataRepresentationId_t data_representation_ {DEFAULT_DATA_REPRESENTATION};
-
     class InnerDataReaderListener : public fastrtps::rtps::ReaderListener
     {
     public:

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/SampleLoanManager.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/SampleLoanManager.hpp
@@ -51,8 +51,10 @@ struct SampleLoanManager
 
     SampleLoanManager(
             const PoolConfig& pool_config,
-            const TypeSupport& type)
-        : limits_(pool_config.initial_size,
+            const TypeSupport& type,
+            const bool is_plain)
+        : is_plain_(is_plain)
+        , limits_(pool_config.initial_size,
                 pool_config.maximum_size ? pool_config.maximum_size : std::numeric_limits<size_t>::max(),
                 1)
         , free_loans_(limits_)
@@ -62,7 +64,7 @@ struct SampleLoanManager
         for (size_t n = 0; n < limits_.initial; ++n)
         {
             OutstandingLoanItem item;
-            if (!type_->is_plain())
+            if (!is_plain_)
             {
                 item.sample = type_->createData();
             }
@@ -72,7 +74,7 @@ struct SampleLoanManager
 
     ~SampleLoanManager()
     {
-        if (!type_->is_plain())
+        if (!is_plain_)
         {
             for (const OutstandingLoanItem& item : free_loans_)
             {
@@ -108,7 +110,7 @@ struct SampleLoanManager
             if (nullptr != item)
             {
                 // Create sample if necessary
-                if (!type_->is_plain())
+                if (!is_plain_)
                 {
                     item->sample = type_->createData();
                 }
@@ -139,7 +141,7 @@ struct SampleLoanManager
         tmp.serializedPayload.data = nullptr;
 
         // Perform deserialization
-        if (type_->is_plain())
+        if (is_plain_)
         {
             auto ptr = item->payload.data;
             ptr += item->payload.representation_header_size;
@@ -212,6 +214,7 @@ private:
 
     using collection_type = eprosima::fastrtps::ResourceLimitedVector<OutstandingLoanItem>;
 
+    bool is_plain_;
     eprosima::fastrtps::ResourceLimitedContainerConfig limits_;
     collection_type free_loans_;
     collection_type used_loans_;

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -241,6 +241,12 @@ public:
         return true;
     }
 
+    inline bool is_plain(
+            DataRepresentationId_t) const override
+    {
+        return true;
+    }
+
     bool getKey(
             void* /*data*/,
             fastrtps::rtps::InstanceHandle_t* /*ihandle*/,

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -2178,19 +2178,20 @@ public:
         return true;
     }
 
-    MOCK_CONST_METHOD1(custom_is_plain, bool(DataRepresentationId_t data_representation_id));
+    MOCK_CONST_METHOD1(custom_is_plain_with_rep, bool(DataRepresentationId_t data_representation_id));
 
     bool is_plain(
             DataRepresentationId_t data_representation_id) const override
     {
-        return custom_is_plain(data_representation_id);
+        return custom_is_plain_with_rep(data_representation_id);
     }
+
+    MOCK_CONST_METHOD0(custom_is_plain, bool());
 
     bool is_plain() const override
     {
-        return is_plain(DataRepresentationId_t::XCDR_DATA_REPRESENTATION); // default XCDR1
+        return custom_is_plain();
     }
-
 };
 
 TEST(DataWriterTests, data_type_is_plain_data_representation)
@@ -2215,9 +2216,10 @@ TEST(DataWriterTests, data_type_is_plain_data_representation)
     qos_xcdr.endpoint().history_memory_policy = PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
 
     /* Expect the "is_plain" method called with default data representation (XCDR1) */
-    EXPECT_CALL(*type, custom_is_plain(DataRepresentationId_t::XCDR_DATA_REPRESENTATION)).Times(
+    EXPECT_CALL(*type, custom_is_plain()).Times(0);
+    EXPECT_CALL(*type, custom_is_plain_with_rep(DataRepresentationId_t::XCDR_DATA_REPRESENTATION)).Times(
         testing::AtLeast(1)).WillRepeatedly(testing::Return(true));
-    EXPECT_CALL(*type, custom_is_plain(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)).Times(0);
+    EXPECT_CALL(*type, custom_is_plain_with_rep(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)).Times(0);
 
     /* Create a datawriter will trigger the "is_plain" call */
     DataWriter* datawriter_xcdr = publisher->create_datawriter(topic, qos_xcdr);
@@ -2232,8 +2234,9 @@ TEST(DataWriterTests, data_type_is_plain_data_representation)
     qos_xcdr2.representation().m_value.push_back(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
 
     /* Expect the "is_plain" method called with XCDR2 data representation */
-    EXPECT_CALL(*type, custom_is_plain(DataRepresentationId_t::XCDR_DATA_REPRESENTATION)).Times(0);
-    EXPECT_CALL(*type, custom_is_plain(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)).Times(
+    EXPECT_CALL(*type, custom_is_plain()).Times(0);
+    EXPECT_CALL(*type, custom_is_plain_with_rep(DataRepresentationId_t::XCDR_DATA_REPRESENTATION)).Times(0);
+    EXPECT_CALL(*type, custom_is_plain_with_rep(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)).Times(
         testing::AtLeast(1)).WillRepeatedly(testing::Return(true));
 
     /* Create a datawriter will trigger the "is_plain" call */

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -2178,6 +2178,7 @@ public:
     {
         return is_plain(DataRepresentationId_t::XCDR_DATA_REPRESENTATION); // default XCDR1
     }
+
 };
 
 TEST(DataWriterTests, data_type_is_plain_data_representation)
@@ -2203,7 +2204,7 @@ TEST(DataWriterTests, data_type_is_plain_data_representation)
 
     /* Expect the "is_plain" method called with default data representation (XCDR1) */
     EXPECT_CALL(*type, custom_is_plain(DataRepresentationId_t::XCDR_DATA_REPRESENTATION)).Times(
-            testing::AtLeast(1)).WillRepeatedly(testing::Return(true));
+        testing::AtLeast(1)).WillRepeatedly(testing::Return(true));
     EXPECT_CALL(*type, custom_is_plain(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)).Times(0);
 
     /* Create a datawriter will trigger the "is_plain" call */
@@ -2221,7 +2222,7 @@ TEST(DataWriterTests, data_type_is_plain_data_representation)
     /* Expect the "is_plain" method called with XCDR2 data representation */
     EXPECT_CALL(*type, custom_is_plain(DataRepresentationId_t::XCDR_DATA_REPRESENTATION)).Times(0);
     EXPECT_CALL(*type, custom_is_plain(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)).Times(
-            testing::AtLeast(1)).WillRepeatedly(testing::Return(true));
+        testing::AtLeast(1)).WillRepeatedly(testing::Return(true));
 
     /* Create a datawriter will trigger the "is_plain" call */
     DataWriter* datawriter_xcdr2 = publisher->create_datawriter(topic, qos_xcdr2);

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -2192,6 +2192,7 @@ public:
     {
         return custom_is_plain();
     }
+
 };
 
 TEST(DataWriterTests, data_type_is_plain_data_representation)

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -1402,6 +1402,12 @@ public:
         return true;
     }
 
+    bool is_plain(
+            DataRepresentationId_t) const override
+    {
+        return true;
+    }
+
     bool construct_sample(
             void* sample) const override
     {
@@ -1505,6 +1511,12 @@ public:
     bool construct_sample_result = true;
 
     bool is_plain() const override
+    {
+        return is_plain_result;
+    }
+
+    bool is_plain(
+            DataRepresentationId_t) const override
     {
         return is_plain_result;
     }

--- a/test/unittest/dds/publisher/PublisherTests.cpp
+++ b/test/unittest/dds/publisher/PublisherTests.cpp
@@ -183,6 +183,12 @@ public:
         return true;
     }
 
+    inline bool is_plain(
+            DataRepresentationId_t) const override
+    {
+        return true;
+    }
+
     bool getKey(
             void* /*data*/,
             fastrtps::rtps::InstanceHandle_t* /*ihandle*/,

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -3832,6 +3832,7 @@ public:
     {
         return custom_is_plain();
     }
+
 };
 
 TEST_F(DataReaderTests, data_type_is_plain_data_representation)

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -3818,26 +3818,20 @@ public:
         return true;
     }
 
-    MOCK_CONST_METHOD1(custom_is_plain, bool(DataRepresentationId_t data_representation_id));
+    MOCK_CONST_METHOD1(custom_is_plain_with_rep, bool(DataRepresentationId_t data_representation_id));
 
     bool is_plain(
             DataRepresentationId_t data_representation_id) const override
     {
-        return custom_is_plain(data_representation_id);
+        return custom_is_plain_with_rep(data_representation_id);
     }
+
+    MOCK_CONST_METHOD0(custom_is_plain, bool());
 
     bool is_plain() const override
     {
-        return is_plain(DataRepresentationId_t::XCDR_DATA_REPRESENTATION); // default XCDR1
+        return custom_is_plain();
     }
-
-    bool construct_sample(
-            void* sample) const override
-    {
-        new (sample) LoanableType();
-        return true;
-    }
-
 };
 
 TEST_F(DataReaderTests, data_type_is_plain_data_representation)
@@ -3864,9 +3858,10 @@ TEST_F(DataReaderTests, data_type_is_plain_data_representation)
     qos_xcdr.type_consistency().representation.m_value.push_back(DataRepresentationId_t::XCDR_DATA_REPRESENTATION);
 
     /* Expect the "is_plain" method called with default data representation (XCDR1) */
-    EXPECT_CALL(*type, custom_is_plain(DataRepresentationId_t::XCDR_DATA_REPRESENTATION)).Times(
+    EXPECT_CALL(*type, custom_is_plain()).Times(0);
+    EXPECT_CALL(*type, custom_is_plain_with_rep(DataRepresentationId_t::XCDR_DATA_REPRESENTATION)).Times(
         testing::AtLeast(1)).WillRepeatedly(testing::Return(true));
-    EXPECT_CALL(*type, custom_is_plain(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)).Times(0);
+    EXPECT_CALL(*type, custom_is_plain_with_rep(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)).Times(0);
 
     /* Create a datareader will trigger the "is_plain" call */
     DataReader* datareader_xcdr = subscriber->create_datareader(topic, qos_xcdr);
@@ -3881,13 +3876,30 @@ TEST_F(DataReaderTests, data_type_is_plain_data_representation)
     qos_xcdr2.type_consistency().representation.m_value.push_back(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
 
     /* Expect the "is_plain" method called with XCDR2 data representation */
-    EXPECT_CALL(*type, custom_is_plain(DataRepresentationId_t::XCDR_DATA_REPRESENTATION)).Times(0);
-    EXPECT_CALL(*type, custom_is_plain(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)).Times(
+    EXPECT_CALL(*type, custom_is_plain()).Times(0);
+    EXPECT_CALL(*type, custom_is_plain_with_rep(DataRepresentationId_t::XCDR_DATA_REPRESENTATION)).Times(0);
+    EXPECT_CALL(*type, custom_is_plain_with_rep(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)).Times(
         testing::AtLeast(1)).WillRepeatedly(testing::Return(true));
 
     /* Create a datareader will trigger the "is_plain" call */
     DataReader* datareader_xcdr2 = subscriber->create_datareader(topic, qos_xcdr2);
     ASSERT_NE(datareader_xcdr2, nullptr);
+
+    /* NOT Define data representation QoS to force "is_plain" call */
+    DataReaderQos qos_no_xcdr = DATAREADER_QOS_DEFAULT;
+    qos_no_xcdr.endpoint().history_memory_policy = PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+    qos_no_xcdr.type_consistency().representation.m_value.clear();
+
+    /* Expect the "is_plain" method called with both data representation */
+    EXPECT_CALL(*type, custom_is_plain()).Times(0);
+    EXPECT_CALL(*type, custom_is_plain_with_rep(DataRepresentationId_t::XCDR_DATA_REPRESENTATION)).Times(
+        testing::AtLeast(1)).WillRepeatedly(testing::Return(true));
+    EXPECT_CALL(*type, custom_is_plain_with_rep(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)).Times(
+        testing::AtLeast(1)).WillRepeatedly(testing::Return(true));
+
+    /* Create a datareader will trigger the "is_plain" call */
+    DataReader* datareader_no_xcdr = subscriber->create_datareader(topic, qos_no_xcdr);
+    ASSERT_NE(datareader_no_xcdr, nullptr);
 
     /* Tear down */
     participant->delete_contained_entities();

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -3865,7 +3865,7 @@ TEST_F(DataReaderTests, data_type_is_plain_data_representation)
 
     /* Expect the "is_plain" method called with default data representation (XCDR1) */
     EXPECT_CALL(*type, custom_is_plain(DataRepresentationId_t::XCDR_DATA_REPRESENTATION)).Times(
-            testing::AtLeast(1)).WillRepeatedly(testing::Return(true));
+        testing::AtLeast(1)).WillRepeatedly(testing::Return(true));
     EXPECT_CALL(*type, custom_is_plain(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)).Times(0);
 
     /* Create a datareader will trigger the "is_plain" call */
@@ -3883,7 +3883,7 @@ TEST_F(DataReaderTests, data_type_is_plain_data_representation)
     /* Expect the "is_plain" method called with XCDR2 data representation */
     EXPECT_CALL(*type, custom_is_plain(DataRepresentationId_t::XCDR_DATA_REPRESENTATION)).Times(0);
     EXPECT_CALL(*type, custom_is_plain(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)).Times(
-            testing::AtLeast(1)).WillRepeatedly(testing::Return(true));
+        testing::AtLeast(1)).WillRepeatedly(testing::Return(true));
 
     /* Create a datareader will trigger the "is_plain" call */
     DataReader* datareader_xcdr2 = subscriber->create_datareader(topic, qos_xcdr2);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
The endpoints implementation (DataReaderImpl and DataWriterImpl) were calling `is_plain` method without the data representation, so it was not being considered.
This PR includes the data representation as an argument to `is_plain` so it is considered in both cases.
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox with ❌ or __NO__.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
