### PR TITLE
[21144] Fix doxygen errors for versions prior to 1.8.19

### DIFF
--- a/include/fastdds/dds/xtypes/type_representation/TypeObjectUtils.hpp
+++ b/include/fastdds/dds/xtypes/type_representation/TypeObjectUtils.hpp
@@ -249,7 +249,7 @@ public:
      *
      * @tparam array Either a SBoundSeq or LBoundSeq.
      * @tparam element Either a SBound or LBound.
-     * @param[in out] array_bound_seq Sequence with the array bounds.
+     * @param[in,out] array_bound_seq Sequence with the array bounds.
      * @param[in] dimension_bound Dimension bound to be added into the sequence.
      */
     template<typename element>
@@ -716,7 +716,7 @@ public:
     /**
      * @brief Add AppliedAnnotationParameter to the sequence.
      *
-     * @param[in out] param_seq AppliedAnnotationParameter sequence to be modified.
+     * @param[in,out] param_seq AppliedAnnotationParameter sequence to be modified.
      * @exception eprosima::fastdds::dds::xtypes::InvalidArgumentError exception if the parameter being added has
      *            already been included in the sequence.
      * @param[in] param AppliedAnnotationParameter to be added.
@@ -745,7 +745,7 @@ public:
     /**
      * @brief Add AppliedAnnotation to the sequence.
      *
-     * @param[in out] ann_custom_seq AppliedAnnotation sequence to be modified.
+     * @param[in,out] ann_custom_seq AppliedAnnotation sequence to be modified.
      * @param[in] ann_custom AppliedAnnotation to be added.
      * @exception eprosima::fastdds::dds::xtypes::InvalidArgumentError exception if:
      *              1. Given AppliedAnnotation is not consistent (only in Debug build mode).
@@ -837,7 +837,7 @@ public:
     /**
      * @brief Add CompleteStructMember to the sequence.
      *
-     * @param[in out] member_seq CompleteStructMember sequence to be modified.
+     * @param[in,out] member_seq CompleteStructMember sequence to be modified.
      * @param[in] member CompleteStructMember to be added.
      * @exception eprosima::fastdds::dds::xtypes::InvalidArgumentError exception if:
      *              1. Given CompleteStructMember is not consistent (only in Debug build mode).
@@ -928,7 +928,7 @@ public:
     /**
      * @brief Add label to the union case label sequence.
      *
-     * @param[in out] label_seq Sequence to be modified.
+     * @param[in,out] label_seq Sequence to be modified.
      * @param[in] label Label to be added.
      */
     FASTDDS_EXPORTED_API static void add_union_case_label(
@@ -970,7 +970,7 @@ public:
     /**
      * @brief Add CompleteUnionMember to sequence.
      *
-     * @param[in out] complete_union_member_seq Sequence to be modified.
+     * @param[in,out] complete_union_member_seq Sequence to be modified.
      * @param[in] member Complete union member to be added.
      * @exception eprosima::fastdds::dds::xtypes::InvalidArgumentError exception if:
      *              1. Given CompleteUnionMember is not consistent (only in Debug build mode).
@@ -1105,7 +1105,7 @@ public:
     /**
      * @brief Add CompleteAnnotationParameter to sequence.
      *
-     * @param[in out] sequence Sequence to be modified.
+     * @param[in,out] sequence Sequence to be modified.
      * @param[in] param Complete annotation parameter to be added.
      * @exception eprosima::fastdds::dds::xtypes::InvalidArgumentError exception if:
      *              1. Given CompleteAnnotationParameter is not consistent (only in Debug build mode).
@@ -1438,7 +1438,7 @@ public:
      * @brief Add CompleteEnumeratedLiteral to sequence.
      *
      * @param[in] sequence Sequence to be modified.
-     * @param[in out] enum_literal CompleteEnumeratedLiteral to be added.
+     * @param[in,out] enum_literal CompleteEnumeratedLiteral to be added.
      * @exception eprosima::fastdds::dds::xtypes::InvalidArgumentError exception if:
      *              1. Given CommonEnumeratedLiteral is not consistent (only in Debug build mode).
      *              2. There is already another literal in the sequence with the same value or the same member name
@@ -1545,7 +1545,7 @@ public:
     /**
      * @brief Add complete bitflag to the sequence.
      *
-     * @param[in out] sequence Sequence to be modified.
+     * @param[in,out] sequence Sequence to be modified.
      * @param[in] bitflag CompleteBitflag to be added.
      * @exception eprosima::fastdds::dds::xtypes::InvalidArgumentError exception if:
      *              1. Given bitflag is inconsistent (only in Debug build mode).
@@ -1626,7 +1626,7 @@ public:
     /**
      * @brief Add complete bitfield to the sequence.
      *
-     * @param[in out] sequence Sequence to be modified.
+     * @param[in,out] sequence Sequence to be modified.
      * @param[in] bitfield CompleteBitfield to be added.
      * @exception eprosima::fastdds::dds::xtypes::InvalidArgumentError exception if:
      *              1. Given bitfield is inconsistent (only in Debug build mode).
@@ -1898,7 +1898,7 @@ protected:
     /**
      * @brief Set the try construct behavior in a given MemberFlag
      *
-     * @param[in out] member_flag Bitmask to be set.
+     * @param[in,out] member_flag Bitmask to be set.
      * @param[in] try_construct_kind TryConstructKind.
      */
     static void set_try_construct_behavior(
@@ -1908,7 +1908,7 @@ protected:
     /**
      * @brief Set the TypeFlag object.
      *
-     * @param[in out] type_flag Bitmask to be set.
+     * @param[in,out] type_flag Bitmask to be set.
      * @param[in] extensibility_kind ExtensibilityKind
      * @param[in] nested nested annotation value.
      * @param[in] autoid_hash autoid annotation has HASH value.
@@ -1922,7 +1922,7 @@ protected:
     /**
      * @brief Set the extensibility kind in a given TypeFlag.
      *
-     * @param[in out] type_flag Bitmask to be set.
+     * @param[in,out] type_flag Bitmask to be set.
      * @param[in] extensibility_kind ExtensibilityKind.
      */
     static void set_extensibility_kind(

--- a/src/cpp/fastdds/xtypes/type_representation/TypeObjectRegistry.hpp
+++ b/src/cpp/fastdds/xtypes/type_representation/TypeObjectRegistry.hpp
@@ -193,7 +193,7 @@ public:
      * @brief Get the type dependencies of the given direct hash type identifiers.
      *
      * @param[in] type_identifiers Sequence with the queried direct hash TypeIdentifiers.
-     * @param[in out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
+     * @param[in,out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
      * @return ReturnCode_t RETCODE_OK if the operation is successful.
      *                      RETCODE_NO_DATA if any given TypeIdentifier is unknown to the registry.
      *                      RETCODE_BAD_PARAMETER if any given TypeIdentifier is not a direct hash.
@@ -281,7 +281,7 @@ public:
      * @brief Get the type dependencies of the given TypeObject.
      *
      * @param[in] type_object TypeObject queried for its dependencies.
-     * @param[in out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
+     * @param[in,out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
      * @return ReturnCode_t RETCODE_OK if the operation is successful.
      *                      RETCODE_NO_DATA if any dependent TypeIdentifier is unknown to the registry.
      *                      RETCODE_BAD_PARAMETER if any given TypeIdentifier is not a direct hash.
@@ -313,7 +313,7 @@ protected:
      * @brief Get the type dependencies of the given type identifiers.
      *
      * @param[in] type_identifiers Sequence with the queried TypeIdentifiers.
-     * @param[in out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
+     * @param[in,out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
      * @return ReturnCode_t RETCODE_OK if the operation is successful.
      *                      RETCODE_NO_DATA if any given TypeIdentifier is unknown to the registry.
      *                      RETCODE_BAD_PARAMETER if any given TypeIdentifier is fully descriptive.
@@ -326,7 +326,7 @@ protected:
      * @brief Add type dependency to the sequence.
      *
      * @param[in] type_id TypeIdentifier to be added.
-     * @param[in out] type_dependencies TypeIdentfierWithSize sequence.
+     * @param[in,out] type_dependencies TypeIdentfierWithSize sequence.
      */
     void add_dependency(
             const TypeIdentifier& type_id,
@@ -336,7 +336,7 @@ protected:
      * @brief Get the type dependencies of custom annotations.
      *
      * @param[in] custom_annotation_seq Sequence of custom annotations.
-     * @param[in out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
+     * @param[in,out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
      * @return ReturnCode_t RETCODE_OK if the operation is successful.
      *                      RETCODE_NO_DATA if any dependent TypeIdentifier is unknown to the registry.
      */
@@ -349,7 +349,7 @@ protected:
      *
      * @tparam T Either PlainSequenceSElemDefn, PlainSequenceLElemDefn, PlainArraySElemDefn or PlainArrayLElemDefn.
      * @param[in] collection_type Plain collection Type.
-     * @param[in out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
+     * @param[in,out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
      * @return ReturnCode_t RETCODE_OK if the operation is successful.
      *                      RETCODE_NO_DATA if any dependent TypeIdentifier is unknown to the registry.
      *                      RETCODE_BAD_PARAMETER if the collection type is fully descriptive.
@@ -384,7 +384,7 @@ protected:
      *
      * @tparam T Either PlainMapSTypeDefn or PlainMapLTypeDefn.
      * @param[in] map_type Plain map Type.
-     * @param[in out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
+     * @param[in,out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
      * @return ReturnCode_t RETCODE_OK if the operation is successful.
      *                      RETCODE_NO_DATA if any dependent TypeIdentifier is unknown to the registry.
      *                      RETCODE_BAD_PARAMETER if both the key and the elements types are fully descriptive.
@@ -425,7 +425,7 @@ protected:
      *
      * @tparam T Either a CompleteAliasType or MinimalAliasType.
      * @param[in] alias_type Alias Type.
-     * @param[in out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
+     * @param[in,out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
      * @return ReturnCode_t RETCODE_OK if the operation is successful.
      *                      RETCODE_NO_DATA if any dependent TypeIdentifier is unknown to the registry.
      */
@@ -459,7 +459,7 @@ protected:
      *
      * @tparam T Either a CompleteAnnotationType or MinimalAnnotationType.
      * @param[in] annotation_type Annotation Type.
-     * @param[in out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
+     * @param[in,out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
      * @return ReturnCode_t RETCODE_OK if the operation is successful.
      *                      RETCODE_NO_DATA if any dependent TypeIdentifier is unknown to the registry.
      */
@@ -492,7 +492,7 @@ protected:
      *
      * @tparam T Either a CompleteStructType or MinimalStructType.
      * @param[in] struct_type Structure Type.
-     * @param[in out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
+     * @param[in,out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
      * @return ReturnCode_t RETCODE_OK if the operation is successful.
      *                      RETCODE_NO_DATA if any dependent TypeIdentifier is unknown to the registry.
      */
@@ -533,7 +533,7 @@ protected:
      *
      * @tparam T Either a CompleteUnionType or MinimalUnionType.
      * @param[in] union_type Union Type.
-     * @param[in out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
+     * @param[in,out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
      * @return ReturnCode_t RETCODE_OK if the operation is successful.
      *                      RETCODE_NO_DATA if any dependent TypeIdentifier is unknown to the registry.
      */
@@ -576,7 +576,7 @@ protected:
      *
      * @tparam T Either a CompleteSequenceType/MinimalSequenceType/CompleteArrayType/MinimalArrayType.
      * @param[in] collection_type Sequence or Array Type.
-     * @param[in out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
+     * @param[in,out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
      * @return ReturnCode_t RETCODE_OK if the operation is successful.
      *                      RETCODE_NO_DATA if any dependent TypeIdentifier is unknown to the registry.
      */
@@ -610,7 +610,7 @@ protected:
      *
      * @tparam T Either a CompleteMapType or MinimalmapType.
      * @param[in] map_type Map Type.
-     * @param[in out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
+     * @param[in,out] type_dependencies Unordered set of TypeIdentifiers with related TypeObject serialized size.
      * @return ReturnCode_t RETCODE_OK if the operation is successful.
      *                      RETCODE_NO_DATA if any dependent TypeIdentifier is unknown to the registry.
      */


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR fixes some Doxygen errors when generating the API reference with Doxygen versions prior to 1.8.19, as it is the case of Fast DDS docs RTD page, which is generated in [Ubuntu 20.04](https://github.com/eProsima/Fast-DDS-docs/blob/93f6c1913e0075dfefbbc9f72edfe7d0684ba23b/readthedocs.yaml#L9) and therefore with Doxygen 1.8.17.
Although [Doxygen documentation](https://doxygen.nl/manual/commands.html#cmdparam) documents the `dir` attribute of the `param` directive to be one of `[in]`, `[out]`, and `[in,out]`, doxygen/doxygen#7881 introduced, among other things, the possibility to set the `dir` attribute to `[in out]`, which #4746 introduced in several places.

Mind that in the dev machines this "mistake" went undetected because of the use of Ubuntu 22.04 (Doxygen 1.9.1).
Also, even though an error when generating the Doxygen documentation makes Fast DDS docs build to fail when building it through CMake, the RTD generation is done within [conf.py](https://github.com/eProsima/Fast-DDS-docs/blob/93f6c1913e0075dfefbbc9f72edfe7d0684ba23b/docs/conf.py#L296) directly, and the return code of the subprocess is not checked, which makes the RTD documentation to finish the build but then show an error on the API reference as follows.

![image](https://github.com/eProsima/Fast-DDS/assets/7962388/769a1547-c1b0-47f4-a56f-f2b3f855f2a2)

This has been addressed in:

* eProsima/Fast-DDS-docs#795

The doxygen documentation is updated in:

* doxygen/doxygen#10927

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
