### PR TITLE
[21077] Update Fast DDS docs QoS examples

### DIFF
--- a/examples/cpp/configuration/SubscriberApp.cpp
+++ b/examples/cpp/configuration/SubscriberApp.cpp
@@ -126,7 +126,7 @@ SubscriberApp::SubscriberApp(
         reader_qos.resource_limits().max_samples_per_instance = config.max_samples_per_instance;
         reader_qos.ownership().kind = config.ownership;
         reader_qos.deadline().period = eprosima::fastdds::Duration_t(config.deadline * 1e-3);
-        reader_qos.reliable_reader_qos().disable_positive_ACKs.enabled = config.disable_positive_ack;
+        reader_qos.reliable_reader_qos().disable_positive_acks.enabled = config.disable_positive_ack;
         reader_qos.lifespan().duration = eprosima::fastdds::Duration_t(config.lifespan * 1e-3);
         reader_qos.liveliness().kind = config.liveliness;
         reader_qos.liveliness().lease_duration = eprosima::fastdds::Duration_t(

--- a/include/fastdds/dds/publisher/qos/DataWriterQos.hpp
+++ b/include/fastdds/dds/publisher/qos/DataWriterQos.hpp
@@ -60,8 +60,7 @@ public:
 
     inline void clear()
     {
-        RTPSReliableWriterQos reset = RTPSReliableWriterQos();
-        std::swap(*this, reset);
+        *this = RTPSReliableWriterQos();
     }
 
     //!Writer Timing Attributes

--- a/include/fastdds/dds/publisher/qos/DataWriterQos.hpp
+++ b/include/fastdds/dds/publisher/qos/DataWriterQos.hpp
@@ -58,6 +58,12 @@ public:
                (this->disable_heartbeat_piggyback == b.disable_heartbeat_piggyback);
     }
 
+    inline void clear()
+    {
+        RTPSReliableWriterQos reset = RTPSReliableWriterQos();
+        std::swap(*this, reset);
+    }
+
     //!Writer Timing Attributes
     fastdds::rtps::WriterTimes times;
 

--- a/include/fastdds/dds/subscriber/qos/DataReaderQos.hpp
+++ b/include/fastdds/dds/subscriber/qos/DataReaderQos.hpp
@@ -55,7 +55,7 @@ public:
             const RTPSReliableReaderQos& b) const
     {
         return (this->times == b.times) &&
-               (this->disable_positive_ACKs == b.disable_positive_ACKs);
+               (this->disable_positive_acks == b.disable_positive_acks);
     }
 
     inline void clear()
@@ -72,7 +72,7 @@ public:
     /*!
      * @brief Control the sending of positive ACKs
      */
-    DisablePositiveACKsQosPolicy disable_positive_ACKs;
+    DisablePositiveACKsQosPolicy disable_positive_acks;
 };
 
 //! Qos Policy to configure the limit of the reader resources

--- a/include/fastdds/dds/subscriber/qos/DataReaderQos.hpp
+++ b/include/fastdds/dds/subscriber/qos/DataReaderQos.hpp
@@ -60,8 +60,7 @@ public:
 
     inline void clear()
     {
-        RTPSReliableReaderQos reset = RTPSReliableReaderQos();
-        std::swap(*this, reset);
+        *this = RTPSReliableReaderQos();
     }
 
     /*!

--- a/include/fastdds/rtps/attributes/PropertyPolicy.h
+++ b/include/fastdds/rtps/attributes/PropertyPolicy.h
@@ -71,6 +71,12 @@ public:
                (this->binary_properties_ == b.binary_properties_);
     }
 
+    FASTDDS_EXPORTED_API bool operator !=(
+            const PropertyPolicy& b) const
+    {
+        return !(*this == b);
+    }
+
     //!Get properties
     FASTDDS_EXPORTED_API const PropertySeq& properties() const
     {

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1663,7 +1663,7 @@ bool DomainParticipantImpl::set_qos(
     {
         to.allocation() = from.allocation();
     }
-    if (first_time && !(to.properties() == from.properties()))
+    if (first_time && (to.properties() != from.properties()))
     {
         to.properties() = from.properties();
     }
@@ -1710,7 +1710,7 @@ bool DomainParticipantImpl::can_qos_be_updated(
         EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK,
                 "ParticipantResourceLimitsQos cannot be changed after the participant is enabled");
     }
-    if (!(to.properties() == from.properties()))
+    if ((to.properties() != from.properties()))
     {
         updatable = false;
         EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK, "PropertyPolicyQos cannot be changed after the participant is enabled");

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1713,7 +1713,7 @@ bool DomainParticipantImpl::can_qos_be_updated(
     if (!(to.properties() == from.properties()))
     {
         updatable = false;
-        EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK, "PropertyPolilyQos cannot be changed after the participant is enabled");
+        EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK, "PropertyPolicyQos cannot be changed after the participant is enabled");
     }
     if (!(to.wire_protocol() == from.wire_protocol()))
     {

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1998,7 +1998,7 @@ bool DataWriterImpl::can_qos_be_updated(
         EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK,
                 "Only the period of Positive ACKs can be changed after the creation of a DataWriter.");
     }
-    if (!(to.properties() == from.properties()))
+    if (to.properties() != from.properties())
     {
         updatable = false;
         EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK, "PropertyPolicyQos cannot be changed after the DataWriter is enabled.");

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1998,6 +1998,12 @@ bool DataWriterImpl::can_qos_be_updated(
         EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK,
                 "Only the period of Positive ACKs can be changed after the creation of a DataWriter.");
     }
+    if (!(to.properties() == from.properties()))
+    {
+        updatable = false;
+        EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK, "PropertyPolicyQos cannot be changed after the DataWriter is enabled.");
+    }
+
     return updatable;
 }
 

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -181,7 +181,7 @@ ReturnCode_t DataReaderImpl::enable()
     att.liveliness_kind = qos_.liveliness().kind;
     att.matched_writers_allocation = qos_.reader_resource_limits().matched_publisher_allocation;
     att.expects_inline_qos = qos_.expects_inline_qos();
-    att.disable_positive_acks = qos_.reliable_reader_qos().disable_positive_ACKs.enabled;
+    att.disable_positive_acks = qos_.reliable_reader_qos().disable_positive_acks.enabled;
     att.data_sharing_listener_thread = qos_.data_sharing().data_sharing_listener_thread();
 
     // TODO(Ricardo) Remove in future
@@ -1633,8 +1633,8 @@ bool DataReaderImpl::can_qos_be_updated(
         EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK,
                 "Unique network flows request cannot be changed after the creation of a DataReader.");
     }
-    if (to.reliable_reader_qos().disable_positive_ACKs.enabled !=
-            from.reliable_reader_qos().disable_positive_ACKs.enabled)
+    if (to.reliable_reader_qos().disable_positive_acks.enabled !=
+            from.reliable_reader_qos().disable_positive_acks.enabled)
     {
         updatable = false;
         EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK,

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1644,7 +1644,12 @@ bool DataReaderImpl::can_qos_be_updated(
     {
         updatable = false;
         EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK,
-                "data_sharing_listener_thread cannot be changed after the DataReader is enabled");
+                "data_sharing_listener_thread cannot be changed after the DataReader is enabled.");
+    }
+    if (!(to.properties() == from.properties()))
+    {
+        updatable = false;
+        EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK, "PropertyPolicyQos cannot be changed after the DataReader is enabled.");
     }
     return updatable;
 }

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1646,7 +1646,7 @@ bool DataReaderImpl::can_qos_be_updated(
         EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK,
                 "data_sharing_listener_thread cannot be changed after the DataReader is enabled.");
     }
-    if (!(to.properties() == from.properties()))
+    if (to.properties() != from.properties())
     {
         updatable = false;
         EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK, "PropertyPolicyQos cannot be changed after the DataReader is enabled.");
@@ -1749,7 +1749,7 @@ void DataReaderImpl::set_qos(
         to.expects_inline_qos(from.expects_inline_qos());
     }
 
-    if (first_time && !(to.properties() == from.properties()))
+    if (first_time && (to.properties() != from.properties()))
     {
         to.properties() = from.properties();
     }

--- a/src/cpp/fastdds/subscriber/qos/DataReaderQos.cpp
+++ b/src/cpp/fastdds/subscriber/qos/DataReaderQos.cpp
@@ -46,7 +46,7 @@ ReaderQos DataReaderQos::get_readerqos(
     qos.m_lifespan = lifespan();
     //qos.m_topicData --> TODO: Fill with TopicQos info
     qos.m_durabilityService = durability_service();
-    qos.m_disablePositiveACKs = reliable_reader_qos().disable_positive_ACKs;
+    qos.m_disablePositiveACKs = reliable_reader_qos().disable_positive_acks;
     qos.type_consistency = type_consistency();
     qos.representation = representation();
     qos.data_sharing = data_sharing();

--- a/src/cpp/fastdds/utils/QosConverters.cpp
+++ b/src/cpp/fastdds/utils/QosConverters.cpp
@@ -98,7 +98,7 @@ void set_qos_from_attributes(
     qos.endpoint().user_defined_id = attr.getUserDefinedID();
     qos.endpoint().entity_id = attr.getEntityID();
     qos.reliable_reader_qos().times = attr.times;
-    qos.reliable_reader_qos().disable_positive_ACKs = attr.qos.m_disablePositiveACKs;
+    qos.reliable_reader_qos().disable_positive_acks = attr.qos.m_disablePositiveACKs;
     qos.durability() = attr.qos.m_durability;
     qos.durability_service() = attr.qos.m_durabilityService;
     qos.deadline() = attr.qos.m_deadline;

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -1002,8 +1002,8 @@ public:
     PubSubReader& keep_duration(
             const eprosima::fastdds::Duration_t duration)
     {
-        datareader_qos_.reliable_reader_qos().disable_positive_ACKs.enabled = true;
-        datareader_qos_.reliable_reader_qos().disable_positive_ACKs.duration = duration;
+        datareader_qos_.reliable_reader_qos().disable_positive_acks.enabled = true;
+        datareader_qos_.reliable_reader_qos().disable_positive_acks.duration = duration;
         return *this;
     }
 

--- a/test/unittest/dds/subscriber/SubscriberTests.cpp
+++ b/test/unittest/dds/subscriber/SubscriberTests.cpp
@@ -306,9 +306,9 @@ TEST(SubscriberTests, ChangeDefaultDataReaderQos)
     qos.reliable_reader_qos().times.initial_acknack_delay.nanosec = 32u;
     qos.reliable_reader_qos().times.heartbeat_response_delay.seconds = 432;
     qos.reliable_reader_qos().times.heartbeat_response_delay.nanosec = 43u;
-    qos.reliable_reader_qos().disable_positive_ACKs.enabled = true;
-    qos.reliable_reader_qos().disable_positive_ACKs.duration.seconds = 13;
-    qos.reliable_reader_qos().disable_positive_ACKs.duration.nanosec = 320u;
+    qos.reliable_reader_qos().disable_positive_acks.enabled = true;
+    qos.reliable_reader_qos().disable_positive_acks.duration.seconds = 13;
+    qos.reliable_reader_qos().disable_positive_acks.duration.nanosec = 320u;
     // .type_consistency
     qos.representation().m_value.push_back(XML_DATA_REPRESENTATION);
     qos.representation().m_value.push_back(XCDR_DATA_REPRESENTATION);
@@ -428,9 +428,9 @@ TEST(SubscriberTests, ChangeDefaultDataReaderQos)
     EXPECT_EQ(32u, rqos.reliable_reader_qos().times.initial_acknack_delay.nanosec);
     EXPECT_EQ(432, rqos.reliable_reader_qos().times.heartbeat_response_delay.seconds);
     EXPECT_EQ(43u, rqos.reliable_reader_qos().times.heartbeat_response_delay.nanosec);
-    EXPECT_TRUE(rqos.reliable_reader_qos().disable_positive_ACKs.enabled);
-    EXPECT_EQ(13, rqos.reliable_reader_qos().disable_positive_ACKs.duration.seconds);
-    EXPECT_EQ(320u, rqos.reliable_reader_qos().disable_positive_ACKs.duration.nanosec);
+    EXPECT_TRUE(rqos.reliable_reader_qos().disable_positive_acks.enabled);
+    EXPECT_EQ(13, rqos.reliable_reader_qos().disable_positive_acks.duration.seconds);
+    EXPECT_EQ(320u, rqos.reliable_reader_qos().disable_positive_acks.duration.nanosec);
     // .type_consistency
     EXPECT_EQ(XML_DATA_REPRESENTATION, rqos.representation().m_value.at(0));
     EXPECT_EQ(XCDR_DATA_REPRESENTATION, rqos.representation().m_value.at(1));


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR reviews that the API of QoS is identical for all entities that share a common QoS. It also makes the PropertyPolicyQoS of DataWriters and DataReader unmutable (such as the one of Participants), until a deeper study is made on what Policies should be mutable on enabled entities.

- Python tests has also been updated: https://github.com/eProsima/Fast-DDS-python/pull/145

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- ❌ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- ❌ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- [X] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
     - Related documentation PR: https://github.com/eProsima/Fast-DDS-docs/pull/781
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
