### PR TITLE
[20945] Fix SecurityTest unittests memory error

### DIFF
--- a/test/unittest/rtps/security/SecurityHandshakeProcessTests.cpp
+++ b/test/unittest/rtps/security/SecurityHandshakeProcessTests.cpp
@@ -337,12 +337,13 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_begin_handshake_r
     info.guid = participant_data.m_guid;
     EXPECT_CALL(*participant_.getListener(), onParticipantAuthentication(_, info)).Times(1);
 
-    CacheChange_t* kx_change = new CacheChange_t(500);
-    expect_kx_exchange(kx_change);
+    CacheChange_t kx_change_to_add;
+    CacheChange_t* kx_change_to_remove = new CacheChange_t(500);
+    expect_kx_exchange(kx_change_to_add, kx_change_to_remove);
 
     stateless_reader_->listener_->onNewCacheChangeAdded(stateless_reader_, change);
 
-    volatile_writer_->listener_->onWriterChangeReceivedByAll(volatile_writer_, kx_change);
+    volatile_writer_->listener_->onWriterChangeReceivedByAll(volatile_writer_, kx_change_to_remove);
 
     return_handle(remote_identity_handle);
     return_handle(handshake_handle);
@@ -527,14 +528,15 @@ TEST_F(SecurityTest, discovered_participant_process_message_pending_handshake_re
             WillOnce(DoAll(SetArgPointee<0>(&remote_identity_handle),
             Return(ValidationResult_t::VALIDATION_PENDING_HANDSHAKE_MESSAGE)));
 
-    CacheChange_t* kx_change = new CacheChange_t(500);
-    expect_kx_exchange(kx_change);
+    CacheChange_t kx_change_to_add;
+    CacheChange_t* kx_change_to_remove = new CacheChange_t(500);
+    expect_kx_exchange(kx_change_to_add, kx_change_to_remove);
 
     ParticipantProxyData participant_data;
     fill_participant_key(participant_data.m_guid);
     ASSERT_TRUE(manager_.discovered_participant(participant_data));
 
-    volatile_writer_->listener_->onWriterChangeReceivedByAll(volatile_writer_, kx_change);
+    volatile_writer_->listener_->onWriterChangeReceivedByAll(volatile_writer_, kx_change_to_remove);
 
     ParticipantGenericMessage message;
     message.message_identity().source_guid(participant_data.m_guid);
@@ -732,12 +734,13 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_process_handshake
     info.guid = remote_participant_key;
     EXPECT_CALL(*participant_.getListener(), onParticipantAuthentication(_, info)).Times(1);
 
-    CacheChange_t* kx_change = new CacheChange_t(500);
-    expect_kx_exchange(kx_change);
+    CacheChange_t kx_change_to_add;
+    CacheChange_t* kx_change_to_remove = new CacheChange_t(500);
+    expect_kx_exchange(kx_change_to_add, kx_change_to_remove);
 
     stateless_reader_->listener_->onNewCacheChangeAdded(stateless_reader_, change);
 
-    volatile_writer_->listener_->onWriterChangeReceivedByAll(volatile_writer_, kx_change);
+    volatile_writer_->listener_->onWriterChangeReceivedByAll(volatile_writer_, kx_change_to_remove);
 }
 
 TEST_F(SecurityTest, discovered_participant_process_message_process_handshake_reply_new_change_fail)
@@ -1131,12 +1134,13 @@ TEST_F(SecurityTest, discovered_participant_process_message_ok_process_handshake
     info.guid = remote_participant_key;
     EXPECT_CALL(*participant_.getListener(), onParticipantAuthentication(_, info)).Times(1);
 
-    CacheChange_t* kx_change = new CacheChange_t(500);
-    expect_kx_exchange(kx_change);
+    CacheChange_t kx_change_to_add;
+    CacheChange_t* kx_change_to_remove = new CacheChange_t(500);
+    expect_kx_exchange(kx_change_to_add, kx_change_to_remove);
 
     stateless_reader_->listener_->onNewCacheChangeAdded(stateless_reader_, change);
 
-    volatile_writer_->listener_->onWriterChangeReceivedByAll(volatile_writer_, kx_change);
+    volatile_writer_->listener_->onWriterChangeReceivedByAll(volatile_writer_, kx_change_to_remove);
 }
 
 int main(

--- a/test/unittest/rtps/security/SecurityTests.hpp
+++ b/test/unittest/rtps/security/SecurityTests.hpp
@@ -125,7 +125,8 @@ protected:
             CacheChange_t** final_message_change = nullptr);
 
     void expect_kx_exchange(
-            CacheChange_t* kx_change);
+            CacheChange_t& kx_change_to_add,
+            CacheChange_t* kx_change_to_remove);
 
     void destroy_manager_and_change(
             CacheChange_t*& change,

--- a/test/unittest/rtps/security/SecurityValidationRemoteTests.cpp
+++ b/test/unittest/rtps/security/SecurityValidationRemoteTests.cpp
@@ -158,12 +158,13 @@ TEST_F(SecurityTest, discovered_participant_validation_remote_identity_pending_h
     info.guid = participant_data.m_guid;
     EXPECT_CALL(*participant_.getListener(), onParticipantAuthentication(_, info)).Times(1);
 
-    CacheChange_t* kx_change = new CacheChange_t(500);
-    expect_kx_exchange(kx_change);
+    CacheChange_t kx_change_to_add;
+    CacheChange_t* kx_change_to_remove = new CacheChange_t(500);
+    expect_kx_exchange(kx_change_to_add, kx_change_to_remove);
 
     ASSERT_TRUE(manager_.discovered_participant(participant_data));
 
-    volatile_writer_->listener_->onWriterChangeReceivedByAll(volatile_writer_, kx_change);
+    volatile_writer_->listener_->onWriterChangeReceivedByAll(volatile_writer_, kx_change_to_remove);
 
     return_handle(remote_identity_handle);
     return_handle(handshake_handle);
@@ -330,12 +331,13 @@ TEST_F(SecurityTest, discovered_participant_validation_remote_identity_pending_h
     info.guid = participant_data.m_guid;
     EXPECT_CALL(*participant_.getListener(), onParticipantAuthentication(_, info)).Times(1);
 
-    CacheChange_t* kx_change = new CacheChange_t(500);
-    expect_kx_exchange(kx_change);
+    CacheChange_t kx_change_to_add;
+    CacheChange_t* kx_change_to_remove = new CacheChange_t(500);
+    expect_kx_exchange(kx_change_to_add, kx_change_to_remove);
 
     ASSERT_TRUE(manager_.discovered_participant(participant_data));
 
-    volatile_writer_->listener_->onWriterChangeReceivedByAll(volatile_writer_, kx_change);
+    volatile_writer_->listener_->onWriterChangeReceivedByAll(volatile_writer_, kx_change_to_remove);
 
     destroy_manager_and_change(change);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR fixes an incorrect memory access error in the SecurityTests. The same `CacheChange` `kx_change` was being deleted and after accessed in the lambda defined within the `expect_kx_exchange` function.

The fix proposes separating the concerns of deletion and addition, defining a CacheChange for each one (in particular, a stack-allocated one for the addition). 

**Important** Backports are not being included since backports from #4673 have not been merged and this could be cherry-picked.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox with ❌ or __NO__.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_ Applicable backports have been included in the description.


## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
