### PR TITLE
[20815] Only apply content filter to ALIVE changes

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -158,6 +158,7 @@ set(${PROJECT_NAME}_source_files
     rtps/participant/RTPSParticipant.cpp
     rtps/participant/RTPSParticipantImpl.cpp
     rtps/persistence/PersistenceFactory.cpp
+    rtps/reader/reader_utils.cpp
     rtps/reader/RTPSReader.cpp
     rtps/reader/StatefulPersistentReader.cpp
     rtps/reader/StatefulReader.cpp

--- a/src/cpp/fastdds/publisher/filtering/ReaderFilterCollection.hpp
+++ b/src/cpp/fastdds/publisher/filtering/ReaderFilterCollection.hpp
@@ -133,13 +133,17 @@ public:
                         // Copy the signature
                         std::copy(entry.filter_signature.begin(), entry.filter_signature.end(), signature);
 
-                        // Evaluate filter and update filtered_out_readers
-                        bool filter_result = entry.filter->evaluate(change.serializedPayload, info, it->first);
-                        if (!filter_result)
+                        // Only evaluate filter on ALIVE changes, as UNREGISTERED and DISPOSED are always relevant
+                        bool filter_result = true;
+                        if (fastrtps::rtps::ALIVE == change.kind)
                         {
-                            change.filtered_out_readers.emplace_back(it->first);
+                            // Evaluate filter and update filtered_out_readers
+                            filter_result = entry.filter->evaluate(change.serializedPayload, info, it->first);
+                            if (!filter_result)
+                            {
+                                change.filtered_out_readers.emplace_back(it->first);
+                            }
                         }
-
                         return filter_result;
                     };
 

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -28,6 +28,8 @@
 #include <fastdds/rtps/history/ReaderHistory.h>
 #include <fastdds/rtps/reader/ReaderListener.h>
 
+#include "reader_utils.hpp"
+#include "rtps/RTPSDomainImpl.hpp"
 #include <rtps/builtin/BuiltinProtocols.h>
 #include <rtps/builtin/liveliness/WLP.h>
 #include <rtps/DataSharing/DataSharingListener.hpp>
@@ -37,9 +39,6 @@
 #include <rtps/participant/RTPSParticipantImpl.h>
 #include <rtps/reader/WriterProxy.h>
 #include <rtps/writer/LivelinessManager.hpp>
-
-#include "rtps/RTPSDomainImpl.hpp"
-
 #ifdef FASTDDS_STATISTICS
 #include <statistics/types/monitorservice_types.hpp>
 #endif // FASTDDS_STATISTICS
@@ -588,7 +587,7 @@ bool StatefulReader::processDataMsg(
                 return false;
             }
 
-            if (data_filter_ && !data_filter_->is_relevant(*change, m_guid))
+            if (!fastdds::rtps::change_is_relevant_for_filter(*change, m_guid, data_filter_))
             {
                 if (pWP)
                 {
@@ -596,6 +595,7 @@ bool StatefulReader::processDataMsg(
                     NotifyChanges(pWP);
                     send_ack_if_datasharing(this, mp_history, pWP, change->sequenceNumber);
                 }
+                // Change was filtered out, so there isn't anything else to do
                 return true;
             }
 
@@ -771,7 +771,8 @@ bool StatefulReader::processDataFragMsg(
 
                     // Temporarilly assign the inline qos while evaluating the data filter
                     work_change->inline_qos = incomingChange->inline_qos;
-                    bool filtered_out = data_filter_ && !data_filter_->is_relevant(*work_change, m_guid);
+                    bool filtered_out =
+                            !fastdds::rtps::change_is_relevant_for_filter(*work_change, m_guid, data_filter_);
                     work_change->inline_qos = SerializedPayload_t();
 
                     if (filtered_out)

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -27,6 +27,8 @@
 #include <fastdds/rtps/history/ReaderHistory.h>
 #include <fastdds/rtps/reader/ReaderListener.h>
 
+#include "reader_utils.hpp"
+#include "rtps/RTPSDomainImpl.hpp"
 #include <rtps/builtin/BuiltinProtocols.h>
 #include <rtps/builtin/liveliness/WLP.h>
 #include <rtps/DataSharing/DataSharingListener.hpp>
@@ -34,9 +36,6 @@
 #include <rtps/participant/RTPSParticipantImpl.h>
 #include <rtps/reader/StatelessReader.hpp>
 #include <rtps/writer/LivelinessManager.hpp>
-
-#include "rtps/RTPSDomainImpl.hpp"
-
 #ifdef FASTDDS_STATISTICS
 #include <statistics/types/monitorservice_types.hpp>
 #endif // FASTDDS_STATISTICS
@@ -582,9 +581,10 @@ bool StatelessReader::processDataMsg(
                 return false;
             }
 
-            if (data_filter_ && !data_filter_->is_relevant(*change, m_guid))
+            if (!fastdds::rtps::change_is_relevant_for_filter(*change, m_guid, data_filter_))
             {
                 update_last_notified(change->writerGUID, change->sequenceNumber);
+                // Change was filtered out, so there isn't anything else to do
                 return true;
             }
 
@@ -797,7 +797,8 @@ bool StatelessReader::processDataFragMsg(
                 {
                     // Temporarilly assign the inline qos while evaluating the data filter
                     change_completed->inline_qos = incomingChange->inline_qos;
-                    bool filtered_out = data_filter_ && !data_filter_->is_relevant(*change_completed, m_guid);
+                    bool filtered_out = !fastdds::rtps::change_is_relevant_for_filter(*change_completed, m_guid,
+                                    data_filter_);
                     change_completed->inline_qos = SerializedPayload_t();
 
                     if (filtered_out)

--- a/src/cpp/rtps/reader/reader_utils.cpp
+++ b/src/cpp/rtps/reader/reader_utils.cpp
@@ -26,13 +26,13 @@ namespace rtps {
 
 bool change_is_relevant_for_filter(
         const CacheChange& change,
-        const GUID& guid,
+        const GUID& reader_guid,
         const IReaderDataFilter* filter)
 {
     bool ret = true;
 
     // Only evaluate filter on ALIVE changes, as UNREGISTERED and DISPOSED are always relevant
-    if ((nullptr != filter) && (fastrtps::rtps::ALIVE == change.kind) && (!filter->is_relevant(change, guid)))
+    if ((nullptr != filter) && (fastrtps::rtps::ALIVE == change.kind) && (!filter->is_relevant(change, reader_guid)))
     {
         ret = false;
     }

--- a/src/cpp/rtps/reader/reader_utils.cpp
+++ b/src/cpp/rtps/reader/reader_utils.cpp
@@ -1,0 +1,45 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file reader_utils.cpp
+ */
+
+#include "reader_utils.hpp"
+
+#include <fastdds/rtps/common/ChangeKind_t.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+
+bool change_is_relevant_for_filter(
+        const CacheChange& change,
+        const GUID& guid,
+        const IReaderDataFilter* filter)
+{
+    bool ret = true;
+
+    // Only evaluate filter on ALIVE changes, as UNREGISTERED and DISPOSED are always relevant
+    if ((nullptr != filter) && (fastrtps::rtps::ALIVE == change.kind) && (!filter->is_relevant(change, guid)))
+    {
+        ret = false;
+    }
+
+    return ret;
+}
+
+} // namespace rtps
+} // namespace fastdds
+} // namespace eprosima

--- a/src/cpp/rtps/reader/reader_utils.hpp
+++ b/src/cpp/rtps/reader/reader_utils.hpp
@@ -35,14 +35,14 @@ using GUID = fastrtps::rtps::GUID_t;
  * @brief Check if a change is relevant for a reader.
  *
  * @param change The CacheChange_t to be evaluated.
- * @param reader_guid Remote reader GUID_t.
+ * @param reader_guid Reader's GUID_t.
  * @param filter The IReaderDataFilter to be used.
  *
  * @return true if relevant, false otherwise.
  */
 bool change_is_relevant_for_filter(
         const CacheChange& change,
-        const GUID& guid,
+        const GUID& reader_guid,
         const IReaderDataFilter* filter);
 
 } // namespace rtps

--- a/src/cpp/rtps/reader/reader_utils.hpp
+++ b/src/cpp/rtps/reader/reader_utils.hpp
@@ -1,0 +1,53 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file reader_utils.hpp
+ */
+
+#ifndef _FASTDDS_RTPS_READER_READERUTILS_H_
+#define _FASTDDS_RTPS_READER_READERUTILS_H_
+
+#include <fastdds/rtps/common/CacheChange.h>
+#include <fastdds/rtps/common/Guid.h>
+#include <fastdds/rtps/interfaces/IReaderDataFilter.hpp>
+#include <fastdds/rtps/common/ChangeKind_t.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+
+using CacheChange = fastrtps::rtps::CacheChange_t;
+using GUID = fastrtps::rtps::GUID_t;
+
+/**
+ * @brief Check if a change is relevant for a reader.
+ *
+ * @param change The CacheChange_t to be evaluated.
+ * @param reader_guid Remote reader GUID_t.
+ * @param filter The IReaderDataFilter to be used.
+ *
+ * @return true if relevant, false otherwise.
+ */
+bool change_is_relevant_for_filter(
+        const CacheChange& change,
+        const GUID& guid,
+        const IReaderDataFilter* filter);
+
+} // namespace rtps
+} // namespace fastdds
+} // namespace eprosima
+
+
+#endif // _FASTDDS_RTPS_READER_READERUTILS_H_

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -20,11 +20,14 @@
 #ifndef _TEST_BLACKBOX_PUBSUBREADER_HPP_
 #define _TEST_BLACKBOX_PUBSUBREADER_HPP_
 
+#include <algorithm>
 #include <atomic>
 #include <condition_variable>
 #include <functional>
 #include <list>
+#include <mutex>
 #include <string>
+#include <vector>
 
 #include <asio.hpp>
 #include <gtest/gtest.h>
@@ -36,6 +39,7 @@
 #include <fastdds/dds/core/condition/WaitSet.hpp>
 #include <fastdds/dds/core/policy/QosPolicies.hpp>
 #include <fastdds/dds/core/ReturnCode.hpp>
+#include <fastdds/dds/core/status/BaseStatus.hpp>
 #include <fastdds/dds/core/UserAllocatedSequence.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
@@ -46,7 +50,9 @@
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 #include <fastdds/dds/subscriber/SampleInfo.hpp>
 #include <fastdds/dds/subscriber/Subscriber.hpp>
+#include <fastdds/dds/topic/ContentFilteredTopic.hpp>
 #include <fastdds/dds/topic/Topic.hpp>
+#include <fastdds/dds/topic/TopicDescription.hpp>
 #include <fastdds/rtps/transport/TCPv4TransportDescriptor.h>
 #include <fastdds/rtps/transport/TCPv6TransportDescriptor.h>
 #include <fastdds/rtps/transport/UDPTransportDescriptor.h>
@@ -292,6 +298,7 @@ public:
         , listener_(*this)
         , participant_(nullptr)
         , topic_(nullptr)
+        , cf_topic_(nullptr)
         , subscriber_(nullptr)
         , datareader_(nullptr)
         , status_mask_(eprosima::fastdds::dds::StatusMask::all())
@@ -320,6 +327,8 @@ public:
         , times_incompatible_qos_(0)
         , last_incompatible_qos_(eprosima::fastdds::dds::INVALID_QOS_POLICY_ID)
         , message_receive_count_(0)
+        , filter_expression_("")
+        , expression_parameters_({})
     {
         // Load default QoS to permit testing with external XML profile files.
         DomainParticipantFactory::get_instance()->load_profiles();
@@ -352,6 +361,19 @@ public:
 
         // By default don't check for overlapping
         loan_sample_validation(false);
+    }
+
+    PubSubReader(
+            const std::string& topic_name,
+            const std::string& filter_expression,
+            const std::vector<std::string>& expression_parameters,
+            bool take = true,
+            bool statistics = false,
+            bool read = true)
+        : PubSubReader(topic_name, take, statistics, read)
+    {
+        filter_expression_ = filter_expression;
+        expression_parameters_ = expression_parameters;
     }
 
     virtual ~PubSubReader()
@@ -413,6 +435,17 @@ public:
             ASSERT_NE(topic_, nullptr);
             ASSERT_TRUE(topic_->is_enabled());
 
+            // Create CFT if needed
+            if (!filter_expression_.empty())
+            {
+                cf_topic_ = participant_->create_contentfilteredtopic(
+                    topic_name_ + "_cft",
+                    topic_,
+                    filter_expression_,
+                    expression_parameters_);
+                ASSERT_NE(cf_topic_, nullptr);
+            }
+
             // Create publisher
             createSubscriber();
         }
@@ -426,11 +459,18 @@ public:
             ASSERT_NE(subscriber_, nullptr);
             ASSERT_TRUE(subscriber_->is_enabled());
 
+            using TopicDescriptionPtr = eprosima::fastdds::dds::TopicDescription*;
+            TopicDescriptionPtr topic_desc {(nullptr !=
+                                            cf_topic_) ? static_cast<TopicDescriptionPtr>(cf_topic_) : static_cast<
+                                                TopicDescriptionPtr>(
+                                                topic_)};
+
             if (!xml_file_.empty())
             {
                 if (!datareader_profile_.empty())
                 {
-                    datareader_ = subscriber_->create_datareader_with_profile(topic_, datareader_profile_, &listener_,
+                    datareader_ = subscriber_->create_datareader_with_profile(topic_desc, datareader_profile_,
+                                    &listener_,
                                     status_mask_);
                     ASSERT_NE(datareader_, nullptr);
                     ASSERT_TRUE(datareader_->is_enabled());
@@ -438,7 +478,7 @@ public:
             }
             if (datareader_ == nullptr)
             {
-                datareader_ = subscriber_->create_datareader(topic_, datareader_qos_, &listener_, status_mask_);
+                datareader_ = subscriber_->create_datareader(topic_desc, datareader_qos_, &listener_, status_mask_);
             }
 
             if (datareader_ != nullptr)
@@ -474,22 +514,14 @@ public:
     {
         if (participant_ != nullptr)
         {
-            if (datareader_)
-            {
-                subscriber_->delete_datareader(datareader_);
-                datareader_ = nullptr;
-            }
-            if (subscriber_)
-            {
-                participant_->delete_subscriber(subscriber_);
-                subscriber_ = nullptr;
-            }
-            if (topic_)
-            {
-                participant_->delete_topic(topic_);
-                topic_ = nullptr;
-            }
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(participant_);
+            ASSERT_EQ(eprosima::fastdds::dds::RETCODE_OK, participant_->delete_contained_entities());
+            datareader_ = nullptr;
+            subscriber_ = nullptr;
+            cf_topic_ = nullptr;
+            topic_ = nullptr;
+
+            ASSERT_EQ(eprosima::fastdds::dds::RETCODE_OK,
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(participant_));
             participant_ = nullptr;
         }
 
@@ -522,6 +554,18 @@ public:
         receiving_.store(true);
         std::lock_guard<std::mutex> lock(mutex_);
         return get_last_sequence_received();
+    }
+
+    void startReception(
+            size_t expected_samples)
+    {
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            current_processed_count_ = 0;
+            number_samples_expected_ = expected_samples;
+            last_seq.clear();
+        }
+        receiving_.store(true);
     }
 
     void stopReception()
@@ -1746,6 +1790,13 @@ public:
         return status;
     }
 
+    eprosima::fastdds::dds::SampleLostStatus get_sample_lost_status() const
+    {
+        eprosima::fastdds::dds::SampleLostStatus status;
+        datareader_->get_sample_lost_status(status);
+        return status;
+    }
+
     bool is_matched() const
     {
         return matched_ > 0;
@@ -1878,13 +1929,18 @@ protected:
             if (info.valid_data
                     && info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
             {
-                auto it = std::find(total_msgs_.begin(), total_msgs_.end(), data);
-                ASSERT_NE(it, total_msgs_.end());
-                total_msgs_.erase(it);
+                if (!total_msgs_.empty())
+                {
+                    auto it = std::find(total_msgs_.begin(), total_msgs_.end(), data);
+                    ASSERT_NE(it, total_msgs_.end());
+                    total_msgs_.erase(it);
+                }
                 ++current_processed_count_;
                 default_receive_print<type>(data);
                 cv_.notify_one();
             }
+
+            postprocess_sample(data, info);
         }
     }
 
@@ -1929,14 +1985,19 @@ protected:
 
                 if (valid_sample)
                 {
-                    auto it = std::find(total_msgs_.begin(), total_msgs_.end(), data);
-                    ASSERT_NE(it, total_msgs_.end());
-                    total_msgs_.erase(it);
+                    if (!total_msgs_.empty())
+                    {
+                        auto it = std::find(total_msgs_.begin(), total_msgs_.end(), data);
+                        ASSERT_NE(it, total_msgs_.end());
+                        total_msgs_.erase(it);
+                    }
                     ++current_processed_count_;
                     default_receive_print<type>(data);
                     cv_.notify_one();
                 }
             }
+
+            postprocess_sample(data, info);
         }
 
         datareader->return_loan(datas, infos);
@@ -1950,6 +2011,14 @@ protected:
             bool& returnedValue)
     {
         receive_(datareader, std::ref(returnedValue));
+    }
+
+    virtual void postprocess_sample(
+            const type& data,
+            const eprosima::fastdds::dds::SampleInfo& info)
+    {
+        static_cast<void>(data);
+        static_cast<void>(info);
     }
 
     void participant_matched()
@@ -2005,6 +2074,7 @@ protected:
     eprosima::fastdds::dds::DomainParticipant* participant_;
     eprosima::fastdds::dds::DomainParticipantQos participant_qos_;
     eprosima::fastdds::dds::Topic* topic_;
+    eprosima::fastdds::dds::ContentFilteredTopic* cf_topic_;
     eprosima::fastdds::dds::Subscriber* subscriber_;
     eprosima::fastdds::dds::SubscriberQos subscriber_qos_;
     eprosima::fastdds::dds::DataReader* datareader_;
@@ -2084,6 +2154,11 @@ protected:
     SampleLostStatusFunctor sample_lost_status_functor_;
     //! Functor called when called SampleRejectedStatus listener.
     SampleRejectedStatusFunctor sample_rejected_status_functor_;
+
+    //! Expression for CFT
+    std::string filter_expression_;
+    //! Parameters for CFT expression
+    std::vector<std::string> expression_parameters_;
 };
 
 template<class TypeSupport>

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -32,10 +32,12 @@
 #if _MSC_VER
 #include <Windows.h>
 #endif // _MSC_VER
+#include <fastdds/dds/common/InstanceHandle.hpp>
 #include <fastdds/dds/core/condition/GuardCondition.hpp>
 #include <fastdds/dds/core/condition/StatusCondition.hpp>
 #include <fastdds/dds/core/condition/WaitSet.hpp>
 #include <fastdds/dds/core/policy/QosPolicies.hpp>
+#include <fastdds/dds/core/ReturnCode.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/DomainParticipantListener.hpp>
@@ -46,11 +48,11 @@
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
 #include <fastdds/dds/topic/Topic.hpp>
 #include <fastdds/rtps/flowcontrol/FlowControllerSchedulerPolicy.hpp>
+#include <fastdds/rtps/transport/TCPv4TransportDescriptor.h>
+#include <fastdds/rtps/transport/TCPv6TransportDescriptor.h>
 #include <fastdds/rtps/transport/UDPTransportDescriptor.h>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
 #include <fastdds/rtps/transport/UDPv6TransportDescriptor.h>
-#include <fastdds/rtps/transport/TCPv4TransportDescriptor.h>
-#include <fastdds/rtps/transport/TCPv6TransportDescriptor.h>
 #include <fastdds/utils/IPLocator.h>
 
 using eprosima::fastdds::dds::DomainParticipantFactory;
@@ -540,6 +542,14 @@ public:
     {
         default_send_print(msg);
         return datawriter_->write((void*)&msg);
+    }
+
+    eprosima::fastdds::dds::ReturnCode_t send_sample(
+            type& msg,
+            const eprosima::fastdds::dds::InstanceHandle_t& instance_handle)
+    {
+        default_send_print(msg);
+        return datawriter_->write((void*)&msg, instance_handle);
     }
 
     void assert_liveliness()

--- a/test/blackbox/common/DDSBlackboxTestsContentFilter.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsContentFilter.cpp
@@ -686,7 +686,7 @@ TEST(DDSContentFilter, OnlyFilterAliveChanges)
     for (size_t i = 0; i < num_samples; ++i)
     {
         KeyedHelloWorld data;
-        data.key(i);
+        data.key(static_cast<uint16_t>(i));
         data.index(1u);  // All samples pass the filter
         InstanceHandle_t handle = writer.register_instance(data);
         ASSERT_NE(HANDLE_NIL, handle);

--- a/test/unittest/dds/publisher/CMakeLists.txt
+++ b/test/unittest/dds/publisher/CMakeLists.txt
@@ -136,6 +136,7 @@ set(DATAWRITERTESTS_SOURCE DataWriterTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/participant/RTPSParticipant.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/persistence/PersistenceFactory.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/reader_utils.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/RTPSReader.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/StatefulPersistentReader.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/StatefulReader.cpp

--- a/test/unittest/statistics/dds/CMakeLists.txt
+++ b/test/unittest/statistics/dds/CMakeLists.txt
@@ -239,6 +239,7 @@ if (SQLITE3_SUPPORT AND FASTDDS_STATISTICS AND NOT QNX)
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/persistence/PersistenceFactory.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/persistence/sqlite3.c
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/persistence/SQLite3PersistenceService.cpp
+        ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/reader_utils.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/RTPSReader.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/StatefulPersistentReader.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/StatefulReader.cpp
@@ -414,6 +415,7 @@ if (SQLITE3_SUPPORT AND FASTDDS_STATISTICS AND NOT QNX)
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/persistence/PersistenceFactory.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/persistence/sqlite3.c
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/persistence/SQLite3PersistenceService.cpp
+        ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/reader_utils.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/RTPSReader.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/StatefulPersistentReader.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/StatefulReader.cpp


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR fixes a bug that caused the content filter to also be applied to `unregister` and `disposed` samples. Since in those messages the only fields populated (if any) are the ones annotated with `@key`, the `unregister` and `dispose` samples did not pass the filter (in general) and thus were being discarded. This caused several issues:

1. When writing to more than 10 instances with default Qos (keep last 1, max_instances 10), only the first 10 samples were been received.
2. In best effort, when setting the history depth and max instances appropriately, all samples were received, but calls to `unregister` or `dispose` followed by a `write` were triggering `sample_lost` events, as the received sequence numbers were not consecutive (because of the filtering out of the `unregister`/`dispose`).

This PR fixes these issues by only querying for sample relevance when the `CacheChange` kind is `ALIVE`.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@EduPonz backport 2.14.x 2.13.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
