### PR TITLE
[21153, 21154] Address XMLDynamicParser Fuzzer regressions 

### DIFF
--- a/src/cpp/xmlparser/XMLDynamicParser.cpp
+++ b/src/cpp/xmlparser/XMLDynamicParser.cpp
@@ -434,7 +434,15 @@ XMLP_ret XMLParser::parseXMLAliasDynamicType(
             const char* boundStr = p_root->Attribute(STR_MAXLENGTH);
             if (boundStr != nullptr)
             {
-                bound = static_cast<uint32_t>(std::stoul(boundStr));
+                try
+                {
+                    bound = static_cast<uint32_t>(std::stoul(boundStr));
+                }
+                catch (const std::exception&)
+                {
+                    EPROSIMA_LOG_ERROR(XMLPARSER, "Error parsing alias type bound: '" << STR_MAXLENGTH << "' out of bounds.");
+                    return XMLP_ret::XML_ERROR;
+                }
             }
             value_type = getDiscriminatorTypeBuilder(type, bound);
         }
@@ -540,10 +548,17 @@ XMLP_ret XMLParser::parseXMLBitsetDynamicType(
             EPROSIMA_LOG_ERROR(XMLPARSER, "Error parsing bitfield bit_bound: Not found.");
             return XMLP_ret::XML_ERROR;
         }
-
         if (nullptr != member_name)
         {
-            bitset_descriptor->bound().push_back(static_cast<uint32_t>(std::stoul(bit_bound)));
+            try
+            {
+                bitset_descriptor->bound().push_back(static_cast<uint32_t>(std::stoul(bit_bound)));
+            }
+            catch (const std::exception&)
+            {
+                EPROSIMA_LOG_ERROR(XMLPARSER, "Error parsing bitfield type bound: '" << BIT_BOUND << "' out of bounds.");
+                return XMLP_ret::XML_ERROR;
+            }
         }
     }
     //}}}
@@ -1595,7 +1610,15 @@ DynamicType::_ref_type XMLParser:: parseXMLMemberDynamicType(
 
         if (nullptr != boundStr)
         {
-            bound = static_cast<uint32_t>(std::stoul(boundStr));
+            try
+            {
+                bound = static_cast<uint32_t>(std::stoul(boundStr));
+            }
+            catch (const std::exception&)
+            {
+                EPROSIMA_LOG_ERROR(XMLPARSER, "Error parsing alias type bound: '" << STR_MAXLENGTH << "' out of bounds.");
+                return {};
+            }
         }
 
         DynamicTypeBuilder::_ref_type string_builder = factory->create_string_type(bound);
@@ -1620,7 +1643,15 @@ DynamicType::_ref_type XMLParser:: parseXMLMemberDynamicType(
 
         if (nullptr != boundStr)
         {
-            bound = static_cast<uint32_t>(std::stoul(boundStr));
+            try
+            {
+                bound = static_cast<uint32_t>(std::stoul(boundStr));
+            }
+            catch (const std::exception&)
+            {
+                EPROSIMA_LOG_ERROR(XMLPARSER, "Error parsing alias type bound: '" << STR_MAXLENGTH << "' out of bounds.");
+                return {};
+            }
         }
 
         DynamicTypeBuilder::_ref_type wstring_builder = factory->create_wstring_type(bound);

--- a/src/cpp/xmlparser/XMLDynamicParser.cpp
+++ b/src/cpp/xmlparser/XMLDynamicParser.cpp
@@ -440,7 +440,8 @@ XMLP_ret XMLParser::parseXMLAliasDynamicType(
                 }
                 catch (const std::exception&)
                 {
-                    EPROSIMA_LOG_ERROR(XMLPARSER, "Error parsing alias type bound: '" << STR_MAXLENGTH << "' out of bounds.");
+                    EPROSIMA_LOG_ERROR(XMLPARSER,
+                            "Error parsing alias type bound: '" << STR_MAXLENGTH << "' out of bounds.");
                     return XMLP_ret::XML_ERROR;
                 }
             }
@@ -556,7 +557,8 @@ XMLP_ret XMLParser::parseXMLBitsetDynamicType(
             }
             catch (const std::exception&)
             {
-                EPROSIMA_LOG_ERROR(XMLPARSER, "Error parsing bitfield type bound: '" << BIT_BOUND << "' out of bounds.");
+                EPROSIMA_LOG_ERROR(XMLPARSER,
+                        "Error parsing bitfield type bound: '" << BIT_BOUND << "' out of bounds.");
                 return XMLP_ret::XML_ERROR;
             }
         }
@@ -892,7 +894,7 @@ XMLP_ret XMLParser::parseXMLEnumDynamicType(
     DynamicTypeBuilder::_ref_type type_builder {DynamicTypeBuilderFactory::get_instance()->create_type(
                                                     enum_descriptor)};
 
-    if(nullptr != type_builder)
+    if (nullptr != type_builder)
     {
         for (tinyxml2::XMLElement* literal = p_root->FirstChildElement(ENUMERATOR);
                 literal != nullptr; literal = literal->NextSiblingElement(ENUMERATOR))
@@ -1616,7 +1618,8 @@ DynamicType::_ref_type XMLParser:: parseXMLMemberDynamicType(
             }
             catch (const std::exception&)
             {
-                EPROSIMA_LOG_ERROR(XMLPARSER, "Error parsing alias type bound: '" << STR_MAXLENGTH << "' out of bounds.");
+                EPROSIMA_LOG_ERROR(XMLPARSER,
+                        "Error parsing alias type bound: '" << STR_MAXLENGTH << "' out of bounds.");
                 return {};
             }
         }
@@ -1649,7 +1652,8 @@ DynamicType::_ref_type XMLParser:: parseXMLMemberDynamicType(
             }
             catch (const std::exception&)
             {
-                EPROSIMA_LOG_ERROR(XMLPARSER, "Error parsing alias type bound: '" << STR_MAXLENGTH << "' out of bounds.");
+                EPROSIMA_LOG_ERROR(XMLPARSER,
+                        "Error parsing alias type bound: '" << STR_MAXLENGTH << "' out of bounds.");
                 return {};
             }
         }

--- a/src/cpp/xmlparser/XMLDynamicParser.cpp
+++ b/src/cpp/xmlparser/XMLDynamicParser.cpp
@@ -569,29 +569,37 @@ XMLP_ret XMLParser::parseXMLBitsetDynamicType(
     DynamicTypeBuilder::_ref_type type_builder =
             DynamicTypeBuilderFactory::get_instance()->create_type(bitset_descriptor);
 
-    const char* element_name {nullptr};
-    MemberId position {0};
-    for (tinyxml2::XMLElement* p_element = p_root->FirstChildElement();
-            p_element != nullptr; p_element = p_element->NextSiblingElement())
+    if (nullptr != type_builder)
     {
-        element_name = p_element->Name();
-        if (strcmp(element_name, BITFIELD) == 0)
+        const char* element_name {nullptr};
+        MemberId position {0};
+        for (tinyxml2::XMLElement* p_element = p_root->FirstChildElement();
+                p_element != nullptr; p_element = p_element->NextSiblingElement())
         {
-            ret = parseXMLBitfieldDynamicType(p_element, type_builder, position);
+            element_name = p_element->Name();
+            if (strcmp(element_name, BITFIELD) == 0)
+            {
+                ret = parseXMLBitfieldDynamicType(p_element, type_builder, position);
+            }
+            else
+            {
+                EPROSIMA_LOG_ERROR(XMLPARSER, "Invalid element found into 'bitsetDcl'. Name: " << element_name);
+                return XMLP_ret::XML_ERROR;
+            }
         }
-        else
+
+        if (XMLP_ret::XML_OK == ret)
         {
-            EPROSIMA_LOG_ERROR(XMLPARSER, "Invalid element found into 'bitsetDcl'. Name: " << element_name);
-            return XMLP_ret::XML_ERROR;
+            if (false == XMLProfileManager::insertDynamicTypeByName(name, type_builder->build()))
+            {
+                ret = XMLP_ret::XML_ERROR;
+            }
         }
     }
-
-    if (XMLP_ret::XML_OK == ret)
+    else
     {
-        if (false == XMLProfileManager::insertDynamicTypeByName(name, type_builder->build()))
-        {
-            ret = XMLP_ret::XML_ERROR;
-        }
+        EPROSIMA_LOG_ERROR(XMLPARSER, "Error creating bitset type: " << name);
+        ret = XMLP_ret::XML_ERROR;
     }
 
     return ret;
@@ -792,27 +800,35 @@ XMLP_ret XMLParser::parseXMLBitmaskDynamicType(
         DynamicTypeBuilderFactory::get_instance()->create_type(bitmask_descriptor)};
     uint16_t position = 0;
 
-    const char* element_name = nullptr;
-    for (tinyxml2::XMLElement* p_element = p_root->FirstChildElement();
-            p_element != nullptr; p_element = p_element->NextSiblingElement())
+    if (nullptr != type_builder)
     {
-        element_name = p_element->Name();
-        if (strcmp(element_name, BIT_VALUE) == 0)
+        const char* element_name = nullptr;
+        for (tinyxml2::XMLElement* p_element = p_root->FirstChildElement();
+                p_element != nullptr; p_element = p_element->NextSiblingElement())
         {
-            if (parseXMLBitvalueDynamicType(p_element, type_builder, position) != XMLP_ret::XML_OK)
+            element_name = p_element->Name();
+            if (strcmp(element_name, BIT_VALUE) == 0)
             {
+                if (parseXMLBitvalueDynamicType(p_element, type_builder, position) != XMLP_ret::XML_OK)
+                {
+                    return XMLP_ret::XML_ERROR;
+                }
+            }
+            else
+            {
+                EPROSIMA_LOG_ERROR(XMLPARSER, "Invalid element found into 'bitmaskDcl'. Name: " << element_name);
                 return XMLP_ret::XML_ERROR;
             }
         }
-        else
+
+        if (false == XMLProfileManager::insertDynamicTypeByName(name, type_builder->build()))
         {
-            EPROSIMA_LOG_ERROR(XMLPARSER, "Invalid element found into 'bitmaskDcl'. Name: " << element_name);
-            return XMLP_ret::XML_ERROR;
+            ret = XMLP_ret::XML_ERROR;
         }
     }
-
-    if (false == XMLProfileManager::insertDynamicTypeByName(name, type_builder->build()))
+    else
     {
+        EPROSIMA_LOG_ERROR(XMLPARSER, "Error creating bitmask type: " << name);
         ret = XMLP_ret::XML_ERROR;
     }
 
@@ -861,31 +877,39 @@ XMLP_ret XMLParser::parseXMLEnumDynamicType(
     DynamicTypeBuilder::_ref_type type_builder {DynamicTypeBuilderFactory::get_instance()->create_type(
                                                     enum_descriptor)};
 
-    for (tinyxml2::XMLElement* literal = p_root->FirstChildElement(ENUMERATOR);
-            literal != nullptr; literal = literal->NextSiblingElement(ENUMERATOR))
+    if(nullptr != type_builder)
     {
-        const char* name = literal->Attribute(NAME);
-        if (name == nullptr)
+        for (tinyxml2::XMLElement* literal = p_root->FirstChildElement(ENUMERATOR);
+                literal != nullptr; literal = literal->NextSiblingElement(ENUMERATOR))
         {
-            EPROSIMA_LOG_ERROR(XMLPARSER, "Error parsing enum type: Literals must have name.");
-            return XMLP_ret::XML_ERROR;
+            const char* name = literal->Attribute(NAME);
+            if (name == nullptr)
+            {
+                EPROSIMA_LOG_ERROR(XMLPARSER, "Error parsing enum type: Literals must have name.");
+                return XMLP_ret::XML_ERROR;
+            }
+
+            MemberDescriptor::_ref_type md {traits<MemberDescriptor>::make_shared()};
+            md->type(DynamicTypeBuilderFactory::get_instance()->get_primitive_type(TK_INT32));
+            md->name(name);
+
+            const char* value = literal->Attribute(VALUE);
+            if (value != nullptr)
+            {
+                md->default_value(value);
+            }
+
+            type_builder->add_member(md);
         }
 
-        MemberDescriptor::_ref_type md {traits<MemberDescriptor>::make_shared()};
-        md->type(DynamicTypeBuilderFactory::get_instance()->get_primitive_type(TK_INT32));
-        md->name(name);
-
-        const char* value = literal->Attribute(VALUE);
-        if (value != nullptr)
+        if (false == XMLProfileManager::insertDynamicTypeByName(enumName, type_builder->build()))
         {
-            md->default_value(value);
+            ret = XMLP_ret::XML_ERROR;
         }
-
-        type_builder->add_member(md);
     }
-
-    if (false == XMLProfileManager::insertDynamicTypeByName(enumName, type_builder->build()))
+    else
     {
+        EPROSIMA_LOG_ERROR(XMLPARSER, "Error creating enum type: " << enumName);
         ret = XMLP_ret::XML_ERROR;
     }
 
@@ -950,27 +974,35 @@ XMLP_ret XMLParser::parseXMLStructDynamicType(
     DynamicTypeBuilder::_ref_type type_builder = DynamicTypeBuilderFactory::get_instance()->create_type(
         structure_descriptor);
 
-    const char* element_name = nullptr;
-    for (tinyxml2::XMLElement* p_element = p_root->FirstChildElement();
-            p_element != nullptr; p_element = p_element->NextSiblingElement())
+    if (nullptr != type_builder)
     {
-        element_name = p_element->Name();
-        if (strcmp(element_name, MEMBER) == 0)
+        const char* element_name = nullptr;
+        for (tinyxml2::XMLElement* p_element = p_root->FirstChildElement();
+                p_element != nullptr; p_element = p_element->NextSiblingElement())
         {
-            if (!parseXMLMemberDynamicType(p_element, type_builder, mId++))
+            element_name = p_element->Name();
+            if (strcmp(element_name, MEMBER) == 0)
             {
+                if (!parseXMLMemberDynamicType(p_element, type_builder, mId++))
+                {
+                    return XMLP_ret::XML_ERROR;
+                }
+            }
+            else
+            {
+                EPROSIMA_LOG_ERROR(XMLPARSER, "Invalid element found into 'structDcl'. Name: " << element_name);
                 return XMLP_ret::XML_ERROR;
             }
         }
-        else
+
+        if (false == XMLProfileManager::insertDynamicTypeByName(name, type_builder->build()))
         {
-            EPROSIMA_LOG_ERROR(XMLPARSER, "Invalid element found into 'structDcl'. Name: " << element_name);
-            return XMLP_ret::XML_ERROR;
+            ret = XMLP_ret::XML_ERROR;
         }
     }
-
-    if (false == XMLProfileManager::insertDynamicTypeByName(name, type_builder->build()))
+    else
     {
+        EPROSIMA_LOG_ERROR(XMLPARSER, "Error creating struct type: " << name);
         ret = XMLP_ret::XML_ERROR;
     }
 
@@ -1037,53 +1069,61 @@ XMLP_ret XMLParser::parseXMLUnionDynamicType(
             DynamicTypeBuilder::_ref_type type_builder {DynamicTypeBuilderFactory::get_instance()->
                                                                 create_type(union_descriptor)};
 
-            MemberId mId{1};
-            for (p_element = p_root->FirstChildElement(CASE);
-                    p_element != nullptr; p_element = p_element->NextSiblingElement(CASE))
+            if (nullptr != type_builder)
             {
-                std::string valuesStr = "";
-                for (tinyxml2::XMLElement* caseValue = p_element->FirstChildElement(CASE_DISCRIMINATOR);
-                        caseValue != nullptr; caseValue = caseValue->NextSiblingElement(CASE_DISCRIMINATOR))
+                MemberId mId{1};
+                for (p_element = p_root->FirstChildElement(CASE);
+                        p_element != nullptr; p_element = p_element->NextSiblingElement(CASE))
                 {
-                    const char* values = caseValue->Attribute(VALUE);
-                    if (values == nullptr)
+                    std::string valuesStr = "";
+                    for (tinyxml2::XMLElement* caseValue = p_element->FirstChildElement(CASE_DISCRIMINATOR);
+                            caseValue != nullptr; caseValue = caseValue->NextSiblingElement(CASE_DISCRIMINATOR))
                     {
-                        EPROSIMA_LOG_ERROR(XMLPARSER, "Error parsing union case value: Not found.");
-                        return XMLP_ret::XML_ERROR;
+                        const char* values = caseValue->Attribute(VALUE);
+                        if (values == nullptr)
+                        {
+                            EPROSIMA_LOG_ERROR(XMLPARSER, "Error parsing union case value: Not found.");
+                            return XMLP_ret::XML_ERROR;
+                        }
+
+                        if (valuesStr.empty())
+                        {
+                            valuesStr = values;
+                        }
+                        else
+                        {
+                            valuesStr += std::string(",") + values;
+                        }
                     }
 
-                    if (valuesStr.empty())
+                    tinyxml2::XMLElement* caseElement = p_element->FirstChildElement();
+                    while (caseElement != nullptr &&
+                            strncmp(caseElement->Value(), CASE_DISCRIMINATOR, CASE_DISCRIMINATOR_len) == 0)
                     {
-                        valuesStr = values;
+                        caseElement = caseElement->NextSiblingElement();
+                    }
+                    if (caseElement != nullptr)
+                    {
+                        if (!parseXMLMemberDynamicType(caseElement, type_builder, mId++, valuesStr))
+                        {
+                            return XMLP_ret::XML_ERROR;
+                        }
                     }
                     else
                     {
-                        valuesStr += std::string(",") + values;
-                    }
-                }
-
-                tinyxml2::XMLElement* caseElement = p_element->FirstChildElement();
-                while (caseElement != nullptr &&
-                        strncmp(caseElement->Value(), CASE_DISCRIMINATOR, CASE_DISCRIMINATOR_len) == 0)
-                {
-                    caseElement = caseElement->NextSiblingElement();
-                }
-                if (caseElement != nullptr)
-                {
-                    if (!parseXMLMemberDynamicType(caseElement, type_builder, mId++, valuesStr))
-                    {
+                        EPROSIMA_LOG_ERROR(XMLPARSER, "Error parsing union case member: Not found.");
                         return XMLP_ret::XML_ERROR;
                     }
                 }
-                else
+
+                if (false == XMLProfileManager::insertDynamicTypeByName(name, type_builder->build()))
                 {
-                    EPROSIMA_LOG_ERROR(XMLPARSER, "Error parsing union case member: Not found.");
-                    return XMLP_ret::XML_ERROR;
+                    ret = XMLP_ret::XML_ERROR;
                 }
             }
-
-            if (false == XMLProfileManager::insertDynamicTypeByName(name, type_builder->build()))
+            else
             {
+                EPROSIMA_LOG_ERROR(XMLPARSER, "Error creating union type: " << name);
                 ret = XMLP_ret::XML_ERROR;
             }
         }

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -79,6 +79,8 @@ TEST_F(XMLParserTests, regressions)
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/20610_profile_bin.xml", root));
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/20732_profile_bin.xml", root));
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/21153_profile_bin.xml", root));
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/21154_profile_bin.xml", root));
+    Log::Flush();
 }
 
 TEST_F(XMLParserTests, NoFile)

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -78,6 +78,7 @@ TEST_F(XMLParserTests, regressions)
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/20608_profile_bin.xml", root));
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/20610_profile_bin.xml", root));
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/20732_profile_bin.xml", root));
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParser::loadXML("regressions/21153_profile_bin.xml", root));
 }
 
 TEST_F(XMLParserTests, NoFile)

--- a/test/unittest/xmlparser/regressions/21153_profile_bin.xml
+++ b/test/unittest/xmlparser/regressions/21153_profile_bin.xml
@@ -1,0 +1,1 @@
+<types><type><bitset name=" <εγγγγγγγÿÿÿÿÿÿÿÿ:typ163,631499Ν574ÿÿ1"/></type></types>

--- a/test/unittest/xmlparser/regressions/21154_profile_bin.xml
+++ b/test/unittest/xmlparser/regressions/21154_profile_bin.xml
@@ -1,0 +1,1 @@
+<types><type><typedef type="string"stringMaxLength="-340282366920938463444927863358058659977"/></type></types>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR addresses some XML fuzzer regressions that affects DynamicTypes Parsing. It is for that reason that there are no backports. In summary, it was a non-captured `std::out_of_range` exception and  a `nullptr` check missing. I tried also protecting analogous code snippets within the file.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- ❌ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- __NO__ New feature has been added to the `versions.md` file (if applicable).
- __NO__ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- ❌ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
