### PR TITLE
[20953] Fix Proxy block in TypeLookup Service

### DIFF
--- a/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.cpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.cpp
@@ -329,7 +329,7 @@ ReturnCode_t TypeLookupManager::check_type_identifier_received(
         typename eprosima::ProxyPool<ProxyType>::smart_ptr& temp_proxy_data,
         const AsyncCallback& callback,
         std::unordered_map<xtypes::TypeIdentfierWithSize,
-        std::vector<std::pair<typename eprosima::ProxyPool<ProxyType>::smart_ptr,
+        std::vector<std::pair<ProxyType*,
         AsyncCallback>>>& async_get_type_callbacks)
 {
     xtypes::TypeIdentfierWithSize type_identifier_with_size =
@@ -341,7 +341,7 @@ ReturnCode_t TypeLookupManager::check_type_identifier_received(
                     is_type_identifier_known(type_identifier_with_size))
     {
         // The type is already known, invoke the callback
-        callback(temp_proxy_data);
+        callback(temp_proxy_data.get());
         return RETCODE_OK;
     }
 
@@ -352,7 +352,9 @@ ReturnCode_t TypeLookupManager::check_type_identifier_received(
         if (it != async_get_type_callbacks.end())
         {
             // TypeIdentfierWithSize exists, add the callback
-            it->second.push_back(std::make_pair(std::move(temp_proxy_data), callback));
+            // Make a copy of the proxy to free the EDP pool
+            ProxyType* temp_proxy_data_copy(new ProxyType(*temp_proxy_data));
+            it->second.push_back(std::make_pair(temp_proxy_data_copy, callback));
             // Return without sending new request
             return RETCODE_NO_DATA;
         }
@@ -365,8 +367,10 @@ ReturnCode_t TypeLookupManager::check_type_identifier_received(
     {
         // Store the sent requests and callback
         add_async_get_type_request(get_type_dependencies_request, type_identifier_with_size);
-        std::vector<std::pair<typename eprosima::ProxyPool<ProxyType>::smart_ptr, AsyncCallback>> types;
-        types.push_back(std::make_pair(std::move(temp_proxy_data), callback));
+        std::vector<std::pair<ProxyType*, AsyncCallback>> types;
+        // Make a copy of the proxy to free the EDP pool
+        ProxyType* temp_proxy_data_copy(new ProxyType(*temp_proxy_data));
+        types.push_back(std::make_pair(temp_proxy_data_copy, callback));
         async_get_type_callbacks.emplace(type_identifier_with_size, std::move(types));
 
         return RETCODE_NO_DATA;
@@ -442,6 +446,11 @@ bool TypeLookupManager::remove_async_get_type_callback(
         auto writer_it = async_get_type_writer_callbacks_.find(type_identifier_with_size);
         if (writer_it != async_get_type_writer_callbacks_.end())
         {
+            // Delete the proxies and remove the entry
+            for (auto& proxy_callback_pair : writer_it->second)
+            {
+                delete proxy_callback_pair.first;
+            }
             async_get_type_writer_callbacks_.erase(writer_it);
             removed = true;
         }
@@ -449,6 +458,11 @@ bool TypeLookupManager::remove_async_get_type_callback(
         auto reader_it = async_get_type_reader_callbacks_.find(type_identifier_with_size);
         if (reader_it != async_get_type_reader_callbacks_.end())
         {
+            // Delete the proxies and remove the entry
+            for (auto& proxy_callback_pair : reader_it->second)
+            {
+                delete proxy_callback_pair.first;
+            }
             async_get_type_reader_callbacks_.erase(reader_it);
             removed = true;
         }

--- a/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.hpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.hpp
@@ -105,9 +105,9 @@ namespace builtin {
 const SampleIdentity INVALID_SAMPLE_IDENTITY;
 
 using AsyncGetTypeWriterCallback = std::function<
-    void (eprosima::ProxyPool<eprosima::fastrtps::rtps::WriterProxyData>::smart_ptr&)>;
+    void (eprosima::fastrtps::rtps::WriterProxyData*)>;
 using AsyncGetTypeReaderCallback = std::function<
-    void (eprosima::ProxyPool<eprosima::fastrtps::rtps::ReaderProxyData>::smart_ptr&)>;
+    void (eprosima::fastrtps::rtps::ReaderProxyData*)>;
 
 /**
  * Class TypeLookupManager that implements the TypeLookup Service described in the DDS-XTYPES 1.3 specification.
@@ -211,7 +211,7 @@ protected:
             typename eprosima::ProxyPool<ProxyType>::smart_ptr& temp_proxy_data,
             const AsyncCallback& callback,
             std::unordered_map<xtypes::TypeIdentfierWithSize,
-            std::vector<std::pair<typename eprosima::ProxyPool<ProxyType>::smart_ptr,
+            std::vector<std::pair<ProxyType*,
             AsyncCallback>>>& async_get_type_callbacks);
 
     /**
@@ -427,12 +427,12 @@ protected:
 
     //! Collection of all the WriterProxyData and their callbacks related to a TypeIdentfierWithSize, hashed by its TypeIdentfierWithSize.
     std::unordered_map < xtypes::TypeIdentfierWithSize,
-            std::vector<std::pair<eprosima::ProxyPool<eprosima::fastrtps::rtps::WriterProxyData>::smart_ptr,
+            std::vector<std::pair<eprosima::fastrtps::rtps::WriterProxyData*,
             AsyncGetTypeWriterCallback>>> async_get_type_writer_callbacks_;
 
     //! Collection of all the ReaderProxyData and their callbacks related to a TypeIdentfierWithSize, hashed by its TypeIdentfierWithSize.
     std::unordered_map < xtypes::TypeIdentfierWithSize,
-            std::vector<std::pair<eprosima::ProxyPool<eprosima::fastrtps::rtps::ReaderProxyData>::smart_ptr,
+            std::vector<std::pair<eprosima::fastrtps::rtps::ReaderProxyData*,
             AsyncGetTypeReaderCallback>>> async_get_type_reader_callbacks_;
 
     //! Collection of all SampleIdentity and the TypeIdentfierWithSize it originated from, hashed by its SampleIdentity.

--- a/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupReplyListener.cpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupReplyListener.cpp
@@ -300,11 +300,11 @@ void TypeLookupReplyListener::onNewCacheChangeAdded(
             return;
         }
 
-        // Add reply to the processing queue
-        replies_queue_.push(ReplyWithServerGUID{reply, change->writerGUID});
         {
-            // Notify processor
             std::unique_lock<std::mutex> guard(replies_processor_cv_mutex_);
+            // Add reply to the processing queue
+            replies_queue_.push(ReplyWithServerGUID{reply, change->writerGUID});
+            // Notify processor
             replies_processor_cv_.notify_all();
         }
     }

--- a/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupRequestListener.cpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupRequestListener.cpp
@@ -435,11 +435,11 @@ void TypeLookupRequestListener::onNewCacheChangeAdded(
     TypeLookup_Request request;
     if (typelookup_manager_->receive(*change, request))
     {
-        // Add request to the processing queue
-        requests_queue_.push(request);
         {
-            // Notify processor
             std::unique_lock<std::mutex> guard(request_processor_cv_mutex_);
+            // Add request to the processing queue
+            requests_queue_.push(request);
+            // Notify processor
             request_processor_cv_.notify_all();
         }
     }

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.cpp
@@ -86,7 +86,7 @@ void EDPBasePUBListener::add_writer_from_change(
         // Callback function to continue after typelookup is complete
         fastdds::dds::builtin::AsyncGetTypeWriterCallback after_typelookup_callback =
                 [reader, change, edp, &network, writer_added_callback]
-                    (eprosima::ProxyPool<eprosima::fastrtps::rtps::WriterProxyData>::smart_ptr& temp_writer_data)
+                    (eprosima::fastrtps::rtps::WriterProxyData* temp_writer_data)
                 {
                     //LOAD INFORMATION IN DESTINATION WRITER PROXY DATA
                     auto copy_data_fun = [&temp_writer_data, &network](
@@ -113,9 +113,6 @@ void EDPBasePUBListener::add_writer_from_change(
                     GUID_t participant_guid;
                     WriterProxyData* writer_data =
                             edp->mp_PDP->addWriterProxyData(temp_writer_data->guid(), participant_guid, copy_data_fun);
-
-                    // release temporary proxy
-                    temp_writer_data.reset();
 
                     if (writer_data != nullptr)
                     {
@@ -148,8 +145,11 @@ void EDPBasePUBListener::add_writer_from_change(
         else
         {
             EPROSIMA_LOG_INFO(RTPS_EDP, "EDPBasePUBListener: No TypeInformation. Trying fallback mechanism");
-            after_typelookup_callback(temp_writer_data);
+            after_typelookup_callback(temp_writer_data.get());
         }
+        // Release temporary proxy
+        temp_writer_data.reset();
+
 
         // Take the reader lock again if needed.
         reader->getMutex().lock();
@@ -226,8 +226,9 @@ void EDPBaseSUBListener::add_reader_from_change(
         // Callback function to continue after typelookup is complete
         fastdds::dds::builtin::AsyncGetTypeReaderCallback after_typelookup_callback =
                 [reader, change, edp, &network, reader_added_callback]
-                    (eprosima::ProxyPool<eprosima::fastrtps::rtps::ReaderProxyData>::smart_ptr& temp_reader_data)
+                    (eprosima::fastrtps::rtps::ReaderProxyData* temp_reader_data)
                 {
+                    //LOAD INFORMATION IN DESTINATION READER PROXY DATA
                     auto copy_data_fun = [&temp_reader_data, &network](
                         ReaderProxyData* data,
                         bool updating,
@@ -253,9 +254,6 @@ void EDPBaseSUBListener::add_reader_from_change(
                     GUID_t participant_guid;
                     ReaderProxyData* reader_data =
                             edp->mp_PDP->addReaderProxyData(temp_reader_data->guid(), participant_guid, copy_data_fun);
-
-                    // Release the temporary proxy
-                    temp_reader_data.reset();
 
                     if (reader_data != nullptr) //ADDED NEW DATA
                     {
@@ -288,8 +286,10 @@ void EDPBaseSUBListener::add_reader_from_change(
         else
         {
             EPROSIMA_LOG_INFO(RTPS_EDP, "EDPBasePUBListener: No TypeInformation. Trying fallback mechanism");
-            after_typelookup_callback(temp_reader_data);
+            after_typelookup_callback(temp_reader_data.get());
         }
+        // Release the temporary proxy
+        temp_reader_data.reset();
 
         // Take the reader lock again if needed.
         reader->getMutex().lock();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR fixes two minor data races and solves a bugfix in which the Proxy Pool was running out of Proxies due multiple requests of the TypeLookup Service. Now, if the type is not known, a copy of the Proxy is made to avoid blocking the discovery.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [X] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
