### PR TITLE
[20989] Don't require Fast CDR v2 in examples

### DIFF
--- a/examples/cpp/dds/AdvancedConfigurationExample/CMakeLists.txt
+++ b/examples/cpp/dds/AdvancedConfigurationExample/CMakeLists.txt
@@ -18,7 +18,7 @@ project(AdvancedConfigurationExample VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT fastrtps_FOUND)

--- a/examples/cpp/dds/BasicConfigurationExample/CMakeLists.txt
+++ b/examples/cpp/dds/BasicConfigurationExample/CMakeLists.txt
@@ -18,7 +18,7 @@ project(BasicConfigurationExample VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT fastrtps_FOUND)

--- a/examples/cpp/dds/Configurability/CMakeLists.txt
+++ b/examples/cpp/dds/Configurability/CMakeLists.txt
@@ -18,7 +18,7 @@ project(Configurability VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT foonathan_memory_FOUND)

--- a/examples/cpp/dds/ContentFilteredTopicExample/CMakeLists.txt
+++ b/examples/cpp/dds/ContentFilteredTopicExample/CMakeLists.txt
@@ -18,7 +18,7 @@ project("ContentFilterTopic" VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT fastrtps_FOUND)

--- a/examples/cpp/dds/CustomListenerExample/CMakeLists.txt
+++ b/examples/cpp/dds/CustomListenerExample/CMakeLists.txt
@@ -18,7 +18,7 @@ project(DDSCustomListener VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT fastrtps_FOUND)

--- a/examples/cpp/dds/CustomPayloadPoolExample/CMakeLists.txt
+++ b/examples/cpp/dds/CustomPayloadPoolExample/CMakeLists.txt
@@ -18,7 +18,7 @@ project(CustomPayloadPoolExample VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT fastrtps_FOUND)

--- a/examples/cpp/dds/DeadlineQoSExample/CMakeLists.txt
+++ b/examples/cpp/dds/DeadlineQoSExample/CMakeLists.txt
@@ -18,7 +18,7 @@ project(DeadlineQoSExample VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT foonathan_memory_FOUND)

--- a/examples/cpp/dds/DisablePositiveACKs/CMakeLists.txt
+++ b/examples/cpp/dds/DisablePositiveACKs/CMakeLists.txt
@@ -18,7 +18,7 @@ project(LifespanQoSExample VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT fastrtps_FOUND)

--- a/examples/cpp/dds/DiscoveryServerExample/CMakeLists.txt
+++ b/examples/cpp/dds/DiscoveryServerExample/CMakeLists.txt
@@ -18,7 +18,7 @@ project(DiscoveryServerExample VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT fastrtps_FOUND)

--- a/examples/cpp/dds/DynamicHelloWorldExample/CMakeLists.txt
+++ b/examples/cpp/dds/DynamicHelloWorldExample/CMakeLists.txt
@@ -18,7 +18,7 @@ project(DDSDynamicHelloWorldExample VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT fastrtps_FOUND)

--- a/examples/cpp/dds/Filtering/CMakeLists.txt
+++ b/examples/cpp/dds/Filtering/CMakeLists.txt
@@ -18,7 +18,7 @@ project(FilteringExample VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT foonathan_memory_FOUND)

--- a/examples/cpp/dds/FlowControlExample/CMakeLists.txt
+++ b/examples/cpp/dds/FlowControlExample/CMakeLists.txt
@@ -18,7 +18,7 @@ project(FlowControlExample VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT foonathan_memory_FOUND)

--- a/examples/cpp/dds/HelloWorldExample/CMakeLists.txt
+++ b/examples/cpp/dds/HelloWorldExample/CMakeLists.txt
@@ -18,7 +18,7 @@ project(DDSHelloWorldExample VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT fastrtps_FOUND)

--- a/examples/cpp/dds/HelloWorldExampleDataSharing/CMakeLists.txt
+++ b/examples/cpp/dds/HelloWorldExampleDataSharing/CMakeLists.txt
@@ -18,7 +18,7 @@ project(DDSHelloWorldExampleDataSharing VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT fastrtps_FOUND)

--- a/examples/cpp/dds/HelloWorldExampleSharedMem/CMakeLists.txt
+++ b/examples/cpp/dds/HelloWorldExampleSharedMem/CMakeLists.txt
@@ -18,7 +18,7 @@ project(HelloWorldExampleSharedMem VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT foonathan_memory_FOUND)

--- a/examples/cpp/dds/HelloWorldExampleTCP/CMakeLists.txt
+++ b/examples/cpp/dds/HelloWorldExampleTCP/CMakeLists.txt
@@ -18,7 +18,7 @@ project("HelloWorldExampleTCP" VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT foonathan_memory_FOUND)

--- a/examples/cpp/dds/HistoryKind/CMakeLists.txt
+++ b/examples/cpp/dds/HistoryKind/CMakeLists.txt
@@ -18,7 +18,7 @@ project(HistoryKindSample VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT foonathan_memory_FOUND)

--- a/examples/cpp/dds/Keys/CMakeLists.txt
+++ b/examples/cpp/dds/Keys/CMakeLists.txt
@@ -18,7 +18,7 @@ project(KeysSample VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT foonathan_memory_FOUND)

--- a/examples/cpp/dds/LateJoiners/CMakeLists.txt
+++ b/examples/cpp/dds/LateJoiners/CMakeLists.txt
@@ -18,7 +18,7 @@ project(LateJoiners VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT foonathan_memory_FOUND)

--- a/examples/cpp/dds/LifespanQoSExample/CMakeLists.txt
+++ b/examples/cpp/dds/LifespanQoSExample/CMakeLists.txt
@@ -18,7 +18,7 @@ project(LifespanQoSExample VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT fastrtps_FOUND)

--- a/examples/cpp/dds/LivelinessQoS/CMakeLists.txt
+++ b/examples/cpp/dds/LivelinessQoS/CMakeLists.txt
@@ -18,7 +18,7 @@ project(LivelinessQoS VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT fastrtps_FOUND)

--- a/examples/cpp/dds/OwnershipStrengthQoSExample/CMakeLists.txt
+++ b/examples/cpp/dds/OwnershipStrengthQoSExample/CMakeLists.txt
@@ -18,7 +18,7 @@ project(OwnershipStrengthQoSExample VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT foonathan_memory_FOUND)

--- a/examples/cpp/dds/RequestReplyExample/CMakeLists.txt
+++ b/examples/cpp/dds/RequestReplyExample/CMakeLists.txt
@@ -18,7 +18,7 @@ project(RequestReplyExample VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT fastrtps_FOUND)

--- a/examples/cpp/dds/SampleConfig_Controller/CMakeLists.txt
+++ b/examples/cpp/dds/SampleConfig_Controller/CMakeLists.txt
@@ -18,7 +18,7 @@ project(SampleControllerConfig VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT foonathan_memory_FOUND)

--- a/examples/cpp/dds/SampleConfig_Events/CMakeLists.txt
+++ b/examples/cpp/dds/SampleConfig_Events/CMakeLists.txt
@@ -18,7 +18,7 @@ project(SampleEventsConfig VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT foonathan_memory_FOUND)

--- a/examples/cpp/dds/SampleConfig_Multimedia/CMakeLists.txt
+++ b/examples/cpp/dds/SampleConfig_Multimedia/CMakeLists.txt
@@ -18,7 +18,7 @@ project(SampleMultimediaConfig VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT foonathan_memory_FOUND)

--- a/examples/cpp/dds/SecureHelloWorldExample/CMakeLists.txt
+++ b/examples/cpp/dds/SecureHelloWorldExample/CMakeLists.txt
@@ -18,7 +18,7 @@ project(SecureHelloWorldExample VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT foonathan_memory_FOUND)

--- a/examples/cpp/dds/StaticHelloWorldExample/CMakeLists.txt
+++ b/examples/cpp/dds/StaticHelloWorldExample/CMakeLists.txt
@@ -18,7 +18,7 @@ project(StaticHelloWorldExample VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT foonathan_memory_FOUND)

--- a/examples/cpp/dds/TypeLookupService/CMakeLists.txt
+++ b/examples/cpp/dds/TypeLookupService/CMakeLists.txt
@@ -18,7 +18,7 @@ project(TypeLookupExample VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT fastrtps_FOUND)

--- a/examples/cpp/dds/WriterLoansExample/CMakeLists.txt
+++ b/examples/cpp/dds/WriterLoansExample/CMakeLists.txt
@@ -18,7 +18,7 @@ project(DDSWriterLoansExample VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT fastrtps_FOUND)

--- a/examples/cpp/dds/ZeroCopyExample/CMakeLists.txt
+++ b/examples/cpp/dds/ZeroCopyExample/CMakeLists.txt
@@ -18,7 +18,7 @@ project(DDSZeroCopyExample VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT fastrtps_FOUND)

--- a/examples/cpp/rtps/AsSocket/CMakeLists.txt
+++ b/examples/cpp/rtps/AsSocket/CMakeLists.txt
@@ -18,7 +18,7 @@ project(RTPSTest_as_socket VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT foonathan_memory_FOUND)

--- a/examples/cpp/rtps/Persistent/CMakeLists.txt
+++ b/examples/cpp/rtps/Persistent/CMakeLists.txt
@@ -18,7 +18,7 @@ project(RTPSTest_persistent VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT foonathan_memory_FOUND)

--- a/examples/cpp/rtps/Registered/CMakeLists.txt
+++ b/examples/cpp/rtps/Registered/CMakeLists.txt
@@ -18,7 +18,7 @@ project(RTPSTest_registered VERSION 1 LANGUAGES CXX)
 
 # Find requirements
 if(NOT fastcdr_FOUND)
-    find_package(fastcdr 2 REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 if(NOT foonathan_memory_FOUND)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR removes the restriction of Fast CDR to be version 2 for examples, as they are prepared to also work with Fast CDR v1.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
