### PR TITLE
[21036] Handle errors when setting socket buffer sizes (backport #4760)

### DIFF
--- a/include/fastdds/rtps/transport/TransportInterface.h
+++ b/include/fastdds/rtps/transport/TransportInterface.h
@@ -38,7 +38,8 @@ namespace rtps {
 constexpr uint32_t s_maximumMessageSize = 65500;
 //! Default maximum initial peers range
 constexpr uint32_t s_maximumInitialPeersRange = 4;
-//! Default minimum socket buffer
+// Default minimum socket buffer
+FASTDDS_DEPRECATED_UNTIL(3, s_minimumSocketBuffer, "Minimum socket buffer is now taken from the maximum msg size")
 constexpr uint32_t s_minimumSocketBuffer = 65536;
 //! Default IPv4 address
 static const std::string s_IPv4AddressAny = "0.0.0.0";

--- a/include/fastrtps/transport/TransportInterface.h
+++ b/include/fastrtps/transport/TransportInterface.h
@@ -29,7 +29,8 @@ using TransportInterface = fastdds::rtps::TransportInterface;
 
 static const uint32_t s_maximumMessageSize = fastdds::rtps::s_maximumMessageSize;
 static const uint32_t s_maximumInitialPeersRange = fastdds::rtps::s_maximumInitialPeersRange;
-static const uint32_t s_minimumSocketBuffer = fastdds::rtps::s_minimumSocketBuffer;
+FASTDDS_DEPRECATED_UNTIL(3, s_minimumSocketBuffer, "Minimum socket buffer is now taken from the maximum msg size")
+static const uint32_t s_minimumSocketBuffer = 65536;
 static const std::string s_IPv4AddressAny = fastdds::rtps::s_IPv4AddressAny;
 static const std::string s_IPv6AddressAny = fastdds::rtps::s_IPv6AddressAny;
 

--- a/src/cpp/rtps/transport/TCPChannelResource.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResource.cpp
@@ -18,6 +18,7 @@
 #include <thread>
 
 #include <fastrtps/utils/IPLocator.h>
+#include <rtps/transport/asio_helpers.hpp>
 #include <rtps/transport/TCPTransportInterface.h>
 
 namespace eprosima {
@@ -370,6 +371,52 @@ bool TCPChannelResource::check_socket_send_buffer(
     return true;
 }
 
+void TCPChannelResource::set_socket_options(
+        asio::basic_socket<asio::ip::tcp>& socket,
+        const TCPTransportDescriptor* options)
+{
+    uint32_t minimum_value = options->maxMessageSize;
+
+    // Set the send buffer size
+    {
+        uint32_t desired_value = options->sendBufferSize;
+        uint32_t configured_value = 0;
+        if (!asio_helpers::try_setting_buffer_size<asio::socket_base::send_buffer_size>(
+                    socket, desired_value, minimum_value, configured_value))
+        {
+            EPROSIMA_LOG_ERROR(TCP_TRANSPORT,
+                    "Couldn't set send buffer size to minimum value: " << minimum_value);
+        }
+        else if (desired_value != configured_value)
+        {
+            EPROSIMA_LOG_WARNING(TCP_TRANSPORT,
+                    "Couldn't set send buffer size to desired value. "
+                    << "Using " << configured_value << " instead of " << desired_value);
+        }
+    }
+
+    // Set the receive buffer size
+    {
+        uint32_t desired_value = options->receiveBufferSize;
+        uint32_t configured_value = 0;
+        if (!asio_helpers::try_setting_buffer_size<asio::socket_base::receive_buffer_size>(
+                    socket, desired_value, minimum_value, configured_value))
+        {
+            EPROSIMA_LOG_ERROR(TCP_TRANSPORT,
+                    "Couldn't set receive buffer size to minimum value: " << minimum_value);
+        }
+        else if (desired_value != configured_value)
+        {
+            EPROSIMA_LOG_WARNING(TCP_TRANSPORT,
+                    "Couldn't set receive buffer size to desired value. "
+                    << "Using " << configured_value << " instead of " << desired_value);
+        }
+    }
+
+    // Set the TCP_NODELAY option
+    socket.set_option(asio::ip::tcp::no_delay(options->enable_tcp_nodelay));
+}
+
 } // namespace rtps
-} // namespace fastrtps
+} // namespace fastdds
 } // namespace eprosima

--- a/src/cpp/rtps/transport/TCPChannelResource.h
+++ b/src/cpp/rtps/transport/TCPChannelResource.h
@@ -234,6 +234,12 @@ protected:
             const size_t& msg_size,
             const asio::ip::tcp::socket::native_handle_type& socket_native_handle);
 
+    /**
+     * @brief Set descriptor options on a socket.
+     *
+     * @param socket Socket on which to set the options.
+     * @param options Descriptor with the options to set.
+     */
     static void set_socket_options(
             asio::basic_socket<asio::ip::tcp>& socket,
             const TCPTransportDescriptor* options);

--- a/src/cpp/rtps/transport/TCPChannelResource.h
+++ b/src/cpp/rtps/transport/TCPChannelResource.h
@@ -234,6 +234,10 @@ protected:
             const size_t& msg_size,
             const asio::ip::tcp::socket::native_handle_type& socket_native_handle);
 
+    static void set_socket_options(
+            asio::basic_socket<asio::ip::tcp>& socket,
+            const TCPTransportDescriptor* options);
+
     TCPConnectionType tcp_connection_type_;
 
     friend class TCPTransportInterface;

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
@@ -200,9 +200,7 @@ asio::ip::tcp::endpoint TCPChannelResourceBasic::local_endpoint(
 void TCPChannelResourceBasic::set_options(
         const TCPTransportDescriptor* options)
 {
-    socket_->set_option(socket_base::receive_buffer_size(options->receiveBufferSize));
-    socket_->set_option(socket_base::send_buffer_size(options->sendBufferSize));
-    socket_->set_option(ip::tcp::no_delay(options->enable_tcp_nodelay));
+    TCPChannelResource::set_socket_options(*socket_, options);
 }
 
 void TCPChannelResourceBasic::cancel()

--- a/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
@@ -280,9 +280,7 @@ asio::ip::tcp::endpoint TCPChannelResourceSecure::local_endpoint(
 void TCPChannelResourceSecure::set_options(
         const TCPTransportDescriptor* options)
 {
-    secure_socket_->lowest_layer().set_option(socket_base::receive_buffer_size(options->receiveBufferSize));
-    secure_socket_->lowest_layer().set_option(socket_base::send_buffer_size(options->sendBufferSize));
-    secure_socket_->lowest_layer().set_option(ip::tcp::no_delay(options->enable_tcp_nodelay));
+    TCPChannelResource::set_socket_options(secure_socket_->lowest_layer(), options);
 }
 
 void TCPChannelResourceSecure::set_tls_verify_mode(

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -442,6 +442,42 @@ bool TCPTransportInterface::init(
         const fastrtps::rtps::PropertyPolicy*,
         const uint32_t& max_msg_size_no_frag)
 {
+    uint32_t maximumMessageSize = max_msg_size_no_frag == 0 ? s_maximumMessageSize : max_msg_size_no_frag;
+    uint32_t cfg_max_msg_size = configuration()->maxMessageSize;
+    uint32_t cfg_send_size = configuration()->sendBufferSize;
+    uint32_t cfg_recv_size = configuration()->receiveBufferSize;
+    uint32_t max_int_value = static_cast<uint32_t>(std::numeric_limits<int32_t>::max());
+
+    if (cfg_max_msg_size > maximumMessageSize)
+    {
+        EPROSIMA_LOG_ERROR(TRANSPORT_TCP, "maxMessageSize cannot be greater than " << maximumMessageSize);
+        return false;
+    }
+
+    if (cfg_send_size > max_int_value)
+    {
+        EPROSIMA_LOG_ERROR(TRANSPORT_TCP, "sendBufferSize cannot be greater than " << max_int_value);
+        return false;
+    }
+
+    if (cfg_recv_size > max_int_value)
+    {
+        EPROSIMA_LOG_ERROR(TRANSPORT_TCP, "receiveBufferSize cannot be greater than " << max_int_value);
+        return false;
+    }
+
+    if ((cfg_send_size > 0) && (cfg_max_msg_size > cfg_send_size))
+    {
+        EPROSIMA_LOG_ERROR(TRANSPORT_TCP, "maxMessageSize cannot be greater than sendBufferSize");
+        return false;
+    }
+
+    if ((cfg_recv_size > 0) && (cfg_max_msg_size > cfg_recv_size))
+    {
+        EPROSIMA_LOG_ERROR(TRANSPORT_TCP, "maxMessageSize cannot be greater than receiveBufferSize");
+        return false;
+    }
+
     if (!apply_tls_config())
     {
         // TODO decide wether the Transport initialization should keep working after this error
@@ -488,42 +524,6 @@ bool TCPTransportInterface::init(
         {
             set_receive_buffer_size(s_minimumSocketBuffer);
         }
-    }
-
-    uint32_t maximumMessageSize = max_msg_size_no_frag == 0 ? s_maximumMessageSize : max_msg_size_no_frag;
-    uint32_t cfg_max_msg_size = configuration()->maxMessageSize;
-    uint32_t cfg_send_size = configuration()->sendBufferSize;
-    uint32_t cfg_recv_size = configuration()->receiveBufferSize;
-    uint32_t max_int_value = static_cast<uint32_t>(std::numeric_limits<int32_t>::max());
-
-    if (cfg_max_msg_size > maximumMessageSize)
-    {
-        EPROSIMA_LOG_ERROR(TRANSPORT_TCP, "maxMessageSize cannot be greater than " << maximumMessageSize);
-        return false;
-    }
-
-    if (cfg_send_size > max_int_value)
-    {
-        EPROSIMA_LOG_ERROR(TRANSPORT_TCP, "sendBufferSize cannot be greater than " << max_int_value);
-        return false;
-    }
-
-    if (cfg_recv_size > max_int_value)
-    {
-        EPROSIMA_LOG_ERROR(TRANSPORT_TCP, "receiveBufferSize cannot be greater than " << max_int_value);
-        return false;
-    }
-
-    if (cfg_max_msg_size > cfg_send_size)
-    {
-        EPROSIMA_LOG_ERROR(TRANSPORT_TCP, "maxMessageSize cannot be greater than sendBufferSize");
-        return false;
-    }
-
-    if (cfg_max_msg_size > cfg_recv_size)
-    {
-        EPROSIMA_LOG_ERROR(TRANSPORT_TCP, "maxMessageSize cannot be greater than receiveBufferSize");
-        return false;
     }
 
     if (!rtcp_message_manager_)

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -54,6 +54,7 @@
 #include <fastrtps/utils/IPLocator.h>
 #include <fastrtps/utils/System.h>
 
+#include <rtps/transport/asio_helpers.hpp>
 #include <statistics/rtps/messages/RTPSStatisticsMessages.hpp>
 #include <utils/SystemInfo.hpp>
 #include <utils/thread.hpp>
@@ -502,29 +503,29 @@ bool TCPTransportInterface::init(
     initial_peer_local_locator_port_ = local_endpoint.port();
 
     // Check system buffer sizes.
-    if (configuration()->sendBufferSize == 0)
+    uint32_t send_size = 0;
+    uint32_t recv_size = 0;
+    if (!asio_helpers::configure_buffer_sizes(
+                *initial_peer_local_locator_socket_, *configuration(), send_size, recv_size))
     {
-        socket_base::send_buffer_size option;
-        initial_peer_local_locator_socket_->get_option(option);
-        set_send_buffer_size(option.value());
-
-        if (configuration()->sendBufferSize < s_minimumSocketBuffer)
-        {
-            set_send_buffer_size(s_minimumSocketBuffer);
-        }
+        EPROSIMA_LOG_ERROR(TRANSPORT_TCP, "Couldn't set buffer sizes to minimum value: " << cfg_max_msg_size);
+        return false;
     }
 
-    if (configuration()->receiveBufferSize == 0)
+    if (cfg_send_size > 0 && send_size != cfg_send_size)
     {
-        socket_base::receive_buffer_size option;
-        initial_peer_local_locator_socket_->get_option(option);
-        set_receive_buffer_size(option.value());
-
-        if (configuration()->receiveBufferSize < s_minimumSocketBuffer)
-        {
-            set_receive_buffer_size(s_minimumSocketBuffer);
-        }
+        EPROSIMA_LOG_WARNING(TRANSPORT_TCP, "UDPTransport sendBufferSize could not be set to the desired value. "
+                << "Using " << send_size << " instead of " << cfg_send_size);
     }
+
+    if (cfg_recv_size > 0 && recv_size != cfg_recv_size)
+    {
+        EPROSIMA_LOG_WARNING(TRANSPORT_TCP, "UDPTransport receiveBufferSize could not be set to the desired value. "
+                << "Using " << recv_size << " instead of " << cfg_recv_size);
+    }
+
+    set_send_buffer_size(send_size);
+    set_receive_buffer_size(recv_size);
 
     if (!rtcp_message_manager_)
     {

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -18,10 +18,11 @@
 #include <cassert>
 #include <chrono>
 #include <cstring>
+#include <limits>
 #include <map>
-#include <set>
 #include <memory>
 #include <mutex>
+#include <set>
 #include <string>
 #include <thread>
 #include <utility>
@@ -490,23 +491,38 @@ bool TCPTransportInterface::init(
     }
 
     uint32_t maximumMessageSize = max_msg_size_no_frag == 0 ? s_maximumMessageSize : max_msg_size_no_frag;
+    uint32_t cfg_max_msg_size = configuration()->maxMessageSize;
+    uint32_t cfg_send_size = configuration()->sendBufferSize;
+    uint32_t cfg_recv_size = configuration()->receiveBufferSize;
+    uint32_t max_int_value = static_cast<uint32_t>(std::numeric_limits<int32_t>::max());
 
-    if (configuration()->maxMessageSize > maximumMessageSize)
+    if (cfg_max_msg_size > maximumMessageSize)
     {
-        EPROSIMA_LOG_ERROR(RTCP_MSG_OUT,
-                "maxMessageSize cannot be greater than " << std::to_string(maximumMessageSize));
+        EPROSIMA_LOG_ERROR(TRANSPORT_TCP, "maxMessageSize cannot be greater than " << maximumMessageSize);
         return false;
     }
 
-    if (configuration()->maxMessageSize > configuration()->sendBufferSize)
+    if (cfg_send_size > max_int_value)
     {
-        EPROSIMA_LOG_ERROR(RTCP_MSG_OUT, "maxMessageSize cannot be greater than send_buffer_size");
+        EPROSIMA_LOG_ERROR(TRANSPORT_TCP, "sendBufferSize cannot be greater than " << max_int_value);
         return false;
     }
 
-    if (configuration()->maxMessageSize > configuration()->receiveBufferSize)
+    if (cfg_recv_size > max_int_value)
     {
-        EPROSIMA_LOG_ERROR(RTCP_MSG_OUT, "maxMessageSize cannot be greater than receive_buffer_size");
+        EPROSIMA_LOG_ERROR(TRANSPORT_TCP, "receiveBufferSize cannot be greater than " << max_int_value);
+        return false;
+    }
+
+    if (cfg_max_msg_size > cfg_send_size)
+    {
+        EPROSIMA_LOG_ERROR(TRANSPORT_TCP, "maxMessageSize cannot be greater than sendBufferSize");
+        return false;
+    }
+
+    if (cfg_max_msg_size > cfg_recv_size)
+    {
+        EPROSIMA_LOG_ERROR(TRANSPORT_TCP, "maxMessageSize cannot be greater than receiveBufferSize");
         return false;
     }
 

--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -175,13 +175,13 @@ bool UDPTransportInterface::init(
         if (cfg_send_size > 0 && mSendBufferSize != cfg_send_size)
         {
             EPROSIMA_LOG_WARNING(TRANSPORT_UDP, "UDPTransport sendBufferSize could not be set to the desired value. "
-                               << "Using " << mSendBufferSize << " instead of " << cfg_send_size);
+                    << "Using " << mSendBufferSize << " instead of " << cfg_send_size);
         }
 
         if (cfg_recv_size > 0 && mReceiveBufferSize != cfg_recv_size)
         {
             EPROSIMA_LOG_WARNING(TRANSPORT_UDP, "UDPTransport receiveBufferSize could not be set to the desired value. "
-                << "Using " << mReceiveBufferSize << " instead of " << cfg_recv_size);
+                    << "Using " << mReceiveBufferSize << " instead of " << cfg_recv_size);
         }
 
         set_send_buffer_size(mSendBufferSize);

--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -142,14 +142,15 @@ void UDPTransportInterface::configure_send_buffer_size()
     }
 
     // Ensure the minimum value is used
-    if (send_buffer_size < s_minimumSocketBuffer)
+    uint32_t minimum_socket_buffer = configuration()->maxMessageSize;
+    if (send_buffer_size < minimum_socket_buffer)
     {
-        send_buffer_size = s_minimumSocketBuffer;
+        send_buffer_size = minimum_socket_buffer;
         set_send_buffer_size(send_buffer_size);
     }
 
     // Try to set the highest possible value the system allows
-    for (; send_buffer_size >= s_minimumSocketBuffer; send_buffer_size /= 2)
+    for (; send_buffer_size >= minimum_socket_buffer; send_buffer_size /= 2)
     {
         socket_base::send_buffer_size option(static_cast<int32_t>(send_buffer_size));
         socket.set_option(option, ec);
@@ -196,14 +197,15 @@ void UDPTransportInterface::configure_receive_buffer_size()
     }
 
     // Ensure the minimum value is used
-    if (receive_buffer_size < s_minimumSocketBuffer)
+    uint32_t minimum_socket_buffer = configuration()->maxMessageSize;
+    if (receive_buffer_size < minimum_socket_buffer)
     {
-        receive_buffer_size = s_minimumSocketBuffer;
+        receive_buffer_size = minimum_socket_buffer;
         set_receive_buffer_size(receive_buffer_size);
     }
 
     // Try to set the highest possible value the system allows
-    for (; receive_buffer_size >= s_minimumSocketBuffer; receive_buffer_size /= 2)
+    for (; receive_buffer_size >= minimum_socket_buffer; receive_buffer_size /= 2)
     {
         socket_base::receive_buffer_size option(static_cast<int32_t>(receive_buffer_size));
         socket.set_option(option, ec);

--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -119,35 +119,6 @@ bool UDPTransportInterface::DoInputLocatorsMatch(
     return IPLocator::getPhysicalPort(left) == IPLocator::getPhysicalPort(right);
 }
 
-/**
- * @brief Set the send buffer size of the socket to the highest possible value the system allows.
- *
- * @param socket The socket on which to set the send buffer size.
- * @param initial_buffer_value The initial value to try to set.
- * @param minimum_buffer_value The minimum value to set.
- *
- * @return The final value set.
- */
-static uint32_t try_setting_send_buffer_size(
-        asio::ip::udp::socket& socket,
-        uint32_t initial_buffer_value,
-        uint32_t minimum_buffer_value)
-{
-    // Try to set the highest possible value the system allows
-    for (auto send_size = initial_buffer_value; send_size >= minimum_buffer_value; send_size /= 2)
-    {
-        asio::error_code ec;
-        socket_base::send_buffer_size option(static_cast<int32_t>(send_size));
-        socket.set_option(option, ec);
-        if (!ec)
-        {
-            return send_size;
-        }
-    }
-
-    return minimum_buffer_value;
-}
-
 bool UDPTransportInterface::configure_send_buffer_size()
 {
     asio::error_code ec;
@@ -354,9 +325,14 @@ eProsimaUDPSocket UDPTransportInterface::OpenAndBindUnicastOutputSocket(
     getSocketPtr(socket)->open(generate_protocol());
     if (mSendBufferSize != 0)
     {
-        uint32_t configured_value;
-        configured_value = try_setting_send_buffer_size(socket, mSendBufferSize, configuration()->maxMessageSize);
-        if (configured_value != mSendBufferSize)
+        uint32_t configured_value = 0;
+        if (!asio_helpers::try_setting_buffer_size<socket_base::send_buffer_size>(
+                    socket, mSendBufferSize, configuration()->maxMessageSize, configured_value))
+        {
+            EPROSIMA_LOG_ERROR(RTPS_MSG_OUT,
+                    "Couldn't set send buffer size to minimum value: " << configuration()->maxMessageSize);
+        }
+        else if (configured_value != mSendBufferSize)
         {
             EPROSIMA_LOG_WARNING(RTPS_MSG_OUT, "UDPTransport sendBufferSize could not be set to the desired value. "
                     << "Using " << configured_value << " instead of " << mSendBufferSize);

--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -23,6 +23,8 @@
 #include <fastdds/rtps/messages/CDRMessage.h>
 #include <fastdds/dds/log/Log.hpp>
 #include <fastrtps/utils/IPLocator.h>
+
+#include <rtps/transport/asio_helpers.hpp>
 #include <rtps/transport/UDPSenderResource.hpp>
 #include <statistics/rtps/messages/RTPSStatisticsMessages.hpp>
 
@@ -178,10 +180,16 @@ bool UDPTransportInterface::configure_send_buffer_size()
     }
 
     // Try to set the highest possible value the system allows
-    send_buffer_size = try_setting_send_buffer_size(socket, send_buffer_size, minimum_socket_buffer);
-    set_send_buffer_size(send_buffer_size);
+    if (!asio_helpers::try_setting_buffer_size<socket_base::send_buffer_size>(
+                socket, send_buffer_size, minimum_socket_buffer, send_buffer_size))
+    {
+        EPROSIMA_LOG_ERROR(RTPS_MSG_OUT,
+                "Couldn't set send buffer size to minimum value: " << minimum_socket_buffer);
+        return false;
+    }
 
     // Keep final configuration value
+    set_send_buffer_size(send_buffer_size);
     mSendBufferSize = send_buffer_size;
 
     // Inform the user if the desired value could not be set
@@ -227,19 +235,17 @@ bool UDPTransportInterface::configure_receive_buffer_size()
     }
 
     // Try to set the highest possible value the system allows
-    for (; receive_buffer_size >= minimum_socket_buffer; receive_buffer_size /= 2)
+    if (!asio_helpers::try_setting_buffer_size<socket_base::receive_buffer_size>(
+                socket, receive_buffer_size, minimum_socket_buffer, receive_buffer_size))
     {
-        socket_base::receive_buffer_size option(static_cast<int32_t>(receive_buffer_size));
-        socket.set_option(option, ec);
-        if (!ec)
-        {
-            set_receive_buffer_size(receive_buffer_size);
-            break;
-        }
+        EPROSIMA_LOG_ERROR(RTPS_MSG_OUT,
+                "Couldn't set receive buffer size to minimum value: " << minimum_socket_buffer);
+        return false;
     }
 
     // Keep final configuration value
-    mReceiveBufferSize = configuration()->receiveBufferSize;
+    set_receive_buffer_size(receive_buffer_size);
+    mReceiveBufferSize = receive_buffer_size;
 
     // Inform the user if the desired value could not be set
     if (initial_value != 0 && mReceiveBufferSize != initial_value)

--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -229,29 +229,31 @@ bool UDPTransportInterface::init(
         const fastrtps::rtps::PropertyPolicy*,
         const uint32_t& max_msg_size_no_frag)
 {
-    configure_send_buffer_size();
-    configure_receive_buffer_size();
-
     uint32_t maximumMessageSize = max_msg_size_no_frag == 0 ? s_maximumMessageSize : max_msg_size_no_frag;
+    uint32_t cfg_max_msg_size = configuration()->maxMessageSize;
+    uint32_t cfg_send_size = configuration()->sendBufferSize;
+    uint32_t cfg_recv_size = configuration()->receiveBufferSize;
 
-    if (configuration()->maxMessageSize > maximumMessageSize)
+    if (cfg_max_msg_size > maximumMessageSize)
     {
         EPROSIMA_LOG_ERROR(RTPS_MSG_OUT,
                 "maxMessageSize cannot be greater than " << std::to_string(maximumMessageSize));
         return false;
     }
-
-    if (configuration()->maxMessageSize > configuration()->sendBufferSize)
+    if ((cfg_send_size > 0) && (cfg_max_msg_size > cfg_send_size))
     {
         EPROSIMA_LOG_ERROR(RTPS_MSG_OUT, "maxMessageSize cannot be greater than send_buffer_size");
         return false;
     }
 
-    if (configuration()->maxMessageSize > configuration()->receiveBufferSize)
+    if ((cfg_recv_size > 0) && (cfg_max_msg_size > cfg_recv_size))
     {
         EPROSIMA_LOG_ERROR(RTPS_MSG_OUT, "maxMessageSize cannot be greater than receive_buffer_size");
         return false;
     }
+
+    configure_send_buffer_size();
+    configure_receive_buffer_size();
 
     return true;
 }

--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -117,42 +117,50 @@ bool UDPTransportInterface::DoInputLocatorsMatch(
     return IPLocator::getPhysicalPort(left) == IPLocator::getPhysicalPort(right);
 }
 
+void UDPTransportInterface::configure_send_buffer_size()
+{
+    ip::udp::socket socket(io_service_);
+    socket.open(generate_protocol());
+
+    if (configuration()->sendBufferSize == 0)
+    {
+        socket_base::send_buffer_size option;
+        socket.get_option(option);
+        set_send_buffer_size(static_cast<uint32_t>(option.value()));
+
+        if (configuration()->sendBufferSize < s_minimumSocketBuffer)
+        {
+            set_send_buffer_size(s_minimumSocketBuffer);
+            mSendBufferSize = s_minimumSocketBuffer;
+        }
+    }
+}
+
+void UDPTransportInterface::configure_receive_buffer_size()
+{
+    ip::udp::socket socket(io_service_);
+    socket.open(generate_protocol());
+
+    if (configuration()->receiveBufferSize == 0)
+    {
+        socket_base::receive_buffer_size option;
+        socket.get_option(option);
+        set_receive_buffer_size(static_cast<uint32_t>(option.value()));
+
+        if (configuration()->receiveBufferSize < s_minimumSocketBuffer)
+        {
+            set_receive_buffer_size(s_minimumSocketBuffer);
+            mReceiveBufferSize = s_minimumSocketBuffer;
+        }
+    }
+}
+
 bool UDPTransportInterface::init(
         const fastrtps::rtps::PropertyPolicy*,
         const uint32_t& max_msg_size_no_frag)
 {
-    if (configuration()->sendBufferSize == 0 || configuration()->receiveBufferSize == 0)
-    {
-        // Check system buffer sizes.
-        ip::udp::socket socket(io_service_);
-        socket.open(generate_protocol());
-
-        if (configuration()->sendBufferSize == 0)
-        {
-            socket_base::send_buffer_size option;
-            socket.get_option(option);
-            set_send_buffer_size(static_cast<uint32_t>(option.value()));
-
-            if (configuration()->sendBufferSize < s_minimumSocketBuffer)
-            {
-                set_send_buffer_size(s_minimumSocketBuffer);
-                mSendBufferSize = s_minimumSocketBuffer;
-            }
-        }
-
-        if (configuration()->receiveBufferSize == 0)
-        {
-            socket_base::receive_buffer_size option;
-            socket.get_option(option);
-            set_receive_buffer_size(static_cast<uint32_t>(option.value()));
-
-            if (configuration()->receiveBufferSize < s_minimumSocketBuffer)
-            {
-                set_receive_buffer_size(s_minimumSocketBuffer);
-                mReceiveBufferSize = s_minimumSocketBuffer;
-            }
-        }
-    }
+    configure_send_buffer_size();
+    configure_receive_buffer_size();
 
     uint32_t maximumMessageSize = max_msg_size_no_frag == 0 ? s_maximumMessageSize : max_msg_size_no_frag;
 

--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -173,20 +173,55 @@ void UDPTransportInterface::configure_send_buffer_size()
 
 void UDPTransportInterface::configure_receive_buffer_size()
 {
+    asio::error_code ec;
     ip::udp::socket socket(io_service_);
-    socket.open(generate_protocol());
+    socket.open(generate_protocol(), ec);
+    if (!!ec)
+    {
+        EPROSIMA_LOG_ERROR(RTPS_MSG_OUT, "Error creating socket: " << ec.message());
+        return;
+    }
 
-    if (configuration()->receiveBufferSize == 0)
+    // If receiveBufferSize is 0, try using the system default value
+    uint32_t receive_buffer_size = configuration()->receiveBufferSize;
+    uint32_t initial_value = receive_buffer_size;
+    if (receive_buffer_size == 0)
     {
         socket_base::receive_buffer_size option;
-        socket.get_option(option);
-        set_receive_buffer_size(static_cast<uint32_t>(option.value()));
-
-        if (configuration()->receiveBufferSize < s_minimumSocketBuffer)
+        socket.get_option(option, ec);
+        if (!ec)
         {
-            set_receive_buffer_size(s_minimumSocketBuffer);
-            mReceiveBufferSize = s_minimumSocketBuffer;
+            receive_buffer_size = static_cast<uint32_t>(option.value());
         }
+    }
+
+    // Ensure the minimum value is used
+    if (receive_buffer_size < s_minimumSocketBuffer)
+    {
+        receive_buffer_size = s_minimumSocketBuffer;
+        set_receive_buffer_size(receive_buffer_size);
+    }
+
+    // Try to set the highest possible value the system allows
+    for (; receive_buffer_size >= s_minimumSocketBuffer; receive_buffer_size /= 2)
+    {
+        socket_base::receive_buffer_size option(static_cast<int32_t>(receive_buffer_size));
+        socket.set_option(option, ec);
+        if (!ec)
+        {
+            set_receive_buffer_size(receive_buffer_size);
+            break;
+        }
+    }
+
+    // Keep final configuration value
+    mReceiveBufferSize = configuration()->receiveBufferSize;
+
+    // Inform the user if the desired value could not be set
+    if (initial_value != 0 && mReceiveBufferSize != initial_value)
+    {
+        EPROSIMA_LOG_WARNING(RTPS_MSG_OUT, "UDPTransport receiveBufferSize could not be set to the desired value. "
+                << "Using " << mReceiveBufferSize << " instead of " << initial_value);
     }
 }
 

--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -146,7 +146,7 @@ static uint32_t try_setting_send_buffer_size(
     return minimum_buffer_value;
 }
 
-void UDPTransportInterface::configure_send_buffer_size()
+bool UDPTransportInterface::configure_send_buffer_size()
 {
     asio::error_code ec;
     ip::udp::socket socket(io_service_);
@@ -154,7 +154,7 @@ void UDPTransportInterface::configure_send_buffer_size()
     if (!!ec)
     {
         EPROSIMA_LOG_ERROR(RTPS_MSG_OUT, "Error creating socket: " << ec.message());
-        return;
+        return false;
     }
 
     // If sendBufferSize is 0, try using the system default value
@@ -190,9 +190,11 @@ void UDPTransportInterface::configure_send_buffer_size()
         EPROSIMA_LOG_WARNING(RTPS_MSG_OUT, "UDPTransport sendBufferSize could not be set to the desired value. "
                 << "Using " << mSendBufferSize << " instead of " << initial_value);
     }
+
+    return true;
 }
 
-void UDPTransportInterface::configure_receive_buffer_size()
+bool UDPTransportInterface::configure_receive_buffer_size()
 {
     asio::error_code ec;
     ip::udp::socket socket(io_service_);
@@ -200,7 +202,7 @@ void UDPTransportInterface::configure_receive_buffer_size()
     if (!!ec)
     {
         EPROSIMA_LOG_ERROR(RTPS_MSG_OUT, "Error creating socket: " << ec.message());
-        return;
+        return false;
     }
 
     // If receiveBufferSize is 0, try using the system default value
@@ -245,6 +247,8 @@ void UDPTransportInterface::configure_receive_buffer_size()
         EPROSIMA_LOG_WARNING(RTPS_MSG_OUT, "UDPTransport receiveBufferSize could not be set to the desired value. "
                 << "Using " << mReceiveBufferSize << " instead of " << initial_value);
     }
+
+    return true;
 }
 
 bool UDPTransportInterface::init(
@@ -274,10 +278,7 @@ bool UDPTransportInterface::init(
         return false;
     }
 
-    configure_send_buffer_size();
-    configure_receive_buffer_size();
-
-    return true;
+    return configure_send_buffer_size() && configure_receive_buffer_size();
 }
 
 bool UDPTransportInterface::IsInputChannelOpen(

--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -119,20 +119,55 @@ bool UDPTransportInterface::DoInputLocatorsMatch(
 
 void UDPTransportInterface::configure_send_buffer_size()
 {
+    asio::error_code ec;
     ip::udp::socket socket(io_service_);
-    socket.open(generate_protocol());
+    socket.open(generate_protocol(), ec);
+    if (!!ec)
+    {
+        EPROSIMA_LOG_ERROR(RTPS_MSG_OUT, "Error creating socket: " << ec.message());
+        return;
+    }
 
-    if (configuration()->sendBufferSize == 0)
+    // If sendBufferSize is 0, try using the system default value
+    uint32_t send_buffer_size = configuration()->sendBufferSize;
+    uint32_t initial_value = send_buffer_size;
+    if (send_buffer_size == 0)
     {
         socket_base::send_buffer_size option;
-        socket.get_option(option);
-        set_send_buffer_size(static_cast<uint32_t>(option.value()));
-
-        if (configuration()->sendBufferSize < s_minimumSocketBuffer)
+        socket.get_option(option, ec);
+        if (!ec)
         {
-            set_send_buffer_size(s_minimumSocketBuffer);
-            mSendBufferSize = s_minimumSocketBuffer;
+            send_buffer_size = static_cast<uint32_t>(option.value());
         }
+    }
+
+    // Ensure the minimum value is used
+    if (send_buffer_size < s_minimumSocketBuffer)
+    {
+        send_buffer_size = s_minimumSocketBuffer;
+        set_send_buffer_size(send_buffer_size);
+    }
+
+    // Try to set the highest possible value the system allows
+    for (; send_buffer_size >= s_minimumSocketBuffer; send_buffer_size /= 2)
+    {
+        socket_base::send_buffer_size option(static_cast<int32_t>(send_buffer_size));
+        socket.set_option(option, ec);
+        if (!ec)
+        {
+            set_send_buffer_size(send_buffer_size);
+            break;
+        }
+    }
+
+    // Keep final configuration value
+    mSendBufferSize = configuration()->sendBufferSize;
+
+    // Inform the user if the desired value could not be set
+    if (initial_value != 0 && mSendBufferSize != initial_value)
+    {
+        EPROSIMA_LOG_WARNING(RTPS_MSG_OUT, "UDPTransport sendBufferSize could not be set to the desired value. "
+                << "Using " << mSendBufferSize << " instead of " << initial_value);
     }
 }
 

--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -14,14 +14,15 @@
 
 #include <rtps/transport/UDPTransportInterface.h>
 
-#include <utility>
-#include <cstring>
 #include <algorithm>
 #include <chrono>
+#include <cstring>
+#include <limits>
+#include <utility>
 
+#include <fastdds/dds/log/Log.hpp>
 #include <fastdds/rtps/transport/TransportInterface.h>
 #include <fastdds/rtps/messages/CDRMessage.h>
-#include <fastdds/dds/log/Log.hpp>
 #include <fastrtps/utils/IPLocator.h>
 
 #include <rtps/transport/asio_helpers.hpp>
@@ -126,7 +127,7 @@ bool UDPTransportInterface::configure_send_buffer_size()
     socket.open(generate_protocol(), ec);
     if (!!ec)
     {
-        EPROSIMA_LOG_ERROR(RTPS_MSG_OUT, "Error creating socket: " << ec.message());
+        EPROSIMA_LOG_ERROR(TRANSPORT_UDP, "Error creating socket: " << ec.message());
         return false;
     }
 
@@ -154,7 +155,7 @@ bool UDPTransportInterface::configure_send_buffer_size()
     if (!asio_helpers::try_setting_buffer_size<socket_base::send_buffer_size>(
                 socket, send_buffer_size, minimum_socket_buffer, send_buffer_size))
     {
-        EPROSIMA_LOG_ERROR(RTPS_MSG_OUT,
+        EPROSIMA_LOG_ERROR(TRANSPORT_UDP,
                 "Couldn't set send buffer size to minimum value: " << minimum_socket_buffer);
         return false;
     }
@@ -166,7 +167,7 @@ bool UDPTransportInterface::configure_send_buffer_size()
     // Inform the user if the desired value could not be set
     if (initial_value != 0 && mSendBufferSize != initial_value)
     {
-        EPROSIMA_LOG_WARNING(RTPS_MSG_OUT, "UDPTransport sendBufferSize could not be set to the desired value. "
+        EPROSIMA_LOG_WARNING(TRANSPORT_UDP, "UDPTransport sendBufferSize could not be set to the desired value. "
                 << "Using " << mSendBufferSize << " instead of " << initial_value);
     }
 
@@ -180,7 +181,7 @@ bool UDPTransportInterface::configure_receive_buffer_size()
     socket.open(generate_protocol(), ec);
     if (!!ec)
     {
-        EPROSIMA_LOG_ERROR(RTPS_MSG_OUT, "Error creating socket: " << ec.message());
+        EPROSIMA_LOG_ERROR(TRANSPORT_UDP, "Error creating socket: " << ec.message());
         return false;
     }
 
@@ -209,7 +210,7 @@ bool UDPTransportInterface::configure_receive_buffer_size()
     if (!asio_helpers::try_setting_buffer_size<socket_base::receive_buffer_size>(
                 socket, receive_buffer_size, minimum_socket_buffer, receive_buffer_size))
     {
-        EPROSIMA_LOG_ERROR(RTPS_MSG_OUT,
+        EPROSIMA_LOG_ERROR(TRANSPORT_UDP,
                 "Couldn't set receive buffer size to minimum value: " << minimum_socket_buffer);
         return false;
     }
@@ -221,7 +222,7 @@ bool UDPTransportInterface::configure_receive_buffer_size()
     // Inform the user if the desired value could not be set
     if (initial_value != 0 && mReceiveBufferSize != initial_value)
     {
-        EPROSIMA_LOG_WARNING(RTPS_MSG_OUT, "UDPTransport receiveBufferSize could not be set to the desired value. "
+        EPROSIMA_LOG_WARNING(TRANSPORT_UDP, "UDPTransport receiveBufferSize could not be set to the desired value. "
                 << "Using " << mReceiveBufferSize << " instead of " << initial_value);
     }
 
@@ -236,22 +237,35 @@ bool UDPTransportInterface::init(
     uint32_t cfg_max_msg_size = configuration()->maxMessageSize;
     uint32_t cfg_send_size = configuration()->sendBufferSize;
     uint32_t cfg_recv_size = configuration()->receiveBufferSize;
+    uint32_t max_int_value = static_cast<uint32_t>(std::numeric_limits<int32_t>::max());
 
     if (cfg_max_msg_size > maximumMessageSize)
     {
-        EPROSIMA_LOG_ERROR(RTPS_MSG_OUT,
-                "maxMessageSize cannot be greater than " << std::to_string(maximumMessageSize));
+        EPROSIMA_LOG_ERROR(TRANSPORT_UDP, "maxMessageSize cannot be greater than " << maximumMessageSize);
         return false;
     }
+
+    if (cfg_send_size > max_int_value)
+    {
+        EPROSIMA_LOG_ERROR(TRANSPORT_UDP, "sendBufferSize cannot be greater than " << max_int_value);
+        return false;
+    }
+
+    if (cfg_recv_size > max_int_value)
+    {
+        EPROSIMA_LOG_ERROR(TRANSPORT_UDP, "receiveBufferSize cannot be greater than " << max_int_value);
+        return false;
+    }
+
     if ((cfg_send_size > 0) && (cfg_max_msg_size > cfg_send_size))
     {
-        EPROSIMA_LOG_ERROR(RTPS_MSG_OUT, "maxMessageSize cannot be greater than send_buffer_size");
+        EPROSIMA_LOG_ERROR(TRANSPORT_UDP, "maxMessageSize cannot be greater than sendBufferSize");
         return false;
     }
 
     if ((cfg_recv_size > 0) && (cfg_max_msg_size > cfg_recv_size))
     {
-        EPROSIMA_LOG_ERROR(RTPS_MSG_OUT, "maxMessageSize cannot be greater than receive_buffer_size");
+        EPROSIMA_LOG_ERROR(TRANSPORT_UDP, "maxMessageSize cannot be greater than receiveBufferSize");
         return false;
     }
 
@@ -293,9 +307,8 @@ bool UDPTransportInterface::OpenAndBindInputSockets(
     catch (asio::system_error const& e)
     {
         (void)e;
-        EPROSIMA_LOG_INFO(RTPS_MSG_OUT, "UDPTransport Error binding at port: (" << IPLocator::getPhysicalPort(
-                    locator) << ")"
-                                                                                << " with msg: " << e.what());
+        EPROSIMA_LOG_INFO(TRANSPORT_UDP, "UDPTransport Error binding at port: ("
+                << IPLocator::getPhysicalPort(locator) << ")" << " with msg: " << e.what());
         mInputSockets.erase(IPLocator::getPhysicalPort(locator));
         return false;
     }
@@ -329,12 +342,12 @@ eProsimaUDPSocket UDPTransportInterface::OpenAndBindUnicastOutputSocket(
         if (!asio_helpers::try_setting_buffer_size<socket_base::send_buffer_size>(
                     socket, mSendBufferSize, configuration()->maxMessageSize, configured_value))
         {
-            EPROSIMA_LOG_ERROR(RTPS_MSG_OUT,
+            EPROSIMA_LOG_ERROR(TRANSPORT_UDP,
                     "Couldn't set send buffer size to minimum value: " << configuration()->maxMessageSize);
         }
         else if (configured_value != mSendBufferSize)
         {
-            EPROSIMA_LOG_WARNING(RTPS_MSG_OUT, "UDPTransport sendBufferSize could not be set to the desired value. "
+            EPROSIMA_LOG_WARNING(TRANSPORT_UDP, "UDPTransport sendBufferSize could not be set to the desired value. "
                     << "Using " << configured_value << " instead of " << mSendBufferSize);
         }
     }
@@ -423,7 +436,7 @@ bool UDPTransportInterface::OpenOutputChannel(
                 catch (asio::system_error const& e)
                 {
                     (void)e;
-                    EPROSIMA_LOG_WARNING(RTPS_MSG_OUT, "UDPTransport Error binding interface "
+                    EPROSIMA_LOG_WARNING(TRANSPORT_UDP, "UDPTransport Error binding interface "
                             << localhost_name() << " (skipping) with msg: " << e.what());
                 }
             }
@@ -447,7 +460,7 @@ bool UDPTransportInterface::OpenOutputChannel(
                     catch (asio::system_error const& e)
                     {
                         (void)e;
-                        EPROSIMA_LOG_WARNING(RTPS_MSG_OUT, "UDPTransport Error binding interface "
+                        EPROSIMA_LOG_WARNING(TRANSPORT_UDP, "UDPTransport Error binding interface "
                                 << (*locIt).name << " (skipping) with msg: " << e.what());
                     }
                 }
@@ -480,7 +493,7 @@ bool UDPTransportInterface::OpenOutputChannel(
     {
         (void)e;
         /* TODO Que hacer?
-           EPROSIMA_LOG_ERROR(RTPS_MSG_OUT, "UDPTransport Error binding at port: (" << IPLocator::getPhysicalPort(locator) << ")"
+           EPROSIMA_LOG_ERROR(TRANSPORT_UDP, "UDPTransport Error binding at port: (" << IPLocator::getPhysicalPort(locator) << ")"
             << " with msg: " << e.what());
            for (auto& socket : mOutputSockets)
            {
@@ -644,23 +657,24 @@ bool UDPTransportInterface::send(
                 if ((ec.value() == asio::error::would_block) ||
                         (ec.value() == asio::error::try_again))
                 {
-                    EPROSIMA_LOG_WARNING(RTPS_MSG_OUT, "UDP send would have blocked. Packet is dropped.");
+                    EPROSIMA_LOG_WARNING(TRANSPORT_UDP, "UDP send would have blocked. Packet is dropped.");
                     return true;
                 }
 
-                EPROSIMA_LOG_WARNING(RTPS_MSG_OUT, ec.message());
+                EPROSIMA_LOG_WARNING(TRANSPORT_UDP, ec.message());
                 return false;
             }
         }
         catch (const std::exception& error)
         {
-            EPROSIMA_LOG_WARNING(RTPS_MSG_OUT, error.what());
+            EPROSIMA_LOG_WARNING(TRANSPORT_UDP, error.what());
             return false;
         }
 
         (void)bytesSent;
-        EPROSIMA_LOG_INFO(RTPS_MSG_OUT, "UDPTransport: " << bytesSent << " bytes TO endpoint: " << destinationEndpoint
-                                                         << " FROM " << getSocketPtr(socket)->local_endpoint());
+        EPROSIMA_LOG_INFO(TRANSPORT_UDP,
+                "UDPTransport: " << bytesSent << " bytes TO endpoint: " << destinationEndpoint <<
+                " FROM " << getSocketPtr(socket)->local_endpoint());
         success = true;
     }
 

--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -146,6 +146,35 @@ static uint32_t try_setting_send_buffer_size(
     return minimum_buffer_value;
 }
 
+/**
+ * @brief Set the receive buffer size of the socket to the highest possible value the system allows.
+ *
+ * @param socket The socket on which to set the receive buffer size.
+ * @param initial_buffer_value The initial value to try to set.
+ * @param minimum_buffer_value The minimum value to set.
+ *
+ * @return The final value set.
+ */
+static uint32_t try_setting_receive_buffer_size(
+        asio::ip::udp::socket& socket,
+        uint32_t initial_buffer_value,
+        uint32_t minimum_buffer_value)
+{
+    // Try to set the highest possible value the system allows
+    for (auto recv_size = initial_buffer_value; recv_size >= minimum_buffer_value; recv_size /= 2)
+    {
+        asio::error_code ec;
+        socket_base::receive_buffer_size option(static_cast<int32_t>(recv_size));
+        socket.set_option(option, ec);
+        if (!ec)
+        {
+            return recv_size;
+        }
+    }
+
+    return minimum_buffer_value;
+}
+
 void UDPTransportInterface::configure_send_buffer_size()
 {
     asio::error_code ec;
@@ -221,23 +250,14 @@ void UDPTransportInterface::configure_receive_buffer_size()
     if (receive_buffer_size < minimum_socket_buffer)
     {
         receive_buffer_size = minimum_socket_buffer;
-        set_receive_buffer_size(receive_buffer_size);
     }
 
     // Try to set the highest possible value the system allows
-    for (; receive_buffer_size >= minimum_socket_buffer; receive_buffer_size /= 2)
-    {
-        socket_base::receive_buffer_size option(static_cast<int32_t>(receive_buffer_size));
-        socket.set_option(option, ec);
-        if (!ec)
-        {
-            set_receive_buffer_size(receive_buffer_size);
-            break;
-        }
-    }
+    receive_buffer_size = try_setting_receive_buffer_size(socket, receive_buffer_size, minimum_socket_buffer);
+    set_receive_buffer_size(receive_buffer_size);
 
     // Keep final configuration value
-    mReceiveBufferSize = configuration()->receiveBufferSize;
+    mReceiveBufferSize = receive_buffer_size;
 
     // Inform the user if the desired value could not be set
     if (initial_value != 0 && mReceiveBufferSize != initial_value)
@@ -334,6 +354,17 @@ UDPChannelResource* UDPTransportInterface::CreateInputChannelResource(
 {
     eProsimaUDPSocket unicastSocket = OpenAndBindInputSocket(sInterface,
                     IPLocator::getPhysicalPort(locator), is_multicast);
+    if (mReceiveBufferSize != 0)
+    {
+        uint32_t configured_value;
+        configured_value = try_setting_receive_buffer_size(unicastSocket, mReceiveBufferSize, maxMsgSize);
+        if (configured_value != mReceiveBufferSize)
+        {
+            EPROSIMA_LOG_WARNING(RTPS_MSG_OUT, "UDPTransport receiveBufferSize could not be set to the desired value. "
+                    << "Using " << configured_value << " instead of " << mReceiveBufferSize);
+        }
+    }
+
     UDPChannelResource* p_channel_resource = new UDPChannelResource(this, unicastSocket, maxMsgSize, locator,
                     sInterface, receiver, configuration()->get_thread_config_for_port(locator.port));
     return p_channel_resource;

--- a/src/cpp/rtps/transport/UDPTransportInterface.h
+++ b/src/cpp/rtps/transport/UDPTransportInterface.h
@@ -308,7 +308,16 @@ protected:
 
 private:
 
+    /**
+     * @brief Prepare transport configuration regarding send buffer size.
+     * @return true if a send buffer size greater than max message size could be set, false otherwise.
+     */
     bool configure_send_buffer_size();
+
+    /**
+     * @brief Prepare transport configuration regarding receive buffer size.
+     * @return true if a receive buffer size greater than max message size could be set, false otherwise.
+     */
     bool configure_receive_buffer_size();
 
 };

--- a/src/cpp/rtps/transport/UDPTransportInterface.h
+++ b/src/cpp/rtps/transport/UDPTransportInterface.h
@@ -306,20 +306,6 @@ protected:
 
     std::atomic_bool rescan_interfaces_ = {true};
 
-private:
-
-    /**
-     * @brief Prepare transport configuration regarding send buffer size.
-     * @return true if a send buffer size greater than max message size could be set, false otherwise.
-     */
-    bool configure_send_buffer_size();
-
-    /**
-     * @brief Prepare transport configuration regarding receive buffer size.
-     * @return true if a receive buffer size greater than max message size could be set, false otherwise.
-     */
-    bool configure_receive_buffer_size();
-
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/transport/UDPTransportInterface.h
+++ b/src/cpp/rtps/transport/UDPTransportInterface.h
@@ -308,8 +308,8 @@ protected:
 
 private:
 
-    void configure_send_buffer_size();
-    void configure_receive_buffer_size();
+    bool configure_send_buffer_size();
+    bool configure_receive_buffer_size();
 
 };
 

--- a/src/cpp/rtps/transport/UDPTransportInterface.h
+++ b/src/cpp/rtps/transport/UDPTransportInterface.h
@@ -305,6 +305,12 @@ protected:
             bool return_loopback = false);
 
     std::atomic_bool rescan_interfaces_ = {true};
+
+private:
+
+    void configure_send_buffer_size();
+    void configure_receive_buffer_size();
+
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/transport/UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/UDPv4Transport.cpp
@@ -27,6 +27,7 @@
 
 #include <rtps/network/ReceiverResource.h>
 #include <rtps/network/utils/netmask_filter.hpp>
+#include <rtps/transport/asio_helpers.hpp>
 
 #include <utils/SystemInfo.hpp>
 
@@ -395,7 +396,20 @@ eProsimaUDPSocket UDPv4Transport::OpenAndBindInputSocket(
     getSocketPtr(socket)->open(generate_protocol());
     if (mReceiveBufferSize != 0)
     {
-        getSocketPtr(socket)->set_option(socket_base::receive_buffer_size(mReceiveBufferSize));
+        uint32_t configured_value = 0;
+        uint32_t minimum_value = configuration()->maxMessageSize;
+        if (!asio_helpers::try_setting_buffer_size<socket_base::receive_buffer_size>(
+                    socket, mReceiveBufferSize, minimum_value, configured_value))
+        {
+            EPROSIMA_LOG_ERROR(TRANSPORT_UDPV4,
+                    "Couldn't set receive buffer size to minimum value: " << minimum_value);
+        }
+        else if (mReceiveBufferSize != configured_value)
+        {
+            EPROSIMA_LOG_WARNING(TRANSPORT_UDPV4,
+                    "Receive buffer size could not be set to the desired value. "
+                    << "Using " << configured_value << " instead of " << mReceiveBufferSize);
+        }
     }
 
     if (is_multicast)

--- a/src/cpp/rtps/transport/UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/UDPv4Transport.cpp
@@ -393,6 +393,10 @@ eProsimaUDPSocket UDPv4Transport::OpenAndBindInputSocket(
 {
     eProsimaUDPSocket socket = createUDPSocket(io_service_);
     getSocketPtr(socket)->open(generate_protocol());
+    if (mReceiveBufferSize != 0)
+    {
+        getSocketPtr(socket)->set_option(socket_base::receive_buffer_size(mReceiveBufferSize));
+    }
 
     if (is_multicast)
     {

--- a/src/cpp/rtps/transport/UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/UDPv4Transport.cpp
@@ -393,10 +393,6 @@ eProsimaUDPSocket UDPv4Transport::OpenAndBindInputSocket(
 {
     eProsimaUDPSocket socket = createUDPSocket(io_service_);
     getSocketPtr(socket)->open(generate_protocol());
-    if (mReceiveBufferSize != 0)
-    {
-        getSocketPtr(socket)->set_option(socket_base::receive_buffer_size(mReceiveBufferSize));
-    }
 
     if (is_multicast)
     {

--- a/src/cpp/rtps/transport/UDPv6Transport.cpp
+++ b/src/cpp/rtps/transport/UDPv6Transport.cpp
@@ -23,7 +23,9 @@
 #include <fastdds/rtps/transport/SenderResource.h>
 #include <fastdds/rtps/transport/TransportInterface.h>
 #include <fastrtps/utils/IPLocator.h>
+
 #include <rtps/network/utils/netmask_filter.hpp>
+#include <rtps/transport/asio_helpers.hpp>
 #include <utils/SystemInfo.hpp>
 
 using namespace std;
@@ -396,7 +398,20 @@ eProsimaUDPSocket UDPv6Transport::OpenAndBindInputSocket(
     getSocketPtr(socket)->open(generate_protocol());
     if (mReceiveBufferSize != 0)
     {
-        getSocketPtr(socket)->set_option(socket_base::receive_buffer_size(mReceiveBufferSize));
+        uint32_t configured_value = 0;
+        uint32_t minimum_value = configuration()->maxMessageSize;
+        if (!asio_helpers::asio_helpers::try_setting_buffer_size<asio::socket_base::receive_buffer_size>(
+                    socket, mReceiveBufferSize, minimum_value, configured_value))
+        {
+            EPROSIMA_LOG_ERROR(TRANSPORT_UDPV6,
+                    "Couldn't set receive buffer size to minimum value: " << minimum_value);
+        }
+        else if (mReceiveBufferSize != configured_value)
+        {
+            EPROSIMA_LOG_WARNING(TRANSPORT_UDPV6,
+                    "Receive buffer size could not be set to the desired value. "
+                    << "Using " << configured_value << " instead of " << mReceiveBufferSize);
+        }
     }
 
     if (is_multicast)

--- a/src/cpp/rtps/transport/UDPv6Transport.cpp
+++ b/src/cpp/rtps/transport/UDPv6Transport.cpp
@@ -394,10 +394,6 @@ eProsimaUDPSocket UDPv6Transport::OpenAndBindInputSocket(
 {
     eProsimaUDPSocket socket = createUDPSocket(io_service_);
     getSocketPtr(socket)->open(generate_protocol());
-    if (mReceiveBufferSize != 0)
-    {
-        getSocketPtr(socket)->set_option(socket_base::receive_buffer_size(mReceiveBufferSize));
-    }
 
     if (is_multicast)
     {

--- a/src/cpp/rtps/transport/UDPv6Transport.cpp
+++ b/src/cpp/rtps/transport/UDPv6Transport.cpp
@@ -394,6 +394,10 @@ eProsimaUDPSocket UDPv6Transport::OpenAndBindInputSocket(
 {
     eProsimaUDPSocket socket = createUDPSocket(io_service_);
     getSocketPtr(socket)->open(generate_protocol());
+    if (mReceiveBufferSize != 0)
+    {
+        getSocketPtr(socket)->set_option(socket_base::receive_buffer_size(mReceiveBufferSize));
+    }
 
     if (is_multicast)
     {

--- a/src/cpp/rtps/transport/asio_helpers.hpp
+++ b/src/cpp/rtps/transport/asio_helpers.hpp
@@ -1,0 +1,77 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RTPS_TRANSPORT__ASIO_HELPERS_HPP_
+#define RTPS_TRANSPORT__ASIO_HELPERS_HPP_
+
+#include <cstdint>
+
+#include <asio.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+
+/// Helper functions for asio.
+// NOTE: using a struct instead of a namespace to avoid linker errors when using inline free functions.
+struct asio_helpers
+{
+    /**
+     * @brief Try to set a buffer size on a socket, trying to set the initial value and then halving it until it is
+     * possible to set it or the minimum value is reached.
+     *
+     * @tparam BufferOptionType Type of the buffer option to set.
+     * @tparam SocketType Type of socket on which to set the buffer size option.
+     *
+     * @param socket Socket on which to set the buffer size option.
+     * @param initial_buffer_value Initial value to try to set.
+     * @param minimum_buffer_value Minimum value to set.
+     * @param final_buffer_value Output parameter where the final value set will be stored.
+     *
+     * @return true if the buffer size was successfully set, false otherwise.
+     */
+    template <typename BufferOptionType, typename SocketType>
+    static inline bool try_setting_buffer_size(
+            SocketType& socket,
+            const uint32_t initial_buffer_value,
+            const uint32_t minimum_buffer_value,
+            uint32_t& final_buffer_value)
+    {
+        asio::error_code ec;
+
+        final_buffer_value = initial_buffer_value;
+        while (final_buffer_value >= minimum_buffer_value)
+        {
+            socket.set_option(BufferOptionType(static_cast<int32_t>(final_buffer_value)), ec);
+            if (!ec)
+            {
+                return true;
+            }
+
+            final_buffer_value /= 2;
+        }
+
+        final_buffer_value = minimum_buffer_value;
+        socket.set_option(BufferOptionType(final_buffer_value), ec);
+        return !ec;
+    }
+
+};
+
+}  // namespace rtps
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif  // RTPS_TRANSPORT__ASIO_HELPERS_HPP_
+

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -1310,6 +1310,7 @@ public:
             uint32_t sockerBufferSize)
     {
         participant_qos_.transport().listen_socket_buffer_size = sockerBufferSize;
+        participant_qos_.transport().send_socket_buffer_size = sockerBufferSize;
         return *this;
     }
 

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -1493,6 +1493,7 @@ public:
             uint32_t sockerBufferSize)
     {
         participant_qos_.transport().listen_socket_buffer_size = sockerBufferSize;
+        participant_qos_.transport().send_socket_buffer_size = sockerBufferSize;
         return *this;
     }
 

--- a/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
@@ -1077,6 +1077,7 @@ public:
             uint32_t sockerBufferSize)
     {
         participant_attr_.rtps.listenSocketBufferSize = sockerBufferSize;
+        participant_attr_.rtps.sendSocketBufferSize = sockerBufferSize;
         return *this;
     }
 

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
@@ -1257,6 +1257,7 @@ public:
             uint32_t sockerBufferSize)
     {
         participant_attr_.rtps.listenSocketBufferSize = sockerBufferSize;
+        participant_attr_.rtps.sendSocketBufferSize = sockerBufferSize;
         return *this;
     }
 

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -674,11 +674,22 @@ TEST_P(DDSStatus, DataAvailableConditions)
     subscriber_reader.wait_waitset_timeout();
 }
 
+// We want to ensure that samples are only lost due to the custom filter we have set in sample_lost_test_dw_init.
+// Since we are going to send 300KB samples in the test for fragments, let's increase the buffer size to avoid any
+// other possible loss.
+static constexpr uint32_t SAMPLE_LOST_TEST_BUFFER_SIZE =
+        300ul * 1024ul // sample size
+        * 13ul         // number of samples
+        * 2ul;         // 2x to avoid any possible loss
+
 template<typename T>
 void sample_lost_test_dw_init(
         PubSubWriter<T>& writer)
 {
     auto testTransport = std::make_shared<test_UDPv4TransportDescriptor>();
+    testTransport->sendBufferSize = SAMPLE_LOST_TEST_BUFFER_SIZE;
+    testTransport->receiveBufferSize = SAMPLE_LOST_TEST_BUFFER_SIZE;
+
     testTransport->drop_data_messages_filter_ = [](eprosima::fastrtps::rtps::CDRMessage_t& msg)-> bool
             {
                 uint32_t old_pos = msg.pos;
@@ -777,15 +788,8 @@ void sample_lost_test_init(
         PubSubWriter<T>& writer,
         std::function<void(const eprosima::fastdds::dds::SampleLostStatus& status)> functor)
 {
-    // We want to ensure that samples are only lost due to the custom filter we have set in sample_lost_test_dw_init.
-    // Since we are going to send 300KB samples in the test for fragments, let's increase the buffer size to avoid any
-    // other possible loss.
-    constexpr uint32_t BUFFER_SIZE =
-            300ul * 1024ul // sample size
-            * 13ul         // number of samples
-            * 2ul;         // 2x to avoid any possible loss
-    reader.socket_buffer_size(BUFFER_SIZE);
-    writer.socket_buffer_size(BUFFER_SIZE);
+    reader.socket_buffer_size(SAMPLE_LOST_TEST_BUFFER_SIZE);
+    writer.socket_buffer_size(SAMPLE_LOST_TEST_BUFFER_SIZE);
 
     sample_lost_test_dw_init(writer);
     sample_lost_test_dr_init(reader, functor);

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <limits>
 #include <memory>
 #include <thread>
 
@@ -80,6 +81,67 @@ public:
     std::unique_ptr<std::thread> senderThread;
     std::unique_ptr<std::thread> receiverThread;
 };
+
+TEST_F(TCPv4Tests, wrong_configuration_values)
+{
+    // Too big sendBufferSize
+    {
+        auto wrong_descriptor = descriptor;
+        wrong_descriptor.sendBufferSize = std::numeric_limits<uint32_t>::max();
+        TCPv4Transport transportUnderTest(wrong_descriptor);
+        ASSERT_FALSE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+
+    // Too big receiveBufferSize
+    {
+        auto wrong_descriptor = descriptor;
+        wrong_descriptor.receiveBufferSize = std::numeric_limits<uint32_t>::max();
+        TCPv4Transport transportUnderTest(wrong_descriptor);
+        ASSERT_FALSE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+
+    // Too big maxMessageSize
+    {
+        auto wrong_descriptor = descriptor;
+        wrong_descriptor.maxMessageSize = std::numeric_limits<uint32_t>::max();
+        TCPv4Transport transportUnderTest(wrong_descriptor);
+        ASSERT_FALSE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+
+    // maxMessageSize bigger than receiveBufferSize
+    {
+        auto wrong_descriptor = descriptor;
+        wrong_descriptor.maxMessageSize = 10;
+        wrong_descriptor.receiveBufferSize = 5;
+        TCPv4Transport transportUnderTest(wrong_descriptor);
+        ASSERT_FALSE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+
+    // maxMessageSize bigger than sendBufferSize
+    {
+        auto wrong_descriptor = descriptor;
+        wrong_descriptor.maxMessageSize = 10;
+        wrong_descriptor.sendBufferSize = 5;
+        TCPv4Transport transportUnderTest(wrong_descriptor);
+        ASSERT_FALSE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+
+    // Buffer sizes automatically decrease
+    {
+        auto wrong_descriptor = descriptor;
+        wrong_descriptor.sendBufferSize = static_cast<uint32_t>(std::numeric_limits<int32_t>::max());
+        wrong_descriptor.receiveBufferSize = static_cast<uint32_t>(std::numeric_limits<int32_t>::max());
+        wrong_descriptor.maxMessageSize = 1470;
+        TCPv4Transport transportUnderTest(wrong_descriptor);
+        ASSERT_TRUE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+}
 
 TEST_F(TCPv4Tests, locators_with_kind_1_supported)
 {

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -139,6 +139,11 @@ TEST_F(TCPv4Tests, wrong_configuration_values)
         wrong_descriptor.maxMessageSize = 1470;
         TCPv4Transport transportUnderTest(wrong_descriptor);
         ASSERT_TRUE(transportUnderTest.init());
+        auto* final_cfg = transportUnderTest.configuration();
+        EXPECT_GE(final_cfg->sendBufferSize, final_cfg->maxMessageSize);
+        EXPECT_LT(final_cfg->sendBufferSize, wrong_descriptor.sendBufferSize);
+        EXPECT_GE(final_cfg->receiveBufferSize, final_cfg->maxMessageSize);
+        EXPECT_LT(final_cfg->receiveBufferSize, wrong_descriptor.receiveBufferSize);
         eprosima::fastdds::dds::Log::Flush();
     }
 }

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -1402,7 +1402,7 @@ TEST_F(TCPv4Tests, secure_non_blocking_send)
     eprosima::fastdds::dds::Log::SetVerbosity(eprosima::fastdds::dds::Log::Kind::Info);
 
     uint16_t port = g_default_port;
-    uint32_t msg_size = eprosima::fastdds::rtps::s_minimumSocketBuffer;
+    uint32_t msg_size = 64ul * 1024ul;
     // Create a TCP Server transport
     using TLSOptions = TCPTransportDescriptor::TLSConfig::TLSOptions;
     using TLSVerifyMode = TCPTransportDescriptor::TLSConfig::TLSVerifyMode;
@@ -1961,7 +1961,7 @@ TEST_F(TCPv4Tests, client_announced_local_port_uniqueness)
 TEST_F(TCPv4Tests, non_blocking_send)
 {
     uint16_t port = g_default_port;
-    uint32_t msg_size = eprosima::fastdds::rtps::s_minimumSocketBuffer;
+    uint32_t msg_size = 64ul * 1024ul;
     // Create a TCP Server transport
     TCPv4TransportDescriptor senderDescriptor;
     senderDescriptor.add_listener_port(port);

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -141,9 +141,11 @@ TEST_F(TCPv4Tests, wrong_configuration_values)
         ASSERT_TRUE(transportUnderTest.init());
         auto* final_cfg = transportUnderTest.configuration();
         EXPECT_GE(final_cfg->sendBufferSize, final_cfg->maxMessageSize);
-        EXPECT_LT(final_cfg->sendBufferSize, wrong_descriptor.sendBufferSize);
+        // The system could allow for the send buffer to be MAX_INT, so we cannot check it to be strictly lower
+        EXPECT_LE(final_cfg->sendBufferSize, wrong_descriptor.sendBufferSize);
         EXPECT_GE(final_cfg->receiveBufferSize, final_cfg->maxMessageSize);
-        EXPECT_LT(final_cfg->receiveBufferSize, wrong_descriptor.receiveBufferSize);
+        // The system could allow for the receive buffer to be MAX_INT, so we cannot check it to be strictly lower
+        EXPECT_LE(final_cfg->receiveBufferSize, wrong_descriptor.receiveBufferSize);
         eprosima::fastdds::dds::Log::Flush();
     }
 }

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <limits>
 #include <memory>
 #include <thread>
 
@@ -82,6 +83,67 @@ public:
     std::unique_ptr<std::thread> senderThread;
     std::unique_ptr<std::thread> receiverThread;
 };
+
+TEST_F(TCPv6Tests, wrong_configuration_values)
+{
+    // Too big sendBufferSize
+    {
+        auto wrong_descriptor = descriptor;
+        wrong_descriptor.sendBufferSize = std::numeric_limits<uint32_t>::max();
+        TCPv6Transport transportUnderTest(wrong_descriptor);
+        ASSERT_FALSE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+
+    // Too big receiveBufferSize
+    {
+        auto wrong_descriptor = descriptor;
+        wrong_descriptor.receiveBufferSize = std::numeric_limits<uint32_t>::max();
+        TCPv6Transport transportUnderTest(wrong_descriptor);
+        ASSERT_FALSE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+
+    // Too big maxMessageSize
+    {
+        auto wrong_descriptor = descriptor;
+        wrong_descriptor.maxMessageSize = std::numeric_limits<uint32_t>::max();
+        TCPv6Transport transportUnderTest(wrong_descriptor);
+        ASSERT_FALSE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+
+    // maxMessageSize bigger than receiveBufferSize
+    {
+        auto wrong_descriptor = descriptor;
+        wrong_descriptor.maxMessageSize = 10;
+        wrong_descriptor.receiveBufferSize = 5;
+        TCPv6Transport transportUnderTest(wrong_descriptor);
+        ASSERT_FALSE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+
+    // maxMessageSize bigger than sendBufferSize
+    {
+        auto wrong_descriptor = descriptor;
+        wrong_descriptor.maxMessageSize = 10;
+        wrong_descriptor.sendBufferSize = 5;
+        TCPv6Transport transportUnderTest(wrong_descriptor);
+        ASSERT_FALSE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+
+    // Buffer sizes automatically decrease
+    {
+        auto wrong_descriptor = descriptor;
+        wrong_descriptor.sendBufferSize = static_cast<uint32_t>(std::numeric_limits<int32_t>::max());
+        wrong_descriptor.receiveBufferSize = static_cast<uint32_t>(std::numeric_limits<int32_t>::max());
+        wrong_descriptor.maxMessageSize = 1470;
+        TCPv6Transport transportUnderTest(wrong_descriptor);
+        ASSERT_TRUE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+}
 
 TEST_F(TCPv6Tests, conversion_to_ip6_string)
 {

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -141,6 +141,11 @@ TEST_F(TCPv6Tests, wrong_configuration_values)
         wrong_descriptor.maxMessageSize = 1470;
         TCPv6Transport transportUnderTest(wrong_descriptor);
         ASSERT_TRUE(transportUnderTest.init());
+        auto* final_cfg = transportUnderTest.configuration();
+        EXPECT_GE(final_cfg->sendBufferSize, final_cfg->maxMessageSize);
+        EXPECT_LT(final_cfg->sendBufferSize, wrong_descriptor.sendBufferSize);
+        EXPECT_GE(final_cfg->receiveBufferSize, final_cfg->maxMessageSize);
+        EXPECT_LT(final_cfg->receiveBufferSize, wrong_descriptor.receiveBufferSize);
         eprosima::fastdds::dds::Log::Flush();
     }
 }

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -143,9 +143,11 @@ TEST_F(TCPv6Tests, wrong_configuration_values)
         ASSERT_TRUE(transportUnderTest.init());
         auto* final_cfg = transportUnderTest.configuration();
         EXPECT_GE(final_cfg->sendBufferSize, final_cfg->maxMessageSize);
-        EXPECT_LT(final_cfg->sendBufferSize, wrong_descriptor.sendBufferSize);
+        // The system could allow for the send buffer to be MAX_INT, so we cannot check it to be strictly lower
+        EXPECT_LE(final_cfg->sendBufferSize, wrong_descriptor.sendBufferSize);
         EXPECT_GE(final_cfg->receiveBufferSize, final_cfg->maxMessageSize);
-        EXPECT_LT(final_cfg->receiveBufferSize, wrong_descriptor.receiveBufferSize);
+        // The system could allow for the receive buffer to be MAX_INT, so we cannot check it to be strictly lower
+        EXPECT_LE(final_cfg->receiveBufferSize, wrong_descriptor.receiveBufferSize);
         eprosima::fastdds::dds::Log::Flush();
     }
 }

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -376,7 +376,7 @@ TEST_F(TCPv6Tests, client_announced_local_port_uniqueness)
 TEST_F(TCPv6Tests, non_blocking_send)
 {
     uint16_t port = g_default_port;
-    uint32_t msg_size = eprosima::fastdds::rtps::s_minimumSocketBuffer;
+    uint32_t msg_size = 64ul * 1024ul;
     // Create a TCP Server transport
     TCPv6TransportDescriptor senderDescriptor;
     senderDescriptor.add_listener_port(port);

--- a/test/unittest/transport/UDPv4Tests.cpp
+++ b/test/unittest/transport/UDPv4Tests.cpp
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <limits>
 #include <memory>
 #include <thread>
 
 #include <asio.hpp>
 #include <gtest/gtest.h>
 
+#include <fastdds/dds/log/Log.hpp>
 #include <fastrtps/transport/UDPv4TransportDescriptor.h>
 #include <fastrtps/utils/IPFinder.h>
 #include <fastrtps/utils/IPLocator.h>
@@ -74,6 +76,67 @@ public:
     std::unique_ptr<std::thread> senderThread;
     std::unique_ptr<std::thread> receiverThread;
 };
+
+TEST_F(UDPv4Tests, wrong_configuration)
+{
+    // Too big sendBufferSize
+    {
+        UDPv4TransportDescriptor wrong_descriptor;
+        wrong_descriptor.sendBufferSize = std::numeric_limits<uint32_t>::max();
+        UDPv4Transport transportUnderTest(wrong_descriptor);
+        ASSERT_FALSE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+
+    // Too big receiveBufferSize
+    {
+        UDPv4TransportDescriptor wrong_descriptor;
+        wrong_descriptor.receiveBufferSize = std::numeric_limits<uint32_t>::max();
+        UDPv4Transport transportUnderTest(wrong_descriptor);
+        ASSERT_FALSE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+
+    // Too big maxMessageSize
+    {
+        UDPv4TransportDescriptor wrong_descriptor;
+        wrong_descriptor.maxMessageSize = std::numeric_limits<uint32_t>::max();
+        UDPv4Transport transportUnderTest(wrong_descriptor);
+        ASSERT_FALSE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+
+    // maxMessageSize bigger than receiveBufferSize
+    {
+        UDPv4TransportDescriptor wrong_descriptor;
+        wrong_descriptor.maxMessageSize = 10;
+        wrong_descriptor.receiveBufferSize = 5;
+        UDPv4Transport transportUnderTest(wrong_descriptor);
+        ASSERT_FALSE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+
+    // maxMessageSize bigger than sendBufferSize
+    {
+        UDPv4TransportDescriptor wrong_descriptor;
+        wrong_descriptor.maxMessageSize = 10;
+        wrong_descriptor.sendBufferSize = 5;
+        UDPv4Transport transportUnderTest(wrong_descriptor);
+        ASSERT_FALSE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+
+    // Buffer sizes automatically decrease
+    {
+        UDPv4TransportDescriptor wrong_descriptor;
+        wrong_descriptor.sendBufferSize = static_cast<uint32_t>(std::numeric_limits<int32_t>::max());
+        wrong_descriptor.receiveBufferSize = static_cast<uint32_t>(std::numeric_limits<int32_t>::max());
+        wrong_descriptor.maxMessageSize = 1470;
+        UDPv4Transport transportUnderTest(wrong_descriptor);
+        ASSERT_TRUE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+}
 
 TEST_F(UDPv4Tests, locators_with_kind_1_supported)
 {

--- a/test/unittest/transport/UDPv4Tests.cpp
+++ b/test/unittest/transport/UDPv4Tests.cpp
@@ -32,10 +32,6 @@ using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 using UDPv4Transport = eprosima::fastdds::rtps::UDPv4Transport;
 
-#ifndef __APPLE__
-const uint32_t ReceiveBufferCapacity = 65536;
-#endif // ifndef __APPLE__
-
 #if defined(_WIN32)
 #define GET_PID _getpid
 #else

--- a/test/unittest/transport/UDPv4Tests.cpp
+++ b/test/unittest/transport/UDPv4Tests.cpp
@@ -130,6 +130,11 @@ TEST_F(UDPv4Tests, wrong_configuration)
         wrong_descriptor.maxMessageSize = 1470;
         UDPv4Transport transportUnderTest(wrong_descriptor);
         ASSERT_TRUE(transportUnderTest.init());
+        auto* final_cfg = transportUnderTest.configuration();
+        EXPECT_GE(final_cfg->sendBufferSize, final_cfg->maxMessageSize);
+        EXPECT_LT(final_cfg->sendBufferSize, wrong_descriptor.sendBufferSize);
+        EXPECT_GE(final_cfg->receiveBufferSize, final_cfg->maxMessageSize);
+        EXPECT_LT(final_cfg->receiveBufferSize, wrong_descriptor.receiveBufferSize);
         eprosima::fastdds::dds::Log::Flush();
     }
 }

--- a/test/unittest/transport/UDPv4Tests.cpp
+++ b/test/unittest/transport/UDPv4Tests.cpp
@@ -132,9 +132,11 @@ TEST_F(UDPv4Tests, wrong_configuration)
         ASSERT_TRUE(transportUnderTest.init());
         auto* final_cfg = transportUnderTest.configuration();
         EXPECT_GE(final_cfg->sendBufferSize, final_cfg->maxMessageSize);
-        EXPECT_LT(final_cfg->sendBufferSize, wrong_descriptor.sendBufferSize);
+        // The system could allow for the send buffer to be MAX_INT, so we cannot check it to be strictly lower
+        EXPECT_LE(final_cfg->sendBufferSize, wrong_descriptor.sendBufferSize);
         EXPECT_GE(final_cfg->receiveBufferSize, final_cfg->maxMessageSize);
-        EXPECT_LT(final_cfg->receiveBufferSize, wrong_descriptor.receiveBufferSize);
+        // The system could allow for the receive buffer to be MAX_INT, so we cannot check it to be strictly lower
+        EXPECT_LE(final_cfg->receiveBufferSize, wrong_descriptor.receiveBufferSize);
         eprosima::fastdds::dds::Log::Flush();
     }
 }

--- a/test/unittest/transport/UDPv6Tests.cpp
+++ b/test/unittest/transport/UDPv6Tests.cpp
@@ -137,6 +137,11 @@ TEST_F(UDPv6Tests, wrong_configuration)
         wrong_descriptor.maxMessageSize = 1470;
         UDPv6Transport transportUnderTest(wrong_descriptor);
         ASSERT_TRUE(transportUnderTest.init());
+        auto* final_cfg = transportUnderTest.configuration();
+        EXPECT_GE(final_cfg->sendBufferSize, final_cfg->maxMessageSize);
+        EXPECT_LT(final_cfg->sendBufferSize, wrong_descriptor.sendBufferSize);
+        EXPECT_GE(final_cfg->receiveBufferSize, final_cfg->maxMessageSize);
+        EXPECT_LT(final_cfg->receiveBufferSize, wrong_descriptor.receiveBufferSize);
         eprosima::fastdds::dds::Log::Flush();
     }
 }

--- a/test/unittest/transport/UDPv6Tests.cpp
+++ b/test/unittest/transport/UDPv6Tests.cpp
@@ -139,9 +139,11 @@ TEST_F(UDPv6Tests, wrong_configuration)
         ASSERT_TRUE(transportUnderTest.init());
         auto* final_cfg = transportUnderTest.configuration();
         EXPECT_GE(final_cfg->sendBufferSize, final_cfg->maxMessageSize);
-        EXPECT_LT(final_cfg->sendBufferSize, wrong_descriptor.sendBufferSize);
+        // The system could allow for the send buffer to be MAX_INT, so we cannot check it to be strictly lower
+        EXPECT_LE(final_cfg->sendBufferSize, wrong_descriptor.sendBufferSize);
         EXPECT_GE(final_cfg->receiveBufferSize, final_cfg->maxMessageSize);
-        EXPECT_LT(final_cfg->receiveBufferSize, wrong_descriptor.receiveBufferSize);
+        // The system could allow for the receive buffer to be MAX_INT, so we cannot check it to be strictly lower
+        EXPECT_LE(final_cfg->receiveBufferSize, wrong_descriptor.receiveBufferSize);
         eprosima::fastdds::dds::Log::Flush();
     }
 }

--- a/test/unittest/transport/UDPv6Tests.cpp
+++ b/test/unittest/transport/UDPv6Tests.cpp
@@ -31,10 +31,6 @@ using namespace eprosima::fastrtps::rtps;
 using namespace eprosima::fastrtps;
 using UDPv6Transport = eprosima::fastdds::rtps::UDPv6Transport;
 
-#ifndef __APPLE__
-const uint32_t ReceiveBufferCapacity = 65536;
-#endif // ifndef __APPLE__
-
 #if defined(_WIN32)
 #define GET_PID _getpid
 #else

--- a/test/unittest/transport/UDPv6Tests.cpp
+++ b/test/unittest/transport/UDPv6Tests.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <limits>
 #include <memory>
 #include <thread>
 
@@ -82,6 +83,67 @@ public:
     std::unique_ptr<std::thread> senderThread;
     std::unique_ptr<std::thread> receiverThread;
 };
+
+TEST_F(UDPv6Tests, wrong_configuration)
+{
+    // Too big sendBufferSize
+    {
+        UDPv6TransportDescriptor wrong_descriptor;
+        wrong_descriptor.sendBufferSize = std::numeric_limits<uint32_t>::max();
+        UDPv6Transport transportUnderTest(wrong_descriptor);
+        ASSERT_FALSE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+
+    // Too big receiveBufferSize
+    {
+        UDPv6TransportDescriptor wrong_descriptor;
+        wrong_descriptor.receiveBufferSize = std::numeric_limits<uint32_t>::max();
+        UDPv6Transport transportUnderTest(wrong_descriptor);
+        ASSERT_FALSE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+
+    // Too big maxMessageSize
+    {
+        UDPv6TransportDescriptor wrong_descriptor;
+        wrong_descriptor.maxMessageSize = std::numeric_limits<uint32_t>::max();
+        UDPv6Transport transportUnderTest(wrong_descriptor);
+        ASSERT_FALSE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+
+    // maxMessageSize bigger than receiveBufferSize
+    {
+        UDPv6TransportDescriptor wrong_descriptor;
+        wrong_descriptor.maxMessageSize = 10;
+        wrong_descriptor.receiveBufferSize = 5;
+        UDPv6Transport transportUnderTest(wrong_descriptor);
+        ASSERT_FALSE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+
+    // maxMessageSize bigger than sendBufferSize
+    {
+        UDPv6TransportDescriptor wrong_descriptor;
+        wrong_descriptor.maxMessageSize = 10;
+        wrong_descriptor.sendBufferSize = 5;
+        UDPv6Transport transportUnderTest(wrong_descriptor);
+        ASSERT_FALSE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+
+    // Buffer sizes automatically decrease
+    {
+        UDPv6TransportDescriptor wrong_descriptor;
+        wrong_descriptor.sendBufferSize = static_cast<uint32_t>(std::numeric_limits<int32_t>::max());
+        wrong_descriptor.receiveBufferSize = static_cast<uint32_t>(std::numeric_limits<int32_t>::max());
+        wrong_descriptor.maxMessageSize = 1470;
+        UDPv6Transport transportUnderTest(wrong_descriptor);
+        ASSERT_TRUE(transportUnderTest.init());
+        eprosima::fastdds::dds::Log::Flush();
+    }
+}
 
 TEST_F(UDPv6Tests, conversion_to_ip6_string)
 {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This is a manual backport of #4760 where `s_minimumSocketBuffer` has been deprecated instead of removed.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
