### PR TITLE
[20821] Make rtps writer impl private

### DIFF
--- a/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.cpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.cpp
@@ -34,12 +34,12 @@
 #include <fastdds/rtps/history/WriterHistory.h>
 #include <fastdds/rtps/reader/RTPSReader.h>
 #include <fastdds/rtps/writer/RTPSWriter.h>
-#include <fastdds/rtps/writer/StatefulWriter.h>
 
 #include <rtps/builtin/BuiltinProtocols.h>
 #include <rtps/participant/RTPSParticipantImpl.h>
 #include <rtps/reader/StatefulReader.hpp>
 #include <rtps/RTPSDomainImpl.hpp>
+#include <rtps/writer/StatefulWriter.hpp>
 
 namespace eprosima {
 

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -39,7 +39,6 @@
 #include <fastdds/rtps/participant/RTPSParticipant.h>
 #include <fastdds/rtps/RTPSDomain.h>
 #include <fastdds/rtps/writer/RTPSWriter.h>
-#include <fastdds/rtps/writer/StatefulWriter.h>
 
 #include <rtps/builtin/liveliness/WLP.h>
 #include <rtps/DataSharing/DataSharingPayloadPool.hpp>
@@ -49,6 +48,7 @@
 #include <rtps/resources/ResourceEvent.h>
 #include <rtps/RTPSDomainImpl.hpp>
 #include <rtps/resources/TimedEvent.h>
+#include <rtps/writer/StatefulWriter.hpp>
 #include <utils/TimeConversion.hpp>
 #ifdef FASTDDS_STATISTICS
 #include <statistics/fastdds/domain/DomainParticipantImpl.hpp>

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPClient.cpp
@@ -27,12 +27,12 @@
 #include <fastdds/rtps/builtin/data/WriterProxyData.h>
 #include <fastdds/rtps/history/WriterHistory.h>
 #include <fastdds/rtps/reader/RTPSReader.h>
-#include <fastdds/rtps/writer/StatefulWriter.h>
 
 #include <rtps/builtin/discovery/participant/PDP.h>
 #if HAVE_SECURITY
 #include <rtps/security/accesscontrol/ParticipantSecurityAttributes.h>
 #endif // if HAVE_SECURITY
+#include <rtps/writer/StatefulWriter.hpp>
 
 namespace eprosima {
 namespace fastdds {

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
@@ -23,8 +23,9 @@
 #include <fastdds/rtps/attributes/HistoryAttributes.h>
 #include <fastdds/rtps/attributes/ReaderAttributes.h>
 #include <fastdds/rtps/history/WriterHistory.h>
-#include <fastdds/rtps/writer/StatefulWriter.h>
+
 #include <rtps/reader/StatefulReader.hpp>
+#include <rtps/writer/StatefulWriter.hpp>
 
 using namespace ::eprosima::fastrtps::rtps;
 

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners.cpp
@@ -23,7 +23,6 @@
 #include <fastdds/rtps/history/ReaderHistory.h>
 #include <fastdds/rtps/reader/RTPSReader.h>
 
-
 #include <rtps/builtin/discovery/endpoint/EDPServer.hpp>
 #include <rtps/builtin/discovery/participant/PDPServer.hpp>
 #include <rtps/writer/StatefulWriter.hpp>

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServerListeners.cpp
@@ -17,15 +17,17 @@
  *
  */
 #include <rtps/builtin/discovery/endpoint/EDPServerListeners.hpp>
-#include <rtps/builtin/discovery/endpoint/EDPServer.hpp>
-#include <rtps/builtin/discovery/participant/PDPServer.hpp>
 
-#include <fastdds/rtps/writer/StatefulWriter.h>
+#include <fastdds/dds/log/Log.hpp>
 #include <fastdds/rtps/history/WriterHistory.h>
 #include <fastdds/rtps/history/ReaderHistory.h>
 #include <fastdds/rtps/reader/RTPSReader.h>
 
-#include <fastdds/dds/log/Log.hpp>
+
+#include <rtps/builtin/discovery/endpoint/EDPServer.hpp>
+#include <rtps/builtin/discovery/participant/PDPServer.hpp>
+#include <rtps/writer/StatefulWriter.hpp>
+
 namespace eprosima {
 namespace fastdds {
 namespace rtps {

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -33,7 +33,6 @@
 #include <fastdds/rtps/builtin/data/WriterProxyData.h>
 #include <fastdds/rtps/history/ReaderHistory.h>
 #include <fastdds/rtps/history/WriterHistory.h>
-#include <fastdds/rtps/writer/StatefulWriter.h>
 
 #include <rtps/builtin/BuiltinProtocols.h>
 #include <rtps/builtin/discovery/endpoint/EDPSimpleListeners.h>
@@ -42,6 +41,7 @@
 #include <rtps/history/TopicPayloadPoolRegistry.hpp>
 #include <rtps/history/TopicPayloadPoolRegistry.hpp>
 #include <rtps/reader/StatefulReader.hpp>
+#include <rtps/writer/StatefulWriter.hpp>
 #ifdef FASTDDS_STATISTICS
 #include <statistics/rtps/monitor-service/interfaces/IProxyObserver.hpp>
 #endif //FASTDDS_STATISTICS

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.cpp
@@ -29,13 +29,13 @@
 #include <fastdds/rtps/common/InstanceHandle.h>
 #include <fastdds/rtps/history/ReaderHistory.h>
 #include <fastdds/rtps/history/WriterHistory.h>
-#include <fastdds/rtps/writer/StatefulWriter.h>
 
 #include <fastdds/builtin/type_lookup_service/TypeLookupManager.hpp>
 #include <rtps/builtin/discovery/endpoint/EDPSimple.h>
 #include <rtps/builtin/discovery/participant/PDPSimple.h>
 #include <rtps/network/NetworkFactory.h>
 #include <rtps/reader/StatefulReader.hpp>
+#include <rtps/writer/StatefulWriter.hpp>
 
 using ParameterList = eprosima::fastdds::dds::ParameterList;
 

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPUtils.hpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPUtils.hpp
@@ -19,22 +19,23 @@
 #ifndef _RTPS_BUILTIN_DISCOVERY_ENDPOINT_EDPUTILS_HPP_
 #define _RTPS_BUILTIN_DISCOVERY_ENDPOINT_EDPUTILS_HPP_
 
+#include <memory>
+#include <string>
+
 #include <fastdds/rtps/attributes/HistoryAttributes.h>
 #include <fastdds/rtps/attributes/ReaderAttributes.h>
 #include <fastdds/rtps/attributes/WriterAttributes.h>
 #include <fastdds/rtps/common/EntityId_t.hpp>
 #include <fastdds/rtps/history/ReaderHistory.h>
 #include <fastdds/rtps/history/WriterHistory.h>
-#include <fastdds/rtps/writer/StatefulWriter.h>
 
 #include <rtps/history/ITopicPayloadPool.h>
 #include <rtps/history/PoolConfig.h>
 #include <rtps/history/TopicPayloadPoolRegistry.hpp>
 #include <rtps/participant/RTPSParticipantImpl.h>
 #include <rtps/reader/StatefulReader.hpp>
+#include <rtps/writer/StatefulWriter.hpp>
 
-#include <memory>
-#include <string>
 
 namespace eprosima {
 namespace fastrtps {

--- a/src/cpp/rtps/builtin/discovery/participant/DS/DiscoveryServerPDPEndpoints.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/DS/DiscoveryServerPDPEndpoints.hpp
@@ -22,13 +22,13 @@
 #include <memory>
 
 #include <fastdds/rtps/builtin/data/BuiltinEndpoints.hpp>
-#include <fastdds/rtps/writer/StatefulWriter.h>
 
 #include <rtps/builtin/BuiltinReader.hpp>
 #include <rtps/builtin/BuiltinWriter.hpp>
 #include <rtps/builtin/discovery/participant/PDPEndpoints.hpp>
 #include <rtps/history/ITopicPayloadPool.h>
 #include <rtps/reader/StatefulReader.hpp>
+#include <rtps/writer/StatefulWriter.hpp>
 
 namespace eprosima {
 namespace fastdds {

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -33,7 +33,6 @@
 #include <fastdds/rtps/history/ReaderHistory.h>
 #include <fastdds/rtps/history/WriterHistory.h>
 #include <fastdds/rtps/participant/RTPSParticipantListener.h>
-#include <fastdds/rtps/writer/StatelessWriter.h>
 
 #include <fastdds/builtin/type_lookup_service/TypeLookupManager.hpp>
 #include <fastdds/utils/IPLocator.h>
@@ -49,6 +48,7 @@
 #include <rtps/participant/RTPSParticipantImpl.h>
 #include <rtps/reader/StatefulReader.hpp>
 #include <rtps/reader/StatelessReader.hpp>
+#include <rtps/writer/StatelessWriter.hpp>
 #include <rtps/resources/TimedEvent.h>
 #if HAVE_SECURITY
 #include <rtps/security/accesscontrol/ParticipantSecurityAttributes.h>

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -33,7 +33,6 @@
 #include <fastdds/rtps/history/WriterHistory.h>
 #include <fastdds/rtps/participant/RTPSParticipantListener.h>
 #include <fastdds/rtps/writer/ReaderProxy.h>
-#include <fastdds/rtps/writer/StatefulWriter.h>
 
 #include <fastdds/builtin/type_lookup_service/TypeLookupManager.hpp>
 #include <rtps/builtin/BuiltinProtocols.h>
@@ -46,6 +45,7 @@
 #include <rtps/builtin/liveliness/WLP.h>
 #include <rtps/participant/RTPSParticipantImpl.h>
 #include <rtps/reader/StatefulReader.hpp>
+#include <rtps/writer/StatefulWriter.hpp>
 #include <utils/shared_mutex.hpp>
 #include <utils/SystemInfo.hpp>
 #include <utils/TimeConversion.hpp>

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -28,7 +28,6 @@
 #include <fastdds/rtps/history/ReaderHistory.h>
 #include <fastdds/rtps/history/WriterHistory.h>
 #include <fastdds/rtps/participant/RTPSParticipantListener.h>
-#include <fastdds/rtps/writer/StatefulWriter.h>
 #include <fastdds/utils/TimedMutex.hpp>
 
 #include <fastdds/builtin/type_lookup_service/TypeLookupManager.hpp>
@@ -47,6 +46,7 @@
 #include <rtps/builtin/liveliness/WLP.h>
 #include <rtps/participant/RTPSParticipantImpl.h>
 #include <rtps/reader/StatefulReader.hpp>
+#include <rtps/writer/StatefulWriter.hpp>
 #include <utils/TimeConversion.hpp>
 
 namespace eprosima {

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -27,7 +27,6 @@
 #include <fastdds/rtps/history/ReaderHistory.h>
 #include <fastdds/rtps/history/WriterHistory.h>
 #include <fastdds/rtps/participant/RTPSParticipantListener.h>
-#include <fastdds/rtps/writer/StatelessWriter.h>
 
 #include <fastdds/builtin/type_lookup_service/TypeLookupManager.hpp>
 #include <fastdds/utils/IPLocator.h>
@@ -45,6 +44,7 @@
 #include <rtps/reader/StatefulReader.hpp>
 #include <rtps/reader/StatelessReader.hpp>
 #include <rtps/resources/TimedEvent.h>
+#include <rtps/writer/StatelessWriter.hpp>
 
 namespace eprosima {
 namespace fastrtps {

--- a/src/cpp/rtps/builtin/discovery/participant/simple/SimplePDPEndpoints.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/simple/SimplePDPEndpoints.hpp
@@ -22,12 +22,13 @@
 #include <memory>
 
 #include <fastdds/rtps/builtin/data/BuiltinEndpoints.hpp>
-#include <fastdds/rtps/writer/StatelessWriter.h>
+
 #include <rtps/builtin/BuiltinReader.hpp>
 #include <rtps/builtin/BuiltinWriter.hpp>
 #include <rtps/builtin/discovery/participant/PDPEndpoints.hpp>
 #include <rtps/history/ITopicPayloadPool.h>
 #include <rtps/reader/StatelessReader.hpp>
+#include <rtps/writer/StatelessWriter.hpp>
 
 namespace eprosima {
 namespace fastdds {

--- a/src/cpp/rtps/builtin/discovery/participant/simple/SimplePDPEndpointsSecure.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/simple/SimplePDPEndpointsSecure.hpp
@@ -22,13 +22,13 @@
 #include <memory>
 
 #include <fastdds/rtps/builtin/data/BuiltinEndpoints.hpp>
-#include <fastdds/rtps/writer/StatefulWriter.h>
 
 #include <rtps/builtin/BuiltinReader.hpp>
 #include <rtps/builtin/BuiltinWriter.hpp>
 #include <rtps/builtin/discovery/participant/simple/SimplePDPEndpoints.hpp>
 #include <rtps/history/ITopicPayloadPool.h>
 #include <rtps/reader/StatefulReader.hpp>
+#include <rtps/writer/StatefulWriter.hpp>
 
 namespace eprosima {
 namespace fastdds {

--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -27,7 +27,6 @@
 #include <fastdds/rtps/builtin/data/WriterProxyData.h>
 #include <fastdds/rtps/history/ReaderHistory.h>
 #include <fastdds/rtps/history/WriterHistory.h>
-#include <fastdds/rtps/writer/StatefulWriter.h>
 #include <fastdds/rtps/writer/WriterListener.h>
 
 #include <rtps/builtin/BuiltinProtocols.h>
@@ -39,6 +38,7 @@
 #include <rtps/resources/TimedEvent.h>
 #include <rtps/resources/ResourceEvent.h>
 #include <rtps/writer/LivelinessManager.hpp>
+#include <rtps/writer/StatefulWriter.hpp>
 #include <utils/TimeConversion.hpp>
 
 namespace eprosima {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -41,7 +41,6 @@
 #include <fastdds/rtps/transport/TCPv4TransportDescriptor.h>
 #include <fastdds/rtps/transport/TCPv6TransportDescriptor.h>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
-#include <fastdds/rtps/writer/StatefulPersistentWriter.h>
 #include <fastdds/rtps/writer/StatefulWriter.h>
 #include <fastdds/rtps/writer/StatelessPersistentWriter.h>
 #include <fastdds/rtps/writer/StatelessWriter.h>
@@ -64,6 +63,7 @@
 #include <rtps/reader/StatefulReader.hpp>
 #include <rtps/reader/StatelessPersistentReader.hpp>
 #include <rtps/reader/StatelessReader.hpp>
+#include <rtps/writer/StatefulPersistentWriter.hpp>
 #include <statistics/rtps/GuidUtils.hpp>
 #include <utils/Semaphore.hpp>
 #include <utils/string_utilities.hpp>

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -41,7 +41,6 @@
 #include <fastdds/rtps/transport/TCPv4TransportDescriptor.h>
 #include <fastdds/rtps/transport/TCPv6TransportDescriptor.h>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
-#include <fastdds/rtps/writer/StatefulWriter.h>
 #include <fastdds/rtps/writer/StatelessWriter.h>
 #include <fastdds/utils/IPFinder.h>
 
@@ -62,6 +61,7 @@
 #include <rtps/reader/StatefulReader.hpp>
 #include <rtps/reader/StatelessPersistentReader.hpp>
 #include <rtps/reader/StatelessReader.hpp>
+#include <rtps/writer/StatefulWriter.hpp>
 #include <rtps/writer/StatefulPersistentWriter.hpp>
 #include <rtps/writer/StatelessPersistentWriter.hpp>
 #include <statistics/rtps/GuidUtils.hpp>

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -41,7 +41,6 @@
 #include <fastdds/rtps/transport/TCPv4TransportDescriptor.h>
 #include <fastdds/rtps/transport/TCPv6TransportDescriptor.h>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
-#include <fastdds/rtps/writer/StatelessWriter.h>
 #include <fastdds/utils/IPFinder.h>
 
 #include <rtps/builtin/BuiltinProtocols.h>
@@ -64,6 +63,7 @@
 #include <rtps/writer/StatefulWriter.hpp>
 #include <rtps/writer/StatefulPersistentWriter.hpp>
 #include <rtps/writer/StatelessPersistentWriter.hpp>
+#include <rtps/writer/StatelessWriter.hpp>
 #include <statistics/rtps/GuidUtils.hpp>
 #include <utils/Semaphore.hpp>
 #include <utils/string_utilities.hpp>

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -42,7 +42,6 @@
 #include <fastdds/rtps/transport/TCPv6TransportDescriptor.h>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
 #include <fastdds/rtps/writer/StatefulWriter.h>
-#include <fastdds/rtps/writer/StatelessPersistentWriter.h>
 #include <fastdds/rtps/writer/StatelessWriter.h>
 #include <fastdds/utils/IPFinder.h>
 
@@ -64,6 +63,7 @@
 #include <rtps/reader/StatelessPersistentReader.hpp>
 #include <rtps/reader/StatelessReader.hpp>
 #include <rtps/writer/StatefulPersistentWriter.hpp>
+#include <rtps/writer/StatelessPersistentWriter.hpp>
 #include <statistics/rtps/GuidUtils.hpp>
 #include <utils/Semaphore.hpp>
 #include <utils/string_utilities.hpp>

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -32,7 +32,6 @@
 #include <fastdds/rtps/history/ReaderHistory.h>
 #include <fastdds/rtps/history/WriterHistory.h>
 #include <fastdds/rtps/participant/RTPSParticipantListener.h>
-#include <fastdds/rtps/writer/StatefulWriter.h>
 #include <fastdds/rtps/writer/StatelessWriter.h>
 
 #include <rtps/builtin/discovery/endpoint/EDP.h>
@@ -48,6 +47,7 @@
 #include <rtps/security/accesscontrol/SecurityMaskUtilities.h>
 #include <rtps/security/authentication/Authentication.h>
 #include <rtps/security/exceptions/SecurityException.h>
+#include <rtps/writer/StatefulWriter.hpp>
 #include <security/OpenSSLInit.hpp>
 
 #define BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_SECURE_WRITER (1 << 20)

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -32,7 +32,6 @@
 #include <fastdds/rtps/history/ReaderHistory.h>
 #include <fastdds/rtps/history/WriterHistory.h>
 #include <fastdds/rtps/participant/RTPSParticipantListener.h>
-#include <fastdds/rtps/writer/StatelessWriter.h>
 
 #include <rtps/builtin/discovery/endpoint/EDP.h>
 #include <rtps/builtin/discovery/participant/PDP.h>
@@ -48,6 +47,7 @@
 #include <rtps/security/authentication/Authentication.h>
 #include <rtps/security/exceptions/SecurityException.h>
 #include <rtps/writer/StatefulWriter.hpp>
+#include <rtps/writer/StatelessWriter.hpp>
 #include <security/OpenSSLInit.hpp>
 
 #define BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_SECURE_WRITER (1 << 20)

--- a/src/cpp/rtps/transport/tcp/RTCPMessageManager.h
+++ b/src/cpp/rtps/transport/tcp/RTCPMessageManager.h
@@ -23,11 +23,10 @@
 #include <memory>
 #include <atomic>
 
-#include <fastdds/rtps/writer/StatelessWriter.h>
-
 #include <rtps/transport/tcp/TCPControlMessage.h>
 #include <rtps/transport/tcp/RTCPHeader.h>
 #include <rtps/writer/StatefulWriter.hpp>
+#include <rtps/writer/StatelessWriter.hpp>
 
 namespace eprosima {
 namespace fastdds {

--- a/src/cpp/rtps/transport/tcp/RTCPMessageManager.h
+++ b/src/cpp/rtps/transport/tcp/RTCPMessageManager.h
@@ -24,9 +24,10 @@
 #include <atomic>
 
 #include <fastdds/rtps/writer/StatelessWriter.h>
-#include <fastdds/rtps/writer/StatefulWriter.h>
+
 #include <rtps/transport/tcp/TCPControlMessage.h>
 #include <rtps/transport/tcp/RTCPHeader.h>
+#include <rtps/writer/StatefulWriter.hpp>
 
 namespace eprosima {
 namespace fastdds {

--- a/src/cpp/rtps/writer/PersistentWriter.cpp
+++ b/src/cpp/rtps/writer/PersistentWriter.cpp
@@ -17,7 +17,7 @@
  *
  */
 
-#include <fastdds/rtps/writer/PersistentWriter.h>
+#include <rtps/writer/PersistentWriter.hpp>
 
 #include <fastdds/rtps/history/WriterHistory.h>
 

--- a/src/cpp/rtps/writer/PersistentWriter.hpp
+++ b/src/cpp/rtps/writer/PersistentWriter.hpp
@@ -13,13 +13,15 @@
 // limitations under the License.
 
 /**
- * @file PersistentWriter.h
+ * @file PersistentWriter.hpp
  */
-#ifndef _FASTDDS_RTPS_PERSISTENTWRITER_H_
-#define _FASTDDS_RTPS_PERSISTENTWRITER_H_
+
+#ifndef RTPS_WRITER__PERSISTENTWRITER_HPP
+#define RTPS_WRITER__PERSISTENTWRITER_HPP
+
+#include <string>
 
 #include <fastdds/rtps/writer/RTPSWriter.h>
-#include <string>
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
@@ -77,4 +79,4 @@ private:
 } // namespace eprosima
 
 #endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
-#endif /* _FASTDDS_RTPS_PERSISTENTWRITER_H_ */
+#endif /* RTPS_WRITER__PERSISTENTWRITER_HPP */

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -25,13 +25,14 @@
 
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/rtps/history/WriterHistory.h>
-#include <fastdds/rtps/writer/StatefulWriter.h>
 #include <fastdds/rtps/common/LocatorListComparisons.hpp>
-#include <rtps/participant/RTPSParticipantImpl.h>
+
+#include <rtps/DataSharing/DataSharingNotifier.hpp>
 #include <rtps/history/HistoryAttributesExtension.hpp>
 #include "rtps/messages/RTPSGapBuilder.hpp"
-#include <rtps/DataSharing/DataSharingNotifier.hpp>
+#include <rtps/participant/RTPSParticipantImpl.h>
 #include <rtps/resources/TimedEvent.h>
+#include <rtps/writer/StatefulWriter.hpp>
 #include <utils/TimeConversion.hpp>
 
 

--- a/src/cpp/rtps/writer/StatefulPersistentWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulPersistentWriter.cpp
@@ -17,7 +17,7 @@
  *
  */
 
-#include <fastdds/rtps/writer/StatefulPersistentWriter.h>
+#include "StatefulPersistentWriter.hpp"
 
 #include <fastdds/rtps/history/WriterHistory.h>
 

--- a/src/cpp/rtps/writer/StatefulPersistentWriter.hpp
+++ b/src/cpp/rtps/writer/StatefulPersistentWriter.hpp
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 /**
- * @file StatefulPersistentWriter.h
+ * @file StatefulPersistentWriter.hpp
  */
-#ifndef _FASTDDS_RTPS_STATEFULPERSISTENTWRITER_H_
-#define _FASTDDS_RTPS_STATEFULPERSISTENTWRITER_H_
+#ifndef RTPS_WRITER__STATEFULPERSISTENTWRITER_HPP
+#define RTPS_WRITER__STATEFULPERSISTENTWRITER_HPP
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
@@ -105,4 +105,4 @@ public:
 } // namespace eprosima
 
 #endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
-#endif /* _FASTDDS_RTPS_STATEFULPERSISTENTWRITER_H_ */
+#endif /* RTPS_WRITER__STATEFULPERSISTENTWRITER_HPP */

--- a/src/cpp/rtps/writer/StatefulPersistentWriter.hpp
+++ b/src/cpp/rtps/writer/StatefulPersistentWriter.hpp
@@ -20,8 +20,10 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
-#include <fastdds/rtps/writer/StatefulWriter.h>
+
 #include <fastdds/rtps/writer/PersistentWriter.h>
+
+#include <rtps/writer/StatefulWriter.hpp>
 
 namespace eprosima {
 namespace fastrtps {

--- a/src/cpp/rtps/writer/StatefulPersistentWriter.hpp
+++ b/src/cpp/rtps/writer/StatefulPersistentWriter.hpp
@@ -20,9 +20,7 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
-
-#include <fastdds/rtps/writer/PersistentWriter.h>
-
+#include <rtps/writer/PersistentWriter.hpp>
 #include <rtps/writer/StatefulWriter.hpp>
 
 namespace eprosima {

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -17,6 +17,8 @@
  *
  */
 
+#include "StatefulWriter.hpp"
+
 #include <mutex>
 #include <stdexcept>
 #include <vector>
@@ -30,7 +32,6 @@
 #include <fastdds/rtps/participant/RTPSParticipant.h>
 #include <fastdds/rtps/reader/RTPSReader.h>
 #include <fastdds/rtps/writer/ReaderProxy.h>
-#include <fastdds/rtps/writer/StatefulWriter.h>
 #include <fastdds/rtps/writer/WriterListener.h>
 
 #include <rtps/builtin/BuiltinProtocols.h>

--- a/src/cpp/rtps/writer/StatefulWriter.hpp
+++ b/src/cpp/rtps/writer/StatefulWriter.hpp
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 /**
- * @file StatefulWriter.h
+ * @file StatefulWriter.hpp
  */
 
-#ifndef _FASTDDS_RTPS_STATEFULWRITER_H_
-#define _FASTDDS_RTPS_STATEFULWRITER_H_
+#ifndef RTPS_WRITER__STATEFULWRITER_HPP
+#define RTPS_WRITER__STATEFULWRITER_HPP
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
@@ -550,4 +550,4 @@ private:
 } /* namespace eprosima */
 
 #endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
-#endif /* _FASTDDS_RTPS_STATEFULWRITER_H_ */
+#endif /* RTPS_WRITER__STATEFULWRITER_HPP */

--- a/src/cpp/rtps/writer/StatelessPersistentWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessPersistentWriter.cpp
@@ -17,7 +17,7 @@
  *
  */
 
-#include <fastdds/rtps/writer/StatelessPersistentWriter.h>
+#include "StatelessPersistentWriter.hpp"
 
 #include <fastdds/rtps/history/WriterHistory.h>
 

--- a/src/cpp/rtps/writer/StatelessPersistentWriter.hpp
+++ b/src/cpp/rtps/writer/StatelessPersistentWriter.hpp
@@ -20,8 +20,9 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
-#include <fastdds/rtps/writer/StatelessWriter.h>
 #include <fastdds/rtps/writer/PersistentWriter.h>
+
+#include <rtps/writer/StatelessWriter.hpp>
 
 namespace eprosima {
 namespace fastrtps {

--- a/src/cpp/rtps/writer/StatelessPersistentWriter.hpp
+++ b/src/cpp/rtps/writer/StatelessPersistentWriter.hpp
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 /**
- * @file StatelessPersistentWriter.h
+ * @file StatelessPersistentWriter.hpp
  */
-#ifndef _FASTDDS_RTPS_STATELESSPERSISTENTWRITER_H_
-#define _FASTDDS_RTPS_STATELESSPERSISTENTWRITER_H_
+#ifndef RTPS_WRITER__STATELESSPERSISTENTWRITER_HPP
+#define RTPS_WRITER__STATELESSPERSISTENTWRITER_HPP
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
@@ -96,4 +96,4 @@ public:
 } // namespace eprosima
 
 #endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
-#endif /* _FASTDDS_RTPS_STATELESSPERSISTENTWRITER_H_ */
+#endif /* RTPS_WRITER__STATELESSPERSISTENTWRITER_HPP */

--- a/src/cpp/rtps/writer/StatelessPersistentWriter.hpp
+++ b/src/cpp/rtps/writer/StatelessPersistentWriter.hpp
@@ -20,8 +20,7 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
-#include <fastdds/rtps/writer/PersistentWriter.h>
-
+#include <rtps/writer/PersistentWriter.hpp>
 #include <rtps/writer/StatelessWriter.hpp>
 
 namespace eprosima {

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -17,7 +17,7 @@
  *
  */
 
-#include <fastdds/rtps/writer/StatelessWriter.h>
+#include "StatelessWriter.hpp"
 
 #include <algorithm>
 #include <mutex>

--- a/src/cpp/rtps/writer/StatelessWriter.hpp
+++ b/src/cpp/rtps/writer/StatelessWriter.hpp
@@ -13,12 +13,17 @@
 // limitations under the License.
 
 /**
- * @file StatelessWriter.h
+ * @file StatelessWriter.hpp
  */
-#ifndef _FASTDDS_RTPS_STATELESSWRITER_H_
-#define _FASTDDS_RTPS_STATELESSWRITER_H_
+#ifndef RTPS_WRITER__STATELESSWRITER_HPP
+#define RTPS_WRITER__STATELESSWRITER_HPP
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+
+#include <condition_variable>
+#include <list>
+#include <memory>
+#include <mutex>
 
 #include <fastdds/rtps/common/Time_t.h>
 #include <fastdds/rtps/history/IChangePool.h>
@@ -28,11 +33,6 @@
 #include <fastdds/rtps/writer/ReaderLocator.h>
 #include <fastdds/rtps/writer/RTPSWriter.h>
 #include <fastdds/utils/collections/ResourceLimitedVector.hpp>
-
-#include <condition_variable>
-#include <list>
-#include <memory>
-#include <mutex>
 
 namespace eprosima {
 namespace fastrtps {
@@ -299,4 +299,4 @@ private:
 } /* namespace eprosima */
 
 #endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
-#endif /* _FASTDDS_RTPS_STATELESSWRITER_H_ */
+#endif /* RTPS_WRITER__STATELESSWRITER_HPP */

--- a/src/cpp/statistics/rtps/monitor-service/MonitorService.hpp
+++ b/src/cpp/statistics/rtps/monitor-service/MonitorService.hpp
@@ -30,11 +30,11 @@
 #include <fastdds/dds/publisher/qos/WriterQos.hpp>
 #include <fastdds/rtps/common/Guid.h>
 #include <fastdds/rtps/history/WriterHistory.h>
-#include <fastdds/rtps/writer/StatefulWriter.h>
 
 #include "Interfaces.hpp"
 #include <rtps/history/ITopicPayloadPool.h>
 #include <rtps/resources/TimedEvent.h>
+#include <rtps/writer/StatefulWriter.hpp>
 #include <statistics/rtps/monitor-service/MonitorServiceListener.hpp>
 #include <statistics/types/monitorservice_types.hpp>
 #include <statistics/types/monitorservice_typesPubSubTypes.h>

--- a/test/mock/rtps/MessageReceiver/rtps/messages/MessageReceiver.h
+++ b/test/mock/rtps/MessageReceiver/rtps/messages/MessageReceiver.h
@@ -24,10 +24,9 @@
 
 #include <fastdds/rtps/common/CDRMessage_t.h>
 #include <fastdds/rtps/common/Locator.h>
-#include <fastdds/rtps/writer/StatelessWriter.h>
 
 #include <rtps/writer/StatefulWriter.hpp>
-
+#include <rtps/writer/StatelessWriter.hpp>
 
 namespace eprosima {
 namespace fastrtps {

--- a/test/mock/rtps/MessageReceiver/rtps/messages/MessageReceiver.h
+++ b/test/mock/rtps/MessageReceiver/rtps/messages/MessageReceiver.h
@@ -25,7 +25,8 @@
 #include <fastdds/rtps/common/CDRMessage_t.h>
 #include <fastdds/rtps/common/Locator.h>
 #include <fastdds/rtps/writer/StatelessWriter.h>
-#include <fastdds/rtps/writer/StatefulWriter.h>
+
+#include <rtps/writer/StatefulWriter.hpp>
 
 
 namespace eprosima {

--- a/test/mock/rtps/StatefulWriter/rtps/writer/StatefulWriter.hpp
+++ b/test/mock/rtps/StatefulWriter/rtps/writer/StatefulWriter.hpp
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 /**
- * @file StatefulWriter.h
+ * @file StatefulWriter.hpp
  */
 
-#ifndef _FASTDDS_RTPS_STATEFULWRITER_H_
-#define _FASTDDS_RTPS_STATEFULWRITER_H_
+#ifndef RTPS_WRITER__STATEFULWRITER_HPP
+#define RTPS_WRITER__STATEFULWRITER_HPP
 
 #include <fastdds/rtps/history/WriterHistory.h>
 #include <fastdds/rtps/interfaces/IReaderDataFilter.hpp>
@@ -129,4 +129,4 @@ private:
 } // namespace fastrtps
 } // namespace eprosima
 
-#endif // _FASTDDS_RTPS_STATEFULWRITER_H_
+#endif // RTPS_WRITER__STATEFULWRITER_HPP

--- a/test/mock/rtps/StatelessWriter/rtps/writer/StatelessWriter.hpp
+++ b/test/mock/rtps/StatelessWriter/rtps/writer/StatelessWriter.hpp
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 /**
- * @file StatelessWriter.h
+ * @file StatelessWriter.hpp
  */
 
-#ifndef _FASTDDS_RTPS_STATELESSWRITER_H_
-#define _FASTDDS_RTPS_STATELESSWRITER_H_
+#ifndef RTPS_WRITER__STATELESSWRITER_HPP
+#define RTPS_WRITER__STATELESSWRITER_HPP
 
 #include <fastdds/rtps/writer/RTPSWriter.h>
 

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -36,13 +36,12 @@
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 #include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
 #include <fastdds/dds/subscriber/Subscriber.hpp>
-#include <fastdds/rtps/writer/RTPSWriter.h>
-#include <fastdds/rtps/writer/StatefulWriter.h>
-
 #include <fastdds/publisher/DataWriterImpl.hpp>
+#include <fastdds/rtps/writer/RTPSWriter.h>
 
 #include "../../common/CustomPayloadPool.hpp"
 #include "../../logging/mock/MockConsumer.h"
+#include <rtps/writer/StatefulWriter.hpp>
 
 namespace eprosima {
 namespace fastdds {

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -37,11 +37,9 @@
 #include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
 #include <fastdds/dds/subscriber/Subscriber.hpp>
 #include <fastdds/publisher/DataWriterImpl.hpp>
-#include <fastdds/rtps/writer/RTPSWriter.h>
 
 #include "../../common/CustomPayloadPool.hpp"
 #include "../../logging/mock/MockConsumer.h"
-#include <rtps/writer/StatefulWriter.hpp>
 
 namespace eprosima {
 namespace fastdds {

--- a/test/unittest/rtps/security/SecurityTests.hpp
+++ b/test/unittest/rtps/security/SecurityTests.hpp
@@ -20,7 +20,6 @@
 #include <fastdds/rtps/builtin/data/ParticipantProxyData.h>
 #include <fastdds/rtps/history/ReaderHistory.h>
 #include <fastdds/rtps/history/WriterHistory.h>
-#include <fastdds/rtps/writer/StatefulWriter.h>
 #include <fastdds/rtps/writer/StatelessWriter.h>
 #include <rtps/builtin/discovery/participant/PDP.h>
 #include <rtps/participant/RTPSParticipantImpl.h>
@@ -32,6 +31,7 @@
 #include <rtps/security/MockCryptographyPlugin.h>
 #include <rtps/security/SecurityManager.h>
 #include <rtps/security/SecurityPluginFactory.h>
+#include <rtps/writer/StatefulWriter.hpp>
 
 using namespace eprosima::fastrtps::rtps;
 using namespace eprosima::fastrtps::rtps::security;

--- a/test/unittest/rtps/security/SecurityTests.hpp
+++ b/test/unittest/rtps/security/SecurityTests.hpp
@@ -20,7 +20,6 @@
 #include <fastdds/rtps/builtin/data/ParticipantProxyData.h>
 #include <fastdds/rtps/history/ReaderHistory.h>
 #include <fastdds/rtps/history/WriterHistory.h>
-#include <fastdds/rtps/writer/StatelessWriter.h>
 #include <rtps/builtin/discovery/participant/PDP.h>
 #include <rtps/participant/RTPSParticipantImpl.h>
 #include <rtps/reader/StatefulReader.hpp>
@@ -32,6 +31,7 @@
 #include <rtps/security/SecurityManager.h>
 #include <rtps/security/SecurityPluginFactory.h>
 #include <rtps/writer/StatefulWriter.hpp>
+#include <rtps/writer/StatelessWriter.hpp>
 
 using namespace eprosima::fastrtps::rtps;
 using namespace eprosima::fastrtps::rtps::security;

--- a/test/unittest/rtps/writer/CMakeLists.txt
+++ b/test/unittest/rtps/writer/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(ReaderProxyTests ${WRITERPROXYTESTS_SOURCE})
 target_compile_definitions(ReaderProxyTests PRIVATE
     BOOST_ASIO_STANDALONE
     ASIO_STANDALONE
+    $<$<BOOL:${MSVC}>:NOMINMAX> # avoid conflict with std::min & std::max in visual studio
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )

--- a/test/unittest/rtps/writer/ReaderProxyTests.cpp
+++ b/test/unittest/rtps/writer/ReaderProxyTests.cpp
@@ -16,9 +16,9 @@
 #include <gtest/gtest.h>
 
 #include <fastdds/rtps/writer/ReaderProxy.h>
-#include <fastdds/rtps/writer/StatefulWriter.h>
 
 #include <rtps/messages/RTPSGapBuilder.hpp>
+#include <rtps/writer/StatefulWriter.hpp>
 
 //using namespace eprosima::fastrtps::rtps;
 namespace eprosima {

--- a/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/monitor-service/MonitorService.hpp
+++ b/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/monitor-service/MonitorService.hpp
@@ -30,10 +30,10 @@
 #include <fastdds/dds/publisher/qos/WriterQos.hpp>
 #include <fastdds/rtps/common/Guid.h>
 #include <fastdds/rtps/history/WriterHistory.h>
-#include <fastdds/rtps/writer/StatefulWriter.h>
 
 #include <rtps/history/ITopicPayloadPool.h>
 #include <rtps/resources/TimedEvent.h>
+#include <rtps/writer/StatefulWriter.hpp>
 #include <statistics/rtps/monitor-service/Interfaces.hpp>
 #include <statistics/rtps/monitor-service/MonitorServiceListener.hpp>
 #include <statistics/types/monitorservice_types.hpp>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR makes RTPS Writer implementations private:

 * PersistentWriter
 * StatefulPersistentWriter
 * StatefulWriter
 * StatelessPersistentWriter
 * StatelessWriter

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- N/A Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- N/A Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- N/A Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- ❌ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- ❌ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- N/A New feature has been added to the `versions.md` file (if applicable).
- N/A New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- N/A Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
