### PR TITLE
Removed warning

### DIFF
--- a/src/cpp/fastdds/core/policy/ParameterList.cpp
+++ b/src/cpp/fastdds/core/policy/ParameterList.cpp
@@ -139,8 +139,8 @@ bool ParameterList::read_guid_from_cdr_msg(
         fastrtps::rtps::GUID_t& guid)
 {
     bool valid = false;
-    uint16_t pid;
-    uint16_t plength;
+    uint16_t pid = 0;
+    uint16_t plength = 0;
     while (msg.pos < msg.length)
     {
         valid = true;

--- a/src/cpp/fastdds/core/policy/ParameterList.cpp
+++ b/src/cpp/fastdds/core/policy/ParameterList.cpp
@@ -146,7 +146,7 @@ bool ParameterList::read_guid_from_cdr_msg(
         valid = true;
         valid &= fastrtps::rtps::CDRMessage::readUInt16(&msg, &pid);
         valid &= fastrtps::rtps::CDRMessage::readUInt16(&msg, &plength);
-        if ((pid == PID_SENTINEL) || !valid)
+        if (!valid || (pid == PID_SENTINEL))
         {
             break;
         }


### PR DESCRIPTION
There is a new warning on CI https://ci.ros2.org/view/packaging/job/packaging_linux/3405/clang-tidy/folder.112366245/

This should fix the warning