### PR TITLE
[21170] Fix DS servers not connecting due to ports logic

### DIFF
--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -489,16 +489,6 @@ bool PDPServer::create_ds_pdp_reliable_endpoints(
         wout->reader_data_filter(pdp_filter);
         // Enable separate sending so the filter can be called for each change and reader proxy
         wout->set_separate_sending(true);
-
-        if (!secure)
-        {
-            eprosima::shared_lock<eprosima::shared_mutex> disc_lock(mp_builtin->getDiscoveryMutex());
-
-            for (const eprosima::fastdds::rtps::RemoteServerAttributes& it : mp_builtin->m_DiscoveryServers)
-            {
-                match_pdp_reader_nts_(it);
-            }
-        }
     }
     // Could not create PDP Writer, so return false
     else

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -339,6 +339,21 @@ RTPSParticipantImpl::RTPSParticipantImpl(
                                     }
                                 });
                     }
+                    for (fastdds::rtps::RemoteServerAttributes& it : m_att.builtin.discovery_config.m_DiscoveryServers)
+                    {
+                        std::for_each(it.metatrafficUnicastLocatorList.begin(),
+                                it.metatrafficUnicastLocatorList.end(), [&](Locator_t& locator)
+                                {
+                                    // TCP DS default logical port is the same as the physical one
+                                    if (locator.kind == LOCATOR_KIND_TCPv4 || locator.kind == LOCATOR_KIND_TCPv6)
+                                    {
+                                        if (IPLocator::getLogicalPort(locator) == 0)
+                                        {
+                                            IPLocator::setLogicalPort(locator, IPLocator::getPhysicalPort(locator));
+                                        }
+                                    }
+                                });
+                    }
                 }
             }
             break;

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -884,6 +884,25 @@ public:
         on_participant_qos_update_ = f;
     }
 
+    PubSubParticipant& fill_server_qos(
+            eprosima::fastdds::dds::WireProtocolConfigQos& qos,
+            eprosima::fastrtps::rtps::GuidPrefix_t& guid,
+            eprosima::fastrtps::rtps::Locator_t& locator_server,
+            uint32_t port,
+            uint32_t kind)
+    {
+        qos.builtin.discovery_config.discoveryProtocol = eprosima::fastrtps::rtps::DiscoveryProtocol_t::SERVER;
+        qos.prefix = guid;
+        // Generate server's listening locator
+        eprosima::fastrtps::rtps::IPLocator::setIPv4(locator_server, 127, 0, 0, 1);
+        eprosima::fastrtps::rtps::IPLocator::setPhysicalPort(locator_server, port);
+        locator_server.kind = kind;
+        // Leave logical port as 0 to use TCP DS default logical port
+        qos.builtin.metatrafficUnicastLocatorList.push_back(locator_server);
+
+        return wire_protocol(qos);
+    }
+
 private:
 
     PubSubParticipant& operator =(

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -888,7 +888,7 @@ public:
             eprosima::fastdds::dds::WireProtocolConfigQos& qos,
             eprosima::fastrtps::rtps::GuidPrefix_t& guid,
             eprosima::fastrtps::rtps::Locator_t& locator_server,
-            uint32_t port,
+            uint16_t port,
             uint32_t kind)
     {
         qos.builtin.discovery_config.discoveryProtocol = eprosima::fastrtps::rtps::DiscoveryProtocol_t::SERVER;

--- a/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
@@ -207,13 +207,12 @@ TEST(DDSDiscovery, AddDiscoveryServerToListTCP)
     using namespace eprosima::fastrtps::rtps;
 
     // TCP default DS port
-    std::string W_UNICAST_PORT_RANDOM_NUMBER_STR = "42100";
+    constexpr uint16_t W_UNICAST_PORT_RANDOM_NUMBER_STR = 42100;
 
     /* Create first server */
     PubSubParticipant<HelloWorldPubSubType> server_1(0u, 0u, 0u, 0u);
     // Set participant as server
     WireProtocolConfigQos server_1_qos;
-    server_1_qos.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SERVER;
     // Generate random GUID prefix
     srand(static_cast<unsigned>(time(nullptr)));
     GuidPrefix_t server_1_prefix;
@@ -221,20 +220,14 @@ TEST(DDSDiscovery, AddDiscoveryServerToListTCP)
     {
         server_1_prefix.value[i] = eprosima::fastrtps::rtps::octet(rand() % 254);
     }
-    server_1_qos.prefix = server_1_prefix;
-    // Generate server's listening locator
+    uint16_t server_1_port = W_UNICAST_PORT_RANDOM_NUMBER_STR;
     Locator_t locator_server_1;
-    IPLocator::setIPv4(locator_server_1, 127, 0, 0, 1);
-    uint16_t server_1_port = static_cast<uint16_t>(stoi(W_UNICAST_PORT_RANDOM_NUMBER_STR));
-    IPLocator::setPhysicalPort(locator_server_1, server_1_port);
-    locator_server_1.kind = LOCATOR_KIND_TCPv4;
-    // Leave logical port as 0 to use TCP DS default logical port
-    server_1_qos.builtin.metatrafficUnicastLocatorList.push_back(locator_server_1);
     // Add TCP transport
     auto descriptor_1 = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
     descriptor_1->add_listener_port(server_1_port);
+
     // Init server
-    ASSERT_TRUE(server_1.wire_protocol(server_1_qos)
+    ASSERT_TRUE(server_1.fill_server_qos(server_1_qos, server_1_prefix, locator_server_1, server_1_port, LOCATOR_KIND_TCPv4)
                     .disable_builtin_transport()
                     .add_user_transport_to_pparams(descriptor_1)
                     .init_participant());
@@ -243,25 +236,16 @@ TEST(DDSDiscovery, AddDiscoveryServerToListTCP)
     PubSubParticipant<HelloWorldPubSubType> server_2(0u, 0u, 0u, 0u);
     // Set participant as server
     WireProtocolConfigQos server_2_qos;
-    server_2_qos.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SERVER;
-    // Generate random GUID prefix
     GuidPrefix_t server_2_prefix = server_1_prefix;
     server_2_prefix.value[11]++;
-    server_2_qos.prefix = server_2_prefix;
-    // Generate server's listening locator
     Locator_t locator_server_2;
-    IPLocator::setIPv4(locator_server_2, 127, 0, 0, 1);
     uint16_t server_2_port = server_1_port + 1;
-    IPLocator::setPhysicalPort(locator_server_2, server_2_port);
-    locator_server_2.kind = LOCATOR_KIND_TCPv4;
-    // Leave logical port as 0 to use TCP DS default logical port
-    server_2_qos.builtin.metatrafficUnicastLocatorList.push_back(locator_server_2);
     // Add TCP transport
     auto descriptor_2 = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
     descriptor_2->add_listener_port(server_2_port);
 
     // Init server
-    ASSERT_TRUE(server_2.wire_protocol(server_2_qos)
+    ASSERT_TRUE(server_2.fill_server_qos(server_2_qos, server_2_prefix, locator_server_2, server_2_port, LOCATOR_KIND_TCPv4)
                     .disable_builtin_transport()
                     .add_user_transport_to_pparams(descriptor_2)
                     .init_participant());
@@ -337,13 +321,12 @@ TEST(DDSDiscovery, ServersConnectionTCP)
     using namespace eprosima::fastrtps::rtps;
 
     // TCP default DS port
-    std::string W_UNICAST_PORT_RANDOM_NUMBER_STR = "42100";
+    constexpr uint16_t W_UNICAST_PORT_RANDOM_NUMBER_STR = 41100;
 
     /* Create first server */
     PubSubParticipant<HelloWorldPubSubType> server_1(0u, 0u, 0u, 0u);
     // Set participant as server
     WireProtocolConfigQos server_1_qos;
-    server_1_qos.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SERVER;
     // Generate random GUID prefix
     srand(static_cast<unsigned>(time(nullptr)));
     GuidPrefix_t server_1_prefix;
@@ -351,20 +334,13 @@ TEST(DDSDiscovery, ServersConnectionTCP)
     {
         server_1_prefix.value[i] = eprosima::fastrtps::rtps::octet(rand() % 254);
     }
-    server_1_qos.prefix = server_1_prefix;
-    // Generate server's listening locator
     Locator_t locator_server_1;
-    IPLocator::setIPv4(locator_server_1, 127, 0, 0, 1);
-    uint16_t server_1_port = static_cast<uint16_t>(stoi(W_UNICAST_PORT_RANDOM_NUMBER_STR));
-    IPLocator::setPhysicalPort(locator_server_1, server_1_port);
-    locator_server_1.kind = LOCATOR_KIND_TCPv4;
-    // Leave logical port as 0 to use TCP DS default logical port
-    server_1_qos.builtin.metatrafficUnicastLocatorList.push_back(locator_server_1);
+    uint16_t server_1_port = W_UNICAST_PORT_RANDOM_NUMBER_STR;
     // Add TCP transport
     auto descriptor_1 = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
     descriptor_1->add_listener_port(server_1_port);
     // Init server
-    ASSERT_TRUE(server_1.wire_protocol(server_1_qos)
+    ASSERT_TRUE(server_1.fill_server_qos(server_1_qos, server_1_prefix, locator_server_1, server_1_port, LOCATOR_KIND_TCPv4)
                     .disable_builtin_transport()
                     .add_user_transport_to_pparams(descriptor_1)
                     .init_participant());
@@ -373,22 +349,14 @@ TEST(DDSDiscovery, ServersConnectionTCP)
     PubSubParticipant<HelloWorldPubSubType> server_2(0u, 0u, 0u, 0u);
     // Set participant as server
     WireProtocolConfigQos server_2_qos;
-    server_2_qos.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SERVER;
-    // Generate random GUID prefix
     GuidPrefix_t server_2_prefix = server_1_prefix;
     server_2_prefix.value[11]++;
-    server_2_qos.prefix = server_2_prefix;
-    // Generate server's listening locator
     Locator_t locator_server_2;
-    IPLocator::setIPv4(locator_server_2, 127, 0, 0, 1);
     uint16_t server_2_port = server_1_port + 1;
-    IPLocator::setPhysicalPort(locator_server_2, server_2_port);
-    locator_server_2.kind = LOCATOR_KIND_TCPv4;
-    // Leave logical port as 0 to use TCP DS default logical port
-    server_2_qos.builtin.metatrafficUnicastLocatorList.push_back(locator_server_2);
     // Add TCP transport
     auto descriptor_2 = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
     descriptor_2->add_listener_port(server_2_port);
+
     // Connect to first server
     RemoteServerAttributes server_1_att;
     server_1_att.guidPrefix = server_1_prefix;
@@ -396,7 +364,7 @@ TEST(DDSDiscovery, ServersConnectionTCP)
     server_2_qos.builtin.discovery_config.m_DiscoveryServers.push_back(server_1_att);
 
     // Init server
-    ASSERT_TRUE(server_2.wire_protocol(server_2_qos)
+    ASSERT_TRUE(server_2.fill_server_qos(server_2_qos, server_2_prefix, locator_server_2, server_2_port, LOCATOR_KIND_TCPv4)
                     .disable_builtin_transport()
                     .add_user_transport_to_pparams(descriptor_2)
                     .init_participant());
@@ -405,19 +373,10 @@ TEST(DDSDiscovery, ServersConnectionTCP)
     PubSubParticipant<HelloWorldPubSubType> server_3(0u, 0u, 0u, 0u);
     // Set participant as server
     WireProtocolConfigQos server_3_qos;
-    server_3_qos.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SERVER;
-    // Generate random GUID prefix
     GuidPrefix_t server_3_prefix = server_1_prefix;
     server_3_prefix.value[11]--;
-    server_3_qos.prefix = server_3_prefix;
-    // Generate server's listening locator
     Locator_t locator_server_3;
-    IPLocator::setIPv4(locator_server_3, 127, 0, 0, 1);
     uint16_t server_3_port = server_1_port - 1;
-    IPLocator::setPhysicalPort(locator_server_3, server_3_port);
-    locator_server_3.kind = LOCATOR_KIND_TCPv4;
-    // Leave logical port as 0 to use TCP DS default logical port
-    server_3_qos.builtin.metatrafficUnicastLocatorList.push_back(locator_server_3);
     // Add TCP transport
     auto descriptor_3 = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
     descriptor_3->add_listener_port(server_3_port);
@@ -425,7 +384,7 @@ TEST(DDSDiscovery, ServersConnectionTCP)
     server_3_qos.builtin.discovery_config.m_DiscoveryServers.push_back(server_1_att);
 
     // Init server
-    ASSERT_TRUE(server_3.wire_protocol(server_3_qos)
+    ASSERT_TRUE(server_3.fill_server_qos(server_3_qos, server_3_prefix, locator_server_3, server_3_port, LOCATOR_KIND_TCPv4)
                     .disable_builtin_transport()
                     .add_user_transport_to_pparams(descriptor_3)
                     .init_participant());

--- a/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
@@ -330,6 +330,124 @@ TEST(DDSDiscovery, AddDiscoveryServerToListTCP)
     server_2.wait_discovery(std::chrono::seconds::zero(), 2, true); // Knows client1 and server1
 }
 
+TEST(DDSDiscovery, ServersConnectionTCP)
+{
+    using namespace eprosima;
+    using namespace eprosima::fastdds::dds;
+    using namespace eprosima::fastrtps::rtps;
+
+    // TCP default DS port
+    std::string W_UNICAST_PORT_RANDOM_NUMBER_STR = "42100";
+
+    /* Create first server */
+    PubSubParticipant<HelloWorldPubSubType> server_1(0u, 0u, 0u, 0u);
+    // Set participant as server
+    WireProtocolConfigQos server_1_qos;
+    server_1_qos.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SERVER;
+    // Generate random GUID prefix
+    srand(static_cast<unsigned>(time(nullptr)));
+    GuidPrefix_t server_1_prefix;
+    for (auto i = 0; i < 12; i++)
+    {
+        server_1_prefix.value[i] = eprosima::fastrtps::rtps::octet(rand() % 254);
+    }
+    server_1_qos.prefix = server_1_prefix;
+    // Generate server's listening locator
+    Locator_t locator_server_1;
+    IPLocator::setIPv4(locator_server_1, 127, 0, 0, 1);
+    uint16_t server_1_port = static_cast<uint16_t>(stoi(W_UNICAST_PORT_RANDOM_NUMBER_STR));
+    IPLocator::setPhysicalPort(locator_server_1, server_1_port);
+    locator_server_1.kind = LOCATOR_KIND_TCPv4;
+    // Leave logical port as 0 to use TCP DS default logical port
+    server_1_qos.builtin.metatrafficUnicastLocatorList.push_back(locator_server_1);
+    // Add TCP transport
+    auto descriptor_1 = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
+    descriptor_1->add_listener_port(server_1_port);
+    // Init server
+    ASSERT_TRUE(server_1.wire_protocol(server_1_qos)
+                    .disable_builtin_transport()
+                    .add_user_transport_to_pparams(descriptor_1)
+                    .init_participant());
+
+    /* Create second server */
+    PubSubParticipant<HelloWorldPubSubType> server_2(0u, 0u, 0u, 0u);
+    // Set participant as server
+    WireProtocolConfigQos server_2_qos;
+    server_2_qos.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SERVER;
+    // Generate random GUID prefix
+    GuidPrefix_t server_2_prefix = server_1_prefix;
+    server_2_prefix.value[11]++;
+    server_2_qos.prefix = server_2_prefix;
+    // Generate server's listening locator
+    Locator_t locator_server_2;
+    IPLocator::setIPv4(locator_server_2, 127, 0, 0, 1);
+    uint16_t server_2_port = server_1_port + 1;
+    IPLocator::setPhysicalPort(locator_server_2, server_2_port);
+    locator_server_2.kind = LOCATOR_KIND_TCPv4;
+    // Leave logical port as 0 to use TCP DS default logical port
+    server_2_qos.builtin.metatrafficUnicastLocatorList.push_back(locator_server_2);
+    // Add TCP transport
+    auto descriptor_2 = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
+    descriptor_2->add_listener_port(server_2_port);
+    // Connect to first server
+    RemoteServerAttributes server_1_att;
+    server_1_att.guidPrefix = server_1_prefix;
+    server_1_att.metatrafficUnicastLocatorList.push_back(Locator_t(locator_server_1));
+    server_2_qos.builtin.discovery_config.m_DiscoveryServers.push_back(server_1_att);
+
+    // Init server
+    ASSERT_TRUE(server_2.wire_protocol(server_2_qos)
+                    .disable_builtin_transport()
+                    .add_user_transport_to_pparams(descriptor_2)
+                    .init_participant());
+
+    /* Create third server */
+    PubSubParticipant<HelloWorldPubSubType> server_3(0u, 0u, 0u, 0u);
+    // Set participant as server
+    WireProtocolConfigQos server_3_qos;
+    server_3_qos.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SERVER;
+    // Generate random GUID prefix
+    GuidPrefix_t server_3_prefix = server_1_prefix;
+    server_3_prefix.value[11]--;
+    server_3_qos.prefix = server_3_prefix;
+    // Generate server's listening locator
+    Locator_t locator_server_3;
+    IPLocator::setIPv4(locator_server_3, 127, 0, 0, 1);
+    uint16_t server_3_port = server_1_port - 1;
+    IPLocator::setPhysicalPort(locator_server_3, server_3_port);
+    locator_server_3.kind = LOCATOR_KIND_TCPv4;
+    // Leave logical port as 0 to use TCP DS default logical port
+    server_3_qos.builtin.metatrafficUnicastLocatorList.push_back(locator_server_3);
+    // Add TCP transport
+    auto descriptor_3 = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
+    descriptor_3->add_listener_port(server_3_port);
+    // Connect to first server
+    server_3_qos.builtin.discovery_config.m_DiscoveryServers.push_back(server_1_att);
+
+    // Init server
+    ASSERT_TRUE(server_3.wire_protocol(server_3_qos)
+                    .disable_builtin_transport()
+                    .add_user_transport_to_pparams(descriptor_3)
+                    .init_participant());
+
+    // Check adding servers before initialization
+    server_1.wait_discovery(std::chrono::seconds::zero(), 2, true); // Knows server2 and server3
+    server_2.wait_discovery(std::chrono::seconds::zero(), 1, true); // Knows server1
+    server_3.wait_discovery(std::chrono::seconds::zero(), 1, true); // Knows server1
+
+    /* Add server_2 to server_1 */
+    RemoteServerAttributes server_3_att;
+    server_3_att.guidPrefix = server_3_prefix;
+    server_3_att.metatrafficUnicastLocatorList.push_back(Locator_t(locator_server_3));
+    server_2_qos.builtin.discovery_config.m_DiscoveryServers.push_back(server_3_att);
+    ASSERT_TRUE(server_2.update_wire_protocol(server_2_qos));
+
+    // Check adding servers after initialization
+    server_1.wait_discovery(std::chrono::seconds::zero(), 2, true); // Knows server2 and server3
+    server_2.wait_discovery(std::chrono::seconds::zero(), 2, true); // Knows server1 and server3
+    server_3.wait_discovery(std::chrono::seconds::zero(), 2, true); // Knows server1 and server2
+}
+
 /**
  * This test checks the addition of network interfaces at run-time.
  *

--- a/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
@@ -227,7 +227,8 @@ TEST(DDSDiscovery, AddDiscoveryServerToListTCP)
     descriptor_1->add_listener_port(server_1_port);
 
     // Init server
-    ASSERT_TRUE(server_1.fill_server_qos(server_1_qos, server_1_prefix, locator_server_1, server_1_port, LOCATOR_KIND_TCPv4)
+    ASSERT_TRUE(server_1.fill_server_qos(server_1_qos, server_1_prefix, locator_server_1, server_1_port,
+            LOCATOR_KIND_TCPv4)
                     .disable_builtin_transport()
                     .add_user_transport_to_pparams(descriptor_1)
                     .init_participant());
@@ -245,7 +246,8 @@ TEST(DDSDiscovery, AddDiscoveryServerToListTCP)
     descriptor_2->add_listener_port(server_2_port);
 
     // Init server
-    ASSERT_TRUE(server_2.fill_server_qos(server_2_qos, server_2_prefix, locator_server_2, server_2_port, LOCATOR_KIND_TCPv4)
+    ASSERT_TRUE(server_2.fill_server_qos(server_2_qos, server_2_prefix, locator_server_2, server_2_port,
+            LOCATOR_KIND_TCPv4)
                     .disable_builtin_transport()
                     .add_user_transport_to_pparams(descriptor_2)
                     .init_participant());
@@ -340,7 +342,8 @@ TEST(DDSDiscovery, ServersConnectionTCP)
     auto descriptor_1 = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
     descriptor_1->add_listener_port(server_1_port);
     // Init server
-    ASSERT_TRUE(server_1.fill_server_qos(server_1_qos, server_1_prefix, locator_server_1, server_1_port, LOCATOR_KIND_TCPv4)
+    ASSERT_TRUE(server_1.fill_server_qos(server_1_qos, server_1_prefix, locator_server_1, server_1_port,
+            LOCATOR_KIND_TCPv4)
                     .disable_builtin_transport()
                     .add_user_transport_to_pparams(descriptor_1)
                     .init_participant());
@@ -364,7 +367,8 @@ TEST(DDSDiscovery, ServersConnectionTCP)
     server_2_qos.builtin.discovery_config.m_DiscoveryServers.push_back(server_1_att);
 
     // Init server
-    ASSERT_TRUE(server_2.fill_server_qos(server_2_qos, server_2_prefix, locator_server_2, server_2_port, LOCATOR_KIND_TCPv4)
+    ASSERT_TRUE(server_2.fill_server_qos(server_2_qos, server_2_prefix, locator_server_2, server_2_port,
+            LOCATOR_KIND_TCPv4)
                     .disable_builtin_transport()
                     .add_user_transport_to_pparams(descriptor_2)
                     .init_participant());
@@ -384,7 +388,8 @@ TEST(DDSDiscovery, ServersConnectionTCP)
     server_3_qos.builtin.discovery_config.m_DiscoveryServers.push_back(server_1_att);
 
     // Init server
-    ASSERT_TRUE(server_3.fill_server_qos(server_3_qos, server_3_prefix, locator_server_3, server_3_port, LOCATOR_KIND_TCPv4)
+    ASSERT_TRUE(server_3.fill_server_qos(server_3_qos, server_3_prefix, locator_server_3, server_3_port,
+            LOCATOR_KIND_TCPv4)
                     .disable_builtin_transport()
                     .add_user_transport_to_pparams(descriptor_3)
                     .init_participant());

--- a/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
@@ -399,7 +399,7 @@ TEST(DDSDiscovery, ServersConnectionTCP)
     server_2.wait_discovery(std::chrono::seconds::zero(), 1, true); // Knows server1
     server_3.wait_discovery(std::chrono::seconds::zero(), 1, true); // Knows server1
 
-    /* Add server_2 to server_1 */
+    /* Add server_3 to server_2 */
     RemoteServerAttributes server_3_att;
     server_3_att.guidPrefix = server_3_prefix;
     server_3_att.metatrafficUnicastLocatorList.push_back(Locator_t(locator_server_3));


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR fixes a bug that was avoiding discovery when a DS server tries to connect to another server which has a smaller physical port. The logic implemented in https://github.com/eProsima/Fast-DDS/pull/4586 needs to be used to fix the issue.
It also adds support to automatically set the logical port of remote servers when the participant `discoveryProtocol` is configured as `DiscoveryProtocol::SERVER`, which was missing.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x 
<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [X] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [X] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
