### PR TITLE
[20822] Refactor Fast DDS Ubuntu CI with different workflows

### DIFF
--- a/.github/workflows/fastdds-build.yml
+++ b/.github/workflows/fastdds-build.yml
@@ -1,4 +1,4 @@
-name: Fast DDS Ubuntu CI - Fast DDS python build
+name: Fast DDS Ubuntu CI - Fast DDS build
 
 on:
   workflow_call:
@@ -33,7 +33,7 @@ defaults:
     shell: bash
 
 jobs:
-  fastdds_python_build:
+  fastdds_build:
     runs-on: ${{ inputs.os-image }}
     if: ${{ (
           !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
@@ -45,11 +45,19 @@ jobs:
         cmake-build-type:
           - 'RelWithDebInfo'
     steps:
-      - name: Download build artifacts
-        uses: eProsima/eProsima-CI/external/download-artifact@v0
+      - name: Add ci-pending label if PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: eProsima/eProsima-CI/external/add_labels@v0
         with:
-          name: fastdds_build_${{ inputs.label }}
-          path: ${{ github.workspace }}
+          labels: ci-pending
+          number: ${{ github.event.number }}
+          repo: eProsima/Fast-DDS
+
+      - name: Sync eProsima/Fast-DDS repository
+        uses: eProsima/eProsima-CI/external/checkout@v0
+        with:
+          path: src/fastdds
+          ref: ${{ inputs.fastdds-branch }}
 
       - name: Install Fix Python version
         uses: eProsima/eProsima-CI/external/setup-python@v0
@@ -61,49 +69,55 @@ jobs:
         with:
           cmakeVersion: '3.22.6'
 
-      - name: Install apt packages
+      - name: Install apt dependencies
         uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
         with:
-          packages: libasio-dev libtinyxml2-dev libssl-dev swig
+          packages: libasio-dev libtinyxml2-dev libssl-dev
+          update: false
+          upgrade: false
 
       - name: Install colcon
         uses: eProsima/eProsima-CI/ubuntu/install_colcon@v0
 
       - name: Install Python dependencies
-        uses: eProsima/eProsima-CI/ubuntu/install_python_packages@v0
+        uses: eProsima/eProsima-CI/multiplatform/install_python_packages@v0
         with:
-          packages: xmlschema
+          packages: vcstool xmlschema
+          upgrade: false
 
       - name: Setup CCache
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
 
-      - name: Get Fast DDS Python branch
-        id: get_fastdds_python_branch
-        uses: eProsima/eProsima-CI/ubuntu/get_related_branch_from_repo@v0
-        with:
-          remote_repository: eProsima/Fast-DDS-python
-          fallback_branch: ${{ inputs.fastdds_python_branch || 'main' }}
+      # TODO(eduponz): Set up libp11 and SoftHSM. NOTE: using SoftHSM requires adding the runner to a group,
+      #                which entails logout/login or rebooting the machine. This is not feasible in a CI environment.
 
-      - name: Download Fast DDS Python repo
-        uses: eProsima/eProsima-CI/external/checkout@v0
+      - name: Fetch Fast DDS dependencies
+        uses: eProsima/eProsima-CI/multiplatform/vcs_import@v0
         with:
-          repository: eProsima/Fast-DDS-python
-          path: src/fastdds-python
-          ref: ${{ steps.get_fastdds_python_branch.outputs.deduced_branch }}
+          vcs_repos_file: ${{ github.workspace }}/src/fastdds/fastdds.repos
+          destination_workspace: src
+          skip_existing: 'true'
+
+      - name: Fetch Fast DDS CI dependencies
+        uses: eProsima/eProsima-CI/multiplatform/vcs_import@v0
+        with:
+          vcs_repos_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/ci.repos
+          destination_workspace: src
+          skip_existing: 'true'
 
       - name: Colcon build
         continue-on-error: false
         uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
         with:
           colcon_meta_file: ''
-          colcon_build_args: '${{ inputs.colcon-args }} --executor parallel --mixin ccache --packages-up-to fastdds_python'
+          colcon_build_args: ${{ inputs.colcon-args }}
           cmake_args: ${{ inputs.cmake-args }}
-          cmake_args_default: ''
+          cmake_args_default: -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra -Wpedantic -Wunused-value -Woverloaded-virtual"
           cmake_build_type: ${{ matrix.cmake-build-type }}
           workspace: ${{ github.workspace }}
 
-      - name: Upload python build artifacts
+      - name: Upload build artifacts
         uses: eProsima/eProsima-CI/external/upload-artifact@v0
         with:
-          name: fastdds_python_build_${{ inputs.label }}
+          name: fastdds_build_${{ inputs.label }}
           path: ${{ github.workspace }}

--- a/.github/workflows/fastdds-docs-build-test.yml
+++ b/.github/workflows/fastdds-docs-build-test.yml
@@ -34,12 +34,11 @@ defaults:
 
 jobs:
   fastdds_docs_build_test:
-    needs: fastdds_python_build
+    runs-on: ${{ inputs.os-image }}
     if: ${{ (
           !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
           !contains(github.event.pull_request.labels.*.name, 'conflicts')
         ) }}
-    runs-on: ${{ inputs.os-image }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/fastdds-docs-build-test.yml
+++ b/.github/workflows/fastdds-docs-build-test.yml
@@ -1,0 +1,134 @@
+name: Fast DDS Ubuntu CI - Fast DDS Docs build test
+
+on:
+  workflow_call:
+    inputs:
+      os-image:
+        description: 'The OS image for the workflow'
+        required: true
+        type: string
+      label:
+        description: 'ID associated to the workflow'
+        required: true
+        type: string
+      colcon-args:
+        description: 'Extra arguments for colcon cli'
+        required: false
+        type: string
+      cmake-args:
+        description: 'Extra arguments for cmake cli'
+        required: false
+        type: string
+      ctest-args:
+        description: 'Extra arguments for ctest cli'
+        required: false
+        type: string
+      fastdds-branch:
+        description: 'Branch or tag of Fast DDS repository (https://github.com/eProsima/Fast-DDS)'
+        required: true
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  fastdds_docs_build_test:
+    needs: fastdds_python_build
+    if: ${{ (
+          !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+          !contains(github.event.pull_request.labels.*.name, 'conflicts')
+        ) }}
+    runs-on: ${{ inputs.os-image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        cmake-build-type:
+          - 'RelWithDebInfo'
+    steps:
+      - name: Download python build artifacts
+        uses: eProsima/eProsima-CI/external/download-artifact@v0
+        with:
+          name: fastdds_python_build_${{ inputs.label }}
+          path: ${{ github.workspace }}
+
+      - name: Install Fix Python version
+        uses: eProsima/eProsima-CI/external/setup-python@v0
+        with:
+          python-version: '3.11'
+
+      - name: Get minimum supported version of CMake
+        uses: eProsima/eProsima-CI/external/get-cmake@v0
+        with:
+          cmakeVersion: '3.22.6'
+
+      - name: Install apt packages
+        uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
+        with:
+          packages: libasio-dev libtinyxml2-dev libssl-dev swig doxygen imagemagick plantuml
+
+      - name: Install colcon
+        uses: eProsima/eProsima-CI/ubuntu/install_colcon@v0
+
+      - name: Install Python dependencies
+        uses: eProsima/eProsima-CI/ubuntu/install_python_packages@v0
+        with:
+          packages: xmlschema
+
+      - name: Setup CCache
+        uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
+
+      - name: Get Fast DDS Docs branch
+        id: get_fastdds_docs_branch
+        uses: eProsima/eProsima-CI/ubuntu/get_related_branch_from_repo@v0
+        with:
+          remote_repository: eProsima/Fast-DDS-docs
+          fallback_branch: ${{ inputs.fastdds_docs_branch || 'master' }}
+
+      - name: Download Fast DDS documentation repo
+        uses: eProsima/eProsima-CI/external/checkout@v0
+        with:
+          repository: eProsima/Fast-DDS-docs
+          path: src/fastdds-docs
+          ref: ${{ steps.get_fastdds_docs_branch.outputs.deduced_branch }}
+
+      - name: Install Fast DDS Docs required python packages
+        uses: eProsima/eProsima-CI/ubuntu/install_python_packages@v0
+        with:
+          upgrade: false
+          requirements_file_name: src/fastdds-docs/docs/requirements.txt
+
+      - name: Colcon build
+        continue-on-error: false
+        uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
+        with:
+          colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/documentation.meta
+          colcon_build_args: '${{ inputs.colcon-args }} --packages-up-to fastdds-docs'
+          cmake_args: ${{ inputs.cmake-args }}
+          cmake_args_default: ''
+          cmake_build_type: ${{ matrix.cmake-build-type }}
+          workspace: ${{ github.workspace }}
+
+      - name: Colcon test
+        id: docs_test
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') }}
+        uses: eProsima/eProsima-CI/multiplatform/colcon_test@v0
+        with:
+          colcon_test_args: ${{ inputs.colcon-args }}
+          colcon_test_args_default: --event-handlers=console_direct+
+          ctest_args: ${{ inputs.ctest-args }}
+          ctest_args_default: ''
+          packages_names: fastdds-docs
+          workspace: ${{ github.workspace }}
+          workspace_dependencies: ''
+          test_report_artifact: ${{ format('test_report_{0}_{1}_{2}', inputs.label, github.job, join(matrix.*, '_')) }}
+
+      - name: Fast DDS Docs test summary
+        uses: eProsima/eProsima-CI/multiplatform/junit_summary@v0
+        if: ${{ !cancelled() && !contains(github.event.pull_request.labels.*.name, 'no-test') }}
+        with:
+          junit_reports_dir: "${{ steps.docs_test.outputs.ctest_results_path }}"
+          print_summary: 'True'
+          show_failed: 'True'
+          show_disabled: 'False'
+          show_skipped: 'False'

--- a/.github/workflows/fastdds-ds-build-test.yml
+++ b/.github/workflows/fastdds-ds-build-test.yml
@@ -34,13 +34,11 @@ defaults:
 
 jobs:
   fastdds_discovery_server_build_test:
-    needs: fastdds_build
-
+    runs-on: ${{ inputs.os-image }}
     if: ${{ (
           !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
           !contains(github.event.pull_request.labels.*.name, 'conflicts')
         ) }}
-    runs-on: ${{ inputs.os-image }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/fastdds-ds-build-test.yml
+++ b/.github/workflows/fastdds-ds-build-test.yml
@@ -1,0 +1,129 @@
+name: Fast DDS Ubuntu CI - Fast DDS Discovery Server build test
+
+on:
+  workflow_call:
+    inputs:
+      os-image:
+        description: 'The OS image for the workflow'
+        required: true
+        type: string
+      label:
+        description: 'ID associated to the workflow'
+        required: true
+        type: string
+      colcon-args:
+        description: 'Extra arguments for colcon cli'
+        required: false
+        type: string
+      cmake-args:
+        description: 'Extra arguments for cmake cli'
+        required: false
+        type: string
+      ctest-args:
+        description: 'Extra arguments for ctest cli'
+        required: false
+        type: string
+      fastdds-branch:
+        description: 'Branch or tag of Fast DDS repository (https://github.com/eProsima/Fast-DDS)'
+        required: true
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  fastdds_discovery_server_build_test:
+    needs: fastdds_build
+
+    if: ${{ (
+          !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+          !contains(github.event.pull_request.labels.*.name, 'conflicts')
+        ) }}
+    runs-on: ${{ inputs.os-image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        cmake-build-type:
+          - 'RelWithDebInfo'
+    steps:
+      - name: Download build artifacts
+        uses: eProsima/eProsima-CI/external/download-artifact@v0
+        with:
+          name: fastdds_build_${{ inputs.label }}
+          path: ${{ github.workspace }}
+
+      - name: Install Fix Python version
+        uses: eProsima/eProsima-CI/external/setup-python@v0
+        with:
+          python-version: '3.11'
+
+      - name: Get minimum supported version of CMake
+        uses: eProsima/eProsima-CI/external/get-cmake@v0
+        with:
+          cmakeVersion: '3.22.6'
+
+      - name: Install apt packages
+        uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
+        with:
+          packages: libasio-dev libtinyxml2-dev libssl-dev
+
+      - name: Install colcon
+        uses: eProsima/eProsima-CI/ubuntu/install_colcon@v0
+
+      - name: Install Python dependencies
+        uses: eProsima/eProsima-CI/ubuntu/install_python_packages@v0
+        with:
+          packages: xmlschema
+
+      - name: Setup CCache
+        uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
+
+      - name: Get Discovery Server branch
+        id: get_discovery_server_branch
+        uses: eProsima/eProsima-CI/ubuntu/get_related_branch_from_repo@v0
+        with:
+          remote_repository: eProsima/Discovery-Server
+          fallback_branch: 'master'
+
+      - name: Download Discovery Server repo
+        uses: eProsima/eProsima-CI/external/checkout@v0
+        with:
+          repository: eProsima/Discovery-Server
+          path: src/discovery_server
+          ref: ${{ steps.get_discovery_server_branch.outputs.deduced_branch }}
+
+      - name: Colcon build
+        continue-on-error: false
+        uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
+        with:
+          colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/ci.meta
+          colcon_build_args: '${{ inputs.colcon-args }} --packages-up-to discovery-server'
+          cmake_args: ${{ inputs.cmake-args }}
+          cmake_args_default: -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra -Wpedantic -Wunused-value -Woverloaded-virtual"
+          cmake_build_type: ${{ matrix.cmake-build-type }}
+          workspace: ${{ github.workspace }}
+
+      - name: Colcon test
+        id: discovery_server_test
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') }}
+        uses: eProsima/eProsima-CI/multiplatform/colcon_test@v0
+        with:
+          colcon_test_args: ${{ inputs.colcon-args }}
+          colcon_test_args_default: --event-handlers=console_direct+
+          ctest_args: ${{ inputs.ctest-args }}
+          ctest_args_default: --repeat until-pass:3 --timeout 300 --label-exclude "xfail"
+          packages_names: discovery-server
+          workspace: ${{ github.workspace }}
+          workspace_dependencies: ''
+          test_report_artifact: ${{ format('test_report_{0}_{1}_{2}', inputs.label, github.job, join(matrix.*, '_')) }}
+
+      - name: Discovery server test summary
+        uses: eProsima/eProsima-CI/multiplatform/junit_summary@v0
+        if: ${{ !cancelled() && !contains(github.event.pull_request.labels.*.name, 'no-test') }}
+        with:
+          junit_reports_dir: "${{ steps.discovery_server_test.outputs.ctest_results_path }}"
+          print_summary: 'True'
+          show_failed: 'True'
+          show_disabled: 'False'
+          show_skipped: 'False'

--- a/.github/workflows/fastdds-python-build.yml
+++ b/.github/workflows/fastdds-python-build.yml
@@ -1,0 +1,110 @@
+name: Fast DDS Ubuntu CI - Fast DDS python build
+
+on:
+  workflow_call:
+    inputs:
+      os-image:
+        description: 'The OS image for the workflow'
+        required: true
+        type: string
+      label:
+        description: 'ID associated to the workflow'
+        required: true
+        type: string
+      colcon-args:
+        description: 'Extra arguments for colcon cli'
+        required: false
+        type: string
+      cmake-args:
+        description: 'Extra arguments for cmake cli'
+        required: false
+        type: string
+      ctest-args:
+        description: 'Extra arguments for ctest cli'
+        required: false
+        type: string
+      fastdds-branch:
+        description: 'Branch or tag of Fast DDS repository (https://github.com/eProsima/Fast-DDS)'
+        required: true
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  fastdds_python_build:
+    needs: fastdds_build
+    if: ${{ (
+          !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+          !contains(github.event.pull_request.labels.*.name, 'conflicts')
+        ) }}
+    runs-on: ${{ inputs.os-image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        cmake-build-type:
+          - 'RelWithDebInfo'
+    steps:
+      - name: Download build artifacts
+        uses: eProsima/eProsima-CI/external/download-artifact@v0
+        with:
+          name: fastdds_build_${{ inputs.label }}
+          path: ${{ github.workspace }}
+
+      - name: Install Fix Python version
+        uses: eProsima/eProsima-CI/external/setup-python@v0
+        with:
+          python-version: '3.11'
+
+      - name: Get minimum supported version of CMake
+        uses: eProsima/eProsima-CI/external/get-cmake@v0
+        with:
+          cmakeVersion: '3.22.6'
+
+      - name: Install apt packages
+        uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
+        with:
+          packages: libasio-dev libtinyxml2-dev libssl-dev swig
+
+      - name: Install colcon
+        uses: eProsima/eProsima-CI/ubuntu/install_colcon@v0
+
+      - name: Install Python dependencies
+        uses: eProsima/eProsima-CI/ubuntu/install_python_packages@v0
+        with:
+          packages: xmlschema
+
+      - name: Setup CCache
+        uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
+
+      - name: Get Fast DDS Python branch
+        id: get_fastdds_python_branch
+        uses: eProsima/eProsima-CI/ubuntu/get_related_branch_from_repo@v0
+        with:
+          remote_repository: eProsima/Fast-DDS-python
+          fallback_branch: ${{ inputs.fastdds_python_branch || 'main' }}
+
+      - name: Download Fast DDS Python repo
+        uses: eProsima/eProsima-CI/external/checkout@v0
+        with:
+          repository: eProsima/Fast-DDS-python
+          path: src/fastdds-python
+          ref: ${{ steps.get_fastdds_python_branch.outputs.deduced_branch }}
+
+      - name: Colcon build
+        continue-on-error: false
+        uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
+        with:
+          colcon_meta_file: ''
+          colcon_build_args: '${{ inputs.colcon-args }} --executor parallel --mixin ccache --packages-up-to fastdds_python'
+          cmake_args: ${{ inputs.cmake-args }}
+          cmake_args_default: ''
+          cmake_build_type: ${{ matrix.cmake-build-type }}
+          workspace: ${{ github.workspace }}
+
+      - name: Upload python build artifacts
+        uses: eProsima/eProsima-CI/external/upload-artifact@v0
+        with:
+          name: fastdds_python_build_${{ inputs.label }}
+          path: ${{ github.workspace }}

--- a/.github/workflows/fastdds-python-test.yml
+++ b/.github/workflows/fastdds-python-test.yml
@@ -34,13 +34,12 @@ defaults:
 
 jobs:
   fastdds_python_build_test:
-    needs: fastdds_python_build
+    runs-on: ${{ inputs.os-image }}
     if: ${{ (
           !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
           !contains(github.event.pull_request.labels.*.name, 'no-test') &&
           !contains(github.event.pull_request.labels.*.name, 'conflicts')
         ) }}
-    runs-on: ${{ inputs.os-image }}
     steps:
       - name: Download python build artifacts
         uses: eProsima/eProsima-CI/external/download-artifact@v0

--- a/.github/workflows/fastdds-python-test.yml
+++ b/.github/workflows/fastdds-python-test.yml
@@ -1,0 +1,110 @@
+name: Fast DDS Ubuntu CI - Fast DDS python test
+
+on:
+  workflow_call:
+    inputs:
+      os-image:
+        description: 'The OS image for the workflow'
+        required: true
+        type: string
+      label:
+        description: 'ID associated to the workflow'
+        required: true
+        type: string
+      colcon-args:
+        description: 'Extra arguments for colcon cli'
+        required: false
+        type: string
+      cmake-args:
+        description: 'Extra arguments for cmake cli'
+        required: false
+        type: string
+      ctest-args:
+        description: 'Extra arguments for ctest cli'
+        required: false
+        type: string
+      fastdds-branch:
+        description: 'Branch or tag of Fast DDS repository (https://github.com/eProsima/Fast-DDS)'
+        required: true
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  fastdds_python_build_test:
+    needs: fastdds_python_build
+    if: ${{ (
+          !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+          !contains(github.event.pull_request.labels.*.name, 'no-test') &&
+          !contains(github.event.pull_request.labels.*.name, 'conflicts')
+        ) }}
+    runs-on: ${{ inputs.os-image }}
+    steps:
+      - name: Download python build artifacts
+        uses: eProsima/eProsima-CI/external/download-artifact@v0
+        with:
+          name: fastdds_python_build_${{ inputs.label }}
+          path: ${{ github.workspace }}
+
+      - name: Install Fix Python version
+        uses: eProsima/eProsima-CI/external/setup-python@v0
+        with:
+          python-version: '3.11'
+
+      - name: Get minimum supported version of CMake
+        uses: eProsima/eProsima-CI/external/get-cmake@v0
+        with:
+          cmakeVersion: '3.22.6'
+
+      - name: Install apt packages
+        uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
+        with:
+          packages: libasio-dev libtinyxml2-dev libssl-dev swig
+
+      - name: Install colcon
+        uses: eProsima/eProsima-CI/ubuntu/install_colcon@v0
+
+      - name: Install Python dependencies
+        uses: eProsima/eProsima-CI/ubuntu/install_python_packages@v0
+        with:
+          packages: xmlschema
+
+      - name: Setup CCache
+        uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
+
+      - name: Colcon build
+        continue-on-error: false
+        uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
+        with:
+          colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/python_colcon.meta
+          colcon_build_args: '${{ inputs.colcon-args }} --executor parallel --mixin ccache --packages-up-to fastdds_python'
+          cmake_args: ${{ inputs.cmake-args }}
+          cmake_args_default: ''
+          cmake_build_type: ${{ matrix.cmake-build-type }}
+          workspace: ${{ github.workspace }}
+
+      - name: Colcon test
+        id: python_test
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') }}
+        uses: eProsima/eProsima-CI/multiplatform/colcon_test@v0
+        with:
+          colcon_test_args: ${{ inputs.colcon-args }}
+          colcon_test_args_default: --event-handlers=console_direct+
+          ctest_args: ${{ inputs.ctest-args }}
+          ctest_args_default: --repeat until-pass:3 --timeout 300 --label-exclude "xfail"
+          packages_names: fastdds_python
+          workspace: ${{ github.workspace }}
+          workspace_dependencies: ''
+          test_report_artifact: ${{ format('test_report_{0}_{1}_{2}', inputs.label, github.job, join(matrix.*, '_')) }}
+
+      - name: Fast DDS Python test summary
+        uses: eProsima/eProsima-CI/multiplatform/junit_summary@v0
+        if: ${{ !cancelled() && !contains(github.event.pull_request.labels.*.name, 'no-test') }}
+        with:
+          junit_reports_dir: "${{ steps.python_test.outputs.ctest_results_path }}"
+          print_summary: 'True'
+          show_failed: 'True'
+          show_disabled: 'False'
+          show_skipped: 'False'

--- a/.github/workflows/fastdds-test.yml
+++ b/.github/workflows/fastdds-test.yml
@@ -1,4 +1,4 @@
-name: Fast DDS Ubuntu CI - Fast DDS build
+name: Fast DDS Ubuntu CI - Fast DDS test
 
 on:
   workflow_call:
@@ -33,31 +33,20 @@ defaults:
     shell: bash
 
 jobs:
-  fastdds_build:
-    runs-on: ${{ inputs.os-image }}
+  fastdds_build_test:
+    needs: fastdds_build
     if: ${{ (
           !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+          !contains(github.event.pull_request.labels.*.name, 'no-test') &&
           !contains(github.event.pull_request.labels.*.name, 'conflicts')
         ) }}
-    strategy:
-      fail-fast: false
-      matrix:
-        cmake-build-type:
-          - 'RelWithDebInfo'
+    runs-on: ${{ inputs.os-image }}
     steps:
-      - name: Add ci-pending label if PR
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/add_labels@v0
+      - name: Download build artifacts
+        uses: eProsima/eProsima-CI/external/download-artifact@v0
         with:
-          labels: ci-pending
-          number: ${{ github.event.number }}
-          repo: eProsima/Fast-DDS
-
-      - name: Sync eProsima/Fast-DDS repository
-        uses: eProsima/eProsima-CI/external/checkout@v0
-        with:
-          path: src/fastdds
-          ref: ${{ inputs.fastdds-branch }}
+          name: fastdds_build_${{ inputs.label }}
+          path: ${{ github.workspace }}
 
       - name: Install Fix Python version
         uses: eProsima/eProsima-CI/external/setup-python@v0
@@ -69,21 +58,18 @@ jobs:
         with:
           cmakeVersion: '3.22.6'
 
-      - name: Install apt dependencies
+      - name: Install apt packages
         uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
         with:
           packages: libasio-dev libtinyxml2-dev libssl-dev
-          update: false
-          upgrade: false
 
       - name: Install colcon
         uses: eProsima/eProsima-CI/ubuntu/install_colcon@v0
 
       - name: Install Python dependencies
-        uses: eProsima/eProsima-CI/multiplatform/install_python_packages@v0
+        uses: eProsima/eProsima-CI/ubuntu/install_python_packages@v0
         with:
-          packages: vcstool xmlschema
-          upgrade: false
+          packages: xmlschema
 
       - name: Setup CCache
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
@@ -100,36 +86,36 @@ jobs:
           sudo echo "140.82.121.3 www.foo.com.test" | sudo tee -a /etc/hosts
           sudo echo "ff1e::ffff:efff:1 acme.org.test" | sudo tee -a /etc/hosts
 
-      # TODO(eduponz): Set up libp11 and SoftHSM. NOTE: using SoftHSM requires adding the runner to a group,
-      #                which entails logout/login or rebooting the machine. This is not feasible in a CI environment.
-
-      - name: Fetch Fast DDS dependencies
-        uses: eProsima/eProsima-CI/multiplatform/vcs_import@v0
-        with:
-          vcs_repos_file: ${{ github.workspace }}/src/fastdds/fastdds.repos
-          destination_workspace: src
-          skip_existing: 'true'
-
-      - name: Fetch Fast DDS CI dependencies
-        uses: eProsima/eProsima-CI/multiplatform/vcs_import@v0
-        with:
-          vcs_repos_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/ci.repos
-          destination_workspace: src
-          skip_existing: 'true'
-
       - name: Colcon build
         continue-on-error: false
         uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
         with:
-          colcon_meta_file: ''
+          colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/ci.meta
           colcon_build_args: ${{ inputs.colcon-args }}
           cmake_args: ${{ inputs.cmake-args }}
-          cmake_args_default: -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra -Wpedantic -Wunused-value -Woverloaded-virtual"
+          cmake_args_default: -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra -Wpedantic -Wunused-value -Woverloaded-virtual" -DFASTDDS_EXAMPLE_TESTS=ON
           cmake_build_type: ${{ matrix.cmake-build-type }}
           workspace: ${{ github.workspace }}
 
-      - name: Upload build artifacts
-        uses: eProsima/eProsima-CI/external/upload-artifact@v0
+      - name: Colcon test
+        id: test
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') }}
+        uses: eProsima/eProsima-CI/multiplatform/colcon_test@v0
         with:
-          name: fastdds_build_${{ inputs.label }}
-          path: ${{ github.workspace }}
+          colcon_test_args: ${{ inputs.colcon-args }}
+          colcon_test_args_default: --event-handlers=console_direct+
+          ctest_args: ${{ inputs.ctest-args }}
+          ctest_args_default: --repeat until-pass:3 --timeout 300 --label-exclude "xfail"
+          packages_names: fastdds
+          workspace: ${{ github.workspace }}
+          test_report_artifact: ${{ format('test_report_{0}_{1}_{2}', inputs.label, github.job, join(matrix.*, '_')) }}
+
+      - name: Fast DDS test summary
+        uses: eProsima/eProsima-CI/multiplatform/junit_summary@v0
+        if: ${{ !cancelled() && !contains(github.event.pull_request.labels.*.name, 'no-test') }}
+        with:
+          junit_reports_dir: "${{ steps.test.outputs.ctest_results_path }}"
+          print_summary: 'True'
+          show_failed: 'True'
+          show_disabled: 'False'
+          show_skipped: 'False'

--- a/.github/workflows/fastdds-test.yml
+++ b/.github/workflows/fastdds-test.yml
@@ -34,13 +34,12 @@ defaults:
 
 jobs:
   fastdds_build_test:
-    needs: fastdds_build
+    runs-on: ${{ inputs.os-image }}
     if: ${{ (
           !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
           !contains(github.event.pull_request.labels.*.name, 'no-test') &&
           !contains(github.event.pull_request.labels.*.name, 'conflicts')
         ) }}
-    runs-on: ${{ inputs.os-image }}
     steps:
       - name: Download build artifacts
         uses: eProsima/eProsima-CI/external/download-artifact@v0

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -38,10 +38,6 @@ concurrency:
 
 jobs:
   mac-ci:
-    if: ${{ (
-              !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
-              !contains(github.event.pull_request.labels.*.name, 'conflicts')
-            ) }}
     uses: ./.github/workflows/reusable-mac-ci.yml
     with:
       label: ${{ inputs.label || 'mac-ci' }}

--- a/.github/workflows/reusable-mac-ci.yml
+++ b/.github/workflows/reusable-mac-ci.yml
@@ -37,7 +37,11 @@ jobs:
     # so we'll use that one for now, as clang 15 is the supported compiler for Fast DDS in macOS.
     # (see https://github.com/eProsima/Fast-DDS/blob/master/PLATFORM_SUPPORT.md#compilers)
     runs-on: macos-13
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+    if: ${{ (
+          !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+          !contains(github.event.pull_request.labels.*.name, 'conflicts') &&
+          (inputs.run_asan_fastdds == true)
+        ) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/reusable-sanitizers-ci.yml
+++ b/.github/workflows/reusable-sanitizers-ci.yml
@@ -134,6 +134,12 @@ jobs:
 
   asan_fastdds_test:
     needs: asan_fastdds_build
+    if: ${{ (
+          !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+          !contains(github.event.pull_request.labels.*.name, 'no-test') &&
+          !contains(github.event.pull_request.labels.*.name, 'conflicts') &&
+          (inputs.run_asan_fastdds == true)
+        ) }}
     runs-on: ubuntu-22.04
     steps:
       - name: Download build artifacts

--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -1,4 +1,4 @@
-name: Fast DDS Ubuntu CI - Fast DDS build
+name: Fast DDS Ubuntu CI reusable workflow
 
 on:
   workflow_call:
@@ -34,102 +34,77 @@ defaults:
 
 jobs:
   fastdds_build:
-    runs-on: ${{ inputs.os-image }}
-    if: ${{ (
-          !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
-          !contains(github.event.pull_request.labels.*.name, 'conflicts')
-        ) }}
-    strategy:
-      fail-fast: false
-      matrix:
-        cmake-build-type:
-          - 'RelWithDebInfo'
-    steps:
-      - name: Add ci-pending label if PR
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: eProsima/eProsima-CI/external/add_labels@v0
-        with:
-          labels: ci-pending
-          number: ${{ github.event.number }}
-          repo: eProsima/Fast-DDS
+    uses: ./.github/workflows/fastdds-build.yml
+    with:
+      os-image: ${{ inputs.os-image }}
+      label: ${{ inputs.label }}
+      colcon-args: ${{ inputs.colcon-args }}
+      cmake-args: ${{ inputs.cmake-args }}
+      ctest-args: ${{ inputs.ctest-args }}
+      fastdds-branch: ${{ inputs.fastdds_branch }}
 
-      - name: Sync eProsima/Fast-DDS repository
-        uses: eProsima/eProsima-CI/external/checkout@v0
-        with:
-          path: src/fastdds
-          ref: ${{ inputs.fastdds-branch }}
+  fastdds_build_test:
+    uses: ./.github/workflows/fastdds-test.yml
+    needs: fastdds_build
+    with:
+      os-image: ${{ inputs.os-image }}
+      label: ${{ inputs.label}}
+      colcon-args: ${{ inputs.colcon-args }}
+      cmake-args: ${{ inputs.cmake-args }}
+      ctest-args: ${{ inputs.ctest-args }}
+      fastdds-branch: ${{ inputs.fastdds_branch }}
 
-      - name: Install Fix Python version
-        uses: eProsima/eProsima-CI/external/setup-python@v0
-        with:
-          python-version: '3.11'
+  fastdds_python_build:
+    uses: ./.github/workflows/fastdds-python-build.yml
+    needs: fastdds_build
+    with:
+      os-image: ${{ inputs.os-image }}
+      label: ${{ inputs.label}}
+      colcon-args: ${{ inputs.colcon-args }}
+      cmake-args: ${{ inputs.cmake-args }}
+      ctest-args: ${{ inputs.ctest-args }}
+      fastdds-branch: ${{ inputs.fastdds_branch }}
 
-      - name: Get minimum supported version of CMake
-        uses: eProsima/eProsima-CI/external/get-cmake@v0
-        with:
-          cmakeVersion: '3.22.6'
+  fastdds_python_test:
+    uses: ./.github/workflows/fastdds-python-test.yml
+    needs: fastdds_python_build
+    with:
+      os-image: ${{ inputs.os-image }}
+      label: ${{ inputs.label}}
+      colcon-args: ${{ inputs.colcon-args }}
+      cmake-args: ${{ inputs.cmake-args }}
+      ctest-args: ${{ inputs.ctest-args }}
+      fastdds-branch: ${{ inputs.fastdds_branch }}
 
-      - name: Install apt dependencies
-        uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
-        with:
-          packages: libasio-dev libtinyxml2-dev libssl-dev
-          update: false
-          upgrade: false
+  fastdds_docs_build_test:
+    uses: ./.github/workflows/fastdds-docs-build-test.yml
+    needs: fastdds_python_build
+    with:
+      os-image: ${{ inputs.os-image }}
+      label: ${{ inputs.label}}
+      colcon-args: ${{ inputs.colcon-args }}
+      cmake-args: ${{ inputs.cmake-args }}
+      ctest-args: ${{ inputs.ctest-args }}
+      fastdds-branch: ${{ inputs.fastdds_branch }}
 
-      - name: Install colcon
-        uses: eProsima/eProsima-CI/ubuntu/install_colcon@v0
+  fastdds_shapesdemo_build:
+    uses: ./.github/workflows/shapesdemo-build.yml
+    needs: fastdds_build
+    with:
+      os-image: ${{ inputs.os-image }}
+      label: ${{ inputs.label}}
+      colcon-args: ${{ inputs.colcon-args }}
+      cmake-args: ${{ inputs.cmake-args }}
+      ctest-args: ${{ inputs.ctest-args }}
+      fastdds-branch: ${{ inputs.fastdds_branch }}
 
-      - name: Install Python dependencies
-        uses: eProsima/eProsima-CI/multiplatform/install_python_packages@v0
-        with:
-          packages: vcstool xmlschema
-          upgrade: false
-
-      - name: Setup CCache
-        uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
-
-      - name: Set up hosts file for DNS testing
-        run: |
-          sudo echo "" | sudo tee -a /etc/hosts
-          sudo echo "127.0.0.1 localhost.test" | sudo tee -a /etc/hosts
-          sudo echo "::1 localhost.test" | sudo tee -a /etc/hosts
-          sudo echo "154.56.134.194 www.eprosima.com.test" | sudo tee -a /etc/hosts
-          sudo echo "216.58.215.164 www.acme.com.test" | sudo tee -a /etc/hosts
-          sudo echo "2a00:1450:400e:803::2004 www.acme.com.test" | sudo tee -a /etc/hosts
-          sudo echo "140.82.121.4 www.foo.com.test" | sudo tee -a /etc/hosts
-          sudo echo "140.82.121.3 www.foo.com.test" | sudo tee -a /etc/hosts
-          sudo echo "ff1e::ffff:efff:1 acme.org.test" | sudo tee -a /etc/hosts
-
-      # TODO(eduponz): Set up libp11 and SoftHSM. NOTE: using SoftHSM requires adding the runner to a group,
-      #                which entails logout/login or rebooting the machine. This is not feasible in a CI environment.
-
-      - name: Fetch Fast DDS dependencies
-        uses: eProsima/eProsima-CI/multiplatform/vcs_import@v0
-        with:
-          vcs_repos_file: ${{ github.workspace }}/src/fastdds/fastdds.repos
-          destination_workspace: src
-          skip_existing: 'true'
-
-      - name: Fetch Fast DDS CI dependencies
-        uses: eProsima/eProsima-CI/multiplatform/vcs_import@v0
-        with:
-          vcs_repos_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/ci.repos
-          destination_workspace: src
-          skip_existing: 'true'
-
-      - name: Colcon build
-        continue-on-error: false
-        uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
-        with:
-          colcon_meta_file: ''
-          colcon_build_args: ${{ inputs.colcon-args }}
-          cmake_args: ${{ inputs.cmake-args }}
-          cmake_args_default: -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra -Wpedantic -Wunused-value -Woverloaded-virtual"
-          cmake_build_type: ${{ matrix.cmake-build-type }}
-          workspace: ${{ github.workspace }}
-
-      - name: Upload build artifacts
-        uses: eProsima/eProsima-CI/external/upload-artifact@v0
-        with:
-          name: fastdds_build_${{ inputs.label }}
-          path: ${{ github.workspace }}
+  fastdds_discovery_server_build_test:
+    uses: ./.github/workflows/fastdds-ds-build-test.yml
+    needs: fastdds_build
+    with:
+      os-image: ${{ inputs.os-image }}
+      label: ${{ inputs.label}}
+      colcon-args: ${{ inputs.colcon-args }}
+      cmake-args: ${{ inputs.cmake-args }}
+      ctest-args: ${{ inputs.ctest-args }}
+      fastdds-branch: ${{ inputs.fastdds_branch }}

--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -35,7 +35,10 @@ defaults:
 jobs:
   fastdds_build:
     runs-on: ${{ inputs.os-image }}
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+    if: ${{ (
+          !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+          !contains(github.event.pull_request.labels.*.name, 'conflicts')
+        ) }}
     strategy:
       fail-fast: false
       matrix:
@@ -133,6 +136,11 @@ jobs:
 
   fastdds_build_test:
     needs: fastdds_build
+    if: ${{ (
+          !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+          !contains(github.event.pull_request.labels.*.name, 'no-test') &&
+          !contains(github.event.pull_request.labels.*.name, 'conflicts')
+        ) }}
     runs-on: ${{ inputs.os-image }}
     steps:
       - name: Download build artifacts
@@ -215,6 +223,10 @@ jobs:
 
   fastdds_python_build:
     needs: fastdds_build
+    if: ${{ (
+          !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+          !contains(github.event.pull_request.labels.*.name, 'conflicts')
+        ) }}
     runs-on: ${{ inputs.os-image }}
     strategy:
       fail-fast: false
@@ -287,6 +299,11 @@ jobs:
 
   fastdds_python_build_test:
     needs: fastdds_python_build
+    if: ${{ (
+          !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+          !contains(github.event.pull_request.labels.*.name, 'no-test') &&
+          !contains(github.event.pull_request.labels.*.name, 'conflicts')
+        ) }}
     runs-on: ${{ inputs.os-image }}
     steps:
       - name: Download python build artifacts
@@ -358,6 +375,10 @@ jobs:
 
   fastdds_docs_build_test:
     needs: fastdds_python_build
+    if: ${{ (
+          !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+          !contains(github.event.pull_request.labels.*.name, 'conflicts')
+        ) }}
     runs-on: ${{ inputs.os-image }}
     strategy:
       fail-fast: false
@@ -454,6 +475,10 @@ jobs:
 
   fastdds_shapesdemo_build:
     needs: fastdds_build
+    if: ${{ (
+          !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+          !contains(github.event.pull_request.labels.*.name, 'conflicts')
+        ) }}
     runs-on: ${{ inputs.os-image }}
     strategy:
       fail-fast: false
@@ -532,6 +557,11 @@ jobs:
 
   fastdds_discovery_server_build_test:
     needs: fastdds_build
+
+    if: ${{ (
+          !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+          !contains(github.event.pull_request.labels.*.name, 'conflicts')
+        ) }}
     runs-on: ${{ inputs.os-image }}
     strategy:
       fail-fast: false

--- a/.github/workflows/reusable-windows-ci.yml
+++ b/.github/workflows/reusable-windows-ci.yml
@@ -31,7 +31,10 @@ defaults:
 jobs:
   reusable-windows-ci:
     runs-on: windows-2019
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+    if: ${{ (
+              !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+              !contains(github.event.pull_request.labels.*.name, 'conflicts')
+            ) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/sanitizers-ci.yml
+++ b/.github/workflows/sanitizers-ci.yml
@@ -58,11 +58,6 @@ concurrency:
 
 jobs:
   sanitizers-ci:
-    if: ${{ (
-              !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
-              !contains(github.event.pull_request.labels.*.name, 'no-test') &&
-              !contains(github.event.pull_request.labels.*.name, 'conflicts')
-            ) }}
     uses: ./.github/workflows/reusable-sanitizers-ci.yml
     with:
       label: ${{ inputs.label || 'fastdds-sanitizers-ci' }}

--- a/.github/workflows/shapesdemo-build.yml
+++ b/.github/workflows/shapesdemo-build.yml
@@ -1,0 +1,116 @@
+name: Fast DDS Ubuntu CI - ShapesDemo build
+
+on:
+  workflow_call:
+    inputs:
+      os-image:
+        description: 'The OS image for the workflow'
+        required: true
+        type: string
+      label:
+        description: 'ID associated to the workflow'
+        required: true
+        type: string
+      colcon-args:
+        description: 'Extra arguments for colcon cli'
+        required: false
+        type: string
+      cmake-args:
+        description: 'Extra arguments for cmake cli'
+        required: false
+        type: string
+      ctest-args:
+        description: 'Extra arguments for ctest cli'
+        required: false
+        type: string
+      fastdds-branch:
+        description: 'Branch or tag of Fast DDS repository (https://github.com/eProsima/Fast-DDS)'
+        required: true
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  fastdds_shapesdemo_build:
+    needs: fastdds_build
+    if: ${{ (
+          !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+          !contains(github.event.pull_request.labels.*.name, 'conflicts')
+        ) }}
+    runs-on: ${{ inputs.os-image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        cmake-build-type:
+          - 'RelWithDebInfo'
+    steps:
+      - name: Download build artifacts
+        uses: eProsima/eProsima-CI/external/download-artifact@v0
+        with:
+          name: fastdds_build_${{ inputs.label }}
+          path: ${{ github.workspace }}
+
+      - name: Install Fix Python version
+        uses: eProsima/eProsima-CI/external/setup-python@v0
+        with:
+          python-version: '3.11'
+
+      - name: Get minimum supported version of CMake
+        uses: eProsima/eProsima-CI/external/get-cmake@v0
+        with:
+          cmakeVersion: '3.22.6'
+
+      - name: Install apt packages
+        uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
+        with:
+          packages: libasio-dev libtinyxml2-dev libssl-dev
+
+      - name: Install colcon
+        uses: eProsima/eProsima-CI/ubuntu/install_colcon@v0
+
+      - name: Install Python dependencies
+        uses: eProsima/eProsima-CI/ubuntu/install_python_packages@v0
+        with:
+          packages: xmlschema
+
+      - name: Setup CCache
+        uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
+
+      # Get Shapes Demo to make sure it keeps compiling
+      - name: Get Shapes Demo branch
+        id: get_shapes_demo_branch
+        uses: eProsima/eProsima-CI/ubuntu/get_related_branch_from_repo@v0
+        with:
+          remote_repository: eProsima/ShapesDemo
+          fallback_branch: 'master'
+
+      - name: Download Shapes Demo repo
+        uses: eProsima/eProsima-CI/external/checkout@v0
+        with:
+          repository: eProsima/ShapesDemo
+          path: src/shapes-demo
+          ref: ${{ steps.get_shapes_demo_branch.outputs.deduced_branch }}
+
+      # Required for Shapes Demo
+      # Do not setup python as it will internally modify the pythonLocation env variable
+      # and we want to use a fix version
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v2.13.0
+        with:
+          version: '5.15.2'
+          dir: '${{ github.workspace }}/qt_installation/'
+          modules: 'qtcharts'
+          setup-python: 'false'
+
+      - name: Colcon build
+        continue-on-error: false
+        uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
+        with:
+          colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/ci.meta
+          colcon_build_args: '${{ inputs.colcon-args }} --packages-up-to ShapesDemo'
+          cmake_args: ${{ inputs.cmake-args }}
+          cmake_args_default: -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra -Wpedantic -Wunused-value -Woverloaded-virtual"
+          cmake_build_type: ${{ matrix.cmake-build-type }}
+          workspace: ${{ github.workspace }}

--- a/.github/workflows/shapesdemo-build.yml
+++ b/.github/workflows/shapesdemo-build.yml
@@ -34,12 +34,11 @@ defaults:
 
 jobs:
   fastdds_shapesdemo_build:
-    needs: fastdds_build
+    runs-on: ${{ inputs.os-image }}
     if: ${{ (
           !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
           !contains(github.event.pull_request.labels.*.name, 'conflicts')
         ) }}
-    runs-on: ${{ inputs.os-image }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -37,7 +37,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ubuntu-ci:
+  fastdds_build:
 
     strategy:
       fail-fast: false
@@ -49,6 +49,114 @@ jobs:
     with:
       os-image: ${{ matrix.os-image }}
       label: ${{ inputs.label || 'ubuntu-ci' }}
+      colcon-args: ${{ inputs.colcon-args }}
+      cmake-args: '-DSECURITY=ON ${{ inputs.cmake-args }}'
+      ctest-args: ${{ inputs.ctest-args || '-LE xfail' }}
+      fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
+
+  fastdds_build_test:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os-image:
+          - 'ubuntu-22.04'
+
+    uses: ./.github/workflows/fastdds-test.yml
+    needs: fastdds_build
+    with:
+      os-image: ${{ matrix.os-image }}
+      label: ${{ inputs.label || 'fastdds_build_test' }}
+      colcon-args: ${{ inputs.colcon-args }}
+      cmake-args: '-DSECURITY=ON ${{ inputs.cmake-args }}'
+      ctest-args: ${{ inputs.ctest-args || '-LE xfail' }}
+      fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
+
+  fastdds_python_build:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os-image:
+          - 'ubuntu-22.04'
+
+    uses: ./.github/workflows/fastdds-python-build.yml
+    needs: fastdds_build
+    with:
+      os-image: ${{ matrix.os-image }}
+      label: ${{ inputs.label || 'fastdds_python_build' }}
+      colcon-args: ${{ inputs.colcon-args }}
+      cmake-args: '-DSECURITY=ON ${{ inputs.cmake-args }}'
+      ctest-args: ${{ inputs.ctest-args || '-LE xfail' }}
+      fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
+
+  fastdds_python_test:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os-image:
+          - 'ubuntu-22.04'
+
+    uses: ./.github/workflows/fastdds-python-test.yml
+    needs: fastdds_python_build
+    with:
+      os-image: ${{ matrix.os-image }}
+      label: ${{ inputs.label || 'fastdds_python_test' }}
+      colcon-args: ${{ inputs.colcon-args }}
+      cmake-args: '-DSECURITY=ON ${{ inputs.cmake-args }}'
+      ctest-args: ${{ inputs.ctest-args || '-LE xfail' }}
+      fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
+
+  fastdds_docs_build_test:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os-image:
+          - 'ubuntu-22.04'
+
+    uses: ./.github/workflows/fastdds-docs-build-test.yml
+    needs: fastdds_python_build
+    with:
+      os-image: ${{ matrix.os-image }}
+      label: ${{ inputs.label || 'fastdds_docs_build_test' }}
+      colcon-args: ${{ inputs.colcon-args }}
+      cmake-args: '-DSECURITY=ON ${{ inputs.cmake-args }}'
+      ctest-args: ${{ inputs.ctest-args || '-LE xfail' }}
+      fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
+
+  fastdds_shapesdemo_build:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os-image:
+          - 'ubuntu-22.04'
+
+    uses: ./.github/workflows/shapesdemo-build.yml
+    needs: fastdds_build
+    with:
+      os-image: ${{ matrix.os-image }}
+      label: ${{ inputs.label || 'fastdds_shapesdemo_build' }}
+      colcon-args: ${{ inputs.colcon-args }}
+      cmake-args: '-DSECURITY=ON ${{ inputs.cmake-args }}'
+      ctest-args: ${{ inputs.ctest-args || '-LE xfail' }}
+      fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
+
+  fastdds_discovery_server_build_test:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os-image:
+          - 'ubuntu-22.04'
+
+    uses: ./.github/workflows/fastdds-ds-build-test.yml
+    needs: fastdds_build
+    with:
+      os-image: ${{ matrix.os-image }}
+      label: ${{ inputs.label || 'fastdds_discovery_server_build_test' }}
       colcon-args: ${{ inputs.colcon-args }}
       cmake-args: '-DSECURITY=ON ${{ inputs.cmake-args }}'
       ctest-args: ${{ inputs.ctest-args || '-LE xfail' }}

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -45,10 +45,6 @@ jobs:
         os-image:
           - 'ubuntu-22.04'
 
-    if: ${{ (
-              !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
-              !contains(github.event.pull_request.labels.*.name, 'conflicts')
-            ) }}
     uses: ./.github/workflows/reusable-ubuntu-ci.yml
     with:
       os-image: ${{ matrix.os-image }}

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -37,7 +37,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  fastdds_build:
+  reusable-ubuntu-ci:
 
     strategy:
       fail-fast: false
@@ -49,114 +49,6 @@ jobs:
     with:
       os-image: ${{ matrix.os-image }}
       label: ${{ inputs.label || 'ubuntu-ci' }}
-      colcon-args: ${{ inputs.colcon-args }}
-      cmake-args: '-DSECURITY=ON ${{ inputs.cmake-args }}'
-      ctest-args: ${{ inputs.ctest-args || '-LE xfail' }}
-      fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
-
-  fastdds_build_test:
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os-image:
-          - 'ubuntu-22.04'
-
-    uses: ./.github/workflows/fastdds-test.yml
-    needs: fastdds_build
-    with:
-      os-image: ${{ matrix.os-image }}
-      label: ${{ inputs.label || 'fastdds_build_test' }}
-      colcon-args: ${{ inputs.colcon-args }}
-      cmake-args: '-DSECURITY=ON ${{ inputs.cmake-args }}'
-      ctest-args: ${{ inputs.ctest-args || '-LE xfail' }}
-      fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
-
-  fastdds_python_build:
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os-image:
-          - 'ubuntu-22.04'
-
-    uses: ./.github/workflows/fastdds-python-build.yml
-    needs: fastdds_build
-    with:
-      os-image: ${{ matrix.os-image }}
-      label: ${{ inputs.label || 'fastdds_python_build' }}
-      colcon-args: ${{ inputs.colcon-args }}
-      cmake-args: '-DSECURITY=ON ${{ inputs.cmake-args }}'
-      ctest-args: ${{ inputs.ctest-args || '-LE xfail' }}
-      fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
-
-  fastdds_python_test:
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os-image:
-          - 'ubuntu-22.04'
-
-    uses: ./.github/workflows/fastdds-python-test.yml
-    needs: fastdds_python_build
-    with:
-      os-image: ${{ matrix.os-image }}
-      label: ${{ inputs.label || 'fastdds_python_test' }}
-      colcon-args: ${{ inputs.colcon-args }}
-      cmake-args: '-DSECURITY=ON ${{ inputs.cmake-args }}'
-      ctest-args: ${{ inputs.ctest-args || '-LE xfail' }}
-      fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
-
-  fastdds_docs_build_test:
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os-image:
-          - 'ubuntu-22.04'
-
-    uses: ./.github/workflows/fastdds-docs-build-test.yml
-    needs: fastdds_python_build
-    with:
-      os-image: ${{ matrix.os-image }}
-      label: ${{ inputs.label || 'fastdds_docs_build_test' }}
-      colcon-args: ${{ inputs.colcon-args }}
-      cmake-args: '-DSECURITY=ON ${{ inputs.cmake-args }}'
-      ctest-args: ${{ inputs.ctest-args || '-LE xfail' }}
-      fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
-
-  fastdds_shapesdemo_build:
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os-image:
-          - 'ubuntu-22.04'
-
-    uses: ./.github/workflows/shapesdemo-build.yml
-    needs: fastdds_build
-    with:
-      os-image: ${{ matrix.os-image }}
-      label: ${{ inputs.label || 'fastdds_shapesdemo_build' }}
-      colcon-args: ${{ inputs.colcon-args }}
-      cmake-args: '-DSECURITY=ON ${{ inputs.cmake-args }}'
-      ctest-args: ${{ inputs.ctest-args || '-LE xfail' }}
-      fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
-
-  fastdds_discovery_server_build_test:
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os-image:
-          - 'ubuntu-22.04'
-
-    uses: ./.github/workflows/fastdds-ds-build-test.yml
-    needs: fastdds_build
-    with:
-      os-image: ${{ matrix.os-image }}
-      label: ${{ inputs.label || 'fastdds_discovery_server_build_test' }}
       colcon-args: ${{ inputs.colcon-args }}
       cmake-args: '-DSECURITY=ON ${{ inputs.cmake-args }}'
       ctest-args: ${{ inputs.ctest-args || '-LE xfail' }}

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -38,10 +38,6 @@ concurrency:
 
 jobs:
   windows-ci:
-    if: ${{ (
-              !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
-              !contains(github.event.pull_request.labels.*.name, 'conflicts')
-            ) }}
     uses: ./.github/workflows/reusable-windows-ci.yml
     with:
       label: ${{ inputs.label || 'windows-ci' }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR is a draft based (and placed on top) on:
- #4860

Which tries to generate a graph dependency in the CI summary

**NOTE**: It has also been moved some check from general CI to the reusable jobs to pass CI requirements, even if the CI jobs are skipped.
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- **N/A** The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- **N/A** Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- **N/A** Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
