### PR TITLE
[20933] Set DataSharing in Writer|ReaderProxyData

### DIFF
--- a/src/cpp/fastdds/core/policy/QosPoliciesSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/QosPoliciesSerializer.hpp
@@ -855,7 +855,7 @@ inline bool QosPoliciesSerializer<DataSharingQosPolicy>::read_content_from_cdr_m
     uint32_t pos_ref = cdr_message->pos;
 
     // If the parameter is sent, the remote endpoint is datasharing compatible
-    qos_policy.automatic();
+    qos_policy.on(".");
 
     uint32_t num_domains = 0;
     bool valid = fastrtps::rtps::CDRMessage::readUInt32(cdr_message, &num_domains);

--- a/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
@@ -645,6 +645,7 @@ bool ReaderProxyData::readFromCDRMessage(
         bool should_filter_locators,
         fastdds::rtps::VendorId_t source_vendor_id)
 {
+    m_qos.data_sharing.off();
     auto param_process = [this, &network, &is_shm_transport_available, &should_filter_locators, source_vendor_id](
         CDRMessage_t* msg, const ParameterId_t& pid, uint16_t plength)
             {
@@ -1078,6 +1079,7 @@ bool ReaderProxyData::readFromCDRMessage(
                                     "Received with error.");
                             return false;
                         }
+                        m_qos.data_sharing.on(".");
                         break;
                     }
 
@@ -1089,6 +1091,8 @@ bool ReaderProxyData::readFromCDRMessage(
 
                 return true;
             };
+
+
 
     uint32_t qos_size;
     clear();

--- a/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
@@ -1078,7 +1078,7 @@ bool ReaderProxyData::readFromCDRMessage(
                                     "Received with error.");
                             return false;
                         }
-                        m_qos.data_sharing.on(".");
+
                         break;
                     }
 

--- a/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
@@ -645,7 +645,6 @@ bool ReaderProxyData::readFromCDRMessage(
         bool should_filter_locators,
         fastdds::rtps::VendorId_t source_vendor_id)
 {
-    m_qos.data_sharing.off();
     auto param_process = [this, &network, &is_shm_transport_available, &should_filter_locators, source_vendor_id](
         CDRMessage_t* msg, const ParameterId_t& pid, uint16_t plength)
             {
@@ -1092,10 +1091,9 @@ bool ReaderProxyData::readFromCDRMessage(
                 return true;
             };
 
-
-
     uint32_t qos_size;
     clear();
+    m_qos.data_sharing.off();
     try
     {
         if (ParameterList::readParameterListfromCDRMsg(*msg, param_process, true, qos_size))

--- a/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.cpp
@@ -621,7 +621,6 @@ bool WriterProxyData::readFromCDRMessage(
         bool should_filter_locators,
         fastdds::rtps::VendorId_t source_vendor_id)
 {
-        m_qos.data_sharing.off();
     auto param_process = [this, &network, &is_shm_transport_available, &should_filter_locators, source_vendor_id](
         CDRMessage_t* msg, const ParameterId_t& pid, uint16_t plength)
             {
@@ -1077,6 +1076,7 @@ bool WriterProxyData::readFromCDRMessage(
 
     uint32_t qos_size;
     clear();
+    m_qos.data_sharing.off();
     try
     {
         if (ParameterList::readParameterListfromCDRMsg(*msg, param_process, true, qos_size))

--- a/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.cpp
@@ -621,6 +621,7 @@ bool WriterProxyData::readFromCDRMessage(
         bool should_filter_locators,
         fastdds::rtps::VendorId_t source_vendor_id)
 {
+        m_qos.data_sharing.off();
     auto param_process = [this, &network, &is_shm_transport_available, &should_filter_locators, source_vendor_id](
         CDRMessage_t* msg, const ParameterId_t& pid, uint16_t plength)
             {
@@ -1061,6 +1062,7 @@ bool WriterProxyData::readFromCDRMessage(
                                     "Received with error.");
                             return false;
                         }
+                        m_qos.data_sharing.on(".");
                         break;
                     }
 

--- a/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.cpp
@@ -1061,7 +1061,6 @@ bool WriterProxyData::readFromCDRMessage(
                                     "Received with error.");
                             return false;
                         }
-                        m_qos.data_sharing.on(".");
                         break;
                     }
 

--- a/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
+++ b/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
@@ -143,7 +143,6 @@ TEST(BuiltinDataSerializationTests, ok_with_defaults)
 TEST(BuiltinDataSerializationTests, msg_without_datasharing)
 {
     {
-        // This was captured with wireshark from OpenDDS iShapes 3.16
         uint8_t data_r_buffer[] =
         {
             // Encapsulation
@@ -160,7 +159,6 @@ TEST(BuiltinDataSerializationTests, msg_without_datasharing)
     }
 
     {
-        // This was captured with wireshark from OpenDDS iShapes 3.16
         uint8_t data_w_buffer[] =
         {
             // Encapsulation
@@ -181,7 +179,6 @@ TEST(BuiltinDataSerializationTests, msg_without_datasharing)
 TEST(BuiltinDataSerializationTests, msg_with_datasharing)
 {
     {
-        // This was captured with wireshark from OpenDDS iShapes 3.16
         uint8_t data_r_buffer[] =
         {
             // Encapsulation
@@ -202,7 +199,6 @@ TEST(BuiltinDataSerializationTests, msg_with_datasharing)
     }
 
     {
-        // This was captured with wireshark from OpenDDS iShapes 3.16
         uint8_t data_w_buffer[] =
         {
             // Encapsulation

--- a/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
+++ b/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
@@ -140,6 +140,90 @@ TEST(BuiltinDataSerializationTests, ok_with_defaults)
     }
 }
 
+TEST(BuiltinDataSerializationTests, msg_without_datasharing)
+{
+    {
+        // This was captured with wireshark from OpenDDS iShapes 3.16
+        uint8_t data_r_buffer[] =
+        {
+            // Encapsulation
+            0x00, 0x03, 0x00, 0x00
+        };
+
+        CDRMessage_t msg(0);
+        msg.init(data_r_buffer, static_cast<uint32_t>(sizeof(data_r_buffer)));
+        msg.length = msg.max_size;
+
+        ReaderProxyData out(max_unicast_locators, max_multicast_locators);
+        out.readFromCDRMessage(&msg, network, false, true);
+        ASSERT_EQ(out.m_qos.data_sharing.kind(), OFF);
+    }
+
+    {
+        // This was captured with wireshark from OpenDDS iShapes 3.16
+        uint8_t data_w_buffer[] =
+        {
+            // Encapsulation
+            0x00, 0x03, 0x00, 0x00
+
+        };
+
+        CDRMessage_t msg(0);
+        msg.init(data_w_buffer, static_cast<uint32_t>(sizeof(data_w_buffer)));
+        msg.length = msg.max_size;
+
+        ReaderProxyData out(max_unicast_locators, max_multicast_locators);
+        out.readFromCDRMessage(&msg, network, false, true);
+        ASSERT_EQ(out.m_qos.data_sharing.kind(), OFF);
+    }
+}
+
+TEST(BuiltinDataSerializationTests, msg_with_datasharing)
+{
+    {
+        // This was captured with wireshark from OpenDDS iShapes 3.16
+        uint8_t data_r_buffer[] =
+        {
+            // Encapsulation
+            0x00, 0x03, 0x00, 0x00,
+            //Data Sharing
+            0x06, 0x80, 0x0c, 0x00,
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x6c, 0x9b, 0xf9, 0xbe, 0x1c, 0xb8
+
+        };
+
+        CDRMessage_t msg(0);
+        msg.init(data_r_buffer, static_cast<uint32_t>(sizeof(data_r_buffer)));
+        msg.length = msg.max_size;
+
+        ReaderProxyData out(max_unicast_locators, max_multicast_locators);
+        out.readFromCDRMessage(&msg, network, false, true);
+        ASSERT_EQ(out.m_qos.data_sharing.kind(), ON);
+    }
+
+    {
+        // This was captured with wireshark from OpenDDS iShapes 3.16
+        uint8_t data_w_buffer[] =
+        {
+            // Encapsulation
+            0x00, 0x03, 0x00, 0x00,
+            //Data Sharing
+            0x06, 0x80, 0x0c, 0x00,
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x6c, 0x9b, 0xf9, 0xbe, 0x1c, 0xb8
+
+        };
+
+        CDRMessage_t msg(0);
+        msg.init(data_w_buffer, static_cast<uint32_t>(sizeof(data_w_buffer)));
+        msg.length = msg.max_size;
+
+        ReaderProxyData out(max_unicast_locators, max_multicast_locators);
+        out.readFromCDRMessage(&msg, network, false, true);
+        ASSERT_EQ(out.m_qos.data_sharing.kind(), ON);
+    }
+}
+
+
 // Regression test for redmine issue #10547.
 // Update against OpenDDS 3.27. With this version we can read the remote DATA(w).
 TEST(BuiltinDataSerializationTests, interoperability_with_opendds_3_27)

--- a/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
+++ b/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
@@ -725,7 +725,7 @@ TEST(BuiltinDataSerializationTests, other_vendor_parameter_list_with_custom_pids
         writer_pdata.m_qos.data_sharing.off();
         writer_pdata.m_qos.data_sharing.set_max_domains(0);
         writer_read(data_buffer, buffer_length, writer_pdata);
-        ASSERT_EQ(writer_pdata.m_qos.data_sharing, DataSharingQosPolicy());
+        ASSERT_EQ(writer_pdata.m_qos.data_sharing.kind(), OFF);
 
         // ReaderProxyData check
         ReaderProxyData reader_pdata(max_unicast_locators, max_multicast_locators);
@@ -733,7 +733,7 @@ TEST(BuiltinDataSerializationTests, other_vendor_parameter_list_with_custom_pids
         reader_pdata.m_qos.data_sharing.set_max_domains(0);
         reader_pdata.m_qos.m_disablePositiveACKs.enabled = false;
         reader_read(data_buffer, buffer_length, reader_pdata);
-        ASSERT_EQ(reader_pdata.m_qos.data_sharing, DataSharingQosPolicy());
+        ASSERT_EQ(reader_pdata.m_qos.data_sharing.kind(), OFF);
 
         // CacheChange_t check
         CacheChange_t change;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Previously, Writer|ReaderProxyData always reported DataSharing as AUTO. This PR set it to ON or OFF based on the PID_DATASHARING.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
 @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x 

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox with ❌ or __NO__.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- N/A Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- N/A New feature has been added to the `versions.md` file (if applicable).
- N/A New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.


## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
