### PR TITLE
Fix: process crash and restart can potentially result in port abnorma…

### DIFF
--- a/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
@@ -1078,6 +1078,31 @@ private:
             {
                 EPROSIMA_LOG_WARNING(RTPS_TRANSPORT_SHM, THREADID << "Port "
                                                                   << port_id << " Zombie. Reset the port");
+                std::unique_ptr<RobustExclusiveLock> lock_read_exclusive;
+                if (open_mode == Port::OpenMode::ReadExclusive)
+                {
+                    lock_read_exclusive = Port::lock_read_exclusive(port_id, domain_name_);
+                }
+                // Try to open the segment of port, if it exists, there is a possibility that this segment
+                // is being used by other participants in a 'write' mode. Therefore, before deleting, it's
+                // necessary to invalidate this port to prevent other participants from mistakenly using
+                // the segment with the same name but has been deleted.
+                auto segment = std::shared_ptr<SharedMemSegment>(
+                    new SharedMemSegment(boost::interprocess::open_only, port_segment_name.c_str()));
+
+                if (segment->check_sanity())
+                {
+                    auto node = segment->get().find<PortNode>(
+                        ("port_node_abi" + std::to_string(CURRENT_ABI_VERSION)).c_str()).first;
+
+                    if (node)
+                    {
+                        // Set is_port_ok to false to prompt other participants to regenerate ports
+                        node->is_port_ok = false;
+                        node = nullptr;
+                        segment.reset();
+                    }
+                }
 
                 SharedMemSegment::remove(port_segment_name.c_str());
 


### PR DESCRIPTION
Cleaning up zombie ports will delete shared segment which  could be used for writing by other participants.  In such cases, using the previously deleted shared memory segment to continue transmitting data can lead to issues.

<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->





## Description

 * Modified:
    File: src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
    Function: `open_port_internal`
  * try to `SharedMemSegment` of zombie port and find `PortNode`, set `PortNode::is_port_ok = false` before `SharedMemSegment::remove(port_segment_name.c_str())` when met zombie_test  condition in function open_port_internal


<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
 @nichoal backport version >= 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox with ❌ or __NO__.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
