### PR TITLE
[21097] Remove RTPSParticipant listener overloaded callbaks

### DIFF
--- a/include/fastdds/rtps/participant/RTPSParticipantListener.h
+++ b/include/fastdds/rtps/participant/RTPSParticipantListener.h
@@ -52,21 +52,6 @@ public:
      *
      * @param[out] participant Pointer to the Participant which discovered the remote participant.
      * @param[out] info Remote participant information. User can take ownership of the object.
-     */
-    virtual void onParticipantDiscovery(
-            RTPSParticipant* participant,
-            ParticipantDiscoveryInfo&& info)
-    {
-        static_cast<void>(participant);
-        static_cast<void>(info);
-    }
-
-    /*!
-     * This method is called when a new Participant is discovered, or a previously discovered participant changes
-     * its QOS or is removed.
-     *
-     * @param[out] participant Pointer to the Participant which discovered the remote participant.
-     * @param[out] info Remote participant information. User can take ownership of the object.
      * @param[out] should_be_ignored Flag to indicate the library to automatically ignore the discovered Participant.
      */
     virtual void onParticipantDiscovery(
@@ -74,7 +59,9 @@ public:
             ParticipantDiscoveryInfo&& info,
             bool& should_be_ignored)
     {
-        onParticipantDiscovery(participant, std::move(info));
+        static_cast<void>(participant);
+        static_cast<void>(info);
+
         should_be_ignored = false;
     }
 

--- a/include/fastdds/rtps/participant/RTPSParticipantListener.h
+++ b/include/fastdds/rtps/participant/RTPSParticipantListener.h
@@ -82,21 +82,6 @@ public:
      *
      * @param[out] participant Pointer to the Participant which discovered the remote reader.
      * @param[out] info Remote reader information. User can take ownership of the object.
-     */
-    virtual void onReaderDiscovery(
-            RTPSParticipant* participant,
-            ReaderDiscoveryInfo&& info)
-    {
-        static_cast<void>(participant);
-        static_cast<void>(info);
-    }
-
-    /*!
-     * This method is called when a new Reader is discovered, or a previously discovered reader changes
-     * its QOS or is removed.
-     *
-     * @param[out] participant Pointer to the Participant which discovered the remote reader.
-     * @param[out] info Remote reader information. User can take ownership of the object.
      * @param[out] should_be_ignored Flag to indicate the library to automatically ignore the discovered Reader.
      */
     virtual void onReaderDiscovery(
@@ -106,22 +91,7 @@ public:
     {
         static_cast<void>(participant);
         static_cast<void>(info);
-        static_cast<void>(should_be_ignored);
-    }
-
-    /*!
-     * This method is called when a new Writer is discovered, or a previously discovered writer changes
-     * its QOS or is removed.
-     *
-     * @param[out] participant Pointer to the Participant which discovered the remote writer.
-     * @param[out] info Remote writer information. User can take ownership of the object.
-     */
-    virtual void onWriterDiscovery(
-            RTPSParticipant* participant,
-            WriterDiscoveryInfo&& info)
-    {
-        static_cast<void>(participant);
-        static_cast<void>(info);
+        should_be_ignored = false;
     }
 
     /*!
@@ -139,7 +109,7 @@ public:
     {
         static_cast<void>(participant);
         static_cast<void>(info);
-        static_cast<void>(should_be_ignored);
+        should_be_ignored = false;
     }
 
 };

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1558,27 +1558,37 @@ void DomainParticipantImpl::MyRTPSParticipantListener::onParticipantAuthenticati
 
 void DomainParticipantImpl::MyRTPSParticipantListener::onReaderDiscovery(
         RTPSParticipant*,
-        ReaderDiscoveryInfo&& info)
+        ReaderDiscoveryInfo&& info,
+        bool& should_be_ignored)
 {
+    should_be_ignored = false;
+
     Sentry sentinel(this);
     if (sentinel)
     {
-        bool should_be_ignored = false;
-        participant_->listener_->on_data_reader_discovery(participant_->participant_, std::move(info),
-                should_be_ignored);
+        DomainParticipantListener* listener = participant_->listener_;
+        if (nullptr != listener)
+        {
+            listener->on_data_reader_discovery(participant_->participant_, std::move(info), should_be_ignored);
+        }
     }
 }
 
 void DomainParticipantImpl::MyRTPSParticipantListener::onWriterDiscovery(
         RTPSParticipant*,
-        WriterDiscoveryInfo&& info)
+        WriterDiscoveryInfo&& info,
+        bool& should_be_ignored)
 {
+    should_be_ignored = false;
+
     Sentry sentinel(this);
     if (sentinel)
     {
-        bool should_be_ignored = false;
-        participant_->listener_->on_data_writer_discovery(participant_->participant_, std::move(info),
-                should_be_ignored);
+        DomainParticipantListener* listener = participant_->listener_;
+        if (nullptr != listener)
+        {
+            listener->on_data_writer_discovery(participant_->participant_, std::move(info), should_be_ignored);
+        }
     }
 }
 

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -624,9 +624,6 @@ protected:
             bool on_guard_;
         };
 
-        using fastrtps::rtps::RTPSParticipantListener::onReaderDiscovery;
-        using fastrtps::rtps::RTPSParticipantListener::onWriterDiscovery;
-
     public:
 
         MyRTPSParticipantListener(
@@ -653,11 +650,13 @@ protected:
 
         void onReaderDiscovery(
                 fastrtps::rtps::RTPSParticipant* participant,
-                fastrtps::rtps::ReaderDiscoveryInfo&& info) override;
+                fastrtps::rtps::ReaderDiscoveryInfo&& info,
+                bool& should_be_ignored) override;
 
         void onWriterDiscovery(
                 fastrtps::rtps::RTPSParticipant* participant,
-                fastrtps::rtps::WriterDiscoveryInfo&& info) override;
+                fastrtps::rtps::WriterDiscoveryInfo&& info,
+                bool& should_be_ignored) override;
 
         DomainParticipantImpl* participant_;
         int callback_counter_ = 0;

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -624,7 +624,6 @@ protected:
             bool on_guard_;
         };
 
-        using fastrtps::rtps::RTPSParticipantListener::onParticipantDiscovery;
         using fastrtps::rtps::RTPSParticipantListener::onReaderDiscovery;
         using fastrtps::rtps::RTPSParticipantListener::onWriterDiscovery;
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -702,9 +702,11 @@ bool PDP::removeReaderProxyData(
                 RTPSParticipantListener* listener = mp_RTPSParticipant->getListener();
                 if (listener)
                 {
+                    RTPSParticipant* participant = mp_RTPSParticipant->getUserRTPSParticipant();
                     ReaderDiscoveryInfo info(std::move(*pR));
+                    bool should_be_ignored = false;
                     info.status = ReaderDiscoveryInfo::REMOVED_READER;
-                    listener->onReaderDiscovery(mp_RTPSParticipant->getUserRTPSParticipant(), std::move(info));
+                    listener->onReaderDiscovery(participant, std::move(info), should_be_ignored);
                 }
 
                 // Clear reader proxy data and move to pool in order to allow reuse
@@ -746,9 +748,11 @@ bool PDP::removeWriterProxyData(
                 RTPSParticipantListener* listener = mp_RTPSParticipant->getListener();
                 if (listener)
                 {
+                    RTPSParticipant* participant = mp_RTPSParticipant->getUserRTPSParticipant();
                     WriterDiscoveryInfo info(std::move(*pW));
+                    bool should_be_ignored = false;
                     info.status = WriterDiscoveryInfo::REMOVED_WRITER;
-                    listener->onWriterDiscovery(mp_RTPSParticipant->getUserRTPSParticipant(), std::move(info));
+                    listener->onWriterDiscovery(participant, std::move(info), should_be_ignored);
                 }
 
                 // Clear writer proxy data and move to pool in order to allow reuse
@@ -838,9 +842,11 @@ ReaderProxyData* PDP::addReaderProxyData(
                 RTPSParticipantListener* listener = mp_RTPSParticipant->getListener();
                 if (listener)
                 {
+                    RTPSParticipant* participant = mp_RTPSParticipant->getUserRTPSParticipant();
                     ReaderDiscoveryInfo info(*ret_val);
+                    bool should_be_ignored = false;
                     info.status = ReaderDiscoveryInfo::CHANGED_QOS_READER;
-                    listener->onReaderDiscovery(mp_RTPSParticipant->getUserRTPSParticipant(), std::move(info));
+                    listener->onReaderDiscovery(participant, std::move(info), should_be_ignored);
                 }
 
                 return ret_val;
@@ -888,9 +894,11 @@ ReaderProxyData* PDP::addReaderProxyData(
             RTPSParticipantListener* listener = mp_RTPSParticipant->getListener();
             if (listener)
             {
+                RTPSParticipant* participant = mp_RTPSParticipant->getUserRTPSParticipant();
                 ReaderDiscoveryInfo info(*ret_val);
+                bool should_be_ignored = false;
                 info.status = ReaderDiscoveryInfo::DISCOVERED_READER;
-                listener->onReaderDiscovery(mp_RTPSParticipant->getUserRTPSParticipant(), std::move(info));
+                listener->onReaderDiscovery(participant, std::move(info), should_be_ignored);
             }
 
             return ret_val;
@@ -935,9 +943,11 @@ WriterProxyData* PDP::addWriterProxyData(
                 RTPSParticipantListener* listener = mp_RTPSParticipant->getListener();
                 if (listener)
                 {
+                    RTPSParticipant* participant = mp_RTPSParticipant->getUserRTPSParticipant();
                     WriterDiscoveryInfo info(*ret_val);
+                    bool should_be_ignored = false;
                     info.status = WriterDiscoveryInfo::CHANGED_QOS_WRITER;
-                    listener->onWriterDiscovery(mp_RTPSParticipant->getUserRTPSParticipant(), std::move(info));
+                    listener->onWriterDiscovery(participant, std::move(info), should_be_ignored);
                 }
 
                 return ret_val;
@@ -984,9 +994,11 @@ WriterProxyData* PDP::addWriterProxyData(
             RTPSParticipantListener* listener = mp_RTPSParticipant->getListener();
             if (listener)
             {
+                RTPSParticipant* participant = mp_RTPSParticipant->getUserRTPSParticipant();
                 WriterDiscoveryInfo info(*ret_val);
+                bool should_be_ignored = false;
                 info.status = WriterDiscoveryInfo::DISCOVERED_WRITER;
-                listener->onWriterDiscovery(mp_RTPSParticipant->getUserRTPSParticipant(), std::move(info));
+                listener->onWriterDiscovery(participant, std::move(info), should_be_ignored);
             }
 
             return ret_val;
@@ -1195,9 +1207,11 @@ void PDP::actions_on_remote_participant_removed(
 
                 if (listener)
                 {
+                    RTPSParticipant* participant = mp_RTPSParticipant->getUserRTPSParticipant();
                     ReaderDiscoveryInfo info(std::move(*rit));
+                    bool should_be_ignored = false;
                     info.status = ReaderDiscoveryInfo::REMOVED_READER;
-                    listener->onReaderDiscovery(mp_RTPSParticipant->getUserRTPSParticipant(), std::move(info));
+                    listener->onReaderDiscovery(participant, std::move(info), should_be_ignored);
                 }
             }
         }
@@ -1212,9 +1226,11 @@ void PDP::actions_on_remote_participant_removed(
 
                 if (listener)
                 {
+                    RTPSParticipant* participant = mp_RTPSParticipant->getUserRTPSParticipant();
                     WriterDiscoveryInfo info(std::move(*wit));
+                    bool should_be_ignored = false;
                     info.status = WriterDiscoveryInfo::REMOVED_WRITER;
-                    listener->onWriterDiscovery(mp_RTPSParticipant->getUserRTPSParticipant(), std::move(info));
+                    listener->onWriterDiscovery(participant, std::move(info), should_be_ignored);
                 }
             }
         }

--- a/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
+++ b/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
@@ -70,15 +70,6 @@ public:
 
     void onParticipantDiscovery(
             RTPSParticipant* participant,
-            ParticipantDiscoveryInfo&& info) override
-    {
-        onParticipantDiscovery_mock(participant, info);
-    }
-
-    MOCK_METHOD2(onParticipantDiscovery_mock, void (RTPSParticipant*, const ParticipantDiscoveryInfo&));
-
-    void onParticipantDiscovery(
-            RTPSParticipant* participant,
             ParticipantDiscoveryInfo&& info,
             bool& should_be_ignored) override
     {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR removes the discovery callback overloads on `RTPSParticipantListener` not receiving `should_be_ignored`.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- __NO__ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- __NO__ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
