### PR TITLE
Bugfix: LifespanQoSExample Using the api incorrectly

### DIFF
--- a/examples/cpp/dds/LifespanQoSExample/LifespanSubscriber.cpp
+++ b/examples/cpp/dds/LifespanQoSExample/LifespanSubscriber.cpp
@@ -154,7 +154,7 @@ void LifespanSubscriber::run(
     // Now wait and try to remove from history
     std::cout << std::endl << "Subscriber waiting for " << sleep_ms << " milliseconds" << std::endl << std::endl;
     std::this_thread::sleep_for(std::chrono::milliseconds(sleep_ms));
-    
+
     LoanableSequence<Lifespan> data_values;
     SampleInfoSeq sample_infos;
 
@@ -163,20 +163,18 @@ void LifespanSubscriber::run(
         data_values,
         sample_infos,
         max_samples,
-        ANY_SAMPLE_STATE
-    );
+        ANY_SAMPLE_STATE);
 
     if (result == ReturnCode_t::RETCODE_OK)
     {
         size_t samples_taken = sample_infos.length();
-        std::cout << samples_taken << std::endl;
         for (size_t i = 0; i < samples_taken; ++i)
         {
-            Lifespan& sample = data_values[i];
-            SampleInfo& sample_info = sample_infos[i];
+            Lifespan &sample = data_values[i];
+            SampleInfo &sample_info = sample_infos[i];
 
-            std::cout << "Message " << sample.message() << " with index " << sample.index() 
-                    << " read from history." << std::endl;
+            std::cout << "Message " << sample.message() << " with index " << sample.index()
+                      << " read from history." << std::endl;
         }
     }
     else

--- a/examples/cpp/dds/LifespanQoSExample/LifespanSubscriber.cpp
+++ b/examples/cpp/dds/LifespanQoSExample/LifespanSubscriber.cpp
@@ -170,8 +170,8 @@ void LifespanSubscriber::run(
         size_t samples_taken = sample_infos.length();
         for (size_t i = 0; i < samples_taken; ++i)
         {
-            Lifespan &sample = data_values[i];
-            SampleInfo &sample_info = sample_infos[i];
+            Lifespan& sample = data_values[i];
+            SampleInfo& sample_info = sample_infos[i];
 
             std::cout << "Message " << sample.message() << " with index " << sample.index()
                       << " read from history." << std::endl;

--- a/examples/cpp/dds/LifespanQoSExample/LifespanSubscriber.cpp
+++ b/examples/cpp/dds/LifespanQoSExample/LifespanSubscriber.cpp
@@ -154,19 +154,35 @@ void LifespanSubscriber::run(
     // Now wait and try to remove from history
     std::cout << std::endl << "Subscriber waiting for " << sleep_ms << " milliseconds" << std::endl << std::endl;
     std::this_thread::sleep_for(std::chrono::milliseconds(sleep_ms));
+    
+    LoanableSequence<Lifespan> data_values;
+    SampleInfoSeq sample_infos;
 
-    LifespanPubSubType::type data;
-    SampleInfo info;
+    int32_t max_samples = listener.n_samples;
+    ReturnCode_t result = reader_->take(
+        data_values,
+        sample_infos,
+        max_samples,
+        ANY_SAMPLE_STATE
+    );
 
-    for ( uint32_t i = 0; i < listener.n_samples; i++ )
+    if (result == ReturnCode_t::RETCODE_OK)
     {
-        if (reader_->take_next_sample((void*) &data, &info) == ReturnCode_t::RETCODE_OK)
+        size_t samples_taken = sample_infos.length();
+        std::cout << samples_taken << std::endl;
+        for (size_t i = 0; i < samples_taken; ++i)
         {
-            std::cout << "Message " << data.message() << " " << data.index() << " read from history" << std::endl;
-        }
-        else
-        {
-            std::cout << "Could not read message " << i << " from history" << std::endl;
+            Lifespan& sample = data_values[i];
+            SampleInfo& sample_info = sample_infos[i];
+
+            std::cout << "Message " << sample.message() << " with index " << sample.index() 
+                    << " read from history." << std::endl;
         }
     }
+    else
+    {
+        std::cout << "Could not read message from history" << std::endl;
+    }
+
+    reader_->return_loan(data_values, sample_infos);
 }


### PR DESCRIPTION
…simultaneously

LifespanQoSExample Use read_next_sample and take_next_sample simultaneously

<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
  LifespanQoSExample Using the api incorrectly,Incorrect read_next_sample and take_next_sample are used at the same time, resulting in the failure to read historical data during the life cycle.

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [ ] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [ ] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
