### PR TITLE
[20733] Fix support for @key annotation in Dynamic types

### DIFF
--- a/include/fastrtps/types/MemberDescriptor.h
+++ b/include/fastrtps/types/MemberDescriptor.h
@@ -18,9 +18,9 @@
 #include <fastrtps/types/TypesBase.h>
 #include <fastrtps/types/DynamicTypePtr.h>
 
-namespace eprosima{
-namespace fastrtps{
-namespace types{
+namespace eprosima {
+namespace fastrtps {
+namespace types {
 
 class DynamicType;
 class AnnotationDescriptor;
@@ -28,6 +28,7 @@ class AnnotationDescriptor;
 class MemberDescriptor
 {
 protected:
+
     std::string name_;                  // Name of the member
     MemberId id_;                       // MemberId, it should be filled automatically when the member is added.
     DynamicType_ptr type_;              // Member's Type.
@@ -43,11 +44,17 @@ protected:
     friend class DynamicTypeMember;
     friend class TypeObjectFactory;
 
-    bool is_default_value_consistent(const std::string& sDefaultValue) const;
+    bool is_default_value_consistent(
+            const std::string& sDefaultValue) const;
 
-    bool is_type_name_consistent(const std::string& sName) const;
+    bool is_type_name_consistent(
+            const std::string& sName) const;
+
+    void copy_annotations_from_type(
+            const DynamicType_ptr& type);
 
 public:
+
     RTPS_DllAPI MemberDescriptor();
 
     RTPS_DllAPI MemberDescriptor(
@@ -57,37 +64,41 @@ public:
     RTPS_DllAPI MemberDescriptor(
             MemberId id,
             const std::string& name,
-            DynamicType_ptr type_);
+            DynamicType_ptr type);
 
     RTPS_DllAPI MemberDescriptor(
             MemberId id,
             const std::string& name,
-            DynamicType_ptr type_,
+            DynamicType_ptr type,
             const std::string& defaultValue);
 
     RTPS_DllAPI MemberDescriptor(
             MemberId id,
             const std::string& name,
-            DynamicType_ptr type_,
+            DynamicType_ptr type,
             const std::string& defaultValue,
             const std::vector<uint64_t>& unionLabels,
             bool isDefaultLabel);
 
-    RTPS_DllAPI MemberDescriptor(const MemberDescriptor* descriptor);
+    RTPS_DllAPI MemberDescriptor(
+            const MemberDescriptor* descriptor);
 
     RTPS_DllAPI ~MemberDescriptor();
 
-    bool check_union_labels(const std::vector<uint64_t>& labels) const;
+    bool check_union_labels(
+            const std::vector<uint64_t>& labels) const;
 
-    RTPS_DllAPI ReturnCode_t copy_from(const MemberDescriptor* other);
+    RTPS_DllAPI ReturnCode_t copy_from(
+            const MemberDescriptor* other);
 
-    RTPS_DllAPI bool equals(const MemberDescriptor* other) const;
+    RTPS_DllAPI bool equals(
+            const MemberDescriptor* other) const;
 
     RTPS_DllAPI TypeKind get_kind() const;
 
     RTPS_DllAPI MemberId get_id() const;
 
-    RTPS_DllAPI  uint32_t get_index() const;
+    RTPS_DllAPI uint32_t get_index() const;
 
     RTPS_DllAPI std::string get_name() const;
 
@@ -105,39 +116,49 @@ public:
 
     RTPS_DllAPI bool is_default_union_value() const;
 
-    RTPS_DllAPI bool is_consistent(TypeKind parentKind) const;
+    RTPS_DllAPI bool is_consistent(
+            TypeKind parentKind) const;
 
-    RTPS_DllAPI void add_union_case_index(uint64_t value);
+    RTPS_DllAPI void add_union_case_index(
+            uint64_t value);
 
-    RTPS_DllAPI void set_id(MemberId id);
+    RTPS_DllAPI void set_id(
+            MemberId id);
 
-    RTPS_DllAPI void set_index(uint32_t index);
+    RTPS_DllAPI void set_index(
+            uint32_t index);
 
-    RTPS_DllAPI void set_name(const std::string& name);
+    RTPS_DllAPI void set_name(
+            const std::string& name);
 
-    RTPS_DllAPI void set_type(DynamicType_ptr type);
+    RTPS_DllAPI void set_type(
+            DynamicType_ptr type);
 
     RTPS_DllAPI DynamicType_ptr get_type() const
     {
         return type_;
     }
 
-    RTPS_DllAPI void set_default_union_value(bool bDefault);
+    RTPS_DllAPI void set_default_union_value(
+            bool bDefault);
 
-    RTPS_DllAPI void set_default_value(const std::string& value)
+    RTPS_DllAPI void set_default_value(
+            const std::string& value)
     {
         default_value_ = value;
     }
 
     // Annotations
-    ReturnCode_t apply_annotation(AnnotationDescriptor& descriptor);
+    ReturnCode_t apply_annotation(
+            AnnotationDescriptor& descriptor);
 
     ReturnCode_t apply_annotation(
             const std::string& annotation_name,
             const std::string& key,
             const std::string& value);
 
-    AnnotationDescriptor* get_annotation(const std::string& name) const;
+    AnnotationDescriptor* get_annotation(
+            const std::string& name) const;
 
     // Annotations application
     RTPS_DllAPI bool annotation_is_optional() const;
@@ -168,23 +189,31 @@ public:
     RTPS_DllAPI uint16_t annotation_get_bit_bound() const;
 
     // Annotations setters
-    RTPS_DllAPI void annotation_set_optional(bool optional);
+    RTPS_DllAPI void annotation_set_optional(
+            bool optional);
 
-    RTPS_DllAPI void annotation_set_key(bool key);
+    RTPS_DllAPI void annotation_set_key(
+            bool key);
 
-    RTPS_DllAPI void annotation_set_must_understand(bool must_understand);
+    RTPS_DllAPI void annotation_set_must_understand(
+            bool must_understand);
 
-    RTPS_DllAPI void annotation_set_non_serialized(bool non_serialized);
+    RTPS_DllAPI void annotation_set_non_serialized(
+            bool non_serialized);
 
-    RTPS_DllAPI void annotation_set_value(const std::string& value);
+    RTPS_DllAPI void annotation_set_value(
+            const std::string& value);
 
-    RTPS_DllAPI void annotation_set_default(const std::string& default_value);
+    RTPS_DllAPI void annotation_set_default(
+            const std::string& default_value);
 
     RTPS_DllAPI void annotation_set_default_literal();
 
-    RTPS_DllAPI void annotation_set_position(uint16_t position);
+    RTPS_DllAPI void annotation_set_position(
+            uint16_t position);
 
-    RTPS_DllAPI void annotation_set_bit_bound(uint16_t bit_bound);
+    RTPS_DllAPI void annotation_set_bit_bound(
+            uint16_t bit_bound);
 };
 
 } // namespace types

--- a/include/fastrtps/xmlparser/XMLProfileManager.h
+++ b/include/fastrtps/xmlparser/XMLProfileManager.h
@@ -255,24 +255,14 @@ public:
      * XMLProfileManager::DeleteDynamicPubSubType method.
      */
     RTPS_DllAPI static types::DynamicPubSubType* CreateDynamicPubSubType(
-            const std::string& type_name)
-    {
-        if (dynamic_types_.find(type_name) != dynamic_types_.end())
-        {
-            return new types::DynamicPubSubType(dynamic_types_[type_name]->build());
-        }
-        return nullptr;
-    }
+            const std::string& type_name);
 
     /**
      * Deletes the given DynamicPubSubType previously created by calling
      * XMLProfileManager::CreateDynamicPubSubType method.
      */
     RTPS_DllAPI static void DeleteDynamicPubSubType(
-            types::DynamicPubSubType* type)
-    {
-        delete type;
-    }
+            types::DynamicPubSubType* type);
 
 private:
 

--- a/resources/xsd/fastRTPS_profiles.xsd
+++ b/resources/xsd/fastRTPS_profiles.xsd
@@ -559,6 +559,7 @@
         <xs:attribute name="sequenceMaxLength" type="int32" use="optional"/>
         <xs:attribute name="arrayDimensions" type="arrayDim" use="optional"/>
         <xs:attribute name="key_type" type="string" use="optional"/>
+        <xs:attribute name="key" type="string" use="optional"/>
         <xs:attribute name="mapMaxLength" type="int32" use="optional"/>
     </xs:complexType>
 

--- a/src/cpp/dynamic-types/AnnotationDescriptor.cpp
+++ b/src/cpp/dynamic-types/AnnotationDescriptor.cpp
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <fastdds/dds/log/Log.hpp>
 #include <fastrtps/types/AnnotationDescriptor.h>
 #include <fastrtps/types/DynamicType.h>
 #include <fastrtps/types/DynamicTypeBuilderFactory.h>
-#include <fastdds/dds/log/Log.hpp>
+#include <fastrtps/types/TypesBase.h>
 
 namespace eprosima {
 namespace fastrtps {
@@ -96,9 +97,9 @@ bool AnnotationDescriptor::key_annotation() const
     if (type_ && (type_->get_name() == ANNOTATION_KEY_ID || type_->get_name() == ANNOTATION_EPKEY_ID))
     {
         // When an annotation is a key annotation, there is only one entry in value_.
-        // Its map key is "value" and its value is either "true" of "false".
+        // Its map key is ANNOTATION_VALUE_ID and its value is either "true" of "false".
         // We cannot call get_value() directly because it is not const-qualified
-        auto it = value_.find("value");
+        auto it = value_.find(ANNOTATION_VALUE_ID);
 
         if (it != value_.end())
         {
@@ -112,7 +113,7 @@ bool AnnotationDescriptor::key_annotation() const
 ReturnCode_t AnnotationDescriptor::get_value(
         std::string& value)
 {
-    return get_value(value, "value");
+    return get_value(value, ANNOTATION_VALUE_ID);
 }
 
 ReturnCode_t AnnotationDescriptor::get_value(

--- a/src/cpp/dynamic-types/AnnotationDescriptor.cpp
+++ b/src/cpp/dynamic-types/AnnotationDescriptor.cpp
@@ -90,12 +90,23 @@ bool AnnotationDescriptor::equals(
 
 bool AnnotationDescriptor::key_annotation() const
 {
-    auto it = value_.find(ANNOTATION_KEY_ID);
-    if (it == value_.end())
+    bool ret = false;
+
+    // Annotations @key and @Key have names "key" and "Key" respectively.
+    if (type_ && (type_->get_name() == ANNOTATION_KEY_ID || type_->get_name() == ANNOTATION_EPKEY_ID))
     {
-        it = value_.find(ANNOTATION_EPKEY_ID); // Legacy "@Key"
+        // When an annotation is a key annotation, there is only one entry in value_.
+        // Its map key is "value" and its value is either "true" of "false".
+        // We cannot call get_value() directly because it is not const-qualified
+        auto it = value_.find("value");
+
+        if (it != value_.end())
+        {
+            ret = it->second == CONST_TRUE;
+        }
     }
-    return (it != value_.end() && it->second == CONST_TRUE);
+
+    return ret;
 }
 
 ReturnCode_t AnnotationDescriptor::get_value(

--- a/src/cpp/dynamic-types/DynamicType.cpp
+++ b/src/cpp/dynamic-types/DynamicType.cpp
@@ -191,7 +191,7 @@ ReturnCode_t DynamicType::copy_from_builder(
         {
             DynamicTypeMember* newMember = new DynamicTypeMember(it->second);
             newMember->set_parent(this);
-            is_key_defined_ = newMember->key_annotation();
+            is_key_defined_ |= newMember->key_annotation();
             member_by_id_.insert(std::make_pair(newMember->get_id(), newMember));
             member_by_name_.insert(std::make_pair(newMember->get_name(), newMember));
         }
@@ -245,14 +245,7 @@ TypeDescriptor* DynamicType::get_descriptor()
 
 bool DynamicType::key_annotation() const
 {
-    for (auto anIt = descriptor_->annotation_.begin(); anIt != descriptor_->annotation_.end(); ++anIt)
-    {
-        if ((*anIt)->key_annotation())
-        {
-            return true;
-        }
-    }
-    return false;
+    return descriptor_->annotation_get_key();
 }
 
 bool DynamicType::equals(

--- a/src/cpp/dynamic-types/MemberDescriptor.cpp
+++ b/src/cpp/dynamic-types/MemberDescriptor.cpp
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <fastrtps/types/MemberDescriptor.h>
-#include <fastrtps/types/DynamicType.h>
-#include <fastrtps/types/TypeDescriptor.h>
-#include <fastrtps/types/AnnotationDescriptor.h>
-#include <fastrtps/types/DynamicTypeBuilderFactory.h>
 #include <fastdds/dds/log/Log.hpp>
+#include <fastrtps/types/AnnotationDescriptor.h>
+#include <fastrtps/types/DynamicType.h>
+#include <fastrtps/types/DynamicTypeBuilderFactory.h>
+#include <fastrtps/types/MemberDescriptor.h>
+#include <fastrtps/types/TypeDescriptor.h>
+#include <fastrtps/types/TypesBase.h>
 
 namespace eprosima {
 namespace fastrtps {
@@ -421,7 +422,7 @@ void MemberDescriptor::copy_annotations_from_type(
 {
     if (type)
     {
-        // Copy annotation from type
+        // Copy annotations from type
         uint32_t num_annotations = type->get_annotation_count();
         for (uint32_t i = 0; i < num_annotations; ++i)
         {

--- a/src/cpp/dynamic-types/MemberDescriptor.cpp
+++ b/src/cpp/dynamic-types/MemberDescriptor.cpp
@@ -31,6 +31,7 @@ MemberDescriptor::MemberDescriptor()
     , index_(INDEX_INVALID)
     , default_label_(false)
 {
+    copy_annotations_from_type(type_);
 }
 
 MemberDescriptor::MemberDescriptor(
@@ -43,6 +44,7 @@ MemberDescriptor::MemberDescriptor(
     , index_(index)
     , default_label_(false)
 {
+    copy_annotations_from_type(type_);
 }
 
 MemberDescriptor::MemberDescriptor(
@@ -55,51 +57,54 @@ MemberDescriptor::MemberDescriptor(
     , default_label_(false)
 {
     copy_from(descriptor);
+    copy_annotations_from_type(type_);
 }
 
 MemberDescriptor::MemberDescriptor(
         MemberId id,
         const std::string& name,
-        DynamicType_ptr type_)
+        DynamicType_ptr type)
     : name_(name)
     , id_(id)
-    , type_(type_)
+    , type_(type)
     , default_value_("")
     , index_(INDEX_INVALID)
     , default_label_(false)
 {
-
+    copy_annotations_from_type(type_);
 }
 
 MemberDescriptor::MemberDescriptor(
         MemberId id,
         const std::string& name,
-        DynamicType_ptr type_,
+        DynamicType_ptr type,
         const std::string& defaultValue)
     : name_(name)
     , id_(id)
-    , type_(type_)
+    , type_(type)
     , default_value_(defaultValue)
     , index_(INDEX_INVALID)
     , default_label_(false)
 {
+    copy_annotations_from_type(type_);
 }
 
 MemberDescriptor::MemberDescriptor(
         MemberId id,
         const std::string& name,
-        DynamicType_ptr type_,
+        DynamicType_ptr type,
         const std::string& defaultValue,
         const std::vector<uint64_t>& unionLabels,
         bool isDefaultLabel)
     : name_(name)
     , id_(id)
-    , type_(type_)
+    , type_(type)
     , default_value_(defaultValue)
     , index_(INDEX_INVALID)
     , default_label_(isDefaultLabel)
 {
     labels_ = unionLabels;
+    copy_annotations_from_type(type_);
 }
 
 MemberDescriptor::~MemberDescriptor()
@@ -409,6 +414,25 @@ bool MemberDescriptor::is_type_name_consistent(
         const std::string& sName) const
 {
     return TypeDescriptor::is_type_name_consistent(sName);
+}
+
+void MemberDescriptor::copy_annotations_from_type(
+        const DynamicType_ptr& type)
+{
+    if (type)
+    {
+        // Copy annotation from type
+        uint32_t num_annotations = type->get_annotation_count();
+        for (uint32_t i = 0; i < num_annotations; ++i)
+        {
+            AnnotationDescriptor ann;
+            type->get_annotation(ann, i);
+            AnnotationDescriptor* pNewDescriptor = new AnnotationDescriptor();
+            pNewDescriptor->copy_from(&ann);
+            annotation_.push_back(pNewDescriptor);
+        }
+    }
+
 }
 
 void MemberDescriptor::set_id(

--- a/src/cpp/rtps/xmlparser/XMLDynamicParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLDynamicParser.cpp
@@ -1464,11 +1464,7 @@ p_dynamictypebuilder_t XMLParser::parseXMLMemberDynamicType(
     {
         if (strncmp(memberTopicKey, "true", 5) == 0)
         {
-            memberBuilder->apply_annotation(types::ANNOTATION_KEY_ID, "key", "true");
-            if (p_dynamictype != nullptr)
-            {
-                p_dynamictype->apply_annotation(types::ANNOTATION_KEY_ID, "key", "true");
-            }
+            memberBuilder->apply_annotation(types::ANNOTATION_KEY_ID, "value", "true");
         }
     }
 

--- a/src/cpp/rtps/xmlparser/XMLDynamicParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLDynamicParser.cpp
@@ -1464,10 +1464,10 @@ p_dynamictypebuilder_t XMLParser::parseXMLMemberDynamicType(
     {
         if (strncmp(memberTopicKey, "true", 5) == 0)
         {
-            memberBuilder->apply_annotation(types::ANNOTATION_KEY_ID, "value", "true");
+            memberBuilder->apply_annotation(types::ANNOTATION_KEY_ID, "key", "true");
             if (p_dynamictype != nullptr)
             {
-                p_dynamictype->apply_annotation(types::ANNOTATION_KEY_ID, "value", "true");
+                p_dynamictype->apply_annotation(types::ANNOTATION_KEY_ID, "key", "true");
             }
         }
     }

--- a/src/cpp/rtps/xmlparser/XMLProfileManager.cpp
+++ b/src/cpp/rtps/xmlparser/XMLProfileManager.cpp
@@ -387,6 +387,22 @@ XMLP_ret XMLProfileManager::loadXMLString(
     return loaded_ret;
 }
 
+types::DynamicPubSubType* XMLProfileManager::CreateDynamicPubSubType(
+        const std::string& type_name)
+{
+    if (dynamic_types_.find(type_name) != dynamic_types_.end())
+    {
+        return new types::DynamicPubSubType(dynamic_types_[type_name]->build());
+    }
+    return nullptr;
+}
+
+void XMLProfileManager::DeleteDynamicPubSubType(
+        types::DynamicPubSubType* type)
+{
+    delete type;
+}
+
 XMLP_ret XMLProfileManager::extractProfiles(
         up_base_node_t profiles,
         const std::string& filename)

--- a/test/system/tools/xmlvalidation/XMLTesterExample_profile.xml
+++ b/test/system/tools/xmlvalidation/XMLTesterExample_profile.xml
@@ -865,6 +865,14 @@
                 <bit_value name="flag1"/>
             </bitmask>
         </type>
+
+        <type>
+            <struct name="my_keyed_struct">
+                <member name="first" type="int32"/>
+                <member name="second" type="int64"/>
+                <member name="third" type="int32" key="true"/>
+            </struct>
+        </type>
     </types>
 
     <library_settings>

--- a/test/system/tools/xmlvalidation/all_profile.xml
+++ b/test/system/tools/xmlvalidation/all_profile.xml
@@ -1108,6 +1108,14 @@
         </type>
 
         <type>
+            <struct name="my_keyed_struct">
+                <member name="first" type="int32"/>
+                <member name="second" type="int64"/>
+                <member name="third" type="int32" key="true"/>
+            </struct>
+        </type>
+
+        <type>
             <bitset name="my_bitset_inner">
                 <bitfield bit_bound="10" name="a" type="int16"/>
                 <bitfield bit_bound="11" name="b"/>

--- a/test/system/tools/xmlvalidation/types_profile.xml
+++ b/test/system/tools/xmlvalidation/types_profile.xml
@@ -88,6 +88,14 @@
         </type>
 
         <type>
+            <struct name="my_keyed_struct">
+                <member name="first" type="int32"/>
+                <member name="second" type="int64"/>
+                <member name="third" type="int32" key="true"/>
+            </struct>
+        </type>
+
+        <type>
             <bitset name="my_bitset_inner">
                 <bitfield bit_bound="10" name="a" type="int16"/>
                 <bitfield bit_bound="11" name="b"/>

--- a/test/unittest/dynamic_types/DynamicTypesTests.cpp
+++ b/test/unittest/dynamic_types/DynamicTypesTests.cpp
@@ -4946,6 +4946,29 @@ TEST_F(DynamicTypesTests, DynamicType_XML_Bitmask_test)
     }
 }
 
+TEST_F(DynamicTypesTests, DynamicType_XML_key_annotation)
+{
+    using namespace xmlparser;
+    using namespace types;
+
+    XMLP_ret ret = XMLProfileManager::loadXMLFile(DynamicTypesTests::config_file());
+    ASSERT_EQ(ret, XMLP_ret::XML_OK);
+
+    {
+        DynamicPubSubType* pbType = XMLProfileManager::CreateDynamicPubSubType("BoolStruct");
+        ASSERT_FALSE(pbType->m_isGetKeyDefined);
+        XMLProfileManager::DeleteDynamicPubSubType(pbType);
+    }
+
+    {
+        DynamicPubSubType* pbType = XMLProfileManager::CreateDynamicPubSubType("my_keyed_struct");
+        ASSERT_TRUE(pbType->m_isGetKeyDefined);
+        XMLProfileManager::DeleteDynamicPubSubType(pbType);
+    }
+
+    XMLProfileManager::DeleteInstance();
+}
+
 TEST(TypeIdentifierTests, MinimalTypeIdentifierComparision)
 {
     TypeIdentifier enum1 = *GetMyEnumIdentifier(false);

--- a/test/unittest/dynamic_types/types_profile.xml
+++ b/test/unittest/dynamic_types/types_profile.xml
@@ -267,4 +267,11 @@
             <bit_value name="flag5" position="5"/>
         </bitmask>
     </type>
+    <type>
+        <struct name="my_keyed_struct">
+            <member name="first" type="int32"/>
+            <member name="second" type="int64"/>
+            <member name="third" type="int32" key="true"/>
+        </struct>
+    </type>
 </types>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR:

- Fixes various things regarding the handling of `@key` annotation on dynamic types:
    - Copy the type annotations when creating MemberDescriptors
    - Fix `AnnotationDescriptor::key_annotation()` implementation
    - Fix population of `is_key_defined_` in `DynamicType::copy_from_builder()`
    - Simplify `DynamicType::key_annotation()` implementation
- On loading types from XML, add the `@key` annotation only to the member builder and not to the dynamic type, as `@key` only makes sense for members but not types.
- Adds the `key` attribute to members in XSD

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox with ❌ or __NO__.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - Related documentation PR: eProsima/Fast-DDS-docs#746
- [x] Applicable backports have been included in the description.


## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
