### PR TITLE
[21096] Feature: use PID_DOMAIN_ID during PDP

### DIFF
--- a/include/fastdds/dds/core/Types.hpp
+++ b/include/fastdds/dds/core/Types.hpp
@@ -23,6 +23,8 @@ namespace dds {
 
 typedef uint32_t DomainId_t;
 
+const DomainId_t c_DomainId_t_Unknown = 0xFFFFFFFF;
+
 const int32_t LENGTH_UNLIMITED = -1;
 
 } // namespace dds

--- a/include/fastdds/dds/core/Types.hpp
+++ b/include/fastdds/dds/core/Types.hpp
@@ -23,7 +23,7 @@ namespace dds {
 
 typedef uint32_t DomainId_t;
 
-const DomainId_t c_DomainId_t_Unknown = 0xFFFFFFFF;
+const DomainId_t DOMAIN_ID_UNKNOWN = 0xFFFFFFFF;
 
 const int32_t LENGTH_UNLIMITED = -1;
 

--- a/include/fastdds/dds/core/policy/ParameterTypes.hpp
+++ b/include/fastdds/dds/core/policy/ParameterTypes.hpp
@@ -528,6 +528,43 @@ public:
 /**
  * @ingroup PARAMETER_MODULE
  */
+class ParameterDomainId_t : public Parameter_t
+{
+public:
+
+    //!Domain ID. <br> By default, 0.
+    uint32_t domain_id;
+
+    /**
+     * @brief Constructor without parameters
+     */
+    ParameterDomainId_t()
+        : domain_id(0)
+    {
+    }
+
+    /**
+     * Constructor using a parameter PID and the parameter length
+     *
+     * @param pid Pid of the parameter
+     * @param in_length Its associated length
+     */
+    ParameterDomainId_t(
+            ParameterId_t pid,
+            uint16_t in_length)
+        : Parameter_t(pid, in_length)
+        , domain_id(0)
+    {
+        domain_id = 0;
+    }
+
+};
+
+#define PARAMETER_DOMAINID_LENGTH 4
+
+/**
+ * @ingroup PARAMETER_MODULE
+ */
 class ParameterProtocolVersion_t : public Parameter_t
 {
 public:

--- a/include/fastdds/dds/core/policy/ParameterTypes.hpp
+++ b/include/fastdds/dds/core/policy/ParameterTypes.hpp
@@ -27,6 +27,7 @@
 
 #include <fastcdr/cdr/fixed_size_string.hpp>
 
+#include <fastdds/dds/core/Types.hpp>
 #include <fastdds/rtps/common/InstanceHandle.h>
 #include <fastdds/rtps/common/Locator.h>
 #include <fastdds/rtps/common/SampleIdentity.h>
@@ -532,14 +533,14 @@ class ParameterDomainId_t : public Parameter_t
 {
 public:
 
-    //!Domain ID. <br> By default, 0.
+    //!Domain ID. <br> By default, DOMAIN_ID_UNKNOWN.
     uint32_t domain_id;
 
     /**
      * @brief Constructor without parameters
      */
     ParameterDomainId_t()
-        : domain_id(0)
+        : domain_id(DOMAIN_ID_UNKNOWN)
     {
     }
 
@@ -553,9 +554,9 @@ public:
             ParameterId_t pid,
             uint16_t in_length)
         : Parameter_t(pid, in_length)
-        , domain_id(0)
+        , domain_id(DOMAIN_ID_UNKNOWN)
     {
-        domain_id = 0;
+        domain_id = DOMAIN_ID_UNKNOWN;
     }
 
 };

--- a/include/fastdds/rtps/builtin/data/ParticipantProxyData.hpp
+++ b/include/fastdds/rtps/builtin/data/ParticipantProxyData.hpp
@@ -25,6 +25,7 @@
 #include <chrono>
 
 #include <fastdds/dds/core/policy/QosPolicies.hpp>
+#include <fastdds/dds/core/Types.hpp>
 #include <fastdds/rtps/attributes/ReaderAttributes.h>
 #include <fastdds/rtps/attributes/RTPSParticipantAllocationAttributes.hpp>
 #include <fastdds/rtps/attributes/WriterAttributes.h>
@@ -77,6 +78,8 @@ public:
     GUID_t m_guid;
     //!Vendor ID
     fastdds::rtps::VendorId_t m_VendorId;
+    //!Domain ID
+    fastdds::dds::DomainId_t m_domain_id;
     //!Expects Inline QOS.
     bool m_expectsInlineQos;
     //!Available builtin endpoints

--- a/include/fastdds/rtps/transport/test_UDPv4TransportDescriptor.h
+++ b/include/fastdds/rtps/transport/test_UDPv4TransportDescriptor.h
@@ -47,8 +47,16 @@ struct test_UDPv4TransportDescriptor : public SocketTransportDescriptor
     //! Test shim parameters
     //! Percentage of data messages being dropped
     mutable std::atomic<uint8_t> dropDataMessagesPercentage;
+    //! Percentage of Data[P] messages being dropped
+    mutable std::atomic<uint8_t> dropParticipantBuiltinDataMessagesPercentage;
+    //! Percentage of Data[W] messages being dropped
+    mutable std::atomic<uint8_t> dropPublicationBuiltinDataMessagesPercentage;
+    //! Percentage of Data[R] messages being dropped
+    mutable std::atomic<uint8_t> dropSubscriptionBuiltinDataMessagesPercentage;
     //! Filtering function for dropping data messages
     filter drop_data_messages_filter_;
+    //! Filtering function for dropping builtin data messages
+    filter drop_builtin_data_messages_filter_;
     //! Flag to enable dropping of discovery Participant DATA(P) messages
     bool dropParticipantBuiltinTopicData;
     //! Flag to enable dropping of discovery Writer DATA(W) messages

--- a/include/fastrtps/qos/ParameterTypes.h
+++ b/include/fastrtps/qos/ParameterTypes.h
@@ -53,6 +53,7 @@ using ParameterPort_t = fastdds::dds::ParameterPort_t;
 using ParameterGuid_t = fastdds::dds::ParameterGuid_t;
 using ParameterProtocolVersion_t = fastdds::dds::ParameterProtocolVersion_t;
 using ParameterVendorId_t = fastdds::dds::ParameterVendorId_t;
+using ParameterDomainId_t = fastdds::dds::ParameterDomainId_t;
 using ParameterIP4Address_t = fastdds::dds::ParameterIP4Address_t;
 using ParameterBool_t = fastdds::dds::ParameterBool_t;
 using ParameterStatusInfo_t = fastdds::dds::ParameterStatusInfo_t;

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -131,6 +131,7 @@ set(${PROJECT_NAME}_source_files
     rtps/builtin/discovery/participant/DirectMessageSender.cpp
     rtps/builtin/discovery/participant/PDP.cpp
     rtps/builtin/discovery/participant/PDPClient.cpp
+    rtps/builtin/discovery/participant/PDPClientListener.cpp
     rtps/builtin/discovery/participant/PDPListener.cpp
     rtps/builtin/discovery/participant/PDPServer.cpp
     rtps/builtin/discovery/participant/PDPServerListener.cpp

--- a/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
@@ -434,6 +434,31 @@ inline bool ParameterSerializer<ParameterVendorId_t>::read_content_from_cdr_mess
 }
 
 template<>
+inline bool ParameterSerializer<ParameterDomainId_t>::add_content_to_cdr_message(
+        const ParameterDomainId_t& parameter,
+        fastrtps::rtps::CDRMessage_t* cdr_message)
+{
+    bool valid = fastrtps::rtps::CDRMessage::addUInt32(cdr_message, parameter.domain_id);
+    return valid;
+}
+
+template<>
+inline bool ParameterSerializer<ParameterDomainId_t>::read_content_from_cdr_message(
+        ParameterDomainId_t& parameter,
+        fastrtps::rtps::CDRMessage_t* cdr_message,
+        const uint16_t parameter_length)
+{
+    if (parameter_length != PARAMETER_VENDOR_LENGTH)
+    {
+        return false;
+    }
+    parameter.length = parameter_length;
+    bool valid = fastrtps::rtps::CDRMessage::readUInt32(cdr_message, &parameter.domain_id);
+    cdr_message->pos += 2; //padding
+    return valid;
+}
+
+template<>
 inline bool ParameterSerializer<ParameterIP4Address_t>::add_content_to_cdr_message(
         const ParameterIP4Address_t& parameter,
         fastrtps::rtps::CDRMessage_t* cdr_message)

--- a/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
@@ -438,8 +438,7 @@ inline bool ParameterSerializer<ParameterDomainId_t>::add_content_to_cdr_message
         const ParameterDomainId_t& parameter,
         fastrtps::rtps::CDRMessage_t* cdr_message)
 {
-    bool valid = fastrtps::rtps::CDRMessage::addUInt32(cdr_message, parameter.domain_id);
-    return valid;
+    return fastrtps::rtps::CDRMessage::addUInt32(cdr_message, parameter.domain_id);
 }
 
 template<>
@@ -448,14 +447,12 @@ inline bool ParameterSerializer<ParameterDomainId_t>::read_content_from_cdr_mess
         fastrtps::rtps::CDRMessage_t* cdr_message,
         const uint16_t parameter_length)
 {
-    if (parameter_length != PARAMETER_VENDOR_LENGTH)
+    if (parameter_length != PARAMETER_DOMAINID_LENGTH)
     {
         return false;
     }
     parameter.length = parameter_length;
-    bool valid = fastrtps::rtps::CDRMessage::readUInt32(cdr_message, &parameter.domain_id);
-    cdr_message->pos += 2; //padding
-    return valid;
+    return fastrtps::rtps::CDRMessage::readUInt32(cdr_message, &parameter.domain_id);
 }
 
 template<>

--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
@@ -52,7 +52,7 @@ ParticipantProxyData::ParticipantProxyData(
         const RTPSParticipantAllocationAttributes& allocation)
     : m_protocolVersion(c_ProtocolVersion)
     , m_VendorId(c_VendorId_Unknown)
-    , m_domain_id(fastdds::dds::c_DomainId_t_Unknown)
+    , m_domain_id(fastdds::dds::DOMAIN_ID_UNKNOWN)
     , m_expectsInlineQos(false)
     , m_availableBuiltinEndpoints(0)
     , m_networkConfiguration(0)
@@ -154,7 +154,7 @@ uint32_t ParticipantProxyData::get_serialized_size(
     ret_val += 4 + 4;
 
     // PID_DOMAIN_ID
-    ret_val += 4 + 4;
+    ret_val += 4 + PARAMETER_DOMAINID_LENGTH;
 
     if (m_expectsInlineQos)
     {
@@ -765,7 +765,7 @@ void ParticipantProxyData::clear()
     m_guid = GUID_t();
     //set_VendorId_Unknown(m_VendorId);
     m_VendorId = c_VendorId_Unknown;
-    m_domain_id = fastdds::dds::c_DomainId_t_Unknown;
+    m_domain_id = fastdds::dds::DOMAIN_ID_UNKNOWN;
     m_expectsInlineQos = false;
     m_availableBuiltinEndpoints = 0;
     m_networkConfiguration = 0;

--- a/src/cpp/rtps/builtin/discovery/participant/DS/PDPSecurityInitiatorListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/DS/PDPSecurityInitiatorListener.cpp
@@ -86,6 +86,18 @@ void PDPSecurityInitiatorListener::process_alive_data(
 
 }
 
+bool PDPSecurityInitiatorListener::check_discovery_conditions(
+        ParticipantProxyData& /* participant_data */,
+        void* /* extra data*/)
+{
+    /* Do not check PID_VENDOR_ID */
+    // In Discovery Server we don't impose
+    // domain ids to be the same
+    /* Do not check PID_DOMAIN_ID */
+    /* Do not check PARTICIPANT_TYPE */
+    return true;
+}
+
 } /* namespace rtps */
 } /* namespace fastrtps */
 } /* namespace eprosima */

--- a/src/cpp/rtps/builtin/discovery/participant/DS/PDPSecurityInitiatorListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/DS/PDPSecurityInitiatorListener.cpp
@@ -87,8 +87,7 @@ void PDPSecurityInitiatorListener::process_alive_data(
 }
 
 bool PDPSecurityInitiatorListener::check_discovery_conditions(
-        ParticipantProxyData& /* participant_data */,
-        void* /* extra data*/)
+        ParticipantProxyData& /* participant_data */)
 {
     /* Do not check PID_VENDOR_ID */
     // In Discovery Server we don't impose

--- a/src/cpp/rtps/builtin/discovery/participant/DS/PDPSecurityInitiatorListener.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/DS/PDPSecurityInitiatorListener.hpp
@@ -55,6 +55,10 @@ public:
 
 protected:
 
+    bool check_discovery_conditions(
+            ParticipantProxyData& participant_data,
+            void* extra_data) override;
+
     void process_alive_data(
             ParticipantProxyData* old_data,
             ParticipantProxyData& new_data,

--- a/src/cpp/rtps/builtin/discovery/participant/DS/PDPSecurityInitiatorListener.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/DS/PDPSecurityInitiatorListener.hpp
@@ -56,8 +56,7 @@ public:
 protected:
 
     bool check_discovery_conditions(
-            ParticipantProxyData& participant_data,
-            void* extra_data) override;
+            ParticipantProxyData& participant_data) override;
 
     void process_alive_data(
             ParticipantProxyData* old_data,

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -232,6 +232,7 @@ void PDP::initializeParticipantProxyData(
     RTPSParticipantAttributes& attributes = mp_RTPSParticipant->getAttributes();
     bool announce_locators = !mp_RTPSParticipant->is_intraprocess_only();
 
+    participant_data->m_domain_id = mp_RTPSParticipant->get_domain_id();
     participant_data->m_leaseDuration = attributes.builtin.discovery_config.leaseDuration;
     //set_VendorId_eProsima(participant_data->m_VendorId);
     participant_data->m_VendorId = c_VendorId_eProsima;

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <rtps/builtin/discovery/participant/PDPClient.h>
+#include <rtps/builtin/discovery/participant/PDPClientListener.hpp>
 
 #include <algorithm>
 #include <forward_list>
@@ -357,7 +358,7 @@ bool PDPClient::create_ds_pdp_reliable_endpoints(
     }
 #endif // HAVE_SECURITY
 
-    endpoints.reader.listener_.reset(new PDPListener(this));
+    endpoints.reader.listener_.reset(new PDPClientListener(this));
 
     RTPSReader* reader = nullptr;
 #if HAVE_SECURITY

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClientListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClientListener.cpp
@@ -1,0 +1,64 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file PDPClientListener.cpp
+ *
+ */
+
+#include <rtps/builtin/discovery/participant/PDPClientListener.hpp>
+
+#include <mutex>
+
+#include <fastdds/core/policy/ParameterList.hpp>
+#include <fastdds/dds/log/Log.hpp>
+#include <fastdds/rtps/history/ReaderHistory.h>
+#include <fastdds/rtps/participant/ParticipantDiscoveryInfo.h>
+#include <fastdds/rtps/participant/RTPSParticipantListener.h>
+#include <fastdds/rtps/reader/RTPSReader.h>
+
+#include <rtps/builtin/discovery/endpoint/EDP.h>
+#include <rtps/builtin/discovery/participant/PDP.h>
+#include <rtps/builtin/discovery/participant/PDPEndpoints.hpp>
+#include <rtps/network/utils/external_locators.hpp>
+#include <rtps/participant/RTPSParticipantImpl.h>
+#include <rtps/resources/TimedEvent.h>
+
+using ParameterList = eprosima::fastdds::dds::ParameterList;
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+
+PDPClientListener::PDPClientListener(
+        PDP* parent_pdp)
+    : PDPListener(parent_pdp)
+{
+}
+
+bool PDPClientListener::check_discovery_conditions(
+    ParticipantProxyData& /* participant_data */,
+    void* /* extra data*/)
+{
+    /* Do not check PID_VENDOR_ID */
+    // In Discovery Server we don't impose
+    // domain ids to be the same
+    /* Do not check PID_DOMAIN_ID */
+    /* Do not check PARTICIPANT_TYPE */
+    return true;
+}
+
+} /* namespace rtps */
+} /* namespace fastrtps */
+} /* namespace eprosima */

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClientListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClientListener.cpp
@@ -48,8 +48,8 @@ PDPClientListener::PDPClientListener(
 }
 
 bool PDPClientListener::check_discovery_conditions(
-    ParticipantProxyData& /* participant_data */,
-    void* /* extra data*/)
+        ParticipantProxyData& /* participant_data */,
+        void* /* extra data*/)
 {
     /* Do not check PID_VENDOR_ID */
     // In Discovery Server we don't impose

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClientListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClientListener.cpp
@@ -48,8 +48,7 @@ PDPClientListener::PDPClientListener(
 }
 
 bool PDPClientListener::check_discovery_conditions(
-        ParticipantProxyData& /* participant_data */,
-        void* /* extra data*/)
+        ParticipantProxyData& /* participant_data */)
 {
     /* Do not check PID_VENDOR_ID */
     // In Discovery Server we don't impose

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClientListener.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClientListener.hpp
@@ -1,0 +1,62 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file PDPClientListener.h
+ *
+ */
+
+#ifndef _FASTDDS_RTPS_PDPCLIENTLISTENER_H_
+#define _FASTDDS_RTPS_PDPCLIENTLISTENER_H_
+#ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+
+#include <rtps/builtin/discovery/participant/PDPListener.h>
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+
+/**
+ * Class PDPClientListener used by a PDP discovery client.
+ * This class is implemented in order to use the same structure than with any other RTPSReader.
+ * @ingroup DISCOVERY_MODULE
+ */
+class PDPClientListener : public PDPListener
+{
+
+public:
+
+    /**
+     * @param parent Pointer to object creating this object
+     */
+    PDPClientListener(
+            PDP* parent);
+
+    virtual ~PDPClientListener() override = default;
+
+protected:
+
+    bool check_discovery_conditions(
+            ParticipantProxyData& pdata,
+            void* extra_data) override;
+
+};
+
+
+} /* namespace rtps */
+} /* namespace fastrtps */
+} /* namespace eprosima */
+
+#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+#endif /* _FASTDDS_RTPS_PDPCLIENTLISTENER_H_ */

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClientListener.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClientListener.hpp
@@ -19,7 +19,6 @@
 
 #ifndef _FASTDDS_RTPS_PDPCLIENTLISTENER_H_
 #define _FASTDDS_RTPS_PDPCLIENTLISTENER_H_
-#ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 #include <rtps/builtin/discovery/participant/PDPListener.h>
 
@@ -48,8 +47,7 @@ public:
 protected:
 
     bool check_discovery_conditions(
-            ParticipantProxyData& pdata,
-            void* extra_data) override;
+            ParticipantProxyData& pdata) override;
 
 };
 
@@ -58,5 +56,4 @@ protected:
 } /* namespace fastrtps */
 } /* namespace eprosima */
 
-#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #endif /* _FASTDDS_RTPS_PDPCLIENTLISTENER_H_ */

--- a/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
@@ -114,9 +114,7 @@ void PDPListener::on_new_cache_change_added(
                 return;
             }
 
-            void* empty_extra_data = nullptr;
-            static_cast<void>(empty_extra_data);
-            if (!check_discovery_conditions(temp_participant_data_, empty_extra_data))
+            if (!check_discovery_conditions(temp_participant_data_))
             {
                 return;
             }
@@ -282,8 +280,7 @@ void PDPListener::process_alive_data(
 }
 
 bool PDPListener::check_discovery_conditions(
-        ParticipantProxyData& participant_data,
-        void* /*extra_data*/)
+        ParticipantProxyData& participant_data)
 {
     bool ret = true;
     uint32_t remote_participant_domain_id = participant_data.m_domain_id;
@@ -291,7 +288,7 @@ bool PDPListener::check_discovery_conditions(
     // In PDPSimple, do not match if the participant is from a different domain.
     // If the domain id is unknown, it is assumed to be the same domain
     if (remote_participant_domain_id != parent_pdp_->getRTPSParticipant()->get_domain_id() &&
-            remote_participant_domain_id != fastdds::dds::c_DomainId_t_Unknown)
+            remote_participant_domain_id != fastdds::dds::DOMAIN_ID_UNKNOWN)
     {
         EPROSIMA_LOG_INFO(RTPS_PDP_DISCOVERY, "Received participant with different domain id ("
                 << remote_participant_domain_id << ") than ours ("

--- a/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
@@ -114,6 +114,13 @@ void PDPListener::on_new_cache_change_added(
                 return;
             }
 
+            void* empty_extra_data = nullptr;
+            static_cast<void>(empty_extra_data);
+            if (!check_discovery_conditions(temp_participant_data_, empty_extra_data))
+            {
+                return;
+            }
+
             // Filter locators
             const auto& pattr = parent_pdp_->getRTPSParticipant()->getAttributes();
             fastdds::rtps::network::external_locators::filter_remote_locators(temp_participant_data_,
@@ -272,6 +279,27 @@ void PDPListener::process_alive_data(
 
     // Take again the reader lock
     reader->getMutex().lock();
+}
+
+bool PDPListener::check_discovery_conditions(
+        ParticipantProxyData& participant_data,
+        void* /*extra_data*/)
+{
+    bool ret = true;
+    uint32_t remote_participant_domain_id = participant_data.m_domain_id;
+
+    // In PDPSimple, do not match if the participant is from a different domain.
+    // If the domain id is unknown, it is assumed to be the same domain
+    if (remote_participant_domain_id != parent_pdp_->getRTPSParticipant()->get_domain_id() &&
+            remote_participant_domain_id != fastdds::dds::c_DomainId_t_Unknown)
+    {
+        EPROSIMA_LOG_INFO(RTPS_PDP_DISCOVERY, "Received participant with different domain id ("
+                << remote_participant_domain_id << ") than ours ("
+                << parent_pdp_->getRTPSParticipant()->get_domain_id() << ")");
+        ret = false;
+    }
+
+    return ret;
 }
 
 bool PDPListener::get_key(

--- a/src/cpp/rtps/builtin/discovery/participant/PDPListener.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPListener.h
@@ -81,6 +81,19 @@ protected:
             std::unique_lock<std::recursive_mutex>& lock);
 
     /**
+     * Checks discovery conditions of an incoming DATA(p).
+     * This method is called from PDPListener::onNewCacheChangeAdded() just right after
+     * having deserialized the DATA(p) message.
+     *
+     * @param [in]      pdata      ParticipantProxyData from the DATA(p) message.
+     * @param [in, out] extra_data Additional data that may be needed to check the discovery conditions.
+     * @remarks Whether discovery routine should continue or discard the participant.
+     */
+    virtual bool check_discovery_conditions(
+            ParticipantProxyData& participant_data,
+            void* extra_data);
+
+    /**
      * Get the key of a CacheChange_t
      * @param change Pointer to the CacheChange_t
      * @return True on success

--- a/src/cpp/rtps/builtin/discovery/participant/PDPListener.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPListener.h
@@ -86,12 +86,10 @@ protected:
      * having deserialized the DATA(p) message.
      *
      * @param [in]      pdata      ParticipantProxyData from the DATA(p) message.
-     * @param [in, out] extra_data Additional data that may be needed to check the discovery conditions.
      * @remarks Whether discovery routine should continue or discard the participant.
      */
     virtual bool check_discovery_conditions(
-            ParticipantProxyData& participant_data,
-            void* extra_data);
+            ParticipantProxyData& participant_data);
 
     /**
      * Get the key of a CacheChange_t

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
@@ -148,98 +148,16 @@ void PDPServerListener::on_new_cache_change_added(
                 return;
             }
 
+            bool is_client = true;
+            if (!check_discovery_conditions(participant_data, &is_client))
+            {
+                return;
+            }
+
             const auto& pattr = pdp_server()->getRTPSParticipant()->getAttributes();
             fastdds::rtps::network::external_locators::filter_remote_locators(participant_data,
                     pattr.builtin.metatraffic_external_unicast_locators, pattr.default_external_unicast_locators,
                     pattr.ignore_non_matching_locators);
-
-            /* Check PID_VENDOR_ID */
-            if (participant_data.m_VendorId != fastrtps::rtps::c_VendorId_eProsima)
-            {
-                EPROSIMA_LOG_INFO(RTPS_PDP_LISTENER,
-                        "DATA(p|Up) from different vendor is not supported for Discover-Server operation");
-                return;
-            }
-
-            fastdds::dds::ParameterPropertyList_t properties = participant_data.m_properties;
-
-            /* Check DS_VERSION */
-            auto ds_version = std::find_if(
-                properties.begin(),
-                properties.end(),
-                [](const dds::ParameterProperty_t& property)
-                {
-                    return property.first() == dds::parameter_property_ds_version;
-                });
-
-            if (ds_version != properties.end())
-            {
-                if (std::stof(ds_version->second()) < 1.0)
-                {
-                    EPROSIMA_LOG_ERROR(RTPS_PDP_LISTENER, "Minimum " << dds::parameter_property_ds_version
-                                                                     << " is 1.0, found: " << ds_version->second());
-                    return;
-                }
-                EPROSIMA_LOG_INFO(RTPS_PDP_LISTENER, "Participant " << dds::parameter_property_ds_version << ": "
-                                                                    << ds_version->second());
-            }
-            else
-            {
-                EPROSIMA_LOG_INFO(RTPS_PDP_LISTENER, dds::parameter_property_ds_version << " is not set. Assuming 1.0");
-            }
-
-            /* Check PARTICIPANT_TYPE */
-            bool is_client = true;
-            auto participant_type = std::find_if(
-                properties.begin(),
-                properties.end(),
-                [](const dds::ParameterProperty_t& property)
-                {
-                    return property.first() == dds::parameter_property_participant_type;
-                });
-
-            if (participant_type != properties.end())
-            {
-                if (participant_type->second() == ParticipantType::SERVER ||
-                        participant_type->second() == ParticipantType::BACKUP ||
-                        participant_type->second() == ParticipantType::SUPER_CLIENT)
-                {
-                    is_client = false;
-                }
-                else if (participant_type->second() == ParticipantType::SIMPLE)
-                {
-                    EPROSIMA_LOG_INFO(RTPS_PDP_LISTENER, "Ignoring " << dds::parameter_property_participant_type << ": "
-                                                                     << participant_type->second());
-                    return;
-                }
-                else if (participant_type->second() != ParticipantType::CLIENT)
-                {
-                    EPROSIMA_LOG_ERROR(RTPS_PDP_LISTENER, "Wrong " << dds::parameter_property_participant_type << ": "
-                                                                   << participant_type->second());
-                    return;
-                }
-                EPROSIMA_LOG_INFO(RTPS_PDP_LISTENER, "Participant type " << participant_type->second());
-            }
-            else
-            {
-                EPROSIMA_LOG_INFO(RTPS_PDP_LISTENER, dds::parameter_property_participant_type << " is not set");
-                // Fallback to checking whether participant is a SERVER looking for the persistence GUID
-                auto persistence_guid = std::find_if(
-                    properties.begin(),
-                    properties.end(),
-                    [](const dds::ParameterProperty_t& property)
-                    {
-                        return property.first() == dds::parameter_property_persistence_guid;
-                    });
-                // The presence of persistence GUID property suggests a SERVER. This assumption is made to keep
-                // backwards compatibility with Discovery Server v1.0. However, any participant that has been configured
-                // as persistent will have this property.
-                if (persistence_guid != properties.end())
-                {
-                    is_client = false;
-                }
-                EPROSIMA_LOG_INFO(RTPS_PDP_LISTENER, "Participant is client: " << std::boolalpha << is_client);
-            }
 
             // Check whether the participant is a client/server of this server or if it has been forwarded from
             //  another entity (server).
@@ -441,6 +359,114 @@ void PDPServerListener::on_new_cache_change_added(
             " --------------------");
     EPROSIMA_LOG_INFO(RTPS_PDP_LISTENER, "------------------ PDP SERVER LISTENER END ------------------");
     EPROSIMA_LOG_INFO(RTPS_PDP_LISTENER, "");
+}
+
+bool PDPServerListener::check_discovery_conditions(
+        ParticipantProxyData& participant_data,
+        void* extra_data /* bool is_client*/)
+{
+    bool ret = true;
+
+    /* Check PID_VENDOR_ID */
+    if (participant_data.m_VendorId != fastrtps::rtps::c_VendorId_eProsima)
+    {
+        EPROSIMA_LOG_INFO(RTPS_PDP_LISTENER,
+                "DATA(p|Up) from different vendor is not supported for Discover-Server operation");
+        ret = false;
+    }
+
+    // In Discovery Server we don't impose
+    // domain ids to be the same
+    /* Do not check PID_DOMAIN_ID */
+
+    fastdds::dds::ParameterPropertyList_t properties = participant_data.m_properties;
+
+    /* Check DS_VERSION */
+    if (ret)
+    {
+        auto ds_version = std::find_if(
+            properties.begin(),
+            properties.end(),
+            [](const dds::ParameterProperty_t& property)
+            {
+                return property.first() == dds::parameter_property_ds_version;
+            });
+
+        if (ds_version != properties.end())
+        {
+            if (std::stof(ds_version->second()) < 1.0)
+            {
+                EPROSIMA_LOG_ERROR(RTPS_PDP_LISTENER, "Minimum " << dds::parameter_property_ds_version
+                                                                 << " is 1.0, found: " << ds_version->second());
+                ret = false;
+            }
+            EPROSIMA_LOG_INFO(RTPS_PDP_LISTENER, "Participant " << dds::parameter_property_ds_version << ": "
+                                                                << ds_version->second());
+        }
+        else
+        {
+            EPROSIMA_LOG_INFO(RTPS_PDP_LISTENER, dds::parameter_property_ds_version << " is not set. Assuming 1.0");
+        }
+    }
+
+    /* Check PARTICIPANT_TYPE */
+    if (ret)
+    {
+        auto participant_type = std::find_if(
+            properties.begin(),
+            properties.end(),
+            [](const dds::ParameterProperty_t& property)
+            {
+                return property.first() == dds::parameter_property_participant_type;
+            });
+
+        if (participant_type != properties.end())
+        {
+            if (participant_type->second() == ParticipantType::SERVER ||
+                    participant_type->second() == ParticipantType::BACKUP ||
+                    participant_type->second() == ParticipantType::SUPER_CLIENT)
+            {
+                *static_cast<bool*>(extra_data) = false;
+            }
+            else if (participant_type->second() == ParticipantType::SIMPLE)
+            {
+                EPROSIMA_LOG_INFO(RTPS_PDP_LISTENER, "Ignoring " << dds::parameter_property_participant_type << ": "
+                                                                 << participant_type->second());
+                ret = false;
+            }
+            else if (participant_type->second() != ParticipantType::CLIENT)
+            {
+                EPROSIMA_LOG_ERROR(RTPS_PDP_LISTENER, "Wrong " << dds::parameter_property_participant_type << ": "
+                                                               << participant_type->second());
+                ret = false;
+            }
+            EPROSIMA_LOG_INFO(RTPS_PDP_LISTENER, "Participant type " << participant_type->second());
+        }
+        else
+        {
+            EPROSIMA_LOG_INFO(RTPS_PDP_LISTENER, dds::parameter_property_participant_type << " is not set");
+            // Fallback to checking whether participant is a SERVER looking for the persistence GUID
+            auto persistence_guid = std::find_if(
+                properties.begin(),
+                properties.end(),
+                [](const dds::ParameterProperty_t& property)
+                {
+                    return property.first() == dds::parameter_property_persistence_guid;
+                });
+            // The presence of persistence GUID property suggests a SERVER. This assumption is made to keep
+            // backwards compatibility with Discovery Server v1.0. However, any participant that has been configured
+            // as persistent will have this property.
+            if (persistence_guid != properties.end())
+            {
+                // is_client = false
+                *static_cast<bool*>(extra_data) = false;
+            }
+            EPROSIMA_LOG_INFO(RTPS_PDP_LISTENER,
+                    "Participant is client: " << std::boolalpha << *static_cast<bool*>(extra_data));
+        }
+    }
+
+    return ret;
 }
 
 } /* namespace rtps */

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.hpp
@@ -58,6 +58,12 @@ public:
     void on_new_cache_change_added(
             fastrtps::rtps::RTPSReader* reader,
             const fastrtps::rtps::CacheChange_t* const change) override;
+
+protected:
+
+    bool check_discovery_conditions(
+            fastrtps::rtps::ParticipantProxyData& participant_data,
+            void* extra_data) override;
 };
 
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.hpp
@@ -61,9 +61,16 @@ public:
 
 protected:
 
-    bool check_discovery_conditions(
-            fastrtps::rtps::ParticipantProxyData& participant_data,
-            void* extra_data) override;
+    /**
+     * Checks discovery conditions on a discovery server entity.
+     * Essentially, it checks for incoming PIDS of remote proxy datas.
+     * @param participant_data Remote participant data to check.
+     * @return A pair of booleans.
+     * The first one indicates if the remote participant data is valid.
+     * The second one indicates if the remote participant data is a client.
+     */
+    std::pair<bool, bool> check_server_discovery_conditions(
+            fastrtps::rtps::ParticipantProxyData& participant_data);
 };
 
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -278,6 +278,12 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     , has_shm_transport_(false)
     , match_local_endpoints_(should_match_local_endpoints(PParam))
 {
+    if (domain_id_ == fastdds::dds::DOMAIN_ID_UNKNOWN)
+    {
+        EPROSIMA_LOG_ERROR(RTPS_PARTICIPANT, "Domain ID has to be set to a correct value");
+        return;
+    }
+
     if (c_GuidPrefix_Unknown != persistence_guid)
     {
         m_persistence_guid = GUID_t(persistence_guid, c_EntityId_RTPSParticipant);

--- a/src/cpp/rtps/transport/test_UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.cpp
@@ -45,7 +45,11 @@ test_UDPv4TransportDescriptor::DestinationLocatorFilter test_UDPv4Transport::loc
 test_UDPv4Transport::test_UDPv4Transport(
         const test_UDPv4TransportDescriptor& descriptor)
     : drop_data_messages_percentage_(descriptor.dropDataMessagesPercentage)
+    , drop_participant_builtin_data_messages_percentage_(descriptor.dropParticipantBuiltinDataMessagesPercentage)
+    , drop_publication_builtin_data_messages_percentage_(descriptor.dropPublicationBuiltinDataMessagesPercentage)
+    , drop_subscription_builtin_data_messages_percentage_(descriptor.dropSubscriptionBuiltinDataMessagesPercentage)
     , drop_data_messages_filter_(descriptor.drop_data_messages_filter_)
+    , drop_builtin_data_messages_filter_(descriptor.drop_builtin_data_messages_filter_)
     , drop_participant_builtin_topic_data_(descriptor.dropParticipantBuiltinTopicData)
     , drop_publication_builtin_topic_data_(descriptor.dropPublicationBuiltinTopicData)
     , drop_subscription_builtin_topic_data_(descriptor.dropSubscriptionBuiltinTopicData)
@@ -78,13 +82,17 @@ test_UDPv4Transport::test_UDPv4Transport(
 test_UDPv4TransportDescriptor::test_UDPv4TransportDescriptor()
     : SocketTransportDescriptor(s_maximumMessageSize, s_maximumInitialPeersRange)
     , dropDataMessagesPercentage(0)
+    , dropParticipantBuiltinDataMessagesPercentage(0)
+    , dropPublicationBuiltinDataMessagesPercentage(0)
+    , dropSubscriptionBuiltinDataMessagesPercentage(0)
     , drop_data_messages_filter_([](CDRMessage_t&)
             {
                 return false;
             })
-    , dropParticipantBuiltinTopicData(false)
-    , dropPublicationBuiltinTopicData(false)
-    , dropSubscriptionBuiltinTopicData(false)
+    , drop_builtin_data_messages_filter_([](CDRMessage_t&)
+            {
+                return false;
+            })
     , dropDataFragMessagesPercentage(0)
     , drop_data_frag_messages_filter_([](CDRMessage_t&)
             {
@@ -376,6 +384,14 @@ bool test_UDPv4Transport::packet_should_drop(
                     {
                         return true;
                     }
+                    else if (should_be_dropped(&drop_participant_builtin_data_messages_percentage_))
+                    {
+                        return true;
+                    }
+                    else if (drop_builtin_data_messages_filter_(cdrMessage))
+                    {
+                        return true;
+                    }
                 }
                 else if (writer_id == fastrtps::rtps::c_EntityId_SEDPPubWriter)
                 {
@@ -383,10 +399,26 @@ bool test_UDPv4Transport::packet_should_drop(
                     {
                         return true;
                     }
+                    else if (should_be_dropped(&drop_publication_builtin_data_messages_percentage_))
+                    {
+                        return true;
+                    }
+                    else if (drop_builtin_data_messages_filter_(cdrMessage))
+                    {
+                        return true;
+                    }
                 }
                 else if (writer_id == fastrtps::rtps::c_EntityId_SEDPSubWriter)
                 {
                     if (drop_subscription_builtin_topic_data_)
+                    {
+                        return true;
+                    }
+                    else if (should_be_dropped(&drop_subscription_builtin_data_messages_percentage_))
+                    {
+                        return true;
+                    }
+                    else if (drop_builtin_data_messages_filter_(cdrMessage))
                     {
                         return true;
                     }

--- a/src/cpp/rtps/transport/test_UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.cpp
@@ -93,6 +93,9 @@ test_UDPv4TransportDescriptor::test_UDPv4TransportDescriptor()
             {
                 return false;
             })
+    , dropParticipantBuiltinTopicData(false)
+    , dropPublicationBuiltinTopicData(false)
+    , dropSubscriptionBuiltinTopicData(false)
     , dropDataFragMessagesPercentage(0)
     , drop_data_frag_messages_filter_([](CDRMessage_t&)
             {

--- a/src/cpp/rtps/transport/test_UDPv4Transport.h
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.h
@@ -85,7 +85,11 @@ private:
     };
 
     PercentageData drop_data_messages_percentage_;
+    PercentageData drop_participant_builtin_data_messages_percentage_;
+    PercentageData drop_publication_builtin_data_messages_percentage_;
+    PercentageData drop_subscription_builtin_data_messages_percentage_;
     test_UDPv4TransportDescriptor::filter drop_data_messages_filter_;
+    test_UDPv4TransportDescriptor::filter drop_builtin_data_messages_filter_;
     bool drop_participant_builtin_topic_data_;
     bool drop_publication_builtin_topic_data_;
     bool drop_subscription_builtin_topic_data_;

--- a/test/blackbox/CMakeLists.txt
+++ b/test/blackbox/CMakeLists.txt
@@ -173,6 +173,10 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/builtin_transports_profile.xml
     ${CMAKE_CURRENT_BINARY_DIR}/builtin_transports_profile.xml)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/auth_handshake_props_profile.xml
     ${CMAKE_CURRENT_BINARY_DIR}/auth_handshake_props_profile.xml COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/discovery_participants_initial_peers_profile.xml
+    ${CMAKE_CURRENT_BINARY_DIR}/discovery_participants_initial_peers_profile.xml)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/discovery_participants_client_server_profile.xml
+    ${CMAKE_CURRENT_BINARY_DIR}/discovery_participants_client_server_profile.xml)
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/datagrams" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
 
 if(FASTDDS_PIM_API_TESTS)

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -304,6 +304,7 @@ public:
         , status_mask_(eprosima::fastdds::dds::StatusMask::all())
         , topic_name_(topic_name)
         , initialized_(false)
+        , use_domain_id_from_profile_(false)
         , matched_(0)
         , participant_matched_(0)
         , receiving_(false)
@@ -401,11 +402,21 @@ public:
             DomainParticipantFactory::get_instance()->load_XML_profiles_file(xml_file_);
             if (!participant_profile_.empty())
             {
-                participant_ = DomainParticipantFactory::get_instance()->create_participant_with_profile(
-                    (uint32_t)GET_PID() % 230,
-                    participant_profile_,
-                    &participant_listener_,
-                    eprosima::fastdds::dds::StatusMask::none());
+                if (use_domain_id_from_profile_)
+                {
+                    participant_ = DomainParticipantFactory::get_instance()->create_participant_with_profile(
+                        participant_profile_,
+                        &participant_listener_,
+                        eprosima::fastdds::dds::StatusMask::none());
+                }
+                else
+                {
+                    participant_ = DomainParticipantFactory::get_instance()->create_participant_with_profile(
+                        (uint32_t)GET_PID() % 230,
+                        participant_profile_,
+                        &participant_listener_,
+                        eprosima::fastdds::dds::StatusMask::none());
+                }
                 ASSERT_NE(participant_, nullptr);
                 ASSERT_TRUE(participant_->is_enabled());
             }
@@ -1819,6 +1830,14 @@ public:
         participant_profile_ = profile;
     }
 
+    void set_participant_profile(
+            const std::string& profile,
+            bool use_domain_id_from_profile)
+    {
+        set_participant_profile(profile);
+        use_domain_id_from_profile_ = use_domain_id_from_profile;
+    }
+
     void set_datareader_profile(
             const std::string& profile)
     {
@@ -2084,6 +2103,7 @@ protected:
     eprosima::fastrtps::rtps::GUID_t participant_guid_;
     eprosima::fastrtps::rtps::GUID_t datareader_guid_;
     bool initialized_;
+    bool use_domain_id_from_profile_;
     std::list<type> total_msgs_;
     std::mutex mutex_;
     std::condition_variable cv_;

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -291,6 +291,7 @@ public:
         , datawriter_(nullptr)
         , status_mask_(eprosima::fastdds::dds::StatusMask::all())
         , initialized_(false)
+        , use_domain_id_from_profile_(false)
         , matched_(0)
         , participant_matched_(0)
         , discovery_result_(false)
@@ -364,11 +365,22 @@ public:
             DomainParticipantFactory::get_instance()->load_XML_profiles_file(xml_file_);
             if (!participant_profile_.empty())
             {
-                participant_ = DomainParticipantFactory::get_instance()->create_participant_with_profile(
-                    (uint32_t)GET_PID() % 230,
-                    participant_profile_,
-                    &participant_listener_,
-                    eprosima::fastdds::dds::StatusMask::none());
+                if (use_domain_id_from_profile_)
+                {
+                    participant_ = DomainParticipantFactory::get_instance()->create_participant_with_profile(
+                        participant_profile_,
+                        &participant_listener_,
+                        eprosima::fastdds::dds::StatusMask::none());
+                }
+                else
+                {
+                    participant_ = DomainParticipantFactory::get_instance()->create_participant_with_profile(
+                        (uint32_t)GET_PID() % 230,
+                        participant_profile_,
+                        &participant_listener_,
+                        eprosima::fastdds::dds::StatusMask::none());
+                }
+
                 ASSERT_NE(participant_, nullptr);
                 ASSERT_TRUE(participant_->is_enabled());
             }
@@ -1672,6 +1684,14 @@ public:
         participant_profile_ = profile;
     }
 
+    void set_participant_profile(
+            const std::string& profile,
+            bool use_domain_id_from_profile)
+    {
+        set_participant_profile(profile);
+        use_domain_id_from_profile_ = use_domain_id_from_profile;
+    }
+
     void set_datawriter_profile(
             const std::string& profile)
     {
@@ -1978,6 +1998,7 @@ protected:
     eprosima::fastrtps::rtps::GUID_t participant_guid_;
     eprosima::fastrtps::rtps::GUID_t datawriter_guid_;
     bool initialized_;
+    bool use_domain_id_from_profile_;
     std::mutex mutexDiscovery_;
     std::condition_variable cv_;
     std::atomic<unsigned int> matched_;

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -2194,7 +2194,8 @@ TEST(Discovery, discovery_cyclone_participant_with_custom_pid)
 
     /* Create participant with custom transport and listener */
     DiscoveryListener listener;
-    uint32_t domain_id = static_cast<uint32_t>(GET_PID()) % 230;
+    /* We need to match the domain id in the datagram */
+    uint32_t domain_id = 0;
     DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
     DomainParticipant* participant = factory->create_participant(domain_id, participant_qos, &listener);
     ASSERT_NE(nullptr, participant);

--- a/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
@@ -2034,7 +2034,6 @@ TEST(DDSDiscovery, pdp_simple_participants_exchange_same_pid_domain_id_and_disco
  * do not discover each other despite the first one is initial peer of the second.
  *
  */
-
 TEST(DDSDiscovery, pdp_simple_initial_peer_participants_with_different_domain_ids_do_not_discover)
 {
     PubSubWriter<HelloWorldPubSubType> writer_domain_1(TEST_TOPIC_NAME);
@@ -2064,7 +2063,6 @@ TEST(DDSDiscovery, pdp_simple_initial_peer_participants_with_different_domain_id
  * discover each other.
  *
  */
-
 TEST(DDSDiscovery, client_server_participants_with_different_domain_ids_discover)
 {
     PubSubReader<HelloWorldPubSubType> server_domain_1(TEST_TOPIC_NAME);

--- a/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
@@ -102,14 +102,15 @@ public:
 
     void setup(
             std::string profiles_file,
-            std::string profile)
+            std::string profile,
+            uint32_t domain_id)
     {
         //! Load XML profiles
         eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->load_XML_profiles_file(profiles_file);
 
         eprosima::fastdds::dds::DomainParticipant* participant =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->
-                        create_participant_with_profile((uint32_t)GET_PID() % 230, profile);
+                        create_participant_with_profile(domain_id, profile);
 
         setup(participant);
     }
@@ -1205,11 +1206,11 @@ TEST(DDSMonitorServiceTest, monitor_service_property)
     MonitorServiceParticipant MSP;
 
     //! Procedure
-    MSP.setup(xml_file, participant_profile_names.first);
+    MSP.setup(xml_file, participant_profile_names.first, 0);
     ASSERT_EQ(eprosima::fastdds::dds::RETCODE_OK, MSP.disable_monitor_service());
 
     MSP.reset();
-    MSP.setup(xml_file, participant_profile_names.second);
+    MSP.setup(xml_file, participant_profile_names.second, 0);
 
     //! Assertions
     ASSERT_EQ(eprosima::fastdds::dds::RETCODE_OK, MSP.disable_monitor_service());
@@ -1350,8 +1351,8 @@ TEST(DDSMonitorServiceTest, monitor_service_simple_connection_list)
     std::pair<std::string, std::string> participant_profiles =
     {"monitor_service_connections_list_participant_1", "monitor_service_connections_list_participant_2"};
 
-    MSP1.setup(xml_profile, participant_profiles.first);
-    MSP2.setup(xml_profile, participant_profiles.second);
+    MSP1.setup(xml_profile, participant_profiles.first, 0);
+    MSP2.setup(xml_profile, participant_profiles.second, 0);
 
     MSP1.enable_monitor_service();
     MSP2.enable_monitor_service();

--- a/test/blackbox/discovery_participants_client_server_profile.xml
+++ b/test/blackbox/discovery_participants_client_server_profile.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"  ?>
+<dds xmlns="http://www.eprosima.com">
+    <profiles>
+        <participant profile_name="ds_server">
+            <domainId>1</domainId>
+            <rtps>
+                <prefix>44.53.00.5f.45.50.52.4f.53.49.4d.41</prefix>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>SERVER</discoveryProtocol>
+                    </discovery_config>
+                    <metatrafficUnicastLocatorList>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>14521</port>
+                            </udpv4>
+                        </locator>
+                    </metatrafficUnicastLocatorList>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <participant profile_name="ds_client_pub">
+            <domainId>2</domainId>
+            <rtps>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
+                                <metatrafficUnicastLocatorList>
+                                    <locator>
+                                        <udpv4>
+                                            <address>127.0.0.1</address>
+                                            <port>14521</port>
+                                        </udpv4>
+                                    </locator>
+                                </metatrafficUnicastLocatorList>
+                            </RemoteServer>
+                        </discoveryServersList>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <participant profile_name="ds_client_sub">
+            <domainId>3</domainId>
+            <rtps>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
+                                <metatrafficUnicastLocatorList>
+                                    <locator>
+                                        <udpv4>
+                                            <address>127.0.0.1</address>
+                                            <port>14521</port>
+                                        </udpv4>
+                                    </locator>
+                                </metatrafficUnicastLocatorList>
+                            </RemoteServer>
+                        </discoveryServersList>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+    </profiles>
+</dds>

--- a/test/blackbox/discovery_participants_initial_peers_profile.xml
+++ b/test/blackbox/discovery_participants_initial_peers_profile.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"  ?>
+<dds xmlns="http://www.eprosima.com">
+    <profiles>
+        <transport_descriptors>
+            <transport_descriptor>
+                    <transport_id>transport</transport_id>
+                    <type>UDPv4</type>
+            </transport_descriptor>
+        </transport_descriptors>
+
+        <participant profile_name="participant_from_domain_1">
+            <domainId>1</domainId>
+            <rtps>
+                <name>Participant.domain1</name>
+                <builtinTransports>NONE</builtinTransports>
+                <!--
+                    Need to add at least one transport in
+                    order to be able to create the participant
+                -->
+                <userTransports>
+                    <transport_id>transport</transport_id>
+                </userTransports>
+                <builtin>
+                    <initialPeersList>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>7412</port>
+                            </udpv4>
+                        </locator>
+                    </initialPeersList>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <participant profile_name="participant_from_domain_2">
+            <domainId>2</domainId>
+            <rtps>
+                <name>Participant.domain2</name>
+                <builtinTransports>NONE</builtinTransports>
+                <!--
+                    Need to add at least one transport in
+                    order to be able to create the participant
+                -->
+                <userTransports>
+                    <transport_id>transport</transport_id>
+                </userTransports>
+                <builtin>
+                    <metatrafficUnicastLocatorList>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>7412</port>
+                            </udpv4>
+                        </locator>
+                    </metatrafficUnicastLocatorList>
+                    <metatrafficMulticastLocatorList>
+                        <locator>
+                            <udpv4>
+                                <port>7400</port>
+                                <address>239.255.0.1</address>
+                            </udpv4>
+                        </locator>
+                    </metatrafficMulticastLocatorList>
+                </builtin>
+            </rtps>
+        </participant>
+    </profiles>
+</dds>

--- a/test/blackbox/discovery_participants_initial_peers_profile.xml
+++ b/test/blackbox/discovery_participants_initial_peers_profile.xml
@@ -25,7 +25,7 @@
                         <locator>
                             <udpv4>
                                 <address>127.0.0.1</address>
-                                <port>7412</port>
+                                <port>11500</port>
                             </udpv4>
                         </locator>
                     </initialPeersList>
@@ -50,14 +50,14 @@
                         <locator>
                             <udpv4>
                                 <address>127.0.0.1</address>
-                                <port>7412</port>
+                                <port>11500</port>
                             </udpv4>
                         </locator>
                     </metatrafficUnicastLocatorList>
                     <metatrafficMulticastLocatorList>
                         <locator>
                             <udpv4>
-                                <port>7400</port>
+                                <port>11600</port>
                                 <address>239.255.0.1</address>
                             </udpv4>
                         </locator>

--- a/test/unittest/dds/publisher/CMakeLists.txt
+++ b/test/unittest/dds/publisher/CMakeLists.txt
@@ -98,6 +98,7 @@ set(DATAWRITERTESTS_SOURCE DataWriterTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/DirectMessageSender.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPClientListener.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp

--- a/test/unittest/rtps/reader/CMakeLists.txt
+++ b/test/unittest/rtps/reader/CMakeLists.txt
@@ -194,6 +194,7 @@ set(STATEFUL_READER_TESTS_SOURCE StatefulReaderTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/DirectMessageSender.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPClientListener.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp

--- a/test/unittest/statistics/dds/CMakeLists.txt
+++ b/test/unittest/statistics/dds/CMakeLists.txt
@@ -200,6 +200,7 @@ if (SQLITE3_SUPPORT AND FASTDDS_STATISTICS AND NOT QNX)
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/DirectMessageSender.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+        ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPClientListener.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
@@ -376,6 +377,7 @@ if (SQLITE3_SUPPORT AND FASTDDS_STATISTICS AND NOT QNX)
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/DirectMessageSender.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+        ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPClientListener.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp

--- a/versions.md
+++ b/versions.md
@@ -49,7 +49,7 @@ Forthcoming
   * `payload_owner` moved from `CacheChange_t` to `SerializedPayload_t`.
   * `SerializedPayload_t` copies are now forbidden.
   * Refactor of `get_payload` methods.
-
+* Use `PID_DOMAIN_ID` during PDP.
 
 Version 2.14.0
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds the `PID_DOMAIN_ID` parameter to the PDP discovery phase with the following considerations:

* `PID_DOMAIN_ID` is always sent.
* In `PDPSimple`, domains have either to be the same or not be defined in the remote incoming `ParticipantProxyData`.
* In `Discovery Server` we do not check the parameter since it is meant to operate across domains.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- ❌ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [X] New feature has been added to the `versions.md` file (if applicable).
- __NO__ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- __NO__ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
