### PR TITLE
[20861] Implement copy_from_topic_qos method

### DIFF
--- a/include/fastdds/dds/publisher/Publisher.hpp
+++ b/include/fastdds/dds/publisher/Publisher.hpp
@@ -322,9 +322,8 @@ public:
      * @param[out] writer_qos
      * @param[in] topic_qos
      * @return RETCODE_OK if successful, an error code otherwise
-     * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
-    RTPS_DllAPI static ReturnCode_t copy_from_topic_qos(
+    RTPS_DllAPI ReturnCode_t copy_from_topic_qos(
             fastdds::dds::DataWriterQos& writer_qos,
             const fastdds::dds::TopicQos& topic_qos);
 

--- a/include/fastdds/dds/publisher/Publisher.hpp
+++ b/include/fastdds/dds/publisher/Publisher.hpp
@@ -323,7 +323,7 @@ public:
      * @param[in] topic_qos
      * @return RETCODE_OK if successful, an error code otherwise
      */
-    RTPS_DllAPI ReturnCode_t copy_from_topic_qos(
+    RTPS_DllAPI static ReturnCode_t copy_from_topic_qos(
             fastdds::dds::DataWriterQos& writer_qos,
             const fastdds::dds::TopicQos& topic_qos);
 

--- a/include/fastdds/dds/publisher/Publisher.hpp
+++ b/include/fastdds/dds/publisher/Publisher.hpp
@@ -324,9 +324,9 @@ public:
      * @return RETCODE_OK if successful, an error code otherwise
      * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
-    RTPS_DllAPI ReturnCode_t copy_from_topic_qos(
+    RTPS_DllAPI static ReturnCode_t copy_from_topic_qos(
             fastdds::dds::DataWriterQos& writer_qos,
-            const fastdds::dds::TopicQos& topic_qos) const;
+            const fastdds::dds::TopicQos& topic_qos);
 
     /**
      * Fills the DataWriterQos with the values of the XML profile.

--- a/include/fastdds/dds/publisher/qos/DataWriterQos.hpp
+++ b/include/fastdds/dds/publisher/qos/DataWriterQos.hpp
@@ -910,6 +910,7 @@ private:
 };
 
 RTPS_DllAPI extern const DataWriterQos DATAWRITER_QOS_DEFAULT;
+RTPS_DllAPI extern const DataWriterQos DATAWRITER_QOS_USE_TOPIC_QOS;
 
 } // namespace dds
 } // namespace fastdds

--- a/include/fastdds/dds/subscriber/Subscriber.hpp
+++ b/include/fastdds/dds/subscriber/Subscriber.hpp
@@ -361,7 +361,7 @@ public:
      * @param[in] topic_qos
      * @return RETCODE_OK if successful, an error code otherwise
      */
-    RTPS_DllAPI ReturnCode_t copy_from_topic_qos(
+    RTPS_DllAPI static ReturnCode_t copy_from_topic_qos(
             DataReaderQos& reader_qos,
             const TopicQos& topic_qos);
 

--- a/include/fastdds/dds/subscriber/Subscriber.hpp
+++ b/include/fastdds/dds/subscriber/Subscriber.hpp
@@ -360,9 +360,8 @@ public:
      * @param[in, out] reader_qos
      * @param[in] topic_qos
      * @return RETCODE_OK if successful, an error code otherwise
-     * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
-    RTPS_DllAPI static ReturnCode_t copy_from_topic_qos(
+    RTPS_DllAPI ReturnCode_t copy_from_topic_qos(
             DataReaderQos& reader_qos,
             const TopicQos& topic_qos);
 

--- a/include/fastdds/dds/subscriber/qos/DataReaderQos.hpp
+++ b/include/fastdds/dds/subscriber/qos/DataReaderQos.hpp
@@ -921,6 +921,7 @@ private:
 };
 
 RTPS_DllAPI extern const DataReaderQos DATAREADER_QOS_DEFAULT;
+RTPS_DllAPI extern const DataReaderQos DATAREADER_QOS_USE_TOPIC_QOS;
 
 } // namespace dds
 } // namespace fastdds

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -214,13 +214,17 @@ DataWriterImpl::DataWriterImpl(
 DataWriterQos DataWriterImpl::get_datawriter_qos_from_settings(
         const DataWriterQos& qos)
 {
-    DataWriterQos return_qos = publisher_->get_default_datawriter_qos();
-
-    if (&DATAWRITER_QOS_USE_TOPIC_QOS == &qos)
+    DataWriterQos return_qos;
+    if (&DATAWRITER_QOS_DEFAULT == &qos)
     {
+        return_qos = publisher_->get_default_datawriter_qos();
+    }
+    else if (&DATAWRITER_QOS_USE_TOPIC_QOS == &qos)
+    {
+        return_qos = publisher_->get_default_datawriter_qos();
         publisher_->copy_from_topic_qos(return_qos, topic_->get_qos());
     }
-    else if (&DATAWRITER_QOS_DEFAULT != &qos)
+    else
     {
         return_qos = qos;
     }

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -217,7 +217,8 @@ DataWriterImpl::DataWriterImpl(
     guid_ = { publisher_->get_participant_impl()->guid().guidPrefix, entity_id};
 }
 
-DataWriterQos DataWriterImpl::get_datawriter_qos_from_settings(const DataWriterQos& qos)
+DataWriterQos DataWriterImpl::get_datawriter_qos_from_settings(
+        const DataWriterQos& qos)
 {
     DataWriterQos data_writer_qos_;
     if (&qos == &DATAWRITER_QOS_DEFAULT)

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -156,14 +156,7 @@ DataWriterImpl::DataWriterImpl(
     : publisher_(p)
     , type_(type)
     , topic_(topic)
-    , qos_(&qos == &DATAWRITER_QOS_DEFAULT ? publisher_->get_default_datawriter_qos() :
-            (&qos == &DATAWRITER_QOS_USE_TOPIC_QOS ?
-            ([this]()->DataWriterQos
-            {
-                DataWriterQos default_qos_with_topic_qos_ = this->publisher_->get_default_datawriter_qos();
-                this->publisher_->copy_from_topic_qos(default_qos_with_topic_qos_, this->topic_->get_qos());
-                return default_qos_with_topic_qos_;
-            })() : qos))
+    , qos_(get_datawriter_qos_from_settings(qos))
     , listener_(listen)
     , history_(get_topic_attributes(qos_, *topic_, type_), type_->m_typeSize, qos_.endpoint().history_memory_policy,
             [this](
@@ -205,14 +198,7 @@ DataWriterImpl::DataWriterImpl(
     : publisher_(p)
     , type_(type)
     , topic_(topic)
-    , qos_(&qos == &DATAWRITER_QOS_DEFAULT ? publisher_->get_default_datawriter_qos() :
-            (&qos == &DATAWRITER_QOS_USE_TOPIC_QOS ?
-            ([this]()->DataWriterQos
-            {
-                DataWriterQos default_qos_with_topic_qos_ = this->publisher_->get_default_datawriter_qos();
-                this->publisher_->copy_from_topic_qos(default_qos_with_topic_qos_, this->topic_->get_qos());
-                return default_qos_with_topic_qos_;
-            })() : qos))
+    , qos_(get_datawriter_qos_from_settings(qos))
     , listener_(listen)
     , history_(get_topic_attributes(qos_, *topic_, type_), type_->m_typeSize, qos_.endpoint().history_memory_policy,
             [this](
@@ -229,6 +215,25 @@ DataWriterImpl::DataWriterImpl(
     , lifespan_duration_us_(qos_.lifespan().duration.to_ns() * 1e-3)
 {
     guid_ = { publisher_->get_participant_impl()->guid().guidPrefix, entity_id};
+}
+
+DataWriterQos DataWriterImpl::get_datawriter_qos_from_settings(const DataWriterQos& qos)
+{
+    DataWriterQos data_writer_qos_;
+    if (&qos == &DATAWRITER_QOS_DEFAULT)
+    {
+        data_writer_qos_ = this->publisher_->get_default_datawriter_qos();
+    }
+    else if (&qos == &DATAWRITER_QOS_USE_TOPIC_QOS)
+    {
+        data_writer_qos_ = this->publisher_->get_default_datawriter_qos();
+        this->publisher_->copy_from_topic_qos(data_writer_qos_, this->topic_->get_qos());
+    }
+    else
+    {
+        data_writer_qos_ = qos;
+    }
+    return data_writer_qos_;
 }
 
 ReturnCode_t DataWriterImpl::enable()

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -156,7 +156,14 @@ DataWriterImpl::DataWriterImpl(
     : publisher_(p)
     , type_(type)
     , topic_(topic)
-    , qos_(&qos == &DATAWRITER_QOS_DEFAULT ? publisher_->get_default_datawriter_qos() : qos)
+    , qos_(&qos == &DATAWRITER_QOS_DEFAULT ? publisher_->get_default_datawriter_qos() :
+            (&qos == &DATAWRITER_QOS_USE_TOPIC_QOS ?
+            ([this]()->DataWriterQos
+            {
+                DataWriterQos default_qos_with_topic_qos_ = this->publisher_->get_default_datawriter_qos();
+                this->publisher_->copy_from_topic_qos(default_qos_with_topic_qos_, this->topic_->get_qos());
+                return default_qos_with_topic_qos_;
+            })() : qos))
     , listener_(listen)
     , history_(get_topic_attributes(qos_, *topic_, type_), type_->m_typeSize, qos_.endpoint().history_memory_policy,
             [this](
@@ -198,7 +205,14 @@ DataWriterImpl::DataWriterImpl(
     : publisher_(p)
     , type_(type)
     , topic_(topic)
-    , qos_(&qos == &DATAWRITER_QOS_DEFAULT ? publisher_->get_default_datawriter_qos() : qos)
+    , qos_(&qos == &DATAWRITER_QOS_DEFAULT ? publisher_->get_default_datawriter_qos() :
+            (&qos == &DATAWRITER_QOS_USE_TOPIC_QOS ?
+            ([this]()->DataWriterQos
+            {
+                DataWriterQos default_qos_with_topic_qos_ = this->publisher_->get_default_datawriter_qos();
+                this->publisher_->copy_from_topic_qos(default_qos_with_topic_qos_, this->topic_->get_qos());
+                return default_qos_with_topic_qos_;
+            })() : qos))
     , listener_(listen)
     , history_(get_topic_attributes(qos_, *topic_, type_), type_->m_typeSize, qos_.endpoint().history_memory_policy,
             [this](

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -733,6 +733,9 @@ protected:
     bool is_relevant(
             const fastrtps::rtps::CacheChange_t& change,
             const fastrtps::rtps::GUID_t& reader_guid) const override;
+private:
+
+    DataWriterQos get_datawriter_qos_from_settings(const DataWriterQos& qos);
 
 };
 

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -733,9 +733,11 @@ protected:
     bool is_relevant(
             const fastrtps::rtps::CacheChange_t& change,
             const fastrtps::rtps::GUID_t& reader_guid) const override;
+
 private:
 
-    DataWriterQos get_datawriter_qos_from_settings(const DataWriterQos& qos);
+    DataWriterQos get_datawriter_qos_from_settings(
+            const DataWriterQos& qos);
 
 };
 

--- a/src/cpp/fastdds/publisher/Publisher.cpp
+++ b/src/cpp/fastdds/publisher/Publisher.cpp
@@ -210,12 +210,7 @@ ReturnCode_t Publisher::copy_from_topic_qos(
         fastdds::dds::DataWriterQos& writer_qos,
         const fastdds::dds::TopicQos& topic_qos)
 {
-    static_cast<void> (writer_qos);
-    static_cast<void> (topic_qos);
-    return ReturnCode_t::RETCODE_UNSUPPORTED;
-    /*
-       return impl_->copy_from_topic_qos(writer_qos, topic_qos);
-     */
+    return impl_->copy_from_topic_qos(writer_qos, topic_qos);
 }
 
 const fastrtps::rtps::InstanceHandle_t& Publisher::get_instance_handle() const

--- a/src/cpp/fastdds/publisher/Publisher.cpp
+++ b/src/cpp/fastdds/publisher/Publisher.cpp
@@ -210,7 +210,7 @@ ReturnCode_t Publisher::copy_from_topic_qos(
         fastdds::dds::DataWriterQos& writer_qos,
         const fastdds::dds::TopicQos& topic_qos)
 {
-    return impl_->copy_from_topic_qos(writer_qos, topic_qos);
+    return PublisherImpl::copy_from_topic_qos(writer_qos, topic_qos);
 }
 
 const fastrtps::rtps::InstanceHandle_t& Publisher::get_instance_handle() const

--- a/src/cpp/fastdds/publisher/Publisher.cpp
+++ b/src/cpp/fastdds/publisher/Publisher.cpp
@@ -208,7 +208,7 @@ ReturnCode_t Publisher::get_default_datawriter_qos(
 
 ReturnCode_t Publisher::copy_from_topic_qos(
         fastdds::dds::DataWriterQos& writer_qos,
-        const fastdds::dds::TopicQos& topic_qos) const
+        const fastdds::dds::TopicQos& topic_qos)
 {
     static_cast<void> (writer_qos);
     static_cast<void> (topic_qos);

--- a/src/cpp/fastdds/publisher/PublisherImpl.cpp
+++ b/src/cpp/fastdds/publisher/PublisherImpl.cpp
@@ -483,7 +483,7 @@ const ReturnCode_t PublisherImpl::get_datawriter_qos_from_profile(
 
 ReturnCode_t PublisherImpl::copy_from_topic_qos(
         DataWriterQos& writer_qos,
-        const TopicQos& topic_qos)const
+        const TopicQos& topic_qos)
 {
     writer_qos.durability(topic_qos.durability());
     writer_qos.durability_service(topic_qos.durability_service());

--- a/src/cpp/fastdds/publisher/PublisherImpl.cpp
+++ b/src/cpp/fastdds/publisher/PublisherImpl.cpp
@@ -481,15 +481,25 @@ const ReturnCode_t PublisherImpl::get_datawriter_qos_from_profile(
     return ReturnCode_t::RETCODE_BAD_PARAMETER;
 }
 
-/* TODO
-   bool PublisherImpl::copy_from_topic_qos(
-        fastrtps::WriterQos&,
-        const fastrtps::TopicAttributes&) const
-   {
-    EPROSIMA_LOG_ERROR(PUBLISHER, "Operation not implemented");
-    return false;
-   }
- */
+ReturnCode_t PublisherImpl::copy_from_topic_qos(
+        DataWriterQos& writer_qos,
+        const TopicQos& topic_qos)const
+{
+    writer_qos.durability(topic_qos.durability());
+    writer_qos.durability_service(topic_qos.durability_service());
+    writer_qos.deadline(topic_qos.deadline());
+    writer_qos.latency_budget(topic_qos.latency_budget());
+    writer_qos.liveliness(topic_qos.liveliness());
+    writer_qos.reliability(topic_qos.reliability());
+    writer_qos.destination_order(topic_qos.destination_order());
+    writer_qos.history(topic_qos.history());
+    writer_qos.resource_limits(topic_qos.resource_limits());
+    writer_qos.transport_priority(topic_qos.transport_priority());
+    writer_qos.lifespan(topic_qos.lifespan());
+    writer_qos.ownership(topic_qos.ownership());
+    writer_qos.representation(topic_qos.representation());
+    return ReturnCode_t::RETCODE_OK;
+}
 
 ReturnCode_t PublisherImpl::wait_for_acknowledgments(
         const Duration_t& max_wait)

--- a/src/cpp/fastdds/publisher/PublisherImpl.hpp
+++ b/src/cpp/fastdds/publisher/PublisherImpl.hpp
@@ -174,9 +174,9 @@ public:
             const std::string& profile_name,
             DataWriterQos& qos) const;
 
-    ReturnCode_t copy_from_topic_qos(
+    ReturnCode_t static copy_from_topic_qos(
             DataWriterQos& writer_qos,
-            const TopicQos& topic_qos) const;
+            const TopicQos& topic_qos);
 
     fastrtps::rtps::RTPSParticipant* rtps_participant() const
     {

--- a/src/cpp/fastdds/publisher/PublisherImpl.hpp
+++ b/src/cpp/fastdds/publisher/PublisherImpl.hpp
@@ -28,6 +28,7 @@
 #include <fastdds/dds/publisher/qos/PublisherQos.hpp>
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
 #include <fastdds/dds/core/status/StatusMask.hpp>
+#include <fastdds/dds/topic/qos/TopicQos.hpp>
 #include <fastrtps/types/TypesBase.h>
 #include <fastrtps/qos/DeadlineMissedStatus.h>
 #include <fastrtps/qos/IncompatibleQosStatus.hpp>
@@ -173,11 +174,9 @@ public:
             const std::string& profile_name,
             DataWriterQos& qos) const;
 
-    /* TODO
-       bool copy_from_topic_qos(
-            WriterQos& writer_qos,
-            const fastrtps::TopicAttributes& topic_qos) const;
-     */
+    ReturnCode_t copy_from_topic_qos(
+            DataWriterQos& writer_qos,
+            const TopicQos& topic_qos) const;
 
     fastrtps::rtps::RTPSParticipant* rtps_participant() const
     {

--- a/src/cpp/fastdds/publisher/qos/DataWriterQos.cpp
+++ b/src/cpp/fastdds/publisher/qos/DataWriterQos.cpp
@@ -23,6 +23,7 @@
 using namespace eprosima::fastdds::dds;
 
 const DataWriterQos eprosima::fastdds::dds::DATAWRITER_QOS_DEFAULT;
+const DataWriterQos eprosima::fastdds::dds::DATAWRITER_QOS_USE_TOPIC_QOS;
 
 DataWriterQos::DataWriterQos()
 {

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -140,7 +140,8 @@ DataReaderImpl::DataReaderImpl(
 
 //TODO when MultiTopic is supported: using DATAREADER_QOS_USE_TOPIC_QOS when creating
 //a DataReader with MultiTopic should return error.
-DataReaderQos DataReaderImpl::get_datareader_qos_from_settings(const DataReaderQos& qos)
+DataReaderQos DataReaderImpl::get_datareader_qos_from_settings(
+        const DataReaderQos& qos)
 {
     Topic* topicPtr = dynamic_cast<Topic*>(this->topic_);
     DataReaderQos data_reader_qos_;

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -133,20 +133,24 @@ DataReaderImpl::DataReaderImpl(
 DataReaderQos DataReaderImpl::get_datareader_qos_from_settings(
         const DataReaderQos& qos)
 {
-    DataReaderQos return_qos = subscriber_->get_default_datareader_qos();
+    DataReaderQos return_qos;
 
-    Topic* topic = dynamic_cast<Topic*>(topic_);
-
-    if (topic != nullptr)
+    if (&DATAREADER_QOS_DEFAULT == &qos)
     {
-        if (&DATAREADER_QOS_USE_TOPIC_QOS == &qos)
+        return_qos = subscriber_->get_default_datareader_qos();
+    }
+    else if (&DATAREADER_QOS_USE_TOPIC_QOS == &qos)
+    {
+        Topic* topic = dynamic_cast<Topic*>(topic_);
+        if (topic != nullptr)
         {
+            return_qos = subscriber_->get_default_datareader_qos();
             subscriber_->copy_from_topic_qos(return_qos, topic->get_qos());
         }
-        else if (&DATAREADER_QOS_DEFAULT != &qos)
-        {
-            return_qos = qos;
-        }
+    }
+    else
+    {
+        return_qos = qos;
     }
 
     return return_qos;

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -15,19 +15,16 @@
 /**
  * @file DataReaderImpl.cpp
  */
+#include <fastdds/subscriber/DataReaderImpl.hpp>
 
 #include <memory>
 #include <stdexcept>
-
 #if defined(__has_include) && __has_include(<version>)
 #   include <version>
 #endif // if defined(__has_include) && __has_include(<version>)
 
-#include <fastrtps/config.h>
-
-#include <fastdds/subscriber/DataReaderImpl.hpp>
-#include <fastdds/subscriber/ReadConditionImpl.hpp>
-
+#include <fastdds/core/condition/StatusConditionImpl.hpp>
+#include <fastdds/core/policy/QosPolicyUtils.hpp>
 #include <fastdds/dds/core/StackAllocatedSequence.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/log/Log.hpp>
@@ -37,30 +34,23 @@
 #include <fastdds/dds/subscriber/SubscriberListener.hpp>
 #include <fastdds/dds/topic/Topic.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
-
-#include <fastdds/rtps/RTPSDomain.h>
+#include <fastdds/domain/DomainParticipantImpl.hpp>
 #include <fastdds/rtps/participant/RTPSParticipant.h>
 #include <fastdds/rtps/reader/RTPSReader.h>
 #include <fastdds/rtps/resources/ResourceEvent.h>
 #include <fastdds/rtps/resources/TimedEvent.h>
-
-#include <fastdds/core/condition/StatusConditionImpl.hpp>
-#include <fastdds/core/policy/QosPolicyUtils.hpp>
-
-#include <fastdds/domain/DomainParticipantImpl.hpp>
-
-#include <fastdds/subscriber/SubscriberImpl.hpp>
+#include <fastdds/rtps/RTPSDomain.h>
 #include <fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp>
 #include <fastdds/subscriber/DataReaderImpl/StateFilter.hpp>
-
+#include <fastdds/subscriber/ReadConditionImpl.hpp>
+#include <fastdds/subscriber/SubscriberImpl.hpp>
 #include <fastdds/topic/ContentFilteredTopicImpl.hpp>
-
-#include <fastrtps/utils/TimeConversion.h>
+#include <fastrtps/config.h>
 #include <fastrtps/subscriber/SampleInfo.h>
+#include <fastrtps/utils/TimeConversion.h>
 
 #include <rtps/history/TopicPayloadPoolRegistry.hpp>
 #include <rtps/participant/RTPSParticipantImpl.h>
-
 #ifdef FASTDDS_STATISTICS
 #include <statistics/fastdds/domain/DomainParticipantImpl.hpp>
 #include <statistics/types/monitorservice_types.h>
@@ -138,27 +128,28 @@ DataReaderImpl::DataReaderImpl(
     }
 }
 
-//TODO when MultiTopic is supported: using DATAREADER_QOS_USE_TOPIC_QOS when creating
-//a DataReader with MultiTopic should return error.
+// TODO(elianalf): when MultiTopic is supported: using DATAREADER_QOS_USE_TOPIC_QOS when creating
+// a DataReader with MultiTopic should return error.
 DataReaderQos DataReaderImpl::get_datareader_qos_from_settings(
         const DataReaderQos& qos)
 {
-    Topic* topicPtr = dynamic_cast<Topic*>(this->topic_);
-    DataReaderQos data_reader_qos_;
-    if (&qos == &DATAREADER_QOS_DEFAULT)
+    DataReaderQos return_qos = subscriber_->get_default_datareader_qos();
+
+    Topic* topic = dynamic_cast<Topic*>(topic_);
+
+    if (topic != nullptr)
     {
-        data_reader_qos_ = this->subscriber_->get_default_datareader_qos();
+        if (&DATAREADER_QOS_USE_TOPIC_QOS == &qos)
+        {
+            subscriber_->copy_from_topic_qos(return_qos, topic->get_qos());
+        }
+        else if (&DATAREADER_QOS_DEFAULT != &qos)
+        {
+            return_qos = qos;
+        }
     }
-    else if (&qos == &DATAREADER_QOS_USE_TOPIC_QOS)
-    {
-        data_reader_qos_ = this->subscriber_->get_default_datareader_qos();
-        this->subscriber_->copy_from_topic_qos(data_reader_qos_, topicPtr->get_qos());
-    }
-    else
-    {
-        data_reader_qos_ = qos;
-    }
-    return data_reader_qos_;
+
+    return return_qos;
 }
 
 ReturnCode_t DataReaderImpl::enable()

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -651,6 +651,8 @@ protected:
 private:
 
     void update_rtps_reader_qos();
+    DataReaderQos get_datareader_qos_from_settings(const DataReaderQos& qos);
+
 
 };
 

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -27,29 +27,26 @@
 #include <fastdds/dds/core/LoanableSequence.hpp>
 #include <fastdds/dds/core/status/StatusMask.hpp>
 #include <fastdds/dds/subscriber/DataReaderListener.hpp>
-#include <fastdds/dds/subscriber/SampleInfo.hpp>
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
-#include <fastdds/dds/topic/TypeSupport.hpp>
 #include <fastdds/dds/subscriber/ReadCondition.hpp>
-
+#include <fastdds/dds/subscriber/SampleInfo.hpp>
+#include <fastdds/dds/topic/TypeSupport.hpp>
 #include <fastdds/rtps/attributes/ReaderAttributes.h>
-#include <fastdds/rtps/common/LocatorList.hpp>
 #include <fastdds/rtps/common/Guid.h>
+#include <fastdds/rtps/common/LocatorList.hpp>
 #include <fastdds/rtps/history/IPayloadPool.h>
 #include <fastdds/rtps/reader/ReaderListener.h>
-
-#include <fastrtps/attributes/TopicAttributes.h>
-#include <fastrtps/qos/LivelinessChangedStatus.h>
-#include <fastrtps/types/TypesBase.h>
-
 #include <fastdds/subscriber/DataReaderImpl/DataReaderLoanManager.hpp>
 #include <fastdds/subscriber/DataReaderImpl/SampleInfoPool.hpp>
 #include <fastdds/subscriber/DataReaderImpl/SampleLoanManager.hpp>
 #include <fastdds/subscriber/DataReaderImpl/StateFilter.hpp>
-#include <fastdds/subscriber/SubscriberImpl.hpp>
-#include <rtps/history/ITopicPayloadPool.h>
-
 #include <fastdds/subscriber/history/DataReaderHistory.hpp>
+#include <fastdds/subscriber/SubscriberImpl.hpp>
+#include <fastrtps/attributes/TopicAttributes.h>
+#include <fastrtps/qos/LivelinessChangedStatus.h>
+#include <fastrtps/types/TypesBase.h>
+
+#include <rtps/history/ITopicPayloadPool.h>
 
 namespace eprosima {
 namespace fastrtps {
@@ -651,6 +648,7 @@ protected:
 private:
 
     void update_rtps_reader_qos();
+
     DataReaderQos get_datareader_qos_from_settings(
             const DataReaderQos& qos);
 

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -651,7 +651,8 @@ protected:
 private:
 
     void update_rtps_reader_qos();
-    DataReaderQos get_datareader_qos_from_settings(const DataReaderQos& qos);
+    DataReaderQos get_datareader_qos_from_settings(
+            const DataReaderQos& qos);
 
 
 };

--- a/src/cpp/fastdds/subscriber/Subscriber.cpp
+++ b/src/cpp/fastdds/subscriber/Subscriber.cpp
@@ -221,12 +221,7 @@ ReturnCode_t Subscriber::copy_from_topic_qos(
         DataReaderQos& reader_qos,
         const TopicQos& topic_qos)
 {
-    static_cast<void> (reader_qos);
-    static_cast<void> (topic_qos);
-    return ReturnCode_t::RETCODE_UNSUPPORTED;
-    /*
-       return impl_->copy_from_topic_qos(reader_qos, topic_qos);
-     */
+    return impl_->copy_from_topic_qos(reader_qos, topic_qos);
 }
 
 const DomainParticipant* Subscriber::get_participant() const

--- a/src/cpp/fastdds/subscriber/Subscriber.cpp
+++ b/src/cpp/fastdds/subscriber/Subscriber.cpp
@@ -221,7 +221,7 @@ ReturnCode_t Subscriber::copy_from_topic_qos(
         DataReaderQos& reader_qos,
         const TopicQos& topic_qos)
 {
-    return impl_->copy_from_topic_qos(reader_qos, topic_qos);
+    return SubscriberImpl::copy_from_topic_qos(reader_qos, topic_qos);
 }
 
 const DomainParticipant* Subscriber::get_participant() const

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -444,7 +444,7 @@ const ReturnCode_t SubscriberImpl::get_datareader_qos_from_profile(
 
 ReturnCode_t SubscriberImpl::copy_from_topic_qos(
         DataReaderQos& reader_qos,
-        const TopicQos& topic_qos) const
+        const TopicQos& topic_qos)
 {
     TypeConsistencyQos new_value;
     reader_qos.durability(topic_qos.durability());

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -16,31 +16,24 @@
  * @file SubscriberImpl.cpp
  *
  */
-
-#include <fastdds/subscriber/SubscriberImpl.hpp>
-#include <fastdds/subscriber/DataReaderImpl.hpp>
-#include <fastdds/topic/TopicDescriptionImpl.hpp>
-#include <fastdds/domain/DomainParticipantImpl.hpp>
-
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/DomainParticipantListener.hpp>
-
+#include <fastdds/dds/log/Log.hpp>
+#include <fastdds/dds/subscriber/DataReader.hpp>
 #include <fastdds/dds/subscriber/Subscriber.hpp>
 #include <fastdds/dds/subscriber/SubscriberListener.hpp>
-#include <fastdds/dds/subscriber/DataReader.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
-#include <fastdds/utils/QosConverters.hpp>
-
-#include <fastdds/dds/log/Log.hpp>
 #include <fastdds/rtps/common/Property.h>
 #include <fastdds/rtps/participant/RTPSParticipant.h>
-
-#include <rtps/network/utils/netmask_filter.hpp>
-
 #include <fastrtps/attributes/SubscriberAttributes.h>
-
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 
+#include <fastdds/domain/DomainParticipantImpl.hpp>
+#include <fastdds/subscriber/DataReaderImpl.hpp>
+#include <fastdds/subscriber/SubscriberImpl.hpp>
+#include <fastdds/topic/TopicDescriptionImpl.hpp>
+#include <fastdds/utils/QosConverters.hpp>
+#include <rtps/network/utils/netmask_filter.hpp>
 #ifdef FASTDDS_STATISTICS
 #include <statistics/types/monitorservice_types.h>
 #endif //FASTDDS_STATISTICS
@@ -456,10 +449,8 @@ ReturnCode_t SubscriberImpl::copy_from_topic_qos(
     reader_qos.destination_order(topic_qos.destination_order());
     reader_qos.history(topic_qos.history());
     reader_qos.resource_limits(topic_qos.resource_limits());
-    reader_qos.lifespan(topic_qos.lifespan());
     reader_qos.ownership(topic_qos.ownership());
-    new_value.representation = topic_qos.representation();
-    reader_qos.type_consistency(new_value);
+    reader_qos.type_consistency().representation = topic_qos.representation();
     return ReturnCode_t::RETCODE_OK;
 }
 

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -442,15 +442,26 @@ const ReturnCode_t SubscriberImpl::get_datareader_qos_from_profile(
     return ReturnCode_t::RETCODE_BAD_PARAMETER;
 }
 
-/* TODO
-   bool SubscriberImpl::copy_from_topic_qos(
-        DataReaderQos&,
-        const fastrtps::TopicAttributes&) const
-   {
-    EPROSIMA_LOG_ERROR(PUBLISHER, "Operation not implemented");
-    return false;
-   }
- */
+ReturnCode_t SubscriberImpl::copy_from_topic_qos(
+        DataReaderQos& reader_qos,
+        const TopicQos& topic_qos) const
+{
+    TypeConsistencyQos new_value;
+    reader_qos.durability(topic_qos.durability());
+    reader_qos.durability_service(topic_qos.durability_service());
+    reader_qos.deadline(topic_qos.deadline());
+    reader_qos.latency_budget(topic_qos.latency_budget());
+    reader_qos.liveliness(topic_qos.liveliness());
+    reader_qos.reliability(topic_qos.reliability());
+    reader_qos.destination_order(topic_qos.destination_order());
+    reader_qos.history(topic_qos.history());
+    reader_qos.resource_limits(topic_qos.resource_limits());
+    reader_qos.lifespan(topic_qos.lifespan());
+    reader_qos.ownership(topic_qos.ownership());
+    new_value.representation = topic_qos.representation();
+    reader_qos.type_consistency(new_value);
+    return ReturnCode_t::RETCODE_OK;
+}
 
 const DomainParticipant* SubscriberImpl::get_participant() const
 {

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
@@ -153,9 +153,9 @@ public:
             const std::string& profile_name,
             DataReaderQos& qos) const;
 
-    ReturnCode_t copy_from_topic_qos(
+    ReturnCode_t static copy_from_topic_qos(
             DataReaderQos& reader_qos,
-            const TopicQos& topic_qos) const;
+            const TopicQos& topic_qos);
 
     const DomainParticipant* get_participant() const;
 

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
@@ -28,6 +28,7 @@
 #include <fastdds/dds/subscriber/DataReaderListener.hpp>
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 #include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
+#include <fastdds/dds/topic/qos/TopicQos.hpp>
 #include <fastrtps/attributes/SubscriberAttributes.h>
 #include <fastrtps/types/TypesBase.h>
 
@@ -152,11 +153,9 @@ public:
             const std::string& profile_name,
             DataReaderQos& qos) const;
 
-    /* TODO
-       bool copy_from_topic_qos(
-            ReaderQos& reader_qos,
-            const fastrtps::TopicAttributes& topic_qos) const;
-     */
+    ReturnCode_t copy_from_topic_qos(
+            DataReaderQos& reader_qos,
+            const TopicQos& topic_qos) const;
 
     const DomainParticipant* get_participant() const;
 

--- a/src/cpp/fastdds/subscriber/qos/DataReaderQos.cpp
+++ b/src/cpp/fastdds/subscriber/qos/DataReaderQos.cpp
@@ -25,6 +25,7 @@ namespace fastdds {
 namespace dds {
 
 const DataReaderQos DATAREADER_QOS_DEFAULT;
+const DataReaderQos DATAREADER_QOS_USE_TOPIC_QOS;
 
 ReaderQos DataReaderQos::get_readerqos(
         const SubscriberQos& sqos) const

--- a/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
@@ -13,11 +13,22 @@
 // limitations under the License.
 
 #include <thread>
+#include <type_traits>
 
 #include <gtest/gtest.h>
 
 #include <fastdds/dds/core/StackAllocatedSequence.hpp>
+#include <fastdds/dds/domain/DomainParticipant.hpp>
+#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
+#include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
+#include <fastdds/dds/subscriber/DataReader.hpp>
+#include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
+#include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
+#include <fastdds/dds/subscriber/Subscriber.hpp>
+#include <fastdds/dds/topic/qos/TopicQos.hpp>
+#include <fastdds/dds/topic/Topic.hpp>
 #include <fastrtps/transport/test_UDPv4TransportDescriptor.h>
+#include <fastrtps/types/TypesBase.h>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 
 #include "BlackboxTests.hpp"
@@ -414,117 +425,114 @@ TEST(DDSDataReader, default_qos_large_history_depth)
     ASSERT_TRUE(reader.isInitialized());
 }
 
+/**
+ * Utility class to set some values other than default to those Qos common to Topic and DataReader.
+ *
+ * This is a class instead of a free function to avoid linking with its TestsDataWriter counterpart.
+ */
+class TestsDataReaderQosCommonUtils
+{
+public:
+
+    // Set common Qos values to both TopicQos and DataReaderQos
+    template<typename T>
+    static void set_common_qos(
+            T& qos)
+    {
+        qos.durability_service().history_kind = eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS;
+        qos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
+        qos.durability().kind = eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS;
+        qos.deadline().period = {0, 500000000};
+        qos.latency_budget().duration = 0;
+        qos.liveliness().kind = eprosima::fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS;
+        qos.resource_limits().max_samples = 1000;
+        qos.ownership().kind = eprosima::fastdds::dds::EXCLUSIVE_OWNERSHIP_QOS;
+        // Representation is not on the same place in DataReaderQos and TopicQos
+        set_representation_qos(qos);
+        qos.history().kind = eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS;
+    }
+
+private:
+
+    // Set representation Qos (as it is not in the same place in DataReaderQos and TopicQos)
+    template<typename T>
+    static void set_representation_qos(
+            T& qos);
+};
+
+// Specialization for DataReaderQos
+template<>
+void TestsDataReaderQosCommonUtils::set_representation_qos(
+        eprosima::fastdds::dds::DataReaderQos& qos)
+{
+    qos.type_consistency().representation.m_value.push_back(
+        eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
+}
+
+// Specialization for TopicQos
+template<>
+void TestsDataReaderQosCommonUtils::set_representation_qos(
+        eprosima::fastdds::dds::TopicQos& qos)
+{
+    qos.representation().m_value.push_back(eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
+}
+
 /*
- * This test creates a DataReader using DATAREADER_QOS_USE_TOPIC_QOS and checks if DataReader QoS
- * are correctly set from Topic QoS. It also checks if the QoS that is not in common with Topic QoS
- * is correctly set as the default ones.
+ * This test:
+ *   1. Creates a Topic with custom Qos
+ *   2. Updates the default DataReader Qos that are not in common with Topic Qos with non-default values
+ *   3. Creates a DataReader with DATAREADER_QOS_USE_TOPIC_QOS
+ *   4. Checks that the used Qos are the merge between the default ones and the Topic ones
  */
 TEST(DDSDataReader, datareader_qos_use_topic_qos)
 {
     using namespace eprosima::fastdds::dds;
 
-    // Set custom Topic QoS
+    /* Create a topic with custom Qos */
+    // Set Topic Qos different from default
     TopicQos topic_qos;
-    DurabilityServiceQosPolicy durability_service;
-    durability_service.history_kind = eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS;
-    topic_qos.durability_service(durability_service);
-    ReliabilityQosPolicy reliability;
-    reliability.kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
-    topic_qos.reliability(reliability);
-    DurabilityQosPolicy durability;
-    durability.kind = eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS;
-    topic_qos.durability(durability);
-    DeadlineQosPolicy deadline;
-    deadline.period = {0, 500000000};
-    topic_qos.deadline(deadline);
-    LatencyBudgetQosPolicy latency;
-    latency.duration = 0;
-    topic_qos.latency_budget(latency);
-    LivelinessQosPolicy liveliness;
-    liveliness.kind = eprosima::fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS;
-    topic_qos.liveliness(liveliness);
-    ResourceLimitsQosPolicy resource_limit;
-    resource_limit.max_samples = 1000;
-    topic_qos.resource_limits(resource_limit);
-    OwnershipQosPolicy ownership;
-    ownership.kind = eprosima::fastdds::dds::EXCLUSIVE_OWNERSHIP_QOS;
-    topic_qos.ownership(ownership);
-    DataRepresentationQosPolicy data_rep;
-    data_rep.m_value.push_back(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
-    topic_qos.representation(data_rep);
-    HistoryQosPolicy history;
-    history.kind = eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS;
-    topic_qos.history(history);
-    LifespanQosPolicy lifespan;
-    lifespan.duration = {5, 0};
-    topic_qos.lifespan(lifespan);
+    TestsDataReaderQosCommonUtils::set_common_qos(topic_qos);
 
-    DomainParticipant* participant_ =
+    // Create DomainParticipant
+    DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
-    ASSERT_NE(participant_, nullptr);
+    ASSERT_NE(participant, nullptr);
 
-    TypeSupport type_support_;
-    type_support_.reset(new HelloWorldPubSubType());
-    type_support_.register_type(participant_, "HelloWorld");
-    Topic* topic_ = participant_->create_topic("HelloWorldTopic", "HelloWorld", topic_qos);
-    //Set default qos
-    SubscriberQos s_qos;
-    s_qos.presentation().access_scope = eprosima::fastdds::dds::TOPIC_PRESENTATION_QOS;
-    std::vector<std::string> part; //Getter function
-    part.push_back("part1");
-    s_qos.partition().names(part);
-    GroupDataQosPolicy group_data;
-    std::vector<eprosima::fastrtps::rtps::octet> vec;
-    eprosima::fastrtps::rtps::octet val = 3;
-    vec.push_back(val);
-    group_data.data_vec(vec);
-    s_qos.group_data(group_data);
-    EntityFactoryQosPolicy entity_factory;
-    entity_factory.autoenable_created_entities = false;
-    s_qos.entity_factory(entity_factory);
-    participant_->set_default_subscriber_qos(s_qos);
-    Subscriber* subscriber_ = participant_->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
-    ASSERT_NE(subscriber_, nullptr);
-    DataReaderQos r_qos;
-    r_qos.reader_data_lifecycle().autopurge_no_writer_samples_delay = {3, 0};
-    r_qos.user_data().push_back(0);
-    RTPSEndpointQos endpoint_;
-    endpoint_.entity_id = 1;
-    r_qos.endpoint(endpoint_);
-    ReaderResourceLimitsQos reader_limits;
-    reader_limits.matched_publisher_allocation = ResourceLimitedContainerConfig::fixed_size_configuration(1u);
-    r_qos.reader_resource_limits(reader_limits);
-    r_qos.data_sharing().off();
-    subscriber_->set_default_datareader_qos(r_qos);
+    // Create Topic
+    TypeSupport type_support;
+    type_support.reset(new HelloWorldPubSubType());
+    type_support.register_type(participant, "HelloWorld");
+    Topic* topic = participant->create_topic("HelloWorldTopic", "HelloWorld", topic_qos);
+
+    /* Create a DataReader with modified default Qos using the Topic Qos */
+    // Create the Subscriber
+    Subscriber* subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
+    ASSERT_NE(subscriber, nullptr);
+
+    // Change default DataReader Qos (only those that are different from Topic Qos)
+    DataReaderQos control_qos;
+    control_qos.reader_data_lifecycle().autopurge_no_writer_samples_delay = {3, 0};
+    control_qos.user_data().push_back(0);
+    control_qos.endpoint().entity_id = 1;
+    control_qos.reader_resource_limits().matched_publisher_allocation =
+            ResourceLimitedContainerConfig::fixed_size_configuration(1u);
+    control_qos.data_sharing().off();
+    subscriber->set_default_datareader_qos(control_qos);
+
     // Create DataReader with DATAREADER_QOS_USE_TOPIC_QOS
-    DataReader* reader_;
-    reader_ = subscriber_->create_datareader(topic_, DATAREADER_QOS_USE_TOPIC_QOS);
-    ASSERT_NE(reader_, nullptr);
+    DataReader* reader = subscriber->create_datareader(topic, DATAREADER_QOS_USE_TOPIC_QOS);
+    ASSERT_NE(reader, nullptr);
 
-    // Check if DataReader QoS have been correctly set from Topic Qos
-    reader_->get_qos(r_qos);
-    ASSERT_EQ(r_qos.durability_service().history_kind, eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS);
-    ASSERT_EQ(r_qos.reliability().kind, eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS);
-    ASSERT_EQ(r_qos.durability().kind, eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS);
-    ASSERT_EQ(r_qos.deadline().period, 0.5);
-    ASSERT_EQ(r_qos.latency_budget().duration, 0);
-    ASSERT_EQ(r_qos.liveliness().kind, eprosima::fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS);
-    ASSERT_EQ(r_qos.resource_limits().max_samples, 1000);
-    ASSERT_EQ(r_qos.ownership().kind, eprosima::fastdds::dds::EXCLUSIVE_OWNERSHIP_QOS);
-    ASSERT_EQ(r_qos.type_consistency().representation.m_value[0], DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
-    ASSERT_EQ(r_qos.history().kind, eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS);
-    ASSERT_EQ(r_qos.lifespan().duration, 5);
-    // Check if QoS have been correctly set from Default Qos
-    subscriber_->get_qos(s_qos);
-    ASSERT_EQ(s_qos.presentation().access_scope, eprosima::fastdds::dds::TOPIC_PRESENTATION_QOS);
-    ASSERT_EQ(s_qos.partition().names()[0], "part1");
-    ASSERT_EQ(s_qos.group_data(), group_data);
-    ASSERT_EQ(s_qos.entity_factory().autoenable_created_entities, false);
-    ASSERT_EQ(r_qos.reader_data_lifecycle().autopurge_no_writer_samples_delay.seconds, 3);
-    ASSERT_EQ(r_qos.user_data()[0], 0);
-    ASSERT_EQ(r_qos.endpoint().entity_id, 1);
-    ASSERT_EQ(r_qos.reader_resource_limits().matched_publisher_allocation.initial, 1u);
-    ASSERT_EQ(r_qos.data_sharing().kind(), eprosima::fastdds::dds::OFF);
+    /* Check that used Qos are the merge between the default ones and the Topic ones */
+    // Set the topic values on the control DataReaderQos
+    TestsDataReaderQosCommonUtils::set_common_qos(control_qos);
+
+    // Get used DataReader Qos
+    DataReaderQos test_qos = reader->get_qos();
+
+    // Check that the Qos that are not in common with Topic Qos are correctly set as the default ones,
+    // and that the rest of the Qos are left unmodified
+    ASSERT_EQ(control_qos, test_qos);
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P

--- a/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
@@ -415,10 +415,10 @@ TEST(DDSDataReader, default_qos_large_history_depth)
 }
 
 /*
-* This test creates a DataReader using DATAREADER_QOS_USE_TOPIC_QOS and checks if DataReader QoS
-* are correctly set from Topic QoS. It also checks if one of the QoS that is not in common with Topic QoS
-* is correctly set as the default one.
-*/
+ * This test creates a DataReader using DATAREADER_QOS_USE_TOPIC_QOS and checks if DataReader QoS
+ * are correctly set from Topic QoS. It also checks if one of the QoS that is not in common with Topic QoS
+ * is correctly set as the default one.
+ */
 TEST(DDSDataReader, datareader_qos_use_topic_qos)
 {
     using namespace eprosima::fastdds::dds;
@@ -457,13 +457,13 @@ TEST(DDSDataReader, datareader_qos_use_topic_qos)
     topic_qos.history(history);
 
     DomainParticipant* participant_ =
-        DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
     ASSERT_NE(participant_, nullptr);
 
     TypeSupport type_support_;
     type_support_.reset(new HelloWorldPubSubType());
     type_support_.register_type(participant_, "HelloWorld");
-    Topic* topic_ = participant_->create_topic("HelloWorldTopic","HelloWorld", topic_qos);
+    Topic* topic_ = participant_->create_topic("HelloWorldTopic", "HelloWorld", topic_qos);
     Subscriber* subscriber_ = participant_->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
     ASSERT_NE(subscriber_, nullptr);
     // Create DataReader with DATAREADER_QOS_USE_TOPIC_QOS

--- a/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
@@ -446,15 +446,15 @@ TEST(DDSDataReader, datareader_qos_use_topic_qos)
     ResourceLimitsQosPolicy resource_limit;
     resource_limit.max_samples = 1000;
     topic_qos.resource_limits(resource_limit);
-    LifespanQosPolicy lifespan;
-    lifespan.duration = {5, 0};
-    topic_qos.lifespan(lifespan);
     OwnershipQosPolicy ownership;
     ownership.kind = eprosima::fastdds::dds::EXCLUSIVE_OWNERSHIP_QOS;
     topic_qos.ownership(ownership);
     DataRepresentationQosPolicy data_rep;
     data_rep.m_value.push_back(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
     topic_qos.representation(data_rep);
+    HistoryQosPolicy history;
+    history.kind = eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS;
+    topic_qos.history(history);
 
     DomainParticipant* participant_ =
         DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
@@ -481,9 +481,9 @@ TEST(DDSDataReader, datareader_qos_use_topic_qos)
     ASSERT_EQ(r_qos.latency_budget().duration, 0);
     ASSERT_EQ(r_qos.liveliness().kind, eprosima::fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS);
     ASSERT_EQ(r_qos.resource_limits().max_samples, 1000);
-    ASSERT_EQ(r_qos.lifespan().duration, 5);
     ASSERT_EQ(r_qos.ownership().kind, eprosima::fastdds::dds::EXCLUSIVE_OWNERSHIP_QOS);
     ASSERT_EQ(r_qos.type_consistency().representation.m_value[0], DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
+    ASSERT_EQ(r_qos.history().kind, eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS);
     // Check default QoS
     ASSERT_EQ(r_qos.data_sharing().kind(), eprosima::fastdds::dds::AUTO);
 }

--- a/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
@@ -432,6 +432,81 @@ TEST(DDSDataWriter, default_qos_large_history_depth)
     ASSERT_TRUE(writer.isInitialized());
 }
 
+/*
+* This test creates a DataWriter using DATAWRITER_QOS_USE_TOPIC_QOS and checks if DataWriter QoS
+* are correctly set from Topic QoS. It also checks if one of the QoS that is not in common with Topic QoS
+* is correctly set as the default one.
+*/
+TEST(DDSDataWriter, datawriter_qos_use_topic_qos)
+{
+    using namespace eprosima::fastdds::dds;
+
+    // Set custom Topic QoS
+    TopicQos topic_qos;
+    DurabilityServiceQosPolicy durability_service;
+    durability_service.history_kind = eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS;
+    topic_qos.durability_service(durability_service);
+    ReliabilityQosPolicy reliability;
+    reliability.kind = eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS;
+    topic_qos.reliability(reliability);
+    DurabilityQosPolicy durability;
+    durability.kind = eprosima::fastdds::dds::VOLATILE_DURABILITY_QOS;
+    topic_qos.durability(durability);
+    DeadlineQosPolicy deadline;
+    deadline.period = {0, 500000000};
+    topic_qos.deadline(deadline);
+    LatencyBudgetQosPolicy latency;
+    latency.duration = 0;
+    topic_qos.latency_budget(latency);
+    LivelinessQosPolicy liveliness;
+    liveliness.kind = eprosima::fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS;
+    topic_qos.liveliness(liveliness);
+    ResourceLimitsQosPolicy resource_limit;
+    resource_limit.max_samples = 1000;
+    topic_qos.resource_limits(resource_limit);
+    TransportPriorityQosPolicy transport_prio;
+    transport_prio.value = 1;
+    topic_qos.transport_priority(transport_prio);
+    LifespanQosPolicy lifespan;
+    lifespan.duration = {5, 0};
+    topic_qos.lifespan(lifespan);
+    OwnershipQosPolicy ownership;
+    ownership.kind = eprosima::fastdds::dds::EXCLUSIVE_OWNERSHIP_QOS;
+    topic_qos.ownership(ownership);
+    DataRepresentationQosPolicy data_rep;
+    data_rep.m_value.push_back(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
+    topic_qos.representation(data_rep);
+
+    DomainParticipant* participant_ =
+        DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant_, nullptr);
+    TypeSupport type_support_;
+    type_support_.reset(new HelloWorldPubSubType());
+    type_support_.register_type(participant_, "HelloWorld");
+    Topic* topic_ = participant_->create_topic("HelloWorldTopic","HelloWorld", topic_qos);
+    Publisher* publisher_ = participant_->create_publisher(PUBLISHER_QOS_DEFAULT);
+    ASSERT_NE(publisher_, nullptr);
+    // Create DataWriter with DATAWRITER_QOS_USE_TOPIC_QOS
+    DataWriter* writer_;
+    writer_ = publisher_->create_datawriter(topic_, DATAWRITER_QOS_USE_TOPIC_QOS);
+    ASSERT_NE(writer_, nullptr);
+
+    // Check if DataWriter QoS have been correctly set from Topic QoS
+    DataWriterQos w_qos;
+    writer_->get_qos(w_qos);
+    ASSERT_EQ(w_qos.durability_service().history_kind, eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS);
+    ASSERT_EQ(w_qos.reliability().kind, eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS);
+    ASSERT_EQ(w_qos.durability().kind, eprosima::fastdds::dds::VOLATILE_DURABILITY_QOS);
+    ASSERT_EQ(w_qos.deadline().period, 0.5);
+    ASSERT_EQ(w_qos.latency_budget().duration, 0);
+    ASSERT_EQ(w_qos.liveliness().kind, eprosima::fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS);
+    ASSERT_EQ(w_qos.resource_limits().max_samples, 1000);
+    ASSERT_EQ(w_qos.transport_priority().value, 1);
+    ASSERT_EQ(w_qos.lifespan().duration, 5);
+    ASSERT_EQ(w_qos.ownership().kind, eprosima::fastdds::dds::EXCLUSIVE_OWNERSHIP_QOS);
+    ASSERT_EQ(w_qos.representation().m_value[0], DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
+}
+
 #ifdef INSTANTIATE_TEST_SUITE_P
 #define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_SUITE_P(x, y, z, w)
 #else

--- a/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
@@ -433,10 +433,10 @@ TEST(DDSDataWriter, default_qos_large_history_depth)
 }
 
 /*
-* This test creates a DataWriter using DATAWRITER_QOS_USE_TOPIC_QOS and checks if DataWriter QoS
-* are correctly set from Topic QoS. It also checks if one of the QoS that is not in common with Topic QoS
-* is correctly set as the default one.
-*/
+ * This test creates a DataWriter using DATAWRITER_QOS_USE_TOPIC_QOS and checks if DataWriter QoS
+ * are correctly set from Topic QoS. It also checks if one of the QoS that is not in common with Topic QoS
+ * is correctly set as the default one.
+ */
 TEST(DDSDataWriter, datawriter_qos_use_topic_qos)
 {
     using namespace eprosima::fastdds::dds;
@@ -478,12 +478,12 @@ TEST(DDSDataWriter, datawriter_qos_use_topic_qos)
     topic_qos.history(history);
 
     DomainParticipant* participant_ =
-        DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
     ASSERT_NE(participant_, nullptr);
     TypeSupport type_support_;
     type_support_.reset(new HelloWorldPubSubType());
     type_support_.register_type(participant_, "HelloWorld");
-    Topic* topic_ = participant_->create_topic("HelloWorldTopic","HelloWorld", topic_qos);
+    Topic* topic_ = participant_->create_topic("HelloWorldTopic", "HelloWorld", topic_qos);
     Publisher* publisher_ = participant_->create_publisher(PUBLISHER_QOS_DEFAULT);
     ASSERT_NE(publisher_, nullptr);
     // Create DataWriter with DATAWRITER_QOS_USE_TOPIC_QOS

--- a/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
@@ -467,15 +467,15 @@ TEST(DDSDataWriter, datawriter_qos_use_topic_qos)
     TransportPriorityQosPolicy transport_prio;
     transport_prio.value = 1;
     topic_qos.transport_priority(transport_prio);
-    LifespanQosPolicy lifespan;
-    lifespan.duration = {5, 0};
-    topic_qos.lifespan(lifespan);
     OwnershipQosPolicy ownership;
     ownership.kind = eprosima::fastdds::dds::EXCLUSIVE_OWNERSHIP_QOS;
     topic_qos.ownership(ownership);
     DataRepresentationQosPolicy data_rep;
     data_rep.m_value.push_back(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
     topic_qos.representation(data_rep);
+    HistoryQosPolicy history;
+    history.kind = eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS;
+    topic_qos.history(history);
 
     DomainParticipant* participant_ =
         DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
@@ -502,8 +502,8 @@ TEST(DDSDataWriter, datawriter_qos_use_topic_qos)
     ASSERT_EQ(w_qos.liveliness().kind, eprosima::fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS);
     ASSERT_EQ(w_qos.resource_limits().max_samples, 1000);
     ASSERT_EQ(w_qos.transport_priority().value, 1);
-    ASSERT_EQ(w_qos.lifespan().duration, 5);
     ASSERT_EQ(w_qos.ownership().kind, eprosima::fastdds::dds::EXCLUSIVE_OWNERSHIP_QOS);
+    ASSERT_EQ(w_qos.history().kind, eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS);
     ASSERT_EQ(w_qos.representation().m_value[0], DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
 }
 

--- a/test/unittest/dds/publisher/PublisherTests.cpp
+++ b/test/unittest/dds/publisher/PublisherTests.cpp
@@ -809,11 +809,10 @@ TEST(Publisher, DeleteContainedEntities)
 /*
  * This test checks that the Publisher methods defined in the standard not yet implemented in FastDDS return
  * ReturnCode_t::RETCODE_UNSUPPORTED. The following methods are checked:
- * 1. copy_from_topic_qos
- * 2. suspend_publications
- * 3. resume_publications
- * 4. begin_coherent_changes
- * 5. end_coherent_changes
+ * 1. suspend_publications
+ * 2. resume_publications
+ * 3. begin_coherent_changes
+ * 4. end_coherent_changes
  */
 TEST(PublisherTests, UnsupportedPublisherMethods)
 {
@@ -825,7 +824,6 @@ TEST(PublisherTests, UnsupportedPublisherMethods)
 
     fastdds::dds::DataWriterQos writer_qos;
     fastdds::dds::TopicQos topic_qos;
-    EXPECT_EQ(ReturnCode_t::RETCODE_UNSUPPORTED, publisher->copy_from_topic_qos(writer_qos, topic_qos));
     EXPECT_EQ(ReturnCode_t::RETCODE_UNSUPPORTED, publisher->suspend_publications());
     EXPECT_EQ(ReturnCode_t::RETCODE_UNSUPPORTED, publisher->resume_publications());
     EXPECT_EQ(ReturnCode_t::RETCODE_UNSUPPORTED, publisher->begin_coherent_changes());

--- a/test/unittest/dds/publisher/PublisherTests.cpp
+++ b/test/unittest/dds/publisher/PublisherTests.cpp
@@ -12,32 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <fstream>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <dds/domain/DomainParticipant.hpp>
-#include <dds/domain/DomainParticipant.hpp>
 #include <dds/pub/DataWriter.hpp>
-#include <dds/pub/Publisher.hpp>
 #include <dds/pub/Publisher.hpp>
 #include <dds/pub/qos/DataWriterQos.hpp>
 #include <dds/pub/qos/PublisherQos.hpp>
 #include <dds/topic/Topic.hpp>
-
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
+#include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
 #include <fastdds/dds/publisher/DataWriter.hpp>
 #include <fastdds/dds/publisher/Publisher.hpp>
 #include <fastdds/dds/publisher/PublisherListener.hpp>
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
-
+#include <fastdds/dds/publisher/qos/PublisherQos.hpp>
 #include <fastdds/rtps/attributes/PropertyPolicy.h>
-
 #include <fastrtps/attributes/PublisherAttributes.h>
 #include <fastrtps/attributes/SubscriberAttributes.h>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
-#include <fstream>
-
 
 namespace eprosima {
 namespace fastdds {
@@ -833,100 +830,84 @@ TEST(PublisherTests, UnsupportedPublisherMethods)
     ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), ReturnCode_t::RETCODE_OK);
 }
 
+/**
+ * Utility class to set some values other than default to those Qos common to Topic and DataWriter.
+ *
+ * This is a class instead of a free function to avoid linking with its TestsSubscriber counterpart.
+ */
+class TestsPublisherQosCommonUtils
+{
+public:
+
+    template<typename T>
+    static void set_common_qos(
+            T& qos)
+    {
+        qos.durability_service().history_kind = KEEP_ALL_HISTORY_QOS;
+        qos.reliability().kind = BEST_EFFORT_RELIABILITY_QOS;
+        qos.durability().kind = VOLATILE_DURABILITY_QOS;
+        qos.deadline().period = {0, 500000000};
+        qos.latency_budget().duration = 0;
+        qos.liveliness().kind = MANUAL_BY_PARTICIPANT_LIVELINESS_QOS;
+        qos.destination_order().kind = BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS;
+        qos.resource_limits().max_samples = 1000;
+        qos.transport_priority().value = 1;
+        qos.ownership().kind = EXCLUSIVE_OWNERSHIP_QOS;
+        qos.representation().m_value.push_back(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
+        qos.destination_order().kind = eprosima::fastdds::dds::BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS;
+        qos.history().kind = KEEP_ALL_HISTORY_QOS;
+        qos.lifespan().duration = {5, 0};
+    }
+
+};
+
 /*
- * This test checks if DataWriter QoS are correctly set from Topic QoS using copy_from_topic_qos() and if
- * DataWriter QoS previously set (which are not in common with Topic QoS) are not modified.
+ * This test:
+ *   1. Creates a Topic with custom Qos
+ *   2. Creates a control DataWriterQos in which the non-common Qos are set to a value different from the default
+ *   3. Creates a test DataWriterQos and assigns it the value of the control Qos
+ *   4. Updates the control Qos' common Qos with the same values used in the Topic Qos
+ *   5. Calls Publisher::copy_from_topic_qos() with the test Qos and the Topic Qos
+ *   6. Checks that the resulting test Qos has the same values as the control Qos
  */
 TEST(PublisherTests, datawriter_copy_from_topic_qos)
 {
-    // Set custom Topic QoS
+    /* Set Topic Qos different from default */
     TopicQos topic_qos;
-    DurabilityServiceQosPolicy durability_service;
-    durability_service.history_kind = KEEP_ALL_HISTORY_QOS;
-    topic_qos.durability_service(durability_service);
-    ReliabilityQosPolicy reliability;
-    reliability.kind = BEST_EFFORT_RELIABILITY_QOS;
-    topic_qos.reliability(reliability);
-    DurabilityQosPolicy durability;
-    durability.kind = VOLATILE_DURABILITY_QOS;
-    topic_qos.durability(durability);
-    DeadlineQosPolicy deadline;
-    deadline.period = {0, 500000000};
-    topic_qos.deadline(deadline);
-    LatencyBudgetQosPolicy latency;
-    latency.duration = 0;
-    topic_qos.latency_budget(latency);
-    LivelinessQosPolicy liveliness;
-    liveliness.kind = MANUAL_BY_PARTICIPANT_LIVELINESS_QOS;
-    topic_qos.liveliness(liveliness);
-    DestinationOrderQosPolicy destination_order;
-    destination_order.kind = BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS;
-    topic_qos.destination_order(destination_order);
-    ResourceLimitsQosPolicy resource_limit;
-    resource_limit.max_samples = 1000;
-    topic_qos.resource_limits(resource_limit);
-    TransportPriorityQosPolicy transport_prio;
-    transport_prio.value = 1;
-    topic_qos.transport_priority(transport_prio);
+    TestsPublisherQosCommonUtils::set_common_qos(topic_qos);
 
-    OwnershipQosPolicy ownership;
-    ownership.kind = EXCLUSIVE_OWNERSHIP_QOS;
-    topic_qos.ownership(ownership);
-    DataRepresentationQosPolicy data_rep;
-    data_rep.m_value.push_back(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
-    topic_qos.representation(data_rep);
-    DestinationOrderQosPolicy dest_order;
-    dest_order.kind = eprosima::fastdds::dds::BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS;
-    topic_qos.destination_order(dest_order);
-    HistoryQosPolicy history;
-    history.kind = KEEP_ALL_HISTORY_QOS;
-    topic_qos.history(history);
-
-    // Set custom DataWriter QoS
-    DataWriterQos w_qos;
-    w_qos.ownership_strength().value = 1;
-    PublishModeQosPolicy publish_mode;
-    publish_mode.kind = eprosima::fastdds::dds::ASYNCHRONOUS_PUBLISH_MODE;
-    w_qos.publish_mode(publish_mode);
-    w_qos.writer_data_lifecycle().autodispose_unregistered_instances = false;
-    w_qos.user_data().push_back(0);
-    RTPSEndpointQos endpoint_;
-    endpoint_.entity_id = 1;
-    w_qos.endpoint(endpoint_);
-    WriterResourceLimitsQos writer_limits;
-    writer_limits.matched_subscriber_allocation = eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
-    w_qos.writer_resource_limits(writer_limits);
-    w_qos.data_sharing().off();
+    /* Create the publisher under test */
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
     ASSERT_NE(participant, nullptr);
+
     Publisher* publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT);
     ASSERT_NE(publisher, nullptr);
 
-    publisher->copy_from_topic_qos(w_qos, topic_qos);
+    /* Create control and test Qos instances */
+    // Override non-common Qos with values different from the default on the control Qos
+    DataWriterQos control_qos;
+    control_qos.ownership_strength().value = 1;
+    control_qos.publish_mode().kind = eprosima::fastdds::dds::ASYNCHRONOUS_PUBLISH_MODE;
+    control_qos.writer_data_lifecycle().autodispose_unregistered_instances = false;
+    control_qos.user_data().push_back(0);
+    control_qos.endpoint().entity_id = 1;
+    control_qos.writer_resource_limits().matched_subscriber_allocation =
+            eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
+    control_qos.data_sharing().off();
 
-    // Check if DataWriter QoS have been correctly set from Topic QoS
-    ASSERT_EQ(w_qos.durability_service().history_kind, KEEP_ALL_HISTORY_QOS);
-    ASSERT_EQ(w_qos.reliability().kind, BEST_EFFORT_RELIABILITY_QOS);
-    ASSERT_EQ(w_qos.durability().kind, VOLATILE_DURABILITY_QOS);
-    ASSERT_EQ(w_qos.deadline().period, 0.5);
-    ASSERT_EQ(w_qos.latency_budget().duration, 0);
-    ASSERT_EQ(w_qos.liveliness().kind, MANUAL_BY_PARTICIPANT_LIVELINESS_QOS);
-    ASSERT_EQ(w_qos.destination_order().kind, BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS);
-    ASSERT_EQ(w_qos.resource_limits().max_samples, 1000);
-    ASSERT_EQ(w_qos.transport_priority().value, 1);
-    ASSERT_EQ(w_qos.ownership().kind, EXCLUSIVE_OWNERSHIP_QOS);
-    ASSERT_EQ(w_qos.representation().m_value[0], DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
-    ASSERT_EQ(w_qos.destination_order().kind, eprosima::fastdds::dds::BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS);
-    ASSERT_EQ(w_qos.history().kind, KEEP_ALL_HISTORY_QOS);
-    // Check if DataWriter QoS previously set are correct
-    ASSERT_EQ(w_qos.ownership_strength().value, 1);
-    ASSERT_EQ(w_qos.publish_mode().kind, eprosima::fastdds::dds::ASYNCHRONOUS_PUBLISH_MODE);
-    ASSERT_EQ(w_qos.writer_data_lifecycle().autodispose_unregistered_instances, false);
-    ASSERT_EQ(w_qos.user_data()[0], 0);
-    ASSERT_EQ(w_qos.endpoint().entity_id, 1);
-    ASSERT_EQ(w_qos.writer_resource_limits().matched_subscriber_allocation.initial, 1u);
-    ASSERT_EQ(w_qos.data_sharing().kind(), eprosima::fastdds::dds::OFF);
+    // Copy control Qos to test Qos. At this point, test_qos has non-default values for the non-common Qos,
+    // and default values for the common Qos
+    DataWriterQos test_qos = control_qos;
+
+    // Set common Qos to the control Qos with the same values used in the Topic Qos
+    TestsPublisherQosCommonUtils::set_common_qos(control_qos);
+
+    /* Function under test call */
+    publisher->copy_from_topic_qos(test_qos, topic_qos);
+
+    /* Check that the test Qos has the same values as the control Qos */
+    ASSERT_EQ(control_qos, test_qos);
 }
 
 } // namespace dds

--- a/test/unittest/dds/publisher/PublisherTests.cpp
+++ b/test/unittest/dds/publisher/PublisherTests.cpp
@@ -868,15 +868,19 @@ TEST(PublisherTests, datawriter_copy_from_topic_qos)
     TransportPriorityQosPolicy transport_prio;
     transport_prio.value = 1;
     topic_qos.transport_priority(transport_prio);
-    LifespanQosPolicy lifespan;
-    lifespan.duration = {5, 0};
-    topic_qos.lifespan(lifespan);
+    
     OwnershipQosPolicy ownership;
     ownership.kind = EXCLUSIVE_OWNERSHIP_QOS;
     topic_qos.ownership(ownership);
     DataRepresentationQosPolicy data_rep;
     data_rep.m_value.push_back(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
     topic_qos.representation(data_rep);
+    DestinationOrderQosPolicy dest_order;
+    dest_order.kind = eprosima::fastdds::dds::BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS;
+    topic_qos.destination_order(dest_order);
+    HistoryQosPolicy history;
+    history.kind = KEEP_ALL_HISTORY_QOS;
+    topic_qos.history(history);
 
     // Set custom DataWriter QoS
     DataWriterQos w_qos;
@@ -899,9 +903,10 @@ TEST(PublisherTests, datawriter_copy_from_topic_qos)
     ASSERT_EQ(w_qos.destination_order().kind, BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS);
     ASSERT_EQ(w_qos.resource_limits().max_samples, 1000);
     ASSERT_EQ(w_qos.transport_priority().value, 1);
-    ASSERT_EQ(w_qos.lifespan().duration, 5);
     ASSERT_EQ(w_qos.ownership().kind, EXCLUSIVE_OWNERSHIP_QOS);
     ASSERT_EQ(w_qos.representation().m_value[0], DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
+    ASSERT_EQ(w_qos.destination_order().kind, eprosima::fastdds::dds::BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS);
+    ASSERT_EQ(w_qos.history().kind, KEEP_ALL_HISTORY_QOS);
     // Check if DataWriter QoS previously set are correct
     ASSERT_EQ(w_qos.ownership_strength().value, 1);
 }

--- a/test/unittest/dds/publisher/PublisherTests.cpp
+++ b/test/unittest/dds/publisher/PublisherTests.cpp
@@ -834,9 +834,9 @@ TEST(PublisherTests, UnsupportedPublisherMethods)
 }
 
 /*
-* This test checks if DataWriter QoS are correctly set from Topic QoS using copy_from_topic_qos() and if
-* DataWriter QoS previously set (which are not in common with Topic QoS) are not modified.
-*/
+ * This test checks if DataWriter QoS are correctly set from Topic QoS using copy_from_topic_qos() and if
+ * DataWriter QoS previously set (which are not in common with Topic QoS) are not modified.
+ */
 TEST(PublisherTests, datawriter_copy_from_topic_qos)
 {
     // Set custom Topic QoS
@@ -868,7 +868,7 @@ TEST(PublisherTests, datawriter_copy_from_topic_qos)
     TransportPriorityQosPolicy transport_prio;
     transport_prio.value = 1;
     topic_qos.transport_priority(transport_prio);
-    
+
     OwnershipQosPolicy ownership;
     ownership.kind = EXCLUSIVE_OWNERSHIP_QOS;
     topic_qos.ownership(ownership);
@@ -886,7 +886,7 @@ TEST(PublisherTests, datawriter_copy_from_topic_qos)
     DataWriterQos w_qos;
     w_qos.ownership_strength().value = 1;
     DomainParticipant* participant =
-        DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
     ASSERT_NE(participant, nullptr);
     Publisher* publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT);
     ASSERT_NE(publisher, nullptr);

--- a/test/unittest/dds/publisher/PublisherTests.cpp
+++ b/test/unittest/dds/publisher/PublisherTests.cpp
@@ -885,6 +885,18 @@ TEST(PublisherTests, datawriter_copy_from_topic_qos)
     // Set custom DataWriter QoS
     DataWriterQos w_qos;
     w_qos.ownership_strength().value = 1;
+    PublishModeQosPolicy publish_mode;
+    publish_mode.kind = eprosima::fastdds::dds::ASYNCHRONOUS_PUBLISH_MODE;
+    w_qos.publish_mode(publish_mode);
+    w_qos.writer_data_lifecycle().autodispose_unregistered_instances = false;
+    w_qos.user_data().push_back(0);
+    RTPSEndpointQos endpoint_;
+    endpoint_.entity_id = 1;
+    w_qos.endpoint(endpoint_);
+    WriterResourceLimitsQos writer_limits;
+    writer_limits.matched_subscriber_allocation = eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
+    w_qos.writer_resource_limits(writer_limits);
+    w_qos.data_sharing().off();
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
     ASSERT_NE(participant, nullptr);
@@ -909,6 +921,12 @@ TEST(PublisherTests, datawriter_copy_from_topic_qos)
     ASSERT_EQ(w_qos.history().kind, KEEP_ALL_HISTORY_QOS);
     // Check if DataWriter QoS previously set are correct
     ASSERT_EQ(w_qos.ownership_strength().value, 1);
+    ASSERT_EQ(w_qos.publish_mode().kind, eprosima::fastdds::dds::ASYNCHRONOUS_PUBLISH_MODE);
+    ASSERT_EQ(w_qos.writer_data_lifecycle().autodispose_unregistered_instances, false);
+    ASSERT_EQ(w_qos.user_data()[0], 0);
+    ASSERT_EQ(w_qos.endpoint().entity_id, 1);
+    ASSERT_EQ(w_qos.writer_resource_limits().matched_subscriber_allocation.initial, 1u);
+    ASSERT_EQ(w_qos.data_sharing().kind(), eprosima::fastdds::dds::OFF);
 }
 
 } // namespace dds

--- a/test/unittest/dds/subscriber/SubscriberTests.cpp
+++ b/test/unittest/dds/subscriber/SubscriberTests.cpp
@@ -1043,6 +1043,14 @@ TEST(SubscriberTests, datareader_copy_from_topic_qos)
 
     // Set custom DataReader QoS
     DataReaderQos r_qos;
+    r_qos.reader_data_lifecycle().autopurge_no_writer_samples_delay = {3, 0};
+    r_qos.user_data().push_back(0);
+    RTPSEndpointQos endpoint_;
+    endpoint_.entity_id = 1;
+    r_qos.endpoint(endpoint_);
+    ReaderResourceLimitsQos reader_limits;
+    reader_limits.matched_publisher_allocation = eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
+    r_qos.reader_resource_limits(reader_limits);
     r_qos.data_sharing().off();
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
@@ -1066,6 +1074,10 @@ TEST(SubscriberTests, datareader_copy_from_topic_qos)
     ASSERT_EQ(r_qos.destination_order().kind, eprosima::fastdds::dds::BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS);
     ASSERT_EQ(r_qos.history().kind, KEEP_ALL_HISTORY_QOS);
     // Check if DataReader QoS previously set are correct
+    ASSERT_EQ(r_qos.reader_data_lifecycle().autopurge_no_writer_samples_delay.seconds, 3);
+    ASSERT_EQ(r_qos.user_data()[0], 0);
+    ASSERT_EQ(r_qos.endpoint().entity_id, 1);
+    ASSERT_EQ(r_qos.reader_resource_limits().matched_publisher_allocation.initial, 1u);
     ASSERT_EQ(r_qos.data_sharing().kind(), eprosima::fastdds::dds::OFF);
 }
 

--- a/test/unittest/dds/subscriber/SubscriberTests.cpp
+++ b/test/unittest/dds/subscriber/SubscriberTests.cpp
@@ -997,9 +997,9 @@ TEST(SubscriberTests, DeleteContainedEntities)
 }
 
 /*
-* This test checks if DataReader QoS are correctly set from Topic QoS using copy_from_topic_qos() and if
-* DataReader QoS previously set (which are not in common with Topic QoS) are not modified.
-*/
+ * This test checks if DataReader QoS are correctly set from Topic QoS using copy_from_topic_qos() and if
+ * DataReader QoS previously set (which are not in common with Topic QoS) are not modified.
+ */
 TEST(SubscriberTests, datareader_copy_from_topic_qos)
 {
     // Set custom Topic QoS
@@ -1045,7 +1045,7 @@ TEST(SubscriberTests, datareader_copy_from_topic_qos)
     DataReaderQos r_qos;
     r_qos.data_sharing().off();
     DomainParticipant* participant =
-        DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
     ASSERT_NE(participant, nullptr);
     Subscriber* subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
     ASSERT_NE(subscriber, nullptr);

--- a/test/unittest/dds/subscriber/SubscriberTests.cpp
+++ b/test/unittest/dds/subscriber/SubscriberTests.cpp
@@ -1028,15 +1028,18 @@ TEST(SubscriberTests, datareader_copy_from_topic_qos)
     ResourceLimitsQosPolicy resource_limit;
     resource_limit.max_samples = 1000;
     topic_qos.resource_limits(resource_limit);
-    LifespanQosPolicy lifespan;
-    lifespan.duration = {5, 0};
-    topic_qos.lifespan(lifespan);
     OwnershipQosPolicy ownership;
     ownership.kind = EXCLUSIVE_OWNERSHIP_QOS;
     topic_qos.ownership(ownership);
     DataRepresentationQosPolicy data_rep;
     data_rep.m_value.push_back(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
     topic_qos.representation(data_rep);
+    DestinationOrderQosPolicy dest_order;
+    dest_order.kind = eprosima::fastdds::dds::BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS;
+    topic_qos.destination_order(dest_order);
+    HistoryQosPolicy history;
+    history.kind = KEEP_ALL_HISTORY_QOS;
+    topic_qos.history(history);
 
     // Set custom DataReader QoS
     DataReaderQos r_qos;
@@ -1058,9 +1061,10 @@ TEST(SubscriberTests, datareader_copy_from_topic_qos)
     ASSERT_EQ(r_qos.liveliness().kind, MANUAL_BY_PARTICIPANT_LIVELINESS_QOS);
     ASSERT_EQ(r_qos.destination_order().kind, BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS);
     ASSERT_EQ(r_qos.resource_limits().max_samples, 1000);
-    ASSERT_EQ(r_qos.lifespan().duration, 5);
     ASSERT_EQ(r_qos.ownership().kind, EXCLUSIVE_OWNERSHIP_QOS);
     ASSERT_EQ(r_qos.type_consistency().representation.m_value[0], DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
+    ASSERT_EQ(r_qos.destination_order().kind, eprosima::fastdds::dds::BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS);
+    ASSERT_EQ(r_qos.history().kind, KEEP_ALL_HISTORY_QOS);
     // Check if DataReader QoS previously set are correct
     ASSERT_EQ(r_qos.data_sharing().kind(), eprosima::fastdds::dds::OFF);
 }

--- a/test/unittest/dds/subscriber/SubscriberTests.cpp
+++ b/test/unittest/dds/subscriber/SubscriberTests.cpp
@@ -817,10 +817,9 @@ TEST(SubscriberTests, SetListener)
 /*
  * This test checks that the Subscriber methods defined in the standard not yet implemented in FastDDS return
  * ReturnCode_t::RETCODE_UNSUPPORTED. The following methods are checked:
- * 1. copy_from_topic_qos
- * 2. begin_access
- * 3. end_access
- * 4. get_datareaders (all parameters)
+ * 1. begin_access
+ * 2. end_access
+ * 3. get_datareaders (all parameters)
  */
 TEST(SubscriberTests, UnsupportedPublisherMethods)
 {
@@ -837,7 +836,6 @@ TEST(SubscriberTests, UnsupportedPublisherMethods)
 
     fastdds::dds::DataReaderQos reader_qos;
     fastdds::dds::TopicQos topic_qos;
-    EXPECT_EQ(ReturnCode_t::RETCODE_UNSUPPORTED, subscriber->copy_from_topic_qos(reader_qos, topic_qos));
     EXPECT_EQ(ReturnCode_t::RETCODE_UNSUPPORTED, subscriber->begin_access());
     EXPECT_EQ(ReturnCode_t::RETCODE_UNSUPPORTED, subscriber->end_access());
     EXPECT_EQ(ReturnCode_t::RETCODE_UNSUPPORTED, subscriber->get_datareaders(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR 
* Implement the method `copy_from_topic_qos()`. 
* Define the value `DATAWRITER_QOS_USE_TOPIC_QOS` and `DATAREADER_QOS_USE_TOPIC_QOS`. These values can be used to indicate that the DataWriter or DataReader should be created with a combination of the default DataWriter QoS and the Topic QoS using `copy_from_topic_qos()`.
* Add the previous logic to the costructor of `DataReaderImpl` and `DataWriterImpl`.
* Remove `copy_from_topic_qos()` from `UnsupportedPublisherMethods` and `UnsupportedSubscriberMethods` tests.


Related documentation PR:
* eProsima/Fast-DDS-docs/pull/752

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox with ❌ or __NO__.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- N/A Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- N/A New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- N/A Applicable backports have been included in the description.


## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
