### PR TITLE
[20953]  Support Type-Lookup Service with new new GUID-less Discovery Server

### DIFF
--- a/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.cpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.cpp
@@ -312,18 +312,20 @@ SampleIdentity TypeLookupManager::get_types(
 
 ReturnCode_t TypeLookupManager::async_get_type(
         eprosima::ProxyPool<eprosima::fastdds::rtps::WriterProxyData>::smart_ptr& temp_writer_data,
+        const fastdds::rtps::GUID_t& type_server,
         const AsyncGetTypeWriterCallback& callback)
 {
     return check_type_identifier_received<eprosima::fastdds::rtps::WriterProxyData>(
-        temp_writer_data, callback, async_get_type_writer_callbacks_);
+        temp_writer_data, type_server, callback, async_get_type_writer_callbacks_);
 }
 
 ReturnCode_t TypeLookupManager::async_get_type(
         eprosima::ProxyPool<eprosima::fastdds::rtps::ReaderProxyData>::smart_ptr&  temp_reader_data,
+        const fastdds::rtps::GUID_t& type_server,
         const AsyncGetTypeReaderCallback& callback)
 {
     return check_type_identifier_received<eprosima::fastdds::rtps::ReaderProxyData>(
-        temp_reader_data, callback, async_get_type_reader_callbacks_);
+        temp_reader_data, type_server, callback, async_get_type_reader_callbacks_);
 }
 
 TypeKind TypeLookupManager::get_type_kind_to_propagate() const
@@ -346,6 +348,7 @@ TypeKind TypeLookupManager::get_type_kind_to_propagate() const
 template <typename ProxyType, typename AsyncCallback>
 ReturnCode_t TypeLookupManager::check_type_identifier_received(
         typename eprosima::ProxyPool<ProxyType>::smart_ptr& temp_proxy_data,
+        const fastdds::rtps::GUID_t& type_server,
         const AsyncCallback& callback,
         std::unordered_map<xtypes::TypeIdentfierWithSize,
         std::vector<std::pair<ProxyType*,
@@ -356,7 +359,6 @@ ReturnCode_t TypeLookupManager::check_type_identifier_received(
             TK_NONE ?
             temp_proxy_data->type_information().type_information.complete().typeid_with_size() :
             temp_proxy_data->type_information().type_information.minimal().typeid_with_size();
-    fastdds::rtps::GUID_t type_server = temp_proxy_data->guid();
 
     // Check if the type is known
     if (fastdds::rtps::RTPSDomainImpl::get_instance()->type_object_registry_observer().

--- a/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.hpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.hpp
@@ -180,6 +180,7 @@ public:
      * Use builtin TypeLookup service to solve the type and dependencies of a given TypeInformation.
      * It receives a callback that will be used to notify when the negotiation is complete.
      * @param temp_proxy_data[in] Temporary Writer/Reader ProxyData that originated the request.
+     * @param type_server[in] GUID of the remote participant that has the type.
      * @param callback Callback called when the negotiation is complete.
      * @return ReturnCode_t RETCODE_OK if the type is already known.
      *                      RETCODE_NO_DATA if type is not known, and a negotiation has been started.
@@ -187,9 +188,11 @@ public:
      */
     ReturnCode_t async_get_type(
             eprosima::ProxyPool<eprosima::fastdds::rtps::WriterProxyData>::smart_ptr& temp_proxy_data,
+            const fastdds::rtps::GUID_t& type_server,
             const AsyncGetTypeWriterCallback& callback);
     ReturnCode_t async_get_type(
             eprosima::ProxyPool<eprosima::fastdds::rtps::ReaderProxyData>::smart_ptr& temp_proxy_data,
+            const fastdds::rtps::GUID_t& type_server,
             const AsyncGetTypeReaderCallback& callback);
 
     /**
@@ -205,6 +208,7 @@ protected:
      * Adds a callback to the async_get_type_callbacks_ entry of the TypeIdentfierWithSize, or creates a new one if
      * TypeIdentfierWithSize was not in the map before
      * @param temp_proxy_data[in] Temporary Writer/Reader ProxyData that originated the request.
+     * @param type_server[in] GUID of the remote participant that has the type.
      * @param callback[in] Callback to add.
      * @param async_get_type_callbacks[in] The collection ProxyData and their callbacks to use.
      * @return ReturnCode_t RETCODE_OK if type is known.
@@ -214,6 +218,7 @@ protected:
     template <typename ProxyType, typename AsyncCallback>
     ReturnCode_t check_type_identifier_received(
             typename eprosima::ProxyPool<ProxyType>::smart_ptr& temp_proxy_data,
+            const fastdds::rtps::GUID_t& type_server,
             const AsyncCallback& callback,
             std::unordered_map<xtypes::TypeIdentfierWithSize,
             std::vector<std::pair<ProxyType*,

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -113,6 +113,7 @@ bool BuiltinProtocols::initBuiltinProtocols(
 
 #if HAVE_SQLITE3
         case DiscoveryProtocol::BACKUP:
+            EPROSIMA_LOG_WARNING(RTPS_PDP, "BACKUP discovery protocol is not yet supported with XTypes.");
             mp_PDP = new fastdds::rtps::PDPServer(this, allocation, DurabilityKind_t::TRANSIENT);
             break;
 #endif // if HAVE_SQLITE3

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.cpp
@@ -73,6 +73,7 @@ void EDPBasePUBListener::add_writer_from_change(
     const NetworkFactory& network = edp->mp_RTPSParticipant->network_factory();
     CDRMessage_t tempMsg(change->serializedPayload);
     auto temp_writer_data = edp->get_temporary_writer_proxies_pool().get();
+    const auto type_server = change->writerGUID;
 
     if (temp_writer_data->readFromCDRMessage(&tempMsg, network,
             edp->mp_RTPSParticipant->has_shm_transport(), true, change->vendor_id))
@@ -141,6 +142,7 @@ void EDPBasePUBListener::add_writer_from_change(
         {
             typelookup_manager->async_get_type(
                 temp_writer_data,
+                type_server,
                 after_typelookup_callback);
         }
         // If TypeInformation does not exist, try fallback mechanism
@@ -216,6 +218,7 @@ void EDPBaseSUBListener::add_reader_from_change(
     const NetworkFactory& network = edp->mp_RTPSParticipant->network_factory();
     CDRMessage_t tempMsg(change->serializedPayload);
     auto temp_reader_data = edp->get_temporary_reader_proxies_pool().get();
+    const auto type_server = change->writerGUID;
 
     if (temp_reader_data->readFromCDRMessage(&tempMsg, network,
             edp->mp_RTPSParticipant->has_shm_transport(), true, change->vendor_id))
@@ -285,6 +288,7 @@ void EDPBaseSUBListener::add_reader_from_change(
         {
             typelookup_manager->async_get_type(
                 temp_reader_data,
+                type_server,
                 after_typelookup_callback);
         }
         // If TypeInformation does not exist, try fallback mechanism

--- a/versions.md
+++ b/versions.md
@@ -96,6 +96,8 @@ Forthcoming
   * Servers only redirect discovery information of their direct clients.
   * Remote Discovery servers connection list can now be updated and modified at runtime without restrictions.
   * Fast DDS CLI has been updated to allow the creation of servers without GUID.
+  * Servers are responsible of answering TypeLookupRequests of others servers when working with X-Types.
+  * Backup server is not compatible with X-Types.
 * Refactor in XML Parser to return DynamicTypeBuilder instead of DynamicType
 * Setting vendor_id in the received CacheChange_t for Data and DataFrag.
 * Added new DynamicData to JSON serializer (`json_serialize`).


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR modifies the behavior of TypeLookup service to ensure compatibility with the Discovery Server. Participants now issue the TypeLookupRequest to the participant that sent them the Data (r|w), rather than to the participant containing the endpoint. This adjustment allows servers to respond to their clients, thereby keeping discovery traffic limited to servers. Additionally, it addresses minor changes to improve functionality with the Discovery Server.

- This PR is on top of https://github.com/eProsima/Fast-DDS/pull/4716 and must be merged after it.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox with ❌ or __NO__.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally: https://github.com/eProsima/Discovery-Server/pull/78  <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_ Applicable backports have been included in the description.


## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
