### PR TITLE
[20965] Fix Python Installation version in Github CI. Address failing system tests environment issues.

### DIFF
--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -56,6 +56,11 @@ jobs:
           path: src/fastrtps
           ref: ${{ inputs.fastdds-branch }}
 
+      - name: Install Fix Python version
+        uses: eProsima/eProsima-CI/external/setup-python@v0
+        with:
+          python-version: '3.11'
+
       - name: Get minimum supported version of CMake
         uses: eProsima/eProsima-CI/external/get-cmake@v0
         with:

--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -119,6 +119,8 @@ jobs:
           ref: ${{ steps.get_shapes_demo_branch.outputs.deduced_branch }}
 
       # Required for Shapes Demo
+      # Do not setup python as it will internally modify the pythonLocation env variable
+      # and we want to use a fix version
       - name: Install Qt
         uses: jurplel/install-qt-action@v2.13.0
         with:

--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -125,6 +125,7 @@ jobs:
           version: '5.15.2'
           dir: '${{ github.workspace }}/qt_installation/'
           modules: 'qtcharts'
+          setup-python: 'false'
 
       - name: Colcon build
         continue-on-error: false

--- a/.github/workflows/reusable-windows-ci.yml
+++ b/.github/workflows/reusable-windows-ci.yml
@@ -56,6 +56,11 @@ jobs:
           submodules: true
           ref: ${{ inputs.fastdds_branch }}
 
+      - name: Install Fix Python version
+        uses: eProsima/eProsima-CI/external/setup-python@v0
+        with:
+          python-version: '3.11'
+
       - name: Get minimum supported version of CMake
         uses: eProsima/eProsima-CI/external/get-cmake@v0
         with:

--- a/test/system/tools/fastdds/CMakeLists.txt
+++ b/test/system/tools/fastdds/CMakeLists.txt
@@ -20,6 +20,10 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 if(Python3_Interpreter_FOUND)
 
+    # Set environment for tests
+    set(TEST_ENVIRONMENT
+        "PYTHON_VERSION=${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}")
+
     set(TESTS
         test_fastdds_installed
         test_fastdds_discovery
@@ -43,184 +47,200 @@ if(Python3_Interpreter_FOUND)
             PROPERTY LABELS "NoMemoryCheck"
         )
 
-    endforeach()
-
-endif()
-
-###############################################################################
-# XML GENERAL validation
-###############################################################################
-message(STATUS "Configuring CLI xml validation...")
-
-# Configure command based on the OS running
-if (MSVC)
-    set(env_fast_command "fastdds.bat") # WINDOWS
-else()
-    set(env_fast_command "fastdds")     # POSIX
-endif()
-
-# Copy the examples validation files over to the build directory
-file(GLOB_RECURSE XML_EXAMPLE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../../../examples/*_profile.xml)
-# for each xml file detected
-foreach(XML_EXAMPLE_FILE_COMPLETE_PATH ${XML_EXAMPLE_FILES})
-    # obtain the file name
-    get_filename_component(XML_EXAMPLE_FILE ${XML_EXAMPLE_FILE_COMPLETE_PATH} NAME_WE)
-    # copy the file from src to build folders
-    configure_file(
-        ${XML_EXAMPLE_FILE_COMPLETE_PATH}                                          # from full src path
-        ${CMAKE_CURRENT_BINARY_DIR}/xmldocuments/examples/${XML_EXAMPLE_FILE}.xml  # to relative build path
-        COPYONLY)
-endforeach()
-
-# Copy the blackbox tests validation files over to the build directory
-file(GLOB_RECURSE XML_BLACKBOX_FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../../blackbox/*_profile.xml)
-# for each xml file detected
-foreach(XML_BLACKBOX_FILE_COMPLETE_PATH ${XML_BLACKBOX_FILES})
-    # obtain the file name
-    get_filename_component(XML_BLACKBOX_FILE ${XML_BLACKBOX_FILE_COMPLETE_PATH} NAME_WE)
-    # copy the file from src to build folders
-    configure_file(
-        ${XML_BLACKBOX_FILE_COMPLETE_PATH}                                               # from full src path
-        ${CMAKE_CURRENT_BINARY_DIR}/xmldocuments/test/blackbox/${XML_BLACKBOX_FILE}.xml  # to relative build path
-        COPYONLY)
-endforeach()
-
-# Copy the unit tests validation files over to the build directory
-file(GLOB_RECURSE XML_UNITTEST_FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../../unittest/*_profile.xml)
-# for each xml file detected
-foreach(XML_UNITTEST_FILE_COMPLETE_PATH ${XML_UNITTEST_FILES})
-    # obtain the file name
-    get_filename_component(XML_UNITTEST_FILE ${XML_UNITTEST_FILE_COMPLETE_PATH} NAME_WE)
-    # copy the file from src to build folders
-    configure_file(
-        ${XML_UNITTEST_FILE_COMPLETE_PATH}                                              # from full src path
-        ${CMAKE_CURRENT_BINARY_DIR}/xmldocuments/test/unittest/${XML_UNITTEST_FILE}.xml # to relative build path
-        COPYONLY)
-endforeach()
-
-# Copy the system tests validation files over to the build directory
-file(GLOB_RECURSE XML_SYSTEM_FILES ${CMAKE_CURRENT_SOURCE_DIR}/../*_profile.xml)
-# for each xml file detected
-foreach(XML_SYSTEM_FILE_COMPLETE_PATH ${XML_SYSTEM_FILES})
-    # obtain the file name
-    get_filename_component(XML_SYSTEM_FILE ${XML_SYSTEM_FILE_COMPLETE_PATH} NAME_WE)
-    # copy the file from src to build folders
-    configure_file(
-        ${XML_SYSTEM_FILE_COMPLETE_PATH}                                            # from full src path
-        ${CMAKE_CURRENT_BINARY_DIR}/xmldocuments/test/system/${XML_SYSTEM_FILE}.xml # to relative build path
-        COPYONLY)
-endforeach()
-
-# Copy the comunication tests validation files over to the build directory
-file(GLOB_RECURSE XML_COMMUNICATION_FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../../communication/*_profile.xml)
-# for each xml file detected
-foreach(XML_COMMUNICATION_FILE_COMPLETE_PATH ${XML_COMMUNICATION_FILES})
-    # obtain the file name
-    get_filename_component(XML_COMMUNICATION_FILE ${XML_COMMUNICATION_FILE_COMPLETE_PATH} NAME_WE)
-    # copy the file from src to build folders
-    configure_file(
-        ${XML_COMMUNICATION_FILE_COMPLETE_PATH}                                                   # from full src path
-        ${CMAKE_CURRENT_BINARY_DIR}/xmldocuments/test/communication/${XML_COMMUNICATION_FILE}.xml # to relative build path
-        COPYONLY)
-endforeach()
-
-# Copy the dds tests validation files over to the build directory
-file(GLOB_RECURSE XML_DDS_TEST_FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../../dds/*_profile.xml)
-# for each xml file detected
-foreach(XML_DDS_TEST_FILE_COMPLETE_PATH ${XML_DDS_TEST_FILES})
-    # obtain the file name
-    get_filename_component(XML_DDS_TEST_FILE ${XML_DDS_TEST_FILE_COMPLETE_PATH} NAME_WE)
-    # copy the file from src to build folders
-    configure_file(
-        ${XML_DDS_TEST_FILE_COMPLETE_PATH}                                         # from full src path
-        ${CMAKE_CURRENT_BINARY_DIR}/xmldocuments/test/dds/${XML_DDS_TEST_FILE}.xml # to relative build path
-        COPYONLY)
-endforeach()
-
-if(PERFORMANCE_TESTS)
-    # Copy the performance tests validation files over to the build directory
-    file(GLOB_RECURSE XML_PERFORMANCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../../performance/*_profile.xml)
-    # for each xml file detected
-    foreach(XML_PERFORMANCE_FILE_COMPLETE_PATH ${XML_PERFORMANCE_FILES})
-        # obtain the file name
-        get_filename_component(XML_PERFORMANCE_FILE ${XML_PERFORMANCE_FILE_COMPLETE_PATH} NAME_WE)
-        # copy the file from src to build folders
-        configure_file(
-            ${XML_PERFORMANCE_FILE_COMPLETE_PATH}                                                 # from full src path
-            ${CMAKE_CURRENT_BINARY_DIR}/xmldocuments/test/performance/${XML_PERFORMANCE_FILE}.xml # to relative build path
-            COPYONLY)
-    endforeach()
-endif()
-
-if(PROFILING_TESTS)
-    # Copy the profiling tests validation files over to the build directory
-    file(GLOB_RECURSE XML_PROFILING_FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../../profiling/*_profile.xml)
-    # for each xml file detected
-    foreach(XML_PROFILING_FILE_COMPLETE_PATH ${XML_PROFILING_FILES})
-        # obtain the file name
-        get_filename_component(XML_PROFILING_FILE ${XML_PROFILING_FILE_COMPLETE_PATH} NAME_WE)
-        # copy the file from src to build folders
-        configure_file(
-            ${XML_PROFILING_FILE_COMPLETE_PATH}                                               # from full src path
-            ${CMAKE_CURRENT_BINARY_DIR}/xmldocuments/test/profiling/${XML_PROFILING_FILE}.xml # to relative build path
-            COPYONLY)
-    endforeach()
-endif()
-
-# Define test
-add_test(NAME xml.validate COMMAND ${env_fast_command} xml validate xmldocuments)
-
-###############################################################################
-# XML Static discovery validation
-###############################################################################
-
-# Copy the examples validation files over to the build directory
-file(GLOB_RECURSE STATIC_DISC_XML_EXAMPLE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../examples/*_static_disc.xml)
-
-# for each xml file detected in examples folder
-foreach(STATIC_DISC_XML_EXAMPLE_COMPLETE_PATH ${STATIC_DISC_XML_EXAMPLE})
-    # obtain the file name
-    get_filename_component(STATIC_DISC_XML_EXAMPLE ${STATIC_DISC_XML_EXAMPLE_COMPLETE_PATH} NAME_WE)
-    # copy the file from src to build folders
-    configure_file(
-        ${STATIC_DISC_XML_EXAMPLE_COMPLETE_PATH}                                                 # from full src path
-        ${CMAKE_CURRENT_BINARY_DIR}/xml_static_disc_docs/examples/${STATIC_DISC_XML_EXAMPLE}.xml # to relative build path
-        COPYONLY)
-endforeach()
-
-# Copy the test validation files over to the build directory
-file(GLOB_RECURSE STATIC_DISC_XML_TEST ${CMAKE_CURRENT_SOURCE_DIR}/../*_static_disc.xml)
-
-# for each xml file detected in test folder
-foreach(STATIC_DISC_XML_TEST_COMPLETE_PATH ${STATIC_DISC_XML_TEST})
-    # obtain the file name
-    get_filename_component(STATIC_DISC_XML_TEST ${STATIC_DISC_XML_TEST_COMPLETE_PATH} NAME_WE)
-    # copy the file from src to build folders
-    configure_file(
-        ${STATIC_DISC_XML_TEST_COMPLETE_PATH}                                             # from full src path
-        ${CMAKE_CURRENT_BINARY_DIR}/xml_static_disc_docs/test/system/${STATIC_DISC_XML_TEST}.xml # to relative build path
-        COPYONLY)
-endforeach()
-
-# Copy the sampled test files over to the build directory
-file(GLOB_RECURSE STATIC_DISC_XML_SAMPLED_TEST ${CMAKE_CURRENT_SOURCE_DIR}/../../../blackbox/*_static_disc.xml.in)
-
-# set the expected CMake variables for the samples
-set(TOPIC_RANDOM_NUMBER "123")
-set(W_UNICAST_PORT_RANDOM_NUMBER "456")
-set(R_UNICAST_PORT_RANDOM_NUMBER "654")
-set(MULTICAST_PORT_RANDOM_NUMBER "789")
-
-# for each xml file detected in examples folder
-foreach(STATIC_DISC_XML_SAMPLED_TEST_COMPLETE_PATH ${STATIC_DISC_XML_SAMPLED_TEST})
-    # obtain the file name
-    get_filename_component(STATIC_DISC_XML_SAMPLED_TEST ${STATIC_DISC_XML_SAMPLED_TEST_COMPLETE_PATH} NAME_WE)
-    # copy the file from src to build folders
-    configure_file(
-        ${STATIC_DISC_XML_SAMPLED_TEST_COMPLETE_PATH}                                                 # from full src path
-        ${CMAKE_CURRENT_BINARY_DIR}/xml_static_disc_docs/test/blackbox/${STATIC_DISC_XML_SAMPLED_TEST}.xml # to relative build path
+        # Set environment
+        set_property(
+            TEST system.tools.fastdds.${TEST}
+            PROPERTY ENVIRONMENT ${TEST_ENVIRONMENT}
         )
-endforeach()
 
-# Define test
-add_test(NAME xml.static_disc_validate COMMAND ${env_fast_command} xml validate xml_static_disc_docs -x ${CMAKE_SOURCE_DIR}/resources/xsd/fastdds_static_discovery.xsd)
+    endforeach()
+
+    ###############################################################################
+    # XML GENERAL validation
+    ###############################################################################
+    message(STATUS "Configuring CLI xml validation...")
+
+    # Configure command based on the OS running
+    if (MSVC)
+        set(env_fast_command "fastdds.bat") # WINDOWS
+    else()
+        set(env_fast_command "fastdds")     # POSIX
+    endif()
+
+    # Copy the examples validation files over to the build directory
+    file(GLOB_RECURSE XML_EXAMPLE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../../../examples/*_profile.xml)
+    # for each xml file detected
+    foreach(XML_EXAMPLE_FILE_COMPLETE_PATH ${XML_EXAMPLE_FILES})
+        # obtain the file name
+        get_filename_component(XML_EXAMPLE_FILE ${XML_EXAMPLE_FILE_COMPLETE_PATH} NAME_WE)
+        # copy the file from src to build folders
+        configure_file(
+            ${XML_EXAMPLE_FILE_COMPLETE_PATH}                                          # from full src path
+            ${CMAKE_CURRENT_BINARY_DIR}/xmldocuments/examples/${XML_EXAMPLE_FILE}.xml  # to relative build path
+            COPYONLY)
+    endforeach()
+
+    # Copy the blackbox tests validation files over to the build directory
+    file(GLOB_RECURSE XML_BLACKBOX_FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../../blackbox/*_profile.xml)
+    # for each xml file detected
+    foreach(XML_BLACKBOX_FILE_COMPLETE_PATH ${XML_BLACKBOX_FILES})
+        # obtain the file name
+        get_filename_component(XML_BLACKBOX_FILE ${XML_BLACKBOX_FILE_COMPLETE_PATH} NAME_WE)
+        # copy the file from src to build folders
+        configure_file(
+            ${XML_BLACKBOX_FILE_COMPLETE_PATH}                                               # from full src path
+            ${CMAKE_CURRENT_BINARY_DIR}/xmldocuments/test/blackbox/${XML_BLACKBOX_FILE}.xml  # to relative build path
+            COPYONLY)
+    endforeach()
+
+    # Copy the unit tests validation files over to the build directory
+    file(GLOB_RECURSE XML_UNITTEST_FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../../unittest/*_profile.xml)
+    # for each xml file detected
+    foreach(XML_UNITTEST_FILE_COMPLETE_PATH ${XML_UNITTEST_FILES})
+        # obtain the file name
+        get_filename_component(XML_UNITTEST_FILE ${XML_UNITTEST_FILE_COMPLETE_PATH} NAME_WE)
+        # copy the file from src to build folders
+        configure_file(
+            ${XML_UNITTEST_FILE_COMPLETE_PATH}                                              # from full src path
+            ${CMAKE_CURRENT_BINARY_DIR}/xmldocuments/test/unittest/${XML_UNITTEST_FILE}.xml # to relative build path
+            COPYONLY)
+    endforeach()
+
+    # Copy the system tests validation files over to the build directory
+    file(GLOB_RECURSE XML_SYSTEM_FILES ${CMAKE_CURRENT_SOURCE_DIR}/../*_profile.xml)
+    # for each xml file detected
+    foreach(XML_SYSTEM_FILE_COMPLETE_PATH ${XML_SYSTEM_FILES})
+        # obtain the file name
+        get_filename_component(XML_SYSTEM_FILE ${XML_SYSTEM_FILE_COMPLETE_PATH} NAME_WE)
+        # copy the file from src to build folders
+        configure_file(
+            ${XML_SYSTEM_FILE_COMPLETE_PATH}                                            # from full src path
+            ${CMAKE_CURRENT_BINARY_DIR}/xmldocuments/test/system/${XML_SYSTEM_FILE}.xml # to relative build path
+            COPYONLY)
+    endforeach()
+
+    # Copy the comunication tests validation files over to the build directory
+    file(GLOB_RECURSE XML_COMMUNICATION_FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../../communication/*_profile.xml)
+    # for each xml file detected
+    foreach(XML_COMMUNICATION_FILE_COMPLETE_PATH ${XML_COMMUNICATION_FILES})
+        # obtain the file name
+        get_filename_component(XML_COMMUNICATION_FILE ${XML_COMMUNICATION_FILE_COMPLETE_PATH} NAME_WE)
+        # copy the file from src to build folders
+        configure_file(
+            ${XML_COMMUNICATION_FILE_COMPLETE_PATH}                                                   # from full src path
+            ${CMAKE_CURRENT_BINARY_DIR}/xmldocuments/test/communication/${XML_COMMUNICATION_FILE}.xml # to relative build path
+            COPYONLY)
+    endforeach()
+
+    # Copy the dds tests validation files over to the build directory
+    file(GLOB_RECURSE XML_DDS_TEST_FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../../dds/*_profile.xml)
+    # for each xml file detected
+    foreach(XML_DDS_TEST_FILE_COMPLETE_PATH ${XML_DDS_TEST_FILES})
+        # obtain the file name
+        get_filename_component(XML_DDS_TEST_FILE ${XML_DDS_TEST_FILE_COMPLETE_PATH} NAME_WE)
+        # copy the file from src to build folders
+        configure_file(
+            ${XML_DDS_TEST_FILE_COMPLETE_PATH}                                         # from full src path
+            ${CMAKE_CURRENT_BINARY_DIR}/xmldocuments/test/dds/${XML_DDS_TEST_FILE}.xml # to relative build path
+            COPYONLY)
+    endforeach()
+
+    if(PERFORMANCE_TESTS)
+        # Copy the performance tests validation files over to the build directory
+        file(GLOB_RECURSE XML_PERFORMANCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../../performance/*_profile.xml)
+        # for each xml file detected
+        foreach(XML_PERFORMANCE_FILE_COMPLETE_PATH ${XML_PERFORMANCE_FILES})
+            # obtain the file name
+            get_filename_component(XML_PERFORMANCE_FILE ${XML_PERFORMANCE_FILE_COMPLETE_PATH} NAME_WE)
+            # copy the file from src to build folders
+            configure_file(
+                ${XML_PERFORMANCE_FILE_COMPLETE_PATH}                                                 # from full src path
+                ${CMAKE_CURRENT_BINARY_DIR}/xmldocuments/test/performance/${XML_PERFORMANCE_FILE}.xml # to relative build path
+                COPYONLY)
+        endforeach()
+    endif()
+
+    if(PROFILING_TESTS)
+        # Copy the profiling tests validation files over to the build directory
+        file(GLOB_RECURSE XML_PROFILING_FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../../profiling/*_profile.xml)
+        # for each xml file detected
+        foreach(XML_PROFILING_FILE_COMPLETE_PATH ${XML_PROFILING_FILES})
+            # obtain the file name
+            get_filename_component(XML_PROFILING_FILE ${XML_PROFILING_FILE_COMPLETE_PATH} NAME_WE)
+            # copy the file from src to build folders
+            configure_file(
+                ${XML_PROFILING_FILE_COMPLETE_PATH}                                               # from full src path
+                ${CMAKE_CURRENT_BINARY_DIR}/xmldocuments/test/profiling/${XML_PROFILING_FILE}.xml # to relative build path
+                COPYONLY)
+        endforeach()
+    endif()
+
+    # Define test
+    add_test(NAME xml.validate COMMAND ${env_fast_command} xml validate xmldocuments)
+
+    set_property(
+        TEST xml.validate
+        PROPERTY ENVIRONMENT ${TEST_ENVIRONMENT}
+    )
+
+    ###############################################################################
+    # XML Static discovery validation
+    ###############################################################################
+
+    # Copy the examples validation files over to the build directory
+    file(GLOB_RECURSE STATIC_DISC_XML_EXAMPLE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../examples/*_static_disc.xml)
+
+    # for each xml file detected in examples folder
+    foreach(STATIC_DISC_XML_EXAMPLE_COMPLETE_PATH ${STATIC_DISC_XML_EXAMPLE})
+        # obtain the file name
+        get_filename_component(STATIC_DISC_XML_EXAMPLE ${STATIC_DISC_XML_EXAMPLE_COMPLETE_PATH} NAME_WE)
+        # copy the file from src to build folders
+        configure_file(
+            ${STATIC_DISC_XML_EXAMPLE_COMPLETE_PATH}                                                 # from full src path
+            ${CMAKE_CURRENT_BINARY_DIR}/xml_static_disc_docs/examples/${STATIC_DISC_XML_EXAMPLE}.xml # to relative build path
+            COPYONLY)
+    endforeach()
+
+    # Copy the test validation files over to the build directory
+    file(GLOB_RECURSE STATIC_DISC_XML_TEST ${CMAKE_CURRENT_SOURCE_DIR}/../*_static_disc.xml)
+
+    # for each xml file detected in test folder
+    foreach(STATIC_DISC_XML_TEST_COMPLETE_PATH ${STATIC_DISC_XML_TEST})
+        # obtain the file name
+        get_filename_component(STATIC_DISC_XML_TEST ${STATIC_DISC_XML_TEST_COMPLETE_PATH} NAME_WE)
+        # copy the file from src to build folders
+        configure_file(
+            ${STATIC_DISC_XML_TEST_COMPLETE_PATH}                                             # from full src path
+            ${CMAKE_CURRENT_BINARY_DIR}/xml_static_disc_docs/test/system/${STATIC_DISC_XML_TEST}.xml # to relative build path
+            COPYONLY)
+    endforeach()
+
+    # Copy the sampled test files over to the build directory
+    file(GLOB_RECURSE STATIC_DISC_XML_SAMPLED_TEST ${CMAKE_CURRENT_SOURCE_DIR}/../../../blackbox/*_static_disc.xml.in)
+
+    # set the expected CMake variables for the samples
+    set(TOPIC_RANDOM_NUMBER "123")
+    set(W_UNICAST_PORT_RANDOM_NUMBER "456")
+    set(R_UNICAST_PORT_RANDOM_NUMBER "654")
+    set(MULTICAST_PORT_RANDOM_NUMBER "789")
+
+    # for each xml file detected in examples folder
+    foreach(STATIC_DISC_XML_SAMPLED_TEST_COMPLETE_PATH ${STATIC_DISC_XML_SAMPLED_TEST})
+        # obtain the file name
+        get_filename_component(STATIC_DISC_XML_SAMPLED_TEST ${STATIC_DISC_XML_SAMPLED_TEST_COMPLETE_PATH} NAME_WE)
+        # copy the file from src to build folders
+        configure_file(
+            ${STATIC_DISC_XML_SAMPLED_TEST_COMPLETE_PATH}                                                 # from full src path
+            ${CMAKE_CURRENT_BINARY_DIR}/xml_static_disc_docs/test/blackbox/${STATIC_DISC_XML_SAMPLED_TEST}.xml # to relative build path
+            )
+    endforeach()
+
+    # Define test
+    add_test(NAME xml.static_disc_validate COMMAND ${env_fast_command} xml validate xml_static_disc_docs -x ${CMAKE_SOURCE_DIR}/resources/xsd/fastdds_static_discovery.xsd)
+
+    set_property(
+            TEST xml.static_disc_validate
+            PROPERTY ENVIRONMENT ${TEST_ENVIRONMENT}
+    )
+
+endif()

--- a/tools/fastdds/fastdds.bat
+++ b/tools/fastdds/fastdds.bat
@@ -21,6 +21,7 @@ if not %ERRORLEVEL%==0 (
    )
 )
 
+:: Python version in the form "Major.Minor"
 if %PYTHON_VERSION%=="" (
       echo error retrieving python version. Please, make sure python is installed and accessible.
       exit /B 65
@@ -28,4 +29,5 @@ if %PYTHON_VERSION%=="" (
 )
 
 :: Use launcher to profit from shebang hints on fastdds.py
+:: Select the correct python version to source the appropriate paths
 py -%PYTHON_VERSION% "%dir%\..\tools\fastdds\fastdds.py" %args%

--- a/tools/fastdds/fastdds.bat
+++ b/tools/fastdds/fastdds.bat
@@ -20,5 +20,12 @@ if not %ERRORLEVEL%==0 (
       exit /B 65
    )
 )
+
+if %PYTHON_VERSION%=="" (
+      echo error retrieving python version. Please, make sure python is installed and accessible.
+      exit /B 65
+   )
+)
+
 :: Use launcher to profit from shebang hints on fastdds.py
-py "%dir%\..\tools\fastdds\fastdds.py" %args%
+py -%PYTHON_VERSION% "%dir%\..\tools\fastdds\fastdds.py" %args%

--- a/tools/fastdds/ros-discovery.bat
+++ b/tools/fastdds/ros-discovery.bat
@@ -21,6 +21,7 @@ if not %ERRORLEVEL%==0 (
    )
 )
 
+:: Python version in the form "Major.Minor"
 if %PYTHON_VERSION%=="" (
       echo error retrieving python version. Please, make sure python is installed and accessible.
       exit /B 65
@@ -28,4 +29,5 @@ if %PYTHON_VERSION%=="" (
 )
 
 :: Use launcher to profit from shebang hints on fastdds.py
+:: Select the correct python version to source the appropriate paths
 py -%PYTHON_VERSION% "%dir%\..\tools\fastdds\fastdds.py" discovery %args%

--- a/tools/fastdds/ros-discovery.bat
+++ b/tools/fastdds/ros-discovery.bat
@@ -20,5 +20,12 @@ if not %ERRORLEVEL%==0 (
       exit /B 65
    )
 )
+
+if %PYTHON_VERSION%=="" (
+      echo error retrieving python version. Please, make sure python is installed and accessible.
+      exit /B 65
+   )
+)
+
 :: Use launcher to profit from shebang hints on fastdds.py
-py "%dir%\..\tools\fastdds\fastdds.py" discovery %args%
+py -%PYTHON_VERSION% "%dir%\..\tools\fastdds\fastdds.py" discovery %args%


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR addresses failing github CI system tests.

* It fixes Python installation version in Windows & Ubuntu Github CIs (macOs was already doing it).
* Selects the appropriate python version in the launcher used in `.bat` tool files by means of an environment variable `PYTHON_VERSION` {Major.Minor}.
* Prevents `Qt` from setting-up Python, as we are who manage the Python installation

_Notes:_ 
* In windows, `pywin32` is not listed as a required python package at the `Python Dependencies` step as it is a requirement of `colcon` and it is installed along with it.
* Python version is not fixed in the sanitizers jobs since system tests are not run there. 

Work done in #4731 precedes this PR.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.10.x 2.6.x 

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox with ❌ or __NO__.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_ Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [X] Applicable backports have been included in the description.


## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
