### PR TITLE
[21081] AllocTest in 3.x

### DIFF
--- a/test/profiling/allocations/AllocTestPublisher.cpp
+++ b/test/profiling/allocations/AllocTestPublisher.cpp
@@ -27,7 +27,6 @@
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
 #include <fastdds/dds/publisher/qos/PublisherQos.hpp>
 #include <fastdds/dds/topic/qos/TopicQos.hpp>
-#include <fastrtps/types/TypesBase.h>
 
 #include "AllocTestCommon.h"
 #include "AllocTestTypePubSubTypes.h"
@@ -35,13 +34,13 @@
 using namespace eprosima::fastdds::dds;
 
 #define CHECK_RETURN_CODE(ret) \
-    if (ReturnCode_t::RETCODE_OK != ret) \
+    if (RETCODE_OK != ret) \
     { \
         return false; \
     }
 
 #define CHECK_ENTITY_CREATION(entity) \
-    if (nullptr != entity) \
+    if (nullptr == entity) \
     { \
         return false; \
     }
@@ -78,7 +77,7 @@ bool AllocTestPublisher::init(
     profile_ = profile;
     output_file_ = output_file;
 
-    ReturnCode_t ret = ReturnCode_t::RETCODE_OK;
+    ReturnCode_t ret = RETCODE_OK;
 
     std::shared_ptr<DomainParticipantFactory> factory = DomainParticipantFactory::get_shared_instance();
     ret = factory->load_XML_profiles_file("test_xml_profile.xml");
@@ -106,7 +105,7 @@ bool AllocTestPublisher::init(
 
     bool show_allocation_traces = std::getenv("FASTDDS_PROFILING_PRINT_TRACES") != nullptr;
     eprosima_profiling::entities_created(show_allocation_traces);
-    return ret == ReturnCode_t::RETCODE_OK;
+    return ret == RETCODE_OK;
 }
 
 void AllocTestPublisher::on_publication_matched(

--- a/test/profiling/allocations/AllocTestPublisher.cpp
+++ b/test/profiling/allocations/AllocTestPublisher.cpp
@@ -53,6 +53,7 @@ AllocTestPublisher::AllocTestPublisher()
     , writer_(nullptr)
     , profile_("")
     , output_file_("")
+    , matched_(0)
 {
 }
 
@@ -99,7 +100,7 @@ bool AllocTestPublisher::init(
     CHECK_ENTITY_CREATION(publisher_);
 
     std::string prof = "test_publisher_profile_" + profile_;
-    writer_ = publisher_->create_datawriter_with_profile(topic_, prof, &listener_);
+    writer_ = publisher_->create_datawriter_with_profile(topic_, prof, this);
     CHECK_ENTITY_CREATION(writer_);
 
     bool show_allocation_traces = std::getenv("FASTDDS_PROFILING_PRINT_TRACES") != nullptr;
@@ -107,7 +108,7 @@ bool AllocTestPublisher::init(
     return ret == RETCODE_OK;
 }
 
-void AllocTestPublisher::PubListener::on_publication_matched(
+void AllocTestPublisher::on_publication_matched(
         DataWriter* /*writer*/,
         const PublicationMatchedStatus& status)
 {
@@ -131,24 +132,24 @@ void AllocTestPublisher::PubListener::on_publication_matched(
 
 bool AllocTestPublisher::is_matched()
 {
-    return listener_.matched_ > 0;
+    return matched_ > 0;
 }
 
 void AllocTestPublisher::wait_match()
 {
-    std::unique_lock<std::mutex> lck(listener_.mtx_);
-    listener_.cv_.wait(lck, [this]()
+    std::unique_lock<std::mutex> lck(mtx_);
+    cv_.wait(lck, [this]()
             {
-                return listener_.matched_ > 0;
+                return matched_ > 0;
             });
 }
 
 void AllocTestPublisher::wait_unmatch()
 {
-    std::unique_lock<std::mutex> lck(listener_.mtx_);
-    listener_.cv_.wait(lck, [this]()
+    std::unique_lock<std::mutex> lck(mtx_);
+    cv_.wait(lck, [this]()
             {
-                return listener_.matched_ <= 0;
+                return matched_ <= 0;
             });
 }
 

--- a/test/profiling/allocations/AllocTestPublisher.hpp
+++ b/test/profiling/allocations/AllocTestPublisher.hpp
@@ -36,7 +36,7 @@
 
 #include "AllocTestType.hpp"
 
-class AllocTestPublisher
+class AllocTestPublisher : public eprosima::fastdds::dds::DataWriterListener
 {
 public:
 
@@ -57,6 +57,10 @@ public:
     void run(
             uint32_t number,
             bool wait_unmatching);
+
+    void on_publication_matched(
+            eprosima::fastdds::dds::DataWriter* writer,
+            const eprosima::fastdds::dds::PublicationMatchedStatus& status) override;
 
 private:
 
@@ -82,30 +86,11 @@ private:
 
     std::string output_file_;
 
-    class PubListener : public eprosima::fastdds::dds::DataWriterListener
-    {
-    public:
+    std::atomic<uint16_t> matched_;
 
-        PubListener()
-            : matched_(0)
-        {
-        }
+    mutable std::mutex mtx_;
 
-        ~PubListener() override
-        {
-        }
-
-        void on_publication_matched(
-                eprosima::fastdds::dds::DataWriter* writer,
-                const eprosima::fastdds::dds::PublicationMatchedStatus& info) override;
-
-        std::atomic<uint16_t> matched_;
-
-        mutable std::mutex mtx_;
-
-        std::condition_variable cv_;
-    }
-    listener_;
+    std::condition_variable cv_;
 
 };
 

--- a/test/profiling/allocations/AllocTestPublisher.hpp
+++ b/test/profiling/allocations/AllocTestPublisher.hpp
@@ -36,7 +36,7 @@
 
 #include "AllocTestType.hpp"
 
-class AllocTestPublisher : public eprosima::fastdds::dds::DataWriterListener
+class AllocTestPublisher
 {
 public:
 
@@ -57,10 +57,6 @@ public:
     void run(
             uint32_t number,
             bool wait_unmatching);
-
-    void on_publication_matched(
-            eprosima::fastdds::dds::DataWriter* writer,
-            const eprosima::fastdds::dds::PublicationMatchedStatus& status) override;
 
 private:
 
@@ -86,11 +82,30 @@ private:
 
     std::string output_file_;
 
-    std::atomic<uint16_t> matched_;
+    class PubListener : public eprosima::fastdds::dds::DataWriterListener
+    {
+    public:
 
-    mutable std::mutex mtx_;
+        PubListener()
+            : matched_(0)
+        {
+        }
 
-    std::condition_variable cv_;
+        ~PubListener() override
+        {
+        }
+
+        void on_publication_matched(
+                eprosima::fastdds::dds::DataWriter* writer,
+                const eprosima::fastdds::dds::PublicationMatchedStatus& info) override;
+
+        std::atomic<uint16_t> matched_;
+
+        mutable std::mutex mtx_;
+
+        std::condition_variable cv_;
+    }
+    listener_;
 
 };
 

--- a/test/profiling/allocations/AllocTestPublisher.hpp
+++ b/test/profiling/allocations/AllocTestPublisher.hpp
@@ -34,7 +34,7 @@
 #include <fastdds/dds/topic/Topic.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
 
-#include "AllocTestType.h"
+#include "AllocTestType.hpp"
 
 class AllocTestPublisher : public eprosima::fastdds::dds::DataWriterListener
 {

--- a/test/profiling/allocations/AllocTestSubscriber.cpp
+++ b/test/profiling/allocations/AllocTestSubscriber.cpp
@@ -33,7 +33,6 @@
 #include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
 #include <fastdds/dds/subscriber/SampleInfo.hpp>
 #include <fastdds/dds/topic/qos/TopicQos.hpp>
-#include <fastrtps/types/TypesBase.h>
 
 #include "AllocTestCommon.h"
 #include "AllocTestTypePubSubTypes.h"
@@ -41,13 +40,13 @@
 using namespace eprosima::fastdds::dds;
 
 #define CHECK_RETURN_CODE(ret) \
-    if (ReturnCode_t::RETCODE_OK != ret) \
+    if (RETCODE_OK != ret) \
     { \
         return false; \
     }
 
 #define CHECK_ENTITY_CREATION(entity) \
-    if (nullptr != entity) \
+    if (nullptr == entity) \
     { \
         return false; \
     }
@@ -83,7 +82,7 @@ bool AllocTestSubscriber::init(
     profile_ = profile;
     output_file_ = output_file;
 
-    ReturnCode_t ret = ReturnCode_t::RETCODE_OK;
+    ReturnCode_t ret = RETCODE_OK;
 
     std::shared_ptr<DomainParticipantFactory> factory = DomainParticipantFactory::get_shared_instance();
     ret = factory->load_XML_profiles_file("test_xml_profile.xml");
@@ -111,7 +110,7 @@ bool AllocTestSubscriber::init(
 
     bool show_allocation_traces = std::getenv("FASTDDS_PROFILING_PRINT_TRACES") != nullptr;
     eprosima_profiling::entities_created(show_allocation_traces);
-    return ret == ReturnCode_t::RETCODE_OK;
+    return ret == RETCODE_OK;
 }
 
 void AllocTestSubscriber::on_subscription_matched(
@@ -140,7 +139,7 @@ void AllocTestSubscriber::on_data_available(
         DataReader* reader)
 {
     SampleInfo info;
-    if (ReturnCode_t::RETCODE_OK == reader->take_next_sample(&data_, &info))
+    if (RETCODE_OK == reader->take_next_sample(&data_, &info))
     {
         if ((info.instance_state == ALIVE_INSTANCE_STATE) && (info.valid_data) &&
                 (reader->is_sample_valid(&data_, &info)))

--- a/test/profiling/allocations/AllocTestSubscriber.cpp
+++ b/test/profiling/allocations/AllocTestSubscriber.cpp
@@ -59,6 +59,8 @@ AllocTestSubscriber::AllocTestSubscriber()
     , reader_(nullptr)
     , profile_("")
     , output_file_("")
+    , matched_(0)
+    , samples_(0)
 {
 }
 
@@ -103,7 +105,7 @@ bool AllocTestSubscriber::init(
     CHECK_ENTITY_CREATION(subscriber_);
 
     std::string prof = "test_subscriber_profile_" + profile_;
-    reader_ = subscriber_->create_datareader_with_profile(topic_, prof, &listener_);
+    reader_ = subscriber_->create_datareader_with_profile(topic_, prof, this);
     CHECK_ENTITY_CREATION(reader_);
 
     bool show_allocation_traces = std::getenv("FASTDDS_PROFILING_PRINT_TRACES") != nullptr;
@@ -111,7 +113,7 @@ bool AllocTestSubscriber::init(
     return ret == RETCODE_OK;
 }
 
-void AllocTestSubscriber::SubListener::on_subscription_matched(
+void AllocTestSubscriber::on_subscription_matched(
         DataReader* /*reader*/,
         const SubscriptionMatchedStatus& status)
 {
@@ -133,7 +135,7 @@ void AllocTestSubscriber::SubListener::on_subscription_matched(
     cv_.notify_all();
 }
 
-void AllocTestSubscriber::SubListener::on_data_available(
+void AllocTestSubscriber::on_data_available(
         DataReader* reader)
 {
     SampleInfo info;
@@ -151,29 +153,29 @@ void AllocTestSubscriber::SubListener::on_data_available(
 
 void AllocTestSubscriber::wait_match()
 {
-    std::unique_lock<std::mutex> lck(listener_.mtx_);
-    listener_.cv_.wait(lck, [this]()
+    std::unique_lock<std::mutex> lck(mtx_);
+    cv_.wait(lck, [this]()
             {
-                return listener_.matched_ > 0;
+                return matched_ > 0;
             });
 }
 
 void AllocTestSubscriber::wait_unmatch()
 {
-    std::unique_lock<std::mutex> lck(listener_.mtx_);
-    listener_.cv_.wait(lck, [this]()
+    std::unique_lock<std::mutex> lck(mtx_);
+    cv_.wait(lck, [this]()
             {
-                return listener_.matched_ <= 0;
+                return matched_ <= 0;
             });
 }
 
 void AllocTestSubscriber::wait_until_total_received_at_least(
         uint32_t n)
 {
-    std::unique_lock<std::mutex> lock(listener_.mtx_);
-    listener_.cv_.wait(lock, [this, n]()
+    std::unique_lock<std::mutex> lock(mtx_);
+    cv_.wait(lock, [this, n]()
             {
-                return listener_.samples_ >= n;
+                return samples_ >= n;
             });
 }
 

--- a/test/profiling/allocations/AllocTestSubscriber.hpp
+++ b/test/profiling/allocations/AllocTestSubscriber.hpp
@@ -36,7 +36,7 @@
 
 #include "AllocTestType.hpp"
 
-class AllocTestSubscriber
+class AllocTestSubscriber : public eprosima::fastdds::dds::DataReaderListener
 {
 public:
 
@@ -58,6 +58,13 @@ public:
             uint32_t number,
             bool wait_unmatching);
 
+    void on_subscription_matched(
+            eprosima::fastdds::dds::DataReader* reader,
+            const eprosima::fastdds::dds::SubscriptionMatchedStatus& status) override;
+
+    void on_data_available(
+            eprosima::fastdds::dds::DataReader* reader) override;
+
 private:
 
     void wait_match();
@@ -68,6 +75,8 @@ private:
             uint32_t n);
 
     eprosima::fastdds::dds::TypeSupport type_;
+
+    AllocTestType data_;
 
     eprosima::fastdds::dds::DomainParticipant* participant_;
 
@@ -81,38 +90,13 @@ private:
 
     std::string output_file_;
 
-    class SubListener : public eprosima::fastdds::dds::DataReaderListener
-    {
-    public:
+    std::atomic<uint16_t> matched_;
 
-        SubListener()
-            : matched_(0)
-            , samples_(0)
-        {
-        }
+    std::atomic<uint16_t> samples_;
 
-        ~SubListener() override
-        {
-        }
+    mutable std::mutex mtx_;
 
-        void on_data_available(
-                eprosima::fastdds::dds::DataReader* reader) override;
-
-        void on_subscription_matched(
-                eprosima::fastdds::dds::DataReader* reader,
-                const eprosima::fastdds::dds::SubscriptionMatchedStatus& info) override;
-
-        AllocTestType data_;
-
-        std::atomic<uint16_t> matched_;
-
-        std::atomic<uint16_t> samples_;
-
-        mutable std::mutex mtx_;
-
-        std::condition_variable cv_;
-    }
-    listener_;
+    std::condition_variable cv_;
 
 };
 

--- a/test/profiling/allocations/AllocTestSubscriber.hpp
+++ b/test/profiling/allocations/AllocTestSubscriber.hpp
@@ -36,7 +36,7 @@
 
 #include "AllocTestType.hpp"
 
-class AllocTestSubscriber : public eprosima::fastdds::dds::DataReaderListener
+class AllocTestSubscriber
 {
 public:
 
@@ -58,13 +58,6 @@ public:
             uint32_t number,
             bool wait_unmatching);
 
-    void on_subscription_matched(
-            eprosima::fastdds::dds::DataReader* reader,
-            const eprosima::fastdds::dds::SubscriptionMatchedStatus& status) override;
-
-    void on_data_available(
-            eprosima::fastdds::dds::DataReader* reader) override;
-
 private:
 
     void wait_match();
@@ -75,8 +68,6 @@ private:
             uint32_t n);
 
     eprosima::fastdds::dds::TypeSupport type_;
-
-    AllocTestType data_;
 
     eprosima::fastdds::dds::DomainParticipant* participant_;
 
@@ -90,13 +81,38 @@ private:
 
     std::string output_file_;
 
-    std::atomic<uint16_t> matched_;
+    class SubListener : public eprosima::fastdds::dds::DataReaderListener
+    {
+    public:
 
-    std::atomic<uint16_t> samples_;
+        SubListener()
+            : matched_(0)
+            , samples_(0)
+        {
+        }
 
-    mutable std::mutex mtx_;
+        ~SubListener() override
+        {
+        }
 
-    std::condition_variable cv_;
+        void on_data_available(
+                eprosima::fastdds::dds::DataReader* reader) override;
+
+        void on_subscription_matched(
+                eprosima::fastdds::dds::DataReader* reader,
+                const eprosima::fastdds::dds::SubscriptionMatchedStatus& info) override;
+
+        AllocTestType data_;
+
+        std::atomic<uint16_t> matched_;
+
+        std::atomic<uint16_t> samples_;
+
+        mutable std::mutex mtx_;
+
+        std::condition_variable cv_;
+    }
+    listener_;
 
 };
 

--- a/test/profiling/allocations/AllocTestSubscriber.hpp
+++ b/test/profiling/allocations/AllocTestSubscriber.hpp
@@ -34,7 +34,7 @@
 #include <fastdds/dds/topic/Topic.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
 
-#include "AllocTestType.h"
+#include "AllocTestType.hpp"
 
 class AllocTestSubscriber : public eprosima::fastdds::dds::DataReaderListener
 {

--- a/test/profiling/allocations/test_xml_profile.xml
+++ b/test/profiling/allocations/test_xml_profile.xml
@@ -69,6 +69,9 @@
                 </resourceLimitsQos>
             </topic>
             <qos>
+                <data_sharing>
+                    <kind>OFF</kind>
+                </data_sharing>
                 <durability>
                     <kind>TRANSIENT_LOCAL</kind>
                 </durability>
@@ -96,6 +99,9 @@
                 </resourceLimitsQos>
             </topic>
             <qos>
+                <data_sharing>
+                    <kind>OFF</kind>
+                </data_sharing>
                 <durability>
                     <kind>TRANSIENT_LOCAL</kind>
                 </durability>
@@ -123,6 +129,9 @@
                 </resourceLimitsQos>
             </topic>
             <qos>
+                <data_sharing>
+                    <kind>OFF</kind>
+                </data_sharing>
                 <durability>
                     <kind>VOLATILE</kind>
                 </durability>
@@ -150,6 +159,9 @@
                 </resourceLimitsQos>
             </topic>
             <qos>
+                <data_sharing>
+                    <kind>OFF</kind>
+                </data_sharing>
                 <durability>
                     <kind>VOLATILE</kind>
                 </durability>
@@ -179,6 +191,9 @@
                 </resourceLimitsQos>
             </topic>
             <qos>
+                <data_sharing>
+                    <kind>OFF</kind>
+                </data_sharing>
                 <durability>
                     <kind>TRANSIENT_LOCAL</kind>
                 </durability>
@@ -206,6 +221,9 @@
                 </resourceLimitsQos>
             </topic>
             <qos>
+                <data_sharing>
+                    <kind>OFF</kind>
+                </data_sharing>
                 <durability>
                     <kind>TRANSIENT_LOCAL</kind>
                 </durability>
@@ -233,6 +251,9 @@
                 </resourceLimitsQos>
             </topic>
             <qos>
+                <data_sharing>
+                    <kind>OFF</kind>
+                </data_sharing>
                 <durability>
                     <kind>VOLATILE</kind>
                 </durability>
@@ -260,6 +281,9 @@
                 </resourceLimitsQos>
             </topic>
             <qos>
+                <data_sharing>
+                    <kind>OFF</kind>
+                </data_sharing>
                 <durability>
                     <kind>VOLATILE</kind>
                 </durability>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR makes the AllocTests compatible with changes implemented in 3.x.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- __NO__ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- _N/A_ Check CI results: failing tests are unrelated with the changes.
