### PR TITLE
[20815] Only apply content filter to ALIVE changes

### DIFF
--- a/include/fastrtps/types/DynamicLoanableSequence.hpp
+++ b/include/fastrtps/types/DynamicLoanableSequence.hpp
@@ -30,6 +30,11 @@ namespace dds {
 
 /**
  * @brief LoanableSequence specialization for DynamicData.
+ *
+ * This class provides a sequence container for handling loanable collections
+ * of DynamicData.
+ *
+ * @tparam _NonConstEnabler to enable data access through [] operator on non-const sequences.
  */
 template<typename _NonConstEnabler>
 class LoanableSequence<fastrtps::types::DynamicData, _NonConstEnabler>
@@ -37,15 +42,28 @@ class LoanableSequence<fastrtps::types::DynamicData, _NonConstEnabler>
 {
 public:
 
+    /// Type for the size of the sequence.
     using size_type = LoanableCollection::size_type;
+
+    /// Type for the elements in the sequence.
     using element_type = LoanableCollection::element_type;
 
+    /**
+     * @brief Construct a LoanableSequence with a specified dynamic type.
+     *
+     * @param[in] dyn_type Pointer to the DynamicType.
+     */
     LoanableSequence(
             fastrtps::types::DynamicType_ptr dyn_type)
         : dynamic_type_support_(new fastrtps::types::DynamicPubSubType(dyn_type))
     {
     }
 
+    /**
+     * @brief Construct a LoanableSequence with a specified maximum size.
+     *
+     * @param[in] max Maximum size of the sequence.
+     */
     LoanableSequence(
             size_type max)
     {
@@ -57,6 +75,9 @@ public:
         resize(max);
     }
 
+    /**
+     * @brief Destructor for LoanableSequence.
+     */
     ~LoanableSequence()
     {
         if (elements_ && !has_ownership_)
@@ -68,12 +89,24 @@ public:
         release();
     }
 
+    /**
+     * @brief Copy constructor for LoanableSequence.
+     *
+     * @param[in] other The other LoanableSequence to copy from.
+     */
     LoanableSequence(
             const LoanableSequence& other)
     {
         *this = other;
     }
 
+    /**
+     * @brief Copy assignment operator for LoanableSequence.
+     *
+     * @param[in] other The other LoanableSequence to assign from.
+     *
+     * @return A reference to this LoanableSequence.
+     */
     LoanableSequence& operator =(
             const LoanableSequence& other)
     {
@@ -93,9 +126,21 @@ public:
         return *this;
     }
 
+    /**
+     * @brief Move constructor for LoanableSequence.
+     *
+     * @param[in] other The other LoanableSequence to move from.
+     */
     LoanableSequence(
             LoanableSequence&&) = default;
 
+    /**
+     * @brief Move assignment operator for LoanableSequence.
+     *
+     * @param[in] other The other LoanableSequence to move from.
+     *
+     * @return A reference to this LoanableSequence.
+     */
     LoanableSequence& operator =(
             LoanableSequence&&) = default;
 
@@ -108,6 +153,11 @@ protected:
 
 private:
 
+    /**
+     * @brief Resize the sequence to a new maximum size.
+     *
+     * @param[in] maximum The new maximum size.
+     */
     void resize(
             size_type maximum) override
     {
@@ -125,6 +175,9 @@ private:
         }
     }
 
+    /**
+     * @brief Release all elements and clear the sequence.
+     */
     void release()
     {
         if (has_ownership_ && elements_)
@@ -143,11 +196,14 @@ private:
         has_ownership_ = true;
     }
 
+    /// Container for holding the DynamicData elements.
     std::vector<fastrtps::types::DynamicData*> data_;
 
+    /// Pointer to the DynamicPubSubType type support.
     std::unique_ptr<fastrtps::types::DynamicPubSubType> dynamic_type_support_;
 };
 
+/// Alias for LoanableSequence with DynamicData and true_type.
 using DynamicLoanableSequence = LoanableSequence<fastrtps::types::DynamicData, std::true_type>;
 
 } // namespace dds

--- a/include/fastrtps/types/DynamicLoanableSequence.hpp
+++ b/include/fastrtps/types/DynamicLoanableSequence.hpp
@@ -93,6 +93,12 @@ public:
         return *this;
     }
 
+    LoanableSequence(
+            LoanableSequence&&) = default;
+
+    LoanableSequence& operator =(
+            LoanableSequence&&) = default;
+
 protected:
 
     using LoanableCollection::maximum_;

--- a/include/fastrtps/types/DynamicLoanableSequence.hpp
+++ b/include/fastrtps/types/DynamicLoanableSequence.hpp
@@ -89,42 +89,13 @@ public:
         release();
     }
 
-    /**
-     * @brief Copy constructor for LoanableSequence.
-     *
-     * @param[in] other The other LoanableSequence to copy from.
-     */
+    /// Deleted copy constructor for LoanableSequence.
     LoanableSequence(
-            const LoanableSequence& other)
-    {
-        *this = other;
-    }
+            const LoanableSequence& other) = delete;
 
-    /**
-     * @brief Copy assignment operator for LoanableSequence.
-     *
-     * @param[in] other The other LoanableSequence to assign from.
-     *
-     * @return A reference to this LoanableSequence.
-     */
+    /// Deleted copy assignment operator for LoanableSequence.
     LoanableSequence& operator =(
-            const LoanableSequence& other)
-    {
-        if (!has_ownership_)
-        {
-            release();
-        }
-
-        LoanableCollection::length(other.length());
-        const element_type* other_buf = other.buffer();
-        for (size_type n = 0; n < length_; ++n)
-        {
-            *static_cast<fastrtps::types::DynamicData*>(elements_[n]) =
-                    *static_cast<const fastrtps::types::DynamicData*>(other_buf[n]);
-        }
-
-        return *this;
-    }
+            const LoanableSequence& other) = delete;
 
     /**
      * @brief Move constructor for LoanableSequence.

--- a/include/fastrtps/types/DynamicLoanableSequence.hpp
+++ b/include/fastrtps/types/DynamicLoanableSequence.hpp
@@ -1,0 +1,151 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _TYPES_DYNAMIC_LOANABLE_SEQUENCE_HPP_
+#define _TYPES_DYNAMIC_LOANABLE_SEQUENCE_HPP_
+
+#include <cassert>
+#include <memory>
+
+#include <fastdds/dds/core/LoanableSequence.hpp>
+#include <fastdds/dds/log/Log.hpp>
+#include <fastrtps/types/DynamicData.h>
+#include <fastrtps/types/DynamicPubSubType.h>
+#include <fastrtps/types/DynamicTypePtr.h>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+
+/**
+ * @brief LoanableSequence specialization for DynamicData.
+ */
+template<typename _NonConstEnabler>
+class LoanableSequence<fastrtps::types::DynamicData, _NonConstEnabler>
+    : public LoanableTypedCollection<fastrtps::types::DynamicData, _NonConstEnabler>
+{
+public:
+
+    using size_type = LoanableCollection::size_type;
+    using element_type = LoanableCollection::element_type;
+
+    LoanableSequence(
+            fastrtps::types::DynamicType_ptr dyn_type)
+        : dynamic_type_support_(new fastrtps::types::DynamicPubSubType(dyn_type))
+    {
+    }
+
+    LoanableSequence(
+            size_type max)
+    {
+        if (max <= 0)
+        {
+            return;
+        }
+
+        resize(max);
+    }
+
+    ~LoanableSequence()
+    {
+        if (elements_ && !has_ownership_)
+        {
+            EPROSIMA_LOG_WARNING(SUBSCRIBER, "Sequence destroyed with active loan");
+            return;
+        }
+
+        release();
+    }
+
+    LoanableSequence(
+            const LoanableSequence& other)
+    {
+        *this = other;
+    }
+
+    LoanableSequence& operator =(
+            const LoanableSequence& other)
+    {
+        if (!has_ownership_)
+        {
+            release();
+        }
+
+        LoanableCollection::length(other.length());
+        const element_type* other_buf = other.buffer();
+        for (size_type n = 0; n < length_; ++n)
+        {
+            *static_cast<fastrtps::types::DynamicData*>(elements_[n]) =
+                    *static_cast<const fastrtps::types::DynamicData*>(other_buf[n]);
+        }
+
+        return *this;
+    }
+
+protected:
+
+    using LoanableCollection::maximum_;
+    using LoanableCollection::length_;
+    using LoanableCollection::elements_;
+    using LoanableCollection::has_ownership_;
+
+private:
+
+    void resize(
+            size_type maximum) override
+    {
+        assert(has_ownership_);
+
+        // Resize collection and get new pointer
+        data_.reserve(maximum);
+        data_.resize(maximum);
+        elements_ = reinterpret_cast<element_type*>(data_.data());
+
+        // Allocate individual elements
+        while (maximum_ < maximum)
+        {
+            data_[maximum_++] = static_cast<fastrtps::types::DynamicData*>(dynamic_type_support_->createData());
+        }
+    }
+
+    void release()
+    {
+        if (has_ownership_ && elements_)
+        {
+            for (size_type n = 0; n < maximum_; ++n)
+            {
+                fastrtps::types::DynamicData* elem = data_[n];
+                dynamic_type_support_->deleteData(elem);
+            }
+            std::vector<fastrtps::types::DynamicData*>().swap(data_);
+        }
+
+        maximum_ = 0u;
+        length_ = 0u;
+        elements_ = nullptr;
+        has_ownership_ = true;
+    }
+
+    std::vector<fastrtps::types::DynamicData*> data_;
+
+    std::unique_ptr<fastrtps::types::DynamicPubSubType> dynamic_type_support_;
+};
+
+using DynamicLoanableSequence = LoanableSequence<fastrtps::types::DynamicData, std::true_type>;
+
+} // namespace dds
+} // namespace fastdds
+} // namespace eprosima
+
+#endif // _TYPES_DYNAMIC_LOANABLE_SEQUENCE_HPP_

--- a/include/fastrtps/types/DynamicPubSubType.h
+++ b/include/fastrtps/types/DynamicPubSubType.h
@@ -45,6 +45,8 @@ protected:
 
 public:
 
+    using type = DynamicData_ptr;
+
     RTPS_DllAPI DynamicPubSubType();
 
     RTPS_DllAPI DynamicPubSubType(

--- a/include/fastrtps/types/DynamicPubSubType.h
+++ b/include/fastrtps/types/DynamicPubSubType.h
@@ -15,10 +15,10 @@
 #ifndef TYPES_DYNAMIC_PUB_SUB_TYPE_H
 #define TYPES_DYNAMIC_PUB_SUB_TYPE_H
 
-#include <fastrtps/types/TypesBase.h>
 #include <fastdds/dds/topic/TopicDataType.hpp>
+#include <fastrtps/types/DynamicData.h>
 #include <fastrtps/types/DynamicTypePtr.h>
-#include <fastrtps/types/DynamicDataPtr.h>
+#include <fastrtps/types/TypesBase.h>
 #include <fastrtps/utils/md5.h>
 
 namespace eprosima {
@@ -45,7 +45,7 @@ protected:
 
 public:
 
-    using type = DynamicData_ptr;
+    typedef DynamicData type;
 
     RTPS_DllAPI DynamicPubSubType();
 

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -65,6 +65,7 @@ set(${PROJECT_NAME}_source_files
     rtps/DataSharing/DataSharingListener.cpp
     rtps/DataSharing/DataSharingNotification.cpp
     rtps/reader/WriterProxy.cpp
+    rtps/reader/reader_utils.cpp
     rtps/reader/StatefulReader.cpp
     rtps/reader/StatelessReader.cpp
     rtps/reader/RTPSReader.cpp

--- a/src/cpp/fastdds/publisher/filtering/ReaderFilterCollection.hpp
+++ b/src/cpp/fastdds/publisher/filtering/ReaderFilterCollection.hpp
@@ -133,13 +133,17 @@ public:
                         // Copy the signature
                         std::copy(entry.filter_signature.begin(), entry.filter_signature.end(), signature);
 
-                        // Evaluate filter and update filtered_out_readers
-                        bool filter_result = entry.filter->evaluate(change.serializedPayload, info, it->first);
-                        if (!filter_result)
+                        // Only evaluate filter on ALIVE changes, as UNREGISTERED and DISPOSED are always relevant
+                        bool filter_result = true;
+                        if (fastrtps::rtps::ALIVE == change.kind)
                         {
-                            change.filtered_out_readers.emplace_back(it->first);
+                            // Evaluate filter and update filtered_out_readers
+                            filter_result = entry.filter->evaluate(change.serializedPayload, info, it->first);
+                            if (!filter_result)
+                            {
+                                change.filtered_out_readers.emplace_back(it->first);
+                            }
                         }
-
                         return filter_result;
                     };
 

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -31,11 +31,11 @@
 #include <fastdds/rtps/reader/StatelessReader.h>
 #include <fastdds/rtps/writer/LivelinessManager.h>
 
-#include <rtps/participant/RTPSParticipantImpl.h>
+#include "reader_utils.hpp"
+#include "rtps/RTPSDomainImpl.hpp"
 #include <rtps/DataSharing/DataSharingListener.hpp>
 #include <rtps/DataSharing/ReaderPool.hpp>
-
-#include "rtps/RTPSDomainImpl.hpp"
+#include <rtps/participant/RTPSParticipantImpl.h>
 
 #define IDSTRING "(ID:" << std::this_thread::get_id() << ") " <<
 
@@ -589,9 +589,10 @@ bool StatelessReader::processDataMsg(
                 return false;
             }
 
-            if (data_filter_ && !data_filter_->is_relevant(*change, m_guid))
+            if (!fastdds::rtps::change_is_relevant_for_filter(*change, m_guid, data_filter_))
             {
                 update_last_notified(change->writerGUID, change->sequenceNumber);
+                // Change was filtered out, so there isn't anything else to do
                 return true;
             }
 
@@ -804,7 +805,8 @@ bool StatelessReader::processDataFragMsg(
                 {
                     // Temporarilly assign the inline qos while evaluating the data filter
                     change_completed->inline_qos = incomingChange->inline_qos;
-                    bool filtered_out = data_filter_ && !data_filter_->is_relevant(*change_completed, m_guid);
+                    bool filtered_out = !fastdds::rtps::change_is_relevant_for_filter(*change_completed, m_guid,
+                                    data_filter_);
                     change_completed->inline_qos = SerializedPayload_t();
 
                     if (filtered_out)

--- a/src/cpp/rtps/reader/reader_utils.cpp
+++ b/src/cpp/rtps/reader/reader_utils.cpp
@@ -26,13 +26,13 @@ namespace rtps {
 
 bool change_is_relevant_for_filter(
         const CacheChange& change,
-        const GUID& guid,
+        const GUID& reader_guid,
         const IReaderDataFilter* filter)
 {
     bool ret = true;
 
     // Only evaluate filter on ALIVE changes, as UNREGISTERED and DISPOSED are always relevant
-    if ((nullptr != filter) && (fastrtps::rtps::ALIVE == change.kind) && (!filter->is_relevant(change, guid)))
+    if ((nullptr != filter) && (fastrtps::rtps::ALIVE == change.kind) && (!filter->is_relevant(change, reader_guid)))
     {
         ret = false;
     }

--- a/src/cpp/rtps/reader/reader_utils.cpp
+++ b/src/cpp/rtps/reader/reader_utils.cpp
@@ -1,0 +1,45 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file reader_utils.cpp
+ */
+
+#include "reader_utils.hpp"
+
+#include <fastdds/rtps/common/ChangeKind_t.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+
+bool change_is_relevant_for_filter(
+        const CacheChange& change,
+        const GUID& guid,
+        const IReaderDataFilter* filter)
+{
+    bool ret = true;
+
+    // Only evaluate filter on ALIVE changes, as UNREGISTERED and DISPOSED are always relevant
+    if ((nullptr != filter) && (fastrtps::rtps::ALIVE == change.kind) && (!filter->is_relevant(change, guid)))
+    {
+        ret = false;
+    }
+
+    return ret;
+}
+
+} // namespace rtps
+} // namespace fastdds
+} // namespace eprosima

--- a/src/cpp/rtps/reader/reader_utils.hpp
+++ b/src/cpp/rtps/reader/reader_utils.hpp
@@ -35,14 +35,14 @@ using GUID = fastrtps::rtps::GUID_t;
  * @brief Check if a change is relevant for a reader.
  *
  * @param change The CacheChange_t to be evaluated.
- * @param reader_guid Remote reader GUID_t.
+ * @param reader_guid Reader's GUID_t.
  * @param filter The IReaderDataFilter to be used.
  *
  * @return true if relevant, false otherwise.
  */
 bool change_is_relevant_for_filter(
         const CacheChange& change,
-        const GUID& guid,
+        const GUID& reader_guid,
         const IReaderDataFilter* filter);
 
 } // namespace rtps

--- a/src/cpp/rtps/reader/reader_utils.hpp
+++ b/src/cpp/rtps/reader/reader_utils.hpp
@@ -1,0 +1,53 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file reader_utils.hpp
+ */
+
+#ifndef _FASTDDS_RTPS_READER_READERUTILS_H_
+#define _FASTDDS_RTPS_READER_READERUTILS_H_
+
+#include <fastdds/rtps/common/CacheChange.h>
+#include <fastdds/rtps/common/Guid.h>
+#include <fastdds/rtps/interfaces/IReaderDataFilter.hpp>
+#include <fastdds/rtps/common/ChangeKind_t.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+
+using CacheChange = fastrtps::rtps::CacheChange_t;
+using GUID = fastrtps::rtps::GUID_t;
+
+/**
+ * @brief Check if a change is relevant for a reader.
+ *
+ * @param change The CacheChange_t to be evaluated.
+ * @param reader_guid Remote reader GUID_t.
+ * @param filter The IReaderDataFilter to be used.
+ *
+ * @return true if relevant, false otherwise.
+ */
+bool change_is_relevant_for_filter(
+        const CacheChange& change,
+        const GUID& guid,
+        const IReaderDataFilter* filter);
+
+} // namespace rtps
+} // namespace fastdds
+} // namespace eprosima
+
+
+#endif // _FASTDDS_RTPS_READER_READERUTILS_H_

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -27,7 +27,9 @@
 #include <vector>
 
 #include <asio.hpp>
+
 #include <gtest/gtest.h>
+
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/DomainParticipantListener.hpp>
@@ -38,14 +40,16 @@
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
 #include <fastdds/dds/subscriber/DataReader.hpp>
 #include <fastdds/dds/subscriber/DataReaderListener.hpp>
-#include <fastdds/dds/subscriber/Subscriber.hpp>
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
+#include <fastdds/dds/subscriber/Subscriber.hpp>
 #include <fastdds/rtps/participant/ParticipantDiscoveryInfo.h>
+
+#include "PubSubTypeTraits.hpp"
 
 /**
  * @brief A class with one participant that can have multiple publishers and subscribers
  */
-template<class TypeSupport>
+template<class TypeSupport, typename TypeTraits = PubSubTypeTraits<TypeSupport>>
 class PubSubParticipant
 {
 public:
@@ -129,13 +133,7 @@ private:
         void on_data_available(
                 eprosima::fastdds::dds::DataReader* reader) override
         {
-            type data;
-            eprosima::fastdds::dds::SampleInfo info;
-
-            while (ReturnCode_t::RETCODE_OK == reader->take_next_sample(&data, &info))
-            {
-                participant_->data_received();
-            }
+            participant_->data_received(reader);
         }
 
     private:
@@ -316,7 +314,7 @@ public:
         if (participant_ != nullptr)
         {
             participant_qos_ = participant_->get_qos();
-            type_.reset(new type_support());
+            TypeTraits::build_type_support(type_);
             participant_->register_type(type_);
             return true;
         }
@@ -414,6 +412,7 @@ public:
             type& msg,
             unsigned int index = 0)
     {
+        TypeTraits::print_sent_data(msg);
         return std::get<2>(publishers_[index])->write((void*)&msg);
     }
 
@@ -817,11 +816,21 @@ public:
         sub_liveliness_cv_.notify_one();
     }
 
-    void data_received()
+    void data_received(
+            eprosima::fastdds::dds::DataReader* reader)
     {
-        std::unique_lock<std::mutex> lock(sub_data_mutex_);
-        sub_times_data_received_++;
-        sub_data_cv_.notify_one();
+        type* data = static_cast<type*>(type_.create_data());
+        eprosima::fastdds::dds::SampleInfo info;
+
+        while (ReturnCode_t::RETCODE_OK == reader->take_next_sample(data, &info))
+        {
+            TypeTraits::print_received_data(*data);
+            std::unique_lock<std::mutex> lock(sub_data_mutex_);
+            sub_times_data_received_++;
+            sub_data_cv_.notify_one();
+        }
+
+        type_.delete_data(data);
     }
 
     unsigned int pub_times_liveliness_lost()

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -20,40 +20,46 @@
 #ifndef _TEST_BLACKBOX_PUBSUBREADER_HPP_
 #define _TEST_BLACKBOX_PUBSUBREADER_HPP_
 
+#include <algorithm>
 #include <atomic>
 #include <condition_variable>
 #include <functional>
 #include <list>
+#include <mutex>
 #include <string>
+#include <vector>
 
 #include <asio.hpp>
 #include <gtest/gtest.h>
 #if _MSC_VER
 #include <Windows.h>
 #endif // _MSC_VER
-#include <fastdds/dds/core/condition/StatusCondition.hpp>
 #include <fastdds/dds/core/condition/GuardCondition.hpp>
+#include <fastdds/dds/core/condition/StatusCondition.hpp>
 #include <fastdds/dds/core/condition/WaitSet.hpp>
-#include <fastdds/dds/core/UserAllocatedSequence.hpp>
 #include <fastdds/dds/core/policy/QosPolicies.hpp>
+#include <fastdds/dds/core/status/BaseStatus.hpp>
+#include <fastdds/dds/core/UserAllocatedSequence.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/DomainParticipantListener.hpp>
 #include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
 #include <fastdds/dds/subscriber/DataReader.hpp>
 #include <fastdds/dds/subscriber/DataReaderListener.hpp>
+#include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 #include <fastdds/dds/subscriber/SampleInfo.hpp>
 #include <fastdds/dds/subscriber/Subscriber.hpp>
-#include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
+#include <fastdds/dds/topic/ContentFilteredTopic.hpp>
 #include <fastdds/dds/topic/Topic.hpp>
+#include <fastdds/dds/topic/TopicDescription.hpp>
+#include <fastdds/rtps/transport/TCPv4TransportDescriptor.h>
+#include <fastdds/rtps/transport/TCPv6TransportDescriptor.h>
 #include <fastdds/rtps/transport/UDPTransportDescriptor.h>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
 #include <fastdds/rtps/transport/UDPv6TransportDescriptor.h>
-#include <fastdds/rtps/transport/TCPv4TransportDescriptor.h>
-#include <fastdds/rtps/transport/TCPv6TransportDescriptor.h>
+#include <fastrtps/utils/IPLocator.h>
 #include <fastrtps/xmlparser/XMLParser.h>
 #include <fastrtps/xmlparser/XMLTree.h>
-#include <fastrtps/utils/IPLocator.h>
 
 using DomainParticipantFactory = eprosima::fastdds::dds::DomainParticipantFactory;
 using eprosima::fastrtps::rtps::IPLocator;
@@ -64,7 +70,18 @@ using eprosima::fastdds::rtps::UDPv6TransportDescriptor;
 using SampleLostStatusFunctor = std::function<void (const eprosima::fastdds::dds::SampleLostStatus&)>;
 using SampleRejectedStatusFunctor = std::function<void (const eprosima::fastdds::dds::SampleRejectedStatus&)>;
 
-template<class TypeSupport>
+template<class T>
+struct PubSubReaderTypeSupportBuilder
+{
+    static void build(
+            eprosima::fastdds::dds::TypeSupport& typesupport)
+    {
+        return typesupport.reset(new T());
+    }
+
+};
+
+template<class TypeSupport, typename TypeSupportBuilder = PubSubReaderTypeSupportBuilder<TypeSupport>>
 class PubSubReader
 {
 public:
@@ -289,6 +306,7 @@ public:
         , listener_(*this)
         , participant_(nullptr)
         , topic_(nullptr)
+        , cf_topic_(nullptr)
         , subscriber_(nullptr)
         , datareader_(nullptr)
         , status_mask_(eprosima::fastdds::dds::StatusMask::all())
@@ -317,6 +335,8 @@ public:
         , times_incompatible_qos_(0)
         , last_incompatible_qos_(eprosima::fastdds::dds::INVALID_QOS_POLICY_ID)
         , message_receive_count_(0)
+        , filter_expression_("")
+        , expression_parameters_({})
     {
         // Load default QoS to permit testing with external XML profile files.
         DomainParticipantFactory::get_instance()->load_profiles();
@@ -349,6 +369,19 @@ public:
 
         // By default don't check for overlapping
         loan_sample_validation(false);
+    }
+
+    PubSubReader(
+            const std::string& topic_name,
+            const std::string& filter_expression,
+            const std::vector<std::string>& expression_parameters,
+            bool take = true,
+            bool statistics = false,
+            bool read = true)
+        : PubSubReader(topic_name, take, statistics, read)
+    {
+        filter_expression_ = filter_expression;
+        expression_parameters_ = expression_parameters;
     }
 
     virtual ~PubSubReader()
@@ -398,7 +431,7 @@ public:
         {
             participant_guid_ = participant_->guid();
 
-            type_.reset(new type_support());
+            TypeSupportBuilder::build(type_);
 
             // Register type
             ASSERT_EQ(participant_->register_type(type_), ReturnCode_t::RETCODE_OK);
@@ -409,6 +442,17 @@ public:
                             eprosima::fastdds::dds::TOPIC_QOS_DEFAULT);
             ASSERT_NE(topic_, nullptr);
             ASSERT_TRUE(topic_->is_enabled());
+
+            // Create CFT if needed
+            if (!filter_expression_.empty())
+            {
+                cf_topic_ = participant_->create_contentfilteredtopic(
+                    topic_name_ + "_cft",
+                    topic_,
+                    filter_expression_,
+                    expression_parameters_);
+                ASSERT_NE(cf_topic_, nullptr);
+            }
 
             // Create publisher
             createSubscriber();
@@ -423,11 +467,18 @@ public:
             ASSERT_NE(subscriber_, nullptr);
             ASSERT_TRUE(subscriber_->is_enabled());
 
+            using TopicDescriptionPtr = eprosima::fastdds::dds::TopicDescription*;
+            TopicDescriptionPtr topic_desc {(nullptr !=
+                                            cf_topic_) ? static_cast<TopicDescriptionPtr>(cf_topic_) : static_cast<
+                                                TopicDescriptionPtr>(
+                                                topic_)};
+
             if (!xml_file_.empty())
             {
                 if (!datareader_profile_.empty())
                 {
-                    datareader_ = subscriber_->create_datareader_with_profile(topic_, datareader_profile_, &listener_,
+                    datareader_ = subscriber_->create_datareader_with_profile(topic_desc, datareader_profile_,
+                                    &listener_,
                                     status_mask_);
                     ASSERT_NE(datareader_, nullptr);
                     ASSERT_TRUE(datareader_->is_enabled());
@@ -435,7 +486,7 @@ public:
             }
             if (datareader_ == nullptr)
             {
-                datareader_ = subscriber_->create_datareader(topic_, datareader_qos_, &listener_, status_mask_);
+                datareader_ = subscriber_->create_datareader(topic_desc, datareader_qos_, &listener_, status_mask_);
             }
 
             if (datareader_ != nullptr)
@@ -471,22 +522,14 @@ public:
     {
         if (participant_ != nullptr)
         {
-            if (datareader_)
-            {
-                subscriber_->delete_datareader(datareader_);
-                datareader_ = nullptr;
-            }
-            if (subscriber_)
-            {
-                participant_->delete_subscriber(subscriber_);
-                subscriber_ = nullptr;
-            }
-            if (topic_)
-            {
-                participant_->delete_topic(topic_);
-                topic_ = nullptr;
-            }
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(participant_);
+            ASSERT_EQ(ReturnCode_t::RETCODE_OK, participant_->delete_contained_entities());
+            datareader_ = nullptr;
+            subscriber_ = nullptr;
+            cf_topic_ = nullptr;
+            topic_ = nullptr;
+
+            ASSERT_EQ(ReturnCode_t::RETCODE_OK,
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(participant_));
             participant_ = nullptr;
         }
 
@@ -519,6 +562,18 @@ public:
         receiving_.store(true);
         std::lock_guard<std::mutex> lock(mutex_);
         return get_last_sequence_received();
+    }
+
+    void startReception(
+            size_t expected_samples)
+    {
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            current_processed_count_ = 0;
+            number_samples_expected_ = expected_samples;
+            last_seq.clear();
+        }
+        receiving_.store(true);
     }
 
     void stopReception()
@@ -1743,6 +1798,13 @@ public:
         return status;
     }
 
+    eprosima::fastdds::dds::SampleLostStatus get_sample_lost_status() const
+    {
+        eprosima::fastdds::dds::SampleLostStatus status;
+        datareader_->get_sample_lost_status(status);
+        return status;
+    }
+
     bool is_matched() const
     {
         return matched_ > 0;
@@ -1847,8 +1909,6 @@ protected:
             bool& returnedValue)
     {
         returnedValue = false;
-        type data;
-        eprosima::fastdds::dds::SampleInfo info;
 
         if (!take_ && !read_)
         {
@@ -1858,9 +1918,14 @@ protected:
             return;
         }
 
+        // DynamicData ctor is protected so we create data using the TypeSupport. This way we can use both static
+        // and dynamic types
+        type* data = static_cast<type*>(type_.create_data());
+        eprosima::fastdds::dds::SampleInfo info;
+
         ReturnCode_t success = take_ ?
-                datareader->take_next_sample((void*)&data, &info) :
-                datareader->read_next_sample((void*)&data, &info);
+                datareader->take_next_sample(data, &info) :
+                datareader->read_next_sample(data, &info);
         if (ReturnCode_t::RETCODE_OK == success)
         {
             returnedValue = true;
@@ -1875,13 +1940,21 @@ protected:
             if (info.valid_data
                     && info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
             {
-                auto it = std::find(total_msgs_.begin(), total_msgs_.end(), data);
-                ASSERT_NE(it, total_msgs_.end());
-                total_msgs_.erase(it);
+                if (!total_msgs_.empty())
+                {
+                    auto it = std::find(total_msgs_.begin(), total_msgs_.end(), *data);
+                    ASSERT_NE(it, total_msgs_.end());
+                    total_msgs_.erase(it);
+                }
                 ++current_processed_count_;
-                default_receive_print<type>(data);
+                default_receive_print<type>(*data);
                 cv_.notify_one();
             }
+
+            postprocess_sample(*data, info);
+
+            // Delete the free-storage allocated data sample
+            type_.delete_data(data);
         }
     }
 
@@ -1926,13 +1999,18 @@ protected:
 
                 if (valid_sample)
                 {
-                    auto it = std::find(total_msgs_.begin(), total_msgs_.end(), data);
-                    ASSERT_NE(it, total_msgs_.end());
-                    total_msgs_.erase(it);
+                    if (!total_msgs_.empty())
+                    {
+                        auto it = std::find(total_msgs_.begin(), total_msgs_.end(), data);
+                        ASSERT_NE(it, total_msgs_.end());
+                        total_msgs_.erase(it);
+                    }
                     ++current_processed_count_;
                     default_receive_print<type>(data);
                     cv_.notify_one();
                 }
+
+                postprocess_sample(data, info);
             }
         }
 
@@ -1947,6 +2025,14 @@ protected:
             bool& returnedValue)
     {
         receive_(datareader, std::ref(returnedValue));
+    }
+
+    virtual void postprocess_sample(
+            const type& data,
+            const eprosima::fastdds::dds::SampleInfo& info)
+    {
+        static_cast<void>(data);
+        static_cast<void>(info);
     }
 
     void participant_matched()
@@ -2002,6 +2088,7 @@ protected:
     eprosima::fastdds::dds::DomainParticipant* participant_;
     eprosima::fastdds::dds::DomainParticipantQos participant_qos_;
     eprosima::fastdds::dds::Topic* topic_;
+    eprosima::fastdds::dds::ContentFilteredTopic* cf_topic_;
     eprosima::fastdds::dds::Subscriber* subscriber_;
     eprosima::fastdds::dds::SubscriberQos subscriber_qos_;
     eprosima::fastdds::dds::DataReader* datareader_;
@@ -2081,6 +2168,11 @@ protected:
     SampleLostStatusFunctor sample_lost_status_functor_;
     //! Functor called when called SampleRejectedStatus listener.
     SampleRejectedStatusFunctor sample_rejected_status_functor_;
+
+    //! Expression for CFT
+    std::string filter_expression_;
+    //! Parameters for CFT expression
+    std::vector<std::string> expression_parameters_;
 };
 
 template<class TypeSupport>

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -82,6 +82,7 @@ public:
 
     typedef TypeSupport type_support;
     typedef typename type_support::type type;
+    typedef typename TypeTraits::DataListType datalist_type;
 
 protected:
 
@@ -529,14 +530,14 @@ public:
         initialized_ = false;
     }
 
-    std::list<typename TypeTraits::DataListType> data_not_received()
+    std::list<datalist_type> data_not_received()
     {
         std::unique_lock<std::mutex> lock(mutex_);
         return total_msgs_;
     }
 
     eprosima::fastrtps::rtps::SequenceNumber_t startReception(
-            const std::list<typename TypeTraits::DataListType>& msgs)
+            const std::list<datalist_type>& msgs)
     {
         mutex_.lock();
         total_msgs_ = msgs;
@@ -672,7 +673,7 @@ public:
                 if (info_seq[n].valid_data)
                 {
                     auto it = std::find_if(expected_messages.begin(), expected_messages.end(),
-                                    [&](const typename TypeTraits::DataListType& elem)
+                                    [&](const datalist_type& elem)
                                     {
                                         return TypeTraits::compare_data(data_seq[n], elem);
                                     });
@@ -1940,7 +1941,7 @@ protected:
                 if (!total_msgs_.empty())
                 {
                     auto it = std::find_if(total_msgs_.begin(), total_msgs_.end(),
-                                    [&](const typename TypeTraits::DataListType& elem)
+                                    [&](const datalist_type& elem)
                                     {
                                         return TypeTraits::compare_data(*data, elem);
                                     });
@@ -2004,7 +2005,7 @@ protected:
                     if (!total_msgs_.empty())
                     {
                         auto it = std::find_if(total_msgs_.begin(), total_msgs_.end(),
-                                        [&data](const typename TypeTraits::DataListType& elem)
+                                        [&data](const datalist_type& elem)
                                         {
                                             return TypeTraits::compare_data(data, elem);
                                         });
@@ -2104,7 +2105,7 @@ protected:
     eprosima::fastrtps::rtps::GUID_t participant_guid_;
     eprosima::fastrtps::rtps::GUID_t datareader_guid_;
     bool initialized_;
-    std::list<typename TypeTraits::DataListType> total_msgs_;
+    std::list<datalist_type> total_msgs_;
     std::mutex mutex_;
     std::condition_variable cv_;
     std::mutex mutexDiscovery_;

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -1951,9 +1951,10 @@ protected:
 
             postprocess_sample(*data, info);
 
-            // Delete the free-storage allocated data sample
-            type_.delete_data(data);
         }
+
+        // Delete the free-storage allocated data sample
+        type_.delete_data(data);
     }
 
     void receive_samples(

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -30,10 +30,13 @@
 #include <vector>
 
 #include <asio.hpp>
+
 #include <gtest/gtest.h>
+
 #if _MSC_VER
 #include <Windows.h>
 #endif // _MSC_VER
+
 #include <fastdds/dds/core/condition/GuardCondition.hpp>
 #include <fastdds/dds/core/condition/StatusCondition.hpp>
 #include <fastdds/dds/core/condition/WaitSet.hpp>

--- a/test/blackbox/api/dds-pim/PubSubTypeTraits.hpp
+++ b/test/blackbox/api/dds-pim/PubSubTypeTraits.hpp
@@ -1,0 +1,102 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file PubSubTypeTraits.hpp
+ *
+ */
+
+#include <fastdds/dds/core/LoanableSequence.hpp>
+#include <fastdds/dds/topic/TypeSupport.hpp>
+
+#include "../../common/BlackboxTests.hpp"
+
+#ifndef _TEST_BLACKBOX_PUBSUBTYPETRAITS_HPP_
+#define _TEST_BLACKBOX_PUBSUBTYPETRAITS_HPP_
+
+/**
+ * @brief This class provides TypeSupport specific traits for the PubSub wrapper classes
+ *
+ * Provides all the type specific functionality needed by the PubSub wrapper classes so that
+ * they can be agnostic to the actual TypeSupport class used, Fast DDS Gen generated or Dynamic.
+ *
+ * @tparam _TypeSupport TypeSupport class for which the traits are provided
+ */
+template<class _TypeSupport>
+struct PubSubTypeTraits
+{
+    //! PubSub readers and writers have a list of datas of the type they are handling
+    using DataListType = typename _TypeSupport::type;
+
+    /**
+     * @brief Create a new instance of the specific TypeSupport
+     *
+     * @param[out] typesupport TypeSupport reference to be populated with the new concrete instance
+     */
+    static void build_type_support(
+            eprosima::fastdds::dds::TypeSupport& typesupport)
+    {
+        return typesupport.reset(new _TypeSupport());
+    }
+
+    /**
+     * @brief Build a LoanableSequence of the specific type
+     *
+     * @return The type specific LoanableSequence
+     */
+    static eprosima::fastdds::dds::LoanableSequence<typename _TypeSupport::type> build_loanable_sequence()
+    {
+        return eprosima::fastdds::dds::LoanableSequence<typename _TypeSupport::type>();
+    }
+
+    /**
+     * @brief Compare two DataListType instances
+     *
+     * @param data1 First DataListType instance
+     * @param data2 Second DataListType instance
+     *
+     * @return True if the two instances are equal, false otherwise
+     */
+    static bool compare_data(
+            const DataListType& data1,
+            const DataListType& data2)
+    {
+        return data1 == data2;
+    }
+
+    /**
+     * @brief Print the received data
+     *
+     * @param data DataListType instance to be printed
+     */
+    static void print_received_data(
+            const DataListType& data)
+    {
+        default_receive_print<DataListType>(data);
+    }
+
+    /**
+     * @brief Print the sent data
+     *
+     * @param data DataListType instance to be printed
+     */
+    static void print_sent_data(
+            const DataListType& data)
+    {
+        default_send_print<DataListType>(data);
+    }
+
+};
+
+#endif // _TEST_BLACKBOX_PUBSUBTYPETRAITS_HPP_

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -281,6 +281,7 @@ public:
 
     typedef TypeSupport type_support;
     typedef typename type_support::type type;
+    typedef typename TypeTraits::DataListType datalist_type;
 
     PubSubWriter(
             const std::string& topic_name)
@@ -495,7 +496,7 @@ public:
     }
 
     void send(
-            std::list<typename TypeTraits::DataListType>& msgs,
+            std::list<datalist_type>& msgs,
             uint32_t milliseconds = 0)
     {
         auto it = msgs.begin();

--- a/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
@@ -306,6 +306,7 @@ public:
 
     typedef TypeSupport type_support;
     typedef typename type_support::type type;
+    typedef typename TypeTraits::DataListType datalist_type;
 
     PubSubWriterReader(
             const std::string& topic_name)
@@ -540,7 +541,7 @@ public:
     }
 
     void send(
-            std::list<typename TypeTraits::DataListType>& msgs)
+            std::list<datalist_type>& msgs)
     {
         auto it = msgs.begin();
 
@@ -564,14 +565,14 @@ public:
         }
     }
 
-    std::list<typename TypeTraits::DataListType> data_not_received()
+    std::list<datalist_type> data_not_received()
     {
         std::unique_lock<std::mutex> lock(mutex_);
         return total_msgs_;
     }
 
     void startReception(
-            std::list<typename TypeTraits::DataListType>& msgs)
+            std::list<datalist_type>& msgs)
     {
         mutex_.lock();
         total_msgs_ = msgs;
@@ -928,7 +929,7 @@ private:
                 if (info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
                 {
                     auto it = std::find_if(total_msgs_.begin(), total_msgs_.end(),
-                                    [&](const typename TypeTraits::DataListType& elem)
+                                    [&](const datalist_type& elem)
                                     {
                                         return TypeTraits::compare_data(elem, *data);
                                     });
@@ -1020,7 +1021,7 @@ private:
 
     std::string topic_name_;
     bool initialized_;
-    std::list<typename TypeTraits::DataListType> total_msgs_;
+    std::list<datalist_type> total_msgs_;
     std::mutex mutex_;
     std::condition_variable cv_;
     std::mutex mutexDiscovery_;

--- a/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
@@ -20,34 +20,37 @@
 #ifndef _TEST_BLACKBOX_PUBSUBWRITERREADER_HPP_
 #define _TEST_BLACKBOX_PUBSUBWRITERREADER_HPP_
 
-#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
+#include <asio.hpp>
+#include <condition_variable>
+#include <list>
+#include <map>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <gtest/gtest.h>
+
 #include <fastdds/dds/domain/DomainParticipant.hpp>
+#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/DomainParticipantListener.hpp>
 #include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
-#include <fastdds/dds/topic/Topic.hpp>
-#include <fastdds/dds/publisher/Publisher.hpp>
 #include <fastdds/dds/publisher/DataWriter.hpp>
 #include <fastdds/dds/publisher/DataWriterListener.hpp>
+#include <fastdds/dds/publisher/Publisher.hpp>
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
-#include <fastdds/dds/subscriber/Subscriber.hpp>
 #include <fastdds/dds/subscriber/DataReader.hpp>
 #include <fastdds/dds/subscriber/DataReaderListener.hpp>
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 #include <fastdds/dds/subscriber/SampleInfo.hpp>
+#include <fastdds/dds/subscriber/Subscriber.hpp>
+#include <fastdds/dds/topic/Topic.hpp>
 #include <fastrtps/transport/TransportDescriptorInterface.h>
 
-#include <string>
-#include <list>
-#include <map>
-#include <vector>
-#include <tuple>
-#include <condition_variable>
-#include <asio.hpp>
-#include <gtest/gtest.h>
+#include "PubSubTypeTraits.hpp"
 
 using DomainParticipantFactory = eprosima::fastdds::dds::DomainParticipantFactory;
 
-template<class TypeSupport>
+template<class TypeSupport, typename TypeTraits = PubSubTypeTraits<TypeSupport>>
 class PubSubWriterReader
 {
     class ParticipantListener : public eprosima::fastdds::dds::DomainParticipantListener
@@ -390,7 +393,7 @@ public:
         ASSERT_NE(participant_, nullptr);
         ASSERT_TRUE(participant_->is_enabled());
 
-        type_.reset(new type_support());
+        TypeTraits::build_type_support(type_);
 
         // Register type
         ASSERT_EQ(participant_->register_type(type_), ReturnCode_t::RETCODE_OK);
@@ -537,7 +540,7 @@ public:
     }
 
     void send(
-            std::list<type>& msgs)
+            std::list<typename TypeTraits::DataListType>& msgs)
     {
         auto it = msgs.begin();
 
@@ -550,7 +553,7 @@ public:
                     std::get<1>(tuple)->write((void*)&(*it));
                 }
 
-                default_send_print<type>(*it);
+                TypeTraits::print_sent_data(*it);
                 it = msgs.erase(it);
 
             }
@@ -561,14 +564,14 @@ public:
         }
     }
 
-    std::list<type> data_not_received()
+    std::list<typename TypeTraits::DataListType> data_not_received()
     {
         std::unique_lock<std::mutex> lock(mutex_);
         return total_msgs_;
     }
 
     void startReception(
-            std::list<type>& msgs)
+            std::list<typename TypeTraits::DataListType>& msgs)
     {
         mutex_.lock();
         total_msgs_ = msgs;
@@ -907,10 +910,10 @@ private:
             bool& returnedValue)
     {
         returnedValue = false;
-        type data;
+        type* data = static_cast<type*>(type_.create_data());
         eprosima::fastdds::dds::SampleInfo info;
 
-        if ((ReturnCode_t::RETCODE_OK == datareader->take_next_sample((void*)&data, &info)))
+        if ((ReturnCode_t::RETCODE_OK == datareader->take_next_sample(data, &info)))
         {
             returnedValue = true;
 
@@ -924,7 +927,11 @@ private:
 
                 if (info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
                 {
-                    auto it = std::find(total_msgs_.begin(), total_msgs_.end(), data);
+                    auto it = std::find_if(total_msgs_.begin(), total_msgs_.end(),
+                                    [&](const typename TypeTraits::DataListType& elem)
+                                    {
+                                        return TypeTraits::compare_data(elem, *data);
+                                    });
                     ASSERT_NE(it, total_msgs_.end());
                     total_msgs_.erase(it);
                 }
@@ -932,10 +939,13 @@ private:
             if (info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
             {
                 ++current_received_count_;
-                default_receive_print<type>(data);
+                TypeTraits::print_received_data(*data);
                 cv_.notify_one();
             }
         }
+
+        // Delete the free-storage allocated data sample
+        type_.delete_data(data);
     }
 
     void publication_matched(
@@ -1010,7 +1020,7 @@ private:
 
     std::string topic_name_;
     bool initialized_;
-    std::list<type> total_msgs_;
+    std::list<typename TypeTraits::DataListType> total_msgs_;
     std::mutex mutex_;
     std::condition_variable cv_;
     std::mutex mutexDiscovery_;

--- a/test/blackbox/common/DDSBlackboxTestsContentFilter.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsContentFilter.cpp
@@ -14,42 +14,32 @@
 
 #include <atomic>
 #include <chrono>
-#include <condition_variable>
 #include <cstdint>
-#include <mutex>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include <gtest/gtest.h>
 
-#include <fastdds/dds/core/status/BaseStatus.hpp>
-#include <fastdds/dds/core/status/PublicationMatchedStatus.hpp>
-#include <fastdds/dds/core/status/SubscriptionMatchedStatus.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
-#include <fastdds/dds/publisher/DataWriter.hpp>
-#include <fastdds/dds/publisher/DataWriterListener.hpp>
-#include <fastdds/dds/publisher/Publisher.hpp>
-#include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
-#include <fastdds/dds/publisher/qos/PublisherQos.hpp>
 #include <fastdds/dds/subscriber/DataReader.hpp>
-#include <fastdds/dds/subscriber/DataReaderListener.hpp>
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 #include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
+#include <fastdds/dds/subscriber/SampleInfo.hpp>
 #include <fastdds/dds/subscriber/Subscriber.hpp>
 #include <fastdds/dds/topic/qos/TopicQos.hpp>
+#include <fastdds/dds/topic/Topic.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
 #include <fastdds/rtps/transport/test_UDPv4TransportDescriptor.h>
 #include <fastrtps/attributes/LibrarySettingsAttributes.h>
 #include <fastrtps/types/DynamicData.h>
-#include <fastrtps/types/DynamicDataFactory.h>
-#include <fastrtps/types/DynamicLoanableSequence.hpp>
 #include <fastrtps/types/DynamicPubSubType.h>
-#include <fastrtps/types/DynamicTypePtr.h>
 #include <fastrtps/types/TypesBase.h>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 
+#include "../types/dynamic_types_traits.hpp"
 #include "../types/HelloWorldTypeObject.h"
 #include "../types/TestRegression3361PubSubTypes.h"
 #include "../types/TestRegression3361TypeObject.h"
@@ -642,202 +632,6 @@ TEST(DDSContentFilter, CorrectlyHandleAliasOtherHeader)
 }
 
 /**
- * @brief PubSubTypeTraits for the PubSubReader and PubSubWriter
- *
- * This struct enables instantiation of a PubSubReader and PubSubWriter with a DynamicTypeSupport
- * for a type equivalent to that of KeyedHelloWorld.idl.
- * That and the fact that this builder sets the auto_fill_type_object flag to true allow for instance to create a
- * PubSubReader with a content filter, which right now is not possible to do with the Fast DDS generated
- * TypeSupport, as it does not contain the TypeObject code.
- *
- * To use it, do one of:
- *   - PubSubReader<fastrtps::types::DynamicPubSubType, DynamicTypeTraits> reader;
- *   - PubSubWriter<fastrtps::types::DynamicPubSubType, DynamicTypeTraits> writer;
- */
-struct DynamicTypeTraits
-{
-    using DataListType = DynamicData*;
-
-    /**
-     * Define the members ids of the struct for readability
-     */
-    enum class KeyedHelloWorldMembers : fastrtps::types::MemberId
-    {
-        KEY = 0,
-        INDEX = 1,
-        MESSAGE = 2
-    };
-
-    /**
-     * @brief Build the DynamicTypeSupport for the KeyedHelloWorld type
-     *
-     * @param[out] type_support The type support to be reset
-     */
-    static void build_type_support(
-            TypeSupport& type_support)
-    {
-        // Create type support
-        type_support.reset(new fastrtps::types::DynamicPubSubType(get_type()));
-
-        // Set the autofill type object to true so that TypeObject is registered upon type registration
-        type_support->auto_fill_type_object(true);
-    }
-
-    /**
-     * @brief Build a DynamicLoanableSequence of the specific type
-     *
-     * @return The DynamicLoanableSequence
-     */
-    static DynamicLoanableSequence build_loanable_sequence()
-    {
-        return DynamicLoanableSequence(get_type());
-    }
-
-    /**
-     * @brief Compare two data instances
-     *
-     * PubSubReader and PubSubWriter compare data within std::find_if calls to remove elements from
-     * their message lists. For Fast DDS Gen generated types, the TypeSupport::type and the type used
-     * for data list elements is the same. However, for the case of DynamicData, the DataListType needs
-     * to be a DynamicData*, as the DynamicData ctor and dtor are protected and so they cannot be called to remove elements from the message lists.
-     * This leads to the need to compare datas of different types when finding elements, as the sent or received data would be a DynamicDaa, whereas the list elements are DynamicData* (a.k.a DataListType).
-     *
-     * @param data1 The compared element (DynamicData)
-     * @param data2 The list element (DataListType)
-     *
-     * @return True if equal, false otherwise
-     */
-    static bool compare_data(
-            const DynamicData& data1,
-            const DataListType& data2)
-    {
-        return data1.equals(data2);
-    }
-
-    /**
-     * @brief Print the received data
-     *
-     * @param data DynamicData to be printed
-     */
-    static void print_received_data(
-            const DynamicData* data)
-    {
-        print_received_data(*data);
-    }
-
-    /**
-     * @brief Print the received data
-     *
-     * @param data DynamicData to be printed
-     */
-    static void print_received_data(
-            const DynamicData& data)
-    {
-        print_data_msg("Received", data);
-    }
-
-    /**
-     * @brief Print the sent data
-     *
-     * @param data DynamicData to be printed
-     */
-    static void print_sent_data(
-            const DynamicData* data)
-    {
-        print_sent_data(*data);
-    }
-
-    /**
-     * @brief Print the sent data
-     *
-     * @param data DynamicData to be printed
-     */
-    static void print_sent_data(
-            const DynamicData& data)
-    {
-        print_data_msg("Sent", data);
-    }
-
-private:
-
-    /**
-     * @brief Get the specific DynamicType equivalent to the KeyedHelloWorld.idl type
-     *
-     * @return The DynamicType_ptr
-     */
-    static DynamicType_ptr get_type()
-    {
-        // Using statics here in combination with std::call_once to avoid rebuilding the type every time.
-        // As the DynamicTypes API is shared_ptr based, we don't need to delete these references manually.
-        static std::once_flag once_flag;
-        static DynamicTypeBuilder_ptr struct_builder;
-        static DynamicTypeBuilder_ptr key_member_builder;
-        static DynamicType_ptr key_member;
-        static DynamicType_ptr struct_type;
-
-        std::call_once(once_flag, [&]()
-                {
-                    // Create the struct type builder
-                    const std::string topic_type_name = "keyed_hello_world";
-                    struct_builder = fastrtps::types::DynamicTypeBuilderFactory::get_instance()->create_struct_builder();
-                    struct_builder->set_name(topic_type_name);
-
-                    // Create the key member with the @key annotation
-                    key_member_builder = fastrtps::types::DynamicTypeBuilderFactory::get_instance()->create_uint16_builder();
-                    key_member_builder->apply_annotation(fastrtps::types::ANNOTATION_KEY_ID, "value", "true");
-                    key_member = key_member_builder->build();
-
-                    // Add members to the struct builder
-                    struct_builder->add_member(
-                        static_cast<fastrtps::types::MemberId>(KeyedHelloWorldMembers::KEY),
-                        "key",
-                        key_member);
-
-                    struct_builder->add_member(
-                        static_cast<fastrtps::types::MemberId>(KeyedHelloWorldMembers::INDEX),
-                        "index",
-                        fastrtps::types::DynamicTypeBuilderFactory::get_instance()->create_uint16_type());
-
-                    struct_builder->add_member(
-                        static_cast<fastrtps::types::MemberId>(KeyedHelloWorldMembers::MESSAGE),
-                        "message",
-                        fastrtps::types::DynamicTypeBuilderFactory::get_instance()->create_string_type(128));
-
-                    // Build the type
-                    struct_type = struct_builder->build();
-                });
-
-        return struct_type;
-    }
-
-    /**
-     * @brief Print a data message
-     *
-     * @param intro Introduction message
-     * @param data DynamicData to be printed.
-     *
-     * @pre data must have been build using the type returned by get_type(), that is through the DynamicTypeSupport
-     * created by build_type_support().
-     */
-    static void print_data_msg(
-            const std::string& intro,
-            const DynamicData& data)
-    {
-        auto key_value =
-                data.get_uint16_value(static_cast<fastrtps::types::MemberId>(KeyedHelloWorldMembers::KEY));
-        auto index_value =
-                data.get_uint16_value(static_cast<fastrtps::types::MemberId>(KeyedHelloWorldMembers::INDEX));
-        auto message_value =
-                data.get_string_value(static_cast<fastrtps::types::MemberId>(KeyedHelloWorldMembers::MESSAGE));
-
-        std::cout << intro << " data: (" << key_value << ", " << index_value << ", \"" << message_value << "\")" <<
-            std::endl;
-    }
-
-};
-
-
-/**
  * @brief PubSubReader specialization for using a DynamicPubSubType with content filtering,
  * overriding postprocess_sample to count valid and invalid samples.
  *
@@ -908,19 +702,19 @@ private:
  * particularity that after each write, the instance is unregistered.
  * The DATA(u) generated would not pass the filter if it was applied. To check that the filter is only applied to
  * ALIVE changes (not unregister or disposed), the test checks that the reader receives 10 valid samples (one per
- * sample sent) and 10 invalid samples (one per unregister). Furthermore, it also checks that no samples are lost.writer
+ * sample sent) and 10 invalid samples (one per unregister). Furthermore, it also checks that no samples are lost.
  */
 TEST(DDSContentFilter, OnlyFilterAliveChanges)
 {
 
     /* Create reader with CFT */
     std::string expression = "index = 1";
-    CFTDynamicPubSubReader<DynamicTypeTraits> reader("TestTopic", expression, {});
+    CFTDynamicPubSubReader<DynamicKeyedHelloworldTypeTraits> reader("TestTopic", expression, {});
     reader.reliability(RELIABLE_RELIABILITY_QOS).history_depth(2).init();
     ASSERT_TRUE(reader.isInitialized());
 
     /* Create writer */
-    PubSubWriter<fastrtps::types::DynamicPubSubType, DynamicTypeTraits> writer("TestTopic");
+    PubSubWriter<fastrtps::types::DynamicPubSubType, DynamicKeyedHelloworldTypeTraits> writer("TestTopic");
     writer.reliability(RELIABLE_RELIABILITY_QOS).history_depth(2).init();
     ASSERT_TRUE(writer.isInitialized());
 
@@ -938,11 +732,11 @@ TEST(DDSContentFilter, OnlyFilterAliveChanges)
 
         data->set_uint16_value(
             static_cast<uint16_t>(i),
-            static_cast<fastrtps::types::MemberId>(DynamicTypeTraits::KeyedHelloWorldMembers::KEY));
+            static_cast<fastrtps::types::MemberId>(DynamicKeyedHelloworldTypeTraits::KeyedHelloWorldMembers::KEY));
 
         data->set_uint16_value(
             1u,
-            static_cast<fastrtps::types::MemberId>(DynamicTypeTraits::KeyedHelloWorldMembers::INDEX));
+            static_cast<fastrtps::types::MemberId>(DynamicKeyedHelloworldTypeTraits::KeyedHelloWorldMembers::INDEX));
 
         InstanceHandle_t handle = writer.register_instance(*data);
         ASSERT_NE(HANDLE_NIL, handle);

--- a/test/blackbox/common/DDSBlackboxTestsContentFilter.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsContentFilter.cpp
@@ -44,6 +44,7 @@
 #include <fastrtps/attributes/LibrarySettingsAttributes.h>
 #include <fastrtps/types/DynamicData.h>
 #include <fastrtps/types/DynamicDataFactory.h>
+#include <fastrtps/types/DynamicLoanableSequence.hpp>
 #include <fastrtps/types/DynamicPubSubType.h>
 #include <fastrtps/types/DynamicTypePtr.h>
 #include <fastrtps/types/TypesBase.h>
@@ -641,7 +642,7 @@ TEST(DDSContentFilter, CorrectlyHandleAliasOtherHeader)
 }
 
 /**
- * @brief TypeSupportBuilder for the PubSubReader and PubSubWriter
+ * @brief PubSubTypeTraits for the PubSubReader and PubSubWriter
  *
  * This struct enables instantiation of a PubSubReader and PubSubWriter with a DynamicTypeSupport
  * for a type equivalent to that of KeyedHelloWorld.idl.
@@ -650,19 +651,13 @@ TEST(DDSContentFilter, CorrectlyHandleAliasOtherHeader)
  * TypeSupport, as it does not contain the TypeObject code.
  *
  * To use it, do one of:
- *   - PubSubReader<fastrtps::types::DynamicPubSubType, DynamicTypeSupportBuilder> reader;
- *   - PubSubWriter<fastrtps::types::DynamicPubSubType, DynamicTypeSupportBuilder> writer;
- *
- * When using this builder, the PubSubWriter cannot be used directly to write data, as it is type aware and its
- * methods receive a type_support::type&. This is a problem as, to call the native writer's API, they do
- * (void*)&sample, and the DynamicTypeSupport::type is defined as DynamicDataPtr, so the previous cast results in
- * a segmentation fault downstream. Instead, the native writer must be used directly, as follows:
- *   1. DynamicData* data = static_cast<DynamicData*>(writer.get_type_support().create_data());
- *   2. writer.get_native_writer().write(data, handle);
- *   3. writer.get_type_support().delete_data(data);
+ *   - PubSubReader<fastrtps::types::DynamicPubSubType, DynamicTypeTraits> reader;
+ *   - PubSubWriter<fastrtps::types::DynamicPubSubType, DynamicTypeTraits> writer;
  */
-struct DynamicTypeSupportBuilder
+struct DynamicTypeTraits
 {
+    using DataListType = DynamicData*;
+
     /**
      * Define the members ids of the struct for readability
      */
@@ -678,8 +673,99 @@ struct DynamicTypeSupportBuilder
      *
      * @param[out] type_support The type support to be reset
      */
-    static void build(
+    static void build_type_support(
             TypeSupport& type_support)
+    {
+        // Create type support
+        type_support.reset(new fastrtps::types::DynamicPubSubType(get_type()));
+
+        // Set the autofill type object to true so that TypeObject is registered upon type registration
+        type_support->auto_fill_type_object(true);
+    }
+
+    /**
+     * @brief Build a DynamicLoanableSequence of the specific type
+     *
+     * @return The DynamicLoanableSequence
+     */
+    static DynamicLoanableSequence build_loanable_sequence()
+    {
+        return DynamicLoanableSequence(get_type());
+    }
+
+    /**
+     * @brief Compare two data instances
+     *
+     * PubSubReader and PubSubWriter compare data within std::find_if calls to remove elements from
+     * their message lists. For Fast DDS Gen generated types, the TypeSupport::type and the type used
+     * for data list elements is the same. However, for the case of DynamicData, the DataListType needs
+     * to be a DynamicData*, as the DynamicData ctor and dtor are protected and so they cannot be called to remove elements from the message lists.
+     * This leads to the need to compare datas of different types when finding elements, as the sent or received data would be a DynamicDaa, whereas the list elements are DynamicData* (a.k.a DataListType).
+     *
+     * @param data1 The compared element (DynamicData)
+     * @param data2 The list element (DataListType)
+     *
+     * @return True if equal, false otherwise
+     */
+    static bool compare_data(
+            const DynamicData& data1,
+            const DataListType& data2)
+    {
+        return data1.equals(data2);
+    }
+
+    /**
+     * @brief Print the received data
+     *
+     * @param data DynamicData to be printed
+     */
+    static void print_received_data(
+            const DynamicData* data)
+    {
+        print_received_data(*data);
+    }
+
+    /**
+     * @brief Print the received data
+     *
+     * @param data DynamicData to be printed
+     */
+    static void print_received_data(
+            const DynamicData& data)
+    {
+        print_data_msg("Received", data);
+    }
+
+    /**
+     * @brief Print the sent data
+     *
+     * @param data DynamicData to be printed
+     */
+    static void print_sent_data(
+            const DynamicData* data)
+    {
+        print_sent_data(*data);
+    }
+
+    /**
+     * @brief Print the sent data
+     *
+     * @param data DynamicData to be printed
+     */
+    static void print_sent_data(
+            const DynamicData& data)
+    {
+        print_data_msg("Sent", data);
+    }
+
+private:
+
+    /**
+     * @brief Get the specific DynamicType equivalent to the KeyedHelloWorld.idl type
+     *
+     * @return The DynamicType_ptr
+     */
+    static DynamicType_ptr get_type()
     {
         // Using statics here in combination with std::call_once to avoid rebuilding the type every time.
         // As the DynamicTypes API is shared_ptr based, we don't need to delete these references manually.
@@ -702,37 +788,63 @@ struct DynamicTypeSupportBuilder
                     key_member = key_member_builder->build();
 
                     // Add members to the struct builder
-                    struct_builder->add_member(static_cast<fastrtps::types::MemberId>(KeyedHelloWorldMembers::KEY),
-                    "key", key_member);
-                    struct_builder->add_member(static_cast<fastrtps::types::MemberId>(KeyedHelloWorldMembers::INDEX),
-                    "index",
-                    fastrtps::types::DynamicTypeBuilderFactory::get_instance()->create_uint16_type());
-                    struct_builder->add_member(static_cast<fastrtps::types::MemberId>(KeyedHelloWorldMembers::MESSAGE),
-                    "message",
-                    fastrtps::types::DynamicTypeBuilderFactory::get_instance()->create_string_type(128));
+                    struct_builder->add_member(
+                        static_cast<fastrtps::types::MemberId>(KeyedHelloWorldMembers::KEY),
+                        "key",
+                        key_member);
+
+                    struct_builder->add_member(
+                        static_cast<fastrtps::types::MemberId>(KeyedHelloWorldMembers::INDEX),
+                        "index",
+                        fastrtps::types::DynamicTypeBuilderFactory::get_instance()->create_uint16_type());
+
+                    struct_builder->add_member(
+                        static_cast<fastrtps::types::MemberId>(KeyedHelloWorldMembers::MESSAGE),
+                        "message",
+                        fastrtps::types::DynamicTypeBuilderFactory::get_instance()->create_string_type(128));
 
                     // Build the type
                     struct_type = struct_builder->build();
                 });
 
-        // Create type support
-        type_support.reset(new fastrtps::types::DynamicPubSubType(struct_type));
+        return struct_type;
+    }
 
-        // Set the autofill type object to true so that TypeObject is registered upon type registration
-        type_support->auto_fill_type_object(true);
+    /**
+     * @brief Print a data message
+     *
+     * @param intro Introduction message
+     * @param data DynamicData to be printed.
+     *
+     * @pre data must have been build using the type returned by get_type(), that is through the DynamicTypeSupport
+     * created by build_type_support().
+     */
+    static void print_data_msg(
+            const std::string& intro,
+            const DynamicData& data)
+    {
+        auto key_value =
+                data.get_uint16_value(static_cast<fastrtps::types::MemberId>(KeyedHelloWorldMembers::KEY));
+        auto index_value =
+                data.get_uint16_value(static_cast<fastrtps::types::MemberId>(KeyedHelloWorldMembers::INDEX));
+        auto message_value =
+                data.get_string_value(static_cast<fastrtps::types::MemberId>(KeyedHelloWorldMembers::MESSAGE));
+
+        std::cout << intro << " data: (" << key_value << ", " << index_value << ", \"" << message_value << "\")" <<
+            std::endl;
     }
 
 };
 
 
 /**
- * @brief PubSubReader specialization for using a DynamicPubSubType, to create a PubSubReader with content filtering,
+ * @brief PubSubReader specialization for using a DynamicPubSubType with content filtering,
  * overriding postprocess_sample to count valid and invalid samples.
  *
- * @tparam TypeSupportBuilder TypeSupportBuilder to be used to create the TypeSupport.
+ * @tparam TypeTraits TypeTraits to be used.
  */
-template<typename TypeSupportBuilder>
-class CFTDynamicPubSubReader : public PubSubReader<fastrtps::types::DynamicPubSubType, TypeSupportBuilder>
+template<typename TypeTraits>
+class CFTDynamicPubSubReader : public PubSubReader<fastrtps::types::DynamicPubSubType, TypeTraits>
 {
 public:
 
@@ -747,8 +859,10 @@ public:
             const std::string& topic_name,
             const std::string& filter_expression,
             const std::vector<std::string>& expression_parameters)
-        : PubSubReader<fastrtps::types::DynamicPubSubType, TypeSupportBuilder>(topic_name, filter_expression,
-                expression_parameters)
+        : PubSubReader<fastrtps::types::DynamicPubSubType, TypeTraits>(
+            topic_name,
+            filter_expression,
+            expression_parameters)
     {
     }
 
@@ -801,12 +915,12 @@ TEST(DDSContentFilter, OnlyFilterAliveChanges)
 
     /* Create reader with CFT */
     std::string expression = "index = 1";
-    CFTDynamicPubSubReader<DynamicTypeSupportBuilder> reader("TestTopic", expression, {});
+    CFTDynamicPubSubReader<DynamicTypeTraits> reader("TestTopic", expression, {});
     reader.reliability(RELIABLE_RELIABILITY_QOS).history_depth(2).init();
     ASSERT_TRUE(reader.isInitialized());
 
     /* Create writer */
-    PubSubWriter<fastrtps::types::DynamicPubSubType, DynamicTypeSupportBuilder> writer("TestTopic");
+    PubSubWriter<fastrtps::types::DynamicPubSubType, DynamicTypeTraits> writer("TestTopic");
     writer.reliability(RELIABLE_RELIABILITY_QOS).history_depth(2).init();
     ASSERT_TRUE(writer.isInitialized());
 
@@ -821,17 +935,20 @@ TEST(DDSContentFilter, OnlyFilterAliveChanges)
     for (size_t i = 0; i < num_samples; ++i)
     {
         DynamicData* data = static_cast<DynamicData*>(writer.get_type_support().create_data());
-        data->set_uint16_value(static_cast<uint16_t>(i),
-                static_cast<fastrtps::types::MemberId>(DynamicTypeSupportBuilder::KeyedHelloWorldMembers::
-                        KEY));
-        data->set_uint16_value(1u,
-                static_cast<fastrtps::types::MemberId>(DynamicTypeSupportBuilder::KeyedHelloWorldMembers::
-                        INDEX));
-        std::cout << "Sent data" << std::endl;
-        InstanceHandle_t handle = writer.get_native_writer().register_instance(data);
+
+        data->set_uint16_value(
+            static_cast<uint16_t>(i),
+            static_cast<fastrtps::types::MemberId>(DynamicTypeTraits::KeyedHelloWorldMembers::KEY));
+
+        data->set_uint16_value(
+            1u,
+            static_cast<fastrtps::types::MemberId>(DynamicTypeTraits::KeyedHelloWorldMembers::INDEX));
+
+        InstanceHandle_t handle = writer.register_instance(*data);
         ASSERT_NE(HANDLE_NIL, handle);
-        ASSERT_EQ(ReturnCode_t::RETCODE_OK, writer.get_native_writer().write(data, handle));
-        ASSERT_EQ(ReturnCode_t::RETCODE_OK, writer.get_native_writer().unregister_instance(data, handle));
+        ASSERT_EQ(ReturnCode_t::RETCODE_OK, writer.send_sample(*data, handle));
+        ASSERT_EQ(true, writer.unregister_instance(*data, handle));
+
         writer.get_type_support().delete_data(data);
     }
 

--- a/test/blackbox/common/DDSBlackboxTestsContentFilter.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsContentFilter.cpp
@@ -821,7 +821,7 @@ TEST(DDSContentFilter, OnlyFilterAliveChanges)
     for (size_t i = 0; i < num_samples; ++i)
     {
         DynamicData* data = static_cast<DynamicData*>(writer.get_type_support().create_data());
-        data->set_uint16_value(i,
+        data->set_uint16_value(static_cast<uint16_t>(i),
                 static_cast<fastrtps::types::MemberId>(DynamicTypeSupportBuilder::KeyedHelloWorldMembers::
                         KEY));
         data->set_uint16_value(1u,

--- a/test/blackbox/types/dynamic_types_traits.hpp
+++ b/test/blackbox/types/dynamic_types_traits.hpp
@@ -1,0 +1,238 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file dynamic_types_traits.hpp
+ *
+ */
+
+#ifndef _FASTDDS_TEST_DYNAMIC_TYPES_TRAITS_HPP_
+#define _FASTDDS_TEST_DYNAMIC_TYPES_TRAITS_HPP_
+
+#include <iostream>
+#include <string>
+
+#include <fastdds/dds/topic/TypeSupport.hpp>
+#include <fastrtps/types/DynamicData.h>
+#include <fastrtps/types/DynamicLoanableSequence.hpp>
+#include <fastrtps/types/DynamicPubSubType.h>
+#include <fastrtps/types/DynamicTypeBuilderFactory.h>
+#include <fastrtps/types/DynamicTypeBuilderPtr.h>
+#include <fastrtps/types/DynamicTypePtr.h>
+#include <fastrtps/types/TypesBase.h>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+
+/**
+ * @brief PubSubTypeTraits for the PubSubReader and PubSubWriter
+ *
+ * This struct enables instantiation of a PubSubReader and PubSubWriter with a DynamicTypeSupport
+ * for a type equivalent to that of KeyedHelloWorld.idl.
+ * That and the fact that this builder sets the auto_fill_type_object flag to true allow for instance to create a
+ * PubSubReader with a content filter, which right now is not possible to do with the Fast DDS generated
+ * TypeSupport, as it does not contain the TypeObject code.
+ *
+ * To use it, do one of:
+ *   - PubSubReader<fastrtps::types::DynamicPubSubType, DynamicKeyedHelloworldTypeTraits> reader;
+ *   - PubSubWriter<fastrtps::types::DynamicPubSubType, DynamicKeyedHelloworldTypeTraits> writer;
+ */
+struct DynamicKeyedHelloworldTypeTraits
+{
+    using DataListType = fastrtps::types::DynamicData*;
+
+    /**
+     * Define the members ids of the struct for readability
+     */
+    enum class KeyedHelloWorldMembers : fastrtps::types::MemberId
+    {
+        KEY = 0,
+        INDEX = 1,
+        MESSAGE = 2
+    };
+
+    /**
+     * @brief Build the DynamicTypeSupport for the KeyedHelloWorld type
+     *
+     * @param[out] type_support The type support to be reset
+     */
+    static void build_type_support(
+            TypeSupport& type_support)
+    {
+        // Create type support
+        type_support.reset(new fastrtps::types::DynamicPubSubType(get_type()));
+
+        // Set the autofill type object to true so that TypeObject is registered upon type registration
+        type_support->auto_fill_type_object(true);
+    }
+
+    /**
+     * @brief Build a DynamicLoanableSequence of the specific type
+     *
+     * @return The DynamicLoanableSequence
+     */
+    static DynamicLoanableSequence build_loanable_sequence()
+    {
+        return DynamicLoanableSequence(get_type());
+    }
+
+    /**
+     * @brief Compare two data instances
+     *
+     * PubSubReader and PubSubWriter compare data within std::find_if calls to remove elements from
+     * their message lists. For Fast DDS Gen generated types, the TypeSupport::type and the type used
+     * for data list elements is the same. However, for the case of DynamicData, the DataListType needs
+     * to be a DynamicData*, as the DynamicData ctor and dtor are protected and so they cannot be called to remove elements from the message lists.
+     * This leads to the need to compare datas of different types when finding elements, as the sent or received data would be a DynamicDaa, whereas the list elements are DynamicData* (a.k.a DataListType).
+     *
+     * @param data1 The compared element (DynamicData)
+     * @param data2 The list element (DataListType)
+     *
+     * @return True if equal, false otherwise
+     */
+    static bool compare_data(
+            const fastrtps::types::DynamicData& data1,
+            const DataListType& data2)
+    {
+        return data1.equals(data2);
+    }
+
+    /**
+     * @brief Print the received data
+     *
+     * @param data DynamicData to be printed
+     */
+    static void print_received_data(
+            const fastrtps::types::DynamicData* data)
+    {
+        print_received_data(*data);
+    }
+
+    /**
+     * @brief Print the received data
+     *
+     * @param data DynamicData to be printed
+     */
+    static void print_received_data(
+            const fastrtps::types::DynamicData& data)
+    {
+        print_data_msg("Received", data);
+    }
+
+    /**
+     * @brief Print the sent data
+     *
+     * @param data DynamicData to be printed
+     */
+    static void print_sent_data(
+            const fastrtps::types::DynamicData* data)
+    {
+        print_sent_data(*data);
+    }
+
+    /**
+     * @brief Print the sent data
+     *
+     * @param data DynamicData to be printed
+     */
+    static void print_sent_data(
+            const fastrtps::types::DynamicData& data)
+    {
+        print_data_msg("Sent", data);
+    }
+
+private:
+
+    /**
+     * @brief Get the specific DynamicType equivalent to the KeyedHelloWorld.idl type
+     *
+     * @return The DynamicType_ptr
+     */
+    static fastrtps::types::DynamicType_ptr get_type()
+    {
+        // Using statics here in combination with std::call_once to avoid rebuilding the type every time.
+        // As the DynamicTypes API is shared_ptr based, we don't need to delete these references manually.
+        static std::once_flag once_flag;
+        static fastrtps::types::DynamicTypeBuilder_ptr struct_builder;
+        static fastrtps::types::DynamicTypeBuilder_ptr key_member_builder;
+        static fastrtps::types::DynamicType_ptr key_member;
+        static fastrtps::types::DynamicType_ptr struct_type;
+
+        std::call_once(once_flag, [&]()
+                {
+                    // Create the struct type builder
+                    const std::string topic_type_name = "keyed_hello_world";
+                    struct_builder = fastrtps::types::DynamicTypeBuilderFactory::get_instance()->create_struct_builder();
+                    struct_builder->set_name(topic_type_name);
+
+                    // Create the key member with the @key annotation
+                    key_member_builder = fastrtps::types::DynamicTypeBuilderFactory::get_instance()->create_uint16_builder();
+                    key_member_builder->apply_annotation(fastrtps::types::ANNOTATION_KEY_ID, "value", "true");
+                    key_member = key_member_builder->build();
+
+                    // Add members to the struct builder
+                    struct_builder->add_member(
+                        static_cast<fastrtps::types::MemberId>(KeyedHelloWorldMembers::KEY),
+                        "key",
+                        key_member);
+
+                    struct_builder->add_member(
+                        static_cast<fastrtps::types::MemberId>(KeyedHelloWorldMembers::INDEX),
+                        "index",
+                        fastrtps::types::DynamicTypeBuilderFactory::get_instance()->create_uint16_type());
+
+                    struct_builder->add_member(
+                        static_cast<fastrtps::types::MemberId>(KeyedHelloWorldMembers::MESSAGE),
+                        "message",
+                        fastrtps::types::DynamicTypeBuilderFactory::get_instance()->create_string_type(128));
+
+                    // Build the type
+                    struct_type = struct_builder->build();
+                });
+
+        return struct_type;
+    }
+
+    /**
+     * @brief Print a data message
+     *
+     * @param intro Introduction message
+     * @param data DynamicData to be printed.
+     *
+     * @pre data must have been built using the type returned by get_type(), that is through the DynamicTypeSupport
+     * created by build_type_support().
+     */
+    static void print_data_msg(
+            const std::string& intro,
+            const fastrtps::types::DynamicData& data)
+    {
+        auto key_value =
+                data.get_uint16_value(static_cast<fastrtps::types::MemberId>(KeyedHelloWorldMembers::KEY));
+        auto index_value =
+                data.get_uint16_value(static_cast<fastrtps::types::MemberId>(KeyedHelloWorldMembers::INDEX));
+        auto message_value =
+                data.get_string_value(static_cast<fastrtps::types::MemberId>(KeyedHelloWorldMembers::MESSAGE));
+
+        std::cout << intro << " data: (" << key_value << ", " << index_value << ", \"" << message_value << "\")" <<
+            std::endl;
+    }
+
+};
+
+} // namespace dds
+} // namespace fastdds
+} // namespace eprosima
+
+#endif // _FASTDDS_TEST_DYNAMIC_TYPES_TRAITS_HPP_

--- a/test/unittest/dds/publisher/CMakeLists.txt
+++ b/test/unittest/dds/publisher/CMakeLists.txt
@@ -160,6 +160,7 @@ set(DATAWRITERTESTS_SOURCE DataWriterTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/participant/RTPSParticipant.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/persistence/PersistenceFactory.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/reader_utils.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/RTPSReader.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/StatefulPersistentReader.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/StatefulReader.cpp

--- a/test/unittest/statistics/dds/CMakeLists.txt
+++ b/test/unittest/statistics/dds/CMakeLists.txt
@@ -235,6 +235,7 @@ if (SQLITE3_SUPPORT AND FASTDDS_STATISTICS AND NOT QNX)
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/persistence/PersistenceFactory.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/persistence/sqlite3.c
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/persistence/SQLite3PersistenceService.cpp
+        ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/reader_utils.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/RTPSReader.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/StatefulPersistentReader.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/StatefulReader.cpp
@@ -436,6 +437,7 @@ if (SQLITE3_SUPPORT AND FASTDDS_STATISTICS AND NOT QNX)
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/persistence/PersistenceFactory.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/persistence/sqlite3.c
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/persistence/SQLite3PersistenceService.cpp
+        ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/reader_utils.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/RTPSReader.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/StatefulPersistentReader.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/reader/StatefulReader.cpp


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Backport of #4835 to 2.x

This PR fixes a bug that caused the content filter to also be applied to `unregister` and `disposed` samples. Since in those messages the only fields populated (if any) are the ones annotated with `@key`, the `unregister` and `dispose` samples did not pass the filter (in general) and thus were being discarded. This caused several issues:

1. When writing to more than 10 instances with default Qos (keep last 1, max_instances 10), only the first 10 samples were been received.
2. In best effort, when setting the history depth and max instances appropriately, all samples were received, but calls to `unregister` or `dispose` followed by a `write` were triggering `sample_lost` events, as the received sequence numbers were not consecutive (because of the filtering out of the `unregister`/`dispose`).

This PR fixes these issues by only querying for sample relevance when the `CacheChange` kind is `ALIVE`.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
