### PR TITLE
[20936] Change backup restore order

### DIFF
--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -413,6 +413,9 @@ bool PDP::enable()
         return true;
     }
 
+    // Perform pre-enable actions (if any)
+    pre_enable_actions();
+
     // Create lease events on already created proxy data objects
     for (ParticipantProxyData* pool_item : participant_proxies_pool_)
     {
@@ -441,6 +444,11 @@ bool PDP::enable()
             get_participant_proxy_data(mp_RTPSParticipant->getGuid().guidPrefix)->m_properties);
 
     return builtin_endpoints_->enable_pdp_readers(mp_RTPSParticipant);
+}
+
+void PDP::pre_enable_actions()
+{
+    // Empty implementation
 }
 
 void PDP::disable()

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.h
@@ -129,7 +129,7 @@ public:
      *
      * @return true if enabled correctly, or if already enabled; false otherwise
      */
-    bool enable();
+    virtual bool enable();
 
     /**
      * @brief Disable the Participant Discovery Protocol

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.h
@@ -129,7 +129,12 @@ public:
      *
      * @return true if enabled correctly, or if already enabled; false otherwise
      */
-    virtual bool enable();
+    bool enable();
+
+    /**
+     * @brief Perform actions before enabling the Participant Discovery Protocol if needed
+     */
+    virtual void pre_enable_actions();
 
     /**
      * @brief Disable the Participant Discovery Protocol

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -152,7 +152,7 @@ bool PDPServer::init(
     return true;
 }
 
-bool PDPServer::enable()
+void PDPServer::pre_enable_actions()
 {
     std::vector<nlohmann::json> backup_queue;
     // Restore the DDB from file if this is a BACKUP server
@@ -190,8 +190,6 @@ bool PDPServer::enable()
         // This vector is empty till backup queue is implemented
         process_backup_restore_queue(backup_queue);
     }
-
-    return PDP::enable();
 }
 
 ParticipantProxyData* PDPServer::createParticipantProxyData(

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
@@ -80,6 +80,13 @@ public:
             fastrtps::rtps::RTPSParticipantImpl* part) override;
 
     /**
+     * @brief Enable the Participant Discovery Protocol and checks if a backup file
+     * needs to be restored for DiscoveryProtocol_t::BACKUP.
+     *
+     * @return true if enabled correctly, or if already enabled; false otherwise
+     */
+    bool enable() override;
+    /**
      * Creates an initializes a new participant proxy from a DATA(p) raw info
      * @param p ParticipantProxyData from DATA msg deserialization
      * @param writer_guid GUID of originating writer

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
@@ -80,12 +80,11 @@ public:
             fastrtps::rtps::RTPSParticipantImpl* part) override;
 
     /**
-     * @brief Enable the Participant Discovery Protocol and checks if a backup file
-     * needs to be restored for DiscoveryProtocol_t::BACKUP.
-     *
-     * @return true if enabled correctly, or if already enabled; false otherwise
+     * @brief Checks if a backup file needs to be restored for
+     * DiscoveryProtocol_t::BACKUP before enabling the Participant Discovery Protocol
      */
-    bool enable() override;
+    void pre_enable_actions() override;
+
     /**
      * Creates an initializes a new participant proxy from a DATA(p) raw info
      * @param p ParticipantProxyData from DATA msg deserialization


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR postpones the execution of the _process_backup_discovery_database_restore_ method until after the initialization of builtinProtocols and the TypeLookUpManager.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox with ❌ or __NO__.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally: https://github.com/eProsima/Discovery-Server/pull/77
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_ Applicable backports have been included in the description.


## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
