### PR TITLE
[21162] Split example tests in different ctest tests

### DIFF
--- a/test/examples/CMakeLists.txt
+++ b/test/examples/CMakeLists.txt
@@ -65,17 +65,19 @@ if(NOT (TINYXML2_FROM_SOURCE OR TINYXML2_FROM_THIRDPARTY))
     set(TINYXML2_LIB_DIR_COMPOSE_LD_LIBRARY_PATH ":${CMAKE_INSTALL_PREFIX}/${DATA_INSTALL_DIR}/fastdds")
 endif()
 
-# Find all docker compose yml files for testing
-file(GLOB files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*.yml)
+# Find all pytest files for testing
+file(GLOB examples_python_tests RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*.py)
 
-# Configure the docker compose files
-foreach(file ${files})
-    message(STATUS "  Configuring example test: ${file}")
-    configure_file(${file} ${CMAKE_CURRENT_BINARY_DIR}/${file} @ONLY)
+# Configure the pytest files, and add a test for each one
+foreach(example_test ${examples_python_tests})
+    get_filename_component(example_name ${example_test} NAME_WE)
+    string(REPLACE "test_" "" example_name "${example_name}")
+    message(STATUS "  Configuring example test: ${example_name}")
+    configure_file(${example_test}
+                   ${CMAKE_CURRENT_BINARY_DIR}/${example_name}/${example_test} @ONLY)
+    configure_file(${example_name}.compose.yml
+                   ${CMAKE_CURRENT_BINARY_DIR}/${example_name}/${example_name}.compose.yml @ONLY)
+    add_test(NAME example_tests.${example_name}
+             COMMAND ${Python3_EXECUTABLE} -m pytest -vrP
+             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${example_name})
 endforeach()
-
-# Copy pytest file
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/test_examples.py ${CMAKE_CURRENT_BINARY_DIR}/test_examples.py @ONLY)
-
-# Add test to ctest runs it
-add_test(NAME example_tests COMMAND ${Python3_EXECUTABLE} -m pytest -vrP WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/test/examples/test_configuration.py
+++ b/test/examples/test_configuration.py
@@ -1,4 +1,3 @@
-
 import subprocess
 import pytest
 
@@ -153,45 +152,6 @@ def test_configuration_expected_output(pub_args, sub_args, expected_message, n_m
 
     except subprocess.CalledProcessError as e:
         print (render_out)
-    except subprocess.TimeoutExpired:
-        print('TIMEOUT')
-        print(out)
-
-    assert(ret)
-
-def test_hello_world():
-    """."""
-    ret = False
-    out = ''
-    try:
-        out = subprocess.check_output(
-            '@DOCKER_EXECUTABLE@ compose -f hello_world.compose.yml up',
-            stderr=subprocess.STDOUT,
-            shell=True,
-            timeout=30
-        ).decode().split('\n')
-
-        sent = 0
-        received = 0
-        for line in out:
-            if 'SENT' in line:
-                sent += 1
-                continue
-
-            if 'RECEIVED' in line:
-                received += 1
-                continue
-
-        if sent != 0 and received != 0 and sent * 2 == received:
-            ret = True
-        else:
-            print('ERROR: sent: ' + str(sent) + ', but received: ' + str(received) +
-                  ' (expected: ' + str(sent * 2) + ')')
-            raise subprocess.CalledProcessError(1, '')
-
-    except subprocess.CalledProcessError:
-        for l in out:
-            print(l)
     except subprocess.TimeoutExpired:
         print('TIMEOUT')
         print(out)

--- a/test/examples/test_hello_world.py
+++ b/test/examples/test_hello_world.py
@@ -1,0 +1,40 @@
+import subprocess
+
+def test_hello_world():
+    """."""
+    ret = False
+    out = ''
+    try:
+        out = subprocess.check_output(
+            '@DOCKER_EXECUTABLE@ compose -f hello_world.compose.yml up',
+            stderr=subprocess.STDOUT,
+            shell=True,
+            timeout=30
+        ).decode().split('\n')
+
+        sent = 0
+        received = 0
+        for line in out:
+            if 'SENT' in line:
+                sent += 1
+                continue
+
+            if 'RECEIVED' in line:
+                received += 1
+                continue
+
+        if sent != 0 and received != 0 and sent * 2 == received:
+            ret = True
+        else:
+            print('ERROR: sent: ' + str(sent) + ', but received: ' + str(received) +
+                  ' (expected: ' + str(sent * 2) + ')')
+            raise subprocess.CalledProcessError(1, '')
+
+    except subprocess.CalledProcessError:
+        for l in out:
+            print(l)
+    except subprocess.TimeoutExpired:
+        print('TIMEOUT')
+        print(out)
+
+    assert(ret)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Current example tests are defined under the same pytest. That makes the "all examples" test fail if the timeout (300 sec) is reached. It didn't happen before but while including new examples (and their corresponding tests) this timeout has been reached.
This PR splits the pytest file with all example tests into different pytest files under different directories, so each of them would run independently with the same timeout (300 sec).
The corresponding compose file for each test has been configured in the same directoy on build time.

**Note**: This has been done assuming the name matches: 
- compose file: `example_name`.compose.yml
- test_`example_name`.py
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- ❌ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
