### PR TITLE
[21165] Correctly initialize `MatchingFailureMask` constants to be used with the `std::bitset` API

### DIFF
--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.h
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.h
@@ -78,19 +78,19 @@ public:
     public:
 
         //! Bit index for matching failing due to different topic
-        static const uint32_t different_topic = (0x00000001 << 0u);
+        static const uint32_t different_topic = 0u;
 
         //! Bit index for matching failing due to inconsistent topic (same topic name but different characteristics)
-        static const uint32_t inconsistent_topic = (0x00000001 << 1u);
+        static const uint32_t inconsistent_topic = 1u;
 
         //! Bit index for matching failing due to incompatible QoS
-        static const uint32_t incompatible_qos = (0x00000001 << 2u);
+        static const uint32_t incompatible_qos = 2u;
 
         //! Bit index for matching failing due to inconsistent partitions
-        static const uint32_t partitions = (0x00000001 << 3u);
+        static const uint32_t partitions = 3u;
 
         //! Bit index for matching failing due to incompatible TypeInformation
-        static const uint32_t different_typeinfo = (0x00000001 << 4u);
+        static const uint32_t different_typeinfo = 4u;
     };
 
     /**

--- a/test/unittest/rtps/discovery/EdpTests.cpp
+++ b/test/unittest/rtps/discovery/EdpTests.cpp
@@ -481,6 +481,27 @@ TEST_F(EdpTests, CheckDataRepresentationCompatibility)
     }
 }
 
+TEST(MatchingFailureMask, matching_failure_mask_overflow)
+{
+    EDP::MatchingFailureMask mask;
+
+    mask.set(EDP::MatchingFailureMask::different_topic);
+    ASSERT_TRUE(mask.test(EDP::MatchingFailureMask::different_topic));
+
+    mask.set(EDP::MatchingFailureMask::inconsistent_topic);
+    ASSERT_TRUE(mask.test(EDP::MatchingFailureMask::inconsistent_topic));
+
+    mask.set(EDP::MatchingFailureMask::incompatible_qos);
+    ASSERT_TRUE(mask.test(EDP::MatchingFailureMask::incompatible_qos));
+
+    mask.set(EDP::MatchingFailureMask::partitions);
+    ASSERT_TRUE(mask.test(EDP::MatchingFailureMask::partitions));
+
+    mask.set(EDP::MatchingFailureMask::different_typeinfo);
+    ASSERT_TRUE(mask.test(EDP::MatchingFailureMask::different_typeinfo));
+}
+
+
 } // namespace rtps
 } // namespace fastrtps
 } // namespace eprosima

--- a/test/unittest/rtps/discovery/EdpTests.cpp
+++ b/test/unittest/rtps/discovery/EdpTests.cpp
@@ -486,19 +486,19 @@ TEST(MatchingFailureMask, matching_failure_mask_overflow)
     EDP::MatchingFailureMask mask;
 
     mask.set(EDP::MatchingFailureMask::different_topic);
-    ASSERT_TRUE(mask.test(EDP::MatchingFailureMask::different_topic));
+    EXPECT_TRUE(mask.test(EDP::MatchingFailureMask::different_topic));
 
     mask.set(EDP::MatchingFailureMask::inconsistent_topic);
-    ASSERT_TRUE(mask.test(EDP::MatchingFailureMask::inconsistent_topic));
+    EXPECT_TRUE(mask.test(EDP::MatchingFailureMask::inconsistent_topic));
 
     mask.set(EDP::MatchingFailureMask::incompatible_qos);
-    ASSERT_TRUE(mask.test(EDP::MatchingFailureMask::incompatible_qos));
+    EXPECT_TRUE(mask.test(EDP::MatchingFailureMask::incompatible_qos));
 
     mask.set(EDP::MatchingFailureMask::partitions);
-    ASSERT_TRUE(mask.test(EDP::MatchingFailureMask::partitions));
+    EXPECT_TRUE(mask.test(EDP::MatchingFailureMask::partitions));
 
     mask.set(EDP::MatchingFailureMask::different_typeinfo);
-    ASSERT_TRUE(mask.test(EDP::MatchingFailureMask::different_typeinfo));
+    EXPECT_TRUE(mask.test(EDP::MatchingFailureMask::different_typeinfo));
 }
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR changes the values of the `MatchingFailureMask` so they can be directly used through the `std::bitset` API. Before this PR, the following code:

```c++
EDP::MatchingFailureMask mask;
mask.set(EDP::MatchingFailureMask::different_typeinfo);
```

resulted in a C++ exception as follows:

```
"bitset::set: __position (which is 16) >= _Nb (which is 16)"
```

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
