### PR TITLE
[21053] Move DR TypeConsistencyEnforcement & DataRepresentation from TypeConsistency to DataReaderQos

### DIFF
--- a/include/fastdds/dds/subscriber/qos/DataReaderQos.hpp
+++ b/include/fastdds/dds/subscriber/qos/DataReaderQos.hpp
@@ -126,45 +126,6 @@ public:
     int32_t max_samples_per_read = 32;
 };
 
-//! Qos Policy to configure the XTypes Qos associated to the DataReader
-class TypeConsistencyQos : public QosPolicy
-{
-public:
-
-    /**
-     * @brief Constructor
-     */
-    FASTDDS_EXPORTED_API TypeConsistencyQos()
-        : QosPolicy(false)
-    {
-    }
-
-    /**
-     * @brief Destructor
-     */
-    virtual FASTDDS_EXPORTED_API ~TypeConsistencyQos() = default;
-
-    bool operator ==(
-            const TypeConsistencyQos& b) const
-    {
-        return (this->type_consistency == b.type_consistency) &&
-               (this->representation == b.representation) &&
-               QosPolicy::operator ==(b);
-    }
-
-    inline void clear() override
-    {
-        TypeConsistencyQos reset = TypeConsistencyQos();
-        std::swap(*this, reset);
-    }
-
-    //!Type consistency enforcement Qos.
-    TypeConsistencyEnforcementQosPolicy type_consistency;
-
-    //!Data Representation Qos.
-    DataRepresentationQosPolicy representation;
-};
-
 /**
  * Class DataReaderQos, containing all the possible Qos that can be set for a determined DataReader.
  * Although these values can be set and are transmitted
@@ -203,6 +164,7 @@ public:
                (durability_service_ == b.durability_service()) &&
                (reliable_reader_qos_ == b.reliable_reader_qos()) &&
                (type_consistency_ == b.type_consistency()) &&
+               (representation_ == b.representation()) &&
                (expects_inline_qos_ == b.expects_inline_qos()) &&
                (properties_ == b.properties()) &&
                (endpoint_ == b.endpoint()) &&
@@ -679,34 +641,65 @@ public:
     }
 
     /**
-     * Getter for TypeConsistencyQos
+     * Getter for TypeConsistencyEnforcementQosPolicy
      *
-     * @return TypeConsistencyQos reference
+     * @return TypeConsistencyEnforcementQosPolicy reference
      */
-    FASTDDS_EXPORTED_API TypeConsistencyQos& type_consistency()
+    FASTDDS_EXPORTED_API TypeConsistencyEnforcementQosPolicy& type_consistency()
     {
         return type_consistency_;
     }
 
     /**
-     * Getter for TypeConsistencyQos
+     * Getter for TypeConsistencyEnforcementQosPolicy
      *
-     * @return TypeConsistencyQos const reference
+     * @return TypeConsistencyEnforcementQosPolicy const reference
      */
-    FASTDDS_EXPORTED_API const TypeConsistencyQos& type_consistency() const
+    FASTDDS_EXPORTED_API const TypeConsistencyEnforcementQosPolicy& type_consistency() const
     {
         return type_consistency_;
     }
 
     /**
-     * Setter for TypeConsistencyQos
+     * Setter for TypeConsistencyEnforcementQosPolicy
      *
-     * @param new_value new value for the TypeConsistencyQos
+     * @param new_value new value for the TypeConsistencyEnforcementQosPolicy
      */
     FASTDDS_EXPORTED_API void type_consistency(
-            const TypeConsistencyQos& new_value)
+            const TypeConsistencyEnforcementQosPolicy& new_value)
     {
         type_consistency_ = new_value;
+    }
+
+    /**
+     * Getter for DataRepresentationQosPolicy
+     *
+     * @return DataRepresentationQosPolicy reference
+     */
+    const DataRepresentationQosPolicy& representation() const
+    {
+        return representation_;
+    }
+
+    /**
+     * Getter for DataRepresentationQosPolicy
+     *
+     * @return DataRepresentationQosPolicy reference
+     */
+    DataRepresentationQosPolicy& representation()
+    {
+        return representation_;
+    }
+
+    /**
+     * Setter for DataRepresentationQosPolicy
+     *
+     * @param representation new value for the DataRepresentationQosPolicy
+     */
+    void representation(
+            const DataRepresentationQosPolicy& representation)
+    {
+        representation_ = representation;
     }
 
     /**
@@ -901,8 +894,11 @@ private:
     //!Reliable reader configuration (Extension)
     RTPSReliableReaderQos reliable_reader_qos_;
 
-    //! Tipe consistency (Extension)
-    TypeConsistencyQos type_consistency_;
+    //! Type consistency (Extension)
+    TypeConsistencyEnforcementQosPolicy type_consistency_;
+
+    //! Data representation (Extension)
+    DataRepresentationQosPolicy representation_;
 
     //!Expects Inline QOS (Extension).
     bool expects_inline_qos_;

--- a/include/fastdds/dds/subscriber/qos/DataReaderQos.hpp
+++ b/include/fastdds/dds/subscriber/qos/DataReaderQos.hpp
@@ -676,7 +676,7 @@ public:
      *
      * @return DataRepresentationQosPolicy reference
      */
-    const DataRepresentationQosPolicy& representation() const
+    FASTDDS_EXPORTED_API const DataRepresentationQosPolicy& representation() const
     {
         return representation_;
     }
@@ -686,7 +686,7 @@ public:
      *
      * @return DataRepresentationQosPolicy reference
      */
-    DataRepresentationQosPolicy& representation()
+    FASTDDS_EXPORTED_API DataRepresentationQosPolicy& representation()
     {
         return representation_;
     }
@@ -696,7 +696,7 @@ public:
      *
      * @param representation new value for the DataRepresentationQosPolicy
      */
-    void representation(
+    FASTDDS_EXPORTED_API void representation(
             const DataRepresentationQosPolicy& representation)
     {
         representation_ = representation;

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1717,6 +1717,11 @@ void DataReaderImpl::set_qos(
         to.type_consistency() = from.type_consistency();
         to.type_consistency().hasChanged = true;
     }
+    if (first_time || !(to.representation() == from.representation()))
+    {
+        to.representation() = from.representation();
+        to.representation().hasChanged = true;
+    }
     if (first_time && (to.history().kind != from.history().kind ||
             to.history().depth != from.history().depth))
     {
@@ -1804,9 +1809,9 @@ std::shared_ptr<IPayloadPool> DataReaderImpl::get_payload_pool()
 {
     // Check whether DataReader's type is plain in all its data representations
     bool is_plain = true;
-    if (qos_.type_consistency().representation.m_value.size() > 0)
+    if (qos_.representation().m_value.size() > 0)
     {
-        for (auto data_representation : qos_.type_consistency().representation.m_value)
+        for (auto data_representation : qos_.representation().m_value)
         {
             is_plain = is_plain && type_->is_plain(data_representation);
         }

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -441,7 +441,6 @@ ReturnCode_t SubscriberImpl::copy_from_topic_qos(
         DataReaderQos& reader_qos,
         const TopicQos& topic_qos)
 {
-    TypeConsistencyQos new_value;
     reader_qos.durability(topic_qos.durability());
     reader_qos.durability_service(topic_qos.durability_service());
     reader_qos.deadline(topic_qos.deadline());
@@ -452,7 +451,7 @@ ReturnCode_t SubscriberImpl::copy_from_topic_qos(
     reader_qos.history(topic_qos.history());
     reader_qos.resource_limits(topic_qos.resource_limits());
     reader_qos.ownership(topic_qos.ownership());
-    reader_qos.type_consistency().representation = topic_qos.representation();
+    reader_qos.representation() = topic_qos.representation();
     return RETCODE_OK;
 }
 

--- a/src/cpp/fastdds/subscriber/qos/DataReaderQos.cpp
+++ b/src/cpp/fastdds/subscriber/qos/DataReaderQos.cpp
@@ -47,8 +47,8 @@ ReaderQos DataReaderQos::get_readerqos(
     //qos.m_topicData --> TODO: Fill with TopicQos info
     qos.m_durabilityService = durability_service();
     qos.m_disablePositiveACKs = reliable_reader_qos().disable_positive_ACKs;
-    qos.type_consistency = type_consistency().type_consistency;
-    qos.representation = type_consistency().representation;
+    qos.type_consistency = type_consistency();
+    qos.representation = representation();
     qos.data_sharing = data_sharing();
 
     if (qos.data_sharing.kind() != OFF &&

--- a/src/cpp/fastdds/utils/QosConverters.cpp
+++ b/src/cpp/fastdds/utils/QosConverters.cpp
@@ -110,8 +110,8 @@ void set_qos_from_attributes(
     qos.user_data().setValue(attr.qos.m_userData);
     qos.ownership() = attr.qos.m_ownership;
     qos.destination_order() = attr.qos.m_destinationOrder;
-    qos.type_consistency().type_consistency = attr.qos.type_consistency;
-    qos.type_consistency().representation = attr.qos.representation;
+    qos.type_consistency() = attr.qos.type_consistency;
+    qos.representation() = attr.qos.representation;
     qos.time_based_filter() = attr.qos.m_timeBasedFilter;
     qos.history() = attr.topic.historyQos;
     qos.resource_limits() = attr.topic.resourceLimitsQos;

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -1594,7 +1594,7 @@ public:
     PubSubReader& data_representation(
             const std::vector<eprosima::fastdds::dds::DataRepresentationId_t>& values)
     {
-        datareader_qos_.type_consistency().representation.m_value = values;
+        datareader_qos_.representation().m_value = values;
         return *this;
     }
 

--- a/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
@@ -464,7 +464,7 @@ template<>
 void TestsDataReaderQosCommonUtils::set_representation_qos(
         eprosima::fastdds::dds::DataReaderQos& qos)
 {
-    qos.type_consistency().representation.m_value.push_back(
+    qos.representation().m_value.push_back(
         eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
 }
 

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -3870,8 +3870,8 @@ TEST_F(DataReaderTests, data_type_is_plain_data_representation)
     /* Define XCDR1 only data representation QoS to force "is_plain" call */
     DataReaderQos qos_xcdr = DATAREADER_QOS_DEFAULT;
     qos_xcdr.endpoint().history_memory_policy = PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
-    qos_xcdr.type_consistency().representation.m_value.clear();
-    qos_xcdr.type_consistency().representation.m_value.push_back(DataRepresentationId_t::XCDR_DATA_REPRESENTATION);
+    qos_xcdr.representation().m_value.clear();
+    qos_xcdr.representation().m_value.push_back(DataRepresentationId_t::XCDR_DATA_REPRESENTATION);
 
     /* Expect the "is_plain" method called with default data representation (XCDR1) */
     EXPECT_CALL(*type, custom_is_plain()).Times(0);
@@ -3888,8 +3888,8 @@ TEST_F(DataReaderTests, data_type_is_plain_data_representation)
     /* Define XCDR2 data representation QoS to force "is_plain" call */
     DataReaderQos qos_xcdr2 = DATAREADER_QOS_DEFAULT;
     qos_xcdr2.endpoint().history_memory_policy = PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
-    qos_xcdr2.type_consistency().representation.m_value.clear();
-    qos_xcdr2.type_consistency().representation.m_value.push_back(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
+    qos_xcdr2.representation().m_value.clear();
+    qos_xcdr2.representation().m_value.push_back(DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
 
     /* Expect the "is_plain" method called with XCDR2 data representation */
     EXPECT_CALL(*type, custom_is_plain()).Times(0);
@@ -3904,7 +3904,7 @@ TEST_F(DataReaderTests, data_type_is_plain_data_representation)
     /* NOT Define data representation QoS to force "is_plain" call */
     DataReaderQos qos_no_xcdr = DATAREADER_QOS_DEFAULT;
     qos_no_xcdr.endpoint().history_memory_policy = PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
-    qos_no_xcdr.type_consistency().representation.m_value.clear();
+    qos_no_xcdr.representation().m_value.clear();
 
     /* Expect the "is_plain" method called with both data representation */
     EXPECT_CALL(*type, custom_is_plain()).Times(0);

--- a/test/unittest/dds/subscriber/SubscriberTests.cpp
+++ b/test/unittest/dds/subscriber/SubscriberTests.cpp
@@ -350,39 +350,40 @@ TEST(SubscriberTests, ChangeDefaultDataReaderQos)
 
     ASSERT_TRUE(subscriber->set_default_datareader_qos(qos) == RETCODE_OK);
 
-    DataReaderQos wqos;
-    subscriber->get_default_datareader_qos(wqos);
+    // Obtain already modified qos
+    DataReaderQos rqos;
+    subscriber->get_default_datareader_qos(rqos);
 
     // .durability
-    EXPECT_EQ(eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS, wqos.durability().kind);
+    EXPECT_EQ(eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS, rqos.durability().kind);
     // .deadline
-    EXPECT_EQ(10, wqos.deadline().period.seconds);
-    EXPECT_EQ(20u, wqos.deadline().period.nanosec);
+    EXPECT_EQ(10, rqos.deadline().period.seconds);
+    EXPECT_EQ(20u, rqos.deadline().period.nanosec);
     // .latency_budget
-    EXPECT_EQ(20, wqos.latency_budget().duration.seconds);
-    EXPECT_EQ(30u, wqos.latency_budget().duration.nanosec);
+    EXPECT_EQ(20, rqos.latency_budget().duration.seconds);
+    EXPECT_EQ(30u, rqos.latency_budget().duration.nanosec);
     // .liveliness
-    EXPECT_EQ(eprosima::fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS, wqos.liveliness().kind);
-    EXPECT_EQ(40, wqos.liveliness().lease_duration.seconds);
-    EXPECT_EQ(61u, wqos.liveliness().lease_duration.nanosec);
-    EXPECT_EQ(30, wqos.liveliness().announcement_period.seconds);
-    EXPECT_EQ(50u, wqos.liveliness().announcement_period.nanosec);
+    EXPECT_EQ(eprosima::fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS, rqos.liveliness().kind);
+    EXPECT_EQ(40, rqos.liveliness().lease_duration.seconds);
+    EXPECT_EQ(61u, rqos.liveliness().lease_duration.nanosec);
+    EXPECT_EQ(30, rqos.liveliness().announcement_period.seconds);
+    EXPECT_EQ(50u, rqos.liveliness().announcement_period.nanosec);
     // .reliability
-    EXPECT_EQ(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS, wqos.reliability().kind);
+    EXPECT_EQ(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS, rqos.reliability().kind);
     // .destination_order
-    EXPECT_EQ(eprosima::fastdds::dds::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS, wqos.destination_order().kind);
+    EXPECT_EQ(eprosima::fastdds::dds::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS, rqos.destination_order().kind);
     // . history
-    EXPECT_EQ(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS, wqos.history().kind);
-    EXPECT_EQ(1000, wqos.history().depth);
+    EXPECT_EQ(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS, rqos.history().kind);
+    EXPECT_EQ(1000, rqos.history().depth);
     // .resource_limits
-    EXPECT_EQ(3000, wqos.resource_limits().max_samples);
-    EXPECT_EQ(100, wqos.resource_limits().max_instances);
-    EXPECT_EQ(500, wqos.resource_limits().max_samples_per_instance);
-    EXPECT_EQ(50, wqos.resource_limits().allocated_samples);
-    EXPECT_EQ(2, wqos.resource_limits().extra_samples);
+    EXPECT_EQ(3000, rqos.resource_limits().max_samples);
+    EXPECT_EQ(100, rqos.resource_limits().max_instances);
+    EXPECT_EQ(500, rqos.resource_limits().max_samples_per_instance);
+    EXPECT_EQ(50, rqos.resource_limits().allocated_samples);
+    EXPECT_EQ(2, rqos.resource_limits().extra_samples);
     // .user_data
     size_t count = 1;
-    for (auto user_value : wqos.user_data())
+    for (auto user_value : rqos.user_data())
     {
         switch (count)
         {
@@ -404,45 +405,45 @@ TEST(SubscriberTests, ChangeDefaultDataReaderQos)
         ++count;
     }
     // .ownership
-    EXPECT_EQ(eprosima::fastdds::dds::EXCLUSIVE_OWNERSHIP_QOS, wqos.ownership().kind);
+    EXPECT_EQ(eprosima::fastdds::dds::EXCLUSIVE_OWNERSHIP_QOS, rqos.ownership().kind);
     // .time_based_filter
-    EXPECT_EQ(eprosima::fastrtps::Time_t::INFINITE_SECONDS, wqos.time_based_filter().minimum_separation.seconds);
-    EXPECT_EQ(eprosima::fastrtps::Time_t::INFINITE_NANOSECONDS, wqos.time_based_filter().minimum_separation.nanosec);
+    EXPECT_EQ(eprosima::fastrtps::Time_t::INFINITE_SECONDS, rqos.time_based_filter().minimum_separation.seconds);
+    EXPECT_EQ(eprosima::fastrtps::Time_t::INFINITE_NANOSECONDS, rqos.time_based_filter().minimum_separation.nanosec);
     // .reader_data_lifecycle
-    EXPECT_EQ(100, wqos.reader_data_lifecycle().autopurge_disposed_samples_delay.seconds);
-    EXPECT_EQ(30000u, wqos.reader_data_lifecycle().autopurge_disposed_samples_delay.nanosec);
-    EXPECT_EQ(30000, wqos.reader_data_lifecycle().autopurge_no_writer_samples_delay.seconds);
-    EXPECT_EQ(100u, wqos.reader_data_lifecycle().autopurge_no_writer_samples_delay.nanosec);
+    EXPECT_EQ(100, rqos.reader_data_lifecycle().autopurge_disposed_samples_delay.seconds);
+    EXPECT_EQ(30000u, rqos.reader_data_lifecycle().autopurge_disposed_samples_delay.nanosec);
+    EXPECT_EQ(30000, rqos.reader_data_lifecycle().autopurge_no_writer_samples_delay.seconds);
+    EXPECT_EQ(100u, rqos.reader_data_lifecycle().autopurge_no_writer_samples_delay.nanosec);
     // .lifespan
-    EXPECT_EQ(10, wqos.lifespan().duration.seconds);
-    EXPECT_EQ(33u, wqos.lifespan().duration.nanosec);
+    EXPECT_EQ(10, rqos.lifespan().duration.seconds);
+    EXPECT_EQ(33u, rqos.lifespan().duration.nanosec);
     // .durability_service
-    EXPECT_EQ(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS, wqos.durability_service().history_kind);
-    EXPECT_EQ(10, wqos.durability_service().history_depth);
-    EXPECT_EQ(5, wqos.durability_service().max_samples);
-    EXPECT_EQ(20, wqos.durability_service().max_instances);
-    EXPECT_EQ(30, wqos.durability_service().max_samples_per_instance);
+    EXPECT_EQ(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS, rqos.durability_service().history_kind);
+    EXPECT_EQ(10, rqos.durability_service().history_depth);
+    EXPECT_EQ(5, rqos.durability_service().max_samples);
+    EXPECT_EQ(20, rqos.durability_service().max_instances);
+    EXPECT_EQ(30, rqos.durability_service().max_samples_per_instance);
     // .reliable_reader_qos
-    EXPECT_EQ(34, wqos.reliable_reader_qos().times.initialAcknackDelay.seconds);
-    EXPECT_EQ(32u, wqos.reliable_reader_qos().times.initialAcknackDelay.nanosec);
-    EXPECT_EQ(432, wqos.reliable_reader_qos().times.heartbeatResponseDelay.seconds);
-    EXPECT_EQ(43u, wqos.reliable_reader_qos().times.heartbeatResponseDelay.nanosec);
-    EXPECT_TRUE(wqos.reliable_reader_qos().disable_positive_ACKs.enabled);
-    EXPECT_EQ(13, wqos.reliable_reader_qos().disable_positive_ACKs.duration.seconds);
-    EXPECT_EQ(320u, wqos.reliable_reader_qos().disable_positive_ACKs.duration.nanosec);
+    EXPECT_EQ(34, rqos.reliable_reader_qos().times.initialAcknackDelay.seconds);
+    EXPECT_EQ(32u, rqos.reliable_reader_qos().times.initialAcknackDelay.nanosec);
+    EXPECT_EQ(432, rqos.reliable_reader_qos().times.heartbeatResponseDelay.seconds);
+    EXPECT_EQ(43u, rqos.reliable_reader_qos().times.heartbeatResponseDelay.nanosec);
+    EXPECT_TRUE(rqos.reliable_reader_qos().disable_positive_ACKs.enabled);
+    EXPECT_EQ(13, rqos.reliable_reader_qos().disable_positive_ACKs.duration.seconds);
+    EXPECT_EQ(320u, rqos.reliable_reader_qos().disable_positive_ACKs.duration.nanosec);
     // .type_consistency
-    EXPECT_EQ(XML_DATA_REPRESENTATION, wqos.representation().m_value.at(0));
-    EXPECT_EQ(XCDR_DATA_REPRESENTATION, wqos.representation().m_value.at(1));
-    EXPECT_FALSE(wqos.type_consistency().m_ignore_sequence_bounds);
-    EXPECT_FALSE(wqos.type_consistency().m_ignore_string_bounds);
-    EXPECT_TRUE(wqos.type_consistency().m_ignore_member_names);
-    EXPECT_TRUE(wqos.type_consistency().m_prevent_type_widening);
-    EXPECT_TRUE(wqos.type_consistency().m_force_type_validation);
+    EXPECT_EQ(XML_DATA_REPRESENTATION, rqos.representation().m_value.at(0));
+    EXPECT_EQ(XCDR_DATA_REPRESENTATION, rqos.representation().m_value.at(1));
+    EXPECT_FALSE(rqos.type_consistency().m_ignore_sequence_bounds);
+    EXPECT_FALSE(rqos.type_consistency().m_ignore_string_bounds);
+    EXPECT_TRUE(rqos.type_consistency().m_ignore_member_names);
+    EXPECT_TRUE(rqos.type_consistency().m_prevent_type_widening);
+    EXPECT_TRUE(rqos.type_consistency().m_force_type_validation);
     // .expects_inline_qos
-    EXPECT_TRUE(wqos.expects_inline_qos());
+    EXPECT_TRUE(rqos.expects_inline_qos());
     // .properties
     count = 1;
-    for (auto prop : wqos.properties().properties())
+    for (auto prop : rqos.properties().properties())
     {
         switch (count)
         {
@@ -460,25 +461,25 @@ TEST(SubscriberTests, ChangeDefaultDataReaderQos)
         ++count;
     }
     // .endpoint
-    EXPECT_EQ(1, wqos.endpoint().user_defined_id);
-    EXPECT_EQ(2, wqos.endpoint().entity_id);
-    EXPECT_EQ(eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE, wqos.endpoint().history_memory_policy);
+    EXPECT_EQ(1, rqos.endpoint().user_defined_id);
+    EXPECT_EQ(2, rqos.endpoint().entity_id);
+    EXPECT_EQ(eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE, rqos.endpoint().history_memory_policy);
     // .reader_resource_limits
-    EXPECT_EQ(30u, wqos.reader_resource_limits().matched_publisher_allocation.initial);
-    EXPECT_EQ(300u, wqos.reader_resource_limits().matched_publisher_allocation.maximum);
-    EXPECT_EQ(4u, wqos.reader_resource_limits().matched_publisher_allocation.increment);
-    EXPECT_EQ(40u, wqos.reader_resource_limits().sample_infos_allocation.initial);
-    EXPECT_EQ(400u, wqos.reader_resource_limits().sample_infos_allocation.maximum);
-    EXPECT_EQ(5u, wqos.reader_resource_limits().sample_infos_allocation.increment);
-    EXPECT_EQ(50u, wqos.reader_resource_limits().outstanding_reads_allocation.initial);
-    EXPECT_EQ(500u, wqos.reader_resource_limits().outstanding_reads_allocation.maximum);
-    EXPECT_EQ(6u, wqos.reader_resource_limits().outstanding_reads_allocation.increment);
-    EXPECT_EQ(33, wqos.reader_resource_limits().max_samples_per_read);
+    EXPECT_EQ(30u, rqos.reader_resource_limits().matched_publisher_allocation.initial);
+    EXPECT_EQ(300u, rqos.reader_resource_limits().matched_publisher_allocation.maximum);
+    EXPECT_EQ(4u, rqos.reader_resource_limits().matched_publisher_allocation.increment);
+    EXPECT_EQ(40u, rqos.reader_resource_limits().sample_infos_allocation.initial);
+    EXPECT_EQ(400u, rqos.reader_resource_limits().sample_infos_allocation.maximum);
+    EXPECT_EQ(5u, rqos.reader_resource_limits().sample_infos_allocation.increment);
+    EXPECT_EQ(50u, rqos.reader_resource_limits().outstanding_reads_allocation.initial);
+    EXPECT_EQ(500u, rqos.reader_resource_limits().outstanding_reads_allocation.maximum);
+    EXPECT_EQ(6u, rqos.reader_resource_limits().outstanding_reads_allocation.increment);
+    EXPECT_EQ(33, rqos.reader_resource_limits().max_samples_per_read);
     // .data_sharing
-    EXPECT_EQ(eprosima::fastdds::dds::ON, wqos.data_sharing().kind());
-    EXPECT_EQ(0, wqos.data_sharing().shm_directory().compare("/"));
+    EXPECT_EQ(eprosima::fastdds::dds::ON, rqos.data_sharing().kind());
+    EXPECT_EQ(0, rqos.data_sharing().shm_directory().compare("/"));
 
-    EXPECT_EQ(qos, wqos);
+    EXPECT_EQ(qos, rqos);
 
     ASSERT_TRUE(participant->delete_subscriber(subscriber) == RETCODE_OK);
     ASSERT_TRUE(DomainParticipantFactory::get_instance()->delete_participant(participant) == RETCODE_OK);

--- a/test/unittest/dds/subscriber/SubscriberTests.cpp
+++ b/test/unittest/dds/subscriber/SubscriberTests.cpp
@@ -310,13 +310,13 @@ TEST(SubscriberTests, ChangeDefaultDataReaderQos)
     qos.reliable_reader_qos().disable_positive_ACKs.duration.seconds = 13;
     qos.reliable_reader_qos().disable_positive_ACKs.duration.nanosec = 320u;
     // .type_consistency
-    qos.type_consistency().representation.m_value.push_back(XML_DATA_REPRESENTATION);
-    qos.type_consistency().representation.m_value.push_back(XCDR_DATA_REPRESENTATION);
-    qos.type_consistency().type_consistency.m_ignore_sequence_bounds = false;
-    qos.type_consistency().type_consistency.m_ignore_string_bounds = false;
-    qos.type_consistency().type_consistency.m_ignore_member_names = true;
-    qos.type_consistency().type_consistency.m_prevent_type_widening = true;
-    qos.type_consistency().type_consistency.m_force_type_validation = true;
+    qos.representation().m_value.push_back(XML_DATA_REPRESENTATION);
+    qos.representation().m_value.push_back(XCDR_DATA_REPRESENTATION);
+    qos.type_consistency().m_ignore_sequence_bounds = false;
+    qos.type_consistency().m_ignore_string_bounds = false;
+    qos.type_consistency().m_ignore_member_names = true;
+    qos.type_consistency().m_prevent_type_widening = true;
+    qos.type_consistency().m_force_type_validation = true;
     // .expects_inline_qos
     qos.expects_inline_qos(true);
     // .properties
@@ -431,13 +431,13 @@ TEST(SubscriberTests, ChangeDefaultDataReaderQos)
     EXPECT_EQ(13, wqos.reliable_reader_qos().disable_positive_ACKs.duration.seconds);
     EXPECT_EQ(320u, wqos.reliable_reader_qos().disable_positive_ACKs.duration.nanosec);
     // .type_consistency
-    EXPECT_EQ(XML_DATA_REPRESENTATION, wqos.type_consistency().representation.m_value.at(0));
-    EXPECT_EQ(XCDR_DATA_REPRESENTATION, wqos.type_consistency().representation.m_value.at(1));
-    EXPECT_FALSE(wqos.type_consistency().type_consistency.m_ignore_sequence_bounds);
-    EXPECT_FALSE(wqos.type_consistency().type_consistency.m_ignore_string_bounds);
-    EXPECT_TRUE(wqos.type_consistency().type_consistency.m_ignore_member_names);
-    EXPECT_TRUE(wqos.type_consistency().type_consistency.m_prevent_type_widening);
-    EXPECT_TRUE(wqos.type_consistency().type_consistency.m_force_type_validation);
+    EXPECT_EQ(XML_DATA_REPRESENTATION, wqos.representation().m_value.at(0));
+    EXPECT_EQ(XCDR_DATA_REPRESENTATION, wqos.representation().m_value.at(1));
+    EXPECT_FALSE(wqos.type_consistency().m_ignore_sequence_bounds);
+    EXPECT_FALSE(wqos.type_consistency().m_ignore_string_bounds);
+    EXPECT_TRUE(wqos.type_consistency().m_ignore_member_names);
+    EXPECT_TRUE(wqos.type_consistency().m_prevent_type_widening);
+    EXPECT_TRUE(wqos.type_consistency().m_force_type_validation);
     // .expects_inline_qos
     EXPECT_TRUE(wqos.expects_inline_qos());
     // .properties
@@ -911,7 +911,7 @@ template<>
 void TestsSubscriberQosCommonUtils::set_representation_qos(
         eprosima::fastdds::dds::DataReaderQos& qos)
 {
-    qos.type_consistency().representation.m_value.push_back(
+    qos.representation().m_value.push_back(
         eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION);
 }
 

--- a/versions.md
+++ b/versions.md
@@ -33,6 +33,7 @@ Forthcoming
 * Calling `DataReader::return_loan` returns `ReturnCode_t::RETCODE_OK` both for empty sequences and for sequences that were not loaned.
 * Refactor examples:
   * Hello world example with wait-sets and environment XML profiles.
+* Removed `TypeConsistencyQos` from DataReader, and included `TypeConsistencyEnforcementQosPolicy` and `DataRepresentationQosPolicy`
 
 Version 2.14.0
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR updates the DataReaderQoS reformatting the TypeConsistencyQos:
1. `DataReaderQos` shall have:
     - `TypeConsistencyEnforcementQosPolicy::type_consistency`
     - `DataRepresentationQosPolicy::representation`
2. `DataReader::TypeConsistencyQos` shall be removed
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- ❌ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- ❌ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - Related documentation PR: eProsima/Fast-DDS-docs#779
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
