### PR TITLE
[21009] Do not require PYTHON_VERSION to be defined in .bat files

### DIFF
--- a/tools/fastdds/fastdds.bat
+++ b/tools/fastdds/fastdds.bat
@@ -22,12 +22,13 @@ if not %ERRORLEVEL%==0 (
 )
 
 :: Python version in the form "Major.Minor"
-if %PYTHON_VERSION%=="" (
-      echo error retrieving python version. Please, make sure python is installed and accessible.
-      exit /B 65
-   )
+if not "%PYTHON_VERSION%" == "" (
+      :: Use launcher to profit from shebang hints on fastdds.py
+      :: Select the correct python version to source the appropriate paths
+      py -%PYTHON_VERSION% "%dir%\..\tools\fastdds\fastdds.py" %args%
+) else (
+      :: Use launcher to profit from shebang hints on fastdds.py
+      :: Select latest available python version
+      py "%dir%\..\tools\fastdds\fastdds.py" %args%
 )
 
-:: Use launcher to profit from shebang hints on fastdds.py
-:: Select the correct python version to source the appropriate paths
-py -%PYTHON_VERSION% "%dir%\..\tools\fastdds\fastdds.py" %args%

--- a/tools/fastdds/ros-discovery.bat
+++ b/tools/fastdds/ros-discovery.bat
@@ -22,12 +22,13 @@ if not %ERRORLEVEL%==0 (
 )
 
 :: Python version in the form "Major.Minor"
-if %PYTHON_VERSION%=="" (
-      echo error retrieving python version. Please, make sure python is installed and accessible.
-      exit /B 65
-   )
+if not "%PYTHON_VERSION%" == "" (
+      :: Use launcher to profit from shebang hints on fastdds.py
+      :: Select the correct python version to source the appropriate paths
+      py -%PYTHON_VERSION% "%dir%\..\tools\fastdds\fastdds.py" discovery %args%
+) else (
+	  :: Use launcher to profit from shebang hints on fastdds.py
+      :: Select latest available python version
+      py "%dir%\..\tools\fastdds\fastdds.py" discovery %args%
 )
 
-:: Use launcher to profit from shebang hints on fastdds.py
-:: Select the correct python version to source the appropriate paths
-py -%PYTHON_VERSION% "%dir%\..\tools\fastdds\fastdds.py" discovery %args%


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
@MiguelCompany identified an error introduced in #4759 as the `PYTHON_VERSION`  does not necessarily need to be defined when executing the `fastdds.bat` or `ros-discovery.bat` scripts.  
The change simply requires a specific version of Python only if `PYTHON_VERSION` is defined.

Tested on Windows.


<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.14.x 2.13.x 

Cherry-pick on #4765 and #4766

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox with ❌ or __NO__.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_  Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_  Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [X] Changes are ABI compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_  New feature has been added to the `versions.md` file (if applicable).
- _N/A_  New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [X] Applicable backports have been included in the description.


## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_ Check CI results: changes do not issue any warning.
- _N/A_ Check CI results: failing tests are unrelated with the changes.
