### PR TITLE
[21055] Automatically unmatch remote participants on participant deletion

### DIFF
--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -52,19 +52,19 @@ BuiltinProtocols::BuiltinProtocols()
 
 BuiltinProtocols::~BuiltinProtocols()
 {
-    // This needs to be done first because of the WriterProxydata and ReaderProxyData smart_ptr
-    delete typelookup_manager_;
-
-    // Send participant is disposed
     if (mp_PDP != nullptr)
     {
+        // Send participant is disposed
         mp_PDP->announceParticipantState(true, true);
+        // Consider all discovered participants as disposed
+        mp_PDP->disable();
     }
 
-    // TODO Auto-generated destructor stub
+    // The type lookup manager should be deleted first, since it will access the PDP database
+    delete typelookup_manager_;
+
     delete mp_WLP;
     delete mp_PDP;
-
 }
 
 bool BuiltinProtocols::initBuiltinProtocols(

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -52,7 +52,7 @@ BuiltinProtocols::BuiltinProtocols()
 
 BuiltinProtocols::~BuiltinProtocols()
 {
-    if (mp_PDP != nullptr)
+    if (nullptr != mp_PDP)
     {
         // Send participant is disposed
         mp_PDP->announceParticipantState(true, true);
@@ -193,7 +193,7 @@ bool BuiltinProtocols::addLocalWriter(
 {
     bool ok = true;
 
-    if (mp_PDP != nullptr)
+    if (nullptr != mp_PDP)
     {
         ok = mp_PDP->getEDP()->newLocalWriterProxyData(w, topicAtt, wqos);
 
@@ -208,7 +208,7 @@ bool BuiltinProtocols::addLocalWriter(
         EPROSIMA_LOG_WARNING(RTPS_EDP, "EDP is not used in this Participant, register a Writer is impossible");
     }
 
-    if (mp_WLP != nullptr)
+    if (nullptr != mp_WLP)
     {
         ok &= mp_WLP->add_local_writer(w, wqos);
     }
@@ -228,7 +228,7 @@ bool BuiltinProtocols::addLocalReader(
 {
     bool ok = true;
 
-    if (mp_PDP != nullptr)
+    if (nullptr != mp_PDP)
     {
         ok = mp_PDP->getEDP()->newLocalReaderProxyData(R, topicAtt, rqos, content_filter);
 
@@ -243,7 +243,7 @@ bool BuiltinProtocols::addLocalReader(
         EPROSIMA_LOG_WARNING(RTPS_EDP, "EDP is not used in this Participant, register a Reader is impossible");
     }
 
-    if (mp_WLP != nullptr)
+    if (nullptr != mp_WLP)
     {
         ok &= mp_WLP->add_local_reader(R, rqos);
     }
@@ -257,7 +257,7 @@ bool BuiltinProtocols::updateLocalWriter(
         const fastdds::dds::WriterQos& wqos)
 {
     bool ok = false;
-    if (mp_PDP != nullptr && mp_PDP->getEDP() != nullptr)
+    if ((nullptr != mp_PDP) && (nullptr != mp_PDP->getEDP()))
     {
         ok = mp_PDP->getEDP()->updatedLocalWriter(W, topicAtt, wqos);
     }
@@ -271,7 +271,7 @@ bool BuiltinProtocols::updateLocalReader(
         const fastdds::rtps::ContentFilterProperty* content_filter)
 {
     bool ok = false;
-    if (mp_PDP != nullptr && mp_PDP->getEDP() != nullptr)
+    if ((nullptr != mp_PDP) && (nullptr != mp_PDP->getEDP()))
     {
         ok = mp_PDP->getEDP()->updatedLocalReader(R, topicAtt, rqos, content_filter);
     }
@@ -282,11 +282,11 @@ bool BuiltinProtocols::removeLocalWriter(
         RTPSWriter* W)
 {
     bool ok = false;
-    if (mp_WLP != nullptr)
+    if (nullptr != mp_WLP)
     {
         ok |= mp_WLP->remove_local_writer(W);
     }
-    if (mp_PDP != nullptr && mp_PDP->getEDP() != nullptr)
+    if ((nullptr != mp_PDP) && (nullptr != mp_PDP->getEDP()))
     {
         ok |= mp_PDP->getEDP()->removeLocalWriter(W);
     }
@@ -297,11 +297,11 @@ bool BuiltinProtocols::removeLocalReader(
         RTPSReader* R)
 {
     bool ok = false;
-    if (mp_WLP != nullptr)
+    if (nullptr != mp_WLP)
     {
         ok |= mp_WLP->remove_local_reader(R);
     }
-    if (mp_PDP != nullptr && mp_PDP->getEDP() != nullptr)
+    if ((nullptr != mp_PDP) && (nullptr != mp_PDP->getEDP()))
     {
         ok |= mp_PDP->getEDP()->removeLocalReader(R);
     }

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -431,6 +431,20 @@ bool PDP::enable()
 
 void PDP::disable()
 {
+    // Extract all the participant proxies excluding first one (ourselves)
+    std::vector<ParticipantProxyData*> participants;
+    {
+        std::lock_guard<std::recursive_mutex> guardPDP(*this->mp_mutex);
+        participants.insert(participants.end(), participant_proxies_.begin() + 1, participant_proxies_.end());
+        participant_proxies_.erase(participant_proxies_.begin() + 1, participant_proxies_.end());
+    }
+
+    // Unmatch all remote participants
+    for (ParticipantProxyData* pdata : participants)
+    {
+        remote_participant_removed(pdata, pdata->m_guid,
+                ParticipantDiscoveryInfo::DISCOVERY_STATUS::REMOVED_PARTICIPANT, nullptr);
+    }
 }
 
 void PDP::announceParticipantState(

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -334,7 +334,7 @@ void PDP::initializeParticipantProxyData(
     if (mp_RTPSParticipant->is_secure())
     {
         IdentityToken* identity_token = nullptr;
-        if (mp_RTPSParticipant->security_manager().get_identity_token(&identity_token) && identity_token != nullptr)
+        if (mp_RTPSParticipant->security_manager().get_identity_token(&identity_token) && (nullptr != identity_token))
         {
             participant_data->identity_token_ = std::move(*identity_token);
             mp_RTPSParticipant->security_manager().return_identity_token(identity_token);
@@ -342,7 +342,7 @@ void PDP::initializeParticipantProxyData(
 
         PermissionsToken* permissions_token = nullptr;
         if (mp_RTPSParticipant->security_manager().get_permissions_token(&permissions_token)
-                && permissions_token != nullptr)
+                && (nullptr != permissions_token))
         {
             participant_data->permissions_token_ = std::move(*permissions_token);
             mp_RTPSParticipant->security_manager().return_permissions_token(permissions_token);
@@ -382,7 +382,7 @@ bool PDP::initPDP(
     ParticipantProxyData* pdata = add_participant_proxy_data(mp_RTPSParticipant->getGuid(), false, nullptr);
     mp_mutex->unlock();
 
-    if (pdata == nullptr)
+    if (nullptr == pdata)
     {
         return false;
     }
@@ -489,7 +489,7 @@ void PDP::announceParticipantState(
                     },
                     ALIVE, key);
 
-                if (change != nullptr)
+                if (nullptr != change)
                 {
                     CDRMessage_t aux_msg(change->serializedPayload);
 
@@ -534,7 +534,7 @@ void PDP::announceParticipantState(
                             },
                             NOT_ALIVE_DISPOSED_UNREGISTERED, key);
 
-            if (change != nullptr)
+            if (nullptr != change)
             {
                 CDRMessage_t aux_msg(change->serializedPayload);
 
@@ -589,7 +589,7 @@ void PDP::notify_and_maybe_ignore_new_participant(
             << " DefLoc:" << pdata->default_locators);
 
     RTPSParticipantListener* listener = getRTPSParticipant()->getListener();
-    if (listener != nullptr)
+    if (listener)
     {
         {
             std::lock_guard<std::mutex> cb_lock(callback_mtx_);
@@ -1178,9 +1178,9 @@ void PDP::remote_participant_removed(
         ParticipantDiscoveryInfo::DISCOVERY_STATUS reason,
         RTPSParticipantListener* listener)
 {
-    assert(pdata != nullptr);
+    assert(nullptr != pdata);
 
-    if (mp_EDP != nullptr)
+    if (nullptr != mp_EDP)
     {
         for (auto pit : *pdata->m_readers)
         {
@@ -1217,7 +1217,7 @@ void PDP::remote_participant_removed(
         }
     }
 
-    if (mp_builtin->mp_WLP != nullptr)
+    if (nullptr != mp_builtin->mp_WLP)
     {
         this->mp_builtin->mp_WLP->removeRemoteEndpoints(pdata);
     }
@@ -1233,7 +1233,7 @@ void PDP::remote_participant_removed(
 
     builtin_endpoints_->remove_from_pdp_reader_history(pdata->m_key);
 
-    if (listener != nullptr)
+    if (listener)
     {
         std::lock_guard<std::mutex> lock(callback_mtx_);
         ParticipantDiscoveryInfo info(*pdata);
@@ -1277,7 +1277,7 @@ void PDP::remote_participant_removed(
     pdata->m_writers->clear();
 
     // Cancel lease event
-    if (pdata->lease_duration_event != nullptr)
+    if (nullptr != pdata->lease_duration_event)
     {
         pdata->lease_duration_event->cancel_timer();
     }

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -304,7 +304,7 @@ void PDP::initializeParticipantProxyData(
     participant_data->metatraffic_locators.unicast.clear();
     if (announce_locators)
     {
-        for (const Locator_t& loc : this->mp_builtin->m_metatrafficUnicastLocatorList)
+        for (const Locator_t& loc : mp_builtin->m_metatrafficUnicastLocatorList)
         {
             participant_data->metatraffic_locators.add_unicast_locator(loc);
         }
@@ -315,7 +315,7 @@ void PDP::initializeParticipantProxyData(
     {
         if (!m_discovery.avoid_builtin_multicast || participant_data->metatraffic_locators.unicast.empty())
         {
-            for (const Locator_t& loc: this->mp_builtin->m_metatrafficMulticastLocatorList)
+            for (const Locator_t& loc: mp_builtin->m_metatrafficMulticastLocatorList)
             {
                 participant_data->metatraffic_locators.add_multicast_locator(loc);
             }
@@ -434,7 +434,7 @@ void PDP::disable()
     // Extract all the participant proxies excluding first one (ourselves)
     std::vector<ParticipantProxyData*> participants;
     {
-        std::lock_guard<std::recursive_mutex> guardPDP(*this->mp_mutex);
+        std::lock_guard<std::recursive_mutex> guardPDP(*mp_mutex);
         participants.insert(participants.end(), participant_proxies_.begin() + 1, participant_proxies_.end());
         participant_proxies_.erase(participant_proxies_.begin() + 1, participant_proxies_.end());
     }
@@ -471,11 +471,11 @@ void PDP::announceParticipantState(
         {
             if (m_hasChangedLocalPDP.exchange(false) || new_change)
             {
-                this->mp_mutex->lock();
+                mp_mutex->lock();
                 ParticipantProxyData* local_participant_data = getLocalParticipantProxyData();
                 InstanceHandle_t key = local_participant_data->m_key;
                 ParticipantProxyData proxy_data_copy(*local_participant_data);
-                this->mp_mutex->unlock();
+                mp_mutex->unlock();
 
                 if (history.getHistorySize() > 0)
                 {
@@ -517,11 +517,11 @@ void PDP::announceParticipantState(
         }
         else
         {
-            this->mp_mutex->lock();
+            mp_mutex->lock();
             ParticipantProxyData* local_participant_data = getLocalParticipantProxyData();
             InstanceHandle_t key = local_participant_data->m_key;
             ParticipantProxyData proxy_data_copy(*local_participant_data);
-            this->mp_mutex->unlock();
+            mp_mutex->unlock();
 
             if (history.getHistorySize() > 0)
             {
@@ -613,7 +613,7 @@ void PDP::notify_and_maybe_ignore_new_participant(
 bool PDP::has_reader_proxy_data(
         const GUID_t& reader)
 {
-    std::lock_guard<std::recursive_mutex> guardPDP(*this->mp_mutex);
+    std::lock_guard<std::recursive_mutex> guardPDP(*mp_mutex);
     for (ParticipantProxyData* pit : participant_proxies_)
     {
         if (pit->m_guid.guidPrefix == reader.guidPrefix)
@@ -629,7 +629,7 @@ bool PDP::lookupReaderProxyData(
         const GUID_t& reader,
         ReaderProxyData& rdata)
 {
-    std::lock_guard<std::recursive_mutex> guardPDP(*this->mp_mutex);
+    std::lock_guard<std::recursive_mutex> guardPDP(*mp_mutex);
     for (ParticipantProxyData* pit : participant_proxies_)
     {
         if (pit->m_guid.guidPrefix == reader.guidPrefix)
@@ -648,7 +648,7 @@ bool PDP::lookupReaderProxyData(
 bool PDP::has_writer_proxy_data(
         const GUID_t& writer)
 {
-    std::lock_guard<std::recursive_mutex> guardPDP(*this->mp_mutex);
+    std::lock_guard<std::recursive_mutex> guardPDP(*mp_mutex);
     for (ParticipantProxyData* pit : participant_proxies_)
     {
         if (pit->m_guid.guidPrefix == writer.guidPrefix)
@@ -664,7 +664,7 @@ bool PDP::lookupWriterProxyData(
         const GUID_t& writer,
         WriterProxyData& wdata)
 {
-    std::lock_guard<std::recursive_mutex> guardPDP(*this->mp_mutex);
+    std::lock_guard<std::recursive_mutex> guardPDP(*mp_mutex);
     for (ParticipantProxyData* pit : participant_proxies_)
     {
         if (pit->m_guid.guidPrefix == writer.guidPrefix)
@@ -684,7 +684,7 @@ bool PDP::removeReaderProxyData(
         const GUID_t& reader_guid)
 {
     EPROSIMA_LOG_INFO(RTPS_PDP, "Removing reader proxy data " << reader_guid);
-    std::lock_guard<std::recursive_mutex> guardPDP(*this->mp_mutex);
+    std::lock_guard<std::recursive_mutex> guardPDP(*mp_mutex);
 
     for (ParticipantProxyData* pit : participant_proxies_)
     {
@@ -728,7 +728,7 @@ bool PDP::removeWriterProxyData(
         const GUID_t& writer_guid)
 {
     EPROSIMA_LOG_INFO(RTPS_PDP, "Removing writer proxy data " << writer_guid);
-    std::lock_guard<std::recursive_mutex> guardPDP(*this->mp_mutex);
+    std::lock_guard<std::recursive_mutex> guardPDP(*mp_mutex);
 
     for (ParticipantProxyData* pit : participant_proxies_)
     {
@@ -773,7 +773,7 @@ bool PDP::lookup_participant_name(
         const GUID_t& guid,
         fastcdr::string_255& name)
 {
-    std::lock_guard<std::recursive_mutex> guardPDP(*this->mp_mutex);
+    std::lock_guard<std::recursive_mutex> guardPDP(*mp_mutex);
     for (ParticipantProxyData* pit : participant_proxies_)
     {
         if (pit->m_guid == guid)
@@ -789,7 +789,7 @@ bool PDP::lookup_participant_key(
         const GUID_t& participant_guid,
         InstanceHandle_t& key)
 {
-    std::lock_guard<std::recursive_mutex> guardPDP(*this->mp_mutex);
+    std::lock_guard<std::recursive_mutex> guardPDP(*mp_mutex);
     for (ParticipantProxyData* pit : participant_proxies_)
     {
         if (pit->m_guid == participant_guid)
@@ -812,7 +812,7 @@ ReaderProxyData* PDP::addReaderProxyData(
     // notify statistics module
     getRTPSParticipant()->on_entity_discovery(reader_guid, ParameterPropertyList_t());
 
-    std::lock_guard<std::recursive_mutex> guardPDP(*this->mp_mutex);
+    std::lock_guard<std::recursive_mutex> guardPDP(*mp_mutex);
 
     for (ParticipantProxyData* pit : participant_proxies_)
     {
@@ -909,7 +909,7 @@ WriterProxyData* PDP::addWriterProxyData(
     // notify statistics module
     getRTPSParticipant()->on_entity_discovery(writer_guid, ParameterPropertyList_t());
 
-    std::lock_guard<std::recursive_mutex> guardPDP(*this->mp_mutex);
+    std::lock_guard<std::recursive_mutex> guardPDP(*mp_mutex);
 
     for (ParticipantProxyData* pit : participant_proxies_)
     {
@@ -1015,7 +1015,7 @@ bool PDP::pairing_remote_reader_with_local_writer_after_security(
 bool PDP::get_all_local_proxies(
         std::vector<GUID_t>& guids)
 {
-    std::lock_guard<std::recursive_mutex> guardPDP(*this->mp_mutex);
+    std::lock_guard<std::recursive_mutex> guardPDP(*mp_mutex);
     ParticipantProxyData* local_participant = getLocalParticipantProxyData();
     guids.reserve(local_participant->m_writers->size() +
             local_participant->m_readers->size() +
@@ -1045,7 +1045,7 @@ bool PDP::get_serialized_proxy(
     bool ret = false;
     bool found = false;
 
-    std::lock_guard<std::recursive_mutex> guardPDP(*this->mp_mutex);
+    std::lock_guard<std::recursive_mutex> guardPDP(*mp_mutex);
 
     if (guid.entityId == c_EntityId_RTPSParticipant)
     {
@@ -1149,7 +1149,7 @@ bool PDP::remove_remote_participant(
     ParticipantProxyData* pdata = nullptr;
 
     //Remove it from our vector or RTPSParticipantProxies:
-    this->mp_mutex->lock();
+    mp_mutex->lock();
     for (ResourceLimitedVector<ParticipantProxyData*>::iterator pit = participant_proxies_.begin();
             pit != participant_proxies_.end(); ++pit)
     {
@@ -1160,7 +1160,7 @@ bool PDP::remove_remote_participant(
             break;
         }
     }
-    this->mp_mutex->unlock();
+    mp_mutex->unlock();
 
     if (nullptr != pdata)
     {
@@ -1219,13 +1219,13 @@ void PDP::remote_participant_removed(
 
     if (nullptr != mp_builtin->mp_WLP)
     {
-        this->mp_builtin->mp_WLP->removeRemoteEndpoints(pdata);
+        mp_builtin->mp_WLP->removeRemoteEndpoints(pdata);
     }
 
     mp_builtin->typelookup_manager_->remove_remote_endpoints(pdata);
 
-    this->mp_EDP->removeRemoteEndpoints(pdata);
-    this->removeRemoteEndpoints(pdata);
+    mp_EDP->removeRemoteEndpoints(pdata);
+    removeRemoteEndpoints(pdata);
 
 #if HAVE_SECURITY
     mp_builtin->mp_participantImpl->security_manager().remove_participant(*pdata);
@@ -1243,7 +1243,7 @@ void PDP::remote_participant_removed(
                     info), should_be_ignored);
     }
 
-    this->mp_mutex->lock();
+    mp_mutex->lock();
 
     // Delete from sender resource list (TCP only)
     LocatorList_t remote_participant_locators;
@@ -1286,7 +1286,7 @@ void PDP::remote_participant_removed(
     pdata->clear();
     participant_proxies_pool_.push_back(pdata);
 
-    this->mp_mutex->unlock();
+    mp_mutex->unlock();
 }
 
 const BuiltinAttributes& PDP::builtin_attributes() const
@@ -1297,9 +1297,9 @@ const BuiltinAttributes& PDP::builtin_attributes() const
 void PDP::assert_remote_participant_liveliness(
         const GuidPrefix_t& remote_guid)
 {
-    std::lock_guard<std::recursive_mutex> guardPDP(*this->mp_mutex);
+    std::lock_guard<std::recursive_mutex> guardPDP(*mp_mutex);
 
-    for (ParticipantProxyData* it : this->participant_proxies_)
+    for (ParticipantProxyData* it : participant_proxies_)
     {
         if (it->m_guid.guidPrefix == remote_guid)
         {
@@ -1314,7 +1314,7 @@ void PDP::assert_remote_participant_liveliness(
 CDRMessage_t PDP::get_participant_proxy_data_serialized(
         Endianness_t endian)
 {
-    std::lock_guard<std::recursive_mutex> guardPDP(*this->mp_mutex);
+    std::lock_guard<std::recursive_mutex> guardPDP(*mp_mutex);
     CDRMessage_t cdr_msg(RTPSMESSAGE_DEFAULT_SIZE);
     cdr_msg.msg_endian = endian;
 
@@ -1348,7 +1348,7 @@ std::list<eprosima::fastdds::rtps::RemoteServerAttributes>& PDP::remote_server_a
 void PDP::check_remote_participant_liveliness(
         ParticipantProxyData* remote_participant)
 {
-    std::unique_lock<std::recursive_mutex> guard(*this->mp_mutex);
+    std::unique_lock<std::recursive_mutex> guard(*mp_mutex);
 
     if (remote_participant->should_check_lease_duration)
     {

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -444,7 +444,7 @@ void PDP::disable()
     // Unmatch all remote participants
     for (ParticipantProxyData* pdata : participants)
     {
-        remote_participant_removed(pdata, pdata->m_guid,
+        actions_on_remote_participant_removed(pdata, pdata->m_guid,
                 ParticipantDiscoveryInfo::DISCOVERY_STATUS::REMOVED_PARTICIPANT, nullptr);
     }
 }
@@ -1168,14 +1168,14 @@ bool PDP::remove_remote_participant(
     if (nullptr != pdata)
     {
         RTPSParticipantListener* listener = mp_RTPSParticipant->getListener();
-        remote_participant_removed(pdata, partGUID, reason, listener);
+        actions_on_remote_participant_removed(pdata, partGUID, reason, listener);
         return true;
     }
 
     return false;
 }
 
-void PDP::remote_participant_removed(
+void PDP::actions_on_remote_participant_removed(
         ParticipantProxyData* pdata,
         const GUID_t& partGUID,
         ParticipantDiscoveryInfo::DISCOVERY_STATUS reason,

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -429,6 +429,10 @@ bool PDP::enable()
     return builtin_endpoints_->enable_pdp_readers(mp_RTPSParticipant);
 }
 
+void PDP::disable()
+{
+}
+
 void PDP::announceParticipantState(
         bool new_change,
         bool dispose /* = false */)

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -378,9 +378,11 @@ bool PDP::initPDP(
     //UPDATE METATRAFFIC.
     update_builtin_locators();
 
-    mp_mutex->lock();
-    ParticipantProxyData* pdata = add_participant_proxy_data(mp_RTPSParticipant->getGuid(), false, nullptr);
-    mp_mutex->unlock();
+    ParticipantProxyData* pdata = nullptr;
+    {
+        std::lock_guard<std::recursive_mutex> guardPDP(*mp_mutex);
+        pdata = add_participant_proxy_data(mp_RTPSParticipant->getGuid(), false, nullptr);
+    }
 
     if (nullptr == pdata)
     {
@@ -1148,19 +1150,20 @@ bool PDP::remove_remote_participant(
     EPROSIMA_LOG_INFO(RTPS_PDP, partGUID );
     ParticipantProxyData* pdata = nullptr;
 
-    //Remove it from our vector or RTPSParticipantProxies:
-    mp_mutex->lock();
-    for (ResourceLimitedVector<ParticipantProxyData*>::iterator pit = participant_proxies_.begin();
-            pit != participant_proxies_.end(); ++pit)
+    // Remove it from our vector of RTPSParticipantProxies
     {
-        if ((*pit)->m_guid == partGUID)
+        std::lock_guard<std::recursive_mutex> guardPDP(*mp_mutex);
+        for (ResourceLimitedVector<ParticipantProxyData*>::iterator pit = participant_proxies_.begin();
+                pit != participant_proxies_.end(); ++pit)
         {
-            pdata = *pit;
-            participant_proxies_.erase(pit);
-            break;
+            if ((*pit)->m_guid == partGUID)
+            {
+                pdata = *pit;
+                participant_proxies_.erase(pit);
+                break;
+            }
         }
     }
-    mp_mutex->unlock();
 
     if (nullptr != pdata)
     {
@@ -1243,50 +1246,50 @@ void PDP::remote_participant_removed(
                     info), should_be_ignored);
     }
 
-    mp_mutex->lock();
-
-    // Delete from sender resource list (TCP only)
-    LocatorList_t remote_participant_locators;
-    for (auto& remote_participant_default_locator : pdata->default_locators.unicast)
     {
-        remote_participant_locators.push_back(remote_participant_default_locator);
-    }
-    for (auto& remote_participant_metatraffic_locator : pdata->metatraffic_locators.unicast)
-    {
-        remote_participant_locators.push_back(remote_participant_metatraffic_locator);
-    }
-    if (!remote_participant_locators.empty())
-    {
-        mp_RTPSParticipant->update_removed_participant(remote_participant_locators);
-    }
+        std::lock_guard<std::recursive_mutex> guardPDP(*mp_mutex);
 
-    // Return reader proxy objects to pool
-    for (auto pit : *pdata->m_readers)
-    {
-        pit.second->clear();
-        reader_proxies_pool_.push_back(pit.second);
+        // Delete from sender resource list (TCP only)
+        LocatorList_t remote_participant_locators;
+        for (auto& remote_participant_default_locator : pdata->default_locators.unicast)
+        {
+            remote_participant_locators.push_back(remote_participant_default_locator);
+        }
+        for (auto& remote_participant_metatraffic_locator : pdata->metatraffic_locators.unicast)
+        {
+            remote_participant_locators.push_back(remote_participant_metatraffic_locator);
+        }
+        if (!remote_participant_locators.empty())
+        {
+            mp_RTPSParticipant->update_removed_participant(remote_participant_locators);
+        }
+
+        // Return reader proxy objects to pool
+        for (auto pit : *pdata->m_readers)
+        {
+            pit.second->clear();
+            reader_proxies_pool_.push_back(pit.second);
+        }
+        pdata->m_readers->clear();
+
+        // Return writer proxy objects to pool
+        for (auto pit : *pdata->m_writers)
+        {
+            pit.second->clear();
+            writer_proxies_pool_.push_back(pit.second);
+        }
+        pdata->m_writers->clear();
+
+        // Cancel lease event
+        if (nullptr != pdata->lease_duration_event)
+        {
+            pdata->lease_duration_event->cancel_timer();
+        }
+
+        // Return proxy object to pool
+        pdata->clear();
+        participant_proxies_pool_.push_back(pdata);
     }
-    pdata->m_readers->clear();
-
-    // Return writer proxy objects to pool
-    for (auto pit : *pdata->m_writers)
-    {
-        pit.second->clear();
-        writer_proxies_pool_.push_back(pit.second);
-    }
-    pdata->m_writers->clear();
-
-    // Cancel lease event
-    if (nullptr != pdata->lease_duration_event)
-    {
-        pdata->lease_duration_event->cancel_timer();
-    }
-
-    // Return proxy object to pool
-    pdata->clear();
-    participant_proxies_pool_.push_back(pdata);
-
-    mp_mutex->unlock();
 }
 
 const BuiltinAttributes& PDP::builtin_attributes() const

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.h
@@ -131,6 +131,11 @@ public:
      */
     bool enable();
 
+    /**
+     * @brief Disable the Participant Discovery Protocol
+     */
+    void disable();
+
     virtual bool init(
             RTPSParticipantImpl* part) = 0;
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.h
@@ -635,7 +635,7 @@ private:
             ParticipantProxyData* participant_data);
 
     /**
-     * Performs unmatching of user and built-in endpoints after removing a ParticipantProxyData from the
+     * Performs all the necessary actions after removing a ParticipantProxyData from the
      * participant_proxies_ collection.
      *
      * @param pdata ParticipantProxyData that was removed.
@@ -643,7 +643,7 @@ private:
      * @param reason Reason why the participant was removed.
      * @param listener Listener to be notified of the unmatches / removal.
      */
-    void remote_participant_removed(
+    void actions_on_remote_participant_removed(
             ParticipantProxyData* pdata,
             const GUID_t& partGUID,
             ParticipantDiscoveryInfo::DISCOVERY_STATUS reason,

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.h
@@ -628,6 +628,22 @@ private:
      */
     void set_external_participant_properties_(
             ParticipantProxyData* participant_data);
+
+    /**
+     * Performs unmatching of user and built-in endpoints after removing a ParticipantProxyData from the
+     * participant_proxies_ collection.
+     *
+     * @param pdata ParticipantProxyData that was removed.
+     * @param partGUID GUID of the removed participant.
+     * @param reason Reason why the participant was removed.
+     * @param listener Listener to be notified of the unmatches / removal.
+     */
+    void remote_participant_removed(
+            ParticipantProxyData* pdata,
+            const GUID_t& partGUID,
+            ParticipantDiscoveryInfo::DISCOVERY_STATUS reason,
+            RTPSParticipantListener* listener);
+
 };
 
 

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -26,6 +26,7 @@
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/qos/DomainParticipantFactoryQos.hpp>
 #include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
+#include <fastdds/dds/log/Log.hpp>
 #include <fastdds/dds/publisher/DataWriter.hpp>
 #include <fastdds/dds/publisher/Publisher.hpp>
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
@@ -41,6 +42,7 @@
 #include <fastdds/rtps/transport/test_UDPv4TransportDescriptor.h>
 
 #include "BlackboxTests.hpp"
+#include "mock/BlackboxMockConsumer.h"
 #include "../api/dds-pim/CustomPayloadPool.hpp"
 #include "../api/dds-pim/PubSubReader.hpp"
 #include "../api/dds-pim/PubSubWriter.hpp"
@@ -52,6 +54,47 @@
 namespace eprosima {
 namespace fastdds {
 namespace dds {
+
+/**
+ * This is a regression test for redmine issue #21060.
+ *
+ * It checks that when intraprocess delivery is set to full, there are no warnings in the desctructor of WriterProxy
+ * when deleting a participant.
+ */
+TEST(DDSBasic, WarningOnDelete)
+{
+    namespace dds = eprosima::fastdds::dds;
+    auto factory = dds::DomainParticipantFactory::get_instance();
+
+    // Set intraprocess delivery to full
+    LibrarySettings library_settings;
+    auto old_library_settings = library_settings;
+    factory->get_library_settings(library_settings);
+    library_settings.intraprocess_delivery = INTRAPROCESS_FULL;
+    factory->set_library_settings(library_settings);
+
+    // Create participants
+    auto participant_1 = factory->create_participant(0, dds::PARTICIPANT_QOS_DEFAULT);
+    auto participant_2 = factory->create_participant(0, dds::PARTICIPANT_QOS_DEFAULT);
+
+    /* Set up log */
+    BlackboxMockConsumer* helper_consumer = new BlackboxMockConsumer();
+    Log::ClearConsumers();  // Remove default consumers
+    Log::RegisterConsumer(std::unique_ptr<LogConsumer>(helper_consumer)); // Registering a consumer transfer ownership
+    // Filter specific message
+    dds::Log::SetErrorStringFilter(std::regex(".*~WriterProxy.*"));
+    dds::Log::SetVerbosity(dds::Log::Warning);
+
+    factory->delete_participant(participant_1);
+    factory->delete_participant(participant_2);
+
+    dds::Log::Flush();
+    EXPECT_EQ(helper_consumer->ConsumedEntries().size(), 0u);
+    helper_consumer->clear_entries();
+
+    // Restore library settings
+    factory->set_library_settings(old_library_settings);
+}
 
 /**
  * This test checks whether it is safe to delete not enabled DDS entities *


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

It's been reported that when several participants are created in the same process, and log warnings are enabled, a call to `delete_participant()` triggers the following warning several times:

`[RTPS_READER Warning] Automatically unmatching on ~WriterProxy -> Function ~WriterProxy`

Debugging revealed that these were shown for the built-in reliable readers.

This PR adds a mechanism to automatically unmatch the built-in endpoints when a participant is deleted.
The mechanism consists of performing the same actions executed when receiving a DATA(p|UD), without triggering the participant listener.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [__NO__] Applicable backports have been included in the description.
    - Backport to 2.14.x will be done manually, and we will backport to the supported branches from that one

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
