### PR TITLE
[21136] Bugfix: Revert XML Flow controller names to `const char*`

### DIFF
--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -2048,7 +2048,7 @@ public:
      *
      * @since 2.4.0
      */
-    std::string flow_controller_name = fastdds::rtps::FASTDDS_FLOW_CONTROLLER_DEFAULT;
+    const char* flow_controller_name = fastdds::rtps::FASTDDS_FLOW_CONTROLLER_DEFAULT;
 
     inline void clear() override
     {
@@ -2060,7 +2060,7 @@ public:
             const PublishModeQosPolicy& b) const
     {
         return (this->kind == b.kind) &&
-               flow_controller_name == b.flow_controller_name.c_str() &&
+               0 == strcmp(flow_controller_name, b.flow_controller_name) &&
                QosPolicy::operator ==(b);
     }
 

--- a/include/fastdds/rtps/attributes/WriterAttributes.h
+++ b/include/fastdds/rtps/attributes/WriterAttributes.h
@@ -143,7 +143,7 @@ public:
     Duration_t keep_duration;
 
     //! Flow controller name. Default: fastdds::rtps::FASTDDS_FLOW_CONTROLLER_DEFAULT.
-    std::string flow_controller_name = fastdds::rtps::FASTDDS_FLOW_CONTROLLER_DEFAULT;
+    const char* flow_controller_name = fastdds::rtps::FASTDDS_FLOW_CONTROLLER_DEFAULT;
 };
 
 } /* namespace rtps */

--- a/include/fastdds/rtps/flowcontrol/FlowControllerDescriptor.hpp
+++ b/include/fastdds/rtps/flowcontrol/FlowControllerDescriptor.hpp
@@ -15,8 +15,6 @@
 #ifndef FASTDDS_RTPS_FLOWCONTROL_FLOWCONTROLLERDESCRIPTOR_HPP
 #define FASTDDS_RTPS_FLOWCONTROL_FLOWCONTROLLERDESCRIPTOR_HPP
 
-#include <string>
-
 #include <fastdds/rtps/attributes/ThreadSettings.hpp>
 
 #include "FlowControllerConsts.hpp"
@@ -35,7 +33,7 @@ namespace rtps {
 struct FlowControllerDescriptor
 {
     //! Name of the flow controller.
-    std::string name = FASTDDS_FLOW_CONTROLLER_DEFAULT;
+    const char* name = FASTDDS_FLOW_CONTROLLER_DEFAULT;
 
     //! Scheduler policy used by the flow controller.
     //!

--- a/include/fastrtps/xmlparser/XMLParser.h
+++ b/include/fastrtps/xmlparser/XMLParser.h
@@ -174,6 +174,14 @@ public:
     RTPS_DllAPI static XMLP_ret loadXMLDynamicTypes(
             tinyxml2::XMLElement& types);
 
+
+    /**
+     * Clears the private static collections.
+     *
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     */
+    RTPS_DllAPI static XMLP_ret clear();
+
 protected:
 
     RTPS_DllAPI static XMLP_ret parseXML(
@@ -706,6 +714,11 @@ protected:
             eprosima::fastdds::rtps::BuiltinTransports* bt,
             eprosima::fastdds::rtps::BuiltinTransportsOptions* bt_opts,
             uint8_t ident);
+
+private:
+
+    static std::mutex collections_mtx_;
+    static std::vector<std::string> flow_controller_descriptor_names_;
 };
 
 } // namespace xmlparser

--- a/include/fastrtps/xmlparser/XMLParser.h
+++ b/include/fastrtps/xmlparser/XMLParser.h
@@ -718,7 +718,7 @@ protected:
 private:
 
     static std::mutex collections_mtx_;
-    static std::vector<std::string> flow_controller_descriptor_names_;
+    static std::set<std::string> flow_controller_descriptor_names_;
 };
 
 } // namespace xmlparser

--- a/src/cpp/rtps/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLElementParser.cpp
@@ -1058,11 +1058,17 @@ XMLP_ret XMLParser::getXMLFlowControllerDescriptorList(
             {
                 std::lock_guard<std::mutex> lock(collections_mtx_);
                 // name - stringType
-                auto element_inserted = flow_controller_descriptor_names_.insert(get_element_text(p_aux1));
-                if (element_inserted.first == flow_controller_descriptor_names_.end() ||
-                        element_inserted.first->empty())
+                std::string element = get_element_text(p_aux1);
+                if (element.empty())
                 {
-                    EPROSIMA_LOG_ERROR(XMLPARSER, "Node flow controller node '" << NAME << "' invalid");
+                    EPROSIMA_LOG_ERROR(XMLPARSER, "Node '" << NAME << "' without content");
+                    return XMLP_ret::XML_ERROR;
+                }
+                auto element_inserted = flow_controller_descriptor_names_.insert(element);
+                if (element_inserted.first == flow_controller_descriptor_names_.end())
+                {
+                    EPROSIMA_LOG_ERROR(XMLPARSER,
+                            "Insertion error for flow controller node '" << FLOW_CONTROLLER_NAME << "'");
                     return XMLP_ret::XML_ERROR;
                 }
                 flow_controller_descriptor->name = element_inserted.first->c_str();
@@ -2846,11 +2852,16 @@ XMLP_ret XMLParser::getXMLPublishModeQos(
         else if (strcmp(name, FLOW_CONTROLLER_NAME) == 0)
         {
             std::lock_guard<std::mutex> lock(collections_mtx_);
-            auto element_inserted = flow_controller_descriptor_names_.insert(get_element_text(p_aux0));
-            if (element_inserted.first == flow_controller_descriptor_names_.end() ||
-                    element_inserted.first->empty())
+            std::string element = get_element_text(p_aux0);
+            if (element.empty())
             {
-                EPROSIMA_LOG_ERROR(XMLPARSER, "Node '" << FLOW_CONTROLLER_NAME << "' invalid");
+                EPROSIMA_LOG_ERROR(XMLPARSER, "Node '" << FLOW_CONTROLLER_NAME << "' without content");
+                return XMLP_ret::XML_ERROR;
+            }
+            auto element_inserted = flow_controller_descriptor_names_.insert(element);
+            if (element_inserted.first == flow_controller_descriptor_names_.end())
+            {
+                EPROSIMA_LOG_ERROR(XMLPARSER, "Insertion error for node '" << FLOW_CONTROLLER_NAME << "'");
                 return XMLP_ret::XML_ERROR;
             }
             publishMode.flow_controller_name = element_inserted.first->c_str();

--- a/src/cpp/rtps/xmlparser/XMLParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLParser.cpp
@@ -2833,6 +2833,13 @@ XMLP_ret XMLParser::fillDataNode(
     return XMLP_ret::XML_OK;
 }
 
+XMLP_ret XMLParser::clear()
+{
+    std::lock_guard<std::mutex> lock(collections_mtx_);
+    flow_controller_descriptor_names_.clear();
+    return XMLP_ret::XML_OK;
+}
+
 } // namespace xmlparser
 } // namespace fastrtps
 } // namespace eprosima

--- a/src/cpp/rtps/xmlparser/XMLProfileManager.cpp
+++ b/src/cpp/rtps/xmlparser/XMLProfileManager.cpp
@@ -854,4 +854,7 @@ void XMLProfileManager::DeleteInstance()
         }
         dynamic_types_.clear();
     }
+
+    // Clear XML Parser collections
+    XMLParser::clear();
 }

--- a/test/unittest/dds/publisher/PublisherTests.cpp
+++ b/test/unittest/dds/publisher/PublisherTests.cpp
@@ -397,7 +397,7 @@ TEST(PublisherTests, ChangeDefaultDataWriterQos)
     EXPECT_FALSE(wqos.writer_data_lifecycle().autodispose_unregistered_instances);
     // .publish_mode
     EXPECT_EQ(eprosima::fastdds::dds::ASYNCHRONOUS_PUBLISH_MODE, wqos.publish_mode().kind);
-    EXPECT_EQ(true, wqos.publish_mode().flow_controller_name == "Prueba");
+    EXPECT_EQ(0, strcmp(wqos.publish_mode().flow_controller_name, "Prueba"));
     count = 1;
     for (auto prop : wqos.properties().properties())
     {

--- a/test/unittest/xmlparser/XMLProfileParserTests.cpp
+++ b/test/unittest/xmlparser/XMLProfileParserTests.cpp
@@ -885,7 +885,7 @@ TEST_P(XMLProfileParserTests, XMLParserPublisher)
     EXPECT_EQ(pub_qos.m_partition.names()[0], "partition_name_a");
     EXPECT_EQ(pub_qos.m_partition.names()[1], "partition_name_b");
     EXPECT_EQ(pub_qos.m_publishMode.kind, ASYNCHRONOUS_PUBLISH_MODE);
-    EXPECT_EQ(pub_qos.m_publishMode.flow_controller_name, "test_flow_controller");
+    EXPECT_EQ(0, strcmp(pub_qos.m_publishMode.flow_controller_name, "test_flow_controller"));
     EXPECT_EQ(pub_times.initialHeartbeatDelay, c_TimeZero);
     EXPECT_EQ(pub_times.heartbeatPeriod.seconds, 11);
     EXPECT_EQ(pub_times.heartbeatPeriod.nanosec, 32u);
@@ -961,7 +961,7 @@ TEST_F(XMLProfileParserBasicTests, XMLParserPublisherDeprecated)
     EXPECT_EQ(pub_qos.m_partition.names()[0], "partition_name_a");
     EXPECT_EQ(pub_qos.m_partition.names()[1], "partition_name_b");
     EXPECT_EQ(pub_qos.m_publishMode.kind, ASYNCHRONOUS_PUBLISH_MODE);
-    EXPECT_EQ(pub_qos.m_publishMode.flow_controller_name, "test_flow_controller");
+    EXPECT_EQ(0, strcmp(pub_qos.m_publishMode.flow_controller_name, "test_flow_controller"));
     EXPECT_EQ(pub_times.initialHeartbeatDelay, c_TimeZero);
     EXPECT_EQ(pub_times.heartbeatPeriod.seconds, 11);
     EXPECT_EQ(pub_times.heartbeatPeriod.nanosec, 32u);
@@ -1035,7 +1035,7 @@ TEST_P(XMLProfileParserTests, XMLParserDefaultPublisherProfile)
     EXPECT_EQ(pub_qos.m_partition.names()[0], "partition_name_a");
     EXPECT_EQ(pub_qos.m_partition.names()[1], "partition_name_b");
     EXPECT_EQ(pub_qos.m_publishMode.kind, ASYNCHRONOUS_PUBLISH_MODE);
-    EXPECT_EQ(pub_qos.m_publishMode.flow_controller_name, "test_flow_controller");
+    EXPECT_EQ(0, strcmp(pub_qos.m_publishMode.flow_controller_name, "test_flow_controller"));
     EXPECT_EQ(pub_times.initialHeartbeatDelay, c_TimeZero);
     EXPECT_EQ(pub_times.heartbeatPeriod.seconds, 11);
     EXPECT_EQ(pub_times.heartbeatPeriod.nanosec, 32u);
@@ -1109,7 +1109,7 @@ TEST_F(XMLProfileParserBasicTests, XMLParserDefaultPublisherProfileDeprecated)
     EXPECT_EQ(pub_qos.m_partition.names()[0], "partition_name_a");
     EXPECT_EQ(pub_qos.m_partition.names()[1], "partition_name_b");
     EXPECT_EQ(pub_qos.m_publishMode.kind, ASYNCHRONOUS_PUBLISH_MODE);
-    EXPECT_EQ(pub_qos.m_publishMode.flow_controller_name, "test_flow_controller");
+    EXPECT_EQ(0, strcmp(pub_qos.m_publishMode.flow_controller_name, "test_flow_controller"));
     EXPECT_EQ(pub_times.initialHeartbeatDelay, c_TimeZero);
     EXPECT_EQ(pub_times.heartbeatPeriod.seconds, 11);
     EXPECT_EQ(pub_times.heartbeatPeriod.nanosec, 32u);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
PR #4893 introduced an ABI break changing the flow controller descriptor names to `std::string`. This PR reverts that change and handles the flow controller names in a collection within `XMLParser`. It also defines a `clear()` method intended to clean the collection upon `XMLProfileManager` destruction.

*Note* I introduced a `mutex` but I dont think it is needed 100% since the XMLParser configuration may be something sequential, but I introduced it anyways.
 
**Important** A cherry pick of this PR should be merged in the following backports
* #4905 
* #4906
* #4907
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- __NO__ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [X] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- __NO__ New feature has been added to the `versions.md` file (if applicable).
- [X] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - Related documentation PR: eProsima/Fast-DDS-docs#806
- __NO__ (see PR description) Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
