### PR TITLE
[21065] Bugfix: correct liveliness state in a multiple reader - one writer scenario

### DIFF
--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -711,6 +711,8 @@ bool WLP::remove_local_writer(
 
     EPROSIMA_LOG_INFO(RTPS_LIVELINESS, W->getGuid().entityId << " from Liveliness Protocol");
 
+    LivelinessData::WriterStatus writer_status;
+
     if (W->get_liveliness_kind() == AUTOMATIC_LIVELINESS_QOS)
     {
         auto it = std::find(
@@ -764,7 +766,8 @@ bool WLP::remove_local_writer(
         if (!pub_liveliness_manager_->remove_writer(
                     W->getGuid(),
                     W->get_liveliness_kind(),
-                    W->get_liveliness_lease_duration()))
+                    W->get_liveliness_lease_duration(),
+                    writer_status))
         {
             EPROSIMA_LOG_ERROR(RTPS_LIVELINESS,
                     "Could not remove writer " << W->getGuid() << " from liveliness manager");
@@ -808,7 +811,8 @@ bool WLP::remove_local_writer(
         if (!pub_liveliness_manager_->remove_writer(
                     W->getGuid(),
                     W->get_liveliness_kind(),
-                    W->get_liveliness_lease_duration()))
+                    W->get_liveliness_lease_duration(),
+                    writer_status))
         {
             EPROSIMA_LOG_ERROR(RTPS_LIVELINESS,
                     "Could not remove writer " << W->getGuid() << " from liveliness manager");

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -382,10 +382,22 @@ bool StatefulReader::matched_writer_remove(
         auto wlp = this->mp_RTPSParticipant->wlp();
         if ( wlp != nullptr)
         {
+            LivelinessData::WriterStatus writer_liveliness_status;
             wlp->sub_liveliness_manager_->remove_writer(
                 writer_guid,
                 liveliness_kind_,
-                liveliness_lease_duration_);
+                liveliness_lease_duration_,
+                writer_liveliness_status);
+
+            if (writer_liveliness_status == LivelinessData::WriterStatus::ALIVE)
+            {
+                wlp->update_liveliness_changed_status(writer_guid, this, -1, 0);
+            }
+            else if (writer_liveliness_status == LivelinessData::WriterStatus::NOT_ALIVE)
+            {
+                wlp->update_liveliness_changed_status(writer_guid, this, 0, -1);
+            }
+
         }
         else
         {

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -232,10 +232,21 @@ bool StatelessReader::matched_writer_remove(
         auto wlp = mp_RTPSParticipant->wlp();
         if ( wlp != nullptr)
         {
+            LivelinessData::WriterStatus writer_liveliness_status;
             wlp->sub_liveliness_manager_->remove_writer(
                 writer_guid,
                 liveliness_kind_,
-                liveliness_lease_duration_);
+                liveliness_lease_duration_,
+                writer_liveliness_status);
+
+            if (writer_liveliness_status == LivelinessData::WriterStatus::ALIVE)
+            {
+                wlp->update_liveliness_changed_status(writer_guid, this, -1, 0);
+            }
+            else if (writer_liveliness_status == LivelinessData::WriterStatus::NOT_ALIVE)
+            {
+                wlp->update_liveliness_changed_status(writer_guid, this, 0, -1);
+            }
         }
         else
         {

--- a/src/cpp/rtps/writer/LivelinessManager.hpp
+++ b/src/cpp/rtps/writer/LivelinessManager.hpp
@@ -85,7 +85,7 @@ public:
      * @param [in] guid GUID of the writer
      * @param [in] kind Liveliness kind
      * @param [in] lease_duration Liveliness lease duration
-     * @param [in,out] writer_liveliness_status The liveliness status of the writer
+     * @param [out] writer_liveliness_status The liveliness status of the writer
      * @return True if the writer was successfully removed
      */
     bool remove_writer(

--- a/src/cpp/rtps/writer/LivelinessManager.hpp
+++ b/src/cpp/rtps/writer/LivelinessManager.hpp
@@ -82,15 +82,17 @@ public:
 
     /**
      * @brief Removes a writer
-     * @param guid GUID of the writer
-     * @param kind Liveliness kind
-     * @param lease_duration Liveliness lease duration
+     * @param [in] guid GUID of the writer
+     * @param [in] kind Liveliness kind
+     * @param [in] lease_duration Liveliness lease duration
+     * @param [in,out] writer_liveliness_status The liveliness status of the writer
      * @return True if the writer was successfully removed
      */
     bool remove_writer(
             GUID_t guid,
             fastdds::dds::LivelinessQosPolicyKind kind,
-            Duration_t lease_duration);
+            Duration_t lease_duration,
+            LivelinessData::WriterStatus& writer_liveliness_status);
 
     /**
      * @brief Asserts liveliness of a writer in the set

--- a/test/blackbox/common/BlackboxTestsLivelinessQos.cpp
+++ b/test/blackbox/common/BlackboxTestsLivelinessQos.cpp
@@ -1998,6 +1998,47 @@ TEST(LivelinessTests, Reader_Successfully_Asserts_Liveliness_on_a_Disconnected_W
     ASSERT_EQ(reader.sub_wait_liveliness_lost_for(1, std::chrono::seconds(4)), 1u);
 }
 
+// Regression test of Refs #21065, github issue #4610
+TEST(LivelinessTests, correct_liveliness_state_one_writer_multiple_readers)
+{
+    uint8_t num_readers = 2;
+
+    // Create one writer participant
+    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+
+    // Create a reader participant containing 2 readers
+    PubSubParticipant<HelloWorldPubSubType> reader(0, num_readers, 0, num_readers);
+
+    reader.init_participant();
+    // Define the reader's lease duration in 1.6 secs
+    reader.sub_liveliness_lease_duration(eprosima::fastrtps::Time_t(1, 600000000));
+    // Both readers on the same topic
+    reader.sub_topic_name(TEST_TOPIC_NAME);
+
+    for (size_t i = 0; i < num_readers; i++)
+    {
+        // Create Subscribers and readers, one for each writer
+        reader.init_subscriber(i);
+    }
+
+    // Create writers
+    writer.lease_duration(c_TimeInfinite, 1)
+            .liveliness_lease_duration(eprosima::fastrtps::Time_t(1, 0))
+            .liveliness_kind(eprosima::fastdds::dds::AUTOMATIC_LIVELINESS_QOS)
+            .liveliness_announcement_period(eprosima::fastrtps::Time_t(0, 500000000))
+            .init();
+
+    // Wait for discovery to occur. Liveliness should be recovered twice,
+    // one per matched reader.
+    reader.sub_wait_liveliness_recovered(2);
+
+    // Destroy the writer
+    writer.destroy();
+
+    // After 1.6 secs, we should receive a on_liveliness_changed(status lost) on the two readers
+    ASSERT_EQ(reader.sub_wait_liveliness_lost_for(2, std::chrono::seconds(4)), 2u);
+}
+
 #ifdef INSTANTIATE_TEST_SUITE_P
 #define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_SUITE_P(x, y, z, w)
 #else

--- a/test/blackbox/common/BlackboxTestsLivelinessQos.cpp
+++ b/test/blackbox/common/BlackboxTestsLivelinessQos.cpp
@@ -2018,7 +2018,7 @@ TEST(LivelinessTests, correct_liveliness_state_one_writer_multiple_readers)
     for (size_t i = 0; i < num_readers; i++)
     {
         // Create Subscribers and readers, one for each writer
-        reader.init_subscriber(i);
+        reader.init_subscriber(static_cast<unsigned int>(i));
     }
 
     // Create writers

--- a/test/unittest/rtps/writer/LivelinessManagerTests.cpp
+++ b/test/unittest/rtps/writer/LivelinessManagerTests.cpp
@@ -154,22 +154,27 @@ TEST_F(LivelinessManagerTests, WriterCannotBeRemovedTwice)
     GuidPrefix_t guidP;
     guidP.value[0] = 1;
     GUID_t guid(guidP, 0);
+    LivelinessData::WriterStatus writer_status;
 
     EXPECT_EQ(liveliness_manager.add_writer(guid, fastdds::dds::AUTOMATIC_LIVELINESS_QOS, Duration_t(1)), true);
-    EXPECT_EQ(liveliness_manager.remove_writer(guid, fastdds::dds::AUTOMATIC_LIVELINESS_QOS, Duration_t(1)), true);
-    EXPECT_EQ(liveliness_manager.remove_writer(guid, fastdds::dds::AUTOMATIC_LIVELINESS_QOS, Duration_t(1)), false);
+    EXPECT_EQ(liveliness_manager.remove_writer(guid, fastdds::dds::AUTOMATIC_LIVELINESS_QOS, Duration_t(1),
+            writer_status), true);
+    EXPECT_EQ(liveliness_manager.remove_writer(guid, fastdds::dds::AUTOMATIC_LIVELINESS_QOS, Duration_t(1),
+            writer_status), false);
 
     EXPECT_EQ(liveliness_manager.add_writer(guid, fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS, Duration_t(
                 1)), true);
     EXPECT_EQ(liveliness_manager.remove_writer(guid, fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS, Duration_t(
-                1)), true);
+                1), writer_status), true);
     EXPECT_EQ(liveliness_manager.remove_writer(guid, fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS, Duration_t(
-                1)), false);
+                1), writer_status), false);
 
     EXPECT_EQ(liveliness_manager.add_writer(guid, fastdds::dds::MANUAL_BY_TOPIC_LIVELINESS_QOS, Duration_t(1)), true);
-    EXPECT_EQ(liveliness_manager.remove_writer(guid, fastdds::dds::MANUAL_BY_TOPIC_LIVELINESS_QOS, Duration_t(1)),
+    EXPECT_EQ(liveliness_manager.remove_writer(guid, fastdds::dds::MANUAL_BY_TOPIC_LIVELINESS_QOS, Duration_t(1),
+            writer_status),
             true);
-    EXPECT_EQ(liveliness_manager.remove_writer(guid, fastdds::dds::MANUAL_BY_TOPIC_LIVELINESS_QOS, Duration_t(1)),
+    EXPECT_EQ(liveliness_manager.remove_writer(guid, fastdds::dds::MANUAL_BY_TOPIC_LIVELINESS_QOS, Duration_t(1),
+            writer_status),
             false);
 }
 
@@ -494,12 +499,14 @@ TEST_F(LivelinessManagerTests, TimerOwnerRemoved)
 
     GuidPrefix_t guidP;
     guidP.value[0] = 1;
+    LivelinessData::WriterStatus writer_status;
 
     liveliness_manager.add_writer(GUID_t(guidP, 1), fastdds::dds::AUTOMATIC_LIVELINESS_QOS, Duration_t(0.5));
     liveliness_manager.add_writer(GUID_t(guidP, 2), fastdds::dds::AUTOMATIC_LIVELINESS_QOS, Duration_t(1));
 
     liveliness_manager.assert_liveliness(GUID_t(guidP, 1), fastdds::dds::AUTOMATIC_LIVELINESS_QOS, Duration_t(0.5));
-    liveliness_manager.remove_writer(GUID_t(guidP, 1), fastdds::dds::AUTOMATIC_LIVELINESS_QOS, Duration_t(0.5));
+    liveliness_manager.remove_writer(GUID_t(guidP, 1), fastdds::dds::AUTOMATIC_LIVELINESS_QOS, Duration_t(
+                0.5), writer_status);
 
     wait_liveliness_lost(1u);
     EXPECT_EQ(writer_losing_liveliness, GUID_t(guidP, 2));


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR corrects a misbehavior given in a single writer - multiple readers scenario. When the writer is destroyed, the `WriterProxy` is removed from readers. When it is removed from the first one, the `LivelinessManager::remove_writer()` returns `false` as `--writer.count` is `1`, hence the `liveliness_changed` callback is not triggered (`callback_` within `LivelinessManager` is not invoked). When the `WriterProxy` is deleted from the second reader, the `LivelinessManager::remove_writer()` correctly removes the writer and fires the `callback`. The problem in this case is that, later, in `WLP::sub_liveliness_changed()` the `update_liveliness_changed_status()` is only called for this later reader, since the first one is not matched anymore and `reader->matched_writer_is_matched()` returns `false`, corrupting its liveliness state. In this situation, if the writer wakes up again, the first reader is going to return an `alive_count` of `2` instead of `1`.

The fix proposes that every time we unpair a `WriterProxy` from a reader, we should also update the liveliness state for that particular reader. The solution tries to avoid defining extra collections for tracking readers/writers.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
Fixes #4610  

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- __NO__ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [X] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- __NO__ New feature has been added to the `versions.md` file (if applicable).
- __NO__ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [X] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
