### PR TITLE
[20706] Make reader get_first_untaken_info() coherent with read()/take()

### DIFF
--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -785,7 +785,9 @@ public:
             const void* instance) const;
 
     /**
-     * @brief Returns information about the first untaken sample.
+     * @brief Returns information about the first untaken sample. This method is meant to be called prior to
+     * a read() or take() operation as it does not modify the status condition of the entity.
+     *
      *
      * @param [out] info Pointer to a SampleInfo_t structure to store first untaken sample information.
      *

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -199,7 +199,8 @@ public:
             SampleInfoSeq& sample_infos);
 
     /**
-     * @brief Returns information about the first untaken sample.
+     * @brief Returns information about the first untaken sample. This method is meant to be called prior to
+     * a read() or take() operation as it does not modify the status condition of the entity.
      * @param [out] info Pointer to a SampleInfo structure to store first untaken sample information.
      * @return true if sample info was returned. false if there is no sample to take.
      */

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
@@ -358,12 +358,13 @@ bool DataReaderHistory::get_first_untaken_info(
         auto& instance_changes = it.second->cache_changes;
         for (auto& instance_change : instance_changes)
         {
-            WriterProxy* wp;
+            WriterProxy* wp = nullptr;
             bool is_future_change = false;
 
+            if (mp_reader->begin_sample_access_nts(instance_change, wp, is_future_change))
             {
-                std::lock_guard<RecursiveTimedMutex> _(mp_reader->getMutex());
-                if (mp_reader->begin_sample_access_nts(instance_change, wp, is_future_change) && is_future_change)
+                mp_reader->end_sample_access_nts(instance_change, wp, false);
+                if (is_future_change)
                 {
                     continue;
                 }

--- a/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
@@ -16,6 +16,8 @@
 
 #include <gtest/gtest.h>
 
+#include <fastdds/dds/core/StackAllocatedSequence.hpp>
+#include <fastrtps/transport/test_UDPv4TransportDescriptor.h>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 
 #include "BlackboxTests.hpp"
@@ -228,6 +230,110 @@ TEST_P(DDSDataReader, ConsistentTotalUnreadAfterGetFirstUntakenInfo)
 
     //! Assert last operation
     ASSERT_EQ(result, ReturnCode_t::RETCODE_OK) << "Reader's unread count is: " << reader.get_unread_count();
+}
+
+//! Regression test for #20706
+//! get_first_untaken_info() returns the first valid change of an instance, not only the first
+//! cache change. This implies searching in all the cache changes of the instance.
+//! In the scenario of having multiple reliable writers and one reader with history size > 1 in the same topic,
+//! it can happen that get_first_untaken_info() returns OK (as it is not currently checking whether the change is in the future)
+//! but take() returns NO_DATA because it is waiting for a previous SequenceNumber from the writer.
+TEST(DDSDataReader, GetFirstUntakenInfoReturnsTheFirstValidChange)
+{
+    PubSubWriter<HelloWorldPubSubType> writer_1(TEST_TOPIC_NAME);
+    PubSubWriter<HelloWorldPubSubType> writer_2(TEST_TOPIC_NAME);
+    // The reader should not take nor read any sample in this test
+    PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME, false, false, false);
+
+    auto testTransport_1 = std::make_shared<test_UDPv4TransportDescriptor>();
+
+    EntityId_t writer1_id;
+    EntityId_t reader_id;
+
+    testTransport_1->drop_data_messages_filter_ =
+            [&writer1_id, &reader_id](eprosima::fastrtps::rtps::CDRMessage_t& msg)-> bool
+            {
+                uint32_t old_pos = msg.pos;
+
+                // see RTPS DDS 9.4.5.3 Data Submessage
+                EntityId_t readerID;
+                EntityId_t writerID;
+                SequenceNumber_t sn;
+
+                msg.pos += 2; // flags
+                msg.pos += 2; // octets to inline quos
+                CDRMessage::readEntityId(&msg, &readerID);
+                CDRMessage::readEntityId(&msg, &writerID);
+                CDRMessage::readSequenceNumber(&msg, &sn);
+
+                // restore buffer pos
+                msg.pos = old_pos;
+
+                // Loose Seqnum 1
+                if (writerID == writer1_id &&
+                        readerID == reader_id &&
+                        (sn == SequenceNumber_t{0, 1}))
+                {
+                    return true;
+                }
+
+                return false;
+            };
+
+    writer_1.disable_builtin_transport()
+            .add_user_transport_to_pparams(testTransport_1)
+            .history_depth(3)
+            .init();
+
+    writer_2.history_depth(3)
+            .init();
+
+    reader.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            .history_depth(3)
+            .init();
+
+    ASSERT_TRUE(writer_1.isInitialized());
+    ASSERT_TRUE(writer_2.isInitialized());
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer1_id = writer_1.datawriter_guid().entityId;
+    reader_id = reader.datareader_guid().entityId;
+
+    // Wait for discovery.
+    writer_1.wait_discovery();
+    writer_2.wait_discovery();
+    reader.wait_discovery(std::chrono::seconds::zero(), 2);
+
+    // Send writer_1 samples
+    auto data = default_helloworld_data_generator(3);
+
+    reader.startReception(data);
+    writer_1.send(data);
+
+    // The reader should have received samples 2,3 but not 1
+    // get_first_untaken_info() should never return OK since the received changes are all in the future.
+    // We try it several times in case the reader has not received the samples yet.
+    eprosima::fastdds::dds::SampleInfo info;
+    for (size_t i = 0; i < 3; i++)
+    {
+        ASSERT_NE(eprosima::fastrtps::types::ReturnCode_t::RETCODE_OK, reader.get_native_reader().get_first_untaken_info(
+                    &info));
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+
+    // Now we send data from writer_2 with no drops and all samples shall be received.
+    data = default_helloworld_data_generator(3);
+    writer_2.send(data);
+    reader.block_for_unread_count_of(3);
+
+    // get_first_untaken_info() must return OK now
+    ASSERT_EQ(eprosima::fastrtps::types::ReturnCode_t::RETCODE_OK,
+            reader.get_native_reader().get_first_untaken_info(&info));
+    eprosima::fastdds::dds::StackAllocatedSequence<HelloWorld*, 1> data_values;
+    eprosima::fastdds::dds::SampleInfoSeq sample_infos{1};
+    // As get_first_untaken_info() returns OK, take() must return OK too
+    ASSERT_EQ(eprosima::fastrtps::types::ReturnCode_t::RETCODE_OK,
+            reader.get_native_reader().take(data_values, sample_infos));
 }
 
 //! Regression test for Issues #3822 Github #3875


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR corrects the behavior of `get_first_untaken_info()` so that it retrieves the first valid cache change (checking whether the change is in the future or not), instead of just returning the first one in the instance (sorted by sourcetimestamp).
In the scenario of having multiple reliable writers and one reader with history size > 1 in the same topic, it can happen that `get_first_untaken_info()` returns `OK` (as it is not currently checking whether the change is in the future) but `take()` returns `NO_DATA`  because the change is in the future.

In addition, a brief doxygen documentation is added to be aware that the method is meant to be followed by a `read()` or `take()` since it does not modify the status condition of the entity.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
Fixes https://github.com/ros2/rmw_fastrtps/issues/749

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox with ❌ or __NO__.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [X] Applicable backports have been included in the description.


## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
